### PR TITLE
Normalize visibility user and workspace ids

### DIFF
--- a/agent-index/packages/assistant.md
+++ b/agent-index/packages/assistant.md
@@ -24,7 +24,7 @@ Exports
 - `renderAssistantPageSource(templateSource = "", surfaceId = "")`
 - `resolveAssistantPageGenerationContext({ appRoot, targetFile = "", options = {}, context = "assistant page" } = {})`
 - `renderAssistantPageLinkPlacementBlock({ marker = "", pageTarget = {}, generationContext = {} } = {})`
-- `renderAssistantPageSummary(pageTarget = {}, { pageAlreadyExisted = false, placementChanged = false } = {})`
+- `renderAssistantPageSummary(pageTarget = {}, { pageAlreadyExisted = false, pageOverwritten = false } = {})`
 Local functions
 - `resolveLinkToPropLine(linkTo = "")`
 - `resolveTemplateFilePath(relativePath = "")`
@@ -44,7 +44,7 @@ Exports
 - `rejectUnexpectedOptions(options = {}, allowedOptionNames = [], { context = "assistant" } = {})`
 - `resolvePathWithinApp(appRoot, targetPath, { context = "assistant" } = {})`
 - `appendBlockIfMarkerMissing(source = "", marker = "", block = "")`
-- `requireManagedOrEmptyPageSource(existingSource = "", expectedSource = "", targetRelativePath = "", { context = "assistant" } = {})`
+- `requireEmptyPageSource(existingSource = "", targetRelativePath = "", { context = "assistant", forceOverwrite = false } = {})`
 Local functions
 - `ensureTrailingNewline(value = "")`
 

--- a/agent-index/packages/users-core.md
+++ b/agent-index/packages/users-core.md
@@ -107,7 +107,7 @@ Exports
 Exports
 - `createWorkspaceRouteVisibilityResolver({ workspaceService } = {})`
 Local functions
-- `buildVisibilityContribution({ visibility, scopeOwnerId = 0, userOwnerId = null } = {})`
+- `buildVisibilityContribution({ visibility, scopeOwnerId = 0, userId = null } = {})`
 
 ### `src/server/common/formatters/accountAvatarFormatter.js`
 Exports

--- a/agent-index/tooling/jskit-cli.md
+++ b/agent-index/tooling/jskit-cli.md
@@ -163,7 +163,7 @@ Local functions
 ### `src/server/cliRuntime/packageInstallFlow.js`
 Exports
 - `adoptAppLocalPackageDependencies({ appRoot, appPackageJson, lock })`
-- `applyPackageInstall({ packageEntry, packageOptions, appRoot, appPackageJson, lock, packageRegistry, touchedFiles })`
+- `applyPackageInstall({ packageEntry, packageOptions, appRoot, appPackageJson, lock, packageRegistry, touchedFiles, reportTemplateFetchStatus = null })`
 - `applyPackageMigrationsOnly({ packageEntry, packageOptions, appRoot, lock, touchedFiles })`
 - `applyPackagePositioning({ packageEntry, packageOptions, appRoot, lock, touchedFiles })`
 Local functions
@@ -253,8 +253,8 @@ Local functions
 ### `src/server/cliRuntime/packageTemplateResolution.js`
 Exports
 - `cleanupMaterializedPackageRoots()`
-- `materializeCatalogPackageRoot({ packageEntry, appRoot, installCatalogPackage = installCatalogPackageIntoCache } = {})`
-- `resolvePackageTemplateRoot({ packageEntry, appRoot, materializeCatalogRoot = materializeCatalogPackageRoot } = {})`
+- `materializeCatalogPackageRoot({ packageEntry, appRoot, reportTemplateFetchStatus = null, installCatalogPackage = installCatalogPackageIntoCache } = {})`
+- `resolvePackageTemplateRoot({ packageEntry, appRoot, reportTemplateFetchStatus = null, materializeCatalogRoot = materializeCatalogPackageRoot } = {})`
 Local functions
 - `isInternalCatalogPackageEntry(packageEntry = {})`
 - `encodePackageCacheSegment(value = "")`
@@ -344,6 +344,9 @@ Local functions
 - `mapDescriptorBackedSubcommandArgsToInlineOptions(packageEntry = {}, subcommandName = "", subcommandArgs = [], inlineOptions = {}, createCliError)`
 - `resolveSubcommandRequiresInput(packageEntry = {}, subcommandName = "")`
 - `collectUnexpectedGeneratorSubcommandOptionNames(packageEntry = {}, subcommandName = "", inlineOptions = {})`
+- `resolveCreateTargetPolicy(packageEntry = {}, subcommandName = "")`
+- `normalizeRelativePathWithinApp(appRoot = "", targetPath = "", createCliError)`
+- `enforceDescriptorBackedCreateTargetPolicy({ packageEntry, subcommandName, inlineOptions = {}, appRoot = "", packageIdInput = "", createCliError, readdir } = {})`
 
 ### `src/server/commandHandlers/packageCommands/migrations.js`
 Exports
@@ -427,9 +430,21 @@ Exports
 
 ### `src/server/core/commandCatalog.js`
 Exports
-- `KNOWN_COMMAND_IDS`
+- `COMMAND_IDS`
+- `OPTION_FLAG_LABELS`
 - `resolveCommandAlias(rawCommand)`
+- `resolveCommandDescriptor(rawCommand)`
 - `isKnownCommandName(rawCommand)`
