### PR TITLE
Scope page placement ids by surface

### DIFF
--- a/packages/assistant/test/subcommands.test.js
+++ b/packages/assistant/test/subcommands.test.js
@@ -89,7 +89,7 @@ test("assistant page subcommand creates a runtime page at an explicit target fil
 
     const placementSource = await readFile(path.join(appRoot, "src/placement.js"), "utf8");
     assert.match(placementSource, /jskit:assistant\.page\.link:admin:\/ops\/copilot/);
-    assert.match(placementSource, /id: "ui-generator\.page\.ops\.copilot\.link"/);
+    assert.match(placementSource, /id: "ui-generator\.page\.admin\.ops\.copilot\.link"/);
     assert.match(placementSource, /host: "shell-layout"/);
     assert.match(placementSource, /position: "primary-menu"/);
     assert.match(placementSource, /label: "Copilot"/);

--- a/packages/crud-ui-generator/test/buildTemplateContext.test.js
+++ b/packages/crud-ui-generator/test/buildTemplateContext.test.js
@@ -324,7 +324,7 @@ test("buildUiTemplateContext resolves list placement from the app default shell 
       options: createOptions()
     });
 
-    assert.equal(context.__JSKIT_UI_MENU_PLACEMENT_ID__, "ui-generator.page.customers.link");
+    assert.equal(context.__JSKIT_UI_MENU_PLACEMENT_ID__, "ui-generator.page.admin.customers.link");
     assert.equal(context.__JSKIT_UI_MENU_PLACEMENT_HOST__, "shell-layout");
     assert.equal(context.__JSKIT_UI_MENU_PLACEMENT_POSITION__, "primary-menu");
     assert.equal(context.__JSKIT_UI_MENU_COMPONENT_TOKEN__, "users.web.shell.surface-aware-menu-link-item");

--- a/packages/kernel/server/support/pageTargets.js
+++ b/packages/kernel/server/support/pageTargets.js
@@ -201,6 +201,7 @@ function deriveRouteInfoFromSurfaceRelativeFile(surfaceRelativeFilePath = "", su
 
   const visibleRouteSegments = routeSegments.filter((segment) => !isRouteGroupSegment(segment));
   const routeUrlSuffix = visibleRouteSegments.length > 0 ? `/${visibleRouteSegments.join("/")}` : "/";
+  const surfacePlacementIdSegment = normalizePlacementIdSegment(surfaceId || "root") || "root";
   const placementIdSegments = visibleRouteSegments
     .map((segment) => normalizePlacementIdSegment(segment))
     .filter(Boolean);
@@ -218,8 +219,8 @@ function deriveRouteInfoFromSurfaceRelativeFile(surfaceRelativeFilePath = "", su
     containsNestedChildrenGroup: routeSegments.some((segment) => isNestedChildrenRouteGroupSegment(segment)),
     placementId:
       placementIdSegments.length > 0
-        ? `ui-generator.page.${placementIdSegments.join(".")}.link`
-        : `ui-generator.page.${normalizePlacementIdSegment(surfaceId || "root") || "root"}.link`
+        ? `ui-generator.page.${surfacePlacementIdSegment}.${placementIdSegments.join(".")}.link`
+        : `ui-generator.page.${surfacePlacementIdSegment}.link`
   });
 }
 

--- a/packages/kernel/server/support/pageTargets.test.js
+++ b/packages/kernel/server/support/pageTargets.test.js
@@ -64,9 +64,39 @@ test("resolvePageTargetDetails derives the surface and route data from an explic
     assert.equal(pageTarget.surfaceId, "admin");
     assert.equal(pageTarget.surfacePagesRoot, "w/[workspaceSlug]/admin");
     assert.equal(pageTarget.routeUrlSuffix, "/catalog/products");
-    assert.equal(pageTarget.placementId, "ui-generator.page.catalog.products.link");
+    assert.equal(pageTarget.placementId, "ui-generator.page.admin.catalog.products.link");
     assert.deepEqual(pageTarget.visibleRouteSegments, ["catalog", "products"]);
     assert.equal(deriveDefaultSubpagesHost(pageTarget), "catalog-products");
+  });
+});
+
+test("resolvePageTargetDetails includes surface in placement ids for identical routes on different surfaces", async () => {
+  await withTempApp(async (appRoot) => {
+    await writeConfig(
+      appRoot,
+      `export const config = {
+  surfaceDefinitions: {
+    app: { id: "app", pagesRoot: "app", enabled: true },
+    admin: { id: "admin", pagesRoot: "admin", enabled: true }
+  }
+};
+`
+    );
+
+    const appPageTarget = await resolvePageTargetDetails({
+      appRoot,
+      targetFile: "src/pages/app/reports/index.vue",
+      context: "page target"
+    });
+    const adminPageTarget = await resolvePageTargetDetails({
+      appRoot,
+      targetFile: "src/pages/admin/reports/index.vue",
+      context: "page target"
+    });
+
+    assert.equal(appPageTarget.placementId, "ui-generator.page.app.reports.link");
+    assert.equal(adminPageTarget.placementId, "ui-generator.page.admin.reports.link");
+    assert.notEqual(appPageTarget.placementId, adminPageTarget.placementId);
   });
 });
 

