### PR TITLE
Tighten generator contracts and CLI command help

### DIFF
--- a/docs/AI/jskit-cheatsheet.md
+++ b/docs/AI/jskit-cheatsheet.md
@@ -1,0 +1,692 @@
+# jskit CLI deep internals (machine-oriented)
+
+## 1) top-level help surface
+- `printTopLevelHelp()` emits:
+  - `JSKit CLI`
+  - `Use: jskit help <command> for command-specific usage.`
+  - `Available commands:`
+    - `create           Scaffold an app-local runtime package.`
+    - `add              Install a runtime bundle or package into the current app.`
+    - `generate         Run a generator package (or generator subcommand).`
+    - `list             List bundles, runtime packages, or generator packages.`
+    - `list-placements  List discovered UI placement targets.`
+    - `list-link-items  List available placement link-item component tokens.`
+    - `show             Show detailed metadata for a bundle or package.`
+    - `migrations       Generate managed migration files only.`
+    - `position         Re-apply positioning-only mutations for an installed package.`
+    - `update           Re-apply one installed package.`
+    - `remove           Remove one installed package.`
+    - `doctor           Validate lockfile and managed-file integrity.`
+    - `lint-descriptors Validate bundle and package descriptor contracts.`
+  - `Global flags: --dry-run --run-npm-install --json --verbose --help`
+- Command invocation path: `node_modules/@jskit-ai/jskit-cli/src/server/core/usageHelp.js` → `printTopLevelHelp()`
+- `npx jskit help <command>` is the canonical usage entrypoint.
+
+## 2) command catalog + alias map
+- `commandCatalog.js` known commands:
+  - `help`
+  - `create`
+  - `generate`
+  - `list`
+  - `list-placements`
+  - `list-link-items`
+  - `show`
+  - `view`
+  - `migrations`
+  - `add`
+  - `position`
+  - `update`
+  - `remove`
+  - `doctor`
+  - `lint-descriptors`
+- Alias map in current runtime:
+  - `view -> show`
+  - `ls -> list`
+  - `gen -> generate`
+  - `lp -> list-placements`
+  - `lpct -> list-link-items`
+  - `list-placement-component-tokens -> list-link-items`
+- `dispatchCli` resolves alias before command dispatch.
+
+## 3) argv parser contract
+- Parser file: `node_modules/@jskit-ai/jskit-cli/src/server/core/argParser.js`
+- Leading `--help` / `-h` as first token converts command to `help` and prints usage.
+- For normal commands, unknown command names fail `Unknown command: ${raw}` with showUsage.
+- Default options object keys:
+  - `dryRun`, `runNpmInstall`, `full`, `expanded`, `details`, `debugExports`, `checkDiLabels`, `verbose`, `json`, `all`, `help`, `inlineOptions`
+- Recognized global flags:
+  - `--dry-run`
+  - `--run-npm-install`
+  - `--full`
+  - `--expanded`
+  - `--details`
+  - `--debug-exports`
+  - `--check-di-labels`
+  - `--verbose`
+  - `--json`
+  - `--all`
+  - `--help` / `-h`
+- Special parser behavior:
+  - `--force` parsed as inline option with value string `true`.
+  - All `--foo value` and `--foo=value` forms supported.
+  - Unknown `-x`/`-abc` (single dash) => unknown option.
+- Generate inline-option parsing is looser than other commands:
+  - command is `generate`
+  - option names regex: `^[A-Za-z][A-Za-z0-9_-]*$` (note case+underscore allowed)
+  - `--<option> <value>` may be optional-ish for generator subcommands.
+- Non-generate commands expect strict lowercase dashed names: `^[a-z][a-z0-9-]*$` and require value.
+
+## 4) dispatch pipeline
+- Runner chain:
+  - `src/server/cliEntrypoint.js` -> `runCliEntrypoint()` -> `runCli()` (`@jskit-ai/jskit-cli/src/server/core/createCliRunner.js`)
+  - `parseArgs`
+  - `runCli` checks:
+    - `options.help` or command `help` => `printUsage()` and exit 0
+    - `shouldShowCommandHelpOnBareInvocation(command, positional)` for certain commands => help and exit 0
+  - command handler dispatch switch (`create/list/list-placements/list-link-items/show/migrations/add/generate/position/update/remove/doctor/lint-descriptors`)
+  - catches errors, prints `jskit: ${message}`, prints usage if `error.showUsage`
+  - finally `cleanupMaterializedPackageRoots()` always executes
+
+## 5) help-driven command contracts (canonical from usageHelp.js)
+### create
+- Minimal: `jskit create package <name>`
+- Parameters: `<name>` = local package slug -> `packages/<name>`
+- Defaults:
+  - no npm install unless `--run-npm-install`
+  - `--scope` inferred from app name
+  - `--package-id` derived from scope+name if omitted
+- Full: `jskit create package <name> [--scope <scope>] [--package-id <id>] [--description <text>] [--dry-run] [--run-npm-install] [--json]`
+
+### add
+- Minimal: `jskit add package <packageId>`
+- Parameters:
+  - target type: `package | bundle`
+  - `<packageId|bundleId>`
+- Defaults:
+  - no npm install unless `--run-npm-install`
+  - short ids resolve to `@jskit-ai/<id>`
+  - running without args lists bundles+runtime packages
+  - existing matching version skipped unless options force reapply
+- Full: `jskit add <package|bundle> <id> [--<option> <value>...] [--dry-run] [--run-npm-install] [--json] [--verbose]`
+
+### generate
+- Minimal: `jskit generate <generatorId>`
+- Parameters:
+  - `<generatorId>`
+  - optional `[subcommand]`
+  - optional `[subcommand args...]`
+- Defaults:
+  - no npm install unless `--run-npm-install`
+  - short ids resolve to `@jskit-ai/<id>`
+  - no args -> list generators
+  - only `<generatorId>` -> generator help
+  - `generate <generatorId> <subcommand> help` for subcommand usage
+- Full: `jskit generate <generatorId> [subcommand] [subcommand args...] [--<option> <value>...] [--dry-run] [--run-npm-install] [--json] [--verbose]`
+
+### list
+- Minimal: `jskit list`
+- Parameter `[mode]` where mode in `{bundles, packages, generators}`
+- Defaults:
+  - without mode: bundles + runtime packages + generators
+  - placements are in `list-placements`
+  - `--full` and `--expanded` affect bundle/package views
+- Full: `jskit list [bundles|packages|generators] [--full] [--expanded] [--json]`
+
+### list-placements
+- Minimal: `jskit list-placements`
+- Full: `jskit list-placements [--json]`
+- Defaults indicate discovery from Vue `ShellOutlet` tags + route meta + installed package metadata.
+
+### list-link-items
+- Minimal: `jskit list-link-items`
+- Parameters:
+  - `[--prefix <value>]` optional token prefix filter
+  - `[--all]` include all discovered tokens
+- Defaults:
+  - defaults to tokens ending in `link-item`
+  - includes app + installed-package sources
+  - `--prefix` to narrow (example `local.main.`)
+- Full: `jskit list-link-items [--prefix <value>] [--all] [--json]`
+
+### show
+- Minimal: `jskit show <id>`
+- Defaults:
+  - `view` is alias of `show`
+  - details output enabled by `--details`
+  - `--debug-exports` implies details
+- Full: `jskit show <id> [--details] [--debug-exports] [--json]`
+
+### migrations
+- Minimal: `jskit migrations changed`
+- Parameters: `<scope> in {all|changed|package}` and optional `[packageId]` only for package scope
+- Defaults:
+  - no npm install unless `--run-npm-install`
+  - inline options only for `migrations package <packageId>`
+  - plain text lists touched migration files unless `--json`
+- Full: `jskit migrations <all|changed|package> [packageId] [--<option> <value>...] [--dry-run] [--json] [--verbose]`
+
+### position
+- Minimal: `jskit position element <packageId>`
+- Defaults:
+  - only positioning mutations applied
+  - no npm install unless `--run-npm-install`
+  - reads current lock options unless overridden inline
+- Full: `jskit position element <packageId> [--<option> <value>...] [--dry-run] [--json]`
+
+### update
+- Minimal: `jskit update package <packageId>`
+- Defaults:
+  - no npm install unless `--run-npm-install`
+  - lock options reused unless overridden inline
+  - update is add-flow with forced reapply
+- Full: `jskit update package <packageId> [--<option> <value>...] [--dry-run] [--run-npm-install] [--json]`
+
+### remove
+- Minimal: `jskit remove package <packageId>`
+- Defaults:
+  - no npm install unless `--run-npm-install`
+  - managed files and lock entries removed
+  - local package source dirs not deleted
+- Full: `jskit remove package <packageId> [--dry-run] [--run-npm-install] [--json]`
+
+### doctor
+- Minimal: `jskit doctor`
+- Defaults:
+  - validates lock entries, managed files, registry visibility
+  - plain text default
+  - machine diagnostics with `--json`
+- Full: `jskit doctor [--json]`
+
+### lint-descriptors
+- Minimal: `jskit lint-descriptors`
+- Defaults:
+  - runs descriptor consistency checks
+  - optional stricter DI checks with `--check-di-labels`
+  - plain text default, `--json` supported
+- Full: `jskit lint-descriptors [--check-di-labels] [--json]`
+
+## 6) bare-invocation help behavior
+- `BARE_COMMAND_HELP` set for commands: `create`, `show`, `migrations`, `position`, `update`, `remove`
+- If positional count < 1 for these commands -> help shown automatically.
+
+## 7) package lifecycle internals (unchanged from prior snapshot, re-grounded to current)
+- `create/run` path in `node_modules/@jskit-ai/jskit-cli/src/server/core/createCommandHandlers.js` with implementation in `src/server/commandHandlers` and `cliRuntime`.
+- `add`/`generate` share installation graph + option validation + mutation application.
+- `generate` wraps add flow with `commandMode = "generate"` and validates generator kind.
+- `update` passes forced reapply semantics into add flow.
+- `position` replays positioning mutations only.
+- `remove` uses lock dependency graph and refuses deleting dependency-broken removals.
+- Migrations and lock updates still use `migrationSyncVersion` and managed mutation records.
+
+## 8) actionable delta since previous cheat-sheet version
+- replace implicit auto-install with explicit `--run-npm-install` semantics everywhere.
+- top-level command list changed wording/order and removed legacy examples.
+- added alias `list-placement-component-tokens -> list-link-items`.
+- global flags now only `dry-run/run-npm-install/json/verbose/help`.
+- command help text is now authoritative in `usageHelp.js` and should be treated as source-of-truth.
+
+## 9) ui-generator deep internals (empirically verified)
+- `npx jskit generate ui-generator <subcommand> <args...>` dispatches through the same generator handler path as other generators; `help` is always `npx jskit generate ui-generator <subcommand> help`.
+- Current generator subcommands in this repo snapshot:
+  - `page`
+  - `outlet`
+  - `add-subpages`
+  - `placed-element`
+  - (`element` is invalid here; use `placed-element`).
+- Global generator parsing is tolerant on option shape (`--force`, `--force true`, etc.) but runtime behavior can still enforce required fields.
+- `page` and `add-subpages` both honor `--dry-run`, `--run-npm-install`, `--json`, `--verbose`.
+
+## 10) `add-subpages`: what it does (not just syntax)
+Example used:
+```bash
+npx jskit generate ui-generator add-subpages \
+  admin/contacts/[contactId]/index.vue \
+  --target contact-view:summary-tabs \
+  --path src/components/admin \
+  --title "Contact" \
+  --subtitle "Manage contact modules."
+```
+- Command-level intent:
+  - Convert a plain page into a subpages host.
+  - Register a placement host position pair (`contact-view:summary-tabs`) derived from route context.
+  - Install tab shell + tab-link component scaffold under the `--path` component folder.
+  - Make child pages render under that shell automatically.
+- Observed file mutations (from dry-run + actual run):
+  - `packages/main/src/client/providers/MainClientProvider.js`:
+    - adds/adjusts `local.main.ui.tab-link-item` registration wiring for `TabLinkItem`.
+  - `src/components/admin/SectionContainerShell.vue`:
+    - scaffolded shell component with title/subtitle and default `tabs` + `default` slots.
+  - `src/components/admin/TabLinkItem.vue`:
+    - scaffolded router-link style tab entry component.
+  - `src/pages/w/[workspaceSlug]/admin/contacts/[contactId]/index.vue` (target page path was relative to project root and prefixed by workspace slug when invoked from a route root):
+    - wrapped existing template in `<SectionContainerShell title="Contact" subtitle="Manage contact modules.">`.
+    - inserted `<ShellOutlet host="contact-view" position="summary-tabs" />`.
+    - inserted `<RouterView />` so children mount under host.
+- Semantics of `--path`:
+  - It is a workspace-relative path (e.g. `src/components/admin`), not a filesystem absolute path.
+- Idempotency:
+  - Running the same `add-subpages` command again returns:
+    - `Subpages are already enabled.`
+    - no structural rewrites.
+
+## 11) child pages + host inference (hard parts)
+- Generator used for child creation:
+```bash
+npx jskit generate ui-generator page \
+  "w/[workspaceSlug]/admin/contacts/[contactId]/index/notes/index.vue" \
+  --name "Notes" \
+  --run-npm-install
+```
+- This generated the child file and placement metadata without requiring explicit host flags.
+- Inferred behavior confirmed:
+  - target parent = nearest ancestor host page (`.../index.vue` with enabled subpages).
+  - host/position inferred from nearest parent `ShellOutlet` (`contact-view:summary-tabs`).
+  - route context inferred relative to parent:
+    - `props.to` was generated as `./notes`.
+    - page registration added under `src/placement.js` with `ui-generator.page.admin.contacts.contact-id.notes.link`.
+  - `surface` was set to `["admin"]` for placement.
+  - workspace/non-workspace suffixes were generated from actual path (`.../contacts/[contactId]/notes`).
+- Observable placement entry fields (from `src/placement.js`):
+  - `host: "contact-view"`
+  - `position: "summary-tabs"`
+  - `componentToken: "local.main.ui.tab-link-item"`
+  - `props.to`
+  - `label` (from `--name`)
+- Re-run check:
+  - `npx jskit list-placements --json` now includes the inferred placement chain with host `contact-view`.
+  - `npx jskit list-link-items --json` includes token `local.main.ui.tab-link-item` once scaffolds are present.
+
+## 12) `add-subpages`/child link generation contract captured from behavior
+- "Host is implicit" pattern:
+  - `add-subpages` creates explicit host metadata.
+  - `page` inherits host context from nearest configured host page.
+- Child page rule:
+  - child paths must be under `index/.../index.vue` for them to be attached to the nearest host.
+- Naming rule:
+  - page name labels and route labels are not auto-extracted from filename unless generator provides defaults from `--name`.
+- Force/update nuance:
+  - `--force` affects overwrite behavior when existing outputs are present.
+  - Without force, existing file exists => command emits existing-file status and skips replacing unless no-op path is safe.
+
+## 13) quick answer bank for prior user questions
+- `--path` question:
+  - it is not an absolute path requirement in this runtime; `src/components/admin` works as expected.
+- `list-commands evidence after enablement`:
+  - `list-placements` reflects `contact-view:summary-tabs`.
+  - `list-link-items` reflects `local.main.ui.tab-link-item`.
+- "What does this do" (single-line summary):
+  - It turns the given page into a tabbed host, creates a reusable shell and tab component, registers link token wiring, and enables child page injection into that slot through placements.
+
+## 14) evidence-first transcripts (no `--dry-run`)
+- This repository now contains only non-dry-run evidence from live commands.
+
+### A) path validation on `add-subpages`
+```bash
+npx jskit generate ui-generator add-subpages "admin/contacts/[contactId]/index.vue" --target contact-view:summary-tabs --path src/components/admin --title "Contact" --subtitle "Manage contact modules."
+```
+Observed output:
+```text
+jskit: ui-generator add-subpages target file must be relative to src/pages/ and resolve to a configured surface: admin/contacts/[contactId]/index.vue.
+```
+
+### B) idempotent host enablement requires exact target path
+```bash
+npx jskit generate ui-generator add-subpages "w/[workspaceSlug]/admin/contacts/[contactId]/index.vue" --target contact-view:summary-tabs --path src/components/admin --title "Contact" --subtitle "Manage contact modules."
+```
+Observed output:
+```text
+jskit: ui-generator add-subpages found existing RouterView in src/pages/w/[workspaceSlug]/admin/contacts/[contactId]/index.vue. Subpages are already enabled.
+```
+Runtime effect: command exits non-zero (1) with explicit no-op status message.
+
+### C) child page creation under configured host
+```bash
+npx jskit generate ui-generator page "w/[workspaceSlug]/admin/contacts/[contactId]/index/activity/index.vue" --name "Activity"
+```
+Observed output:
+```text
+Generated with @jskit-ai/ui-generator (page).
+Generated UI page "/contacts/[contactId]/activity" at src/pages/w/[workspaceSlug]/admin/contacts/[contactId]/index/activity/index.vue.
+Touched files (2):
+- src/pages/w/[workspaceSlug]/admin/contacts/[contactId]/index/activity/index.vue
+- src/placement.js
+```
+
+### D) placement registry snapshot after live run (`--json`)
+`npx jskit list-placements --json` includes:
+```json
+{
+  "id": "contact-view:summary-tabs",
+  "host": "contact-view",
+  "position": "summary-tabs",
+  "sourcePath": "src/pages/w/[workspaceSlug]/admin/contacts/[contactId]/index.vue"
+}
+```
+`jskit list-link-items --json` includes:
+```json
+{
+  "token": "local.main.ui.tab-link-item",
+  "sources": [
+    "app:packages/main/src/client/providers/MainClientProvider.js",
+    "app:src/placement.js"
+  ]
+}
+```
+
+### E) generated page and placement artifacts (verbatim snippets)
+- Generated child page scaffold:
+```vue
+<template>
+  <section class="pa-4">
+    <h1 class="text-h5 mb-2">Activity</h1>
+    <p class="text-body-2 text-medium-emphasis">Replace this scaffold with your page implementation.</p>
+  </section>
+</template>
+```
+- Host page now wraps content in shell + outlet:
+```vue
+<SectionContainerShell title="Contact" subtitle="Manage contact modules.">
+  <template #tabs>
+    <ShellOutlet host="contact-view" position="summary-tabs" />
+  </template>
+
+    <main>
+      <h1>Contact detail</h1>
+    </main>
+
+  <RouterView />
+</SectionContainerShell>
+```
+- Placement append for child in `src/placement.js`:
+```js
+// jskit:ui-generator.page.link:admin:/contacts/[contactId]/activity
+{
+  addPlacement({
+    id: "ui-generator.page.admin.contacts.contact-id.activity.link",
+    host: "contact-view",
+    position: "summary-tabs",
+    surfaces: ["admin"],
+    componentToken: "local.main.ui.tab-link-item",
+    props: {
+      label: "Activity",
+      surface: "admin",
+      workspaceSuffix: "/contacts/[contactId]/activity",
+      nonWorkspaceSuffix: "/contacts/[contactId]/activity",
+      to: "./activity",
+    },
+    when: ({ auth }) => Boolean(auth?.authenticated)
+  });
+}
+```
+
+### F) inferred behavior confirmed by this evidence set
+- `--target` and shell metadata are scoped by route-contexted host page when subpages are already enabled.
+- Host path in `add-subpages` must resolve to a configured page surface under `src/pages/`.
+- Child route generation can infer host/position and emits `placement.js` entries with:
+  - `to: "./<child>"` relative links from parent host page location.
+  - stable id format `ui-generator.page.<route-segments>.link` with bracket params normalized (`[contactId]` -> `contact-id`).
+  - same `surface` and `componentToken` contract as host's configured host.
+
+## 15) extended matrix (all high-signal combinations captured)
+
+### 15.1 add-subpages matrix
+- `target-file` required shape:
+  - relative to `src/pages/` without `src/pages/` prefix and without leading `src/`.
+  - must resolve to configured surface.
+- accepted format examples:
+  - ok: `w/[workspaceSlug]/admin/contacts/[contactId]/index.vue`
+  - fail (prefix): `admin/...` and `src/pages/...`.
+- `--target` contract:
+  - host-only: `contact-view` => `contact-view:sub-pages`.
+  - host:position: `contact-view:summary-tabs`.
+  - invalid format: `badhost:` => `"must be \"host\" or \"host:position\"."`.
+- `--path` is app-relative scaffold path; no absolute path requirement.
+- `--title/--subtitle` only affect generated host shell attrs.
+- `--force` is intentionally unsupported for this subcommand.
+- output semantics:
+  - configured file + existing `<RouterView>` => `Subpages are already enabled.` with non-zero exit.
+  - first-run with valid target => wraps page in SectionContainerShell + tabs + RouterView and writes scaffold support.
+
+#### exact runs I captured
+- `npx jskit generate ui-generator add-subpages "admin/contacts/[contactId]/index.vue" --target contact-view:summary-tabs ...`
+  - output: `target file must be relative to src/pages/ and resolve to a configured surface`.
+- `npx jskit generate ui-generator add-subpages "w/[workspaceSlug]/admin/contacts/[contactId]/index.vue" --target badhost:`
+  - output: `option "target" must be "host" or "host:position".`
+- `npx jskit generate ui-generator add-subpages "w/[workspaceSlug]/admin/contacts/[contactId]/index.vue" --force`
+  - output includes help and `Unknown option ... --force`.
+- `npx jskit generate ui-generator add-subpages "w/[workspaceSlug]/admin/customers/[customerId]/index.vue" --path src/components/admin --title "Customer"`
+  - output: `Enabled subpages ... using outlet target "customers-customer-id:sub-pages"`.
+
+### 15.2 page matrix
+- required positional:
+  - required: one `target-file` positional arg only.
+- overwrite:
+  - no overwrite without `--force` when file exists.
+  - `--force` overwrites file and returns `Regenerated ...` when target existed.
+- inference:
+  - nearest parent host search prefers a single upstream host outlet.
+  - if parent and child are index-route nested, `props.to` derives `./<child>`.
+  - if no resolvable single parent, falls back to default placement target.
+- defaults:
+  - if no `--name`, label derived from route segment.
+  - if no explicit `--link-placement`, uses inferred host if found.
+  - if no explicit `--link-component-token`, uses:
+    - subpage default for inferred host = `local.main.ui.tab-link-item`.
+    - general default if not inferred = `users.web.shell.surface-aware-menu-link-item`.
+
+#### exact runs I captured
+- `npx jskit generate ui-generator page "w/[workspaceSlug]/admin/contacts/[contactId]/index/activity/index.vue" --name "Activity"`
+  - output: overwrite error because file exists.
+- same path + `--force`
+  - output: `Regenerated UI page "/contacts/[contactId]/activity" ...`.
+- no `--name`:
+  - `npx ... page ".../index/task/index.vue"`
+  - output scaffold heading is `Task` and placement label `Task`.
+- explicit link override:
+  - `npx ... page ".../index/letters/index.vue" --name "Letters" --link-placement shell-layout:primary-menu --link-component-token users.web.shell.surface-aware-menu-link-item --link-to "/contacts/letters"`.
+  - placement ended on `host: "shell-layout", position: "primary-menu"`, token override, explicit to.
+- bad placement format:
+  - `... --link-placement bad` -> `"must be in \"host:position\" format."`.
+- unknown placement:
+  - `... --link-placement bad:placement` -> not declared list error.
+- token override not validated:
+  - `--link-component-token local.main.ui.missing-token` accepted and written.
+
+### 15.3 outlet matrix
+- required positional:
+  - required existing Vue SFC file relative to app root.
+- required option:
+  - required `--target`.
+- target contract:
+  - same `host`/`host:position` parsing as add-subpages.
+  - host-only => sub-pages.
+- insertion behavior:
+  - adds `<ShellOutlet ... />` inside existing template close by default; creates template when absent.
+  - injects `import ShellOutlet` in script/setup if missing.
+
+#### exact runs I captured
+- no-op detection:
+  - `... outlet src/pages/.../contacts/[contactId]/index.vue --target contact-view:summary-tabs`
+  - output `Outlet ... is already present`, `Touched files (0)`.
+- first-time insertion:
+  - `... outlet .../index/letters/index.vue --target shell-layout`
+  - output `Injected outlet "shell-layout:sub-pages" ...`.
+- bad host value:
+  - `... --target badplacement` (or no colon format) => format error.
+- placement not declared:
+  - `... --target impossible:slot` => `option "placement" target ... is not declared ...`.
+- unknown option:
+  - `... --bogus` => unknown-option + help.
+
+### 15.4 placed-element matrix
+- required:
+  - `--name` and `--surface` required.
+- optional:
+  - `--path` (default `src/components`), `--placement` (default `shell-layout:top-right`), `--force`.
+- derived outputs:
+  - file name = `<PascalCase(name)>Element.vue`.
+  - token = `local.main.ui.element.<kebab-name>`.
+  - component marker key `jskit:ui-generator.element:<surface>:<kebab>`.
+- placement target resolution:
+  - requires requested target to exist in app or installed package declarations.
+
+#### exact runs I captured
+- `npx ... placed-element --name "Ops Panel" --surface admin --path src/widgets --placement contact-view:summary-tabs`
+  - touches provider, placement, component and emits token `local.main.ui.element.ops-panel`.
+- repeat same command:
+  - overwrite error on existing component.
+- same + `--force` with unchanged content:
+  - `Placed UI element "ops-panel" is already up to date.`
+- invalid surface:
+  - missing `--surface` => explicit `requires --surface`.
+- invalid option:
+  - `--bogus` => unknown-option + help.
+- invalid placement:
+  - `--placement impossible:slot` => `option "placement" target ... is not declared ... Available targets: ...`.
+
+### 15.5 list-* command matrix
+- `list-placements`:
+  - default/non-json and json both work.
+  - shows discovered placements with host/position/source and default marker.
+- `list-link-items` default:
+  - filters to link-like tokens only.
+- `list-link-items --all`:
+  - includes non-link tokens (e.g., `local.main.ui.element.ops-panel` once placed-elements are generated).
+- `list-link-items --prefix local.main --all`:
+  - returns local scoped tokens, including non-link-item entries when `--all` is set.
+
+### 15.6 critical gotchas worth encoding in automation
+- Host inference requires ancestor host page to expose exactly one outlet target.
+  - If host page has multiple `ShellOutlet` targets, nearest parent inference can fail, causing fallback to app default placement.
+  - Observed: adding `shell-layout:sub-pages` to contact host made `page` child `shift` use `shell-layout:primary-menu`; explicit `--link-placement` fixed it.
+- Provider registration contract is hard-checked in `add-subpages` and `placed-element`; missing `registerMainClientComponent` aborts.
+- `outlet` changes are discoverable by `list-placements` and become valid destinations for future page/element generation.
+
+## 16) additional evidence: full-surface behavior matrix and caveats
+
+### 16.0 invocation routing rules (critical)
+- Top-level discovery commands:
+  - `npx jskit list-placements` ✅
+  - `npx jskit list-link-items` ✅
+- Generator-local list-commands under `generate` are not valid here:
+  - `npx jskit generate ui-generator list-placements` ❌
+  - `npx jskit generate ui-generator list-link-items` ❌
+- Generator subcommand help path:
+  - `npx jskit generate ui-generator <subcommand> help`
+- Error shapes:
+  - `Unknown command` for bad top-level commands.
+  - `Unknown generator usage` when generator argument points to invalid shape.
+
+### 16.1 add-subpages matrix (expanded)
+- `--target` contract:
+  - accepts `host` or `host:position`.
+  - host-only means position defaults to `sub-pages`.
+- `target-file` rules:
+  - must resolve relative to `src/pages`.
+  - must resolve to a configured surface path.
+- `--target` is optional:
+  - when omitted and page is valid, target is inferred from route.
+- `--path` defaults `src/components`.
+- `--force` is unsupported.
+
+Observed:
+- `npx jskit generate ui-generator add-subpages "w/[workspaceSlug]/admin/assistant/index.vue" --title Assistant --subtitle "Assistants"`
+  - output: `Enabled subpages ... using outlet target "assistant:sub-pages"`.
+- `npx jskit generate ui-generator add-subpages "admin/contacts/[contactId]/index.vue" --target contact-view:summary-tabs ...`
+  - output: `target file must be relative to src/pages/ ...`
+- `... --target badhost:`
+  - output: `option "target" must be "host" or "host:position".`
+- `... --target nohost:sub-pages` on first-time host file:
+  - output succeeds and creates `host:sub-pages` placement entry even if host was not pre-existing.
+  - `npx jskit list-placements --json` then includes that host.
+- `... --target nope:sub-pages` on an already enabled host still short-circuits:
+  - output: `Subpages are already enabled`.
+- repeated invocation on enabled host returns no-op and exit non-zero.
+
+### 16.2 page matrix (deeper inference coverage)
+- Always generates a page scaffold.
+- Overwrite behavior:
+  - without `--force`, existing page blocks run.
+  - with `--force`, page and placement regenerate.
+- `to` inference:
+  - child under host index defaults to `./child`.
+  - explicit `--link-to` is preserved exactly (relative or absolute).
+- Inferred host and token path:
+  - if nearest parent host has exactly one subpages outlet, host/position/token are inferred.
+  - if parent cannot be cleanly resolved, placement falls back to default host/position behavior.
+- Token override:
+  - `--link-component-token` does not validate token existence.
+- Placement override:
+  - `--link-placement` must be `host:position` and must exist.
+
+Observed:
+- `npx jskit generate ui-generator page "w/[workspaceSlug]/admin/customers/[customerId]/index/notes/index.vue" --name Notes --link-component-token users.web.shell.surface-aware-menu-link-item`
+  - writes placement with explicit token.
+- `npx jskit generate ui-generator page ".../index/finance/index.vue" --name Finance --link-placement shell-layout:sub-pages --force`
+  - writes `host: "shell-layout", position: "sub-pages"`.
+- `npx jskit generate ui-generator page ".../index/sla/index.vue" --name SLA --link-to "/customers/sla-dashboard"`
+  - writes `props.to: "/customers/sla-dashboard"`.
+- `npx jskit generate ui-generator page ".../index/terms/index.vue" --name Terms --link-placement shell-layout:secondary-menu --link-to "./terms"`
+  - writes explicit placement.
+- `npx jskit generate ui-generator page ".../index/notes2/index.vue" --name Notes2 --link-component-token local.main.ui.missing-token`
+  - writes missing token placement.
+- `npx jskit generate ui-generator page ".../index/new/notes/index.vue" --name NewChild`
+  - child under `/admin/contacts/new` inferred host became `nope:sub-pages` from earlier add-subpages run.
+- invalid placement inputs:
+  - `... --link-placement shell-layout` => `must be in "host:position" format.`
+  - `... --link-placement impossible:slot` after a host exists => undeclared target error.
+  - malformed input can create file then fail later if placement is invalid (observed: first no-colon format produced scaffold; follow-up `--force` + invalid target rejected with explicit declared-target list).
+
+### 16.3 outlet matrix (newly observed edge cases)
+- `--target` is mandatory and accepts host/host:position.
+- Insertion semantics:
+  - adds `import ShellOutlet` for SFCs when missing.
+  - injects `<ShellOutlet host="..." position="..." />` near template end/appropriate slot.
+- No-op semantics:
+  - already-present outlet => `Touched files (0)`.
+
+Observed:
+- `npx jskit generate ui-generator outlet src/pages/w/[workspaceSlug]/admin/assistant/index.vue --target assistant`
+  - first: injects. second: no-op.
+- `npx jskit generate ui-generator outlet src/components/admin/SectionContainerShell.vue --target shell-layout:top-left`
+  - first injects, second no-op.
+- `npx jskit generate ui-generator outlet src/components/admin/SectionContainerShell.vue --target shell-layout:top-right`
+  - injects additional outlet.
+- `npx jskit generate ui-generator outlet src/components/ShellLayout.vue --target shell-layout`
+  - injected `shell-layout:sub-pages`.
+- `npx jskit generate ui-generator outlet src/pages/w/[workspaceSlug]/admin/practice/vets/_components/VetAddEditFormFields.js --target shell-layout`
+  - output says injected, but this file is JS; check resulting file for corruption risk.
+
+### 16.4 placed-element matrix
+- Required:
+  - `--name` and `--surface`.
+- Optional defaults:
+  - `--path` → `src/components`
+  - `--placement` → `shell-layout:top-right` when omitted.
+- Required validation:
+  - unknown surface is rejected.
+  - unknown explicit placement is rejected.
+- Outputs:
+  - `<PascalName>Element.vue`
+  - component token `local.main.ui.element.<kebab-name>`
+  - provider registration via `registerMainClientComponent`.
+
+Observed:
+- `npx jskit generate ui-generator placed-element --name "Billing Panel" --surface admin --placement shell-layout:top-right`
+  - wrote provider, component, placement.
+- second run same command => overwrite blocked until `--force`.
+- second with `--force` unchanged => `is already up to date`.
+
+### 16.5 list-* caveats
+- `jskit list-placements --json --prefix nope` still returned all placements in this repo; prefix filtering appears non-functional for placements.
+- `jskit list-link-items --all --prefix local.main.ui` filters correctly.
+- `jskit list-link-items --all --prefix does-not-exist` returns `- none`.
+- `jskit list-link-items` default output still filters to link-item suffix only.
+
+### 16.6 non-obvious coupling and generated artifacts
+- `add-subpages` writes directly into page file only for host enablement; it does not inject top-level page placement entries.
+- `placed-element` and `page` use discovered placement targets from list state, so ordering of command runs changes what is valid as a target.
+- Host inference can be brittle with non-unique child outlets and can force fallback/default placement; explicit `--link-placement` is the deterministic fix.
+- Placement IDs are canonicalized; dynamic route params collapse brackets: `[customerId]` => `customer-id`.
+- `to` defaults are inferred only for `page`; explicit override always wins.
+