+- `listOverviewCommandDescriptors()`
+- `shouldShowCommandHelpOnBareInvocation(command = "", positional = [])`
+- `validateCommandOptions({ command = "", positional = [], options = {} } = {}, { createCliError, renderUsage = null } = {})`
+Local functions
+- `isHelpToken(value = "")`
+- `canDelegateAddInlineOptions(positional = [])`
+- `canDelegateGenerateInlineOptions(positional = [])`
+- `canDelegateMigrationsInlineOptions(positional = [])`
+- `canDelegatePackageTargetInlineOptions(positional = [], expectedTargetType = "")`
+- `sortOptionLabels(labels = [])`
 
 ### `src/server/core/createCliRunner.js`
 Exports
@@ -441,12 +456,12 @@ Exports
 
 ### `src/server/core/dispatchCli.js`
 Exports
-- `createRunCli({ parseArgs, printUsage, shouldShowCommandHelpOnBareInvocation, commandHandlers, cleanupMaterializedPackageRoots, createCliError } = {})`
+- `createRunCli({ parseArgs, printUsage, shouldShowCommandHelpOnBareInvocation, validateCommandOptions, resolveCommandDescriptor, commandHandlers, cleanupMaterializedPackageRoots, createCliError } = {})`
 
 ### `src/server/core/usageHelp.js`
 Exports
 - `printUsage(stream = process.stderr, { command = "" } = {})`
-- `shouldShowCommandHelpOnBareInvocation(command = "", positional = [])`
+- `shouldShowCommandHelpOnBareInvocation`
 Local functions
 - `appendSeparatedBlocks(lines = [], blocks = [])`
 - `writeHelpLines(stream, lines = [])`

--- a/install.txt
+++ b/install.txt
@@ -40,10 +40,7 @@ export __APP=swayatlas
 npm install --verbose
 npm run devlinks
 
-npx jskit add package auth-provider-supabase-core \
-  --auth-supabase-url https://glpphkajclpefydvepim.supabase.co \
-  --auth-supabase-publishable-key sb_publishable_CK1yeg-yCzy17z_isXOzPg_58K33KTb
-
+npx jskit add package auth-provider-supabase-core 
 npx jskit add package shell-web
 npx jskit add package auth-web
 npx jskit add package database-runtime-mysql

--- a/packages/auth-core/src/server/lib/routeVisibilityResolver.js
+++ b/packages/auth-core/src/server/lib/routeVisibilityResolver.js
@@ -9,13 +9,13 @@ function createAuthRouteVisibilityResolver() {
       }
 
       const actor = context?.actor || request?.user || null;
-      const userOwnerId = normalizeOpaqueId(actor?.id);
-      if (userOwnerId == null) {
+      const userId = normalizeOpaqueId(actor?.id);
+      if (userId == null) {
         return {};
       }
 
       return {
-        userOwnerId,
+        userId,
         requiresActorScope: true
       };
     }

--- a/packages/auth-core/test/routeVisibilityResolver.test.js
+++ b/packages/auth-core/test/routeVisibilityResolver.test.js
@@ -15,7 +15,7 @@ test("auth route visibility resolver contributes actor scope for core user visib
       }
     }),
     {
-      userOwnerId: "user_7",
+      userId: "user_7",
       requiresActorScope: true
     }
   );

--- a/packages/crud-core/src/server/lookupHydration.js
+++ b/packages/crud-core/src/server/lookupHydration.js
@@ -529,7 +529,7 @@ function resolveLookupVisibilityContext(
     nextVisibilityContext.scopeOwnerId = parentVisibilityContext.scopeOwnerId;
   }
   if (providerOwnershipFilter === "user" || providerOwnershipFilter === "workspace_user") {
-    nextVisibilityContext.userOwnerId = parentVisibilityContext.userOwnerId;
+    nextVisibilityContext.userId = parentVisibilityContext.userId;
   }
 
   return nextVisibilityContext;

--- a/packages/crud-core/test/createCrudRepositoryFromResource.test.js
+++ b/packages/crud-core/test/createCrudRepositoryFromResource.test.js
@@ -1232,7 +1232,7 @@ test("createCrudRepositoryFromResource remaps child lookup visibility for worksp
     visibilityContext: {
       visibility: "workspace_user",
       scopeOwnerId: "workspace-1",
-      userOwnerId: "user-1"
+      userId: "user-1"
     }
   });
 
@@ -1613,7 +1613,7 @@ test("createCrudRepositoryFromResource list hooks keep visibility and canonical 
   });
 
   assert.ok(calls.some((call) => call[0] === "where" && call[1] === "contact_id" && call[2] === ">" && call[3] === 2));
-  assert.ok(calls.some((call) => call[0] === "where" && call[1] === "workspace_owner_id" && call[2] === "workspace-1"));
+  assert.ok(calls.some((call) => call[0] === "where" && call[1] === "workspace_id" && call[2] === "workspace-1"));
   assert.ok(calls.some((call) => call[0] === "clearOrder"));
   assert.ok(calls.some((call) => call[0] === "clear" && call[1] === "limit"));
   assert.ok(calls.some((call) => call[0] === "orderBy" && call[1] === "contact_id" && call[2] === "asc"));
@@ -1643,7 +1643,7 @@ test("createCrudRepositoryFromResource findById hooks keep visibility and id pre
   });
 
   assert.ok(calls.some((call) => call[0] === "where" && call[1] === "contact_id" && call[2] === 999));