--- a/packages/ui-generator/test/buildTemplateContext.test.js
+++ b/packages/ui-generator/test/buildTemplateContext.test.js
@@ -63,7 +63,7 @@ test("buildUiPageTemplateContext resolves link placement from default app ShellO
     assert.equal(context.__JSKIT_UI_LINK_WORKSPACE_SUFFIX__, "/reports");
     assert.equal(context.__JSKIT_UI_LINK_NON_WORKSPACE_SUFFIX__, "/reports");
     assert.equal(context.__JSKIT_UI_LINK_TO_PROP_LINE__, "");
-    assert.equal(context.__JSKIT_UI_LINK_PLACEMENT_ID__, "ui-generator.page.reports.link");
+    assert.equal(context.__JSKIT_UI_LINK_PLACEMENT_ID__, "ui-generator.page.admin.reports.link");
   });
 });
 
@@ -180,7 +180,7 @@ test("buildUiPageTemplateContext supports explicit link component token and link
     assert.equal(context.__JSKIT_UI_LINK_WORKSPACE_SUFFIX__, "/contacts/[contactId]/notes");
     assert.equal(context.__JSKIT_UI_LINK_NON_WORKSPACE_SUFFIX__, "/contacts/[contactId]/notes");
     assert.equal(context.__JSKIT_UI_LINK_TO_PROP_LINE__, "      to: \"./notes\",\n");
-    assert.equal(context.__JSKIT_UI_LINK_PLACEMENT_ID__, "ui-generator.page.contacts.contact-id.notes.link");
+    assert.equal(context.__JSKIT_UI_LINK_PLACEMENT_ID__, "ui-generator.page.admin.contacts.contact-id.notes.link");
   });
 });
 
@@ -404,8 +404,8 @@ test("buildUiPageTemplateContext derives the same visible route from file and in
 
     assert.equal(fileContext.__JSKIT_UI_LINK_WORKSPACE_SUFFIX__, "/catalog");
     assert.equal(indexContext.__JSKIT_UI_LINK_WORKSPACE_SUFFIX__, "/catalog");
-    assert.equal(fileContext.__JSKIT_UI_LINK_PLACEMENT_ID__, "ui-generator.page.catalog.link");
-    assert.equal(indexContext.__JSKIT_UI_LINK_PLACEMENT_ID__, "ui-generator.page.catalog.link");
+    assert.equal(fileContext.__JSKIT_UI_LINK_PLACEMENT_ID__, "ui-generator.page.admin.catalog.link");
+    assert.equal(indexContext.__JSKIT_UI_LINK_PLACEMENT_ID__, "ui-generator.page.admin.catalog.link");
   });
 });
 

--- a/packages/ui-generator/test/pageSubcommand.test.js
+++ b/packages/ui-generator/test/pageSubcommand.test.js
@@ -74,7 +74,7 @@ test("ui-generator page subcommand creates an index page from an explicit target
     assert.match(pageSource, /<h1 class="text-h5 mb-2">Practice<\/h1>/);
 
     const placementSource = await readFile(path.join(appRoot, "src", "placement.js"), "utf8");
-    assert.match(placementSource, /id: "ui-generator\.page\.practice\.link"/);
+    assert.match(placementSource, /id: "ui-generator\.page\.admin\.practice\.link"/);
     assert.match(placementSource, /workspaceSuffix: "\/practice"/);
     assert.match(placementSource, /label: "Practice"/);
   });