--- a/install.txt
+++ b/install.txt
@@ -28,6 +28,8 @@ drop table  users                 ;
 
 export __APP=swayatlas
 
+// npx @jskit-ai/create-app "$__APP" --title "$__APP" --target . --tenancy-mode personal --force
+
 ../jskit-ai/tooling/create-app/bin/jskit-create-app.js \
   "$__APP" \
   --tenancy-mode personal \

--- a/package-lock.json
+++ b/package-lock.json
@@ -5951,18 +5951,18 @@
     },
     "packages/assistant": {
       "name": "@jskit-ai/assistant",
-      "version": "0.1.40",
+      "version": "0.1.41",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.31"
+        "@jskit-ai/kernel": "0.1.32"
       }
     },
     "packages/assistant-core": {
       "name": "@jskit-ai/assistant-core",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
-        "@jskit-ai/http-runtime": "0.1.30",
-        "@jskit-ai/kernel": "0.1.31",
-        "@jskit-ai/users-core": "0.1.41",
+        "@jskit-ai/http-runtime": "0.1.31",
+        "@jskit-ai/kernel": "0.1.32",
+        "@jskit-ai/users-core": "0.1.42",
         "@tanstack/vue-query": "^5.90.5",
         "dompurify": "^3.3.3",
         "marked": "^17.0.4",
@@ -6040,15 +6040,15 @@
     },
     "packages/assistant-runtime": {
       "name": "@jskit-ai/assistant-runtime",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "dependencies": {
-        "@jskit-ai/assistant-core": "0.1.7",
-        "@jskit-ai/database-runtime": "0.1.31",
-        "@jskit-ai/http-runtime": "0.1.30",
-        "@jskit-ai/kernel": "0.1.31",
-        "@jskit-ai/shell-web": "0.1.30",
-        "@jskit-ai/users-core": "0.1.41",
-        "@jskit-ai/users-web": "0.1.46",
+        "@jskit-ai/assistant-core": "0.1.8",
+        "@jskit-ai/database-runtime": "0.1.32",
+        "@jskit-ai/http-runtime": "0.1.31",
+        "@jskit-ai/kernel": "0.1.32",
+        "@jskit-ai/shell-web": "0.1.31",
+        "@jskit-ai/users-core": "0.1.42",
+        "@jskit-ai/users-web": "0.1.47",
         "@tanstack/vue-query": "^5.90.5",
         "vuetify": "^4.0.0"
       }
@@ -6122,34 +6122,34 @@
     },
     "packages/auth-core": {
       "name": "@jskit-ai/auth-core",
-      "version": "0.1.30",
+      "version": "0.1.31",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0",
-        "@jskit-ai/kernel": "0.1.31",
+        "@jskit-ai/kernel": "0.1.32",
         "typebox": "^1.0.81"
       }
     },
     "packages/auth-provider-supabase-core": {
       "name": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.30",
+      "version": "0.1.31",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.30",
-        "@jskit-ai/kernel": "0.1.31",
+        "@jskit-ai/auth-core": "0.1.31",
+        "@jskit-ai/kernel": "0.1.32",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0"
       }
     },
     "packages/auth-web": {
       "name": "@jskit-ai/auth-web",
-      "version": "0.1.32",
+      "version": "0.1.33",
       "dependencies": {
         "@fastify/type-provider-typebox": "^6.1.0",
-        "@jskit-ai/auth-core": "0.1.30",
-        "@jskit-ai/http-runtime": "0.1.30",
-        "@jskit-ai/kernel": "0.1.31",
-        "@jskit-ai/shell-web": "0.1.30",
+        "@jskit-ai/auth-core": "0.1.31",
+        "@jskit-ai/http-runtime": "0.1.31",
+        "@jskit-ai/kernel": "0.1.32",
+        "@jskit-ai/shell-web": "0.1.31",
         "@mdi/js": "^7.4.47",
         "@tanstack/vue-query": "^5.90.5",
         "vuetify": "^4.0.0"
@@ -6235,13 +6235,13 @@
     },
     "packages/crud-core": {
       "name": "@jskit-ai/crud-core",
-      "version": "0.1.39",
+      "version": "0.1.40",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.31",
-        "@jskit-ai/realtime": "0.1.30",
-        "@jskit-ai/shell-web": "0.1.30",
-        "@jskit-ai/users-core": "0.1.41",
-        "@jskit-ai/users-web": "0.1.46",
+        "@jskit-ai/kernel": "0.1.32",
+        "@jskit-ai/realtime": "0.1.31",
+        "@jskit-ai/shell-web": "0.1.31",
+        "@jskit-ai/users-core": "0.1.42",
+        "@jskit-ai/users-web": "0.1.47",
         "@tanstack/vue-query": "^5.90.5",
         "typebox": "^1.0.81"
       }
@@ -6315,68 +6315,68 @@
     },
     "packages/crud-server-generator": {
       "name": "@jskit-ai/crud-server-generator",
-      "version": "0.1.39",
+      "version": "0.1.40",
       "dependencies": {
         "@babel/parser": "^7.29.2",
-        "@jskit-ai/crud-core": "0.1.39",
-        "@jskit-ai/database-runtime": "0.1.31",
-        "@jskit-ai/http-runtime": "0.1.30",
-        "@jskit-ai/kernel": "0.1.31",
-        "@jskit-ai/users-core": "0.1.41",
+        "@jskit-ai/crud-core": "0.1.40",
+        "@jskit-ai/database-runtime": "0.1.32",
+        "@jskit-ai/http-runtime": "0.1.31",
+        "@jskit-ai/kernel": "0.1.32",
+        "@jskit-ai/users-core": "0.1.42",
         "recast": "^0.23.11",
         "typebox": "^1.0.81"
       }
     },
     "packages/crud-ui-generator": {
       "name": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "dependencies": {
-        "@jskit-ai/crud-core": "0.1.39",
-        "@jskit-ai/kernel": "0.1.31"
+        "@jskit-ai/crud-core": "0.1.40",
+        "@jskit-ai/kernel": "0.1.32"
       }
     },
     "packages/database-runtime": {
       "name": "@jskit-ai/database-runtime",
-      "version": "0.1.31",
+      "version": "0.1.32",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.31"
+        "@jskit-ai/kernel": "0.1.32"
       }
     },
     "packages/database-runtime-mysql": {
       "name": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.30",
+      "version": "0.1.31",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.31"
+        "@jskit-ai/database-runtime": "0.1.32"
       }
     },
     "packages/database-runtime-postgres": {
       "name": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.30",
+      "version": "0.1.31",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.31"
+        "@jskit-ai/database-runtime": "0.1.32"
       }
     },
     "packages/http-runtime": {
       "name": "@jskit-ai/http-runtime",
-      "version": "0.1.30",
+      "version": "0.1.31",
       "dependencies": {
         "@fastify/type-provider-typebox": "^6.1.0",
-        "@jskit-ai/kernel": "0.1.31",
+        "@jskit-ai/kernel": "0.1.32",
         "typebox": "^1.0.81"
       }
     },
     "packages/kernel": {
       "name": "@jskit-ai/kernel",
-      "version": "0.1.31",
+      "version": "0.1.32",
       "dependencies": {
         "typebox": "^1.0.81"
       }
     },
     "packages/realtime": {
       "name": "@jskit-ai/realtime",
-      "version": "0.1.30",
+      "version": "0.1.31",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.31",
+        "@jskit-ai/kernel": "0.1.32",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",
@@ -6385,9 +6385,9 @@
     },
     "packages/shell-web": {
       "name": "@jskit-ai/shell-web",
-      "version": "0.1.30",
+      "version": "0.1.31",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.31",
+        "@jskit-ai/kernel": "0.1.32",
         "@tanstack/vue-query": "^5.90.5",
         "vuetify": "^4.0.0"
       }
