### PR TITLE
Bump jskit-cli to 0.2.41

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6630,7 +6630,7 @@
     },
     "tooling/jskit-cli": {
       "name": "@jskit-ai/jskit-cli",
-      "version": "0.2.40",
+      "version": "0.2.41",
       "dependencies": {
         "@jskit-ai/jskit-catalog": "0.1.40",
         "@jskit-ai/kernel": "0.1.32"

--- a/tooling/jskit-cli/package.json
+++ b/tooling/jskit-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-cli",
-  "version": "0.2.40",
+  "version": "0.2.41",
   "description": "Bundle and package orchestration CLI for JSKIT apps.",
   "type": "module",
   "files": [


### PR DESCRIPTION
## Summary
- bump @jskit-ai/jskit-cli to 0.2.41 in the workspace package
- refresh the root package-lock entry for the new CLI version
