### PR TITLE
Report catalog template fetch status during add and generate

### DIFF
--- a/tooling/jskit-cli/src/server/cliRuntime/packageInstallFlow.js
+++ b/tooling/jskit-cli/src/server/cliRuntime/packageInstallFlow.js
@@ -275,7 +275,8 @@ async function applyPackageInstall({
   appPackageJson,
   lock,
   packageRegistry,
-  touchedFiles
+  touchedFiles,
+  reportTemplateFetchStatus = null
 }) {
   const existingInstall = ensureObject(lock.installedPackages[packageEntry.packageId]);
   const existingManaged = ensureObject(existingInstall.managed);
@@ -292,7 +293,11 @@ async function applyPackageInstall({
   const mutationWarnings = [];
   const mutations = ensureObject(packageEntry.descriptor.mutations);
   const fileMutations = ensureArray(mutations.files);
-  const templateRoot = await resolvePackageTemplateRoot({ packageEntry, appRoot });
+  const templateRoot = await resolvePackageTemplateRoot({
+    packageEntry,
+    appRoot,
+    reportTemplateFetchStatus
+  });
   const packageEntryForMutations =
     templateRoot === packageEntry.rootDir
       ? packageEntry

--- a/tooling/jskit-cli/src/server/cliRuntime/packageTemplateResolution.js
+++ b/tooling/jskit-cli/src/server/cliRuntime/packageTemplateResolution.js
@@ -68,7 +68,10 @@ async function ensureMaterializedInstallWorkspace(installRoot) {
   );
 }
 
-async function installCatalogPackageIntoCache({ installRoot, packageEntry }) {
+async function installCatalogPackageIntoCache({
+  installRoot,
+  packageEntry
+}) {
   const packageId = String(packageEntry?.packageId || "").trim();
   const version = String(packageEntry?.version || "").trim();
   const packageSpec = version ? `${packageId}@${version}` : packageId;
@@ -124,6 +127,7 @@ async function installCatalogPackageIntoCache({ installRoot, packageEntry }) {
 async function materializeCatalogPackageRoot({
   packageEntry,
   appRoot,
+  reportTemplateFetchStatus = null,
   installCatalogPackage = installCatalogPackageIntoCache
 } = {}) {
   if (!isInternalCatalogPackageEntry(packageEntry)) {
@@ -139,18 +143,33 @@ async function materializeCatalogPackageRoot({
   const installRoot = buildMaterializedInstallRoot({ appRoot, packageEntry });
   const candidateRoot = path.join(installRoot, "node_modules", ...packageId.split("/"));
   const descriptorPath = path.join(candidateRoot, "package.descriptor.mjs");
+  let didInstallPackage = false;
 
   if (!(await fileExists(descriptorPath))) {
+    if (typeof reportTemplateFetchStatus === "function") {
+      reportTemplateFetchStatus({
+        packageEntry,
+        state: "start"
+      });
+    }
     await installCatalogPackage({
       installRoot,
       packageEntry
     });
+    didInstallPackage = true;
   }
 
   if (!(await fileExists(descriptorPath))) {
     throw createCliError(
       `Unable to resolve template source for ${packageId} after materialization. Missing package.descriptor.mjs in cache.`
     );
+  }
+
+  if (didInstallPackage && typeof reportTemplateFetchStatus === "function") {
+    reportTemplateFetchStatus({
+      packageEntry,
+      state: "complete"
+    });
   }
 
   MATERIALIZED_PACKAGE_ROOTS.set(cacheKey, candidateRoot);
@@ -243,6 +262,7 @@ async function resolvePackageRootFromLocalWorkspace({ packageId }) {
 async function resolvePackageTemplateRoot({
   packageEntry,
   appRoot,
+  reportTemplateFetchStatus = null,
   materializeCatalogRoot = materializeCatalogPackageRoot
 } = {}) {
   const packageRoot = String(packageEntry?.rootDir || "").trim();
@@ -267,7 +287,8 @@ async function resolvePackageTemplateRoot({
 
   const materializedCatalogPackageRoot = await materializeCatalogRoot({
     packageEntry,
-    appRoot
+    appRoot,
+    reportTemplateFetchStatus
   });
   if (materializedCatalogPackageRoot) {
     return materializedCatalogPackageRoot;

--- a/tooling/jskit-cli/src/server/commandHandlers/packageCommands/add.js
+++ b/tooling/jskit-cli/src/server/commandHandlers/packageCommands/add.js
@@ -38,7 +38,8 @@ async function runPackageAddCommand(ctx = {}, { positional, options, cwd, io }) 
     adoptAppLocalPackageDependencies,
     writeJsonFile,
     runNpmInstall,
-    renderResolvedSummary
+    renderResolvedSummary,
+    createCatalogFetchStatusReporter = () => () => {}
   } = ctx;
 
   const invocationMode = options?.commandMode === "generate" ? "generate" : "add";
@@ -242,6 +243,9 @@ async function runPackageAddCommand(ctx = {}, { positional, options, cwd, io }) 
 
   const packagesToInstall = [];
   const resolvedOptionsByPackage = {};
+  const reportTemplateFetchStatus = createCatalogFetchStatusReporter(io, {
+    enabled: options.json !== true
+  });
   const forceReapplyTarget = options?.forceReapplyTarget === true;
   const hasInlineOptions = Object.keys(ensureObject(options.inlineOptions)).length > 0;
   for (const packageId of resolvedPackageIds) {
@@ -293,7 +297,8 @@ async function runPackageAddCommand(ctx = {}, { positional, options, cwd, io }) 
       appPackageJson: packageJson,
       lock,
       packageRegistry: combinedPackageRegistry,
-      touchedFiles
+      touchedFiles,
+      reportTemplateFetchStatus
     });
     installedPackageRecords.push(managedRecord);
   }

--- a/tooling/jskit-cli/src/server/commandHandlers/packageCommands/generate.js
+++ b/tooling/jskit-cli/src/server/commandHandlers/packageCommands/generate.js
@@ -230,7 +230,8 @@ async function runPackageGenerateCommand(
     hasGeneratorSubcommandDefinition,
     readdir,
     validateInlineOptionValuesForPackage,
-    runGeneratorSubcommand
+    runGeneratorSubcommand,
+    createCatalogFetchStatusReporter = () => () => {}
   } = ctx;
 
   const firstToken = String(positional[0] || "").trim();
@@ -244,6 +245,9 @@ async function runPackageGenerateCommand(
   const targetId = firstToken === "package" ? secondToken : firstToken;
   const subcommandName = firstToken === "package" ? thirdToken : secondToken;
   const subcommandArgs = firstToken === "package" ? positional.slice(3) : positional.slice(2);
+  const reportTemplateFetchStatus = createCatalogFetchStatusReporter(io, {
+    enabled: options.json !== true
+  });
 
   async function resolveGeneratorPackageEntry(packageIdInput = "") {
     const appRoot = await resolveAppRootFromCwd(cwd);
@@ -425,7 +429,8 @@ async function runPackageGenerateCommand(
 
     const templateRoot = await resolvePackageTemplateRoot({
       packageEntry,
-      appRoot
+      appRoot,
+      reportTemplateFetchStatus
     });
     const executablePackageEntry =
       templateRoot === packageEntry.rootDir

--- a/tooling/jskit-cli/src/server/commandHandlers/shared.js
+++ b/tooling/jskit-cli/src/server/commandHandlers/shared.js
@@ -39,6 +39,44 @@ function createCommandHandlerShared(ctx = {}) {
     return lines.join("\n");
   }
 
+  function createCatalogFetchStatusReporter(io = {}, { enabled = true } = {}) {
+    if (enabled !== true) {
+      return () => {};
+    }
+
+    const stdout = io?.stdout;
+    if (!stdout || typeof stdout.write !== "function") {
+      return () => {};
+    }
+
+    const activeFetchLabels = new Set();
+    return ({ packageEntry, state } = {}) => {
+      const packageId = String(packageEntry?.packageId || "").trim();
+      const version = String(packageEntry?.version || "").trim();
+      const packageLabel = version ? `${packageId}@${version}` : packageId;
+      if (!packageLabel) {
+        return;
+      }
+
+      if (state === "start") {
+        if (activeFetchLabels.has(packageLabel)) {
+          return;
+        }
+        activeFetchLabels.add(packageLabel);
+        stdout.write(`Fetching ${packageLabel}...\n`);
+        return;
+      }
+
+      if (state === "complete") {
+        if (!activeFetchLabels.has(packageLabel)) {
+          return;
+        }
+        activeFetchLabels.delete(packageLabel);
+        stdout.write(`Fetching ${packageLabel}... done!\n`);
+      }
+    };
+  }
+
   async function runNpmInstall(appRoot, stderr) {
     await new Promise((resolve, reject) => {
       const child = spawn("npm", ["install"], {
@@ -298,6 +336,7 @@ function createCommandHandlerShared(ctx = {}) {
 
   return {
     renderResolvedSummary,
+    createCatalogFetchStatusReporter,
     runNpmInstall,
     getInstalledDependents,
     resolvePackageKind,

--- a/tooling/jskit-cli/test/addPackageFetchStatus.test.js
+++ b/tooling/jskit-cli/test/addPackageFetchStatus.test.js
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { runPackageAddCommand } from "../src/server/commandHandlers/packageCommands/add.js";
+import { createCommandHandlerShared } from "../src/server/commandHandlers/shared.js";
+
+test("add package reports fetching status when template source is materialized", async () => {
+  const packageEntry = {
+    packageId: "@jskit-ai/demo-package",
+    version: "1.2.3",
+    descriptor: {
+      kind: "runtime",
+      options: {},
+      mutations: {}
+    }
+  };
+  const packageRegistry = new Map([[packageEntry.packageId, packageEntry]]);
+  let stdout = "";
+  const { createCatalogFetchStatusReporter } = createCommandHandlerShared({});
+
+  const exitCode = await runPackageAddCommand(
+    {
+      createCliError(message) {
+        return new Error(String(message || ""));
+      },
+      normalizeRelativePath: (_appRoot, targetPath) => String(targetPath || ""),
+      resolveAppRootFromCwd: async (cwd) => cwd,
+      loadPackageRegistry: async () => packageRegistry,
+      loadAppLocalPackageRegistry: async () => new Map(),
+      loadBundleRegistry: async () => new Map(),
+      mergePackageRegistries: (...registries) => {
+        const merged = new Map();
+        for (const registry of registries) {
+          for (const [packageId, entry] of registry.entries()) {
+            merged.set(packageId, entry);
+          }
+        }
+        return merged;
+      },
+      loadAppPackageJson: async () => ({
+        packageJsonPath: "/tmp/demo-app/package.json",
+        packageJson: {}
+      }),
+      loadLockFile: async () => ({
+        lockPath: "/tmp/demo-app/.jskit/lock.json",
+        lock: {
+          installedPackages: {}
+        }
+      }),
+      resolvePackageIdFromRegistryOrNodeModules: async ({ packageIdInput }) => packageIdInput,
+      hydratePackageRegistryFromInstalledNodeModules: async () => {},
+      resolvePackageKind: () => "runtime",
+      validateInlineOptionsForPackage: () => {},
+      resolveLocalDependencyOrder: (packageIds) => ({
+        ordered: packageIds,
+        externalDependencies: []
+      }),
+      validatePlannedCapabilityClosure: () => {},
+      validateInlineOptionsForBundle: () => {},
+      resolveBundleInlineOptionsForPackage: () => ({}),
+      resolvePackageOptions: async () => ({}),
+      applyPackageInstall: async ({ packageEntry, reportTemplateFetchStatus, touchedFiles }) => {
+        assert.equal(typeof reportTemplateFetchStatus, "function");
+        reportTemplateFetchStatus({
+          packageEntry,
+          state: "start"
+        });
+        reportTemplateFetchStatus({
+          packageEntry,
+          state: "complete"
+        });
+        touchedFiles.add("package.json");
+        return {};
+      },
+      adoptAppLocalPackageDependencies: async () => ({
+        appLocalRegistry: new Map(),
+        adoptedPackageIds: []
+      }),
+      writeJsonFile: async () => {},
+      runNpmInstall: async () => {},
+      renderResolvedSummary: () => "Added package demo.",
+      createCatalogFetchStatusReporter
+    },
+    {
+      positional: ["package", "@jskit-ai/demo-package"],
+      options: {
+        inlineOptions: {},
+        dryRun: false,
+        json: false
+      },
+      cwd: "/tmp/demo-app",
+      io: {
+        stdout: {
+          write(value) {
+            stdout += String(value || "");
+          }
+        },
+        stderr: { write() {} }
+      }
+    }
+  );
+
+  assert.equal(exitCode, 0);
+  assert.match(stdout, /Fetching @jskit-ai\/demo-package@1\.2\.3\.\.\./);
+  assert.match(stdout, /Fetching @jskit-ai\/demo-package@1\.2\.3\.\.\. done!/);
+});

--- a/tooling/jskit-cli/test/generatePackageTemplateResolution.test.js
+++ b/tooling/jskit-cli/test/generatePackageTemplateResolution.test.js
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { runPackageGenerateCommand } from "../src/server/commandHandlers/packageCommands/generate.js";
+import { createCommandHandlerShared } from "../src/server/commandHandlers/shared.js";
 
 test("generate subcommands resolve package template root before invoking generator entrypoint", async () => {
   const packageEntry = {
@@ -19,6 +20,8 @@ test("generate subcommands resolve package template root before invoking generat
   };
   const packageRegistry = new Map([[packageEntry.packageId, packageEntry]]);
   const runCalls = [];
+  let stdout = "";
+  const { createCatalogFetchStatusReporter } = createCommandHandlerShared({});
 
   const exitCode = await runPackageGenerateCommand(
     {
@@ -39,11 +42,22 @@ test("generate subcommands resolve package template root before invoking generat
       },
       resolvePackageIdFromRegistryOrNodeModules: async ({ packageIdInput }) => packageIdInput,
       hydratePackageRegistryFromInstalledNodeModules: async () => {},
-      resolvePackageTemplateRoot: async () => "/tmp/materialized-generator",
+      resolvePackageTemplateRoot: async ({ packageEntry, reportTemplateFetchStatus }) => {
+        reportTemplateFetchStatus({
+          packageEntry,
+          state: "start"
+        });
+        reportTemplateFetchStatus({
+          packageEntry,
+          state: "complete"
+        });
+        return "/tmp/materialized-generator";
+      },
       resolvePackageKind: () => "generator",
       resolveGeneratorPrimarySubcommand: () => "",
       hasGeneratorSubcommandDefinition: () => true,
       validateInlineOptionValuesForPackage: async () => {},
+      createCatalogFetchStatusReporter,
       runGeneratorSubcommand: async (payload) => {
         runCalls.push(payload);
         return 0;
@@ -58,7 +72,7 @@ test("generate subcommands resolve package template root before invoking generat
       },
       cwd: "/tmp/demo-app",
       io: {
-        stdout: { write() {} },
+        stdout: { write(value) { stdout += String(value || ""); } },
         stderr: { write() {} }
       }
     },
@@ -72,4 +86,6 @@ test("generate subcommands resolve package template root before invoking generat
   assert.equal(exitCode, 0);
   assert.equal(runCalls.length, 1);
   assert.equal(runCalls[0].packageEntry.rootDir, "/tmp/materialized-generator");
+  assert.match(stdout, /Fetching @jskit-ai\/demo-generator\.\.\./);
+  assert.match(stdout, /Fetching @jskit-ai\/demo-generator\.\.\. done!/);
 });

--- a/tooling/jskit-cli/test/packageTemplateResolution.test.js
+++ b/tooling/jskit-cli/test/packageTemplateResolution.test.js
@@ -68,6 +68,7 @@ test("resolvePackageTemplateRoot keeps failing for non-internal catalog packages
 test("materializeCatalogPackageRoot reuses cached package roots after first materialization", async () => {
   await withTempDir(async (appRoot) => {
     const calls = [];
+    const events = [];
     const expectedRoot = path.join(
       appRoot,
       ".jskit",
@@ -86,6 +87,13 @@ test("materializeCatalogPackageRoot reuses cached package roots after first mate
         packageId: "@jskit-ai/demo-package",
         version: "1.2.3",
         sourceType: "catalog"
+      },
+      reportTemplateFetchStatus: ({ packageEntry, state }) => {
+        events.push({
+          packageId: packageEntry.packageId,
+          version: packageEntry.version,
+          state
+        });
       },
       installCatalogPackage: async ({ installRoot }) => {
         calls.push(installRoot);
@@ -110,6 +118,13 @@ test("materializeCatalogPackageRoot reuses cached package roots after first mate
         version: "1.2.3",
         sourceType: "catalog"
       },
+      reportTemplateFetchStatus: ({ packageEntry, state }) => {
+        events.push({
+          packageId: packageEntry.packageId,
+          version: packageEntry.version,
+          state
+        });
+      },
       installCatalogPackage: async () => {
         calls.push("unexpected");
       }
@@ -118,5 +133,54 @@ test("materializeCatalogPackageRoot reuses cached package roots after first mate
     assert.equal(first, expectedRoot);
     assert.equal(second, expectedRoot);
     assert.equal(calls.length, 1);
+    assert.deepEqual(events, [
+      {
+        packageId: "@jskit-ai/demo-package",
+        version: "1.2.3",
+        state: "start"
+      },
+      {
+        packageId: "@jskit-ai/demo-package",
+        version: "1.2.3",
+        state: "complete"
+      }
+    ]);
+  });
+});
+
+test("materializeCatalogPackageRoot does not emit complete when install fails", async () => {
+  await withTempDir(async (appRoot) => {
+    const events = [];
+
+    await assert.rejects(
+      () =>
+        materializeCatalogPackageRoot({
+          appRoot,
+          packageEntry: {
+            packageId: "@jskit-ai/demo-package",
+            version: "1.2.3",
+            sourceType: "catalog"
+          },
+          reportTemplateFetchStatus: ({ packageEntry, state }) => {
+            events.push({
+              packageId: packageEntry.packageId,
+              version: packageEntry.version,
+              state
+            });
+          },
+          installCatalogPackage: async () => {
+            throw new Error("install failed");
+          }
+        }),
+      /install failed/
+    );
+
+    assert.deepEqual(events, [
+      {
+        packageId: "@jskit-ai/demo-package",
+        version: "1.2.3",
+        state: "start"
+      }
+    ]);
   });
 });


### PR DESCRIPTION
## Summary\n- report when a catalog package template is fetched during add/generate flows\n- keep fetch lifecycle ownership inside template materialization\n- cover the new reporter and failure path with jskit-cli tests\n\n## Verification\n- npm run verify