@@ -6451,24 +6451,24 @@
     },
     "packages/storage-runtime": {
       "name": "@jskit-ai/storage-runtime",
-      "version": "0.1.30",
+      "version": "0.1.31",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.31",
+        "@jskit-ai/kernel": "0.1.32",
         "unstorage": "^1.17.3"
       }
     },
     "packages/ui-generator": {
       "name": "@jskit-ai/ui-generator",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.31"
+        "@jskit-ai/kernel": "0.1.32"
       }
     },
     "packages/uploads-image-web": {
       "name": "@jskit-ai/uploads-image-web",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "dependencies": {
-        "@jskit-ai/uploads-runtime": "0.1.9",
+        "@jskit-ai/uploads-runtime": "0.1.10",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",
@@ -6478,35 +6478,35 @@
     },
     "packages/uploads-runtime": {
       "name": "@jskit-ai/uploads-runtime",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "dependencies": {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.31"
+        "@jskit-ai/kernel": "0.1.32"
       }
     },
     "packages/users-core": {
       "name": "@jskit-ai/users-core",
-      "version": "0.1.41",
+      "version": "0.1.42",
       "dependencies": {
         "@fastify/type-provider-typebox": "^6.1.0",
-        "@jskit-ai/auth-core": "0.1.30",
-        "@jskit-ai/database-runtime": "0.1.31",
-        "@jskit-ai/http-runtime": "0.1.30",
-        "@jskit-ai/kernel": "0.1.31",
-        "@jskit-ai/uploads-runtime": "0.1.9",
+        "@jskit-ai/auth-core": "0.1.31",
+        "@jskit-ai/database-runtime": "0.1.32",
+        "@jskit-ai/http-runtime": "0.1.31",
+        "@jskit-ai/kernel": "0.1.32",
+        "@jskit-ai/uploads-runtime": "0.1.10",
         "typebox": "^1.0.81"
       }
     },
     "packages/users-web": {
       "name": "@jskit-ai/users-web",
-      "version": "0.1.46",
+      "version": "0.1.47",
       "dependencies": {
-        "@jskit-ai/http-runtime": "0.1.30",
-        "@jskit-ai/kernel": "0.1.31",
-        "@jskit-ai/realtime": "0.1.30",
-        "@jskit-ai/shell-web": "0.1.30",
-        "@jskit-ai/uploads-image-web": "0.1.9",
-        "@jskit-ai/users-core": "0.1.41",
+        "@jskit-ai/http-runtime": "0.1.31",
+        "@jskit-ai/kernel": "0.1.32",
+        "@jskit-ai/realtime": "0.1.31",
+        "@jskit-ai/shell-web": "0.1.31",
+        "@jskit-ai/uploads-image-web": "0.1.10",
+        "@jskit-ai/users-core": "0.1.42",
         "@mdi/js": "^7.4.47",
         "@tanstack/vue-query": "5.92.12",
         "vuetify": "^4.0.0"
@@ -6581,21 +6581,21 @@
     },
     "packages/workspaces-core": {
       "name": "@jskit-ai/workspaces-core",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
-        "@jskit-ai/users-core": "0.1.41"
+        "@jskit-ai/users-core": "0.1.42"
       }
     },
     "packages/workspaces-web": {
       "name": "@jskit-ai/workspaces-web",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
-        "@jskit-ai/users-web": "0.1.46"
+        "@jskit-ai/users-web": "0.1.47"
       }
     },
     "tooling/config-eslint": {
       "name": "@jskit-ai/config-eslint",
-      "version": "0.1.30",
+      "version": "0.1.31",
       "dependencies": {
         "@eslint/js": "^9.39.1",
         "eslint-plugin-vue": "^10.5.1",
@@ -6613,7 +6613,7 @@
     },
     "tooling/create-app": {
       "name": "@jskit-ai/create-app",
-      "version": "0.1.38",
+      "version": "0.1.39",
       "bin": {
         "jskit-create-app": "bin/jskit-create-app.js"
       },
@@ -6623,17 +6623,17 @@
     },
     "tooling/jskit-catalog": {
       "name": "@jskit-ai/jskit-catalog",
-      "version": "0.1.39",
+      "version": "0.1.40",
       "engines": {
         "node": "20.x"
       }
     },
     "tooling/jskit-cli": {
       "name": "@jskit-ai/jskit-cli",
-      "version": "0.2.39",
+      "version": "0.2.40",
       "dependencies": {
-        "@jskit-ai/jskit-catalog": "0.1.39",
-        "@jskit-ai/kernel": "0.1.31"
+        "@jskit-ai/jskit-catalog": "0.1.40",
+        "@jskit-ai/kernel": "0.1.32"
       },
       "bin": {
         "jskit": "bin/jskit.js"

--- a/packages/assistant-core/package.descriptor.mjs
+++ b/packages/assistant-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-core",
-  version: "0.1.7",
+  version: "0.1.8",
   kind: "runtime",
   description: "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
   dependsOn: [
@@ -45,9 +45,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/http-runtime": "0.1.30",
-        "@jskit-ai/kernel": "0.1.31",
-        "@jskit-ai/users-core": "0.1.41",
+        "@jskit-ai/http-runtime": "0.1.31",
+        "@jskit-ai/kernel": "0.1.32",
+        "@jskit-ai/users-core": "0.1.42",
         "@tanstack/vue-query": "^5.90.5",
         "dompurify": "^3.3.3",
         "marked": "^17.0.4",

--- a/packages/assistant-core/package.json
+++ b/packages/assistant-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-core",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,9 +11,9 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/http-runtime": "0.1.30",
-    "@jskit-ai/kernel": "0.1.31",
-    "@jskit-ai/users-core": "0.1.41",
+    "@jskit-ai/http-runtime": "0.1.31",
+    "@jskit-ai/kernel": "0.1.32",
+    "@jskit-ai/users-core": "0.1.42",
     "@tanstack/vue-query": "^5.90.5",
     "dompurify": "^3.3.3",
     "marked": "^17.0.4",

--- a/packages/assistant-runtime/package.descriptor.mjs
+++ b/packages/assistant-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-runtime",
-  version: "0.1.2",
+  version: "0.1.3",
   kind: "runtime",
   description: "Shared assistant runtime with per-surface assistant registration.",
   dependsOn: [
@@ -74,13 +74,13 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/assistant-core": "0.1.7",
-        "@jskit-ai/database-runtime": "0.1.31",
-        "@jskit-ai/http-runtime": "0.1.30",
-        "@jskit-ai/kernel": "0.1.31",
-        "@jskit-ai/shell-web": "0.1.30",
-        "@jskit-ai/users-core": "0.1.41",
-        "@jskit-ai/users-web": "0.1.46",
+        "@jskit-ai/assistant-core": "0.1.8",
+        "@jskit-ai/database-runtime": "0.1.32",
+        "@jskit-ai/http-runtime": "0.1.31",
+        "@jskit-ai/kernel": "0.1.32",
+        "@jskit-ai/shell-web": "0.1.31",
+        "@jskit-ai/users-core": "0.1.42",
+        "@jskit-ai/users-web": "0.1.47",
         "@tanstack/vue-query": "^5.90.5",
         "vuetify": "^4.0.0"
       },

--- a/packages/assistant-runtime/package.json
+++ b/packages/assistant-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-runtime",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "module",
   "exports": {
     "./client": "./src/client/index.js",
@@ -8,13 +8,13 @@
     "./server/actionIds": "./src/server/actionIds.js"
   },
   "dependencies": {
-    "@jskit-ai/assistant-core": "0.1.7",
-    "@jskit-ai/database-runtime": "0.1.31",
-    "@jskit-ai/http-runtime": "0.1.30",
-    "@jskit-ai/kernel": "0.1.31",
-    "@jskit-ai/shell-web": "0.1.30",
-    "@jskit-ai/users-core": "0.1.41",
-    "@jskit-ai/users-web": "0.1.46",
+    "@jskit-ai/assistant-core": "0.1.8",
+    "@jskit-ai/database-runtime": "0.1.32",
+    "@jskit-ai/http-runtime": "0.1.31",
+    "@jskit-ai/kernel": "0.1.32",
+    "@jskit-ai/shell-web": "0.1.31",
+    "@jskit-ai/users-core": "0.1.42",
+    "@jskit-ai/users-web": "0.1.47",
     "@tanstack/vue-query": "^5.90.5",
     "vuetify": "^4.0.0"
   }

--- a/packages/assistant/package.descriptor.mjs
+++ b/packages/assistant/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant",
-  version: "0.1.40",
+  version: "0.1.41",
   kind: "generator",
   description: "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
   options: {

--- a/packages/assistant/package.json
+++ b/packages/assistant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant",
-  "version": "0.1.40",
+  "version": "0.1.41",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.31"
+    "@jskit-ai/kernel": "0.1.32"
   }
 }

--- a/packages/assistant/src/server/pageSupport.js
+++ b/packages/assistant/src/server/pageSupport.js
@@ -94,7 +94,7 @@ function renderAssistantPageLinkPlacementBlock({
 
 function renderAssistantPageSummary(
   pageTarget = {},
-  { pageAlreadyExisted = false, pageOverwritten = false, placementChanged = false } = {}
+  { pageAlreadyExisted = false, pageOverwritten = false } = {}
 ) {
   if (!pageAlreadyExisted) {
     return `Generated assistant page "${String(pageTarget?.routeUrlSuffix || "")}".`;
@@ -102,10 +102,7 @@ function renderAssistantPageSummary(
   if (pageOverwritten) {
     return `Regenerated assistant page "${String(pageTarget?.routeUrlSuffix || "")}".`;
   }
-  if (placementChanged) {
-    return `Updated assistant page link placement for "${String(pageTarget?.routeUrlSuffix || "")}".`;
-  }
-  return `Assistant page "${String(pageTarget?.routeUrlSuffix || "")}" is already up to date.`;
+  return `Generated assistant page "${String(pageTarget?.routeUrlSuffix || "")}".`;
 }
 
 export {

--- a/packages/assistant/src/server/subcommands/page.js
+++ b/packages/assistant/src/server/subcommands/page.js
@@ -96,8 +96,7 @@ async function runGeneratorSubcommand({
     touchedFiles: [...touchedFiles].sort((left, right) => left.localeCompare(right)),
     summary: renderAssistantPageSummary(pageTarget, {
       pageAlreadyExisted,
-      pageOverwritten: pageAlreadyExisted && forceOverwrite,
-      placementChanged: placementApplied.changed
+      pageOverwritten: pageAlreadyExisted && forceOverwrite
     })
   };
 }

--- a/packages/assistant/src/server/subcommands/settingsPage.js
+++ b/packages/assistant/src/server/subcommands/settingsPage.js
@@ -100,8 +100,7 @@ async function runGeneratorSubcommand({
     touchedFiles: [...touchedFiles].sort((left, right) => left.localeCompare(right)),
     summary: renderAssistantPageSummary(pageTarget, {
       pageAlreadyExisted,
-      pageOverwritten: pageAlreadyExisted && forceOverwrite,
-      placementChanged: placementApplied.changed
+      pageOverwritten: pageAlreadyExisted && forceOverwrite
     })
   };
 }

--- a/packages/assistant/test/subcommands.test.js
+++ b/packages/assistant/test/subcommands.test.js
@@ -87,6 +87,7 @@ test("assistant page subcommand creates a runtime page at an explicit target fil
     });
 
     assert.deepEqual(result.touchedFiles, [toPagePath(targetFile), "src/placement.js"]);
+    assert.equal(result.summary, 'Generated assistant page "/ops/copilot".');
 
     const pageSource = await readFile(path.join(appRoot, toPagePath(targetFile)), "utf8");
     assert.match(pageSource, /<AssistantSurfaceClientElement surface-id="admin" \/>/);
@@ -129,6 +130,7 @@ test("assistant settings-page subcommand uses the target assistant surface and i
     });
 
     assert.deepEqual(result.touchedFiles, [toPagePath(targetFile), "src/placement.js"]);
+    assert.equal(result.summary, 'Generated assistant page "/settings/assistant".');
 
     const pageSource = await readFile(path.join(appRoot, toPagePath(targetFile)), "utf8");
     assert.match(pageSource, /<AssistantSettingsClientElement target-surface-id="console" \/>/);

--- a/packages/auth-core/package.descriptor.mjs
+++ b/packages/auth-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-core",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "kind": "runtime",
   "dependsOn": [
     "@jskit-ai/value-app-config-shared"
@@ -69,7 +69,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.31",
+        "@jskit-ai/kernel": "0.1.32",
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0"

--- a/packages/auth-core/package.json
+++ b/packages/auth-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-core",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -43,7 +43,7 @@
     "./shared/commands/authSessionReadCommand": "./src/shared/commands/authSessionReadCommand.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.31",
+    "@jskit-ai/kernel": "0.1.32",
     "@fastify/cookie": "^11.0.2",
     "@fastify/csrf-protection": "^7.1.0",
     "@fastify/rate-limit": "^10.3.0",

--- a/packages/auth-provider-supabase-core/package.descriptor.mjs
+++ b/packages/auth-provider-supabase-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "kind": "runtime",
   "options": {
     "auth-supabase-url": {
@@ -83,8 +83,8 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/auth-core": "0.1.30",
-        "@jskit-ai/kernel": "0.1.31",
+        "@jskit-ai/auth-core": "0.1.31",
+        "@jskit-ai/kernel": "0.1.32",
         "dotenv": "^16.4.5",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0"

--- a/packages/auth-provider-supabase-core/package.json
+++ b/packages/auth-provider-supabase-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,8 +12,8 @@
     "./client": "./src/client/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.30",
-    "@jskit-ai/kernel": "0.1.31",
+    "@jskit-ai/auth-core": "0.1.31",
+    "@jskit-ai/kernel": "0.1.32",
     "jose": "^6.1.0",
     "@supabase/supabase-js": "^2.57.4"
   }

--- a/packages/auth-web/package.descriptor.mjs
+++ b/packages/auth-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-web",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "kind": "runtime",
   "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
   "dependsOn": [
@@ -223,10 +223,10 @@ export default Object.freeze({
         "@tanstack/vue-query": "5.92.12",
         "@mdi/js": "^7.4.47",
         "@fastify/type-provider-typebox": "^6.1.0",
-        "@jskit-ai/auth-core": "0.1.30",
-        "@jskit-ai/http-runtime": "0.1.30",
-        "@jskit-ai/kernel": "0.1.31",
-        "@jskit-ai/shell-web": "0.1.30",
+        "@jskit-ai/auth-core": "0.1.31",
+        "@jskit-ai/http-runtime": "0.1.31",
+        "@jskit-ai/kernel": "0.1.32",
+        "@jskit-ai/shell-web": "0.1.31",
         "vuetify": "^4.0.0"
       },
       "dev": {}

--- a/packages/auth-web/package.json
+++ b/packages/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-web",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -18,12 +18,12 @@
   },
   "dependencies": {
     "@tanstack/vue-query": "^5.90.5",
-    "@jskit-ai/auth-core": "0.1.30",
+    "@jskit-ai/auth-core": "0.1.31",
     "@mdi/js": "^7.4.47",
     "@fastify/type-provider-typebox": "^6.1.0",
-    "@jskit-ai/kernel": "0.1.31",
-    "@jskit-ai/shell-web": "0.1.30",
+    "@jskit-ai/kernel": "0.1.32",
+    "@jskit-ai/shell-web": "0.1.31",
     "vuetify": "^4.0.0",
-    "@jskit-ai/http-runtime": "0.1.30"
+    "@jskit-ai/http-runtime": "0.1.31"
   }
 }

--- a/packages/crud-core/package.descriptor.mjs
+++ b/packages/crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-core",
-  version: "0.1.39",
+  version: "0.1.40",
   kind: "runtime",
   description: "Shared CRUD helpers used by CRUD modules.",
   dependsOn: [
@@ -26,7 +26,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/crud-core": "0.1.39"
+        "@jskit-ai/crud-core": "0.1.40"
       },
       dev: {}
     },

--- a/packages/crud-core/package.json
+++ b/packages/crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-core",
-  "version": "0.1.39",
+  "version": "0.1.40",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -26,11 +26,11 @@
   },
   "dependencies": {
     "@tanstack/vue-query": "^5.90.5",
-    "@jskit-ai/kernel": "0.1.31",
-    "@jskit-ai/realtime": "0.1.30",
-    "@jskit-ai/shell-web": "0.1.30",
-    "@jskit-ai/users-core": "0.1.41",
-    "@jskit-ai/users-web": "0.1.46",
+    "@jskit-ai/kernel": "0.1.32",
+    "@jskit-ai/realtime": "0.1.31",
+    "@jskit-ai/shell-web": "0.1.31",
+    "@jskit-ai/users-core": "0.1.42",
+    "@jskit-ai/users-web": "0.1.47",
     "typebox": "^1.0.81"
   }
 }

--- a/packages/crud-server-generator/package.descriptor.mjs
+++ b/packages/crud-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-server-generator",
-  version: "0.1.39",
+  version: "0.1.40",
   kind: "generator",
   description: "CRUD server generator with routes, actions, and persistence scaffolding.",
   options: {
@@ -148,13 +148,13 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.30",
-        "@jskit-ai/crud-core": "0.1.39",
-        "@jskit-ai/database-runtime": "0.1.31",
-        "@jskit-ai/http-runtime": "0.1.30",
-        "@jskit-ai/kernel": "0.1.31",
-        "@jskit-ai/realtime": "0.1.30",
-        "@jskit-ai/users-core": "0.1.41",
+        "@jskit-ai/auth-core": "0.1.31",
+        "@jskit-ai/crud-core": "0.1.40",
+        "@jskit-ai/database-runtime": "0.1.32",
+        "@jskit-ai/http-runtime": "0.1.31",
+        "@jskit-ai/kernel": "0.1.32",
+        "@jskit-ai/realtime": "0.1.31",
+        "@jskit-ai/users-core": "0.1.42",
         "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}",
         "typebox": "^1.0.81"
       },

--- a/packages/crud-server-generator/package.json
+++ b/packages/crud-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-server-generator",
-  "version": "0.1.39",
+  "version": "0.1.40",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,11 +13,11 @@
   },
   "dependencies": {
     "@babel/parser": "^7.29.2",
-    "@jskit-ai/crud-core": "0.1.39",
-    "@jskit-ai/database-runtime": "0.1.31",
-    "@jskit-ai/http-runtime": "0.1.30",
-    "@jskit-ai/kernel": "0.1.31",
-    "@jskit-ai/users-core": "0.1.41",
+    "@jskit-ai/crud-core": "0.1.40",
+    "@jskit-ai/database-runtime": "0.1.32",
+    "@jskit-ai/http-runtime": "0.1.31",
+    "@jskit-ai/kernel": "0.1.32",
+    "@jskit-ai/users-core": "0.1.42",
     "recast": "^0.23.11",
     "typebox": "^1.0.81"
   }

--- a/packages/crud-ui-generator/package.descriptor.mjs
+++ b/packages/crud-ui-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-ui-generator",
-  version: "0.1.14",
+  version: "0.1.15",
   kind: "generator",
   description: "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
   options: {
@@ -147,7 +147,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.46"
+        "@jskit-ai/users-web": "0.1.47"
       },
       dev: {}
     },

--- a/packages/crud-ui-generator/package.json
+++ b/packages/crud-ui-generator/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/crud-ui-generator",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/crud-core": "0.1.39",
-    "@jskit-ai/kernel": "0.1.31"
+    "@jskit-ai/crud-core": "0.1.40",
+    "@jskit-ai/kernel": "0.1.32"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/database-runtime-mysql/package.descriptor.mjs
+++ b/packages/database-runtime-mysql/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-mysql",
-  version: "0.1.30",
+  version: "0.1.31",
   kind: "runtime",
   options: {
     "db-host": {
@@ -91,7 +91,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.31",
+        "@jskit-ai/database-runtime": "0.1.32",
         "mysql2": "^3.11.2"
       },
       dev: {}

--- a/packages/database-runtime-mysql/package.json
+++ b/packages/database-runtime-mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-mysql",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,6 +12,6 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.31"
+    "@jskit-ai/database-runtime": "0.1.32"
   }
 }

--- a/packages/database-runtime-postgres/package.descriptor.mjs
+++ b/packages/database-runtime-postgres/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-postgres",
-  version: "0.1.30",
+  version: "0.1.31",
   kind: "runtime",
   options: {
     "db-host": {
@@ -91,7 +91,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.31",
+        "@jskit-ai/database-runtime": "0.1.32",
         "pg": "^8.13.1"
       },
       dev: {}

--- a/packages/database-runtime-postgres/package.json
+++ b/packages/database-runtime-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-postgres",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,6 +12,6 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.31"
+    "@jskit-ai/database-runtime": "0.1.32"
   }
 }

--- a/packages/database-runtime/package.descriptor.mjs
+++ b/packages/database-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime",
-  version: "0.1.31",
+  version: "0.1.32",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -58,7 +58,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.31",
+        "@jskit-ai/kernel": "0.1.32",
         "dotenv": "^16.4.5",
         "knex": "^3.1.0"
       },