-  assert.ok(calls.some((call) => call[0] === "where" && call[1] === "workspace_owner_id" && call[2] === "workspace-1"));
+  assert.ok(calls.some((call) => call[0] === "where" && call[1] === "workspace_id" && call[2] === "workspace-1"));
   assert.ok(calls.some((call) => call[0] === "where" && call[1]?.contact_id === 7));
 });
 
@@ -1742,7 +1742,7 @@ test("createCrudRepositoryFromResource create hooks keep write-key filtering and
       return {
         ...payload,
         unexpectedField: "blocked",
-        workspaceOwnerId: "blocked"
+        workspaceId: "blocked"
       };
     },
     modifyQuery(_dbQuery, context = {}) {
@@ -1756,8 +1756,8 @@ test("createCrudRepositoryFromResource create hooks keep write-key filtering and
   assert.deepEqual(state.insertPayloads[0].first_name, "Tony");
   assert.equal(Object.hasOwn(state.insertPayloads[0], "unexpectedField"), false);
   assert.equal(Object.hasOwn(state.insertPayloads[0], "unexpectedFieldFromQuery"), false);
-  assert.equal(Object.hasOwn(state.insertPayloads[0], "workspaceOwnerId"), false);
-  assert.equal(state.insertPayloads[0].workspace_owner_id, "workspace-1");
+  assert.equal(Object.hasOwn(state.insertPayloads[0], "workspaceId"), false);
+  assert.equal(state.insertPayloads[0].workspace_id, "workspace-1");
   assert.ok(state.insertPayloads[0].created_at);
   assert.ok(state.insertPayloads[0].updated_at);
 });
@@ -1899,7 +1899,7 @@ test("createCrudRepositoryFromResource update hooks keep write-key filtering and
   assert.equal(Object.hasOwn(state.updatePayloads[0], "unexpectedFieldFromQuery"), false);
   assert.ok(state.updatePayloads[0].updated_at);
   assert.ok(calls.some((call) => call[0] === "where" && call[1] === "vip" && call[2] === 1));
-  assert.ok(calls.some((call) => call[0] === "where" && call[1] === "workspace_owner_id" && call[2] === "workspace-1"));
+  assert.ok(calls.some((call) => call[0] === "where" && call[1] === "workspace_id" && call[2] === "workspace-1"));
   assert.ok(calls.some((call) => call[0] === "where" && call[1]?.contact_id === 11));
 });
 