@@ -99,7 +99,7 @@ test("ui-generator page subcommand creates a file route and derives label from t
 
     const placementSource = await readFile(path.join(appRoot, "src", "placement.js"), "utf8");
     assert.match(placementSource, /workspaceSuffix: "\/contacts\/\[contactId\]"/);
-    assert.match(placementSource, /id: "ui-generator\.page\.contacts\.contact-id\.link"/);
+    assert.match(placementSource, /id: "ui-generator\.page\.admin\.contacts\.contact-id\.link"/);
     assert.match(placementSource, /label: "Contact Id"/);
   });
 });

--- a/tooling/jskit-cli/test/uiElementGeneratorPackage.test.js
+++ b/tooling/jskit-cli/test/uiElementGeneratorPackage.test.js
@@ -169,7 +169,7 @@ test("generate @jskit-ai/ui-generator page scaffolds page and menu placement", a
     assert.match(pageSource, /Reports Dashboard/);
 
     const placementSource = await readFile(placementPath, "utf8");
-    assert.match(placementSource, /id: "ui-generator\.page\.reports-dashboard\.link"/);
+    assert.match(placementSource, /id: "ui-generator\.page\.admin\.reports-dashboard\.link"/);
     assert.match(placementSource, /position: "primary-menu"/);
     assert.match(placementSource, /componentToken: "users\.web\.shell\.surface-aware-menu-link-item"/);
     assert.match(placementSource, /workspaceSuffix: "\/reports-dashboard"/);
@@ -206,7 +206,7 @@ test("generate @jskit-ai/ui-generator page creates an explicit file-route target
 
     const placementSource = await readFile(placementPath, "utf8");
     assert.match(placementSource, /workspaceSuffix: "\/contacts\/\[contactId\]"/);
-    assert.match(placementSource, /id: "ui-generator\.page\.contacts\.contact-id\.link"/);
+    assert.match(placementSource, /id: "ui-generator\.page\.admin\.contacts\.contact-id\.link"/);
   });
 });
 
@@ -377,8 +377,8 @@ test("generate @jskit-ai/ui-generator page uses path-aware placement IDs for sam
       (match) => match[1]
     );
 
-    assert.match(placementSource, /id: "ui-generator\.page\.alpha\.one\.link"/);
-    assert.match(placementSource, /id: "ui-generator\.page\.beta\.one\.link"/);
+    assert.match(placementSource, /id: "ui-generator\.page\.admin\.alpha\.one\.link"/);
+    assert.match(placementSource, /id: "ui-generator\.page\.admin\.beta\.one\.link"/);
     assert.equal(placementIds.includes("ui-generator.page.one.link"), false);
     assert.equal(new Set(placementIds).size, placementIds.length);
   });

--- a/tooling/jskit-cli/test/uiGeneratorPackage.test.js
+++ b/tooling/jskit-cli/test/uiGeneratorPackage.test.js
@@ -287,7 +287,7 @@ test("generate @jskit-ai/crud-ui-generator crud scaffolds CRUD pages at an expli
 
     const placementSource = await readFile(path.join(appRoot, "src", "placement.js"), "utf8");
     assert.match(placementSource, /jskit:crud-ui-generator\.page\.link:admin:\/ops\/customers-ui/);
-    assert.match(placementSource, /id: "ui-generator\.page\.ops\.customers-ui\.link"/);
+    assert.match(placementSource, /id: "ui-generator\.page\.admin\.ops\.customers-ui\.link"/);
     assert.match(placementSource, /host: "shell-layout"/);
     assert.match(placementSource, /position: "primary-menu"/);
     assert.match(placementSource, /workspaceSuffix: "\/ops\/customers-ui"/);


### PR DESCRIPTION
## Summary
- include the owning surface in generated page placement ids so identical routes on different surfaces do not collide
- extend the shared kernel page-target tests to cover the cross-surface collision case
- update assistant, crud-ui, ui-generator, and CLI generator tests to match the new placement id contract

## Testing
- npm run lint
- node --test packages/kernel/server/support/pageTargets.test.js packages/assistant/test/subcommands.test.js packages/crud-ui-generator/test/buildTemplateContext.test.js packages/ui-generator/test/buildTemplateContext.test.js tooling/jskit-cli/test/uiElementGeneratorPackage.test.js