--- a/packages/database-runtime/package.json
+++ b/packages/database-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime",
-  "version": "0.1.31",
+  "version": "0.1.32",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -25,6 +25,6 @@
     "./shared/transactions": "./src/shared/transactions.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.31"
+    "@jskit-ai/kernel": "0.1.32"
   }
 }

--- a/packages/http-runtime/package.descriptor.mjs
+++ b/packages/http-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/http-runtime",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "kind": "runtime",
   "dependsOn": [],
   "capabilities": {
@@ -67,7 +67,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.31",
+        "@jskit-ai/kernel": "0.1.32",
         "@fastify/type-provider-typebox": "^6.1.0",
         "typebox": "^1.0.81"
       },

--- a/packages/http-runtime/package.json
+++ b/packages/http-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/http-runtime",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -17,7 +17,7 @@
     "./shared/validators/operationValidation": "./src/shared/validators/operationValidation.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.31",
+    "@jskit-ai/kernel": "0.1.32",
     "@fastify/type-provider-typebox": "^6.1.0",
     "typebox": "^1.0.81"
   }

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/kernel",
-  "version": "0.1.31",
+  "version": "0.1.32",
   "type": "module",
   "dependencies": {
     "typebox": "^1.0.81"

--- a/packages/realtime/package.descriptor.mjs
+++ b/packages/realtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/realtime",
-  version: "0.1.30",
+  version: "0.1.31",
   kind: "runtime",
   description: "Thin, generic realtime runtime wrappers for socket.io server and client.",
   options: {
@@ -95,7 +95,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.31",
+        "@jskit-ai/kernel": "0.1.32",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/realtime",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@socket.io/redis-adapter": "^8.3.0",
-    "@jskit-ai/kernel": "0.1.31",
+    "@jskit-ai/kernel": "0.1.32",
     "redis": "^5.8.2",
     "socket.io": "^4.8.3",
     "socket.io-client": "^4.8.3"

--- a/packages/shell-web/package.descriptor.mjs
+++ b/packages/shell-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/shell-web",
-  version: "0.1.30",
+  version: "0.1.31",
   kind: "runtime",
   description: "Web shell layout runtime with outlet-based placement contributions.",
   dependsOn: [],
@@ -93,7 +93,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@tanstack/vue-query": "^5.90.5",
-        "@jskit-ai/kernel": "0.1.31",
+        "@jskit-ai/kernel": "0.1.32",
         "vuetify": "^4.0.0"
       },
       dev: {}

--- a/packages/shell-web/package.json
+++ b/packages/shell-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/shell-web",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@tanstack/vue-query": "^5.90.5",
-    "@jskit-ai/kernel": "0.1.31",
+    "@jskit-ai/kernel": "0.1.32",
     "vuetify": "^4.0.0"
   }
 }

--- a/packages/storage-runtime/package.descriptor.mjs
+++ b/packages/storage-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/storage-runtime",
-  version: "0.1.30",
+  version: "0.1.31",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -50,7 +50,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.31",
+        "@jskit-ai/kernel": "0.1.32",
         "unstorage": "^1.17.3"
       },
       dev: {}

--- a/packages/storage-runtime/package.json
+++ b/packages/storage-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/storage-runtime",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./server/providers/StorageRuntimeServiceProvider": "./src/server/providers/StorageRuntimeServiceProvider.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.31",
+    "@jskit-ai/kernel": "0.1.32",
     "unstorage": "^1.17.3"
   }
 }

--- a/packages/ui-generator/package.descriptor.mjs
+++ b/packages/ui-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/ui-generator",
-  version: "0.1.14",
+  version: "0.1.15",
   kind: "generator",
   description: "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
   options: {
@@ -274,7 +274,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.46"
+        "@jskit-ai/users-web": "0.1.47"
       },
       dev: {}
     },