--- a/packages/crud-server-generator/src/server/buildTemplateContext.js
+++ b/packages/crud-server-generator/src/server/buildTemplateContext.js
@@ -61,8 +61,8 @@ function normalizeRequestedOwnershipFilter(value, { strict = false } = {}) {
 }
 
 function inferOwnershipFilterFromSnapshot(snapshot) {
-  const hasWorkspace = snapshot?.hasWorkspaceOwnerColumn === true;
-  const hasUser = snapshot?.hasUserOwnerColumn === true;
+  const hasWorkspace = snapshot?.hasWorkspaceIdColumn === true;
+  const hasUser = snapshot?.hasUserIdColumn === true;
   if (hasWorkspace && hasUser) {
     return "workspace_user";
   }
@@ -76,24 +76,24 @@ function inferOwnershipFilterFromSnapshot(snapshot) {
 }
 
 function assertOwnershipColumnsForFilter(snapshot, filter) {
-  const hasWorkspace = snapshot?.hasWorkspaceOwnerColumn === true;
-  const hasUser = snapshot?.hasUserOwnerColumn === true;
+  const hasWorkspace = snapshot?.hasWorkspaceIdColumn === true;
+  const hasUser = snapshot?.hasUserIdColumn === true;
   if (filter === "public") {
     return;
   }
   if (filter === "workspace" && !hasWorkspace) {
     throw new Error(
-      'Ownership filter "workspace" requires column "workspace_owner_id".'
+      'Ownership filter "workspace" requires column "workspace_id".'
     );
   }
   if (filter === "user" && !hasUser) {
     throw new Error(
-      'Ownership filter "user" requires column "user_owner_id".'
+      'Ownership filter "user" requires column "user_id".'
     );
   }
   if (filter === "workspace_user" && (!hasWorkspace || !hasUser)) {
     throw new Error(
-      'Ownership filter "workspace_user" requires both columns "workspace_owner_id" and "user_owner_id".'
+      'Ownership filter "workspace_user" requires both columns "workspace_id" and "user_id".'
     );
   }
 }
@@ -272,9 +272,9 @@ function resolveScaffoldColumns(snapshot) {
   const seenKeys = new Set();
 
   const columns = sourceColumns.map((column) => {
-    const isWorkspaceOwnerColumn = column.name === "workspace_owner_id";
-    const isUserOwnerColumn = column.name === "user_owner_id";
-    const isOwnerColumn = isWorkspaceOwnerColumn || isUserOwnerColumn;
+    const isWorkspaceIdColumn = column.name === "workspace_id";
+    const isUserIdColumn = column.name === "user_id";
+    const isOwnerColumn = isWorkspaceIdColumn || isUserIdColumn;
     const isIdColumn = column.name === idColumn;
     const isCreatedAtColumn = column.name === "created_at";
     const isUpdatedAtColumn = column.name === "updated_at";

--- a/packages/crud-server-generator/test/addFieldSubcommand.test.js
+++ b/packages/crud-server-generator/test/addFieldSubcommand.test.js
@@ -107,8 +107,8 @@ function createSnapshot() {
     idColumn: "id",
     columns: [
       { name: "id", key: "id", typeKind: "integer", nullable: false, unsigned: true },
-      { name: "workspace_owner_id", key: "workspaceOwnerId", typeKind: "integer", nullable: true, unsigned: true },
-      { name: "user_owner_id", key: "userOwnerId", typeKind: "integer", nullable: true, unsigned: true },
+      { name: "workspace_id", key: "workspaceId", typeKind: "integer", nullable: true, unsigned: true },
+      { name: "user_id", key: "userId", typeKind: "integer", nullable: true, unsigned: true },
       { name: "created_at", key: "createdAt", typeKind: "datetime", nullable: false },
       { name: "updated_at", key: "updatedAt", typeKind: "datetime", nullable: false },
       { name: "first_name", key: "firstName", typeKind: "string", nullable: true, maxLength: 160 },

--- a/packages/crud-server-generator/test/buildTemplateContext.test.js
+++ b/packages/crud-server-generator/test/buildTemplateContext.test.js
@@ -8,8 +8,8 @@ import { buildTemplateContext, __testables } from "../src/server/buildTemplateCo
 
 function createSnapshot({
   tableName = "contacts",
-  hasWorkspaceOwnerColumn = true,
-  hasUserOwnerColumn = true,
+  hasWorkspaceIdColumn = true,
+  hasUserIdColumn = true,
   hasCreatedAtColumn = true
 } = {}) {
   const createdAtColumn = hasCreatedAtColumn
@@ -37,8 +37,8 @@ function createSnapshot({
     tableName,
     idColumn: "id",
     primaryKeyColumns: Object.freeze(["id"]),
-    hasWorkspaceOwnerColumn,
-    hasUserOwnerColumn,
+    hasWorkspaceIdColumn,
+    hasUserIdColumn,
     columns: Object.freeze([
       Object.freeze({
         name: "id",
@@ -58,8 +58,8 @@ function createSnapshot({
         enumValues: Object.freeze([])
       }),
       Object.freeze({
-        name: "workspace_owner_id",
-        key: "workspaceOwnerId",
+        name: "workspace_id",
+        key: "workspaceId",
         dataType: "int",
         columnType: "int unsigned",
         typeKind: "integer",
@@ -75,8 +75,8 @@ function createSnapshot({
         enumValues: Object.freeze([])
       }),
       Object.freeze({
-        name: "user_owner_id",
-        key: "userOwnerId",
+        name: "user_id",
+        key: "userId",
         dataType: "int",
         columnType: "int unsigned",
         typeKind: "integer",
@@ -134,20 +134,20 @@ function createSnapshot({
 
 test("resolveOwnershipFilterForGeneration infers ownership filter for table introspection mode", () => {
   const snapshotBoth = createSnapshot({
-    hasWorkspaceOwnerColumn: true,
-    hasUserOwnerColumn: true
+    hasWorkspaceIdColumn: true,
+    hasUserIdColumn: true
   });
   const snapshotWorkspaceOnly = createSnapshot({
-    hasWorkspaceOwnerColumn: true,
-    hasUserOwnerColumn: false
+    hasWorkspaceIdColumn: true,
+    hasUserIdColumn: false
   });
   const snapshotUserOnly = createSnapshot({
-    hasWorkspaceOwnerColumn: false,
-    hasUserOwnerColumn: true
+    hasWorkspaceIdColumn: false,
+    hasUserIdColumn: true
   });
   const snapshotPublic = createSnapshot({
-    hasWorkspaceOwnerColumn: false,
-    hasUserOwnerColumn: false
+    hasWorkspaceIdColumn: false,
+    hasUserIdColumn: false
   });
 
   assert.equal(
@@ -178,8 +178,8 @@ test("resolveOwnershipFilterForGeneration infers ownership filter for table intr
 
 test("resolveOwnershipFilterForGeneration rejects explicit ownership filters when required columns are missing", () => {
   const snapshotPublic = createSnapshot({
-    hasWorkspaceOwnerColumn: false,
-    hasUserOwnerColumn: false
+    hasWorkspaceIdColumn: false,
+    hasUserIdColumn: false
   });
 
   assert.throws(
@@ -187,14 +187,14 @@ test("resolveOwnershipFilterForGeneration rejects explicit ownership filters whe
       __testables.resolveOwnershipFilterForGeneration(snapshotPublic, "workspace", {
         enforceTableColumns: true
       }),
-    /requires column "workspace_owner_id"/
+    /requires column "workspace_id"/
   );
   assert.throws(
     () =>
       __testables.resolveOwnershipFilterForGeneration(snapshotPublic, "user", {
         enforceTableColumns: true
       }),
-    /requires column "user_owner_id"/
+    /requires column "user_id"/
   );
 });
 
@@ -332,8 +332,8 @@ test("buildReplacementsFromSnapshot renders append-only field meta entries from 
 
 test("buildReplacementsFromSnapshot renders enum field meta options as select controls", () => {
   const baseSnapshot = createSnapshot({
-    hasWorkspaceOwnerColumn: false,
-    hasUserOwnerColumn: false
+    hasWorkspaceIdColumn: false,
+    hasUserIdColumn: false
   });
   const snapshot = {
     ...baseSnapshot,
@@ -374,7 +374,7 @@ test("buildReplacementsFromSnapshot renders enum field meta options as select co
 test("renderMigrationColumnLine ignores SQL NULL string defaults", () => {
   const line = __testables.renderMigrationColumnLine(
     {
-      name: "workspace_owner_id",
+      name: "workspace_id",
       dataType: "int",
       columnType: "int unsigned",
       typeKind: "integer",
@@ -400,8 +400,8 @@ test("renderMigrationColumnLine ignores SQL NULL string defaults", () => {
 
 test("buildReplacementsFromSnapshot normalizes nullable temporal inputs without invalid date errors", () => {
   const snapshot = createSnapshot({
-    hasWorkspaceOwnerColumn: false,
-    hasUserOwnerColumn: false
+    hasWorkspaceIdColumn: false,
+    hasUserIdColumn: false
   });
   const temporalColumns = [
     ...snapshot.columns.filter((column) => column.key !== "updatedAt"),

--- a/packages/database-runtime-mysql/src/shared/introspectCrudTable.js
+++ b/packages/database-runtime-mysql/src/shared/introspectCrudTable.js
@@ -451,8 +451,8 @@ async function introspectCrudTableSnapshot(knex, { tableName = "", idColumn = "i
     tableName: resolvedTableName,
     idColumn: resolvedIdColumn,
     primaryKeyColumns,
-    hasWorkspaceOwnerColumn: columns.some((column) => column.name === "workspace_owner_id"),
-    hasUserOwnerColumn: columns.some((column) => column.name === "user_owner_id"),
+    hasWorkspaceIdColumn: columns.some((column) => column.name === "workspace_id"),
+    hasUserIdColumn: columns.some((column) => column.name === "user_id"),
     columns,
     indexes: normalizeIndexes(indexRows),
     foreignKeys: normalizeForeignKeys(foreignKeyRows)

--- a/packages/database-runtime-mysql/test/introspectCrudTable.test.js
+++ b/packages/database-runtime-mysql/test/introspectCrudTable.test.js
@@ -63,7 +63,7 @@ test("introspectCrudTableSnapshot maps MySQL table metadata to normalized snapsh
         ordinalPosition: 1
       },
       {
-        columnName: "workspace_owner_id",
+        columnName: "workspace_id",
         dataType: "int",
         columnType: "int unsigned",
         isNullable: "YES",
@@ -76,7 +76,7 @@ test("introspectCrudTableSnapshot maps MySQL table metadata to normalized snapsh
         ordinalPosition: 2
       },
       {
-        columnName: "user_owner_id",
+        columnName: "user_id",
         dataType: "int",
         columnType: "int unsigned",
         isNullable: "YES",
@@ -158,8 +158,8 @@ test("introspectCrudTableSnapshot maps MySQL table metadata to normalized snapsh
     ],
     foreignKeys: [
       {
-        constraintName: "contacts_workspace_owner_id_foreign",
-        columnName: "workspace_owner_id",
+        constraintName: "contacts_workspace_id_foreign",
+        columnName: "workspace_id",
         referencedTableName: "workspaces",
         referencedColumnName: "id",
         ordinalPosition: 1,
@@ -178,8 +178,8 @@ test("introspectCrudTableSnapshot maps MySQL table metadata to normalized snapsh
   assert.equal(snapshot.tableName, "contacts");
   assert.equal(snapshot.idColumn, "id");
   assert.deepEqual(snapshot.primaryKeyColumns, ["id"]);
-  assert.equal(snapshot.hasWorkspaceOwnerColumn, true);
-  assert.equal(snapshot.hasUserOwnerColumn, true);
+  assert.equal(snapshot.hasWorkspaceIdColumn, true);
+  assert.equal(snapshot.hasUserIdColumn, true);
 
   const firstName = snapshot.columns.find((column) => column.name === "first_name");
   assert.ok(firstName);
@@ -187,9 +187,9 @@ test("introspectCrudTableSnapshot maps MySQL table metadata to normalized snapsh
   assert.equal(firstName.typeKind, "string");
   assert.equal(firstName.maxLength, 160);
 
-  const workspaceOwnerId = snapshot.columns.find((column) => column.name === "workspace_owner_id");
-  assert.ok(workspaceOwnerId);
-  assert.equal(workspaceOwnerId.hasDefault, false);
+  const workspaceId = snapshot.columns.find((column) => column.name === "workspace_id");
+  assert.ok(workspaceId);
+  assert.equal(workspaceId.hasDefault, false);
 
   const vip = snapshot.columns.find((column) => column.name === "vip");
   assert.ok(vip);
@@ -214,13 +214,13 @@ test("introspectCrudTableSnapshot maps MySQL table metadata to normalized snapsh
   ]);
   assert.deepEqual(snapshot.foreignKeys, [
     {
-      name: "contacts_workspace_owner_id_foreign",
+      name: "contacts_workspace_id_foreign",
       referencedTableName: "workspaces",
       updateRule: "CASCADE",
       deleteRule: "SET NULL",
       columns: [
         {
-          name: "workspace_owner_id",
+          name: "workspace_id",
           referencedName: "id"
         }
       ]

--- a/packages/database-runtime/src/shared/visibility.js
+++ b/packages/database-runtime/src/shared/visibility.js
@@ -2,14 +2,14 @@ import { normalizeVisibilityContext } from "@jskit-ai/kernel/shared/support/visi
 
 const ALWAYS_FALSE_SQL = "1 = 0";
 const DEFAULT_VISIBILITY_COLUMNS = Object.freeze({
-  scopeOwnerId: "workspace_owner_id",
-  userOwnerId: "user_owner_id"
+  scopeOwnerId: "workspace_id",
+  userId: "user_id"
 });
 
 function applyVisibility(queryBuilder, visibilityContext = {}) {
   const context = normalizeVisibilityContext(visibilityContext);
   const workspaceColumn = DEFAULT_VISIBILITY_COLUMNS.scopeOwnerId;
-  const userColumn = DEFAULT_VISIBILITY_COLUMNS.userOwnerId;
+  const userColumn = DEFAULT_VISIBILITY_COLUMNS.userId;
 
   if (context.visibility === "public") {
     return queryBuilder;
@@ -23,17 +23,17 @@ function applyVisibility(queryBuilder, visibilityContext = {}) {
   }
 
   if (context.visibility === "user") {
-    if (!context.userOwnerId) {
+    if (!context.userId) {
       return queryBuilder.whereRaw(ALWAYS_FALSE_SQL);
     }
-    return queryBuilder.where(userColumn, context.userOwnerId);
+    return queryBuilder.where(userColumn, context.userId);
   }
 
-  if (!context.scopeOwnerId || !context.userOwnerId) {
+  if (!context.scopeOwnerId || !context.userId) {
     return queryBuilder.whereRaw(ALWAYS_FALSE_SQL);
   }
 
-  return queryBuilder.where(workspaceColumn, context.scopeOwnerId).where(userColumn, context.userOwnerId);
+  return queryBuilder.where(workspaceColumn, context.scopeOwnerId).where(userColumn, context.userId);
 }
 
 function applyVisibilityOwners(payload = {}, visibilityContext = {}) {
@@ -49,11 +49,11 @@ function applyVisibilityOwners(payload = {}, visibilityContext = {}) {
   if (context.visibility === "workspace" && !context.scopeOwnerId) {
     throw new Error("Visibility context requires scopeOwnerId.");
   }
-  if (context.visibility === "user" && !context.userOwnerId) {
-    throw new Error("Visibility context requires userOwnerId.");
+  if (context.visibility === "user" && !context.userId) {
+    throw new Error("Visibility context requires userId.");
   }
-  if (context.visibility === "workspace_user" && (!context.scopeOwnerId || !context.userOwnerId)) {
-    throw new Error("Visibility context requires scopeOwnerId and userOwnerId.");
+  if (context.visibility === "workspace_user" && (!context.scopeOwnerId || !context.userId)) {
+    throw new Error("Visibility context requires scopeOwnerId and userId.");
   }
 
   const ownedPayload = {
@@ -61,10 +61,10 @@ function applyVisibilityOwners(payload = {}, visibilityContext = {}) {
   };
 
   if (context.scopeOwnerId) {
-    ownedPayload.workspace_owner_id = context.scopeOwnerId;
+    ownedPayload.workspace_id = context.scopeOwnerId;
   }
-  if (context.userOwnerId) {
-    ownedPayload.user_owner_id = context.userOwnerId;
+  if (context.userId) {
+    ownedPayload.user_id = context.userId;
   }
 
   return ownedPayload;

--- a/packages/database-runtime/test/repositoryScope.test.js
+++ b/packages/database-runtime/test/repositoryScope.test.js
@@ -37,7 +37,7 @@ test("createRepositoryScope builds explicit scoped query helpers", () => {
     }
   });
 
-  assert.deepEqual(calls, [["table", "contacts"], ["where", "workspace_owner_id", 12]]);
+  assert.deepEqual(calls, [["table", "contacts"], ["where", "workspace_id", 12]]);
 });
 
 test("createRepositoryScope supports scopedById with custom id column", () => {
@@ -49,11 +49,11 @@ test("createRepositoryScope supports scopedById with custom id column", () => {
   scope.scopedById(33, {
     visibilityContext: {
       visibility: "user",
-      userOwnerId: 7
+      userId: 7
     }
   });
 
-  assert.deepEqual(calls, [["table", "contacts"], ["where", "user_owner_id", 7], ["where", "contact_id", 33]]);
+  assert.deepEqual(calls, [["table", "contacts"], ["where", "user_id", 7], ["where", "contact_id", 33]]);
 });
 
 test("createRepositoryScope exposes applyToQuery and owner stamping", () => {
@@ -65,11 +65,11 @@ test("createRepositoryScope exposes applyToQuery and owner stamping", () => {
     visibilityContext: {
       visibility: "workspace_user",
       scopeOwnerId: 4,
-      userOwnerId: 9
+      userId: 9
     }
   });
 
-  assert.deepEqual(calls, [["where", "workspace_owner_id", 4], ["where", "user_owner_id", 9]]);
+  assert.deepEqual(calls, [["where", "workspace_id", 4], ["where", "user_id", 9]]);
 
   assert.deepEqual(
     scope.withOwners(
@@ -80,14 +80,14 @@ test("createRepositoryScope exposes applyToQuery and owner stamping", () => {
         visibilityContext: {
           visibility: "workspace_user",
           scopeOwnerId: 4,
-          userOwnerId: 9
+          userId: 9
         }
       }
     ),
     {
       name: "Ada",
-      workspace_owner_id: 4,
-      user_owner_id: 9
+      workspace_id: 4,
+      user_id: 9
     }
   );
 

--- a/packages/database-runtime/test/visibility.test.js
+++ b/packages/database-runtime/test/visibility.test.js
@@ -28,14 +28,14 @@ test("applyVisibility appends scope filters to query builders", () => {
     visibility: "workspace",
     scopeOwnerId: 12
   });
-  assert.deepEqual(workspaceQuery.calls, [["where", "workspace_owner_id", 12]]);
+  assert.deepEqual(workspaceQuery.calls, [["where", "workspace_id", 12]]);
 
   const userQuery = createQueryBuilderStub();
   applyVisibility(userQuery, {
     visibility: "user",
-    userOwnerId: 7
+    userId: 7
   });
-  assert.deepEqual(userQuery.calls, [["where", "user_owner_id", 7]]);
+  assert.deepEqual(userQuery.calls, [["where", "user_id", 7]]);
 
   const deniedQuery = createQueryBuilderStub();
   applyVisibility(deniedQuery, {
@@ -68,13 +68,13 @@ test("applyVisibilityOwners injects owner columns for write payloads", () => {
       {
         visibility: "workspace_user",
         scopeOwnerId: 4,
-        userOwnerId: 9
+        userId: 9
       }
     ),
     {
       name: "Alice",
-      workspace_owner_id: 4,
-      user_owner_id: 9
+      workspace_id: 4,
+      user_id: 9
     }
   );
 
@@ -88,6 +88,6 @@ test("applyVisibilityOwners injects owner columns for write payloads", () => {
           visibility: "user"
         }
       ),
-    /requires userOwnerId/
+    /requires userId/
   );
 });

--- a/packages/kernel/server/http/lib/kernel.test.js
+++ b/packages/kernel/server/http/lib/kernel.test.js
@@ -236,7 +236,7 @@ test("registerRoutes attaches visibilityContext from route visibility resolvers"
       }
 
       return {
-        userOwnerId: context?.actor?.id,
+        userId: context?.actor?.id,
         requiresActorScope: true
       };
     }
@@ -281,7 +281,7 @@ test("registerRoutes attaches visibilityContext from route visibility resolvers"
     scopeKind: null,
     requiresActorScope: true,
     scopeOwnerId: null,
-    userOwnerId: 23
+    userId: 23
   });
   assert.deepEqual(observed[0].context.requestMeta.visibilityContext, observed[0].context.visibilityContext);
   assert.equal(observed[0].context.requestMeta.routeVisibility, "user");
@@ -309,7 +309,7 @@ test("registerRoutes keeps actor scope requirement for core user visibility with
       }
 
       return {
-        userOwnerId: context?.actor?.id
+        userId: context?.actor?.id
       };
     }
   }));
@@ -353,7 +353,7 @@ test("registerRoutes keeps actor scope requirement for core user visibility with
     scopeKind: null,
     requiresActorScope: true,
     scopeOwnerId: null,
-    userOwnerId: 23
+    userId: 23
   });
   assert.equal(observed[0].context.requestMeta.routeVisibility, "user");
 });
@@ -399,7 +399,7 @@ test("registerRoutes does not infer actor scope from non-core route visibility t
     scopeKind: null,
     requiresActorScope: false,
     scopeOwnerId: null,
-    userOwnerId: null
+    userId: null
   });
   assert.equal(observed[0].context.requestMeta.routeVisibility, "workspace_user");
 });

--- a/packages/kernel/server/runtime/entityChangeEvents.js
+++ b/packages/kernel/server/runtime/entityChangeEvents.js
@@ -43,10 +43,10 @@ function resolveVisibilityScope(visibilityContext = {}, runtimeContext = {}) {
   const visibility = normalizeText(visibilityContext.visibility).toLowerCase();
   const scopeKind = normalizeText(visibilityContext.scopeKind || visibility).toLowerCase();
   const scopeOwnerId = normalizeOpaqueId(visibilityContext.scopeOwnerId);
-  const userOwnerId = normalizeOpaqueId(visibilityContext.userOwnerId);
+  const userId = normalizeOpaqueId(visibilityContext.userId);
   const requiresActorScope = visibilityContext.requiresActorScope === true;
 
-  if (requiresActorScope && userOwnerId == null) {
+  if (requiresActorScope && userId == null) {
     return null;
   }
 
@@ -57,7 +57,7 @@ function resolveVisibilityScope(visibilityContext = {}, runtimeContext = {}) {
     };
     if (requiresActorScope) {
       scope.scopeId = scopeOwnerId;
-      scope.userId = userOwnerId;
+      scope.userId = userId;
     }
     return scope;
   }
@@ -72,10 +72,10 @@ function resolveVisibilityScope(visibilityContext = {}, runtimeContext = {}) {
     };
   }
 
-  if (scopeKind === "user" && userOwnerId != null) {
+  if (scopeKind === "user" && userId != null) {
     return {
       kind: "user",
-      id: userOwnerId
+      id: userId
     };
   }
 

--- a/packages/kernel/server/runtime/entityChangeEvents.test.js
+++ b/packages/kernel/server/runtime/entityChangeEvents.test.js
@@ -133,7 +133,7 @@ test("entity change publisher supports opaque actor and scope identifiers", asyn
       visibilityContext: {
         scopeKind: "workspace_user",
         scopeOwnerId: "workspace_23",
-        userOwnerId: "user_17",
+        userId: "user_17",
         requiresActorScope: true
       }
     }

--- a/packages/kernel/shared/support/visibility.js
+++ b/packages/kernel/shared/support/visibility.js
@@ -49,7 +49,7 @@ function normalizeVisibilityContext(value = {}) {
     scopeKind: normalizedScopeKind,
     requiresActorScope: source.requiresActorScope === true,
     scopeOwnerId: normalizeOpaqueId(source.scopeOwnerId),
-    userOwnerId: normalizeOpaqueId(source.userOwnerId)
+    userId: normalizeOpaqueId(source.userId)
   });
 }
 

--- a/packages/kernel/shared/support/visibility.test.js
+++ b/packages/kernel/shared/support/visibility.test.js
@@ -19,20 +19,20 @@ test("normalizeRouteVisibilityToken normalizes visibility tokens for module-leve
 });
 
 test("normalizeVisibilityContext normalizes mode and owner identifiers", () => {
-  assert.deepEqual(normalizeVisibilityContext({ visibility: "user", userOwnerId: "7" }), {
+  assert.deepEqual(normalizeVisibilityContext({ visibility: "user", userId: "7" }), {
     visibility: "user",
     scopeKind: null,
     requiresActorScope: false,
     scopeOwnerId: null,
-    userOwnerId: "7"
+    userId: "7"
   });
 
-  assert.deepEqual(normalizeVisibilityContext({ visibility: "workspace_user", scopeOwnerId: "4", userOwnerId: 9 }), {
+  assert.deepEqual(normalizeVisibilityContext({ visibility: "workspace_user", scopeOwnerId: "4", userId: 9 }), {
     visibility: "workspace_user",
     scopeKind: null,
     requiresActorScope: false,
     scopeOwnerId: "4",
-    userOwnerId: 9
+    userId: 9
   });
 
   assert.deepEqual(normalizeVisibilityContext({ visibility: "workspace", scopeOwnerId: "0" }), {
@@ -40,6 +40,6 @@ test("normalizeVisibilityContext normalizes mode and owner identifiers", () => {
     scopeKind: null,
     requiresActorScope: false,
     scopeOwnerId: "0",
-    userOwnerId: null
+    userId: null
   });
 });

--- a/packages/users-core/src/server/common/contributors/workspaceRouteVisibilityResolver.js
+++ b/packages/users-core/src/server/common/contributors/workspaceRouteVisibilityResolver.js
@@ -1,7 +1,7 @@
 import { normalizeOpaqueId, normalizeText } from "@jskit-ai/kernel/shared/support/normalize";
 import { parsePositiveInteger } from "@jskit-ai/kernel/server/runtime";
 
-function buildVisibilityContribution({ visibility, scopeOwnerId = 0, userOwnerId = null } = {}) {
+function buildVisibilityContribution({ visibility, scopeOwnerId = 0, userId = null } = {}) {
   const requiresActorScope = visibility === "workspace_user";
   const contribution = {
     scopeKind: requiresActorScope ? "workspace_user" : "workspace",
@@ -11,8 +11,8 @@ function buildVisibilityContribution({ visibility, scopeOwnerId = 0, userOwnerId
   if (scopeOwnerId > 0) {
     contribution.scopeOwnerId = scopeOwnerId;
   }
-  if (requiresActorScope && userOwnerId != null) {
-    contribution.userOwnerId = userOwnerId;
+  if (requiresActorScope && userId != null) {
+    contribution.userId = userId;
   }
 
   return contribution;
@@ -31,7 +31,7 @@ function createWorkspaceRouteVisibilityResolver({ workspaceService } = {}) {
       }
 
       const actor = context?.actor || request?.user || null;
-      const userOwnerId = normalizeOpaqueId(actor?.id);
+      const userId = normalizeOpaqueId(actor?.id);
       const workspace =
         context?.workspace || context?.requestMeta?.resolvedWorkspaceContext?.workspace || request?.workspace || null;
       const scopeOwnerId = parsePositiveInteger(workspace?.id);
@@ -42,7 +42,7 @@ function createWorkspaceRouteVisibilityResolver({ workspaceService } = {}) {
           return visibility === "workspace_user"
             ? buildVisibilityContribution({
                 visibility,
-                userOwnerId
+                userId
               })
             : {};
         }
@@ -55,7 +55,7 @@ function createWorkspaceRouteVisibilityResolver({ workspaceService } = {}) {
           return visibility === "workspace_user"
             ? buildVisibilityContribution({
                 visibility,
-                userOwnerId
+                userId
               })
             : {};
         }
@@ -63,14 +63,14 @@ function createWorkspaceRouteVisibilityResolver({ workspaceService } = {}) {
         return buildVisibilityContribution({
           visibility,
           scopeOwnerId: resolvedWorkspaceOwnerId,
-          userOwnerId
+          userId
         });
       }
 
       return buildVisibilityContribution({
         visibility,
         scopeOwnerId,
-        userOwnerId
+        userId
       });
     }
   });

--- a/packages/users-core/test/workspaceRouteVisibilityResolver.test.js
+++ b/packages/users-core/test/workspaceRouteVisibilityResolver.test.js
@@ -27,7 +27,7 @@ test("workspace route visibility resolver contributes workspace_user scope and a
     scopeKind: "workspace_user",
     requiresActorScope: true,
     scopeOwnerId: 11,
-    userOwnerId: "user_42"
+    userId: "user_42"
   });
 });
 
@@ -78,6 +78,6 @@ test("workspace route visibility resolver still marks workspace_user as actor-sc
   assert.deepEqual(contribution, {
     scopeKind: "workspace_user",
     requiresActorScope: true,
-    userOwnerId: "user_99"
+    userId: "user_99"
   });
 });


### PR DESCRIPTION
## Summary
- rename visibility context ownership fields to use  and /
- align CRUD server generation and MySQL introspection with the normalized ownership column names
- refresh related tests, docs, and agent index entries