--- a/packages/ui-generator/package.json
+++ b/packages/ui-generator/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@jskit-ai/ui-generator",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.31"
+    "@jskit-ai/kernel": "0.1.32"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/ui-generator/src/server/subcommands/outlet.js
+++ b/packages/ui-generator/src/server/subcommands/outlet.js
@@ -141,6 +141,11 @@ async function runGeneratorSubcommand({
   const targetFilePath = resolvePathWithinApp(appRoot, targetFile, {
     context: "ui-generator outlet"
   });
+  if (!targetFilePath.relativePath.toLowerCase().endsWith(".vue")) {
+    throw new Error(
+      `ui-generator outlet target file must be an existing Vue SFC (.vue): ${targetFilePath.relativePath}.`
+    );
+  }
 
   let source = "";
   try {

--- a/packages/ui-generator/src/server/subcommands/page.js
+++ b/packages/ui-generator/src/server/subcommands/page.js
@@ -11,7 +11,7 @@ import {
 } from "./support.js";
 import {
   resolvePageTargetDetails,
-  renderPlainPageSource,
+  renderPlainPageSource
 } from "./pageSupport.js";
 
 function renderPageLinkPlacementBlock({
@@ -86,14 +86,6 @@ async function runGeneratorSubcommand({
     );
   }
 
-  if (!pageAlreadyExisted || forceOverwrite) {
-    if (dryRun !== true) {
-      await mkdir(path.dirname(pageFilePath), { recursive: true });
-      await writeFile(pageFilePath, renderPlainPageSource(pageLabel), "utf8");
-    }
-    touchedFiles.add(pageRelativePath);
-  }
-
   const placementContext = await buildUiPageTemplateContext({
     appRoot: pageTarget.appRoot,
     targetFile,
@@ -114,6 +106,15 @@ async function runGeneratorSubcommand({
       surface: pageTarget.surfaceId
     })
   );
+
+  if (!pageAlreadyExisted || forceOverwrite) {
+    if (dryRun !== true) {
+      await mkdir(path.dirname(pageFilePath), { recursive: true });
+      await writeFile(pageFilePath, renderPlainPageSource(pageLabel), "utf8");
+    }
+    touchedFiles.add(pageRelativePath);
+  }
+
   if (placementApplied.changed) {
     if (dryRun !== true) {
       await writeFile(placementPath.absolutePath, placementApplied.content, "utf8");
@@ -122,20 +123,11 @@ async function runGeneratorSubcommand({
   }
 
   const touchedFileList = [...touchedFiles].sort((left, right) => left.localeCompare(right));
-  const summaryParts = [];
-  if (!pageAlreadyExisted) {
-    summaryParts.push(`Generated UI page "${pageTarget.routeUrlSuffix}" at ${pageRelativePath}.`);
-  } else if (forceOverwrite) {
-    summaryParts.push(`Regenerated UI page "${pageTarget.routeUrlSuffix}" at ${pageRelativePath}.`);
-  } else if (placementApplied.changed) {
-    summaryParts.push(`Updated page link placement for existing UI page "${pageTarget.routeUrlSuffix}".`);
-  } else {
-    summaryParts.push(`UI page "${pageTarget.routeUrlSuffix}" is already up to date.`);
-  }
-
   return {
     touchedFiles: touchedFileList,
-    summary: summaryParts.join(" ")
+    summary: !pageAlreadyExisted
+      ? `Generated UI page "${pageTarget.routeUrlSuffix}" at ${pageRelativePath}.`
+      : `Regenerated UI page "${pageTarget.routeUrlSuffix}" at ${pageRelativePath}.`
   };
 }
 

--- a/packages/ui-generator/test/outletSubcommand.test.js
+++ b/packages/ui-generator/test/outletSubcommand.test.js
@@ -259,6 +259,32 @@ test("ui-generator outlet supports explicit target host:position", async () => {
   });
 });
 
+test("ui-generator outlet rejects non-vue target files without changing them", async () => {
+  await withTempApp(async (appRoot) => {
+    const targetFile = "src/pages/w/[workspaceSlug]/admin/practice/vets/_components/VetAddEditFormFields.js";
+    const targetPath = path.join(appRoot, targetFile);
+    const originalSource = "export const fields = [];\n";
+
+    await mkdir(path.dirname(targetPath), { recursive: true });
+    await writeFile(targetPath, originalSource, "utf8");
+
+    await assert.rejects(
+      runGeneratorSubcommand({
+        appRoot,
+        subcommand: "outlet",
+        args: [targetFile],
+        options: {
+          target: "vet-view"
+        }
+      }),
+      /ui-generator outlet target file must be an existing Vue SFC \(\.vue\): src\/pages\/w\/\[workspaceSlug\]\/admin\/practice\/vets\/_components\/VetAddEditFormFields\.js\./
+    );
+
+    const output = await readFile(targetPath, "utf8");
+    assert.equal(output, originalSource);
+  });
+});
+
 test("ui-generator outlet validates target format", async () => {
   await withTempApp(async (appRoot) => {
     const targetFile = "src/components/ContactDetailsPanel.vue";

--- a/packages/ui-generator/test/pageSubcommand.test.js
+++ b/packages/ui-generator/test/pageSubcommand.test.js
@@ -73,6 +73,7 @@ test("ui-generator page subcommand creates an index page from an explicit target
     });
 
     assert.deepEqual(result.touchedFiles, [toPagePath(targetFile), "src/placement.js"]);
+    assert.equal(result.summary, 'Generated UI page "/practice" at src/pages/w/[workspaceSlug]/admin/practice/index.vue.');
 
     const pageSource = await readFile(path.join(appRoot, toPagePath(targetFile)), "utf8");
     assert.match(pageSource, /<h1 class="text-h5 mb-2">Practice<\/h1>/);
@@ -348,5 +349,67 @@ test("ui-generator page subcommand overwrites an existing page when --force is p
     const pageSource = await readFile(path.join(appRoot, toPagePath(targetFile)), "utf8");
     assert.match(pageSource, /<h1 class="text-h5 mb-2">Practice<\/h1>/);
     assert.doesNotMatch(pageSource, /custom practice page/);
+  });
+});
+
+test("ui-generator page subcommand rejects invalid link placement before creating a new page", async () => {
+  await withTempApp(async (appRoot) => {
+    await writeAppFixture(appRoot);
+
+    const targetFile = "w/[workspaceSlug]/admin/practice/index.vue";
+    const placementPath = path.join(appRoot, "src", "placement.js");
+    const originalPlacementSource = await readFile(placementPath, "utf8");
+
+    await assert.rejects(
+      runGeneratorSubcommand({
+        appRoot,
+        subcommand: "page",
+        args: [targetFile],
+        options: {
+          "link-placement": "missing:target"
+        }
+      }),
+      /ui-generator page option "placement" target "missing:target" is not declared/
+    );
+
+    await assert.rejects(readFile(path.join(appRoot, toPagePath(targetFile)), "utf8"), /ENOENT/);
+    const placementSource = await readFile(placementPath, "utf8");
+    assert.equal(placementSource, originalPlacementSource);
+  });
+});
+
+test("ui-generator page subcommand rejects invalid link placement before overwriting an existing page", async () => {
+  await withTempApp(async (appRoot) => {
+    await writeAppFixture(appRoot);
+
+    const targetFile = "w/[workspaceSlug]/admin/practice/index.vue";
+    const targetPath = path.join(appRoot, toPagePath(targetFile));
+    const originalPageSource = `<template>
+  <div>custom practice page</div>
+</template>
+`;
+    const placementPath = path.join(appRoot, "src", "placement.js");
+    const originalPlacementSource = await readFile(placementPath, "utf8");
+
+    await mkdir(path.dirname(targetPath), { recursive: true });
+    await writeFile(targetPath, originalPageSource, "utf8");
+
+    await assert.rejects(
+      runGeneratorSubcommand({
+        appRoot,
+        subcommand: "page",
+        args: [targetFile],
+        options: {
+          force: "true",
+          "link-placement": "missing:target"
+        }
+      }),
+      /ui-generator page option "placement" target "missing:target" is not declared/
+    );
+
+    const pageSource = await readFile(targetPath, "utf8");
+    assert.equal(pageSource, originalPageSource);
+    const placementSource = await readFile(placementPath, "utf8");
+    assert.equal(placementSource, originalPlacementSource);
   });
 });

--- a/packages/uploads-image-web/package.descriptor.mjs
+++ b/packages/uploads-image-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-image-web",
-  version: "0.1.9",
+  version: "0.1.10",
   kind: "runtime",
   description: "Reusable client-side image upload runtime with pre-upload image editing.",
   dependsOn: [
@@ -65,7 +65,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/uploads-runtime": "0.1.9",
+        "@jskit-ai/uploads-runtime": "0.1.10",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-image-web/package.json
+++ b/packages/uploads-image-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-image-web",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,7 +13,7 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/uploads-runtime": "0.1.9",
+    "@jskit-ai/uploads-runtime": "0.1.10",
     "@uppy/compressor": "^3.1.0",
     "@uppy/core": "^5.2.0",
     "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-runtime/package.descriptor.mjs
+++ b/packages/uploads-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-runtime",
-  version: "0.1.9",
+  version: "0.1.10",
   kind: "runtime",
   description: "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
   dependsOn: [
@@ -71,7 +71,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.31"
+        "@jskit-ai/kernel": "0.1.32"
       },
       dev: {}
     },

--- a/packages/uploads-runtime/package.json
+++ b/packages/uploads-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-runtime",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,6 +16,6 @@
   },
   "dependencies": {
     "@fastify/multipart": "^9.4.0",
-    "@jskit-ai/kernel": "0.1.31"
+    "@jskit-ai/kernel": "0.1.32"
   }
 }

--- a/packages/users-core/package.descriptor.mjs
+++ b/packages/users-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-core",
-  version: "0.1.41",
+  version: "0.1.42",
   kind: "runtime",
   description: "Users/account runtime plus HTTP routes for account and console features.",
   dependsOn: [
@@ -138,11 +138,11 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.30",
-        "@jskit-ai/database-runtime": "0.1.31",
-        "@jskit-ai/http-runtime": "0.1.30",
-        "@jskit-ai/kernel": "0.1.31",
-        "@jskit-ai/uploads-runtime": "0.1.9",
+        "@jskit-ai/auth-core": "0.1.31",
+        "@jskit-ai/database-runtime": "0.1.32",
+        "@jskit-ai/http-runtime": "0.1.31",
+        "@jskit-ai/kernel": "0.1.32",
+        "@jskit-ai/uploads-runtime": "0.1.10",
         "@fastify/type-provider-typebox": "^6.1.0",
         typebox: "^1.0.81"
       },

--- a/packages/users-core/package.json
+++ b/packages/users-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-core",
-  "version": "0.1.41",
+  "version": "0.1.42",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -24,11 +24,11 @@
     "./shared/resources/consoleSettingsFields": "./src/shared/resources/consoleSettingsFields.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.30",
-    "@jskit-ai/database-runtime": "0.1.31",
-    "@jskit-ai/http-runtime": "0.1.30",
-    "@jskit-ai/kernel": "0.1.31",
-    "@jskit-ai/uploads-runtime": "0.1.9",
+    "@jskit-ai/auth-core": "0.1.31",
+    "@jskit-ai/database-runtime": "0.1.32",
+    "@jskit-ai/http-runtime": "0.1.31",
+    "@jskit-ai/kernel": "0.1.32",
+    "@jskit-ai/uploads-runtime": "0.1.10",
     "@fastify/type-provider-typebox": "^6.1.0",
     "typebox": "^1.0.81"
   }

--- a/packages/users-web/package.descriptor.mjs
+++ b/packages/users-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-web",
-  version: "0.1.46",
+  version: "0.1.47",
   kind: "runtime",
   description: "Users web module: account/profile UI plus shared shell link components.",
   dependsOn: [
@@ -153,12 +153,12 @@ export default Object.freeze({
       runtime: {
         "@tanstack/vue-query": "5.92.12",
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/http-runtime": "0.1.30",
-        "@jskit-ai/realtime": "0.1.30",
-        "@jskit-ai/kernel": "0.1.31",
-        "@jskit-ai/shell-web": "0.1.30",
-        "@jskit-ai/uploads-image-web": "0.1.9",
-        "@jskit-ai/users-core": "0.1.41",
+        "@jskit-ai/http-runtime": "0.1.31",
+        "@jskit-ai/realtime": "0.1.31",
+        "@jskit-ai/kernel": "0.1.32",
+        "@jskit-ai/shell-web": "0.1.31",
+        "@jskit-ai/uploads-image-web": "0.1.10",
+        "@jskit-ai/users-core": "0.1.42",
         vuetify: "^4.0.0"
       },
       dev: {}

--- a/packages/users-web/package.json
+++ b/packages/users-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-web",
-  "version": "0.1.46",
+  "version": "0.1.47",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -28,12 +28,12 @@
   "dependencies": {
     "@tanstack/vue-query": "5.92.12",
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/http-runtime": "0.1.30",
-    "@jskit-ai/kernel": "0.1.31",
-    "@jskit-ai/realtime": "0.1.30",
-    "@jskit-ai/shell-web": "0.1.30",
-    "@jskit-ai/uploads-image-web": "0.1.9",
-    "@jskit-ai/users-core": "0.1.41",
+    "@jskit-ai/http-runtime": "0.1.31",
+    "@jskit-ai/kernel": "0.1.32",
+    "@jskit-ai/realtime": "0.1.31",
+    "@jskit-ai/shell-web": "0.1.31",
+    "@jskit-ai/uploads-image-web": "0.1.10",
+    "@jskit-ai/users-core": "0.1.42",
     "vuetify": "^4.0.0"
   }
 }

--- a/packages/workspaces-core/package.descriptor.mjs
+++ b/packages/workspaces-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-core",
-  version: "0.1.7",
+  version: "0.1.8",
   kind: "runtime",
   description: "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
   dependsOn: [
@@ -110,7 +110,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-core": "0.1.41"
+        "@jskit-ai/users-core": "0.1.42"
       },
       dev: {}
     },

--- a/packages/workspaces-core/package.json
+++ b/packages/workspaces-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-core",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./server/WorkspacesCoreServiceProvider": "./src/server/WorkspacesCoreServiceProvider.js"
   },
   "dependencies": {
-    "@jskit-ai/users-core": "0.1.41"
+    "@jskit-ai/users-core": "0.1.42"
   }
 }

--- a/packages/workspaces-web/package.descriptor.mjs
+++ b/packages/workspaces-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-web",
-  version: "0.1.7",
+  version: "0.1.8",
   kind: "runtime",
   description: "Workspace web module: workspace selector, tools widget, workspace surfaces, and members/settings UI.",
   dependsOn: [
@@ -124,8 +124,8 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/workspaces-core": "0.1.7",
-        "@jskit-ai/users-web": "0.1.46"
+        "@jskit-ai/workspaces-core": "0.1.8",
+        "@jskit-ai/users-web": "0.1.47"
       },
       dev: {}
     },

--- a/packages/workspaces-web/package.json
+++ b/packages/workspaces-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-web",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,6 +10,6 @@
     "./client/providers/WorkspacesWebClientProvider": "./src/client/providers/WorkspacesWebClientProvider.js"
   },
   "dependencies": {
-    "@jskit-ai/users-web": "0.1.46"
+    "@jskit-ai/users-web": "0.1.47"
   }
 }

--- a/tooling/config-eslint/package.descriptor.mjs
+++ b/tooling/config-eslint/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/config-eslint",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "dependsOn": [],
   "capabilities": {
     "provides": [

--- a/tooling/config-eslint/package.json
+++ b/tooling/config-eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/config-eslint",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "description": "Shared flat ESLint presets for JSKIT projects.",
   "type": "module",
   "files": [

--- a/tooling/create-app/package.descriptor.mjs
+++ b/tooling/create-app/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/create-app",
-  "version": "0.1.38",
+  "version": "0.1.39",
   "dependsOn": [],
   "capabilities": {
     "provides": [

--- a/tooling/create-app/package.json
+++ b/tooling/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/create-app",
-  "version": "0.1.38",
+  "version": "0.1.39",
   "description": "Scaffold minimal JSKIT app shells.",
   "type": "module",
   "files": [

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -6,11 +6,11 @@
   "packages": [
     {
       "packageId": "@jskit-ai/assistant",
-      "version": "0.1.40",
+      "version": "0.1.41",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant",
-        "version": "0.1.40",
+        "version": "0.1.41",
         "kind": "generator",
         "description": "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
         "options": {
@@ -334,11 +334,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-core",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-core",
-        "version": "0.1.7",
+        "version": "0.1.8",
         "kind": "runtime",
         "description": "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
         "dependsOn": [
@@ -384,9 +384,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/http-runtime": "0.1.30",
-              "@jskit-ai/kernel": "0.1.31",
-              "@jskit-ai/users-core": "0.1.41",
+              "@jskit-ai/http-runtime": "0.1.31",
+              "@jskit-ai/kernel": "0.1.32",
+              "@jskit-ai/users-core": "0.1.42",
               "@tanstack/vue-query": "^5.90.5",
               "dompurify": "^3.3.3",
               "marked": "^17.0.4",
@@ -407,11 +407,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-runtime",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-runtime",
-        "version": "0.1.2",
+        "version": "0.1.3",
         "kind": "runtime",
         "description": "Shared assistant runtime with per-surface assistant registration.",
         "dependsOn": [
@@ -486,13 +486,13 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/assistant-core": "0.1.7",
-              "@jskit-ai/database-runtime": "0.1.31",
-              "@jskit-ai/http-runtime": "0.1.30",
-              "@jskit-ai/kernel": "0.1.31",
-              "@jskit-ai/shell-web": "0.1.30",
-              "@jskit-ai/users-core": "0.1.41",
-              "@jskit-ai/users-web": "0.1.46",
+              "@jskit-ai/assistant-core": "0.1.8",
+              "@jskit-ai/database-runtime": "0.1.32",
+              "@jskit-ai/http-runtime": "0.1.31",
+              "@jskit-ai/kernel": "0.1.32",
+              "@jskit-ai/shell-web": "0.1.31",
+              "@jskit-ai/users-core": "0.1.42",
+              "@jskit-ai/users-web": "0.1.47",
               "@tanstack/vue-query": "^5.90.5",
               "vuetify": "^4.0.0"
             },
@@ -549,11 +549,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-core",
-      "version": "0.1.30",
+      "version": "0.1.31",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-core",
-        "version": "0.1.30",
+        "version": "0.1.31",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/value-app-config-shared"
@@ -621,7 +621,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.31",
+              "@jskit-ai/kernel": "0.1.32",
               "@fastify/cookie": "^11.0.2",
               "@fastify/csrf-protection": "^7.1.0",
               "@fastify/rate-limit": "^10.3.0"
@@ -639,11 +639,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.30",
+      "version": "0.1.31",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-supabase-core",
-        "version": "0.1.30",
+        "version": "0.1.31",
         "kind": "runtime",
         "options": {
           "auth-supabase-url": {
@@ -725,8 +725,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.30",
-              "@jskit-ai/kernel": "0.1.31",
+              "@jskit-ai/auth-core": "0.1.31",
+              "@jskit-ai/kernel": "0.1.32",
               "dotenv": "^16.4.5",
               "@supabase/supabase-js": "^2.57.4",
               "jose": "^6.1.0"
@@ -791,11 +791,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-web",
-      "version": "0.1.32",
+      "version": "0.1.33",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-web",
-        "version": "0.1.32",
+        "version": "0.1.33",
         "kind": "runtime",
         "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
         "dependsOn": [
@@ -1025,10 +1025,10 @@
               "@tanstack/vue-query": "5.92.12",
               "@mdi/js": "^7.4.47",
               "@fastify/type-provider-typebox": "^6.1.0",
-              "@jskit-ai/auth-core": "0.1.30",
-              "@jskit-ai/http-runtime": "0.1.30",
-              "@jskit-ai/kernel": "0.1.31",
-              "@jskit-ai/shell-web": "0.1.30",
+              "@jskit-ai/auth-core": "0.1.31",
+              "@jskit-ai/http-runtime": "0.1.31",
+              "@jskit-ai/kernel": "0.1.32",
+              "@jskit-ai/shell-web": "0.1.31",
               "vuetify": "^4.0.0"
             },
             "dev": {}
@@ -1098,11 +1098,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-core",
-      "version": "0.1.39",
+      "version": "0.1.40",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-core",
-        "version": "0.1.39",
+        "version": "0.1.40",
         "kind": "runtime",
         "description": "Shared CRUD helpers used by CRUD modules.",
         "dependsOn": [
@@ -1129,7 +1129,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/crud-core": "0.1.39"
+              "@jskit-ai/crud-core": "0.1.40"
             },
             "dev": {}
           },
@@ -1143,11 +1143,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-server-generator",
-      "version": "0.1.39",
+      "version": "0.1.40",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-server-generator",
-        "version": "0.1.39",
+        "version": "0.1.40",
         "kind": "generator",
         "description": "CRUD server generator with routes, actions, and persistence scaffolding.",
         "options": {
@@ -1296,13 +1296,13 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.30",
-              "@jskit-ai/crud-core": "0.1.39",
-              "@jskit-ai/database-runtime": "0.1.31",
-              "@jskit-ai/http-runtime": "0.1.30",
-              "@jskit-ai/kernel": "0.1.31",
-              "@jskit-ai/realtime": "0.1.30",
-              "@jskit-ai/users-core": "0.1.41",
+              "@jskit-ai/auth-core": "0.1.31",
+              "@jskit-ai/crud-core": "0.1.40",
+              "@jskit-ai/database-runtime": "0.1.32",
+              "@jskit-ai/http-runtime": "0.1.31",
+              "@jskit-ai/kernel": "0.1.32",
+              "@jskit-ai/realtime": "0.1.31",
+              "@jskit-ai/users-core": "0.1.42",
               "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}",
               "typebox": "^1.0.81"
             },
@@ -1426,11 +1426,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-ui-generator",
-        "version": "0.1.14",
+        "version": "0.1.15",
         "kind": "generator",
         "description": "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
         "options": {
@@ -1588,7 +1588,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.46"
+              "@jskit-ai/users-web": "0.1.47"
             },
             "dev": {}
           },
@@ -1821,11 +1821,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime",
-      "version": "0.1.31",
+      "version": "0.1.32",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime",
-        "version": "0.1.31",
+        "version": "0.1.32",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -1882,7 +1882,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.31",
+              "@jskit-ai/kernel": "0.1.32",
               "dotenv": "^16.4.5",
               "knex": "^3.1.0"
             },
@@ -1917,11 +1917,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.30",
+      "version": "0.1.31",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-mysql",
-        "version": "0.1.30",
+        "version": "0.1.31",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -2011,7 +2011,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.31",
+              "@jskit-ai/database-runtime": "0.1.32",
               "mysql2": "^3.11.2"
             },
             "dev": {}
@@ -2082,11 +2082,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.30",
+      "version": "0.1.31",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-postgres",
-        "version": "0.1.30",
+        "version": "0.1.31",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -2176,7 +2176,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.31",
+              "@jskit-ai/database-runtime": "0.1.32",
               "pg": "^8.13.1"
             },
             "dev": {}
@@ -2247,11 +2247,11 @@
     },
     {
       "packageId": "@jskit-ai/http-runtime",
-      "version": "0.1.30",
+      "version": "0.1.31",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/http-runtime",
-        "version": "0.1.30",
+        "version": "0.1.31",
         "kind": "runtime",
         "dependsOn": [],
         "capabilities": {
@@ -2317,7 +2317,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.31",
+              "@jskit-ai/kernel": "0.1.32",
               "@fastify/type-provider-typebox": "^6.1.0",
               "typebox": "^1.0.81"
             },
@@ -2333,11 +2333,11 @@
     },
     {
       "packageId": "@jskit-ai/realtime",
-      "version": "0.1.30",
+      "version": "0.1.31",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/realtime",
-        "version": "0.1.30",
+        "version": "0.1.31",
         "kind": "runtime",
         "description": "Thin, generic realtime runtime wrappers for socket.io server and client.",
         "options": {
@@ -2433,7 +2433,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.31",
+              "@jskit-ai/kernel": "0.1.32",
               "@socket.io/redis-adapter": "^8.3.0",
               "redis": "^5.8.2",
               "socket.io": "^4.8.3",
@@ -2482,11 +2482,11 @@
     },
     {
       "packageId": "@jskit-ai/shell-web",
-      "version": "0.1.30",
+      "version": "0.1.31",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/shell-web",
-        "version": "0.1.30",
+        "version": "0.1.31",
         "kind": "runtime",
         "description": "Web shell layout runtime with outlet-based placement contributions.",
         "dependsOn": [],
@@ -2588,7 +2588,7 @@
           "dependencies": {
             "runtime": {
               "@tanstack/vue-query": "^5.90.5",
-              "@jskit-ai/kernel": "0.1.31",
+              "@jskit-ai/kernel": "0.1.32",
               "vuetify": "^4.0.0"
             },
             "dev": {}
@@ -2685,11 +2685,11 @@
     },
     {
       "packageId": "@jskit-ai/storage-runtime",
-      "version": "0.1.30",
+      "version": "0.1.31",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/storage-runtime",
-        "version": "0.1.30",
+        "version": "0.1.31",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -2738,7 +2738,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.31",
+              "@jskit-ai/kernel": "0.1.32",
               "unstorage": "^1.17.3"
             },
             "dev": {}
@@ -2754,11 +2754,11 @@
     },
     {
       "packageId": "@jskit-ai/ui-generator",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/ui-generator",
-        "version": "0.1.14",
+        "version": "0.1.15",
         "kind": "generator",
         "description": "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
         "options": {
@@ -3053,7 +3053,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.46"
+              "@jskit-ai/users-web": "0.1.47"
             },
             "dev": {}
           },
@@ -3068,11 +3068,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-image-web",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-image-web",
-        "version": "0.1.9",
+        "version": "0.1.10",
         "kind": "runtime",
         "description": "Reusable client-side image upload runtime with pre-upload image editing.",
         "dependsOn": [
@@ -3136,7 +3136,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/uploads-runtime": "0.1.9",
+              "@jskit-ai/uploads-runtime": "0.1.10",
               "@uppy/compressor": "^3.1.0",
               "@uppy/core": "^5.2.0",
               "@uppy/dashboard": "^5.1.1",
@@ -3156,11 +3156,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-runtime",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-runtime",
-        "version": "0.1.9",
+        "version": "0.1.10",
         "kind": "runtime",
         "description": "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
         "dependsOn": [
@@ -3230,7 +3230,7 @@
           "dependencies": {
             "runtime": {
               "@fastify/multipart": "^9.4.0",
-              "@jskit-ai/kernel": "0.1.31"
+              "@jskit-ai/kernel": "0.1.32"
             },
             "dev": {}
           },
@@ -3245,11 +3245,11 @@
     },
     {
       "packageId": "@jskit-ai/users-core",
-      "version": "0.1.41",
+      "version": "0.1.42",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-core",
-        "version": "0.1.41",
+        "version": "0.1.42",
         "kind": "runtime",
         "description": "Users/account runtime plus HTTP routes for account and console features.",
         "dependsOn": [
@@ -3385,11 +3385,11 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.30",
-              "@jskit-ai/database-runtime": "0.1.31",
-              "@jskit-ai/http-runtime": "0.1.30",
-              "@jskit-ai/kernel": "0.1.31",
-              "@jskit-ai/uploads-runtime": "0.1.9",
+              "@jskit-ai/auth-core": "0.1.31",
+              "@jskit-ai/database-runtime": "0.1.32",
+              "@jskit-ai/http-runtime": "0.1.31",
+              "@jskit-ai/kernel": "0.1.32",
+              "@jskit-ai/uploads-runtime": "0.1.10",
               "@fastify/type-provider-typebox": "^6.1.0",
               "typebox": "^1.0.81"
             },
@@ -3500,11 +3500,11 @@
     },
     {
       "packageId": "@jskit-ai/users-web",
-      "version": "0.1.46",
+      "version": "0.1.47",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-web",
-        "version": "0.1.46",
+        "version": "0.1.47",
         "kind": "runtime",
         "description": "Users web module: account/profile UI plus shared shell link components.",
         "dependsOn": [
@@ -3664,12 +3664,12 @@
             "runtime": {
               "@tanstack/vue-query": "5.92.12",
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/http-runtime": "0.1.30",
-              "@jskit-ai/realtime": "0.1.30",
-              "@jskit-ai/kernel": "0.1.31",
-              "@jskit-ai/shell-web": "0.1.30",
-              "@jskit-ai/uploads-image-web": "0.1.9",
-              "@jskit-ai/users-core": "0.1.41",
+              "@jskit-ai/http-runtime": "0.1.31",
+              "@jskit-ai/realtime": "0.1.31",
+              "@jskit-ai/kernel": "0.1.32",
+              "@jskit-ai/shell-web": "0.1.31",
+              "@jskit-ai/uploads-image-web": "0.1.10",
+              "@jskit-ai/users-core": "0.1.42",
               "vuetify": "^4.0.0"
             },
             "dev": {}
@@ -3789,11 +3789,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-core",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-core",
-        "version": "0.1.7",
+        "version": "0.1.8",
         "kind": "runtime",
         "description": "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
         "dependsOn": [
@@ -3902,7 +3902,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-core": "0.1.41"
+              "@jskit-ai/users-core": "0.1.42"
             },
             "dev": {}
           },
@@ -4092,11 +4092,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-web",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-web",
-        "version": "0.1.7",
+        "version": "0.1.8",
         "kind": "runtime",
         "description": "Workspace web module: workspace selector, tools widget, workspace surfaces, and members/settings UI.",
         "dependsOn": [
@@ -4233,8 +4233,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/workspaces-core": "0.1.7",
-              "@jskit-ai/users-web": "0.1.46"
+              "@jskit-ai/workspaces-core": "0.1.8",
+              "@jskit-ai/users-web": "0.1.47"
             },
             "dev": {}
           },

--- a/tooling/jskit-catalog/package.json
+++ b/tooling/jskit-catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-catalog",
-  "version": "0.1.39",
+  "version": "0.1.40",
   "description": "Published metadata catalog for JSKIT package descriptors.",
   "type": "module",
   "files": [

--- a/tooling/jskit-cli/package.json
+++ b/tooling/jskit-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-cli",
-  "version": "0.2.39",
+  "version": "0.2.40",
   "description": "Bundle and package orchestration CLI for JSKIT apps.",
   "type": "module",
   "files": [
@@ -20,8 +20,8 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/jskit-catalog": "0.1.39",
-    "@jskit-ai/kernel": "0.1.31"
+    "@jskit-ai/jskit-catalog": "0.1.40",
+    "@jskit-ai/kernel": "0.1.32"
   },
   "engines": {
     "node": "20.x"

--- a/tooling/jskit-cli/src/server/core/commandCatalog.js
+++ b/tooling/jskit-cli/src/server/core/commandCatalog.js
@@ -1,50 +1,569 @@
-const KNOWN_COMMAND_IDS = Object.freeze([
-  "help",
-  "create",
-  "generate",
-  "list",
-  "list-placements",
-  "list-link-items",
-  "show",
-  "view",
-  "migrations",
-  "add",
-  "position",
-  "update",
-  "remove",
-  "doctor",
-  "lint-descriptors"
-]);
-
-const KNOWN_COMMANDS = new Set(KNOWN_COMMAND_IDS);
-
-const COMMAND_ALIASES = Object.freeze({
-  view: "show",
-  ls: "list",
-  gen: "generate",
-  lp: "list-placements",
-  lpct: "list-link-items",
-  "list-placement-component-tokens": "list-link-items"
+const OPTION_FLAG_LABELS = Object.freeze({
+  dryRun: "--dry-run",
+  runNpmInstall: "--run-npm-install",
+  full: "--full",
+  expanded: "--expanded",
+  details: "--details",
+  debugExports: "--debug-exports",
+  checkDiLabels: "--check-di-labels",
+  verbose: "--verbose",
+  json: "--json",
+  all: "--all"
 });
+
+const PARSED_BOOLEAN_OPTION_KEYS = Object.freeze(Object.keys(OPTION_FLAG_LABELS));
+
+function isHelpToken(value = "") {
+  return String(value || "").trim().toLowerCase() === "help";
+}
+
+function canDelegateAddInlineOptions(positional = []) {
+  const [first, second, third] = Array.isArray(positional) ? positional : [];
+  const targetType = String(first || "").trim();
+  const targetId = String(second || "").trim();
+  if (!targetType || !targetId || isHelpToken(targetId) || isHelpToken(third)) {
+    return false;
+  }
+  return targetType === "package" || targetType === "bundle";
+}
+
+function canDelegateGenerateInlineOptions(positional = []) {
+  const normalizedPositionals = Array.isArray(positional) ? positional : [];
+  const first = String(normalizedPositionals[0] || "").trim();
+  const second = String(normalizedPositionals[1] || "").trim();
+  const last = String(normalizedPositionals[normalizedPositionals.length - 1] || "").trim();
+  if (!first || !second || isHelpToken(first) || isHelpToken(second) || isHelpToken(last)) {
+    return false;
+  }
+  return true;
+}
+
+function canDelegateMigrationsInlineOptions(positional = []) {
+  const [first, second] = Array.isArray(positional) ? positional : [];
+  return String(first || "").trim().toLowerCase() === "package" && Boolean(String(second || "").trim());
+}
+
+function canDelegatePackageTargetInlineOptions(positional = [], expectedTargetType = "") {
+  const [first, second] = Array.isArray(positional) ? positional : [];
+  const targetType = String(first || "").trim();
+  const targetId = String(second || "").trim();
+  if (!targetType || !targetId || isHelpToken(targetId)) {
+    return false;
+  }
+  return targetType === String(expectedTargetType || "").trim();
+}
+
+const COMMAND_DESCRIPTORS = Object.freeze({
+  help: Object.freeze({
+    command: "help",
+    aliases: Object.freeze([]),
+    showInOverview: false,
+    summary: "Show command-specific usage.",
+    minimalUse: "jskit help [command]",
+    parameters: Object.freeze([
+      Object.freeze({
+        name: "[command]",
+        description: "Optional command name to inspect."
+      })
+    ]),
+    defaults: Object.freeze([
+      "Without a command, help prints the top-level overview.",
+      "Use jskit help <command> for command-specific usage."
+    ]),
+    fullUse: "jskit help [command]",
+    showHelpOnBareInvocation: false,
+    handlerName: "",
+    allowedFlagKeys: Object.freeze([]),
+    inlineOptionMode: "none",
+    allowedValueOptionNames: Object.freeze([])
+  }),
+  create: Object.freeze({
+    command: "create",
+    aliases: Object.freeze([]),
+    showInOverview: true,
+    summary: "Scaffold an app-local runtime package.",
+    minimalUse: "jskit create package <name>",
+    parameters: Object.freeze([
+      Object.freeze({
+        name: "<name>",
+        description: "Local package slug used to scaffold packages/<name>."
+      })
+    ]),
+    defaults: Object.freeze([
+      "No npm install runs unless --run-npm-install is passed.",
+      "If --scope is omitted, scope is inferred from app name.",
+      "If --package-id is omitted, it is derived from scope + name."
+    ]),
+    fullUse:
+      "jskit create package <name> [--scope <scope>] [--package-id <id>] [--description <text>] [--dry-run] [--run-npm-install] [--json]",
+    showHelpOnBareInvocation: true,
+    handlerName: "commandCreate",
+    allowedFlagKeys: Object.freeze(["dryRun", "runNpmInstall", "json"]),
+    inlineOptionMode: "enumerated",
+    allowedValueOptionNames: Object.freeze(["scope", "package-id", "description"])
+  }),
+  add: Object.freeze({
+    command: "add",
+    aliases: Object.freeze([]),
+    showInOverview: true,
+    summary: "Install a runtime bundle or package into the current app.",
+    minimalUse: "jskit add package <packageId>",
+    parameters: Object.freeze([
+      Object.freeze({
+        name: "package | bundle",
+        description: "Target type. Use package for one runtime package, bundle for a bundle id."
+      }),
+      Object.freeze({
+        name: "<packageId|bundleId>",
+        description: "Catalog id or installed node_modules package id."
+      })
+    ]),
+    defaults: Object.freeze([
+      "No npm install runs unless --run-npm-install is passed.",
+      "Short ids resolve to @jskit-ai/<id> when available.",
+      "Running without args lists bundles and runtime packages.",
+      "Existing matching version is skipped unless options force reapply."
+    ]),
+    fullUse:
+      "jskit add <package|bundle> <id> [--<option> <value>...] [--dry-run] [--run-npm-install] [--json] [--verbose]",
+    showHelpOnBareInvocation: false,
+    handlerName: "commandAdd",
+    allowedFlagKeys: Object.freeze(["dryRun", "runNpmInstall", "json", "verbose"]),
+    inlineOptionMode: "delegate",
+    allowedValueOptionNames: Object.freeze([]),
+    canDelegateInlineOptions: canDelegateAddInlineOptions
+  }),
+  generate: Object.freeze({
+    command: "generate",
+    aliases: Object.freeze(["gen"]),
+    showInOverview: true,
+    summary: "Run a generator package (or generator subcommand).",
+    minimalUse: "jskit generate <generatorId>",
+    parameters: Object.freeze([
+      Object.freeze({
+        name: "<generatorId>",
+        description: "Generator package id (for example: crud-ui-generator)."
+      }),
+      Object.freeze({
+        name: "[subcommand]",
+        description: "Optional generator subcommand (for example: scaffold or scaffold-field)."
+      }),
+      Object.freeze({
+        name: "[subcommand args...]",
+        description: "Optional positional args consumed by the chosen subcommand."
+      })
+    ]),
+    defaults: Object.freeze([
+      "No npm install runs unless --run-npm-install is passed.",
+      "Short ids resolve to @jskit-ai/<id> when available.",
+      "Running without args lists available generators.",
+      "Running with only <generatorId> shows generator help.",
+      "Use jskit generate <generatorId> <subcommand> help for subcommand-specific usage."
+    ]),
+    examples: Object.freeze([
+      Object.freeze({
+        label: "Common usage",
+        lines: Object.freeze([
+          "npx jskit generate ui-generator page \\",
+          "  admin/reports/index.vue"
+        ])
+      }),
+      Object.freeze({
+        label: "More advanced usage",
+        lines: Object.freeze([
+          "npx jskit generate crud-ui-generator crud \\",
+          "  admin/catalog/index/products \\",
+          "  --resource-file packages/products/src/shared/productResource.js"
+        ])
+      })
+    ]),
+    fullUse:
+      "jskit generate <generatorId> [subcommand] [subcommand args...] [--<option> <value>...] [--dry-run] [--run-npm-install] [--json] [--verbose]",
+    showHelpOnBareInvocation: false,
+    handlerName: "commandGenerate",
+    allowedFlagKeys: Object.freeze(["dryRun", "runNpmInstall", "json", "verbose"]),
+    inlineOptionMode: "delegate",
+    allowedValueOptionNames: Object.freeze([]),
+    canDelegateInlineOptions: canDelegateGenerateInlineOptions
+  }),
+  list: Object.freeze({
+    command: "list",
+    aliases: Object.freeze(["ls"]),
+    showInOverview: true,
+    summary: "List bundles, runtime packages, or generator packages.",
+    minimalUse: "jskit list",
+    parameters: Object.freeze([
+      Object.freeze({
+        name: "[mode]",
+        description: "Optional mode: bundles, packages, or generators."
+      })
+    ]),
+    defaults: Object.freeze([
+      "Without mode, list prints bundles + runtime packages + generators.",
+      "placements are listed by the dedicated list-placements command.",
+      "--full and --expanded only affect bundle/package listing views."
+    ]),
+    fullUse: "jskit list [bundles|packages|generators] [--full] [--expanded] [--json]",
+    showHelpOnBareInvocation: false,
+    handlerName: "commandList",
+    allowedFlagKeys: Object.freeze(["full", "expanded", "json"]),
+    inlineOptionMode: "none",
+    allowedValueOptionNames: Object.freeze([])
+  }),
+  "list-placements": Object.freeze({
+    command: "list-placements",
+    aliases: Object.freeze(["lp"]),
+    showInOverview: true,
+    summary: "List discovered UI placement targets.",
+    minimalUse: "jskit list-placements",
+    parameters: Object.freeze([]),
+    defaults: Object.freeze([
+      "Discovers placement outlets from app Vue ShellOutlet tags and route meta.",
+      "Includes placement outlets contributed by installed package metadata.",
+      "Shows plain text by default; use --json for structured output."
+    ]),
+    fullUse: "jskit list-placements [--json]",
+    showHelpOnBareInvocation: false,
+    handlerName: "commandListPlacements",
+    allowedFlagKeys: Object.freeze(["json"]),
+    inlineOptionMode: "none",
+    allowedValueOptionNames: Object.freeze([])
+  }),
+  "list-link-items": Object.freeze({
+    command: "list-link-items",
+    aliases: Object.freeze(["lpct", "list-placement-component-tokens"]),
+    showInOverview: true,
+    summary: "List available placement link-item component tokens.",
+    minimalUse: "jskit list-link-items",
+    parameters: Object.freeze([
+      Object.freeze({
+        name: "[--prefix <value>]",
+        description: "Optional token prefix filter (example: local.main. or users.web.shell.)."
+      }),
+      Object.freeze({
+        name: "[--all]",
+        description: "Include all discovered tokens (including non-link-item and client container/runtime tokens)."
+      })
+    ]),
+    defaults: Object.freeze([
+      "Default output shows link-item tokens only (token names ending with link-item).",
+      "Default includes app and installed-package placement-linked token sources.",
+      "Use --prefix to narrow quickly (recommended: --prefix local.main.).",
+      "Use --all when you want the full discovered token set.",
+      "Shows plain text by default; use --json for structured output."
+    ]),
+    fullUse: "jskit list-link-items [--prefix <value>] [--all] [--json]",
+    showHelpOnBareInvocation: false,
+    handlerName: "commandListLinkItems",
+    allowedFlagKeys: Object.freeze(["json", "all"]),
+    inlineOptionMode: "enumerated",
+    allowedValueOptionNames: Object.freeze(["prefix"])
+  }),
+  show: Object.freeze({
+    command: "show",
+    aliases: Object.freeze(["view"]),
+    showInOverview: true,
+    summary: "Show detailed metadata for a bundle or package.",
+    minimalUse: "jskit show <id>",
+    parameters: Object.freeze([
+      Object.freeze({
+        name: "<id>",
+        description: "Bundle id or package id to inspect."
+      })
+    ]),
+    defaults: Object.freeze([
+      "view is an alias of show.",
+      "Basic output is compact; --details expands capability and runtime sections.",
+      "--debug-exports implies --details."
+    ]),
+    fullUse: "jskit show <id> [--details] [--debug-exports] [--json]",
+    showHelpOnBareInvocation: true,
+    handlerName: "commandShow",
+    allowedFlagKeys: Object.freeze(["details", "debugExports", "json"]),
+    inlineOptionMode: "none",
+    allowedValueOptionNames: Object.freeze([])
+  }),
+  migrations: Object.freeze({
+    command: "migrations",
+    aliases: Object.freeze([]),
+    showInOverview: true,
+    summary: "Generate managed migration files only.",
+    minimalUse: "jskit migrations changed",
+    parameters: Object.freeze([
+      Object.freeze({
+        name: "<scope>",
+        description: "all | changed | package."
+      }),
+      Object.freeze({
+        name: "[packageId]",
+        description: "Required only when scope is package."
+      })
+    ]),
+    defaults: Object.freeze([
+      "Inline options are accepted only for 'migrations package <packageId>'.",
+      "This command only materializes managed migration files; it does not run npm install.",
+      "Without --json, output lists touched migration files."
+    ]),
+    fullUse: "jskit migrations <all|changed|package> [packageId] [--<option> <value>...] [--dry-run] [--json] [--verbose]",
+    showHelpOnBareInvocation: true,
+    handlerName: "commandMigrations",
+    allowedFlagKeys: Object.freeze(["dryRun", "json", "verbose"]),
+    inlineOptionMode: "delegate",
+    allowedValueOptionNames: Object.freeze([]),
+    canDelegateInlineOptions: canDelegateMigrationsInlineOptions
+  }),
+  position: Object.freeze({
+    command: "position",
+    aliases: Object.freeze([]),
+    showInOverview: true,
+    summary: "Re-apply positioning-only mutations for an installed package.",
+    minimalUse: "jskit position element <packageId>",
+    parameters: Object.freeze([
+      Object.freeze({
+        name: "element",
+        description: "Target type for positioning command."
+      }),
+      Object.freeze({
+        name: "<packageId>",
+        description: "Installed package id to re-position."
+      })
+    ]),
+    defaults: Object.freeze([
+      "Only positioning mutations are applied.",
+      "This command does not run npm install.",
+      "Reads current options from lock unless overridden inline."
+    ]),
+    fullUse: "jskit position element <packageId> [--<option> <value>...] [--dry-run] [--json]",
+    showHelpOnBareInvocation: true,
+    handlerName: "commandPosition",
+    allowedFlagKeys: Object.freeze(["dryRun", "json"]),
+    inlineOptionMode: "delegate",
+    allowedValueOptionNames: Object.freeze([]),
+    canDelegateInlineOptions: (positional = []) => canDelegatePackageTargetInlineOptions(positional, "element")
+  }),
+  update: Object.freeze({
+    command: "update",
+    aliases: Object.freeze([]),
+    showInOverview: true,
+    summary: "Re-apply one installed package.",
+    minimalUse: "jskit update package <packageId>",
+    parameters: Object.freeze([
+      Object.freeze({
+        name: "package",
+        description: "Target type for update command."
+      }),
+      Object.freeze({
+        name: "<packageId>",
+        description: "Installed package id to re-apply."
+      })
+    ]),
+    defaults: Object.freeze([
+      "No npm install runs unless --run-npm-install is passed.",
+      "Existing lock options are reused unless overridden inline.",
+      "update reuses add package flow with forced reapply."
+    ]),
+    fullUse: "jskit update package <packageId> [--<option> <value>...] [--dry-run] [--run-npm-install] [--json]",
+    showHelpOnBareInvocation: true,
+    handlerName: "commandUpdate",
+    allowedFlagKeys: Object.freeze(["dryRun", "runNpmInstall", "json"]),
+    inlineOptionMode: "delegate",
+    allowedValueOptionNames: Object.freeze([]),
+    canDelegateInlineOptions: (positional = []) => canDelegatePackageTargetInlineOptions(positional, "package")
+  }),
+  remove: Object.freeze({
+    command: "remove",
+    aliases: Object.freeze([]),
+    showInOverview: true,
+    summary: "Remove one installed package.",
+    minimalUse: "jskit remove package <packageId>",
+    parameters: Object.freeze([
+      Object.freeze({
+        name: "package",
+        description: "Target type for remove command."
+      }),
+      Object.freeze({
+        name: "<packageId>",
+        description: "Installed package id to remove."
+      })
+    ]),
+    defaults: Object.freeze([
+      "No npm install runs unless --run-npm-install is passed.",
+      "Managed files and lock entries are removed for the package.",
+      "Local package source directories are not deleted."
+    ]),
+    fullUse: "jskit remove package <packageId> [--dry-run] [--run-npm-install] [--json]",
+    showHelpOnBareInvocation: true,
+    handlerName: "commandRemove",
+    allowedFlagKeys: Object.freeze(["dryRun", "runNpmInstall", "json"]),
+    inlineOptionMode: "none",
+    allowedValueOptionNames: Object.freeze([])
+  }),
+  doctor: Object.freeze({
+    command: "doctor",
+    aliases: Object.freeze([]),
+    showInOverview: true,
+    summary: "Validate lockfile and managed-file integrity.",
+    minimalUse: "jskit doctor",
+    parameters: Object.freeze([]),
+    defaults: Object.freeze([
+      "Validates lock entries, managed files, and registry visibility.",
+      "Reports issues as plain text by default.",
+      "Use --json for machine-readable diagnostics."
+    ]),
+    fullUse: "jskit doctor [--json]",
+    showHelpOnBareInvocation: false,
+    handlerName: "commandDoctor",
+    allowedFlagKeys: Object.freeze(["json"]),
+    inlineOptionMode: "none",
+    allowedValueOptionNames: Object.freeze([])
+  }),
+  "lint-descriptors": Object.freeze({
+    command: "lint-descriptors",
+    aliases: Object.freeze([]),
+    showInOverview: true,
+    summary: "Validate bundle and package descriptor contracts.",
+    minimalUse: "jskit lint-descriptors",
+    parameters: Object.freeze([]),
+    defaults: Object.freeze([
+      "Runs descriptor consistency checks.",
+      "check-di-labels is optional and adds stricter DI token label checks.",
+      "Outputs plain text by default and supports --json."
+    ]),
+    fullUse: "jskit lint-descriptors [--check-di-labels] [--json]",
+    showHelpOnBareInvocation: false,
+    handlerName: "commandLintDescriptors",
+    allowedFlagKeys: Object.freeze(["checkDiLabels", "json"]),
+    inlineOptionMode: "none",
+    allowedValueOptionNames: Object.freeze([])
+  })
+});
+
+const COMMAND_ALIAS_TO_ID = Object.freeze(
+  Object.fromEntries(
+    Object.values(COMMAND_DESCRIPTORS)
+      .flatMap((descriptor) =>
+        Array.isArray(descriptor.aliases)
+          ? descriptor.aliases.map((alias) => [alias, descriptor.command])
+          : [])
+      .sort((left, right) => String(left[0] || "").localeCompare(String(right[0] || "")))
+  )
+);
+
+const COMMAND_IDS = Object.freeze(Object.keys(COMMAND_DESCRIPTORS));
+const KNOWN_COMMANDS = new Set(COMMAND_IDS);
 
 function resolveCommandAlias(rawCommand) {
   const command = String(rawCommand || "").trim();
   if (!command) {
     return "";
   }
-  return COMMAND_ALIASES[command] || command;
+  return COMMAND_ALIAS_TO_ID[command] || command;
+}
+
+function resolveCommandDescriptor(rawCommand) {
+  const command = resolveCommandAlias(rawCommand);
+  if (!command) {
+    return null;
+  }
+  return COMMAND_DESCRIPTORS[command] || null;
 }
 
 function isKnownCommandName(rawCommand) {
-  const command = resolveCommandAlias(rawCommand);
-  if (!command) {
+  const descriptor = resolveCommandDescriptor(rawCommand);
+  return Boolean(descriptor && KNOWN_COMMANDS.has(descriptor.command));
+}
+
+function listOverviewCommandDescriptors() {
+  return Object.values(COMMAND_DESCRIPTORS)
+    .filter((descriptor) => descriptor.showInOverview !== false)
+    .sort((left, right) => left.command.localeCompare(right.command));
+}
+
+function shouldShowCommandHelpOnBareInvocation(command = "", positional = []) {
+  const descriptor = resolveCommandDescriptor(command);
+  if (!descriptor || descriptor.showHelpOnBareInvocation !== true) {
     return false;
   }
-  return KNOWN_COMMANDS.has(command);
+  const argumentList = Array.isArray(positional) ? positional : [];
+  return argumentList.length < 1;
+}
+
+function sortOptionLabels(labels = []) {
+  return [...new Set((Array.isArray(labels) ? labels : []).filter(Boolean))]
+    .sort((left, right) => left.localeCompare(right));
+}
+
+function validateCommandOptions(
+  { command = "", positional = [], options = {} } = {},
+  { createCliError, renderUsage = null } = {}
+) {
+  if (typeof createCliError !== "function") {
+    throw new TypeError("validateCommandOptions requires createCliError.");
+  }
+
+  const descriptor = resolveCommandDescriptor(command);
+  if (!descriptor) {
+    return;
+  }
+
+  const allowedFlagKeys = new Set(Array.isArray(descriptor.allowedFlagKeys) ? descriptor.allowedFlagKeys : []);
+  const unsupportedOptionLabels = [];
+  for (const flagKey of PARSED_BOOLEAN_OPTION_KEYS) {
+    if (options?.[flagKey] !== true) {
+      continue;
+    }
+    if (!allowedFlagKeys.has(flagKey)) {
+      unsupportedOptionLabels.push(OPTION_FLAG_LABELS[flagKey]);
+    }
+  }
+
+  const inlineOptions = options && typeof options === "object" ? options.inlineOptions : null;
+  const inlineOptionNames = Object.keys(inlineOptions && typeof inlineOptions === "object" ? inlineOptions : {});
+  const inlineOptionMode = String(descriptor.inlineOptionMode || "none").trim().toLowerCase() || "none";
+  if (inlineOptionMode === "none") {
+    for (const optionName of inlineOptionNames) {
+      unsupportedOptionLabels.push(`--${optionName}`);
+    }
+  } else if (inlineOptionMode === "enumerated") {
+    const allowedValueOptionNames = new Set(
+      Array.isArray(descriptor.allowedValueOptionNames) ? descriptor.allowedValueOptionNames : []
+    );
+    for (const optionName of inlineOptionNames) {
+      if (!allowedValueOptionNames.has(optionName)) {
+        unsupportedOptionLabels.push(`--${optionName}`);
+      }
+    }
+  } else if (
+    inlineOptionMode === "delegate" &&
+    inlineOptionNames.length > 0 &&
+    typeof descriptor.canDelegateInlineOptions === "function" &&
+    descriptor.canDelegateInlineOptions(positional) !== true
+  ) {
+    for (const optionName of inlineOptionNames) {
+      unsupportedOptionLabels.push(`--${optionName}`);
+    }
+  }
+
+  const normalizedUnsupportedLabels = sortOptionLabels(unsupportedOptionLabels);
+  if (normalizedUnsupportedLabels.length < 1) {
+    return;
+  }
+
+  throw createCliError(
+    `Unknown option${normalizedUnsupportedLabels.length === 1 ? "" : "s"} for command ${descriptor.command}: ${normalizedUnsupportedLabels.join(", ")}.`,
+    {
+      renderUsage: typeof renderUsage === "function" ? renderUsage : null
+    }
+  );
 }
 
 export {
-  KNOWN_COMMAND_IDS,
+  COMMAND_IDS,
+  OPTION_FLAG_LABELS,
   resolveCommandAlias,
-  isKnownCommandName
+  resolveCommandDescriptor,
+  isKnownCommandName,
+  listOverviewCommandDescriptors,
+  shouldShowCommandHelpOnBareInvocation,
+  validateCommandOptions
 };

--- a/tooling/jskit-cli/src/server/core/createCliRunner.js
+++ b/tooling/jskit-cli/src/server/core/createCliRunner.js
@@ -15,6 +15,10 @@ import {
 import { createCommandHandlers } from "./createCommandHandlers.js";
 import { parseArgs } from "./argParser.js";
 import { printUsage, shouldShowCommandHelpOnBareInvocation } from "./usageHelp.js";
+import {
+  resolveCommandDescriptor,
+  validateCommandOptions
+} from "./commandCatalog.js";
 import { createCommandHandlerDeps } from "./buildCommandDeps.js";
 import { createRunCli } from "./dispatchCli.js";
 import {
@@ -148,6 +152,8 @@ const runCli = createRunCli({
   parseArgs,
   printUsage,
   shouldShowCommandHelpOnBareInvocation,
+  validateCommandOptions,
+  resolveCommandDescriptor,
   commandHandlers,
   cleanupMaterializedPackageRoots,
   createCliError

--- a/tooling/jskit-cli/src/server/core/dispatchCli.js
+++ b/tooling/jskit-cli/src/server/core/dispatchCli.js
@@ -2,6 +2,8 @@ function createRunCli({
   parseArgs,
   printUsage,
   shouldShowCommandHelpOnBareInvocation,
+  validateCommandOptions,
+  resolveCommandDescriptor,
   commandHandlers,
   cleanupMaterializedPackageRoots,
   createCliError
@@ -14,6 +16,12 @@ function createRunCli({
   }
   if (typeof shouldShowCommandHelpOnBareInvocation !== "function") {
     throw new TypeError("createRunCli requires shouldShowCommandHelpOnBareInvocation.");
+  }
+  if (typeof validateCommandOptions !== "function") {
+    throw new TypeError("createRunCli requires validateCommandOptions.");
+  }
+  if (typeof resolveCommandDescriptor !== "function") {
+    throw new TypeError("createRunCli requires resolveCommandDescriptor.");
   }
   if (!commandHandlers || typeof commandHandlers !== "object") {
     throw new TypeError("createRunCli requires commandHandlers.");
@@ -33,6 +41,16 @@ function createRunCli({
 
     try {
       const { command, options, positional } = parseArgs(argv, { createCliError });
+      validateCommandOptions(
+        { command, positional, options },
+        {
+          createCliError,
+          renderUsage: () => {
+            const helpCommand = command === "help" ? String(positional[0] || "").trim() : command;
+            printUsage(stderr, { command: helpCommand });
+          }
+        }
+      );
       if (options.help || command === "help") {
         const helpCommand = command === "help" ? String(positional[0] || "").trim() : command;
         printUsage(stdout, { command: helpCommand });
@@ -44,79 +62,21 @@ function createRunCli({
         return 0;
       }
 
-      if (command === "create") {
-        return await commandHandlers.commandCreate({
+      const commandDescriptor = resolveCommandDescriptor(command);
+      const handlerName = String(commandDescriptor?.handlerName || "").trim();
+      if (handlerName) {
+        const commandHandler = commandHandlers[handlerName];
+        if (typeof commandHandler !== "function") {
+          throw createCliError(`Unhandled command: ${command}`, { showUsage: true });
+        }
+        return await commandHandler({
           positional,
           options,
           cwd,
+          stdout,
+          stderr,
           io: { stdin, stdout, stderr }
         });
-      }
-      if (command === "list") {
-        return await commandHandlers.commandList({ positional, options, cwd, stdout });
-      }
-      if (command === "list-placements") {
-        return await commandHandlers.commandListPlacements({ options, cwd, stdout });
-      }
-      if (command === "list-link-items") {
-        return await commandHandlers.commandListLinkItems({ options, cwd, stdout });
-      }
-      if (command === "show") {
-        return await commandHandlers.commandShow({ positional, options, stdout });
-      }
-      if (command === "migrations") {
-        return await commandHandlers.commandMigrations({
-          positional,
-          options,
-          cwd,
-          io: { stdin, stdout, stderr }
-        });
-      }
-      if (command === "add") {
-        return await commandHandlers.commandAdd({
-          positional,
-          options,
-          cwd,
-          io: { stdin, stdout, stderr }
-        });
-      }
-      if (command === "generate") {
-        return await commandHandlers.commandGenerate({
-          positional,
-          options,
-          cwd,
-          io: { stdin, stdout, stderr }
-        });
-      }
-      if (command === "position") {
-        return await commandHandlers.commandPosition({
-          positional,
-          options,
-          cwd,
-          io: { stdin, stdout, stderr }
-        });
-      }
-      if (command === "update") {
-        return await commandHandlers.commandUpdate({
-          positional,
-          options,
-          cwd,
-          io: { stdin, stdout, stderr }
-        });
-      }
-      if (command === "remove") {
-        return await commandHandlers.commandRemove({
-          positional,
-          options,
-          cwd,
-          io: { stdin, stdout, stderr }
-        });
-      }
-      if (command === "doctor") {
-        return await commandHandlers.commandDoctor({ cwd, options, stdout });
-      }
-      if (command === "lint-descriptors") {
-        return await commandHandlers.commandLintDescriptors({ options, stdout });
       }
 
       throw createCliError(`Unhandled command: ${command}`, { showUsage: true });

--- a/tooling/jskit-cli/src/server/core/usageHelp.js
+++ b/tooling/jskit-cli/src/server/core/usageHelp.js
@@ -1,322 +1,12 @@
-import { resolveCommandAlias } from "./commandCatalog.js";
+import {
+  listOverviewCommandDescriptors,
+  resolveCommandDescriptor,
+  shouldShowCommandHelpOnBareInvocation
+} from "./commandCatalog.js";
 import {
   createColorFormatter,
   writeWrappedLines
 } from "../shared/outputFormatting.js";
-
-const COMMAND_OVERVIEW = Object.freeze([
-  Object.freeze({
-    command: "create",
-    summary: "Scaffold an app-local runtime package."
-  }),
-  Object.freeze({
-    command: "add",
-    summary: "Install a runtime bundle or package into the current app."
-  }),
-  Object.freeze({
-    command: "generate",
-    summary: "Run a generator package (or generator subcommand)."
-  }),
-  Object.freeze({
-    command: "list",
-    summary: "List bundles, runtime packages, or generator packages."
-  }),
-  Object.freeze({
-    command: "list-placements",
-    summary: "List discovered UI placement targets."
-  }),
-  Object.freeze({
-    command: "list-link-items",
-    summary: "List available placement link-item component tokens."
-  }),
-  Object.freeze({
-    command: "show",
-    summary: "Show detailed metadata for a bundle or package."
-  }),
-  Object.freeze({
-    command: "migrations",
-    summary: "Generate managed migration files only."
-  }),
-  Object.freeze({
-    command: "position",
-    summary: "Re-apply positioning-only mutations for an installed package."
-  }),
-  Object.freeze({
-    command: "update",
-    summary: "Re-apply one installed package."
-  }),
-  Object.freeze({
-    command: "remove",
-    summary: "Remove one installed package."
-  }),
-  Object.freeze({
-    command: "doctor",
-    summary: "Validate lockfile and managed-file integrity."
-  }),
-  Object.freeze({
-    command: "lint-descriptors",
-    summary: "Validate bundle and package descriptor contracts."
-  })
-]);
-
-const COMMAND_HELP = Object.freeze({
-  create: Object.freeze({
-    title: "create",
-    minimalUse: "jskit create package <name>",
-    parameters: Object.freeze([
-      Object.freeze({
-        name: "<name>",
-        description: "Local package slug used to scaffold packages/<name>."
-      })
-    ]),
-    defaults: Object.freeze([
-      "No npm install runs unless --run-npm-install is passed.",
-      "If --scope is omitted, scope is inferred from app name.",
-      "If --package-id is omitted, it is derived from scope + name."
-    ]),
-    fullUse: "jskit create package <name> [--scope <scope>] [--package-id <id>] [--description <text>] [--dry-run] [--run-npm-install] [--json]"
-  }),
-  add: Object.freeze({
-    title: "add",
-    minimalUse: "jskit add package <packageId>",
-    parameters: Object.freeze([
-      Object.freeze({
-        name: "package | bundle",
-        description: "Target type. Use package for one runtime package, bundle for a bundle id."
-      }),
-      Object.freeze({
-        name: "<packageId|bundleId>",
-        description: "Catalog id or installed node_modules package id."
-      })
-    ]),
-    defaults: Object.freeze([
-      "No npm install runs unless --run-npm-install is passed.",
-      "Short ids resolve to @jskit-ai/<id> when available.",
-      "Running without args lists bundles and runtime packages.",
-      "Existing matching version is skipped unless options force reapply."
-    ]),
-    fullUse: "jskit add <package|bundle> <id> [--<option> <value>...] [--dry-run] [--run-npm-install] [--json] [--verbose]"
-  }),
-  generate: Object.freeze({
-    title: "generate",
-    minimalUse: "jskit generate <generatorId>",
-    parameters: Object.freeze([
-      Object.freeze({
-        name: "<generatorId>",
-        description: "Generator package id (for example: crud-ui-generator)."
-      }),
-      Object.freeze({
-        name: "[subcommand]",
-        description: "Optional generator subcommand (for example: scaffold or scaffold-field)."
-      }),
-      Object.freeze({
-        name: "[subcommand args...]",
-        description: "Optional positional args consumed by the chosen subcommand."
-      })
-    ]),
-    defaults: Object.freeze([
-      "No npm install runs unless --run-npm-install is passed.",
-      "Short ids resolve to @jskit-ai/<id> when available.",
-      "Running without args lists available generators.",
-      "Running with only <generatorId> shows generator help.",
-      "Use jskit generate <generatorId> <subcommand> help for subcommand-specific usage."
-    ]),
-    examples: Object.freeze([
-      Object.freeze({
-        label: "Common usage",
-        lines: Object.freeze([
-          "npx jskit generate ui-generator page \\",
-          "  admin/reports/index.vue"
-        ])
-      }),
-      Object.freeze({
-        label: "More advanced usage",
-        lines: Object.freeze([
-          "npx jskit generate crud-ui-generator crud \\",
-          "  admin/catalog/index/products \\",
-          "  --resource-file packages/products/src/shared/productResource.js"
-        ])
-      })
-    ]),
-    fullUse: "jskit generate <generatorId> [subcommand] [subcommand args...] [--<option> <value>...] [--dry-run] [--run-npm-install] [--json] [--verbose]"
-  }),
-  list: Object.freeze({
-    title: "list",
-    minimalUse: "jskit list",
-    parameters: Object.freeze([
-      Object.freeze({
-        name: "[mode]",
-        description: "Optional mode: bundles, packages, or generators."
-      })
-    ]),
-    defaults: Object.freeze([
-      "Without mode, list prints bundles + runtime packages + generators.",
-      "placements are listed by the dedicated list-placements command.",
-      "--full and --expanded only affect bundle/package listing views."
-    ]),
-    fullUse: "jskit list [bundles|packages|generators] [--full] [--expanded] [--json]"
-  }),
-  "list-placements": Object.freeze({
-    title: "list-placements",
-    minimalUse: "jskit list-placements",
-    parameters: Object.freeze([]),
-    defaults: Object.freeze([
-      "Discovers placement outlets from app Vue ShellOutlet tags and route meta.",
-      "Includes placement outlets contributed by installed package metadata.",
-      "Shows plain text by default; use --json for structured output."
-    ]),
-    fullUse: "jskit list-placements [--json]"
-  }),
-  "list-link-items": Object.freeze({
-    title: "list-link-items",
-    minimalUse: "jskit list-link-items",
-    parameters: Object.freeze([
-      Object.freeze({
-        name: "[--prefix <value>]",
-        description: "Optional token prefix filter (example: local.main. or users.web.shell.)."
-      }),
-      Object.freeze({
-        name: "[--all]",
-        description: "Include all discovered tokens (including non-link-item and client container/runtime tokens)."
-      })
-    ]),
-    defaults: Object.freeze([
-      "Default output shows link-item tokens only (token names ending with link-item).",
-      "Default includes app and installed-package placement-linked token sources.",
-      "Use --prefix to narrow quickly (recommended: --prefix local.main.).",
-      "Use --all when you want the full discovered token set.",
-      "Shows plain text by default; use --json for structured output."
-    ]),
-    fullUse: "jskit list-link-items [--prefix <value>] [--all] [--json]"
-  }),
-  show: Object.freeze({
-    title: "show",
-    minimalUse: "jskit show <id>",
-    parameters: Object.freeze([
-      Object.freeze({
-        name: "<id>",
-        description: "Bundle id or package id to inspect."
-      })
-    ]),
-    defaults: Object.freeze([
-      "view is an alias of show.",
-      "Basic output is compact; --details expands capability and runtime sections.",
-      "--debug-exports implies --details."
-    ]),
-    fullUse: "jskit show <id> [--details] [--debug-exports] [--json]"
-  }),
-  migrations: Object.freeze({
-    title: "migrations",
-    minimalUse: "jskit migrations changed",
-    parameters: Object.freeze([
-      Object.freeze({
-        name: "<scope>",
-        description: "all | changed | package."
-      }),
-      Object.freeze({
-        name: "[packageId]",
-        description: "Required only when scope is package."
-      })
-    ]),
-    defaults: Object.freeze([
-      "No npm install runs unless --run-npm-install is passed.",
-      "Inline options are accepted only for 'migrations package <packageId>'.",
-      "Without --json, output lists touched migration files."
-    ]),
-    fullUse: "jskit migrations <all|changed|package> [packageId] [--<option> <value>...] [--dry-run] [--json] [--verbose]"
-  }),
-  position: Object.freeze({
-    title: "position",
-    minimalUse: "jskit position element <packageId>",
-    parameters: Object.freeze([
-      Object.freeze({
-        name: "element",
-        description: "Target type for positioning command."
-      }),
-      Object.freeze({
-        name: "<packageId>",
-        description: "Installed package id to re-position."
-      })
-    ]),
-    defaults: Object.freeze([
-      "Only positioning mutations are applied.",
-      "No npm install runs unless --run-npm-install is passed.",
-      "Reads current options from lock unless overridden inline."
-    ]),
-    fullUse: "jskit position element <packageId> [--<option> <value>...] [--dry-run] [--json]"
-  }),
-  update: Object.freeze({
-    title: "update",
-    minimalUse: "jskit update package <packageId>",
-    parameters: Object.freeze([
-      Object.freeze({
-        name: "package",
-        description: "Target type for update command."
-      }),
-      Object.freeze({
-        name: "<packageId>",
-        description: "Installed package id to re-apply."
-      })
-    ]),
-    defaults: Object.freeze([
-      "No npm install runs unless --run-npm-install is passed.",
-      "Existing lock options are reused unless overridden inline.",
-      "update reuses add package flow with forced reapply."
-    ]),
-    fullUse: "jskit update package <packageId> [--<option> <value>...] [--dry-run] [--run-npm-install] [--json]"
-  }),
-  remove: Object.freeze({
-    title: "remove",
-    minimalUse: "jskit remove package <packageId>",
-    parameters: Object.freeze([
-      Object.freeze({
-        name: "package",
-        description: "Target type for remove command."
-      }),
-      Object.freeze({
-        name: "<packageId>",
-        description: "Installed package id to remove."
-      })
-    ]),
-    defaults: Object.freeze([
-      "No npm install runs unless --run-npm-install is passed.",
-      "Managed files and lock entries are removed for the package.",
-      "Local package source directories are not deleted."
-    ]),
-    fullUse: "jskit remove package <packageId> [--dry-run] [--run-npm-install] [--json]"
-  }),
-  doctor: Object.freeze({
-    title: "doctor",
-    minimalUse: "jskit doctor",
-    parameters: Object.freeze([]),
-    defaults: Object.freeze([
-      "Validates lock entries, managed files, and registry visibility.",
-      "Reports issues as plain text by default.",
-      "Use --json for machine-readable diagnostics."
-    ]),
-    fullUse: "jskit doctor [--json]"
-  }),
-  "lint-descriptors": Object.freeze({
-    title: "lint-descriptors",
-    minimalUse: "jskit lint-descriptors",
-    parameters: Object.freeze([]),
-    defaults: Object.freeze([
-      "Runs descriptor consistency checks.",
-      "check-di-labels is optional and adds stricter DI token label checks.",
-      "Outputs plain text by default and supports --json."
-    ]),
-    fullUse: "jskit lint-descriptors [--check-di-labels] [--json]"
-  })
-});
-
-const BARE_COMMAND_HELP = new Set([
-  "create",
-  "show",
-  "migrations",
-  "position",
-  "update",
-  "remove"
-]);
 
 function appendSeparatedBlocks(lines = [], blocks = []) {
   const normalizedBlocks = Array.isArray(blocks) ? blocks : [];
@@ -346,18 +36,14 @@ function printTopLevelHelp(stream = process.stderr) {
   lines.push("Use: jskit help <command> for command-specific usage.");
   lines.push("");
   lines.push(color.heading("Available commands:"));
-  for (const entry of COMMAND_OVERVIEW) {
+  for (const entry of listOverviewCommandDescriptors()) {
     lines.push(`  ${color.item(entry.command.padEnd(16, " "))} ${entry.summary}`);
   }
-  lines.push("");
-  lines.push(color.heading("Global flags:"));
-  lines.push("  --dry-run --run-npm-install --json --verbose --help");
   writeHelpLines(stream, lines);
 }
 
 function printCommandHelp(stream = process.stderr, command = "") {
-  const resolvedCommand = resolveCommandAlias(command);
-  const entry = COMMAND_HELP[resolvedCommand];
+  const entry = resolveCommandDescriptor(command);
   if (!entry) {
     printTopLevelHelp(stream);
     return;
@@ -365,7 +51,7 @@ function printCommandHelp(stream = process.stderr, command = "") {
 
   const color = createColorFormatter(stream);
   const lines = [];
-  lines.push(`Command: ${color.emphasis(entry.title)}`);
+  lines.push(`Command: ${color.emphasis(entry.command)}`);
   lines.push("");
 
   let sectionNumber = 1;
@@ -421,15 +107,6 @@ function printUsage(stream = process.stderr, { command = "" } = {}) {
   }
 
   printCommandHelp(stream, normalizedCommand);
-}
-
-function shouldShowCommandHelpOnBareInvocation(command = "", positional = []) {
-  const resolvedCommand = resolveCommandAlias(command);
-  const argumentList = Array.isArray(positional) ? positional : [];
-  if (!BARE_COMMAND_HELP.has(resolvedCommand)) {
-    return false;
-  }
-  return argumentList.length < 1;
 }
 
 export {

--- a/tooling/jskit-cli/test/coreCommandOptionValidation.test.js
+++ b/tooling/jskit-cli/test/coreCommandOptionValidation.test.js
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import test from "node:test";
+import { createCliRunner } from "../../testUtils/runCli.js";
+
+const CLI_PATH = fileURLToPath(new URL("../bin/jskit.js", import.meta.url));
+const runCli = createCliRunner(CLI_PATH);
+const CLI_ROOT = path.resolve(path.dirname(CLI_PATH), "..");
+
+test("list-placements rejects unsupported value options and prints command help", () => {
+  const result = runCli({
+    cwd: CLI_ROOT,
+    args: ["list-placements", "--prefix", "nope"]
+  });
+
+  assert.equal(result.status, 1);
+  const stderr = String(result.stderr || "");
+  assert.match(stderr, /Unknown option for command list-placements: --prefix\./);
+  assert.match(stderr, /Command: list-placements/);
+  assert.match(stderr, /jskit list-placements \[--json\]/);
+});
+
+test("show rejects unsupported flags and prints command help", () => {
+  const result = runCli({
+    cwd: CLI_ROOT,
+    args: ["show", "auth-web", "--all"]
+  });
+
+  assert.equal(result.status, 1);
+  const stderr = String(result.stderr || "");
+  assert.match(stderr, /Unknown option for command show: --all\./);
+  assert.match(stderr, /Command: show/);
+  assert.match(stderr, /jskit show <id> \[--details] \[--debug-exports] \[--json]/);
+});
+
+test("migrations rejects unsupported flags and prints command help", () => {
+  const result = runCli({
+    cwd: CLI_ROOT,
+    args: ["migrations", "changed", "--run-npm-install"]
+  });
+
+  assert.equal(result.status, 1);
+  const stderr = String(result.stderr || "");
+  assert.match(stderr, /Unknown option for command migrations: --run-npm-install\./);
+  assert.match(stderr, /Command: migrations/);
+  assert.match(stderr, /jskit migrations <all\|changed\|package> \[packageId] \[--<option> <value>\.\.\.] \[--dry-run] \[--json]/);
+  assert.match(stderr, /\[--verbose]/);
+});
+
+test("add rejects delegated inline options when no target contract is active", () => {
+  const result = runCli({
+    cwd: CLI_ROOT,
+    args: ["add", "--bogus", "value"]
+  });
+
+  assert.equal(result.status, 1);
+  const stderr = String(result.stderr || "");
+  assert.match(stderr, /Unknown option for command add: --bogus\./);
+  assert.match(stderr, /Command: add/);
+});
+
+test("generate rejects delegated inline options when no subcommand is active", () => {
+  const result = runCli({
+    cwd: CLI_ROOT,
+    args: ["generate", "ui-generator", "--force"]
+  });
+
+  assert.equal(result.status, 1);
+  const stderr = String(result.stderr || "");
+  assert.match(stderr, /Unknown option for command generate: --force\./);
+  assert.match(stderr, /Command: generate/);
+});


### PR DESCRIPTION
## Summary
- tighten UI generator page and outlet command contracts
- clean up assistant and UI page overwrite messaging
- centralize core CLI command help/validation metadata and improve command help output
- refresh package descriptors, catalog output, and docs for the updated generator model

## Verification
- npm run verify
