### PR TITLE
Make record IDs BIGINT-safe strings above the DB boundary

### DIFF
--- a/agent-index/packages/assistant-core.md
+++ b/agent-index/packages/assistant-core.md
@@ -277,7 +277,7 @@ Local functions
 - `normalizeSurfaceId(value)`
 - `normalizeWorkspaceSlug(value)`
 - `normalizePositiveInteger(value, fallback)`
-- `normalizeScopeKey({ targetSurfaceId = "", workspaceSlug = "", workspaceId = 0 } = {})`
+- `normalizeScopeKey({ targetSurfaceId = "", workspaceSlug = "", workspaceId = null } = {})`
 - `normalizeStatus(value)`
 - `normalizeConversationId(value)`
 

--- a/agent-index/packages/crud-core.md
+++ b/agent-index/packages/crud-core.md
@@ -37,11 +37,11 @@ Exports
 - `crudScopeQueryKey(namespace = "")`
 - `invalidateCrudQueries(queryClient, namespace = "")`
 - `crudListQueryKey(surfaceId = "", workspaceSlug = "", namespace = "")`
-- `crudViewQueryKey(surfaceId = "", workspaceSlug = "", recordId = 0, namespace = "")`
+- `crudViewQueryKey(surfaceId = "", workspaceSlug = "", recordId = "", namespace = "")`
 - `toRouteRecordId(value)`
 - `normalizeCrudRouteParamName(value, { context = "normalizeCrudRouteParamName" } = {})`
 - `resolveCrudRecordPathTemplates(relativePath = "", recordIdParam = "recordId")`
-- `resolveCrudRecordPathParams(recordIdLike = 0, recordIdParam = "recordId")`
+- `resolveCrudRecordPathParams(recordIdLike = "", recordIdParam = "recordId")`
 Local functions
 - `normalizeRelativePath(value, { context = "resolveCrudClientConfig" } = {})`
 
@@ -194,6 +194,7 @@ Exports
 - `crudRepositoryUpdateById(runtime, knex, recordId, patch = {}, repositoryOptions = {}, callOptions = {}, hooks = null)`
 - `crudRepositoryDeleteById(runtime, knex, recordId, repositoryOptions = {}, callOptions = {}, hooks = null)`
 Local functions
+- `requireCrudRecordId(value, { context = "crudRepository" } = {})`
 - `resolveRepositoryDefaults(resource = {}, repositoryMapping = {})`
 - `normalizeSearchColumns(searchColumns = [], fallbackColumns = [])`
 - `normalizeListOrderDirection(value = LIST_ORDER_DIRECTION_ASC)`
@@ -234,7 +235,7 @@ Exports
 - `normalizeCrudListCursor(cursor = null, { allowEmpty = true } = {})`
 - `requireCrudTableName(tableName, { context = "crudRepository" } = {})`
 - `deriveRepositoryMappingFromResource(resource = {}, { context = "crudRepository" } = {})`
-- `applyCrudListQueryFilters(query, { idColumn = "id", cursor = 0, applyCursor = true, q = "", searchColumns = [], parentFilters = {}, parentFilterColumns = {} } = {})`
+- `applyCrudListQueryFilters(query, { idColumn = "id", cursor = "", applyCursor = true, q = "", searchColumns = [], parentFilters = {}, parentFilterColumns = {} } = {})`
 - `mapRecordRow(row, fieldKeys = [], overrides = {})`
 - `buildWritePayload(sourcePayload = {}, fieldKeys = [], overrides = {})`
 - `resolveColumnName(fieldKey, overrides = {})`

--- a/agent-index/packages/crud-server-generator.md
+++ b/agent-index/packages/crud-server-generator.md
@@ -43,15 +43,15 @@ Local functions
 - `renderObjectPropertyKey(value)`
 - `renderIntegerSchema(column)`
 - `renderStringSchema(column, { forOutput = false } = {})`
-- `renderResourceValidatorsImport({ needsHtmlTimeSchemas = false } = {})`
+- `renderResourceValidatorsImport({ needsHtmlTimeSchemas = false, needsRecordIdSchemas = false } = {})`
 - `renderResourceSchemaPropertyLines(columns, { forOutput = false } = {})`
 - `renderResourceInputNormalizationLines(columns)`
 - `renderResourceOutputNormalizationLines(columns)`
 - `renderResourceDatabaseRuntimeImport({ needsToIsoString = false, needsToDatabaseDateTimeUtc = false } = {})`
 - `renderResourceJsonImport({ needsJson = false } = {})`
-- `renderResourceNormalizeSupportImport({ needsNormalizeText = false, needsNormalizeBoolean = false, needsNormalizeFiniteNumber = false, needsNormalizeFiniteInteger = false, needsNormalizeIfInSource = false, needsNormalizeIfPresent = false, needsNormalizeOrNull = false } = {})`
+- `renderResourceNormalizeSupportImport({ needsNormalizeText = false, needsNormalizeBoolean = false, needsNormalizeFiniteNumber = false, needsNormalizeFiniteInteger = false, needsNormalizeRecordId = false, needsNormalizeIfInSource = false, needsNormalizeIfPresent = false, needsNormalizeOrNull = false } = {})`
 - `renderMigrationDefaultClause(column)`
-- `renderMigrationColumnLine(column, { idColumn = DEFAULT_ID_COLUMN, primaryKeyColumns = [] } = {})`
+- `renderMigrationColumnLine(column, { idColumn = DEFAULT_ID_COLUMN, primaryKeyColumns = [], foreignKeyColumnNames = new Set() } = {})`
 - `renderMigrationColumnLines(snapshot)`
 - `renderMigrationIndexLine(index)`
 - `renderMigrationIndexLines(snapshot)`

--- a/agent-index/packages/database-runtime.md
+++ b/agent-index/packages/database-runtime.md
@@ -42,6 +42,7 @@ Exports
 - `parseDatabaseUrl(databaseUrl, { context = "DATABASE_URL", allowEmpty = false } = {})`
 - `resolveDatabaseClientFromEnvironment(env = {}, { allowEmpty = false } = {})`
 - `resolveDatabaseConnectionFromEnvironment(env = {}, { defaultHost = "localhost", defaultPort = 3306, context = "database runtime" } = {})`
+- `resolveKnexConnectionFromEnvironment(env = {}, { client = "", defaultHost = "localhost", defaultPort = 3306, context = "database runtime" } = {})`
 Local functions
 - `toPositiveInteger(value, fallback)`
 
@@ -91,6 +92,7 @@ Exports
 - `parseDatabaseUrl`
 - `resolveDatabaseClientFromEnvironment`
 - `resolveDatabaseConnectionFromEnvironment`
+- `resolveKnexConnectionFromEnvironment`
 - `isDuplicateEntryError`
 - `normalizePath`
 - `jsonTextExpression`
@@ -109,6 +111,8 @@ Exports
 - `stringifyMetadataJson`
 - `normalizeMetadataJsonInput`
 - `normalizeNullableString`
+- `normalizeDbRecordId`
+- `resolveInsertedRecordId`
 - `normalizeIdList`
 - `normalizeCountRow`
 - `parseJsonValue`
@@ -144,6 +148,8 @@ Exports
 - `stringifyMetadataJson(metadata, fallback = "{}")`
 - `normalizeMetadataJsonInput(value, fallback = null)`
 - `normalizeNullableString(value, { trim = true } = {})`
+- `normalizeDbRecordId(value, { fallback = null } = {})`
+- `resolveInsertedRecordId(insertResult, { fallback = null } = {})`
 - `normalizeIdList(values, { parseValue } = {})`
 - `normalizeCountRow(row)`
 - `parseJsonValue(value, fallback = null, options = {})`

--- a/agent-index/packages/kernel.md
+++ b/agent-index/packages/kernel.md
@@ -269,6 +269,7 @@ Exports
 - `normalizeUniqueTextList(value, { acceptSingle = false } = {})`
 - `normalizeInteger(value, { fallback = 0, min = null, max = null } = {})`
 - `normalizePositiveInteger(value, { fallback = 0 } = {})`
+- `normalizeRecordId(value, { fallback = null } = {})`
 - `normalizeOpaqueId(value, { fallback = null } = {})`
 - `normalizeOneOf(value, allowedValues = [], fallback = "")`
 - `ensureNonEmptyText(value, label = "value")`
@@ -441,6 +442,13 @@ Exports
 - `mergeObjectSchemas`
 - `mergeValidators`
 - `nestValidator`
+- `RECORD_ID_PATTERN`
+- `recordIdSchema`
+- `recordIdInputSchema`
+- `nullableRecordIdSchema`
+- `nullableRecordIdInputSchema`
+- `recordIdValidator`
+- `nullableRecordIdValidator`
 - `recordIdParamsValidator`
 - `positiveIntegerValidator`
 - `normalizeSettingsFieldInput`
@@ -472,10 +480,15 @@ Local functions
 
 ### `shared/validators/recordIdParamsValidator.js`
 Exports
+- `RECORD_ID_PATTERN`
+- `recordIdSchema`
+- `recordIdInputSchema`
+- `nullableRecordIdSchema`
+- `nullableRecordIdInputSchema`
+- `recordIdValidator`
+- `nullableRecordIdValidator`
 - `recordIdParamsValidator`
 - `positiveIntegerValidator`
-Local functions
-- `normalizeRecordId(value)`
 
 ### `shared/validators/resourceRequiredMetadata.js`
 Exports

--- a/agent-index/packages/users-core.md
+++ b/agent-index/packages/users-core.md
@@ -107,7 +107,7 @@ Exports
 Exports
 - `createWorkspaceRouteVisibilityResolver({ workspaceService } = {})`
 Local functions
-- `buildVisibilityContribution({ visibility, scopeOwnerId = 0, userId = null } = {})`
+- `buildVisibilityContribution({ visibility, scopeOwnerId = null, userId = null } = {})`
 
 ### `src/server/common/formatters/accountAvatarFormatter.js`
 Exports
@@ -151,6 +151,7 @@ Exports
 - `isDuplicateEntryError`
 - `normalizeText`
 - `normalizeLowerText`
+- `normalizeRecordId`
 - `nowDb()`
 - `toNullableIso(value)`
 - `uniqueSorted(values)`
@@ -168,8 +169,8 @@ Local functions
 ### `src/server/common/repositories/usersRepository.js`
 Exports
 - `createRepository(knex)`
-- `normalizeIdentity(identityLike)`
 - `mapProfileRow(row)`
+- `normalizeIdentity(identityLike)`
 Local functions
 - `normalizeUsername(value)`
 - `usernameBaseFromEmail(email)`
@@ -177,7 +178,7 @@ Local functions
 - `duplicateTargetsEmail(error)`
 - `duplicateTargetsUsername(error)`
 - `createDuplicateEmailConflictError()`
-- `resolveUniqueUsername(client, baseUsername, { excludeUserId = 0 } = {})`
+- `resolveUniqueUsername(client, baseUsername, { excludeUserId = null } = {})`
 
 ### `src/server/common/repositories/workspaceInvitesRepository.js`
 Exports

--- a/agents/KERNEL_MAP.md
+++ b/agents/KERNEL_MAP.md
@@ -95,6 +95,7 @@ Exports
 - `normalizeUniqueTextList(value, { acceptSingle = false } = {})`
 - `normalizeInteger(value, { fallback = 0, min = null, max = null } = {})`
 - `normalizePositiveInteger(value, { fallback = 0 } = {})`
+- `normalizeRecordId(value, { fallback = null } = {})`
 - `normalizeOpaqueId(value, { fallback = null } = {})`
 - `normalizeOneOf(value, allowedValues = [], fallback = "")`
 - `ensureNonEmptyText(value, label = "value")`
@@ -271,6 +272,13 @@ Exports
 - `mergeObjectSchemas`
 - `mergeValidators`
 - `nestValidator`
+- `RECORD_ID_PATTERN`
+- `recordIdSchema`
+- `recordIdInputSchema`
+- `nullableRecordIdSchema`
+- `nullableRecordIdInputSchema`
+- `recordIdValidator`
+- `nullableRecordIdValidator`
 - `recordIdParamsValidator`
 - `positiveIntegerValidator`
 - `normalizeSettingsFieldInput`
@@ -302,10 +310,15 @@ Local functions
 
 ### `validators/recordIdParamsValidator.js`
 Exports
+- `RECORD_ID_PATTERN`
+- `recordIdSchema`
+- `recordIdInputSchema`
+- `nullableRecordIdSchema`
+- `nullableRecordIdInputSchema`
+- `recordIdValidator`
+- `nullableRecordIdValidator`
 - `recordIdParamsValidator`
 - `positiveIntegerValidator`
-Local functions
-- `normalizeRecordId(value)`
 
 ### `validators/resourceRequiredMetadata.js`
 Exports

--- a/package-lock.json
+++ b/package-lock.json
@@ -5960,6 +5960,7 @@
       "name": "@jskit-ai/assistant-core",
       "version": "0.1.8",
       "dependencies": {
+        "@jskit-ai/database-runtime": "0.1.32",
         "@jskit-ai/http-runtime": "0.1.31",
         "@jskit-ai/kernel": "0.1.32",
         "@jskit-ai/users-core": "0.1.42",
@@ -6237,6 +6238,7 @@
       "name": "@jskit-ai/crud-core",
       "version": "0.1.40",
       "dependencies": {
+        "@jskit-ai/database-runtime": "0.1.32",
         "@jskit-ai/kernel": "0.1.32",
         "@jskit-ai/realtime": "0.1.31",
         "@jskit-ai/shell-web": "0.1.31",

--- a/packages/assistant-core/package.json
+++ b/packages/assistant-core/package.json
@@ -11,6 +11,7 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
+    "@jskit-ai/database-runtime": "0.1.32",
     "@jskit-ai/http-runtime": "0.1.31",
     "@jskit-ai/kernel": "0.1.32",
     "@jskit-ai/users-core": "0.1.42",

--- a/packages/assistant-core/src/client/components/AssistantClientElement.vue
+++ b/packages/assistant-core/src/client/components/AssistantClientElement.vue
@@ -248,6 +248,7 @@ import { computed, nextTick, onActivated, onBeforeUnmount, onMounted, ref, shall
 import { createComponentInteractionEmitter } from "@jskit-ai/kernel/client";
 import {
   normalizeObject,
+  normalizeRecordId,
   normalizeText,
   normalizeOneOf
 } from "@jskit-ai/kernel/shared/support/normalize";
@@ -615,8 +616,8 @@ function resolveConversationActorLabel(conversation) {
     return email;
   }
 
-  const userId = Number(conversation?.createdByUserId);
-  if (Number.isInteger(userId) && userId > 0) {
+  const userId = normalizeRecordId(conversation?.createdByUserId, { fallback: null });
+  if (userId) {
     return `User #${userId}`;
   }
 
@@ -624,7 +625,7 @@ function resolveConversationActorLabel(conversation) {
 }
 
 function conversationSubtitle(conversation) {
-  const id = Number(conversation?.id) || 0;
+  const id = normalizeRecordId(conversation?.id, { fallback: "?" });
   const status = normalizeConversationStatus(conversation?.status);
   const startedAt = formatConversationStartedAt(conversation?.startedAt);
   const messageCount = Number(conversation?.messageCount || 0);

--- a/packages/assistant-core/src/server/repositories/repositoryPersistenceUtils.js
+++ b/packages/assistant-core/src/server/repositories/repositoryPersistenceUtils.js
@@ -1,3 +1,4 @@
+import { resolveInsertedRecordId } from "@jskit-ai/database-runtime/shared";
 import { parseJsonObject } from "../../shared/support/jsonObject.js";
 
 function stringifyJsonObject(value) {
@@ -22,27 +23,7 @@ function toIso(value) {
 }
 
 function resolveInsertedId(insertResult) {
-  if (Array.isArray(insertResult) && insertResult.length > 0) {
-    const first = insertResult[0];
-    if (first && typeof first === "object" && !Array.isArray(first)) {
-      const objectId = Number(first.id);
-      if (Number.isInteger(objectId) && objectId > 0) {
-        return objectId;
-      }
-    }
-
-    const scalarId = Number(first);
-    if (Number.isInteger(scalarId) && scalarId > 0) {
-      return scalarId;
-    }
-  }
-
-  const directId = Number(insertResult);
-  if (Number.isInteger(directId) && directId > 0) {
-    return directId;
-  }
-
-  return 0;
+  return resolveInsertedRecordId(insertResult, { fallback: "" }) || "";
 }
 
 export { parseJsonObject, stringifyJsonObject, toIso, resolveInsertedId };

--- a/packages/assistant-core/src/shared/assistantResource.js
+++ b/packages/assistant-core/src/shared/assistantResource.js
@@ -1,9 +1,12 @@
 import { Type } from "typebox";
 import {
   normalizeObjectInput,
-  createCursorListValidator
+  createCursorListValidator,
+  recordIdSchema,
+  recordIdInputSchema,
+  nullableRecordIdSchema
 } from "@jskit-ai/kernel/shared/validators";
-import { normalizeText } from "@jskit-ai/kernel/shared/support/normalize";
+import { normalizeRecordId, normalizeText } from "@jskit-ai/kernel/shared/support/normalize";
 import { normalizeConversationStatus } from "./support/conversationStatus.js";
 import { toPositiveInteger } from "./support/positiveInteger.js";
 
@@ -24,8 +27,8 @@ function normalizeChatStreamBody(payload = {}) {
     input: normalizeText(source.input)
   };
 
-  const conversationId = toPositiveInteger(source.conversationId, 0);
-  if (conversationId > 0) {
+  const conversationId = normalizeRecordId(source.conversationId, { fallback: null });
+  if (conversationId) {
     normalized.conversationId = conversationId;
   }
 
@@ -70,7 +73,7 @@ function normalizeConversationsListQuery(payload = {}) {
   const normalized = {};
 
   if (Object.hasOwn(source, "cursor")) {
-    normalized.cursor = toPositiveInteger(source.cursor, 0);
+    normalized.cursor = normalizeRecordId(source.cursor, { fallback: "" });
   }
   if (Object.hasOwn(source, "limit")) {
     normalized.limit = toPositiveInteger(source.limit, 0);
@@ -94,7 +97,7 @@ function normalizeConversationMessagesQuery(payload = {}) {
 function normalizeConversationMessagesParams(payload = {}) {
   const source = normalizeObjectInput(payload);
   return {
-    conversationId: toPositiveInteger(source.conversationId, 0)
+    conversationId: normalizeRecordId(source.conversationId, { fallback: "" })
   };
 }
 
@@ -115,10 +118,10 @@ function normalizeConversationRecord(payload = {}) {
   const source = normalizeObjectInput(payload);
 
   return {
-    id: toPositiveInteger(source.id, 0),
-    workspaceId: toPositiveInteger(source.workspaceId, 0) || null,
+    id: normalizeRecordId(source.id, { fallback: "" }),
+    workspaceId: normalizeRecordId(source.workspaceId, { fallback: null }),
     title: normalizeText(source.title),
-    createdByUserId: toPositiveInteger(source.createdByUserId, 0) || null,
+    createdByUserId: normalizeRecordId(source.createdByUserId, { fallback: null }),
     status: normalizeText(source.status),
     provider: normalizeText(source.provider),
     model: normalizeText(source.model),
@@ -136,14 +139,14 @@ function normalizeConversationMessageRecord(payload = {}) {
   const source = normalizeObjectInput(payload);
 
   return {
-    id: toPositiveInteger(source.id, 0),
-    conversationId: toPositiveInteger(source.conversationId, 0),
-    workspaceId: toPositiveInteger(source.workspaceId, 0) || null,
+    id: normalizeRecordId(source.id, { fallback: "" }),
+    conversationId: normalizeRecordId(source.conversationId, { fallback: "" }),
+    workspaceId: normalizeRecordId(source.workspaceId, { fallback: null }),
     seq: toPositiveInteger(source.seq, 0),
     role: normalizeText(source.role),
     kind: normalizeText(source.kind),
     clientMessageSid: normalizeText(source.clientMessageSid),
-    actorUserId: toPositiveInteger(source.actorUserId, 0) || null,
+    actorUserId: normalizeRecordId(source.actorUserId, { fallback: null }),
     contentText: source.contentText == null ? null : String(source.contentText),
     metadata: normalizeObjectInput(source.metadata),
     createdAt: normalizeText(source.createdAt)
@@ -161,7 +164,7 @@ const historyMessageSchema = Type.Object(
 const chatStreamBodySchema = Type.Object(
   {
     messageId: Type.String({ minLength: 1, maxLength: 128 }),
-    conversationId: Type.Optional(Type.Integer({ minimum: 1 })),
+    conversationId: Type.Optional(recordIdInputSchema),
     input: Type.String({ minLength: 1, maxLength: MAX_INPUT_CHARS }),
     history: Type.Optional(Type.Array(historyMessageSchema, { maxItems: MAX_HISTORY_MESSAGES })),
     clientContext: Type.Optional(
@@ -181,10 +184,10 @@ const chatStreamBodySchema = Type.Object(
 
 const conversationRecordSchema = Type.Object(
   {
-    id: Type.Integer({ minimum: 1 }),
-    workspaceId: Type.Union([Type.Integer({ minimum: 1 }), Type.Null()]),
+    id: recordIdSchema,
+    workspaceId: nullableRecordIdSchema,
     title: Type.String(),
-    createdByUserId: Type.Union([Type.Integer({ minimum: 1 }), Type.Null()]),
+    createdByUserId: nullableRecordIdSchema,
     status: Type.String(),
     provider: Type.String(),
     model: Type.String(),
@@ -206,14 +209,14 @@ const conversationRecordValidator = Object.freeze({
 
 const messageRecordSchema = Type.Object(
   {
-    id: Type.Integer({ minimum: 1 }),
-    conversationId: Type.Integer({ minimum: 1 }),
-    workspaceId: Type.Union([Type.Integer({ minimum: 1 }), Type.Null()]),
+    id: recordIdSchema,
+    conversationId: recordIdSchema,
+    workspaceId: nullableRecordIdSchema,
     seq: Type.Integer({ minimum: 1 }),
     role: Type.String({ minLength: 1 }),
     kind: Type.String({ minLength: 1 }),
     clientMessageSid: Type.String(),
-    actorUserId: Type.Union([Type.Integer({ minimum: 1 }), Type.Null()]),
+    actorUserId: nullableRecordIdSchema,
     contentText: Type.Union([Type.String(), Type.Null()]),
     metadata: Type.Record(Type.String(), Type.Unknown()),
     createdAt: Type.String({ minLength: 1 })
@@ -243,7 +246,7 @@ const assistantResource = Object.freeze({
       queryValidator: Object.freeze({
         schema: Type.Object(
           {
-            cursor: createOptionalPositiveIntegerQuerySchema(),
+            cursor: Type.Optional(recordIdInputSchema),
             limit: createOptionalPositiveIntegerQuerySchema(MAX_PAGE_SIZE),
             status: Type.Optional(Type.String({ minLength: 1, maxLength: 32 }))
           },
@@ -258,10 +261,7 @@ const assistantResource = Object.freeze({
       paramsValidator: Object.freeze({
         schema: Type.Object(
           {
-            conversationId: Type.Union([
-              Type.Integer({ minimum: 1 }),
-              Type.String({ pattern: "^[1-9][0-9]*$" })
-            ])
+            conversationId: recordIdInputSchema
           },
           { additionalProperties: false }
         ),

--- a/packages/assistant-core/src/shared/assistantSettingsResource.js
+++ b/packages/assistant-core/src/shared/assistantSettingsResource.js
@@ -1,7 +1,9 @@
 import { Type } from "typebox";
-import { normalizeText } from "@jskit-ai/kernel/shared/support/normalize";
-import { normalizeObjectInput } from "@jskit-ai/kernel/shared/validators";
-import { toPositiveInteger } from "./support/positiveInteger.js";
+import { normalizeText, normalizeRecordId } from "@jskit-ai/kernel/shared/support/normalize";
+import {
+  normalizeObjectInput,
+  nullableRecordIdSchema
+} from "@jskit-ai/kernel/shared/validators";
 
 const MAX_SYSTEM_PROMPT_CHARS = 12_000;
 
@@ -9,7 +11,7 @@ const assistantConfigRecordSchema = Type.Object(
   {
     targetSurfaceId: Type.String({ minLength: 1, maxLength: 64 }),
     scopeKey: Type.String({ minLength: 1, maxLength: 160 }),
-    workspaceId: Type.Union([Type.Integer({ minimum: 1 }), Type.Null()]),
+    workspaceId: nullableRecordIdSchema,
     settings: Type.Object(
       {
         systemPrompt: Type.String({ maxLength: MAX_SYSTEM_PROMPT_CHARS })
@@ -53,7 +55,7 @@ function normalizeConfigRecord(payload = {}) {
   return {
     targetSurfaceId: normalizeText(source.targetSurfaceId).toLowerCase(),
     scopeKey: normalizeText(source.scopeKey),
-    workspaceId: toPositiveInteger(source.workspaceId, 0) || null,
+    workspaceId: normalizeRecordId(source.workspaceId, { fallback: null }),
     settings: {
       systemPrompt: String(settings.systemPrompt || "")
     }

--- a/packages/assistant-core/src/shared/queryKeys.js
+++ b/packages/assistant-core/src/shared/queryKeys.js
@@ -1,3 +1,5 @@
+import { normalizeRecordId } from "@jskit-ai/kernel/shared/support/normalize";
+
 const ASSISTANT_QUERY_KEY_PREFIX = Object.freeze(["assistant"]);
 
 function normalizeSurfaceId(value) {
@@ -17,10 +19,10 @@ function normalizePositiveInteger(value, fallback) {
   return parsed;
 }
 
-function normalizeScopeKey({ targetSurfaceId = "", workspaceSlug = "", workspaceId = 0 } = {}) {
-  const normalizedWorkspaceId = normalizePositiveInteger(workspaceId, 0);
+function normalizeScopeKey({ targetSurfaceId = "", workspaceSlug = "", workspaceId = null } = {}) {
+  const normalizedWorkspaceId = normalizeRecordId(workspaceId, { fallback: null });
   const normalizedSurfaceId = normalizeSurfaceId(targetSurfaceId);
-  if (normalizedWorkspaceId > 0) {
+  if (normalizedWorkspaceId) {
     return `${normalizedSurfaceId}:workspace:${normalizedWorkspaceId}`;
   }
 
@@ -38,7 +40,7 @@ function normalizeStatus(value) {
 }
 
 function normalizeConversationId(value) {
-  return String(normalizePositiveInteger(value, 0) || "none");
+  return normalizeRecordId(value, { fallback: "none" });
 }
 
 function assistantRootQueryKey() {

--- a/packages/assistant-core/test/assistantResource.test.js
+++ b/packages/assistant-core/test/assistantResource.test.js
@@ -14,10 +14,10 @@ test("assistant output schemas accept normalized paginated payloads", () => {
 
   const messagesPayload = {
     conversation: {
-      id: 1,
-      workspaceId: 10,
+      id: "1",
+      workspaceId: "10",
       title: "Conversation",
-      createdByUserId: 7,
+      createdByUserId: "7",
       status: "active",
       provider: "openai",
       model: "gpt-4.1",
@@ -40,10 +40,10 @@ test("assistant output schemas accept normalized paginated payloads", () => {
   assert.equal(Check(conversationMessagesSchema, messagesPayload), true);
 });
 
-test("assistant conversation message params accept numeric path strings and normalize to integer", () => {
+test("assistant conversation message params accept numeric path strings and normalize to record-id strings", () => {
   const paramsValidator = assistantResource.operations.conversationMessagesList.paramsValidator;
   assert.equal(Check(paramsValidator.schema, { conversationId: "2" }), true);
   assert.deepEqual(paramsValidator.normalize({ conversationId: "2" }), {
-    conversationId: 2
+    conversationId: "2"
   });
 });

--- a/packages/assistant-core/test/queryKeys.test.js
+++ b/packages/assistant-core/test/queryKeys.test.js
@@ -28,7 +28,10 @@ test("assistant query keys normalize scope and paging", () => {
   ]);
 
   assert.deepEqual(
-    assistantConversationsListQueryKey({ targetSurfaceId: "admin", workspaceId: 9 }, { limit: 10, status: "ACTIVE" }),
+    assistantConversationsListQueryKey(
+      { targetSurfaceId: "admin", workspaceId: "9" },
+      { limit: 10, status: "ACTIVE" }
+    ),
     ["assistant", "admin:workspace:9", "conversations", "list", 10, "active"]
   );
 

--- a/packages/assistant-runtime/src/client/components/AssistantSettingsClientElement.vue
+++ b/packages/assistant-runtime/src/client/components/AssistantSettingsClientElement.vue
@@ -25,7 +25,7 @@
 import { computed, reactive, watch } from "vue";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/vue-query";
 import { getClientAppConfig } from "@jskit-ai/kernel/client";
-import { normalizeObject, normalizeText } from "@jskit-ai/kernel/shared/support/normalize";
+import { normalizeObject, normalizeRecordId, normalizeText } from "@jskit-ai/kernel/shared/support/normalize";
 import { validateOperationSection } from "@jskit-ai/http-runtime/shared/validators/operationValidation";
 import { assistantHttpClient, createAssistantApi, AssistantSettingsFormCard } from "@jskit-ai/assistant-core/client";
 import { assistantConfigResource, assistantSettingsQueryKey, buildAssistantApiPath } from "@jskit-ai/assistant-core/shared";
@@ -65,8 +65,8 @@ const scope = computed(() => {
     targetSurfaceId: normalizeText(assistantSurface.value?.targetSurfaceId).toLowerCase(),
     workspaceSlug,
     workspaceId: settingsRequiresWorkspace
-      ? Number(placementSnapshot.value?.workspace?.id || 0) || 0
-      : 0
+      ? normalizeRecordId(placementSnapshot.value?.workspace?.id, { fallback: null })
+      : null
   };
 });
 const hasScope = computed(() =>

--- a/packages/assistant-runtime/src/client/composables/useAssistantRuntime.js
+++ b/packages/assistant-runtime/src/client/composables/useAssistantRuntime.js
@@ -1,7 +1,7 @@
 import { computed, ref, watch } from "vue";
 import { useQueryClient } from "@tanstack/vue-query";
 import { getClientAppConfig } from "@jskit-ai/kernel/client";
-import { normalizeObject, normalizeText } from "@jskit-ai/kernel/shared/support/normalize";
+import { normalizeObject, normalizeRecordId, normalizeText } from "@jskit-ai/kernel/shared/support/normalize";
 import { buildAssistantApiPath } from "@jskit-ai/assistant-core/shared";
 import {
   ASSISTANT_STREAM_EVENT_TYPES,
@@ -47,13 +47,13 @@ function buildScopeStorageKey(scope = {}) {
 
 function readStoredActiveConversationId(scope = {}) {
   if (typeof window === "undefined" || !window.sessionStorage) {
-    return 0;
+    return "";
   }
 
   try {
-    return toPositiveInteger(window.sessionStorage.getItem(buildScopeStorageKey(scope)), 0);
+    return normalizeRecordId(window.sessionStorage.getItem(buildScopeStorageKey(scope)), { fallback: "" });
   } catch {
-    return 0;
+    return "";
   }
 }
 
@@ -62,11 +62,11 @@ function writeStoredActiveConversationId(scope = {}, conversationId) {
     return;
   }
 
-  const normalizedConversationId = toPositiveInteger(conversationId, 0);
+  const normalizedConversationId = normalizeRecordId(conversationId, { fallback: null });
   const storageKey = buildScopeStorageKey(scope);
   try {
-    if (normalizedConversationId > 0) {
-      window.sessionStorage.setItem(storageKey, String(normalizedConversationId));
+    if (normalizedConversationId) {
+      window.sessionStorage.setItem(storageKey, normalizedConversationId);
       return;
     }
 
@@ -164,7 +164,8 @@ function mapTranscriptEntriesToAssistantState(entries) {
     const role = normalizeText(entry?.role).toLowerCase();
     const kind = normalizeText(entry?.kind).toLowerCase();
     const metadata = normalizeObject(entry?.metadata);
-    const messageId = Number(entry?.id) > 0 ? `transcript_${entry.id}` : buildId("transcript");
+    const transcriptId = normalizeRecordId(entry?.id, { fallback: null });
+    const messageId = transcriptId ? `transcript_${transcriptId}` : buildId("transcript");
 
     if (kind === "chat" && (role === "user" || role === "assistant")) {
       messages.push({
@@ -258,8 +259,8 @@ function useAssistantRuntime({ api = null, surfaceId = "" } = {}) {
       targetSurfaceId: normalizeText(assistantSurface.value?.targetSurfaceId).toLowerCase(),
       workspaceSlug,
       workspaceId: assistantSurface.value?.runtimeSurfaceRequiresWorkspace
-        ? toPositiveInteger(placementSnapshot.value?.workspace?.id, 0)
-        : 0
+        ? normalizeRecordId(placementSnapshot.value?.workspace?.id, { fallback: null })
+        : null
     };
   });
   const hasRuntimeScope = computed(() =>
@@ -278,7 +279,7 @@ function useAssistantRuntime({ api = null, surfaceId = "" } = {}) {
     resolveSurfaceId: () => normalizeText(currentSurfaceId.value).toLowerCase()
   });
 
-  const activeConversationId = computed(() => normalizeText(conversationId.value));
+  const activeConversationId = computed(() => normalizeRecordId(conversationId.value, { fallback: "" }));
   const isAdminSurface = computed(() => normalizeText(currentSurfaceId.value).toLowerCase() === "admin");
   const canSend = computed(() => {
     return Boolean(
@@ -320,8 +321,7 @@ function useAssistantRuntime({ api = null, surfaceId = "" } = {}) {
       }),
     initialPageParam: null,
     dedupeBy(entry) {
-      const conversationNumericId = toPositiveInteger(entry?.id, 0);
-      return conversationNumericId > 0 ? String(conversationNumericId) : normalizeText(entry?.id);
+      return normalizeRecordId(entry?.id, { fallback: normalizeText(entry?.id) });
     },
     enabled: computed(() => hasRuntimeScope.value),
     queryOptions: {
@@ -345,15 +345,15 @@ function useAssistantRuntime({ api = null, surfaceId = "" } = {}) {
       return;
     }
 
-    const nextConversationNumericId = toPositiveInteger(nextConversationId, 0);
-    if (nextConversationNumericId > 0) {
-      writeStoredActiveConversationId(runtimeScope.value, nextConversationNumericId);
+    const nextConversationIdKey = normalizeRecordId(nextConversationId, { fallback: null });
+    if (nextConversationIdKey) {
+      writeStoredActiveConversationId(runtimeScope.value, nextConversationIdKey);
       return;
     }
 
-    const previousConversationNumericId = toPositiveInteger(previousConversationId, 0);
-    if (previousConversationNumericId > 0) {
-      writeStoredActiveConversationId(runtimeScope.value, 0);
+    const previousConversationIdKey = normalizeRecordId(previousConversationId, { fallback: null });
+    if (previousConversationIdKey) {
+      writeStoredActiveConversationId(runtimeScope.value, "");
     }
   });
 
@@ -378,8 +378,8 @@ function useAssistantRuntime({ api = null, surfaceId = "" } = {}) {
         return;
       }
 
-      const activeConversationNumericId = toPositiveInteger(nextConversationId, 0);
-      if (activeConversationNumericId > 0) {
+      const activeConversationIdKey = normalizeRecordId(nextConversationId, { fallback: null });
+      if (activeConversationIdKey) {
         return;
       }
 
@@ -394,10 +394,10 @@ function useAssistantRuntime({ api = null, surfaceId = "" } = {}) {
       }
 
       const hasStoredConversation = sourceEntries.some(
-        (entry) => toPositiveInteger(entry?.id, 0) === storedConversationId
+        (entry) => normalizeRecordId(entry?.id, { fallback: null }) === storedConversationId
       );
       if (!hasStoredConversation) {
-        writeStoredActiveConversationId(nextRuntimeScope, 0);
+        writeStoredActiveConversationId(nextRuntimeScope, "");
         return;
       }
 
@@ -458,13 +458,13 @@ function useAssistantRuntime({ api = null, surfaceId = "" } = {}) {
       return;
     }
 
-    const parsedConversationId = toPositiveInteger(normalizedConversationId, 0);
+    const parsedConversationId = normalizeRecordId(normalizedConversationId, { fallback: null });
     if (!parsedConversationId) {
       return;
     }
 
     const previousConversationId = conversationId.value;
-    conversationId.value = String(parsedConversationId);
+    conversationId.value = parsedConversationId;
     isRestoringConversation.value = true;
     setRuntimeError("");
 
@@ -507,7 +507,7 @@ function useAssistantRuntime({ api = null, surfaceId = "" } = {}) {
     input.value = "";
     setRuntimeError("");
     conversationId.value = null;
-    writeStoredActiveConversationId(runtimeScope.value, 0);
+    writeStoredActiveConversationId(runtimeScope.value, "");
     isStreaming.value = false;
     isRestoringConversation.value = false;
     abortController.value = null;
@@ -546,7 +546,7 @@ function useAssistantRuntime({ api = null, surfaceId = "" } = {}) {
     const messageId = buildId("message");
     const assistantMessageId = buildId("assistant");
     const history = buildHistory(messages.value);
-    const parsedConversationId = toPositiveInteger(conversationId.value, 0);
+    const parsedConversationId = normalizeRecordId(conversationId.value, { fallback: null });
 
     appendMessage({
       id: buildId("user"),
@@ -581,7 +581,7 @@ function useAssistantRuntime({ api = null, surfaceId = "" } = {}) {
       await runtimeApi.streamChat(
         {
           messageId,
-          ...(parsedConversationId > 0 ? { conversationId: parsedConversationId } : {}),
+          ...(parsedConversationId ? { conversationId: parsedConversationId } : {}),
           input: normalizedInput,
           history
         },
@@ -591,7 +591,7 @@ function useAssistantRuntime({ api = null, surfaceId = "" } = {}) {
             const eventType = normalizeAssistantStreamEventType(event?.type, "");
 
             if (eventType === ASSISTANT_STREAM_EVENT_TYPES.META && Object.hasOwn(event || {}, "conversationId")) {
-              conversationId.value = event?.conversationId ? String(event.conversationId) : null;
+              conversationId.value = normalizeRecordId(event?.conversationId, { fallback: null });
               return;
             }
 

--- a/packages/assistant-runtime/src/server/repositories/assistantConfigRepository.js
+++ b/packages/assistant-runtime/src/server/repositories/assistantConfigRepository.js
@@ -1,6 +1,6 @@
-import { parsePositiveInteger } from "@jskit-ai/kernel/server/runtime";
+import { normalizeDbRecordId } from "@jskit-ai/database-runtime/shared";
 import { normalizeSurfaceId } from "@jskit-ai/kernel/shared/surface/registry";
-import { normalizeText } from "@jskit-ai/kernel/shared/support/normalize";
+import { normalizeRecordId, normalizeText } from "@jskit-ai/kernel/shared/support/normalize";
 import { resolveInsertedId } from "@jskit-ai/assistant-core/server";
 import { assistantRuntimeConfig } from "../../shared/assistantRuntimeConfig.js";
 
@@ -9,7 +9,11 @@ function normalizeTargetSurfaceId(value = "") {
 }
 
 function normalizeWorkspaceId(value) {
-  return parsePositiveInteger(value) || null;
+  return normalizeRecordId(value, { fallback: null });
+}
+
+function normalizeWorkspaceDbId(value) {
+  return normalizeDbRecordId(value, { fallback: null });
 }
 
 function buildScopeKey(targetSurfaceId, workspaceId = null) {
@@ -29,7 +33,7 @@ function mapConfigRow(row = {}) {
   return {
     targetSurfaceId: normalizeTargetSurfaceId(row.target_surface_id),
     scopeKey: normalizeText(row.scope_key),
-    workspaceId: normalizeWorkspaceId(row.workspace_id),
+    workspaceId: normalizeWorkspaceDbId(row.workspace_id),
     settings: {
       systemPrompt: String(row.system_prompt || "")
     }

--- a/packages/assistant-runtime/src/server/repositories/conversationsRepository.js
+++ b/packages/assistant-runtime/src/server/repositories/conversationsRepository.js
@@ -1,7 +1,6 @@
-import { runInTransaction } from "@jskit-ai/database-runtime/shared/repositoryOptions";
-import { parsePositiveInteger } from "@jskit-ai/kernel/server/runtime";
+import { normalizeDbRecordId, runInTransaction } from "@jskit-ai/database-runtime/shared/repositoryOptions";
 import { normalizeSurfaceId } from "@jskit-ai/kernel/shared/surface/registry";
-import { normalizeText } from "@jskit-ai/kernel/shared/support/normalize";
+import { normalizeRecordId, normalizeText } from "@jskit-ai/kernel/shared/support/normalize";
 import {
   parseJsonObject,
   resolveInsertedId,
@@ -11,7 +10,15 @@ import {
 import { assistantRuntimeConfig } from "../../shared/assistantRuntimeConfig.js";
 
 function normalizeWorkspaceId(value) {
-  return parsePositiveInteger(value) || null;
+  return normalizeRecordId(value, { fallback: null });
+}
+
+function normalizeDbWorkspaceId(value) {
+  return normalizeDbRecordId(value, { fallback: null });
+}
+
+function normalizeInputRecordId(value) {
+  return normalizeRecordId(value, { fallback: null });
 }
 
 function normalizeRequiredSurfaceId(value) {
@@ -34,10 +41,10 @@ function applyWorkspaceScope(query, columnName, workspaceId) {
 
 function mapConversationRow(row = {}) {
   return {
-    id: Number(row.id),
-    workspaceId: normalizeWorkspaceId(row.workspace_id),
+    id: normalizeDbRecordId(row.id, { fallback: "" }),
+    workspaceId: normalizeDbWorkspaceId(row.workspace_id),
     title: String(row.title || "New conversation"),
-    createdByUserId: row.created_by_user_id == null ? null : Number(row.created_by_user_id),
+    createdByUserId: row.created_by_user_id == null ? null : normalizeDbRecordId(row.created_by_user_id, { fallback: null }),
     status: String(row.status || "active"),
     provider: String(row.provider || ""),
     model: String(row.model || ""),
@@ -52,8 +59,11 @@ function mapConversationRow(row = {}) {
 }
 
 function normalizeCursorPagination(pagination = {}, { defaultLimit = 20, maxLimit = 200 } = {}) {
-  const cursor = parsePositiveInteger(pagination.cursor) || 0;
-  const limit = Math.max(1, Math.min(maxLimit, parsePositiveInteger(pagination.limit) || defaultLimit));
+  const cursor = normalizeInputRecordId(pagination.cursor) || "";
+  const parsedLimit = Number(pagination.limit);
+  const limit = Number.isInteger(parsedLimit) && parsedLimit > 0
+    ? Math.max(1, Math.min(maxLimit, parsedLimit))
+    : defaultLimit;
 
   return {
     cursor,
@@ -71,14 +81,14 @@ function createRepository(knex) {
   }
 
   async function findById(conversationId, options = {}) {
-    const numericConversationId = parsePositiveInteger(conversationId);
-    if (!numericConversationId) {
+    const normalizedConversationId = normalizeInputRecordId(conversationId);
+    if (!normalizedConversationId) {
       return null;
     }
 
     const client = options?.trx || knex;
     const row = await createConversationBaseQuery(client)
-      .where("c.id", numericConversationId)
+      .where("c.id", normalizedConversationId)
       .first();
 
     return row ? mapConversationRow(row) : null;
@@ -89,17 +99,17 @@ function createRepository(knex) {
     { workspaceId = null, actorUserId = null, surfaceId = "" } = {},
     options = {}
   ) {
-    const numericConversationId = parsePositiveInteger(conversationId);
-    const numericActorUserId = parsePositiveInteger(actorUserId);
+    const normalizedConversationId = normalizeInputRecordId(conversationId);
+    const normalizedActorUserId = normalizeInputRecordId(actorUserId);
     const normalizedSurfaceId = normalizeSurfaceId(surfaceId);
-    if (!numericConversationId || !numericActorUserId || !normalizedSurfaceId) {
+    if (!normalizedConversationId || !normalizedActorUserId || !normalizedSurfaceId) {
       return null;
     }
 
     const client = options?.trx || knex;
     const query = createConversationBaseQuery(client)
-      .where("c.id", numericConversationId)
-      .where("c.created_by_user_id", numericActorUserId)
+      .where("c.id", normalizedConversationId)
+      .where("c.created_by_user_id", normalizedActorUserId)
       .where("c.surface_id", normalizedSurfaceId);
     applyWorkspaceScope(query, "c.workspace_id", workspaceId);
     const row = await query.first();
@@ -113,13 +123,13 @@ function createRepository(knex) {
     const surfaceId = normalizeRequiredSurfaceId(payload.surfaceId);
     const insertResult = await client(assistantRuntimeConfig.conversationsTable).insert({
       workspace_id: normalizeWorkspaceId(payload.workspaceId),
-      created_by_user_id: parsePositiveInteger(payload.createdByUserId) || null,
+      created_by_user_id: normalizeInputRecordId(payload.createdByUserId),
       title: normalizeText(payload.title) || "New conversation",
       status: normalizeText(payload.status).toLowerCase() || "active",
       provider: normalizeText(payload.provider),
       model: normalizeText(payload.model),
       surface_id: surfaceId,
-      message_count: parsePositiveInteger(payload.messageCount) || 0,
+      message_count: Math.max(0, Number(payload.messageCount || 0)),
       metadata_json: stringifyJsonObject(payload.metadata),
       started_at: payload.startedAt ? new Date(payload.startedAt) : now,
       ended_at: payload.endedAt ? new Date(payload.endedAt) : null,
@@ -137,8 +147,8 @@ function createRepository(knex) {
   }
 
   async function updateById(conversationId, patch = {}, options = {}) {
-    const numericConversationId = parsePositiveInteger(conversationId);
-    if (!numericConversationId) {
+    const normalizedConversationId = normalizeInputRecordId(conversationId);
+    if (!normalizedConversationId) {
       return null;
     }
 
@@ -173,31 +183,31 @@ function createRepository(knex) {
     if (Object.keys(updatePatch).length > 0) {
       updatePatch.updated_at = new Date();
       await client(assistantRuntimeConfig.conversationsTable)
-        .where({ id: numericConversationId })
+        .where({ id: normalizedConversationId })
         .update(updatePatch);
     }
 
-    return findById(numericConversationId, {
+    return findById(normalizedConversationId, {
       trx: client
     });
   }
 
   async function incrementMessageCount(conversationId, delta = 1, options = {}) {
-    const numericConversationId = parsePositiveInteger(conversationId);
-    if (!numericConversationId) {
+    const normalizedConversationId = normalizeInputRecordId(conversationId);
+    if (!normalizedConversationId) {
       return null;
     }
 
     const client = options?.trx || knex;
     const incrementBy = Number.isInteger(Number(delta)) ? Number(delta) : 1;
     await client(assistantRuntimeConfig.conversationsTable)
-      .where({ id: numericConversationId })
+      .where({ id: normalizedConversationId })
       .update({
         message_count: client.raw("GREATEST(0, message_count + ?)", [incrementBy]),
         updated_at: new Date()
       });
 
-    return findById(numericConversationId, {
+    return findById(normalizedConversationId, {
       trx: client
     });
   }
@@ -206,9 +216,9 @@ function createRepository(knex) {
     { workspaceId = null, actorUserId = null, surfaceId = "", pagination = {}, filters = {} } = {},
     options = {}
   ) {
-    const numericActorUserId = parsePositiveInteger(actorUserId);
+    const normalizedActorUserId = normalizeInputRecordId(actorUserId);
     const normalizedSurfaceId = normalizeSurfaceId(surfaceId);
-    if (!numericActorUserId || !normalizedSurfaceId) {
+    if (!normalizedActorUserId || !normalizedSurfaceId) {
       return {
         items: [],
         nextCursor: null
@@ -218,7 +228,7 @@ function createRepository(knex) {
     const client = options?.trx || knex;
     const { cursor, limit } = normalizeCursorPagination(pagination);
     let query = createConversationBaseQuery(client)
-      .where("c.created_by_user_id", numericActorUserId)
+      .where("c.created_by_user_id", normalizedActorUserId)
       .where("c.surface_id", normalizedSurfaceId);
     query = applyWorkspaceScope(query, "c.workspace_id", workspaceId);
 
@@ -226,7 +236,7 @@ function createRepository(knex) {
     if (normalizedStatus) {
       query = query.where("c.status", normalizedStatus);
     }
-    if (cursor > 0) {
+    if (cursor) {
       query = query.where("c.id", "<", cursor);
     }
 
@@ -237,7 +247,9 @@ function createRepository(knex) {
     const hasMore = rows.length > limit;
     const pageRows = hasMore ? rows.slice(0, limit) : rows;
     const items = pageRows.map(mapConversationRow);
-    const nextCursor = hasMore && pageRows.length > 0 ? String(pageRows[pageRows.length - 1].id) : null;
+    const nextCursor = hasMore && pageRows.length > 0
+      ? normalizeDbRecordId(pageRows[pageRows.length - 1].id, { fallback: null })
+      : null;
 
     return {
       items,

--- a/packages/assistant-runtime/src/server/repositories/messagesRepository.js
+++ b/packages/assistant-runtime/src/server/repositories/messagesRepository.js
@@ -1,6 +1,5 @@
-import { runInTransaction } from "@jskit-ai/database-runtime/shared/repositoryOptions";
-import { parsePositiveInteger } from "@jskit-ai/kernel/server/runtime";
-import { normalizeText } from "@jskit-ai/kernel/shared/support/normalize";
+import { normalizeDbRecordId, runInTransaction } from "@jskit-ai/database-runtime/shared/repositoryOptions";
+import { normalizeRecordId, normalizeText } from "@jskit-ai/kernel/shared/support/normalize";
 import {
   parseJsonObject,
   resolveInsertedId,
@@ -10,7 +9,15 @@ import {
 import { assistantRuntimeConfig } from "../../shared/assistantRuntimeConfig.js";
 
 function normalizeWorkspaceId(value) {
-  return parsePositiveInteger(value) || null;
+  return normalizeRecordId(value, { fallback: null });
+}
+
+function normalizeDbWorkspaceId(value) {
+  return normalizeDbRecordId(value, { fallback: null });
+}
+
+function normalizeInputRecordId(value) {
+  return normalizeRecordId(value, { fallback: null });
 }
 
 function applyWorkspaceScope(query, columnName, workspaceId) {
@@ -24,14 +31,14 @@ function applyWorkspaceScope(query, columnName, workspaceId) {
 
 function mapMessageRow(row = {}) {
   return {
-    id: Number(row.id),
-    conversationId: Number(row.conversation_id),
-    workspaceId: normalizeWorkspaceId(row.workspace_id),
+    id: normalizeDbRecordId(row.id, { fallback: "" }),
+    conversationId: normalizeDbRecordId(row.conversation_id, { fallback: "" }),
+    workspaceId: normalizeDbWorkspaceId(row.workspace_id),
     seq: Number(row.seq),
     role: String(row.role || ""),
     kind: String(row.kind || "chat"),
     clientMessageSid: String(row.client_message_sid || ""),
-    actorUserId: row.actor_user_id == null ? null : Number(row.actor_user_id),
+    actorUserId: row.actor_user_id == null ? null : normalizeDbRecordId(row.actor_user_id, { fallback: null }),
     contentText: row.content_text == null ? null : String(row.content_text),
     metadata: parseJsonObject(row.metadata_json),
     createdAt: toIso(row.created_at)
@@ -39,8 +46,12 @@ function mapMessageRow(row = {}) {
 }
 
 function normalizePagination(pagination = {}, { defaultPage = 1, defaultPageSize = 200, maxPageSize = 500 } = {}) {
-  const page = Math.max(1, parsePositiveInteger(pagination.page) || defaultPage);
-  const pageSize = Math.max(1, Math.min(maxPageSize, parsePositiveInteger(pagination.pageSize) || defaultPageSize));
+  const rawPage = Number(pagination.page);
+  const rawPageSize = Number(pagination.pageSize);
+  const page = Number.isInteger(rawPage) && rawPage > 0 ? rawPage : defaultPage;
+  const pageSize = Number.isInteger(rawPageSize) && rawPageSize > 0
+    ? Math.max(1, Math.min(maxPageSize, rawPageSize))
+    : defaultPageSize;
 
   return {
     page,
@@ -67,14 +78,14 @@ function createRepository(knex) {
   }
 
   async function findById(messageId, options = {}) {
-    const numericMessageId = parsePositiveInteger(messageId);
-    if (!numericMessageId) {
+    const normalizedMessageId = normalizeInputRecordId(messageId);
+    if (!normalizedMessageId) {
       return null;
     }
 
     const client = options?.trx || knex;
     const row = await client(assistantRuntimeConfig.messagesTable)
-      .where({ id: numericMessageId })
+      .where({ id: normalizedMessageId })
       .first();
 
     return row ? mapMessageRow(row) : null;
@@ -82,12 +93,13 @@ function createRepository(knex) {
 
   async function create(payload = {}, options = {}) {
     const client = options?.trx || knex;
-    const conversationId = parsePositiveInteger(payload.conversationId);
+    const conversationId = normalizeInputRecordId(payload.conversationId);
     if (!conversationId) {
       throw new TypeError("messagesRepository.create requires conversationId.");
     }
 
-    const seq = parsePositiveInteger(payload.seq) || (await resolveNextSequence(client, conversationId));
+    const providedSeq = Number(payload.seq);
+    const seq = Number.isInteger(providedSeq) && providedSeq > 0 ? providedSeq : (await resolveNextSequence(client, conversationId));
     const insertResult = await client(assistantRuntimeConfig.messagesTable).insert({
       conversation_id: conversationId,
       workspace_id: normalizeWorkspaceId(payload.workspaceId),
@@ -95,7 +107,7 @@ function createRepository(knex) {
       role: normalizeText(payload.role).toLowerCase(),
       kind: normalizeText(payload.kind).toLowerCase() || "chat",
       client_message_sid: normalizeText(payload.clientMessageSid),
-      actor_user_id: parsePositiveInteger(payload.actorUserId) || null,
+      actor_user_id: normalizeInputRecordId(payload.actorUserId),
       content_text: payload.contentText == null ? null : String(payload.contentText),
       metadata_json: stringifyJsonObject(payload.metadata),
       created_at: payload.createdAt ? new Date(payload.createdAt) : new Date()
@@ -111,14 +123,14 @@ function createRepository(knex) {
   }
 
   async function countByConversationScope(conversationId, { workspaceId = null } = {}, options = {}) {
-    const numericConversationId = parsePositiveInteger(conversationId);
-    if (!numericConversationId) {
+    const normalizedConversationId = normalizeInputRecordId(conversationId);
+    if (!normalizedConversationId) {
       return 0;
     }
 
     const client = options?.trx || knex;
     const query = client(assistantRuntimeConfig.messagesTable).where({
-      conversation_id: numericConversationId
+      conversation_id: normalizedConversationId
     });
     applyWorkspaceScope(query, "workspace_id", workspaceId);
     const row = await query.count({ total: "*" }).first();
@@ -128,8 +140,8 @@ function createRepository(knex) {
   }
 
   async function listByConversationScope(conversationId, { workspaceId = null } = {}, pagination = {}, options = {}) {
-    const numericConversationId = parsePositiveInteger(conversationId);
-    if (!numericConversationId) {
+    const normalizedConversationId = normalizeInputRecordId(conversationId);
+    if (!normalizedConversationId) {
       return [];
     }
 
@@ -138,7 +150,7 @@ function createRepository(knex) {
     const offset = (page - 1) * pageSize;
 
     const query = client(assistantRuntimeConfig.messagesTable).where({
-      conversation_id: numericConversationId
+      conversation_id: normalizedConversationId
     });
     applyWorkspaceScope(query, "workspace_id", workspaceId);
     const rows = await query

--- a/packages/assistant-runtime/src/server/services/assistantConfigService.js
+++ b/packages/assistant-runtime/src/server/services/assistantConfigService.js
@@ -1,5 +1,5 @@
-import { AppError, parsePositiveInteger, requireAuth } from "@jskit-ai/kernel/server/runtime";
-import { normalizeObject } from "@jskit-ai/kernel/shared/support/normalize";
+import { AppError, requireAuth } from "@jskit-ai/kernel/server/runtime";
+import { normalizeObject, normalizeRecordId } from "@jskit-ai/kernel/shared/support/normalize";
 import { resolveWorkspace } from "@jskit-ai/users-core/server/support/resolveWorkspace";
 import { resolveAssistantSurfaceConfig } from "../../shared/assistantSurfaces.js";
 
@@ -64,7 +64,7 @@ function createService({ assistantConfigRepository, consoleService = null, appCo
     }
 
     const resolvedWorkspace = workspace || resolveWorkspace(context, input);
-    const workspaceId = parsePositiveInteger(resolvedWorkspace?.id);
+    const workspaceId = normalizeRecordId(resolvedWorkspace?.id, { fallback: null });
     if (!workspaceId) {
       throw new AppError(409, "Workspace selection required.");
     }

--- a/packages/assistant-runtime/src/server/services/chatService.js
+++ b/packages/assistant-runtime/src/server/services/chatService.js
@@ -1,5 +1,5 @@
-import { AppError, parsePositiveInteger } from "@jskit-ai/kernel/server/runtime";
-import { normalizeObject, normalizeText } from "@jskit-ai/kernel/shared/support/normalize";
+import { AppError } from "@jskit-ai/kernel/server/runtime";
+import { normalizeObject, normalizeRecordId, normalizeText } from "@jskit-ai/kernel/shared/support/normalize";
 import { resolveWorkspace } from "@jskit-ai/users-core/server/support/resolveWorkspace";
 import { resolveWorkspaceSlug } from "@jskit-ai/assistant-core/server";
 import {
@@ -12,8 +12,7 @@ const MAX_INPUT_CHARS = 8000;
 const MAX_TOOL_ROUNDS = 4;
 
 function normalizeConversationId(value) {
-  const parsed = parsePositiveInteger(value);
-  return parsed > 0 ? parsed : null;
+  return normalizeRecordId(value, { fallback: null });
 }
 
 function normalizeHistory(history = []) {

--- a/packages/assistant-runtime/src/server/services/transcriptService.js
+++ b/packages/assistant-runtime/src/server/services/transcriptService.js
@@ -1,6 +1,6 @@
 import { AppError, parsePositiveInteger } from "@jskit-ai/kernel/server/runtime";
 import { normalizeSurfaceId } from "@jskit-ai/kernel/shared/surface/registry";
-import { normalizeObject, normalizeText } from "@jskit-ai/kernel/shared/support/normalize";
+import { normalizeObject, normalizeRecordId, normalizeText } from "@jskit-ai/kernel/shared/support/normalize";
 import { normalizeConversationStatus } from "@jskit-ai/assistant-core/shared";
 
 const DEFAULT_PAGE_SIZE = 20;
@@ -11,21 +11,21 @@ const DEFAULT_CONVERSATION_TITLE = "New conversation";
 const MAX_CONVERSATION_TITLE_LENGTH = 80;
 
 function resolveWorkspaceId(workspace, { required = false } = {}) {
-  const workspaceId = parsePositiveInteger(workspace?.id || workspace);
+  const workspaceId = normalizeRecordId(workspace?.id || workspace, { fallback: null });
   if (!workspaceId && required) {
     throw new AppError(409, "Workspace selection required.");
   }
 
-  return workspaceId || null;
+  return workspaceId;
 }
 
 function resolveActorUserId(user, { required = false } = {}) {
-  const actorUserId = parsePositiveInteger(user?.id);
+  const actorUserId = normalizeRecordId(user?.id, { fallback: null });
   if (!actorUserId && required) {
     throw new AppError(401, "Authentication required.");
   }
 
-  return actorUserId || null;
+  return actorUserId;
 }
 
 function normalizePagination(pagination = {}, { defaultPageSize = DEFAULT_PAGE_SIZE, maxPageSize = MAX_PAGE_SIZE } = {}) {
@@ -39,7 +39,7 @@ function normalizePagination(pagination = {}, { defaultPageSize = DEFAULT_PAGE_S
 }
 
 function normalizeCursorPagination(query = {}, { defaultLimit = DEFAULT_PAGE_SIZE, maxLimit = MAX_PAGE_SIZE } = {}) {
-  const cursor = parsePositiveInteger(query.cursor) || 0;
+  const cursor = normalizeRecordId(query.cursor, { fallback: null });
   const limit = Math.max(1, Math.min(maxLimit, parsePositiveInteger(query.limit) || defaultLimit));
 
   return {
@@ -92,7 +92,7 @@ function createTranscriptService({ conversationsRepository, messagesRepository }
       required: true
     });
     const source = normalizeObject(options);
-    const conversationId = parsePositiveInteger(source.conversationId);
+    const conversationId = normalizeRecordId(source.conversationId, { fallback: null });
 
     if (conversationId) {
       const existing = await conversationsRepository.findByIdForActorScope(conversationId, {
@@ -143,16 +143,16 @@ function createTranscriptService({ conversationsRepository, messagesRepository }
 
   async function appendMessage(assistantSurface, conversationId, payload = {}, options = {}) {
     const resolvedAssistantSurface = requireAssistantSurface(assistantSurface);
-    const numericConversationId = parsePositiveInteger(conversationId);
-    if (!numericConversationId) {
+    const normalizedConversationId = normalizeRecordId(conversationId, { fallback: null });
+    if (!normalizedConversationId) {
       throw new TypeError("appendMessage requires conversationId.");
     }
 
     const source = normalizeObject(payload);
     const context = normalizeObject(options.context);
-    const actorUserId = parsePositiveInteger(source.actorUserId) || resolveActorUserId(context.actor);
+    const actorUserId = normalizeRecordId(source.actorUserId, { fallback: null }) || resolveActorUserId(context.actor);
     const workspaceId = resolveExpectedWorkspaceId(resolvedAssistantSurface, options.workspace || context.workspace);
-    const conversation = await conversationsRepository.findByIdForActorScope(numericConversationId, {
+    const conversation = await conversationsRepository.findByIdForActorScope(normalizedConversationId, {
       workspaceId,
       actorUserId,
       surfaceId: resolvedAssistantSurface.targetSurfaceId
@@ -162,7 +162,7 @@ function createTranscriptService({ conversationsRepository, messagesRepository }
     }
 
     const createdMessage = await messagesRepository.create({
-      conversationId: numericConversationId,
+      conversationId: normalizedConversationId,
       workspaceId: conversation.workspaceId,
       role: normalizeText(source.role).toLowerCase(),
       kind: normalizeText(source.kind).toLowerCase() || "chat",
@@ -172,29 +172,29 @@ function createTranscriptService({ conversationsRepository, messagesRepository }
       metadata: normalizeObject(source.metadata)
     });
 
-    await conversationsRepository.incrementMessageCount(numericConversationId, 1);
+    await conversationsRepository.incrementMessageCount(normalizedConversationId, 1);
 
     const messageRole = normalizeText(source.role).toLowerCase();
     const messageKind = normalizeText(source.kind).toLowerCase() || "chat";
     if (messageRole === "user" && messageKind === "chat" && isDefaultConversationTitle(conversation.title)) {
       const derivedTitle = deriveConversationTitleFromMessage(source.contentText);
       if (derivedTitle) {
-        await conversationsRepository.updateById(numericConversationId, {
+        await conversationsRepository.updateById(normalizedConversationId, {
           title: derivedTitle
         });
       }
     }
 
     return {
-      conversationId: numericConversationId,
+      conversationId: normalizedConversationId,
       message: createdMessage
     };
   }
 
   async function completeConversation(assistantSurface, conversationId, payload = {}, options = {}) {
     const resolvedAssistantSurface = requireAssistantSurface(assistantSurface);
-    const numericConversationId = parsePositiveInteger(conversationId);
-    if (!numericConversationId) {
+    const normalizedConversationId = normalizeRecordId(conversationId, { fallback: null });
+    if (!normalizedConversationId) {
       throw new TypeError("completeConversation requires conversationId.");
     }
 
@@ -204,7 +204,7 @@ function createTranscriptService({ conversationsRepository, messagesRepository }
       required: true
     });
     const workspaceId = resolveExpectedWorkspaceId(resolvedAssistantSurface, options.workspace || context.workspace);
-    const existing = await conversationsRepository.findByIdForActorScope(numericConversationId, {
+    const existing = await conversationsRepository.findByIdForActorScope(normalizedConversationId, {
       workspaceId,
       actorUserId,
       surfaceId: resolvedAssistantSurface.targetSurfaceId
@@ -213,7 +213,7 @@ function createTranscriptService({ conversationsRepository, messagesRepository }
       throw new AppError(404, "Conversation not found.");
     }
 
-    return conversationsRepository.updateById(numericConversationId, {
+    return conversationsRepository.updateById(normalizedConversationId, {
       status: normalizeConversationStatus(source.status, {
         fallback: "completed"
       }),
@@ -243,18 +243,16 @@ function createTranscriptService({ conversationsRepository, messagesRepository }
       ...(status ? { status } : {})
     };
 
-    return conversationsRepository.listForActorScope(
-      {
-        workspaceId,
-        actorUserId,
-        surfaceId: resolvedAssistantSurface.targetSurfaceId,
-        pagination: {
-          cursor: pagination.cursor,
-          limit: pagination.limit
-        },
-        filters
-      }
-    );
+    return conversationsRepository.listForActorScope({
+      workspaceId,
+      actorUserId,
+      surfaceId: resolvedAssistantSurface.targetSurfaceId,
+      pagination: {
+        cursor: pagination.cursor,
+        limit: pagination.limit
+      },
+      filters
+    });
   }
 
   async function getConversationMessagesForUser(assistantSurface, workspace, user, conversationId, query = {}) {
@@ -263,19 +261,19 @@ function createTranscriptService({ conversationsRepository, messagesRepository }
     const actorUserId = resolveActorUserId(user, {
       required: true
     });
-    const numericConversationId = parsePositiveInteger(conversationId);
-    if (!numericConversationId) {
+    const normalizedConversationId = normalizeRecordId(conversationId, { fallback: null });
+    if (!normalizedConversationId) {
       throw new AppError(400, "Validation failed.", {
         details: {
           fieldErrors: {
-            conversationId: "conversationId must be a positive integer."
+            conversationId: "conversationId must be a valid record id."
           }
         }
       });
     }
 
     const conversation = await conversationsRepository.findByIdForActorScope(
-      numericConversationId,
+      normalizedConversationId,
       {
         workspaceId,
         actorUserId,
@@ -291,7 +289,7 @@ function createTranscriptService({ conversationsRepository, messagesRepository }
       maxPageSize: MAX_MESSAGES_PAGE_SIZE
     });
     const total = await messagesRepository.countByConversationScope(
-      numericConversationId,
+      normalizedConversationId,
       {
         workspaceId
       }
@@ -299,7 +297,7 @@ function createTranscriptService({ conversationsRepository, messagesRepository }
     const totalPages = Math.max(1, Math.ceil(total / pagination.pageSize));
     const page = Math.min(pagination.page, totalPages);
     const entries = await messagesRepository.listByConversationScope(
-      numericConversationId,
+      normalizedConversationId,
       {
         workspaceId
       },

--- a/packages/assistant-runtime/templates/migrations/assistant_config_initial.cjs
+++ b/packages/assistant-runtime/templates/migrations/assistant_config_initial.cjs
@@ -4,10 +4,10 @@ exports.up = async function up(knex) {
     const hasWorkspacesTable = await knex.schema.hasTable("workspaces");
 
     await knex.schema.createTable("assistant_config", (table) => {
-      table.increments("id").unsigned().primary();
+      table.bigIncrements("id").primary();
       table.string("target_surface_id", 64).notNullable();
       table.string("scope_key", 160).notNullable();
-      table.integer("workspace_id").unsigned().nullable();
+      table.bigInteger("workspace_id").unsigned().nullable();
       if (hasWorkspacesTable) {
         table.foreign("workspace_id").references("id").inTable("workspaces").onDelete("CASCADE");
       }

--- a/packages/assistant-runtime/templates/migrations/assistant_transcripts_initial.cjs
+++ b/packages/assistant-runtime/templates/migrations/assistant_transcripts_initial.cjs
@@ -3,12 +3,12 @@ exports.up = async function up(knex) {
   const hasConversationsTable = await knex.schema.hasTable("assistant_conversations");
   if (!hasConversationsTable) {
     await knex.schema.createTable("assistant_conversations", (table) => {
-      table.increments("id").unsigned().primary();
-      table.integer("workspace_id").unsigned().nullable();
+      table.bigIncrements("id").primary();
+      table.bigInteger("workspace_id").unsigned().nullable();
       if (hasWorkspacesTable) {
         table.foreign("workspace_id").references("id").inTable("workspaces").onDelete("CASCADE");
       }
-      table.integer("created_by_user_id").unsigned().nullable().references("id").inTable("users").onDelete("SET NULL").index();
+      table.bigInteger("created_by_user_id").unsigned().nullable().references("id").inTable("users").onDelete("SET NULL").index();
       table.string("title", 160).notNullable().defaultTo("New conversation");
       table.string("status", 32).notNullable().defaultTo("active");
       table.string("provider", 64).notNullable().defaultTo("");
@@ -30,9 +30,9 @@ exports.up = async function up(knex) {
   const hasMessagesTable = await knex.schema.hasTable("assistant_messages");
   if (!hasMessagesTable) {
     await knex.schema.createTable("assistant_messages", (table) => {
-      table.increments("id").unsigned().primary();
-      table.integer("conversation_id").unsigned().notNullable().references("id").inTable("assistant_conversations").onDelete("CASCADE");
-      table.integer("workspace_id").unsigned().nullable();
+      table.bigIncrements("id").primary();
+      table.bigInteger("conversation_id").unsigned().notNullable().references("id").inTable("assistant_conversations").onDelete("CASCADE");
+      table.bigInteger("workspace_id").unsigned().nullable();
       if (hasWorkspacesTable) {
         table.foreign("workspace_id").references("id").inTable("workspaces").onDelete("CASCADE");
       }
@@ -40,7 +40,7 @@ exports.up = async function up(knex) {
       table.string("role", 32).notNullable();
       table.string("kind", 32).notNullable().defaultTo("chat");
       table.string("client_message_sid", 128).notNullable().defaultTo("");
-      table.integer("actor_user_id").unsigned().nullable().references("id").inTable("users").onDelete("SET NULL").index();
+      table.bigInteger("actor_user_id").unsigned().nullable().references("id").inTable("users").onDelete("SET NULL").index();
       table.text("content_text").nullable();
       table.text("metadata_json").nullable();
       table.timestamp("created_at").notNullable().defaultTo(knex.fn.now());

--- a/packages/auth-core/src/server/membershipAccess.js
+++ b/packages/auth-core/src/server/membershipAccess.js
@@ -1,3 +1,5 @@
+import { normalizeRecordId } from "@jskit-ai/kernel/shared/support/normalize";
+
 function resolveMembershipRoleId(membershipLike) {
   return String(membershipLike?.roleSid || "").trim();
 }
@@ -36,10 +38,10 @@ function createMembershipIndexes(memberships) {
   const bySlug = new Map();
 
   for (const membership of memberships) {
-    const workspaceId = Number(membership?.id);
+    const workspaceId = normalizeRecordId(membership?.id, { fallback: null });
     const workspaceSlug = String(membership?.slug || "").trim();
 
-    if (Number.isInteger(workspaceId) && workspaceId > 0) {
+    if (workspaceId) {
       byId.set(workspaceId, membership);
     }
     if (workspaceSlug) {

--- a/packages/auth-provider-supabase-core/src/server/lib/authSessionEventsService.js
+++ b/packages/auth-provider-supabase-core/src/server/lib/authSessionEventsService.js
@@ -1,8 +1,8 @@
-import { normalizePositiveInteger } from "@jskit-ai/kernel/shared/support/normalize";
+import { normalizeRecordId } from "@jskit-ai/kernel/shared/support/normalize";
 
 function createAuthSessionEventsService() {
   async function notifySessionChanged(options = {}) {
-    const actorId = normalizePositiveInteger(options?.context?.actor?.id);
+    const actorId = normalizeRecordId(options?.context?.actor?.id, { fallback: null });
     if (!actorId) {
       return null;
     }

--- a/packages/auth-provider-supabase-core/src/server/lib/service.js
+++ b/packages/auth-provider-supabase-core/src/server/lib/service.js
@@ -6,6 +6,7 @@ import {
   buildOAuthMethodId
 } from "@jskit-ai/auth-core/shared/authMethods";
 import { normalizeEmail } from "@jskit-ai/auth-core/server/utils";
+import { normalizeRecordId } from "@jskit-ai/kernel/shared/support/normalize";
 import { validators } from "@jskit-ai/auth-core/server/validators";
 import {
   isTransientAuthMessage,
@@ -387,7 +388,7 @@ function createService(options) {
   }
 
   function requireSynchronizedProfile(profile) {
-    if (profile && Number.isFinite(Number(profile.id)) && String(profile.displayName || "").trim()) {
+    if (profile && normalizeRecordId(profile.id, { fallback: null }) && String(profile.displayName || "").trim()) {
       return profile;
     }
 

--- a/packages/auth-provider-supabase-core/src/server/lib/standaloneProfileSyncService.js
+++ b/packages/auth-provider-supabase-core/src/server/lib/standaloneProfileSyncService.js
@@ -48,7 +48,7 @@ function createEmailConflictError() {
 function createStandaloneProfileSyncService() {
   const profilesByIdentityKey = new Map();
   const identityKeyByEmail = new Map();
-  let nextId = 1;
+  let nextId = 1n;
 
   async function findByIdentity(identityLike) {
     const identity = normalizeIdentity(identityLike);
@@ -65,8 +65,13 @@ function createStandaloneProfileSyncService() {
       throw createEmailConflictError();
     }
 
+    const nextIdValue = existing?.id ? String(existing.id) : String(nextId);
+    if (!existing?.id) {
+      nextId += 1n;
+    }
+
     const next = {
-      id: Number(existing?.id || nextId++),
+      id: nextIdValue,
       authProvider: normalizedProfile.authProvider,
       authProviderUserSid: normalizedProfile.authProviderUserSid,
       email: normalizedProfile.email,

--- a/packages/auth-provider-supabase-core/src/server/providers/AuthSupabaseServiceProvider.js
+++ b/packages/auth-provider-supabase-core/src/server/providers/AuthSupabaseServiceProvider.js
@@ -1,5 +1,6 @@
 import { resolveAllowedOriginsFromSurfaceDefinitions } from "@jskit-ai/kernel/shared/support/returnToPath";
 import { withActionDefaults } from "@jskit-ai/kernel/shared/actions";
+import { normalizeRecordId } from "@jskit-ai/kernel/shared/support/normalize";
 import { createService } from "../lib/service.js";
 import { createStandaloneProfileSyncService } from "../lib/standaloneProfileSyncService.js";
 import { createAuthSessionEventsService } from "../lib/authSessionEventsService.js";
@@ -91,15 +92,18 @@ function createInMemoryUserSettingsRepository() {
   const settingsByUserId = new Map();
 
   function ensure(userId) {
-    const numericUserId = Number(userId);
-    if (!settingsByUserId.has(numericUserId)) {
-      settingsByUserId.set(numericUserId, {
-        userId: numericUserId,
+    const normalizedUserId = normalizeRecordId(userId, { fallback: null });
+    if (!normalizedUserId) {
+      throw new TypeError("User settings require a valid user id.");
+    }
+    if (!settingsByUserId.has(normalizedUserId)) {
+      settingsByUserId.set(normalizedUserId, {
+        userId: normalizedUserId,
         passwordSignInEnabled: true,
         passwordSetupRequired: false
       });
     }
-    return settingsByUserId.get(numericUserId);
+    return settingsByUserId.get(normalizedUserId);
   }
 
   return Object.freeze({

--- a/packages/crud-core/package.json
+++ b/packages/crud-core/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "@tanstack/vue-query": "^5.90.5",
+    "@jskit-ai/database-runtime": "0.1.32",
     "@jskit-ai/kernel": "0.1.32",
     "@jskit-ai/realtime": "0.1.31",
     "@jskit-ai/shell-web": "0.1.31",

--- a/packages/crud-core/src/client/composables/createCrudClientSupport.js
+++ b/packages/crud-core/src/client/composables/createCrudClientSupport.js
@@ -113,7 +113,7 @@ function useCrudClientContext(source = {}) {
     return resolveCrudRecordPathTemplates(listPathTemplate, recordIdParam);
   }
 
-  function resolveRecordParams(recordIdLike = 0, { recordIdParam = defaultRecordIdParam } = {}) {
+  function resolveRecordParams(recordIdLike = "", { recordIdParam = defaultRecordIdParam } = {}) {
     return resolveCrudRecordPathParams(recordIdLike, recordIdParam);
   }
 
@@ -122,7 +122,7 @@ function useCrudClientContext(source = {}) {
     return crudListQueryKey(normalizedSurfaceId, workspaceSlugToken.value, crudConfig.namespace);
   }
 
-  function viewQueryKey(surfaceId = "", recordId = 0) {
+  function viewQueryKey(surfaceId = "", recordId = "") {
     const normalizedSurfaceId = String(surfaceId || paths.currentSurfaceId.value || "").trim();
     return crudViewQueryKey(normalizedSurfaceId, workspaceSlugToken.value, recordId, crudConfig.namespace);
   }

--- a/packages/crud-core/src/client/composables/crudClientSupportHelpers.js
+++ b/packages/crud-core/src/client/composables/crudClientSupportHelpers.js
@@ -1,4 +1,4 @@
-import { normalizeText, normalizeQueryToken } from "@jskit-ai/kernel/shared/support/normalize";
+import { normalizeQueryToken, normalizeRecordId, normalizeText } from "@jskit-ai/kernel/shared/support/normalize";
 import { normalizeRouteVisibilityToken } from "@jskit-ai/kernel/shared/support/visibility";
 import { formatDateTime } from "@jskit-ai/kernel/shared/support";
 import {
@@ -58,13 +58,13 @@ function crudListQueryKey(surfaceId = "", workspaceSlug = "", namespace = "") {
   ]);
 }
 
-function crudViewQueryKey(surfaceId = "", workspaceSlug = "", recordId = 0, namespace = "") {
+function crudViewQueryKey(surfaceId = "", workspaceSlug = "", recordId = "", namespace = "") {
   return Object.freeze([
     ...crudScopeQueryKey(namespace),
     "view",
     normalizeQueryToken(surfaceId),
     normalizeQueryToken(workspaceSlug),
-    Number(recordId) || 0
+    normalizeRecordId(recordId, { fallback: "0" })
   ]);
 }
 
@@ -87,8 +87,9 @@ function toRouteRecordId(value) {
     return toRouteRecordId(value[0]);
   }
 
-  const parsed = Number(value);
-  return Number.isInteger(parsed) && parsed > 0 ? parsed : 0;
+  return normalizeRecordId(value, {
+    fallback: ""
+  });
 }
 
 function normalizeCrudRouteParamName(value, { context = "normalizeCrudRouteParamName" } = {}) {
@@ -120,7 +121,7 @@ function resolveCrudRecordPathTemplates(relativePath = "", recordIdParam = "reco
   });
 }
 
-function resolveCrudRecordPathParams(recordIdLike = 0, recordIdParam = "recordId") {
+function resolveCrudRecordPathParams(recordIdLike = "", recordIdParam = "recordId") {
   const normalizedRecordIdParam = normalizeCrudRouteParamName(recordIdParam, {
     context: "resolveCrudRecordPathParams"
   });
@@ -130,7 +131,7 @@ function resolveCrudRecordPathParams(recordIdLike = 0, recordIdParam = "recordId
   }
 
   return Object.freeze({
-    [normalizedRecordIdParam]: String(normalizedRecordId)
+    [normalizedRecordIdParam]: normalizedRecordId
   });
 }
 

--- a/packages/crud-core/src/server/repositoryMethods.js
+++ b/packages/crud-core/src/server/repositoryMethods.js
@@ -1,7 +1,7 @@
-import { toInsertDateTime } from "@jskit-ai/database-runtime/shared";
+import { resolveInsertedRecordId, toInsertDateTime } from "@jskit-ai/database-runtime/shared";
 import { applyVisibility, applyVisibilityOwners } from "@jskit-ai/database-runtime/shared/visibility";
 import { AppError } from "@jskit-ai/kernel/server/runtime/errors";
-import { normalizeText, normalizeUniqueTextList } from "@jskit-ai/kernel/shared/support/normalize";
+import { normalizeRecordId, normalizeText, normalizeUniqueTextList } from "@jskit-ai/kernel/shared/support/normalize";
 import { Check, Errors } from "typebox/value";
 import {
   DEFAULT_LIST_LIMIT,
@@ -28,6 +28,14 @@ const LIST_ORDER_NULLS_LAST = "last";
 const ORDERED_LIST_CURSOR_VALUE_TYPE_KEY = "__jskitCursorValueType";
 const ORDERED_LIST_CURSOR_VALUE_KEY = "value";
 const ORDERED_LIST_CURSOR_VALUE_TYPE_DATE = "date";
+
+function requireCrudRecordId(value, { context = "crudRepository" } = {}) {
+  const recordId = normalizeRecordId(value, { fallback: null });
+  if (!recordId) {
+    throw new TypeError(`${context} requires recordId.`);
+  }
+  return recordId;
+}
 
 function resolveRepositoryDefaults(resource = {}, repositoryMapping = {}) {
   const resourceName = normalizeText(resource.resource);
@@ -757,7 +765,12 @@ async function crudRepositoryList(runtime, knex, query = {}, repositoryOptions =
   const pageRows = hasMore ? rows.slice(0, normalizedLimit) : rows;
   const items = [];
   for (const row of pageRows) {
-    const mappedRecord = mapRecordRow(row, runtime.mapping.outputKeys, runtime.mapping.columnOverrides);
+    const mappedRecord = mapRecordRow(
+      row,
+      runtime.mapping.outputKeys,
+      runtime.mapping.columnOverrides,
+      { recordIdKeys: runtime.mapping.outputRecordIdKeys }
+    );
     if (!mappedRecord) {
       continue;
     }
@@ -855,6 +868,7 @@ async function crudRepositoryList(runtime, knex, query = {}, repositoryOptions =
 
 async function crudRepositoryFindById(runtime, knex, recordId, repositoryOptions = {}, callOptions = {}, hooks = null) {
   const { client, tableName, idColumn, visible } = resolveCrudRepositoryCall(runtime, knex, repositoryOptions, callOptions);
+  const normalizedRecordId = requireCrudRecordId(recordId, { context: "crudRepositoryFindById" });
   const methodHooks = normalizeCrudRepositoryHooks(
     hooks,
     ["modifyQuery", "afterQuery", "transformReturnedRecord", "finalizeOutput"],
@@ -895,12 +909,17 @@ async function crudRepositoryFindById(runtime, knex, recordId, repositoryOptions
   dbQuery = dbQuery
     .where(visible)
     .where({
-      [idColumn]: Number(recordId)
+      [idColumn]: normalizedRecordId
     });
 
   const row = await dbQuery.first();
 
-  const mappedRecord = mapRecordRow(row, runtime.mapping.outputKeys, runtime.mapping.columnOverrides);
+  const mappedRecord = mapRecordRow(
+    row,
+    runtime.mapping.outputKeys,
+    runtime.mapping.columnOverrides,
+    { recordIdKeys: runtime.mapping.outputRecordIdKeys }
+  );
   let records = [];
   if (mappedRecord) {
     const normalizedRecord = await normalizeRepositoryOutputRecord(runtime, mappedRecord, {
@@ -1032,7 +1051,12 @@ async function crudRepositoryListByIds(runtime, knex, ids = [], repositoryOption
 
   const records = [];
   for (const row of rows) {
-    const mappedRecord = mapRecordRow(row, runtime.mapping.outputKeys, runtime.mapping.columnOverrides);
+    const mappedRecord = mapRecordRow(
+      row,
+      runtime.mapping.outputKeys,
+      runtime.mapping.columnOverrides,
+      { recordIdKeys: runtime.mapping.outputRecordIdKeys }
+    );
     if (!mappedRecord) {
       continue;
     }
@@ -1206,7 +1230,11 @@ async function crudRepositoryCreate(runtime, knex, payload = {}, repositoryOptio
   );
   createQuery = createHookResult.queryBuilder;
 
-  const [recordId] = await createQuery.insert(withOwners);
+  const insertResult = await createQuery.insert(withOwners);
+  const recordId = resolveInsertedRecordId(insertResult, { fallback: null });
+  if (!recordId) {
+    throw new Error("crudRepositoryCreate could not resolve inserted id.");
+  }
 
   const createdRecord = await crudRepositoryFindById(runtime, knex, recordId, repositoryOptions, {
     ...callOptions,
@@ -1237,6 +1265,7 @@ async function crudRepositoryCreate(runtime, knex, payload = {}, repositoryOptio
 
 async function crudRepositoryUpdateById(runtime, knex, recordId, patch = {}, repositoryOptions = {}, callOptions = {}, hooks = null) {
   const { client, tableName, idColumn, visible } = resolveCrudRepositoryCall(runtime, knex, repositoryOptions, callOptions);
+  const normalizedRecordId = requireCrudRecordId(recordId, { context: "crudRepositoryUpdateById" });
   const methodHooks = normalizeCrudRepositoryHooks(hooks, ["modifyPatch", "modifyQuery", "afterWrite"], {
     context: "crudRepositoryUpdateById"
   });
@@ -1299,7 +1328,7 @@ async function crudRepositoryUpdateById(runtime, knex, recordId, patch = {}, rep
   updateQuery = updateQuery
     .where(visible)
     .where({
-      [idColumn]: Number(recordId)
+      [idColumn]: normalizedRecordId
     });
 
   await updateQuery.update(dbPatch);
@@ -1333,6 +1362,7 @@ async function crudRepositoryUpdateById(runtime, knex, recordId, patch = {}, rep
 
 async function crudRepositoryDeleteById(runtime, knex, recordId, repositoryOptions = {}, callOptions = {}, hooks = null) {
   const { client, tableName, idColumn, visible } = resolveCrudRepositoryCall(runtime, knex, repositoryOptions, callOptions);
+  const normalizedRecordId = requireCrudRecordId(recordId, { context: "crudRepositoryDeleteById" });
   const methodHooks = normalizeCrudRepositoryHooks(hooks, ["modifyQuery", "finalizeOutput", "afterWrite"], {
     context: "crudRepositoryDeleteById"
   });
@@ -1394,7 +1424,7 @@ async function crudRepositoryDeleteById(runtime, knex, recordId, repositoryOptio
   deleteQuery = deleteQuery
     .where(visible)
     .where({
-      [idColumn]: Number(recordId)
+      [idColumn]: normalizedRecordId
     });
 
   await deleteQuery.delete();

--- a/packages/crud-core/src/server/repositorySupport.js
+++ b/packages/crud-core/src/server/repositorySupport.js
@@ -1,5 +1,7 @@
+import { normalizeDbRecordId } from "@jskit-ai/database-runtime/shared";
 import { AppError } from "@jskit-ai/kernel/server/runtime/errors";
-import { normalizeText } from "@jskit-ai/kernel/shared/support/normalize";
+import { RECORD_ID_PATTERN } from "@jskit-ai/kernel/shared/validators";
+import { normalizeRecordId, normalizeText } from "@jskit-ai/kernel/shared/support/normalize";
 import { normalizeObjectInput } from "@jskit-ai/kernel/shared/validators/inputNormalization";
 import { toSnakeCase } from "@jskit-ai/kernel/shared/support/stringCase";
 import {
@@ -13,24 +15,24 @@ const MAX_LIST_LIMIT = 100;
 
 function normalizeCrudListCursor(cursor = null, { allowEmpty = true } = {}) {
   if (cursor === undefined || cursor === null) {
-    return allowEmpty === true ? 0 : null;
+    return allowEmpty === true ? "" : null;
   }
 
   const normalizedCursor = typeof cursor === "string"
     ? cursor.trim()
     : cursor;
   if (normalizedCursor === "" || normalizedCursor === 0 || normalizedCursor === "0") {
-    return allowEmpty === true ? 0 : null;
+    return allowEmpty === true ? "" : null;
   }
 
-  const numericCursor = Number(normalizedCursor);
-  if (!Number.isInteger(numericCursor) || numericCursor < 1) {
+  const recordId = normalizeRecordId(normalizedCursor, { fallback: null });
+  if (!recordId) {
     throw new AppError(400, "Invalid cursor.", {
       code: "INVALID_CURSOR"
     });
   }
 
-  return numericCursor;
+  return recordId;
 }
 
 function normalizeCrudListLimit(value, { fallback = DEFAULT_LIST_LIMIT, max = MAX_LIST_LIMIT } = {}) {
@@ -152,6 +154,29 @@ function schemaIncludesStringType(schema = {}) {
   return variants.some((entry) => schemaIncludesStringType(entry));
 }
 
+function schemaIncludesRecordIdType(schema = {}) {
+  if (!schema || typeof schema !== "object" || Array.isArray(schema)) {
+    return false;
+  }
+
+  const type = Array.isArray(schema.type)
+    ? schema.type.map((entry) => normalizeText(entry).toLowerCase()).filter(Boolean)
+    : normalizeText(schema.type).toLowerCase();
+  const hasStringType = Array.isArray(type)
+    ? type.includes("string")
+    : type === "string";
+  if (hasStringType && normalizeText(schema.pattern) === RECORD_ID_PATTERN) {
+    return true;
+  }
+
+  const variants = Array.isArray(schema.anyOf)
+    ? schema.anyOf
+    : Array.isArray(schema.oneOf)
+      ? schema.oneOf
+      : [];
+  return variants.some((entry) => schemaIncludesRecordIdType(entry));
+}
+
 function deriveRepositoryMappingFromResource(resource = {}, { context = "crudRepository" } = {}) {
   if (!resource || typeof resource !== "object" || Array.isArray(resource)) {
     throw new TypeError(`${context} requires resource object.`);
@@ -214,20 +239,33 @@ function deriveRepositoryMappingFromResource(resource = {}, { context = "crudRep
     parentFilterColumns[key] = columnName;
   }
 
+  const outputRecordIdKeys = [];
+  for (const [key, schema] of Object.entries(outputProperties)) {
+    if (schemaIncludesRecordIdType(schema)) {
+      outputRecordIdKeys.push(key);
+    }
+  }
+
   return Object.freeze({
     outputKeys,
     writeKeys,
     columnOverrides: Object.freeze(columnOverrides),
     listSearchColumns: Object.freeze(listSearchColumns),
-    parentFilterColumns: Object.freeze(parentFilterColumns)
+    parentFilterColumns: Object.freeze(parentFilterColumns),
+    outputRecordIdKeys: Object.freeze(outputRecordIdKeys)
   });
 }
 
-function mapRecordRow(row, fieldKeys = [], overrides = {}) {
+function mapRecordRow(row, fieldKeys = [], overrides = {}, { recordIdKeys = [] } = {}) {
   if (!row) {
     return null;
   }
 
+  const recordIdKeySet = new Set(
+    (Array.isArray(recordIdKeys) ? recordIdKeys : [])
+      .map((key) => String(key || "").trim())
+      .filter(Boolean)
+  );
   const mapped = {};
   for (const key of fieldKeys) {
     const normalizedKey = String(key || "").trim();
@@ -235,7 +273,15 @@ function mapRecordRow(row, fieldKeys = [], overrides = {}) {
     if (!normalizedKey || !columnName) {
       continue;
     }
-    mapped[normalizedKey] = row[columnName];
+
+    const rawValue = row[columnName];
+    if (recordIdKeySet.has(normalizedKey)) {
+      const normalizedIdValue = normalizeDbRecordId(rawValue, { fallback: null });
+      mapped[normalizedKey] = normalizedIdValue || rawValue;
+      continue;
+    }
+
+    mapped[normalizedKey] = rawValue;
   }
   return mapped;
 }
@@ -244,7 +290,7 @@ function applyCrudListQueryFilters(
   query,
   {
     idColumn = "id",
-    cursor = 0,
+    cursor = "",
     applyCursor = true,
     q = "",
     searchColumns = [],
@@ -307,7 +353,7 @@ function applyCrudListQueryFilters(
   const normalizedIdColumn = String(idColumn || "").trim() || "id";
   if (applyCursor !== false) {
     const normalizedCursor = normalizeCrudListCursor(cursor);
-    if (normalizedCursor > 0) {
+    if (normalizedCursor) {
       nextQuery = nextQuery.where(normalizedIdColumn, ">", normalizedCursor);
     }
   }

--- a/packages/crud-core/test/createCrudClientSupport.test.js
+++ b/packages/crud-core/test/createCrudClientSupport.test.js
@@ -61,7 +61,7 @@ test("crudListQueryKey and crudViewQueryKey normalize cache keys", () => {
     "view",
     "admin",
     "tonymobily3",
-    12
+    "12"
   ]);
 });
 
@@ -85,9 +85,9 @@ test("invalidateCrudQueries invalidates by CRUD namespace scope key", async () =
 });
 
 test("toRouteRecordId parses scalar and array params safely", () => {
-  assert.equal(toRouteRecordId("42"), 42);
-  assert.equal(toRouteRecordId(["7"]), 7);
-  assert.equal(toRouteRecordId("not-a-number"), 0);
+  assert.equal(toRouteRecordId("42"), "42");
+  assert.equal(toRouteRecordId(["7"]), "7");
+  assert.equal(toRouteRecordId("not-a-number"), "");
 });
 
 test("normalizeCrudRouteParamName validates route parameter names", () => {
@@ -114,7 +114,7 @@ test("resolveCrudRecordPathTemplates supports custom route parameter names", () 
 });
 
 test("resolveCrudRecordPathParams maps record ids to selected route parameter names", () => {
-  assert.deepEqual(resolveCrudRecordPathParams(42, "addressId"), { addressId: "42" });
+  assert.deepEqual(resolveCrudRecordPathParams("42", "addressId"), { addressId: "42" });
   assert.deepEqual(resolveCrudRecordPathParams("7", "recordId"), { recordId: "7" });
   assert.deepEqual(resolveCrudRecordPathParams("invalid", "addressId"), {});
 });

--- a/packages/crud-core/test/createCrudRepositoryFromResource.test.js
+++ b/packages/crud-core/test/createCrudRepositoryFromResource.test.js
@@ -1,6 +1,19 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { RECORD_ID_PATTERN } from "@jskit-ai/kernel/shared/validators";
 import { createCrudRepositoryFromResource } from "../src/server/createCrudRepositoryFromResource.js";
+
+const recordIdSchema = Object.freeze({
+  type: "string",
+  pattern: RECORD_ID_PATTERN
+});
+
+const nullableRecordIdSchema = Object.freeze({
+  anyOf: [
+    recordIdSchema,
+    { type: "null" }
+  ]
+});
 
 function createListKnexDouble(
   rows = [],
@@ -185,7 +198,7 @@ function createResourceFixture() {
           schema: {
             type: "object",
             properties: {
-              id: { type: "integer" },
+              id: recordIdSchema,
               firstName: { type: "string" }
             }
           }
@@ -222,10 +235,10 @@ function createLookupResourceFixture() {
           schema: {
             type: "object",
             properties: {
-              id: { type: "integer" },
+              id: recordIdSchema,
               firstName: { type: "string" },
-              primaryVetId: { type: "integer" },
-              secondaryVetId: { type: ["integer", "null"] },
+              primaryVetId: recordIdSchema,
+              secondaryVetId: nullableRecordIdSchema,
               lookups: {
                 type: "object"
               }
@@ -239,8 +252,8 @@ function createLookupResourceFixture() {
             type: "object",
             properties: {
               firstName: { type: "string" },
-              primaryVetId: { type: "integer" },
-              secondaryVetId: { type: "integer" }
+              primaryVetId: recordIdSchema,
+              secondaryVetId: recordIdSchema
             }
           }
         }
@@ -289,10 +302,10 @@ function createLookupResourceWithCustomContainerKeyFixture() {
           schema: {
             type: "object",
             properties: {
-              id: { type: "integer" },
+              id: recordIdSchema,
               firstName: { type: "string" },
-              primaryVetId: { type: "integer" },
-              secondaryVetId: { type: "integer" },
+              primaryVetId: recordIdSchema,
+              secondaryVetId: recordIdSchema,
               lookupData: {
                 type: "object"
               }
@@ -306,8 +319,8 @@ function createLookupResourceWithCustomContainerKeyFixture() {
             type: "object",
             properties: {
               firstName: { type: "string" },
-              primaryVetId: { type: "integer" },
-              secondaryVetId: { type: "integer" }
+              primaryVetId: recordIdSchema,
+              secondaryVetId: recordIdSchema
             }
           }
         }
@@ -351,7 +364,7 @@ function createCollectionLookupResourceFixture() {
           schema: {
             type: "object",
             properties: {
-              id: { type: "integer" },
+              id: recordIdSchema,
               firstName: { type: "string" },
               lookups: {
                 type: "object"
@@ -400,9 +413,9 @@ function createPetsLookupBackToContactsResourceFixture() {
           schema: {
             type: "object",
             properties: {
-              id: { type: "integer" },
+              id: recordIdSchema,
               name: { type: "string" },
-              customerId: { type: "integer" },
+              customerId: recordIdSchema,
               lookups: {
                 type: "object"
               }
@@ -450,14 +463,14 @@ function createNormalizedResourceFixture() {
           schema: {
             type: "object",
             properties: {
-              id: { type: "integer" },
+              id: recordIdSchema,
               firstName: { type: "string" }
             },
             required: ["id", "firstName"]
           },
           normalize(payload = {}) {
             return {
-              id: Number(payload.id),
+              id: String(payload.id || ""),
               firstName: String(payload.firstName || "").trim()
             };
           }
@@ -494,7 +507,7 @@ function createWritableHookResourceFixture() {
           schema: {
             type: "object",
             properties: {
-              id: { type: "integer" },
+              id: recordIdSchema,
               firstName: { type: "string" },
               createdAt: { type: "string" },
               updatedAt: { type: "string" }
@@ -545,7 +558,7 @@ test("createCrudRepositoryFromResource requires table metadata from resource", (
               schema: {
                 type: "object",
                 properties: {
-                  id: { type: "integer" }
+                  id: recordIdSchema
                 }
               }
             }
@@ -576,21 +589,21 @@ test("createCrudRepositoryFromResource defaults table and id columns from resour
   const repository = createRepository(knex);
 
   const result = await repository.list({
-    cursor: 2,
+    cursor: "2",
     q: "to"
   });
 
   assert.deepEqual(result, {
     items: [
       {
-        id: 3,
+        id: "3",
         firstName: "Tony"
       }
     ],
     nextCursor: null
   });
   assert.equal(calls[0][1], "contacts_table");
-  assert.ok(calls.some((call) => call[0] === "where" && call[1] === "contact_id" && call[2] === ">" && call[3] === 2));
+  assert.ok(calls.some((call) => call[0] === "where" && call[1] === "contact_id" && call[2] === ">" && call[3] === "2"));
 });
 
 test("createCrudRepositoryFromResource createRepository requires knex", () => {
@@ -646,8 +659,8 @@ test("createCrudRepositoryFromResource supports declarative ordered list paginat
 
   assert.deepEqual(result, {
     items: [
-      { id: 9, firstName: "Tina" },
-      { id: 7, firstName: "Tony" }
+      { id: "9", firstName: "Tina" },
+      { id: "7", firstName: "Tony" }
     ],
     nextCursor: Buffer.from(
       JSON.stringify({ values: ["2026-04-04T09:00:00.000Z", 7] }),
@@ -855,11 +868,11 @@ test("createCrudRepositoryFromResource exposes listByIds for lookup providers", 
   ]);
   const repository = createRepository(knex);
 
-  const records = await repository.listByIds([3, 3, 4]);
+  const records = await repository.listByIds(["3", "3", "4"]);
 
   assert.equal(records.length, 1);
   assert.deepEqual(records[0], {
-    id: 3,
+    id: "3",
     firstName: "Tony"
   });
   assert.ok(calls.some((call) => call[0] === "whereIn" && call[1] === "contact_id"));
@@ -879,7 +892,7 @@ test("createCrudRepositoryFromResource exposes listByForeignIds for arbitrary ou
 
   assert.equal(records.length, 1);
   assert.deepEqual(records[0], {
-    id: 3,
+    id: "3",
     firstName: "Tony"
   });
   assert.ok(calls.some((call) => call[0] === "whereIn" && call[1] === "first_name"));
@@ -913,7 +926,7 @@ test("createCrudRepositoryFromResource listByIds fails fast when valueKey is not
 
   await assert.rejects(
     () =>
-      repository.listByIds([3], {
+      repository.listByIds(["3"], {
         valueKey: "externalCustomerId"
       }),
     /valueKey "externalCustomerId" to exist in output schema/
@@ -930,10 +943,10 @@ test("createCrudRepositoryFromResource normalizes listByIds output using resourc
   ]);
   const repository = createRepository(knex);
 
-  const result = await repository.listByIds([3]);
+  const result = await repository.listByIds(["3"]);
   assert.deepEqual(result, [
     {
-      id: 3,
+      id: "3",
       firstName: "Tony"
     }
   ]);
@@ -943,14 +956,14 @@ test("createCrudRepositoryFromResource fails when mapped output violates resourc
   const createRepository = createCrudRepositoryFromResource(createResourceFixture());
   const { knex } = createListKnexDouble([
     {
-      contact_id: "3",
+      contact_id: "invalid-id",
       first_name: "Tony"
     }
   ]);
   const repository = createRepository(knex);
 
   await assert.rejects(
-    () => repository.listByIds([3]),
+    () => repository.listByIds(["3"]),
     /output validation failed/
   );
 });
@@ -983,8 +996,8 @@ test("createCrudRepositoryFromResource hydrates lookup relations by default and 
             options
           });
           return [
-            { id: 10, name: "Vet A" },
-            { id: 12, name: "Vet B" }
+            { id: "10", name: "Vet A" },
+            { id: "12", name: "Vet B" }
           ];
         }
       };
@@ -994,16 +1007,16 @@ test("createCrudRepositoryFromResource hydrates lookup relations by default and 
   const result = await repository.list({});
 
   assert.equal(lookupCalls.length, 1);
-  assert.deepEqual(lookupCalls[0].ids, [10, 12]);
+  assert.deepEqual(lookupCalls[0].ids, ["10", "12"]);
   assert.equal(lookupCalls[0].options.include, "*");
   assert.equal(lookupCalls[0].options.lookupDepth, 1);
   assert.equal(lookupCalls[0].options.lookupMaxDepth, 3);
   assert.deepEqual(result.items[0].lookups, {
-    primaryVetId: { id: 10, name: "Vet A" },
-    secondaryVetId: { id: 12, name: "Vet B" }
+    primaryVetId: { id: "10", name: "Vet A" },
+    secondaryVetId: { id: "12", name: "Vet B" }
   });
   assert.deepEqual(result.items[1].lookups, {
-    primaryVetId: { id: 10, name: "Vet A" },
+    primaryVetId: { id: "10", name: "Vet A" },
     secondaryVetId: null
   });
 });
@@ -1023,8 +1036,8 @@ test("createCrudRepositoryFromResource writes hydrated lookups into custom outpu
       return {
         async listByIds() {
           return [
-            { id: 10, name: "Vet A" },
-            { id: 12, name: "Vet B" }
+            { id: "10", name: "Vet A" },
+            { id: "12", name: "Vet B" }
           ];
         }
       };
@@ -1034,8 +1047,8 @@ test("createCrudRepositoryFromResource writes hydrated lookups into custom outpu
   const result = await repository.list({});
   assert.equal(Object.hasOwn(result.items[0], "lookups"), false);
   assert.deepEqual(result.items[0].lookupData, {
-    primaryVetId: { id: 10, name: "Vet A" },
-    secondaryVetId: { id: 12, name: "Vet B" }
+    primaryVetId: { id: "10", name: "Vet A" },
+    secondaryVetId: { id: "12", name: "Vet B" }
   });
 });
 
@@ -1113,7 +1126,7 @@ test("createCrudRepositoryFromResource forwards nested include paths to child lo
             ids,
             options
           });
-          return [{ id: 10, name: "Vet A" }, { id: 12, name: "Vet B" }];
+          return [{ id: "10", name: "Vet A" }, { id: "12", name: "Vet B" }];
         }
       };
     }
@@ -1147,7 +1160,7 @@ test("createCrudRepositoryFromResource forwards wildcard nested include paths to
             ids,
             options
           });
-          return [{ id: 10, name: "Vet A" }, { id: 12, name: "Vet B" }];
+          return [{ id: "10", name: "Vet A" }, { id: "12", name: "Vet B" }];
         }
       };
     }
@@ -1182,7 +1195,7 @@ test("createCrudRepositoryFromResource remaps child lookup visibility for public
             ids,
             options
           });
-          return [{ id: 10, name: "Vet A" }, { id: 12, name: "Vet B" }];
+          return [{ id: "10", name: "Vet A" }, { id: "12", name: "Vet B" }];
         }
       };
     }
@@ -1222,7 +1235,7 @@ test("createCrudRepositoryFromResource remaps child lookup visibility for worksp
             ids,
             options
           });
-          return [{ id: 10, name: "Vet A" }, { id: 12, name: "Vet B" }];
+          return [{ id: "10", name: "Vet A" }, { id: "12", name: "Vet B" }];
         }
       };
     }
@@ -1299,9 +1312,9 @@ test("createCrudRepositoryFromResource hydrates collection relations through lis
             options
           });
           return [
-            { id: 11, name: "Milo", customerId: 3 },
-            { id: 12, name: "Luna", customerId: 3 },
-            { id: 20, name: "Ruby", customerId: 4 }
+            { id: "11", name: "Milo", customerId: "3" },
+            { id: "12", name: "Luna", customerId: "3" },
+            { id: "20", name: "Ruby", customerId: "4" }
           ];
         }
       };
@@ -1313,7 +1326,7 @@ test("createCrudRepositoryFromResource hydrates collection relations through lis
   });
 
   assert.equal(lookupCalls.length, 1);
-  assert.deepEqual(lookupCalls[0].ids, [3, 4]);
+  assert.deepEqual(lookupCalls[0].ids, ["3", "4"]);
   assert.equal(lookupCalls[0].options.include, "none");
   assert.equal(lookupCalls[0].options.valueKey, "customerId");
   assert.deepEqual(result.items[0].lookups?.pets?.map((item) => item.name), ["Milo", "Luna"]);
@@ -1402,7 +1415,7 @@ test("createCrudRepositoryFromResource forwards configured lookup maxDepth to ch
             ids,
             options
           });
-          return [{ id: 10, name: "Vet A" }, { id: 12, name: "Vet B" }];
+          return [{ id: "10", name: "Vet A" }, { id: "12", name: "Vet B" }];
         }
       };
     }
@@ -1598,7 +1611,7 @@ test("createCrudRepositoryFromResource list hooks keep visibility and canonical 
   const repository = createRepository(knex);
 
   await repository.list({
-    cursor: 2,
+    cursor: "2",
     limit: 5
   }, {
     visibilityContext: {
@@ -1612,7 +1625,7 @@ test("createCrudRepositoryFromResource list hooks keep visibility and canonical 
     }
   });
 
-  assert.ok(calls.some((call) => call[0] === "where" && call[1] === "contact_id" && call[2] === ">" && call[3] === 2));
+  assert.ok(calls.some((call) => call[0] === "where" && call[1] === "contact_id" && call[2] === ">" && call[3] === "2"));
   assert.ok(calls.some((call) => call[0] === "where" && call[1] === "workspace_id" && call[2] === "workspace-1"));
   assert.ok(calls.some((call) => call[0] === "clearOrder"));
   assert.ok(calls.some((call) => call[0] === "clear" && call[1] === "limit"));
@@ -1630,7 +1643,7 @@ test("createCrudRepositoryFromResource findById hooks keep visibility and id pre
   ]);
   const repository = createRepository(knex);
 
-  await repository.findById(7, {
+  await repository.findById("7", {
     visibilityContext: {
       visibility: "workspace",
       scopeOwnerId: "workspace-1"
@@ -1644,7 +1657,7 @@ test("createCrudRepositoryFromResource findById hooks keep visibility and id pre
 
   assert.ok(calls.some((call) => call[0] === "where" && call[1] === "contact_id" && call[2] === 999));
   assert.ok(calls.some((call) => call[0] === "where" && call[1] === "workspace_id" && call[2] === "workspace-1"));
-  assert.ok(calls.some((call) => call[0] === "where" && call[1]?.contact_id === 7));
+  assert.ok(calls.some((call) => call[0] === "where" && call[1]?.contact_id === "7"));
 });
 
 test("createCrudRepositoryFromResource findById hooks share state between query and transformReturnedRecord", async () => {
@@ -1657,7 +1670,7 @@ test("createCrudRepositoryFromResource findById hooks share state between query 
   ]);
   const repository = createRepository(knex);
 
-  const record = await repository.findById(7, {}, {
+  const record = await repository.findById("7", {}, {
     modifyQuery(_dbQuery, context = {}) {
       context.state.recordTag = "from-state";
     },
@@ -1712,7 +1725,7 @@ test("createCrudRepositoryFromResource listByIds hooks support afterQuery/transf
     }
   });
 
-  assert.deepEqual(items.map((item) => item.id), [4, 3]);
+  assert.deepEqual(items.map((item) => item.id), ["4", "3"]);
   assert.deepEqual(items.map((item) => item.nameTag), ["SAM", "TONY"]);
 });
 
@@ -1855,7 +1868,7 @@ test("createCrudRepositoryFromResource create hooks support afterWrite and canon
   assert.equal(afterWriteCalls.length, 1);
   assert.equal(afterWriteCalls[0].operation, "create");
   assert.equal(afterWriteCalls[0].createdName, "Tony");
-  assert.equal(afterWriteCalls[0].recordId, 11);
+  assert.equal(afterWriteCalls[0].recordId, "11");
 });
 
 test("createCrudRepositoryFromResource update hooks keep write-key filtering and by-id visibility constraints", async () => {
@@ -1870,7 +1883,7 @@ test("createCrudRepositoryFromResource update hooks keep write-key filtering and
   ]);
   const repository = createRepository(knex);
 
-  await repository.updateById(11, {
+  await repository.updateById("11", {
     firstName: "Tony"
   }, {
     visibilityContext: {
@@ -1900,7 +1913,7 @@ test("createCrudRepositoryFromResource update hooks keep write-key filtering and
   assert.ok(state.updatePayloads[0].updated_at);
   assert.ok(calls.some((call) => call[0] === "where" && call[1] === "vip" && call[2] === 1));
   assert.ok(calls.some((call) => call[0] === "where" && call[1] === "workspace_id" && call[2] === "workspace-1"));
-  assert.ok(calls.some((call) => call[0] === "where" && call[1]?.contact_id === 11));
+  assert.ok(calls.some((call) => call[0] === "where" && call[1]?.contact_id === "11"));
 });
 
 test("createCrudRepositoryFromResource update hooks reject read-phase hook keys", async () => {
@@ -1916,7 +1929,7 @@ test("createCrudRepositoryFromResource update hooks reject read-phase hook keys"
   const repository = createRepository(knex);
 
   await assert.rejects(
-    () => repository.updateById(11, {
+    () => repository.updateById("11", {
       firstName: "Tony"
     }, {}, {
       transformReturnedRecord(record = {}) {
@@ -1940,7 +1953,7 @@ test("createCrudRepositoryFromResource update hooks support afterWrite and canon
   const repository = createRepository(knex);
   const afterWriteCalls = [];
 
-  const record = await repository.updateById(11, {
+  const record = await repository.updateById("11", {
     firstName: "Tony"
   }, {}, {
     modifyPatch(patch = {}, context = {}) {
@@ -1961,7 +1974,7 @@ test("createCrudRepositoryFromResource update hooks support afterWrite and canon
   assert.equal(afterWriteCalls.length, 1);
   assert.equal(afterWriteCalls[0].operation, "update");
   assert.deepEqual(afterWriteCalls[0].patchKeys, ["firstName"]);
-  assert.equal(afterWriteCalls[0].recordId, 11);
+  assert.equal(afterWriteCalls[0].recordId, "11");
 });
 
 test("createCrudRepositoryFromResource delete hooks run through callOptions.trx client", async () => {
@@ -1980,7 +1993,7 @@ test("createCrudRepositoryFromResource delete hooks run through callOptions.trx 
   ]);
   const repository = createRepository(baseKnex.knex);
 
-  await repository.deleteById(3, {
+  await repository.deleteById("3", {
     trx: trxKnex.knex,
     visibilityContext: {
       visibility: "workspace",
@@ -2010,7 +2023,7 @@ test("createCrudRepositoryFromResource delete hooks support afterWrite", async (
   const repository = createRepository(knex);
   const afterWriteCalls = [];
 
-  const result = await repository.deleteById(3, {}, {
+  const result = await repository.deleteById("3", {}, {
     afterWrite(meta = {}, context = {}) {
       context.state.deletedId = meta?.output?.id || null;
       afterWriteCalls.push({
@@ -2023,7 +2036,7 @@ test("createCrudRepositoryFromResource delete hooks support afterWrite", async (
   assert.equal(result.deleted, true);
   assert.equal(afterWriteCalls.length, 1);
   assert.equal(afterWriteCalls[0].operation, "delete");
-  assert.equal(afterWriteCalls[0].deletedId, 3);
+  assert.equal(afterWriteCalls[0].deletedId, "3");
 });
 
 test("createCrudRepositoryFromResource delete hooks support finalizeOutput for record and null flows", async () => {
@@ -2038,7 +2051,7 @@ test("createCrudRepositoryFromResource delete hooks support finalizeOutput for r
   const presentRepository = createRepository(presentKnex.knex);
   const missingRepository = createRepository(missingKnex.knex);
 
-  const deletedOutput = await presentRepository.deleteById(3, {}, {
+  const deletedOutput = await presentRepository.deleteById("3", {}, {
     finalizeOutput(output) {
       return output
         ? { ...output, status: "deleted" }
@@ -2046,7 +2059,7 @@ test("createCrudRepositoryFromResource delete hooks support finalizeOutput for r
     }
   });
 
-  const missingOutput = await missingRepository.deleteById(3, {}, {
+  const missingOutput = await missingRepository.deleteById("3", {}, {
     finalizeOutput(output) {
       return output === null ? { deleted: false } : output;
     }

--- a/packages/crud-core/test/repositorySupport.test.js
+++ b/packages/crud-core/test/repositorySupport.test.js
@@ -89,8 +89,8 @@ test("normalizeCrudListLimit enforces fallback and max", () => {
 });
 
 test("normalizeCrudListCursor rejects malformed id cursors", () => {
-  assert.equal(normalizeCrudListCursor("7"), 7);
-  assert.equal(normalizeCrudListCursor(""), 0);
+  assert.equal(normalizeCrudListCursor("7"), "7");
+  assert.equal(normalizeCrudListCursor(""), "");
   assert.throws(
     () => normalizeCrudListCursor("abc"),
     /Invalid cursor/
@@ -147,7 +147,7 @@ test("applyCrudListQueryFilters applies search and cursor filters", () => {
     ["whereGroup"],
     ["innerWhere", "first_name", "like", "%ani%"],
     ["innerOrWhere", "last_name", "like", "%ani%"],
-    ["where", "id", ">", 3]
+    ["where", "id", ">", "3"]
   ]);
 });
 

--- a/packages/crud-server-generator/src/server/buildTemplateContext.js
+++ b/packages/crud-server-generator/src/server/buildTemplateContext.js
@@ -5,7 +5,7 @@ import { pathToFileURL } from "node:url";
 import {
   normalizeText,
   resolveDatabaseClientFromEnvironment,
-  resolveDatabaseConnectionFromEnvironment,
+  resolveKnexConnectionFromEnvironment,
   toKnexClientId
 } from "@jskit-ai/database-runtime/shared";
 import { checkCrudLookupFormControl } from "@jskit-ai/crud-core/shared/crudFieldMetaSupport";
@@ -221,7 +221,8 @@ async function resolveMysqlSnapshotFromDatabase({
     );
   }
 
-  const connection = resolveDatabaseConnectionFromEnvironment(env, {
+  const connection = resolveKnexConnectionFromEnvironment(env, {
+    client: dbClient,
     defaultPort: 3306,
     context: "crud table introspection"
   });
@@ -269,6 +270,12 @@ function resolveColumnKey(column, idColumn) {
 function resolveScaffoldColumns(snapshot) {
   const idColumn = String(snapshot.idColumn || DEFAULT_ID_COLUMN);
   const sourceColumns = Array.isArray(snapshot.columns) ? snapshot.columns : [];
+  const foreignKeyColumnNames = new Set(
+    (Array.isArray(snapshot.foreignKeys) ? snapshot.foreignKeys : [])
+      .flatMap((foreignKey) => Array.isArray(foreignKey?.columns) ? foreignKey.columns : [])
+      .map((entry) => String(entry?.name || "").trim())
+      .filter(Boolean)
+  );
   const seenKeys = new Set();
 
   const columns = sourceColumns.map((column) => {
@@ -276,9 +283,11 @@ function resolveScaffoldColumns(snapshot) {
     const isUserIdColumn = column.name === "user_id";
     const isOwnerColumn = isWorkspaceIdColumn || isUserIdColumn;
     const isIdColumn = column.name === idColumn;
+    const isForeignIdColumn = foreignKeyColumnNames.has(column.name) || /_id$/i.test(String(column.name || ""));
     const isCreatedAtColumn = column.name === "created_at";
     const isUpdatedAtColumn = column.name === "updated_at";
     const key = resolveColumnKey(column, idColumn);
+    const isRecordIdColumn = isIdColumn || isOwnerColumn || isForeignIdColumn || /Id$/.test(String(key || ""));
     if (!key) {
       throw new Error(`Could not derive API field key for column "${column.name}".`);
     }
@@ -297,6 +306,8 @@ function resolveScaffoldColumns(snapshot) {
       key,
       isOwnerColumn,
       isIdColumn,
+      isForeignIdColumn,
+      isRecordIdColumn,
       isCreatedAtColumn,
       isUpdatedAtColumn,
       writable: !isOwnerColumn && !isIdColumn && !isCreatedAtColumn && !isUpdatedAtColumn
@@ -327,9 +338,7 @@ function renderPropertyAccess(sourceName, key) {
 
 function renderIntegerSchema(column) {
   const options = [];
-  if (column.isIdColumn === true) {
-    options.push("minimum: 1");
-  } else if (column.unsigned === true) {
+  if (column.unsigned === true) {
     options.push("minimum: 0");
   }
   if (options.length > 0) {
@@ -359,6 +368,11 @@ function renderResourceFieldSchema(column, { forOutput = false } = {}) {
   if (typeKind === "string") {
     schemaExpression = renderStringSchema(column, { forOutput });
   } else if (typeKind === "integer") {
+    if (column?.isRecordIdColumn === true) {
+      return forOutput
+        ? (column.nullable === true ? "nullableRecordIdSchema" : "recordIdSchema")
+        : (column.nullable === true ? "nullableRecordIdInputSchema" : "recordIdInputSchema");
+    }
     schemaExpression = renderIntegerSchema(column);
   } else if (typeKind === "number") {
     schemaExpression = "Type.Number()";
@@ -382,11 +396,14 @@ function renderResourceFieldSchema(column, { forOutput = false } = {}) {
   return schemaExpression;
 }
 
-function renderResourceValidatorsImport({ needsHtmlTimeSchemas = false } = {}) {
+function renderResourceValidatorsImport({ needsHtmlTimeSchemas = false, needsRecordIdSchemas = false } = {}) {
   const imports = [
     "normalizeObjectInput",
     "createCursorListValidator"
   ];
+  if (needsRecordIdSchemas) {
+    imports.push("recordIdSchema", "recordIdInputSchema", "nullableRecordIdSchema", "nullableRecordIdInputSchema");
+  }
   if (needsHtmlTimeSchemas) {
     imports.push("HTML_TIME_STRING_SCHEMA", "NULLABLE_HTML_TIME_STRING_SCHEMA");
   }
@@ -406,6 +423,12 @@ function renderInputNormalizer(column) {
     return "normalizeText";
   }
   if (typeKind === "integer") {
+    if (column?.isRecordIdColumn === true) {
+      if (nullable) {
+        return "(value) => normalizeRecordId(value, { fallback: null })";
+      }
+      return "normalizeRecordId";
+    }
     return "normalizeFiniteInteger";
   }
   if (typeKind === "number") {
@@ -434,10 +457,17 @@ function renderInputNormalizer(column) {
 
 function renderOutputNormalizerExpression(column) {
   const typeKind = String(column.typeKind || "");
+  const nullable = column?.nullable === true;
   if (typeKind === "string" || typeKind === "time") {
     return "normalizeText";
   }
   if (typeKind === "integer") {
+    if (column?.isRecordIdColumn === true) {
+      if (nullable) {
+        return "(value) => normalizeRecordId(value, { fallback: null })";
+      }
+      return "normalizeRecordId";
+    }
     return "normalizeFiniteInteger";
   }
   if (typeKind === "number") {
@@ -522,6 +552,7 @@ function renderResourceNormalizeSupportImport({
   needsNormalizeBoolean = false,
   needsNormalizeFiniteNumber = false,
   needsNormalizeFiniteInteger = false,
+  needsNormalizeRecordId = false,
   needsNormalizeIfInSource = false,
   needsNormalizeIfPresent = false,
   needsNormalizeOrNull = false
@@ -538,6 +569,9 @@ function renderResourceNormalizeSupportImport({
   }
   if (needsNormalizeFiniteInteger) {
     imports.push("normalizeFiniteInteger");
+  }
+  if (needsNormalizeRecordId) {
+    imports.push("normalizeRecordId");
   }
   if (needsNormalizeIfInSource) {
     imports.push("normalizeIfInSource");
@@ -599,12 +633,13 @@ function renderMigrationDefaultClause(column) {
   return `.defaultTo(${JSON.stringify(rawDefault)})`;
 }
 
-function renderMigrationColumnLine(column, { idColumn = DEFAULT_ID_COLUMN, primaryKeyColumns = [] } = {}) {
+function renderMigrationColumnLine(column, { idColumn = DEFAULT_ID_COLUMN, primaryKeyColumns = [], foreignKeyColumnNames = new Set() } = {}) {
   const isPrimary = Array.isArray(primaryKeyColumns) && primaryKeyColumns.includes(column.name);
   const isIdColumn = column.name === idColumn;
+  const isRecordIdColumn = isIdColumn || column.name === "workspace_id" || column.name === "user_id" || foreignKeyColumnNames.has(column.name) || /_id$/i.test(String(column.name || ""));
 
   if (isIdColumn && column.autoIncrement) {
-    let line = `table.increments(${JSON.stringify(column.name)})`;
+    let line = `table.bigIncrements(${JSON.stringify(column.name)})`;
     if (column.unsigned) {
       line += ".unsigned()";
     }
@@ -633,7 +668,7 @@ function renderMigrationColumnLine(column, { idColumn = DEFAULT_ID_COLUMN, prima
   } else if (column.typeKind === "boolean") {
     line = `table.boolean(${nameLiteral})`;
   } else if (dataType === "int" || dataType === "integer") {
-    line = `table.integer(${nameLiteral})`;
+    line = isRecordIdColumn ? `table.bigInteger(${nameLiteral})` : `table.integer(${nameLiteral})`;
   } else if (dataType === "smallint") {
     line = `table.smallint(${nameLiteral})`;
   } else if (dataType === "bigint") {
@@ -682,10 +717,17 @@ function renderMigrationColumnLine(column, { idColumn = DEFAULT_ID_COLUMN, prima
 
 function renderMigrationColumnLines(snapshot) {
   const columns = Array.isArray(snapshot.columns) ? snapshot.columns : [];
+  const foreignKeyColumnNames = new Set(
+    (Array.isArray(snapshot.foreignKeys) ? snapshot.foreignKeys : [])
+      .flatMap((foreignKey) => Array.isArray(foreignKey?.columns) ? foreignKey.columns : [])
+      .map((entry) => String(entry?.name || "").trim())
+      .filter(Boolean)
+  );
   const lines = columns.map((column) =>
     `    ${renderMigrationColumnLine(column, {
       idColumn: snapshot.idColumn,
-      primaryKeyColumns: snapshot.primaryKeyColumns
+      primaryKeyColumns: snapshot.primaryKeyColumns,
+      foreignKeyColumnNames
     })}`
   );
   return lines.join("\n");
@@ -1116,7 +1158,8 @@ function buildReplacementsFromSnapshot({
     writableColumns,
     snapshot
   });
-  const needsFiniteInteger = resourceColumns.some((column) => column.typeKind === "integer");
+  const needsFiniteInteger = resourceColumns.some((column) => column.typeKind === "integer" && column.isRecordIdColumn !== true);
+  const needsRecordIdSchemas = resourceColumns.some((column) => column.typeKind === "integer" && column.isRecordIdColumn === true);
   const needsFiniteNumber = resourceColumns.some((column) => column.typeKind === "number");
   const needsDateTimeOutput = outputColumns.some((column) => column.typeKind === "datetime");
   const needsDateTimeInput = writableColumns.some((column) => column.typeKind === "datetime");
@@ -1145,7 +1188,8 @@ function buildReplacementsFromSnapshot({
     __JSKIT_CRUD_ID_COLUMN__: JSON.stringify(snapshot.idColumn || DEFAULT_ID_COLUMN),
     __JSKIT_CRUD_RESOLVED_OWNERSHIP_FILTER__: resolvedOwnershipFilter,
     __JSKIT_CRUD_RESOURCE_VALIDATORS_IMPORT__: renderResourceValidatorsImport({
-      needsHtmlTimeSchemas
+      needsHtmlTimeSchemas,
+      needsRecordIdSchemas
     }),
     __JSKIT_CRUD_RESOURCE_DATABASE_RUNTIME_IMPORT__: renderResourceDatabaseRuntimeImport({
       needsToIsoString: needsDateTimeOutput || needsDate,
@@ -1156,6 +1200,7 @@ function buildReplacementsFromSnapshot({
       needsNormalizeBoolean,
       needsNormalizeFiniteNumber: needsFiniteNumber,
       needsNormalizeFiniteInteger: needsFiniteInteger,
+      needsNormalizeRecordId: needsRecordIdSchemas,
       needsNormalizeIfInSource,
       needsNormalizeIfPresent,
       needsNormalizeOrNull

--- a/packages/crud-server-generator/src/shared/crud/crudResource.js
+++ b/packages/crud-server-generator/src/shared/crud/crudResource.js
@@ -5,10 +5,12 @@ import {
 } from "@jskit-ai/database-runtime/shared";
 import {
   normalizeObjectInput,
-  createCursorListValidator
+  createCursorListValidator,
+  recordIdSchema
 } from "@jskit-ai/kernel/shared/validators";
 import {
   normalizeText,
+  normalizeRecordId,
   normalizeFiniteNumber,
   normalizeIfPresent
 } from "@jskit-ai/kernel/shared/support/normalize";
@@ -17,7 +19,7 @@ const RESOURCE_LOOKUP_CONTAINER_KEY = "lookups";
 
 const recordOutputSchema = Type.Object(
   {
-    id: Type.Integer({ minimum: 1 }),
+    id: recordIdSchema,
     textField: Type.String({ minLength: 1, maxLength: 160 }),
     dateField: Type.String({ minLength: 1 }),
     numberField: Type.Number(),
@@ -71,7 +73,7 @@ const recordOutputValidator = Object.freeze({
   normalize(payload = {}) {
     const source = normalizeObjectInput(payload);
     const normalized = {
-      id: Number(source.id),
+      id: normalizeRecordId(source.id, { fallback: "" }),
       textField: normalizeText(source.textField),
       dateField: toIsoString(source.dateField),
       numberField: normalizeFiniteNumber(source.numberField),
@@ -116,7 +118,7 @@ const patchBodyValidator = Object.freeze({
 const deleteOutputValidator = Object.freeze({
   schema: Type.Object(
     {
-      id: Type.Integer({ minimum: 1 }),
+      id: recordIdSchema,
       deleted: Type.Literal(true)
     },
     { additionalProperties: false }
@@ -125,7 +127,7 @@ const deleteOutputValidator = Object.freeze({
     const source = normalizeObjectInput(payload);
 
     return {
-      id: Number(source.id),
+      id: normalizeRecordId(source.id, { fallback: "" }),
       deleted: true
     };
   }

--- a/packages/crud-server-generator/templates/src/local-package/shared/crudResource.js
+++ b/packages/crud-server-generator/templates/src/local-package/shared/crudResource.js
@@ -65,7 +65,7 @@ const patchBodyValidator = Object.freeze({
 const deleteOutputValidator = Object.freeze({
   schema: Type.Object(
     {
-      id: Type.Integer({ minimum: 1 }),
+      id: recordIdSchema,
       deleted: Type.Literal(true)
     },
     { additionalProperties: false }
@@ -74,7 +74,7 @@ const deleteOutputValidator = Object.freeze({
     const source = normalizeObjectInput(payload);
 
     return {
-      id: Number(source.id),
+      id: normalizeRecordId(source.id, { fallback: "" }),
       deleted: true
     };
   }

--- a/packages/crud-server-generator/test/addFieldSubcommand.test.js
+++ b/packages/crud-server-generator/test/addFieldSubcommand.test.js
@@ -145,15 +145,21 @@ test("scaffold-field patches CRUD resource file using DB snapshot metadata", asy
     assert.deepEqual(result.touchedFiles, [resourceFile]);
 
     const content = await readFile(path.join(appRoot, resourceFile), "utf8");
-    assert.match(content, /categoryId: Type\.Union\(\[Type\.Integer\(\{ minimum: 0 \}\), Type\.Null\(\)\]\)/);
-    assert.match(content, /normalizeIfInSource\(source, normalized, "categoryId", normalizeFiniteInteger\);/);
-    assert.match(content, /categoryId: normalizeOrNull\(source\.categoryId, normalizeFiniteInteger\)/);
+    assert.match(content, /categoryId: nullableRecordIdSchema/);
+    assert.match(
+      content,
+      /normalizeIfInSource\(source, normalized, "categoryId", \(value\) => normalizeRecordId\(value, \{ fallback: null \}\)\);/
+    );
+    assert.match(
+      content,
+      /categoryId: normalizeOrNull\(source\.categoryId, \(value\) => normalizeRecordId\(value, \{ fallback: null \}\)\)/
+    );
     assert.match(content, /RESOURCE_FIELD_META\.push\(\{/);
     assert.match(content, /key: "categoryId"/);
     assert.match(content, /namespace: "customer-categories"/);
     assert.match(content, /valueKey: "id"/);
     assert.match(content, /formControl: "autocomplete" \/\/ or "select"/);
-    assert.match(content, /normalizeFiniteInteger/);
+    assert.match(content, /normalizeRecordId/);
 
     const secondRun = await runGeneratorSubcommand({
       appRoot,

--- a/packages/crud-server-generator/test/buildTemplateContext.test.js
+++ b/packages/crud-server-generator/test/buildTemplateContext.test.js
@@ -221,13 +221,13 @@ test("buildReplacementsFromSnapshot builds deterministic template replacement pa
   assert.equal(replacements.__JSKIT_CRUD_TABLE_NAME__, "\"contacts\"");
   assert.equal(replacements.__JSKIT_CRUD_ID_COLUMN__, "\"id\"");
   assert.equal(replacements.__JSKIT_CRUD_RESOLVED_OWNERSHIP_FILTER__, "workspace_user");
-  assert.match(replacements.__JSKIT_CRUD_MIGRATION_COLUMN_LINES__, /table\.increments\("id"\)/);
+  assert.match(replacements.__JSKIT_CRUD_MIGRATION_COLUMN_LINES__, /table\.bigIncrements\("id"\)/);
   assert.match(replacements.__JSKIT_CRUD_MIGRATION_COLUMN_LINES__, /table\.string\("first_name", 160\)/);
   assert.equal(replacements.__JSKIT_CRUD_RESOURCE_FIELD_META_PUSH_LINES__, "");
   assert.match(replacements.__JSKIT_CRUD_RESOURCE_OUTPUT_SCHEMA_PROPERTIES__, /updatedAt: Type\.String/);
   assert.match(
     replacements.__JSKIT_CRUD_RESOURCE_OUTPUT_SCHEMA_PROPERTIES__,
-    /id: Type\.Integer\(\{ minimum: 1 \}\),/
+    /id: recordIdSchema,/
   );
   assert.match(replacements.__JSKIT_CRUD_RESOURCE_CREATE_SCHEMA_PROPERTIES__, /firstName: Type\.String/);
   assert.match(

--- a/packages/crud-server-generator/test/crudResource.test.js
+++ b/packages/crud-server-generator/test/crudResource.test.js
@@ -31,7 +31,7 @@ test("crudResource normalizes list output", () => {
     nextCursor: " 8 "
   });
 
-  assert.equal(normalized.items[0].id, 7);
+  assert.equal(normalized.items[0].id, "7");
   assert.equal(normalized.items[0].textField, "Example text");
   assert.equal(normalized.items[0].dateField, "2026-03-10T00:00:00.000Z");
   assert.equal(normalized.items[0].numberField, 99);

--- a/packages/database-runtime/src/server/providers/DatabaseRuntimeServiceProvider.js
+++ b/packages/database-runtime/src/server/providers/DatabaseRuntimeServiceProvider.js
@@ -5,7 +5,7 @@ import {
   normalizeDatabaseClient,
   toKnexClientId
 } from "../../shared/databaseClient.js";
-import { resolveDatabaseConnectionFromEnvironment } from "../../shared/databaseConnection.js";
+import { resolveKnexConnectionFromEnvironment } from "../../shared/databaseConnection.js";
 
 const DATABASE_RUNTIME_SERVER_API = Object.freeze({
   ...databaseRuntime
@@ -120,7 +120,8 @@ function createKnexConfig(scope) {
 
   const client = toKnexClientId(dialectId);
   const defaultPort = dialectId === "pg" ? 5432 : 3306;
-  const connection = resolveDatabaseConnectionFromEnvironment(env, {
+  const connection = resolveKnexConnectionFromEnvironment(env, {
+    client: dialectId,
     defaultPort,
     context: "database runtime"
   });

--- a/packages/database-runtime/src/shared/databaseConnection.js
+++ b/packages/database-runtime/src/shared/databaseConnection.js
@@ -100,7 +100,6 @@ function resolveDatabaseConnectionFromEnvironment(
   const hasDbPassword = Object.prototype.hasOwnProperty.call(source, "DB_PASSWORD");
   const password = hasDbPassword ? String(source.DB_PASSWORD ?? "") : String(parsedUrl?.password || "");
 
-  // Knex may redefine connection.password as a hidden property; keep this mutable.
   return {
     host,
     port,
@@ -110,8 +109,38 @@ function resolveDatabaseConnectionFromEnvironment(
   };
 }
 
+function resolveKnexConnectionFromEnvironment(
+  env = {},
+  {
+    client = "",
+    defaultHost = "localhost",
+    defaultPort = 3306,
+    context = "database runtime"
+  } = {}
+) {
+  const resolvedClient = client
+    ? normalizeDatabaseClient(client, { allowEmpty: true })
+    : resolveDatabaseClientFromEnvironment(env, { allowEmpty: true });
+  const connection = resolveDatabaseConnectionFromEnvironment(env, {
+    defaultHost,
+    defaultPort,
+    context
+  });
+
+  if (resolvedClient === "mysql2") {
+    return {
+      ...connection,
+      supportBigNumbers: true,
+      bigNumberStrings: true
+    };
+  }
+
+  return connection;
+}
+
 export {
   parseDatabaseUrl,
   resolveDatabaseClientFromEnvironment,
-  resolveDatabaseConnectionFromEnvironment
+  resolveDatabaseConnectionFromEnvironment,
+  resolveKnexConnectionFromEnvironment
 };

--- a/packages/database-runtime/src/shared/index.js
+++ b/packages/database-runtime/src/shared/index.js
@@ -18,7 +18,8 @@ export { normalizeText, normalizeDatabaseClient, toKnexClientId } from "./databa
 export {
   parseDatabaseUrl,
   resolveDatabaseClientFromEnvironment,
-  resolveDatabaseConnectionFromEnvironment
+  resolveDatabaseConnectionFromEnvironment,
+  resolveKnexConnectionFromEnvironment
 } from "./databaseConnection.js";
 export { isDuplicateEntryError } from "./duplicateEntry.js";
 export { normalizePath, jsonTextExpression, whereJsonTextEquals } from "./json.js";
@@ -35,6 +36,8 @@ export {
   stringifyMetadataJson,
   normalizeMetadataJsonInput,
   normalizeNullableString,
+  normalizeDbRecordId,
+  resolveInsertedRecordId,
   normalizeIdList,
   normalizeCountRow,
   parseJsonValue,

--- a/packages/database-runtime/src/shared/repositoryOptions.js
+++ b/packages/database-runtime/src/shared/repositoryOptions.js
@@ -1,3 +1,5 @@
+import { normalizeCanonicalRecordIdText } from "@jskit-ai/kernel/shared/support/normalize";
+
 function resolveQueryOptions(options = {}) {
   if (!options || typeof options !== "object") {
     return {
@@ -120,6 +122,44 @@ function normalizeNullableString(value, { trim = true } = {}) {
   return normalized || null;
 }
 
+function normalizeDbRecordId(value, { fallback = null } = {}) {
+  if (value == null) {
+    return fallback;
+  }
+
+  if (typeof value === "string") {
+    return normalizeCanonicalRecordIdText(value, { fallback });
+  }
+
+  if (typeof value === "number") {
+    if (!Number.isSafeInteger(value) || value < 1) {
+      return fallback;
+    }
+    return normalizeCanonicalRecordIdText(value, { fallback });
+  }
+
+  if (typeof value === "bigint") {
+    if (value < 1n) {
+      return fallback;
+    }
+    return normalizeCanonicalRecordIdText(value, { fallback });
+  }
+
+  if (typeof value === "object" && !Array.isArray(value) && Object.hasOwn(value, "id")) {
+    return normalizeDbRecordId(value.id, { fallback });
+  }
+
+  return normalizeCanonicalRecordIdText(value, { fallback });
+}
+
+function resolveInsertedRecordId(insertResult, { fallback = null } = {}) {
+  if (Array.isArray(insertResult) && insertResult.length > 0) {
+    return normalizeDbRecordId(insertResult[0], { fallback });
+  }
+
+  return normalizeDbRecordId(insertResult, { fallback });
+}
+
 function normalizeIdList(values, { parseValue } = {}) {
   const source = Array.isArray(values) ? values : [];
   const parser = typeof parseValue === "function" ? parseValue : (value) => value;
@@ -207,6 +247,8 @@ export {
   stringifyMetadataJson,
   normalizeMetadataJsonInput,
   normalizeNullableString,
+  normalizeDbRecordId,
+  resolveInsertedRecordId,
   normalizeIdList,
   normalizeCountRow,
   parseJsonValue,

--- a/packages/database-runtime/src/shared/retention.js
+++ b/packages/database-runtime/src/shared/retention.js
@@ -1,4 +1,5 @@
 import { toDatabaseDateTimeUtc } from "./dateUtils.js";
+import { normalizeDbRecordId } from "./repositoryOptions.js";
 
 function normalizeBatchSize(value, { fallback = 1000, max = 10_000 } = {}) {
   const parsed = Number(value);
@@ -40,12 +41,12 @@ async function deleteRowsOlderThan({ client, tableName, dateColumn, cutoffDate, 
     return 0;
   }
 
-  const numericIds = ids.map((entry) => Number(entry.id)).filter((id) => Number.isInteger(id) && id > 0);
-  if (numericIds.length < 1) {
+  const recordIds = ids.map((entry) => normalizeDbRecordId(entry?.id)).filter(Boolean);
+  if (recordIds.length < 1) {
     return 0;
   }
 
-  const deleted = await client(tableName).whereIn("id", numericIds).del();
+  const deleted = await client(tableName).whereIn("id", recordIds).del();
   return normalizeDeletedRowCount(deleted);
 }
 

--- a/packages/database-runtime/templates/knexfile.js
+++ b/packages/database-runtime/templates/knexfile.js
@@ -4,7 +4,7 @@ import {
   normalizeText,
   toKnexClientId,
   resolveDatabaseClientFromEnvironment,
-  resolveDatabaseConnectionFromEnvironment
+  resolveKnexConnectionFromEnvironment
 } from "@jskit-ai/database-runtime/shared";
 
 const appRoot = process.cwd();
@@ -20,7 +20,8 @@ const migrationsDirectory = path.resolve(appRoot, normalizeText(process.env.DB_M
 
 export default {
   client,
-  connection: resolveDatabaseConnectionFromEnvironment(process.env, {
+  connection: resolveKnexConnectionFromEnvironment(process.env, {
+    client: dialectId,
     defaultPort,
     context: "knex migrations"
   }),

--- a/packages/database-runtime/test/repositoryOptions.test.js
+++ b/packages/database-runtime/test/repositoryOptions.test.js
@@ -1,6 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { parseMetadataJson, stringifyMetadataJson } from "../src/shared/repositoryOptions.js";
+import {
+  normalizeDbRecordId,
+  parseMetadataJson,
+  resolveInsertedRecordId,
+  stringifyMetadataJson
+} from "../src/shared/repositoryOptions.js";
 
 test("parseMetadataJson parses object-like metadata payloads", () => {
   assert.deepEqual(parseMetadataJson(""), {});
@@ -19,4 +24,19 @@ test("stringifyMetadataJson returns fallback for non-serializable values", () =>
   const circular = {};
   circular.self = circular;
   assert.equal(stringifyMetadataJson(circular), "{}");
+});
+
+test("normalizeDbRecordId preserves canonical DB ids and rejects unsafe JS numbers", () => {
+  const unsafeNumericId = Number(9007199254740993n);
+  assert.equal(normalizeDbRecordId("9007199254740993"), "9007199254740993");
+  assert.equal(normalizeDbRecordId(42), "42");
+  assert.equal(normalizeDbRecordId(42n), "42");
+  assert.equal(normalizeDbRecordId(unsafeNumericId), null);
+});
+
+test("resolveInsertedRecordId normalizes insert ids without accepting unsafe JS numbers", () => {
+  const unsafeNumericId = Number(9007199254740993n);
+  assert.equal(resolveInsertedRecordId(["9007199254740993"]), "9007199254740993");
+  assert.equal(resolveInsertedRecordId([42]), "42");
+  assert.equal(resolveInsertedRecordId([unsafeNumericId]), null);
 });

--- a/packages/database-runtime/test/repositoryScope.test.js
+++ b/packages/database-runtime/test/repositoryScope.test.js
@@ -37,7 +37,7 @@ test("createRepositoryScope builds explicit scoped query helpers", () => {
     }
   });
 
-  assert.deepEqual(calls, [["table", "contacts"], ["where", "workspace_id", 12]]);
+  assert.deepEqual(calls, [["table", "contacts"], ["where", "workspace_id", "12"]]);
 });
 
 test("createRepositoryScope supports scopedById with custom id column", () => {
@@ -53,7 +53,7 @@ test("createRepositoryScope supports scopedById with custom id column", () => {
     }
   });
 
-  assert.deepEqual(calls, [["table", "contacts"], ["where", "user_id", 7], ["where", "contact_id", 33]]);
+  assert.deepEqual(calls, [["table", "contacts"], ["where", "user_id", "7"], ["where", "contact_id", 33]]);
 });
 
 test("createRepositoryScope exposes applyToQuery and owner stamping", () => {
@@ -69,7 +69,7 @@ test("createRepositoryScope exposes applyToQuery and owner stamping", () => {
     }
   });
 
-  assert.deepEqual(calls, [["where", "workspace_id", 4], ["where", "user_id", 9]]);
+  assert.deepEqual(calls, [["where", "workspace_id", "4"], ["where", "user_id", "9"]]);
 
   assert.deepEqual(
     scope.withOwners(
@@ -86,8 +86,8 @@ test("createRepositoryScope exposes applyToQuery and owner stamping", () => {
     ),
     {
       name: "Ada",
-      workspace_id: 4,
-      user_id: 9
+      workspace_id: "4",
+      user_id: "9"
     }
   );
 

--- a/packages/database-runtime/test/visibility.test.js
+++ b/packages/database-runtime/test/visibility.test.js
@@ -28,14 +28,14 @@ test("applyVisibility appends scope filters to query builders", () => {
     visibility: "workspace",
     scopeOwnerId: 12
   });
-  assert.deepEqual(workspaceQuery.calls, [["where", "workspace_id", 12]]);
+  assert.deepEqual(workspaceQuery.calls, [["where", "workspace_id", "12"]]);
 
   const userQuery = createQueryBuilderStub();
   applyVisibility(userQuery, {
     visibility: "user",
     userId: 7
   });
-  assert.deepEqual(userQuery.calls, [["where", "user_id", 7]]);
+  assert.deepEqual(userQuery.calls, [["where", "user_id", "7"]]);
 
   const deniedQuery = createQueryBuilderStub();
   applyVisibility(deniedQuery, {
@@ -73,8 +73,8 @@ test("applyVisibilityOwners injects owner columns for write payloads", () => {
     ),
     {
       name: "Alice",
-      workspace_id: 4,
-      user_id: 9
+      workspace_id: "4",
+      user_id: "9"
     }
   );
 

--- a/packages/kernel/server/http/lib/kernel.test.js
+++ b/packages/kernel/server/http/lib/kernel.test.js
@@ -281,7 +281,7 @@ test("registerRoutes attaches visibilityContext from route visibility resolvers"
     scopeKind: null,
     requiresActorScope: true,
     scopeOwnerId: null,
-    userId: 23
+    userId: "23"
   });
   assert.deepEqual(observed[0].context.requestMeta.visibilityContext, observed[0].context.visibilityContext);
   assert.equal(observed[0].context.requestMeta.routeVisibility, "user");
@@ -353,7 +353,7 @@ test("registerRoutes keeps actor scope requirement for core user visibility with
     scopeKind: null,
     requiresActorScope: true,
     scopeOwnerId: null,
-    userId: 23
+    userId: "23"
   });
   assert.equal(observed[0].context.requestMeta.routeVisibility, "user");
 });

--- a/packages/kernel/server/runtime/entityChangeEvents.test.js
+++ b/packages/kernel/server/runtime/entityChangeEvents.test.js
@@ -33,9 +33,9 @@ test("entity change publisher emits normalized event payload", async () => {
   });
 
   assert.equal(payload?.operation, "created");
-  assert.equal(payload?.entityId, 5);
-  assert.deepEqual(payload?.scope, { kind: "scope", id: 23 });
-  assert.equal(payload?.actorId, 17);
+  assert.equal(payload?.entityId, "5");
+  assert.deepEqual(payload?.scope, { kind: "scope", id: "23" });
+  assert.equal(payload?.actorId, "17");
   assert.equal(payload?.commandId, "cmd-1");
   assert.equal(payload?.sourceClientId, "client-a");
   assert.equal(payload?.meta?.service?.token, "crud.customers");
@@ -111,7 +111,7 @@ test("entity change publisher infers scoped owner from service context when visi
     }
   );
 
-  assert.deepEqual(payload?.scope, { kind: "workspace", id: 23 });
+  assert.deepEqual(payload?.scope, { kind: "workspace", id: "23" });
   assert.equal(published.length, 1);
 });
 

--- a/packages/kernel/server/runtime/serviceAuthorization.test.js
+++ b/packages/kernel/server/runtime/serviceAuthorization.test.js
@@ -24,7 +24,7 @@ test("requireAuth accepts actor context", () => {
     }
   });
 
-  assert.equal(actor.id, 7);
+  assert.equal(actor.id, "7");
 });
 
 test("requireAuth accepts non-numeric actor ids", () => {

--- a/packages/kernel/shared/support/normalize.js
+++ b/packages/kernel/shared/support/normalize.js
@@ -180,6 +180,34 @@ function normalizePositiveInteger(value, { fallback = 0 } = {}) {
   return numeric;
 }
 
+function normalizeCanonicalRecordIdText(value, { fallback = null } = {}) {
+  if (value == null) {
+    return fallback;
+  }
+
+  const normalized = String(value).trim();
+  return /^[1-9][0-9]*$/.test(normalized) ? normalized : fallback;
+}
+
+function normalizeRecordId(value, { fallback = null } = {}) {
+  if (value == null) {
+    return fallback;
+  }
+
+  if (typeof value === "string") {
+    return normalizeCanonicalRecordIdText(value, { fallback });
+  }
+
+  if (typeof value === "bigint") {
+    if (value < 1n) {
+      return fallback;
+    }
+    return normalizeCanonicalRecordIdText(value, { fallback });
+  }
+
+  return fallback;
+}
+
 function normalizeOpaqueId(value, { fallback = null } = {}) {
   if (value == null) {
     return fallback;
@@ -191,7 +219,7 @@ function normalizeOpaqueId(value, { fallback = null } = {}) {
   }
 
   if (typeof value === "number") {
-    return Number.isFinite(value) ? value : fallback;
+    return Number.isFinite(value) ? String(value) : fallback;
   }
 
   if (typeof value === "bigint") {
@@ -244,6 +272,8 @@ export {
   normalizeUniqueTextList,
   normalizeInteger,
   normalizePositiveInteger,
+  normalizeCanonicalRecordIdText,
+  normalizeRecordId,
   normalizeOpaqueId,
   normalizeOneOf,
   ensureNonEmptyText

--- a/packages/kernel/shared/support/normalize.test.js
+++ b/packages/kernel/shared/support/normalize.test.js
@@ -3,11 +3,13 @@ import assert from "node:assert/strict";
 import {
   hasValue,
   normalizeBoolean,
+  normalizeCanonicalRecordIdText,
   normalizeFiniteInteger,
   normalizeFiniteNumber,
   normalizeIfInSource,
   normalizeIfPresent,
   normalizeOrNull,
+  normalizeRecordId,
   normalizeOpaqueId,
   normalizePositiveInteger,
   normalizeOneOf,
@@ -172,10 +174,27 @@ test("normalizeOrNull normalizes non-nullish values and coerces nullish to null"
   );
 });
 
+test("normalizeRecordId accepts canonical string and bigint identifiers only", () => {
+  const unsafeNumericId = Number(9007199254740993n);
+  assert.equal(normalizeRecordId("  7  "), "7");
+  assert.equal(normalizeRecordId(10n), "10");
+  assert.equal(normalizeRecordId(7), null);
+  assert.equal(normalizeRecordId(unsafeNumericId), null);
+  assert.equal(normalizeRecordId(""), null);
+  assert.equal(normalizeRecordId(null), null);
+});
+
+test("normalizeCanonicalRecordIdText validates canonical positive decimal identifiers", () => {
+  assert.equal(normalizeCanonicalRecordIdText("  7  "), "7");
+  assert.equal(normalizeCanonicalRecordIdText("007"), null);
+  assert.equal(normalizeCanonicalRecordIdText("0"), null);
+  assert.equal(normalizeCanonicalRecordIdText("abc"), null);
+});
+
 test("normalizeOpaqueId preserves opaque identifiers", () => {
   assert.equal(normalizeOpaqueId("  user-123  "), "user-123");
-  assert.equal(normalizeOpaqueId(7), 7);
-  assert.equal(normalizeOpaqueId(0), 0);
+  assert.equal(normalizeOpaqueId(7), "7");
+  assert.equal(normalizeOpaqueId(0), "0");
   assert.equal(normalizeOpaqueId(10n), "10");
   assert.equal(normalizeOpaqueId(""), null);
   assert.equal(normalizeOpaqueId(null), null);

--- a/packages/kernel/shared/support/visibility.test.js
+++ b/packages/kernel/shared/support/visibility.test.js
@@ -32,7 +32,7 @@ test("normalizeVisibilityContext normalizes mode and owner identifiers", () => {
     scopeKind: null,
     requiresActorScope: false,
     scopeOwnerId: "4",
-    userId: 9
+    userId: "9"
   });
 
   assert.deepEqual(normalizeVisibilityContext({ visibility: "workspace", scopeOwnerId: "0" }), {

--- a/packages/kernel/shared/validators/cursorPaginationQueryValidator.js
+++ b/packages/kernel/shared/validators/cursorPaginationQueryValidator.js
@@ -1,14 +1,13 @@
 import { Type } from "typebox";
-import { normalizeText } from "../support/normalize.js";
 import { normalizeObjectInput } from "./inputNormalization.js";
-import { positiveIntegerValidator } from "./recordIdParamsValidator.js";
+import { positiveIntegerValidator, recordIdInputSchema, recordIdValidator } from "./recordIdParamsValidator.js";
 
 function normalizeCursorPaginationQuery(input = {}) {
   const source = normalizeObjectInput(input);
   const normalized = {};
 
   if (Object.hasOwn(source, "cursor")) {
-    normalized.cursor = normalizeText(source.cursor);
+    normalized.cursor = recordIdValidator.normalize(source.cursor);
   }
 
   if (Object.hasOwn(source, "limit")) {
@@ -21,7 +20,7 @@ function normalizeCursorPaginationQuery(input = {}) {
 const cursorPaginationQueryValidator = Object.freeze({
   schema: Type.Object(
     {
-      cursor: Type.Optional(positiveIntegerValidator.schema),
+      cursor: Type.Optional(recordIdInputSchema),
       limit: Type.Optional(positiveIntegerValidator.schema)
     },
     { additionalProperties: false }

--- a/packages/kernel/shared/validators/cursorPaginationQueryValidator.test.js
+++ b/packages/kernel/shared/validators/cursorPaginationQueryValidator.test.js
@@ -11,9 +11,8 @@ test("cursorPaginationQueryValidator normalizes numeric strings as cursor text",
 
 test("cursorPaginationQueryValidator schema rejects opaque cursor strings", () => {
   assert.equal(
-    cursorPaginationQueryValidator.schema.properties.cursor.anyOf.some(
-      (entry) => entry.type === "string" && entry.pattern === "^[1-9][0-9]*$"
-    ),
+    cursorPaginationQueryValidator.schema.properties.cursor.type === "string" &&
+      cursorPaginationQueryValidator.schema.properties.cursor.pattern === "^[1-9][0-9]*$",
     true
   );
 });

--- a/packages/kernel/shared/validators/index.js
+++ b/packages/kernel/shared/validators/index.js
@@ -8,7 +8,17 @@ export {
 export { mergeObjectSchemas } from "./mergeObjectSchemas.js";
 export { mergeValidators } from "./mergeValidators.js";
 export { nestValidator } from "./nestValidator.js";
-export { recordIdParamsValidator, positiveIntegerValidator } from "./recordIdParamsValidator.js";
+export {
+  RECORD_ID_PATTERN,
+  recordIdSchema,
+  recordIdInputSchema,
+  nullableRecordIdSchema,
+  nullableRecordIdInputSchema,
+  recordIdValidator,
+  nullableRecordIdValidator,
+  recordIdParamsValidator,
+  positiveIntegerValidator
+} from "./recordIdParamsValidator.js";
 export { normalizeSettingsFieldInput, normalizeSettingsFieldOutput } from "./settingsFieldNormalization.js";
 export {
   normalizeRequiredFieldList,

--- a/packages/kernel/shared/validators/recordIdParamsValidator.js
+++ b/packages/kernel/shared/validators/recordIdParamsValidator.js
@@ -1,23 +1,51 @@
 import { Type } from "typebox";
 import { normalizeObjectInput } from "./inputNormalization.js";
-import { normalizePositiveInteger, normalizeText } from "../support/normalize.js";
+import { normalizePositiveInteger, normalizeRecordId } from "../support/normalize.js";
 
-function normalizeRecordId(value) {
-  return normalizePositiveInteger(normalizeText(value));
-}
+const RECORD_ID_PATTERN = "^[1-9][0-9]*$";
+
+const recordIdSchema = Type.String({
+  minLength: 1,
+  pattern: RECORD_ID_PATTERN
+});
+
+const recordIdInputSchema = recordIdSchema;
+
+const nullableRecordIdSchema = Type.Union([recordIdSchema, Type.Null()]);
+const nullableRecordIdInputSchema = Type.Union([recordIdInputSchema, Type.Null()]);
 
 const positiveIntegerValidator = Object.freeze({
   schema: Type.Union([
     Type.Integer({ minimum: 1 }),
-    Type.String({ minLength: 1, pattern: "^[1-9][0-9]*$" })
+    Type.String({ minLength: 1, pattern: RECORD_ID_PATTERN })
   ]),
-  normalize: normalizeRecordId
+  normalize(value) {
+    return normalizePositiveInteger(value);
+  }
+});
+
+const recordIdValidator = Object.freeze({
+  schema: recordIdInputSchema,
+  normalize(value) {
+    return normalizeRecordId(value, {
+      fallback: ""
+    });
+  }
+});
+
+const nullableRecordIdValidator = Object.freeze({
+  schema: nullableRecordIdInputSchema,
+  normalize(value) {
+    return normalizeRecordId(value, {
+      fallback: null
+    });
+  }
 });
 
 const recordIdParamsValidator = Object.freeze({
   schema: Type.Object(
     {
-      recordId: Type.Optional(positiveIntegerValidator.schema)
+      recordId: Type.Optional(recordIdInputSchema)
     },
     { additionalProperties: false }
   ),
@@ -26,11 +54,21 @@ const recordIdParamsValidator = Object.freeze({
     const normalized = {};
 
     if (Object.hasOwn(source, "recordId")) {
-      normalized.recordId = normalizeRecordId(source.recordId);
+      normalized.recordId = recordIdValidator.normalize(source.recordId);
     }
 
     return normalized;
   }
 });
 
-export { recordIdParamsValidator, positiveIntegerValidator };
+export {
+  RECORD_ID_PATTERN,
+  recordIdSchema,
+  recordIdInputSchema,
+  nullableRecordIdSchema,
+  nullableRecordIdInputSchema,
+  recordIdValidator,
+  nullableRecordIdValidator,
+  recordIdParamsValidator,
+  positiveIntegerValidator
+};

--- a/packages/kernel/shared/validators/recordIdParamsValidator.test.js
+++ b/packages/kernel/shared/validators/recordIdParamsValidator.test.js
@@ -3,15 +3,18 @@ import assert from "node:assert/strict";
 
 import { recordIdParamsValidator } from "./recordIdParamsValidator.js";
 
-test("recordIdParamsValidator normalizes string id to positive integer", () => {
+test("recordIdParamsValidator normalizes canonical string ids", () => {
   assert.deepEqual(recordIdParamsValidator.normalize({ recordId: "42" }), {
-    recordId: 42
+    recordId: "42"
   });
 });
 
-test("recordIdParamsValidator normalizes invalid id to 0", () => {
+test("recordIdParamsValidator rejects invalid ids", () => {
   assert.deepEqual(recordIdParamsValidator.normalize({ recordId: "nope" }), {
-    recordId: 0
+    recordId: ""
+  });
+  assert.deepEqual(recordIdParamsValidator.normalize({ recordId: 42 }), {
+    recordId: ""
   });
 });
 

--- a/packages/realtime/src/server/RealtimeServiceProvider.js
+++ b/packages/realtime/src/server/RealtimeServiceProvider.js
@@ -1,4 +1,4 @@
-import { normalizePositiveInteger, normalizeText } from "@jskit-ai/kernel/shared/support/normalize";
+import { normalizeRecordId, normalizeText } from "@jskit-ai/kernel/shared/support/normalize";
 import { createProviderLogger as createSharedProviderLogger } from "@jskit-ai/kernel/shared/support/providerLogger";
 import {
   registerDomainEventListener,
@@ -41,15 +41,15 @@ function normalizeArray(value) {
 }
 
 function roomForUser(userId) {
-  return `user:${Number(userId)}`;
+  return `user:${String(userId || "").trim()}`;
 }
 
 function roomForWorkspace(workspaceId) {
-  return `workspace:${Number(workspaceId)}`;
+  return `workspace:${String(workspaceId || "").trim()}`;
 }
 
 function roomForWorkspaceUser(workspaceId, userId) {
-  return `workspace:${Number(workspaceId)}:user:${Number(userId)}`;
+  return `workspace:${String(workspaceId || "").trim()}:user:${String(userId || "").trim()}`;
 }
 
 function parseCookieHeader(value = "") {
@@ -186,23 +186,23 @@ function mergeRealtimePayload(event, payloadPatch) {
 function resolveScopeWorkspaceId(scope = {}) {
   const source = scope && typeof scope === "object" && !Array.isArray(scope) ? scope : {};
   if (String(source.kind || "").trim().toLowerCase() === "workspace") {
-    return normalizePositiveInteger(source.id);
+    return normalizeRecordId(source.id, { fallback: null });
   }
   if (String(source.kind || "").trim().toLowerCase() === "workspace_user") {
-    return normalizePositiveInteger(source.workspaceId || source.id);
+    return normalizeRecordId(source.workspaceId || source.id, { fallback: null });
   }
-  return normalizePositiveInteger(source.workspaceId);
+  return normalizeRecordId(source.workspaceId, { fallback: null });
 }
 
 function resolveScopeUserId(scope = {}) {
   const source = scope && typeof scope === "object" && !Array.isArray(scope) ? scope : {};
   if (String(source.kind || "").trim().toLowerCase() === "user") {
-    return normalizePositiveInteger(source.id);
+    return normalizeRecordId(source.id, { fallback: null });
   }
   if (String(source.kind || "").trim().toLowerCase() === "workspace_user") {
-    return normalizePositiveInteger(source.userId);
+    return normalizeRecordId(source.userId, { fallback: null });
   }
-  return normalizePositiveInteger(source.userId);
+  return normalizeRecordId(source.userId, { fallback: null });
 }
 
 function applyAudiencePreset(preset, { event, rooms, flags, logger } = {}) {
@@ -222,8 +222,8 @@ function applyAudiencePreset(preset, { event, rooms, flags, logger } = {}) {
   }
 
   if (normalizedPreset === "actor_user") {
-    const actorId = normalizePositiveInteger(event?.actorId);
-    if (actorId > 0) {
+    const actorId = normalizeRecordId(event?.actorId, { fallback: null });
+    if (actorId) {
       rooms.add(roomForUser(actorId));
     }
     return;
@@ -231,7 +231,7 @@ function applyAudiencePreset(preset, { event, rooms, flags, logger } = {}) {
 
   if (normalizedPreset === "all_workspace_users") {
     const workspaceId = resolveScopeWorkspaceId(event?.scope);
-    if (workspaceId > 0) {
+    if (workspaceId) {
       rooms.add(roomForWorkspace(workspaceId));
       return;
     }
@@ -249,7 +249,7 @@ function applyAudiencePreset(preset, { event, rooms, flags, logger } = {}) {
     const scopeKind = normalizeText(event?.scope?.kind).toLowerCase();
     if (scopeKind === "workspace") {
       const workspaceId = resolveScopeWorkspaceId(event?.scope);
-      if (workspaceId > 0) {
+      if (workspaceId) {
         rooms.add(roomForWorkspace(workspaceId));
       }
       return;
@@ -257,14 +257,14 @@ function applyAudiencePreset(preset, { event, rooms, flags, logger } = {}) {
     if (scopeKind === "workspace_user") {
       const workspaceId = resolveScopeWorkspaceId(event?.scope);
       const userId = resolveScopeUserId(event?.scope);
-      if (workspaceId > 0 && userId > 0) {
+      if (workspaceId && userId) {
         rooms.add(roomForWorkspaceUser(workspaceId, userId));
       }
       return;
     }
     if (scopeKind === "user") {
       const userId = resolveScopeUserId(event?.scope);
-      if (userId > 0) {
+      if (userId) {
         rooms.add(roomForUser(userId));
       }
       return;
@@ -309,33 +309,33 @@ function addAudienceRoomsFromObject(selection, { event, rooms, flags, logger } =
     }
   }
 
-  const userId = normalizePositiveInteger(selection.userId);
-  if (userId > 0) {
+  const userId = normalizeRecordId(selection.userId, { fallback: null });
+  if (userId) {
     rooms.add(roomForUser(userId));
   }
   for (const entry of normalizeArray(selection.userIds)) {
-    const normalizedUserId = normalizePositiveInteger(entry);
-    if (normalizedUserId > 0) {
+    const normalizedUserId = normalizeRecordId(entry, { fallback: null });
+    if (normalizedUserId) {
       rooms.add(roomForUser(normalizedUserId));
     }
   }
 
-  const workspaceId = normalizePositiveInteger(selection.workspaceId);
-  if (workspaceId > 0) {
+  const workspaceId = normalizeRecordId(selection.workspaceId, { fallback: null });
+  if (workspaceId) {
     rooms.add(roomForWorkspace(workspaceId));
   }
   for (const entry of normalizeArray(selection.workspaceIds)) {
-    const normalizedWorkspaceId = normalizePositiveInteger(entry);
-    if (normalizedWorkspaceId > 0) {
+    const normalizedWorkspaceId = normalizeRecordId(entry, { fallback: null });
+    if (normalizedWorkspaceId) {
       rooms.add(roomForWorkspace(normalizedWorkspaceId));
     }
   }
 
   const workspaceUser = selection.workspaceUser;
   if (workspaceUser && typeof workspaceUser === "object") {
-    const targetWorkspaceId = normalizePositiveInteger(workspaceUser.workspaceId);
-    const targetUserId = normalizePositiveInteger(workspaceUser.userId);
-    if (targetWorkspaceId > 0 && targetUserId > 0) {
+    const targetWorkspaceId = normalizeRecordId(workspaceUser.workspaceId, { fallback: null });
+    const targetUserId = normalizeRecordId(workspaceUser.userId, { fallback: null });
+    if (targetWorkspaceId && targetUserId) {
       rooms.add(roomForWorkspaceUser(targetWorkspaceId, targetUserId));
     }
   }
@@ -344,9 +344,9 @@ function addAudienceRoomsFromObject(selection, { event, rooms, flags, logger } =
     if (!entry || typeof entry !== "object") {
       continue;
     }
-    const targetWorkspaceId = normalizePositiveInteger(entry.workspaceId);
-    const targetUserId = normalizePositiveInteger(entry.userId);
-    if (targetWorkspaceId > 0 && targetUserId > 0) {
+    const targetWorkspaceId = normalizeRecordId(entry.workspaceId, { fallback: null });
+    const targetUserId = normalizeRecordId(entry.userId, { fallback: null });
+    if (targetWorkspaceId && targetUserId) {
       rooms.add(roomForWorkspaceUser(targetWorkspaceId, targetUserId));
     }
   }
@@ -356,8 +356,8 @@ function collectUserIdsFromQueryRows(rows = []) {
   const result = new Set();
   for (const row of normalizeArray(rows)) {
     if (typeof row === "number") {
-      const directId = normalizePositiveInteger(row);
-      if (directId > 0) {
+      const directId = normalizeRecordId(row, { fallback: null });
+      if (directId) {
         result.add(directId);
       }
       continue;
@@ -365,8 +365,8 @@ function collectUserIdsFromQueryRows(rows = []) {
     if (!row || typeof row !== "object" || Array.isArray(row)) {
       continue;
     }
-    const userId = normalizePositiveInteger(row.userId || row.user_id || row.id);
-    if (userId > 0) {
+    const userId = normalizeRecordId(row.userId || row.user_id || row.id, { fallback: null });
+    if (userId) {
       result.add(userId);
     }
   }
@@ -447,7 +447,7 @@ async function resolveAudienceTargets(dispatcher, event, { scope, logger } = {})
 
 async function resolveSocketActorId(authService, socket) {
   if (!authService || typeof authService.authenticateRequest !== "function") {
-    return 0;
+    return null;
   }
 
   const cookies = parseCookieHeader(socket?.request?.headers?.cookie);
@@ -455,9 +455,9 @@ async function resolveSocketActorId(authService, socket) {
     cookies
   });
   if (!authResult || authResult.authenticated !== true) {
-    return 0;
+    return null;
   }
-  return normalizePositiveInteger(authResult?.profile?.id);
+  return normalizeRecordId(authResult?.profile?.id, { fallback: null });
 }
 
 async function resolveActorWorkspaceIds(workspaceMembershipsRepository, actorId) {
@@ -467,8 +467,8 @@ async function resolveActorWorkspaceIds(workspaceMembershipsRepository, actorId)
 
   const workspaceIds = await workspaceMembershipsRepository.listActiveWorkspaceIdsByUserId(actorId);
   return normalizeArray(workspaceIds)
-    .map((entry) => normalizePositiveInteger(entry))
-    .filter((entry) => entry > 0);
+    .map((entry) => normalizeRecordId(entry, { fallback: null }))
+    .filter(Boolean);
 }
 
 function registerRealtimeSocketAudienceBootstrap(scope, io, logger) {
@@ -496,7 +496,7 @@ function registerRealtimeSocketAudienceBootstrap(scope, io, logger) {
       );
 
       const actorId = await resolveSocketActorId(authService, socket);
-      if (actorId < 1) {
+      if (!actorId) {
         logger.debug(
           {
             listenerId: "runtime.realtime.domain-event-bridge",

--- a/packages/realtime/test/providerRuntime.test.js
+++ b/packages/realtime/test/providerRuntime.test.js
@@ -471,7 +471,7 @@ test("RealtimeServiceProvider merges custom realtime payload with canonical doma
   assert.equal(emitted[0].payload?.entity, "settings");
   assert.equal(emitted[0].payload?.operation, "updated");
   assert.equal(emitted[0].payload?.scope?.kind, "workspace");
-  assert.equal(emitted[0].payload?.scope?.id, 11);
+  assert.equal(emitted[0].payload?.scope?.id, "11");
 });
 
 test("RealtimeServiceProvider emits only the matching dispatcher event for each service method event", async () => {

--- a/packages/users-core/src/server/accountProfile/avatarStorageService.js
+++ b/packages/users-core/src/server/accountProfile/avatarStorageService.js
@@ -1,4 +1,4 @@
-import { parsePositiveInteger } from "@jskit-ai/kernel/server/runtime";
+import { normalizeRecordId } from "@jskit-ai/kernel/shared/support/normalize";
 import {
   createUploadStorageService,
   detectCommonMimeTypeFromBuffer
@@ -7,9 +7,9 @@ import {
 const AVATAR_STORAGE_PREFIX = "users/avatars";
 
 function buildAvatarStorageKey(userId) {
-  const normalizedUserId = parsePositiveInteger(userId);
+  const normalizedUserId = normalizeRecordId(userId, { fallback: null });
   if (!normalizedUserId) {
-    throw new TypeError("Avatar storage requires a positive integer user id.");
+    throw new TypeError("Avatar storage requires a valid user id.");
   }
 
   return `${AVATAR_STORAGE_PREFIX}/${normalizedUserId}/avatar`;

--- a/packages/users-core/src/server/common/contributors/workspaceRouteVisibilityResolver.js
+++ b/packages/users-core/src/server/common/contributors/workspaceRouteVisibilityResolver.js
@@ -1,14 +1,13 @@
-import { normalizeOpaqueId, normalizeText } from "@jskit-ai/kernel/shared/support/normalize";
-import { parsePositiveInteger } from "@jskit-ai/kernel/server/runtime";
+import { normalizeOpaqueId, normalizeRecordId, normalizeText } from "@jskit-ai/kernel/shared/support/normalize";
 
-function buildVisibilityContribution({ visibility, scopeOwnerId = 0, userId = null } = {}) {
+function buildVisibilityContribution({ visibility, scopeOwnerId = null, userId = null } = {}) {
   const requiresActorScope = visibility === "workspace_user";
   const contribution = {
     scopeKind: requiresActorScope ? "workspace_user" : "workspace",
     requiresActorScope
   };
 
-  if (scopeOwnerId > 0) {
+  if (scopeOwnerId) {
     contribution.scopeOwnerId = scopeOwnerId;
   }
   if (requiresActorScope && userId != null) {
@@ -34,7 +33,7 @@ function createWorkspaceRouteVisibilityResolver({ workspaceService } = {}) {
       const userId = normalizeOpaqueId(actor?.id);
       const workspace =
         context?.workspace || context?.requestMeta?.resolvedWorkspaceContext?.workspace || request?.workspace || null;
-      const scopeOwnerId = parsePositiveInteger(workspace?.id);
+      const scopeOwnerId = normalizeRecordId(workspace?.id, { fallback: null });
       if (!scopeOwnerId) {
         const workspaceSlug = normalizeText(input?.workspaceSlug).toLowerCase();
 
@@ -50,7 +49,7 @@ function createWorkspaceRouteVisibilityResolver({ workspaceService } = {}) {
         const resolvedWorkspaceContext = await workspaceService.resolveWorkspaceContextForUserBySlug(actor, workspaceSlug, {
           request
         });
-        const resolvedWorkspaceOwnerId = parsePositiveInteger(resolvedWorkspaceContext?.workspace?.id);
+        const resolvedWorkspaceOwnerId = normalizeRecordId(resolvedWorkspaceContext?.workspace?.id, { fallback: null });
         if (!resolvedWorkspaceOwnerId) {
           return visibility === "workspace_user"
             ? buildVisibilityContribution({

--- a/packages/users-core/src/server/common/formatters/workspaceFormatter.js
+++ b/packages/users-core/src/server/common/formatters/workspaceFormatter.js
@@ -1,9 +1,10 @@
 import { resolveWorkspaceThemePalettes } from "../../../shared/settings.js";
 import { normalizeLowerText, normalizeText } from "@jskit-ai/kernel/shared/actions/textNormalization";
+import { normalizeRecordId } from "@jskit-ai/kernel/shared/support/normalize";
 
 function mapWorkspaceSummary(workspace, membership) {
   return {
-    id: Number(workspace.id),
+    id: normalizeRecordId(workspace.id, { fallback: "" }),
     slug: normalizeText(workspace.slug),
     name: normalizeText(workspace.name),
     avatarUrl: normalizeText(workspace.avatarUrl),
@@ -39,7 +40,7 @@ function mapMembershipSummary(membership, workspace) {
   }
 
   return {
-    workspaceId: Number(workspace?.id || membership.workspaceId),
+    workspaceId: normalizeRecordId(workspace?.id || membership.workspaceId, { fallback: "" }),
     roleSid: normalizeLowerText(membership.roleSid || "member") || "member",
     status: normalizeLowerText(membership.status || "active") || "active"
   };

--- a/packages/users-core/src/server/common/repositories/repositoryUtils.js
+++ b/packages/users-core/src/server/common/repositories/repositoryUtils.js
@@ -1,6 +1,11 @@
-import { toInsertDateTime, toNullableDateTime, toIsoString } from "@jskit-ai/database-runtime/shared";
+import {
+  normalizeDbRecordId,
+  toInsertDateTime,
+  toNullableDateTime,
+  toIsoString
+} from "@jskit-ai/database-runtime/shared";
 import { isDuplicateEntryError } from "@jskit-ai/database-runtime/shared/duplicateEntry";
-import { normalizeText, normalizeLowerText } from "@jskit-ai/kernel/shared/support/normalize";
+import { normalizeLowerText, normalizeRecordId, normalizeText } from "@jskit-ai/kernel/shared/support/normalize";
 
 function nowDb() {
   return toInsertDateTime();
@@ -42,6 +47,8 @@ export {
   isDuplicateEntryError,
   normalizeText,
   normalizeLowerText,
+  normalizeRecordId,
+  normalizeDbRecordId,
   nowDb,
   toNullableIso,
   uniqueSorted,

--- a/packages/users-core/src/server/common/repositories/userSettingsRepository.js
+++ b/packages/users-core/src/server/common/repositories/userSettingsRepository.js
@@ -1,4 +1,6 @@
 import {
+  normalizeDbRecordId,
+  normalizeRecordId,
   toIsoString,
   nowDb,
   isDuplicateEntryError
@@ -14,7 +16,7 @@ function mapRow(row) {
   }
 
   const mapped = {
-    userId: Number(row.user_id),
+    userId: normalizeDbRecordId(row.user_id, { fallback: "" }),
     passwordSignInEnabled: row.password_sign_in_enabled == null ? true : Boolean(row.password_sign_in_enabled),
     passwordSetupRequired: row.password_setup_required == null ? false : Boolean(row.password_setup_required),
     createdAt: toIsoString(row.created_at),
@@ -45,8 +47,13 @@ function normalizeBoolean(value, fallback = false) {
 }
 
 function createInsertPayload(userId) {
+  const normalizedUserId = normalizeRecordId(userId, { fallback: null });
+  if (!normalizedUserId) {
+    throw new TypeError("userSettingsRepository requires a valid user id.");
+  }
+
   const payload = {
-    user_id: Number(userId),
+    user_id: normalizedUserId,
     password_sign_in_enabled: DEFAULT_USER_SETTINGS.passwordSignInEnabled,
     password_setup_required: DEFAULT_USER_SETTINGS.passwordSetupRequired,
     created_at: nowDb(),
@@ -77,32 +84,46 @@ function createRepository(knex) {
 
   async function findByUserId(userId, options = {}) {
     const client = options?.trx || knex;
-    const row = await client("user_settings").where({ user_id: Number(userId) }).first();
+    const normalizedUserId = normalizeRecordId(userId, { fallback: null });
+    if (!normalizedUserId) {
+      return null;
+    }
+
+    const row = await client("user_settings").where({ user_id: normalizedUserId }).first();
     return mapRow(row);
   }
 
   async function ensureForUserId(userId, options = {}) {
     const client = options?.trx || knex;
-    const numericUserId = Number(userId);
-    const existing = await findByUserId(numericUserId, { trx: client });
+    const normalizedUserId = normalizeRecordId(userId, { fallback: null });
+    if (!normalizedUserId) {
+      throw new TypeError("userSettingsRepository.ensureForUserId requires a valid user id.");
+    }
+
+    const existing = await findByUserId(normalizedUserId, { trx: client });
     if (existing) {
       return existing;
     }
 
     try {
-      await client("user_settings").insert(createInsertPayload(numericUserId));
+      await client("user_settings").insert(createInsertPayload(normalizedUserId));
     } catch (error) {
       if (!isDuplicateEntryError(error)) {
         throw error;
       }
     }
 
-    return findByUserId(numericUserId, { trx: client });
+    return findByUserId(normalizedUserId, { trx: client });
   }
 
   async function patchUserSettings(userId, patch = {}, options = {}) {
     const client = options?.trx || knex;
-    const ensured = await ensureForUserId(userId, { trx: client });
+    const normalizedUserId = normalizeRecordId(userId, { fallback: null });
+    if (!normalizedUserId) {
+      throw new TypeError("userSettingsRepository.patchUserSettings requires a valid user id.");
+    }
+
+    const ensured = await ensureForUserId(normalizedUserId, { trx: client });
     const source = patch && typeof patch === "object" ? patch : {};
 
     const dbPatch = {
@@ -125,8 +146,8 @@ function createRepository(knex) {
     if (Object.hasOwn(source, "passwordSetupRequired")) {
       dbPatch.password_setup_required = normalizeBoolean(source.passwordSetupRequired, ensured.passwordSetupRequired);
     }
-    await client("user_settings").where({ user_id: Number(userId) }).update(dbPatch);
-    return findByUserId(userId, { trx: client });
+    await client("user_settings").where({ user_id: normalizedUserId }).update(dbPatch);
+    return findByUserId(normalizedUserId, { trx: client });
   }
 
   async function updatePreferences(userId, patch = {}, options = {}) {

--- a/packages/users-core/src/server/common/repositories/usersRepository.js
+++ b/packages/users-core/src/server/common/repositories/usersRepository.js
@@ -1,6 +1,8 @@
 import {
   isDuplicateEntryError,
   normalizeLowerText,
+  normalizeDbRecordId,
+  normalizeRecordId,
   normalizeText,
   toIsoString,
   toNullableDateTime,
@@ -55,7 +57,7 @@ function mapProfileRow(row) {
     return null;
   }
   return {
-    id: Number(row.id),
+    id: normalizeDbRecordId(row.id, { fallback: "" }),
     authProvider: normalizeLowerText(row.auth_provider),
     authProviderUserSid: normalizeText(row.auth_provider_user_sid),
     email: normalizeLowerText(row.email),
@@ -90,11 +92,13 @@ function createDuplicateEmailConflictError() {
   return error;
 }
 
-async function resolveUniqueUsername(client, baseUsername, { excludeUserId = 0 } = {}) {
+async function resolveUniqueUsername(client, baseUsername, { excludeUserId = null } = {}) {
+  const normalizedExcludeUserId = normalizeDbRecordId(excludeUserId, { fallback: null });
   for (let suffix = 0; suffix < 1000; suffix += 1) {
     const candidate = buildUsernameCandidate(baseUsername, suffix);
     const existing = await client("users").where({ username: candidate }).first();
-    if (!existing || Number(existing.id) === Number(excludeUserId || 0)) {
+    const existingId = normalizeDbRecordId(existing?.id, { fallback: null });
+    if (!existing || existingId === normalizedExcludeUserId) {
       return candidate;
     }
   }
@@ -108,8 +112,13 @@ function createRepository(knex) {
   }
 
   async function findById(userId, options = {}) {
+    const normalizedUserId = normalizeRecordId(userId, { fallback: null });
+    if (!normalizedUserId) {
+      return null;
+    }
+
     const client = options?.trx || knex;
-    const row = await client("users").where({ id: userId }).first();
+    const row = await client("users").where({ id: normalizedUserId }).first();
     return mapProfileRow(row);
   }
 
@@ -130,42 +139,56 @@ function createRepository(knex) {
   }
 
   async function updateDisplayNameById(userId, displayName, options = {}) {
+    const normalizedUserId = normalizeRecordId(userId, { fallback: null });
+    if (!normalizedUserId) {
+      return null;
+    }
+
     const client = options?.trx || knex;
     await client("users")
-      .where({ id: userId })
+      .where({ id: normalizedUserId })
       .update({
         display_name: normalizeText(displayName)
       });
-    return findById(userId, { trx: client });
+    return findById(normalizedUserId, { trx: client });
   }
 
   async function updateAvatarById(userId, avatar = {}, options = {}) {
+    const normalizedUserId = normalizeRecordId(userId, { fallback: null });
+    if (!normalizedUserId) {
+      return null;
+    }
+
     const client = options?.trx || knex;
     await client("users")
-      .where({ id: userId })
+      .where({ id: normalizedUserId })
       .update({
         avatar_storage_key: avatar.avatarStorageKey || null,
         avatar_version: avatar.avatarVersion == null ? null : String(avatar.avatarVersion),
         avatar_updated_at: toNullableDateTime(avatar.avatarUpdatedAt) || nowDb()
       });
 
-    return findById(userId, { trx: client });
+    return findById(normalizedUserId, { trx: client });
   }
 
   async function clearAvatarById(userId, options = {}) {
+    const normalizedUserId = normalizeRecordId(userId, { fallback: null });
+    if (!normalizedUserId) {
+      return null;
+    }
+
     const client = options?.trx || knex;
     await client("users")
-      .where({ id: userId })
+      .where({ id: normalizedUserId })
       .update({
         avatar_storage_key: null,
         avatar_version: null,
         avatar_updated_at: null
       });
-    return findById(userId, { trx: client });
+    return findById(normalizedUserId, { trx: client });
   }
 
   async function upsert(profileLike = {}, options = {}) {
-    const client = options?.trx || knex;
     const identity = normalizeIdentity(profileLike);
     if (!identity) {
       throw new TypeError("upsert requires provider/authProvider and providerUserId/authProviderUserSid.");
@@ -191,7 +214,7 @@ function createRepository(knex) {
           const username = existingUsername || (await resolveUniqueUsername(trx, requestedUsername || usernameBaseFromEmail(email), {
             excludeUserId: existing.id
           }));
-          await trx("users").where({ id: existing.id }).update({
+          await trx("users").where({ id: normalizeDbRecordId(existing.id, { fallback: null }) }).update({
             email,
             display_name: displayName,
             username
@@ -218,23 +241,15 @@ function createRepository(knex) {
         }
       }
 
-      const reloaded = await trx("users").where(where).first();
-      return mapProfileRow(reloaded);
+      const resolved = await trx("users").where(where).first();
+      return mapProfileRow(resolved);
     };
 
     if (options?.trx) {
-      return executeUpsert(client);
+      return executeUpsert(options.trx);
     }
 
     return knex.transaction(executeUpsert);
-  }
-
-  async function withTransaction(work) {
-    if (typeof work !== "function") {
-      throw new TypeError("withTransaction requires a callback.");
-    }
-
-    return knex.transaction((trx) => work(trx));
   }
 
   return Object.freeze({
@@ -243,9 +258,8 @@ function createRepository(knex) {
     updateDisplayNameById,
     updateAvatarById,
     clearAvatarById,
-    upsert,
-    withTransaction
+    upsert
   });
 }
 
-export { createRepository, normalizeIdentity, mapProfileRow };
+export { createRepository, mapProfileRow, normalizeIdentity };

--- a/packages/users-core/src/server/common/repositories/workspaceInvitesRepository.js
+++ b/packages/users-core/src/server/common/repositories/workspaceInvitesRepository.js
@@ -1,5 +1,8 @@
+import { resolveInsertedRecordId } from "@jskit-ai/database-runtime/shared";
 import {
   normalizeLowerText,
+  normalizeDbRecordId,
+  normalizeRecordId,
   normalizeText,
   toIsoString,
   toNullableIso,
@@ -14,13 +17,13 @@ function mapRow(row) {
   }
 
   return {
-    id: Number(row.id),
-    workspaceId: Number(row.workspace_id),
+    id: normalizeDbRecordId(row.id, { fallback: "" }),
+    workspaceId: normalizeDbRecordId(row.workspace_id, { fallback: "" }),
     email: normalizeLowerText(row.email),
     roleSid: normalizeLowerText(row.role_sid || "member") || "member",
     status: normalizeLowerText(row.status || "pending") || "pending",
     tokenHash: normalizeText(row.token_hash),
-    invitedByUserId: row.invited_by_user_id == null ? null : Number(row.invited_by_user_id),
+    invitedByUserId: row.invited_by_user_id == null ? null : normalizeDbRecordId(row.invited_by_user_id, { fallback: null }),
     expiresAt: toNullableIso(row.expires_at),
     acceptedAt: toNullableIso(row.accepted_at),
     revokedAt: toNullableIso(row.revoked_at),
@@ -69,10 +72,15 @@ function createRepository(knex) {
   }
 
   async function listPendingByWorkspaceIdWithWorkspace(workspaceId, options = {}) {
+    const normalizedWorkspaceId = normalizeRecordId(workspaceId, { fallback: null });
+    if (!normalizedWorkspaceId) {
+      return [];
+    }
+
     const client = options?.trx || knex;
     const rows = await client("workspace_invites as wi")
       .join("workspaces as w", "w.id", "wi.workspace_id")
-      .where({ "wi.workspace_id": Number(workspaceId), "wi.status": "pending" })
+      .where({ "wi.workspace_id": normalizedWorkspaceId, "wi.status": "pending" })
       .orderBy("wi.created_at", "desc")
       .select(WORKSPACE_INVITE_WITH_WORKSPACE_SELECT);
 
@@ -82,14 +90,18 @@ function createRepository(knex) {
   async function insert(payload = {}, options = {}) {
     const client = options?.trx || knex;
     const source = payload && typeof payload === "object" ? payload : {};
+    const workspaceId = normalizeRecordId(source.workspaceId, { fallback: null });
+    if (!workspaceId) {
+      throw new TypeError("workspaceInvitesRepository.insert requires workspaceId.");
+    }
 
     const insertPayload = {
-      workspace_id: Number(source.workspaceId),
+      workspace_id: workspaceId,
       email: normalizeLowerText(source.email),
       role_sid: normalizeLowerText(source.roleSid || "member") || "member",
       status: normalizeLowerText(source.status || "pending") || "pending",
       token_hash: normalizeText(source.tokenHash),
-      invited_by_user_id: source.invitedByUserId == null ? null : Number(source.invitedByUserId),
+      invited_by_user_id: source.invitedByUserId == null ? null : normalizeRecordId(source.invitedByUserId, { fallback: null }),
       expires_at: toNullableDateTime(source.expiresAt),
       accepted_at: null,
       revoked_at: null,
@@ -99,8 +111,8 @@ function createRepository(knex) {
 
     try {
       const result = await client("workspace_invites").insert(insertPayload);
-      const insertedId = Array.isArray(result) ? Number(result[0]) : Number(result);
-      if (Number.isInteger(insertedId) && insertedId > 0) {
+      const insertedId = resolveInsertedRecordId(result, { fallback: null });
+      if (insertedId) {
         const row = await client("workspace_invites").where({ id: insertedId }).first();
         return mapRow(row);
       }
@@ -118,9 +130,14 @@ function createRepository(knex) {
   }
 
   async function expirePendingByWorkspaceIdAndEmail(workspaceId, email, options = {}) {
+    const normalizedWorkspaceId = normalizeRecordId(workspaceId, { fallback: null });
+    if (!normalizedWorkspaceId) {
+      return;
+    }
+
     const client = options?.trx || knex;
     await client("workspace_invites")
-      .where({ workspace_id: Number(workspaceId), email: normalizeLowerText(email), status: "pending" })
+      .where({ workspace_id: normalizedWorkspaceId, email: normalizeLowerText(email), status: "pending" })
       .update({
         status: "expired",
         updated_at: nowDb()
@@ -128,9 +145,14 @@ function createRepository(knex) {
   }
 
   async function markAcceptedById(inviteId, options = {}) {
+    const normalizedInviteId = normalizeRecordId(inviteId, { fallback: null });
+    if (!normalizedInviteId) {
+      return;
+    }
+
     const client = options?.trx || knex;
     await client("workspace_invites")
-      .where({ id: Number(inviteId) })
+      .where({ id: normalizedInviteId })
       .update({
         status: "accepted",
         accepted_at: nowDb(),
@@ -139,9 +161,14 @@ function createRepository(knex) {
   }
 
   async function revokeById(inviteId, options = {}) {
+    const normalizedInviteId = normalizeRecordId(inviteId, { fallback: null });
+    if (!normalizedInviteId) {
+      return;
+    }
+
     const client = options?.trx || knex;
     await client("workspace_invites")
-      .where({ id: Number(inviteId) })
+      .where({ id: normalizedInviteId })
       .update({
         status: "revoked",
         revoked_at: nowDb(),
@@ -150,9 +177,15 @@ function createRepository(knex) {
   }
 
   async function findPendingByIdForWorkspace(inviteId, workspaceId, options = {}) {
+    const normalizedInviteId = normalizeRecordId(inviteId, { fallback: null });
+    const normalizedWorkspaceId = normalizeRecordId(workspaceId, { fallback: null });
+    if (!normalizedInviteId || !normalizedWorkspaceId) {
+      return null;
+    }
+
     const client = options?.trx || knex;
     const row = await client("workspace_invites")
-      .where({ id: Number(inviteId), workspace_id: Number(workspaceId), status: "pending" })
+      .where({ id: normalizedInviteId, workspace_id: normalizedWorkspaceId, status: "pending" })
       .first();
     return mapRow(row);
   }

--- a/packages/users-core/src/server/common/repositories/workspaceMembershipsRepository.js
+++ b/packages/users-core/src/server/common/repositories/workspaceMembershipsRepository.js
@@ -1,5 +1,7 @@
 import {
   normalizeLowerText,
+  normalizeRecordId,
+  normalizeDbRecordId,
   normalizeText,
   toIsoString,
   nowDb,
@@ -13,9 +15,9 @@ function mapRow(row) {
   }
 
   return {
-    id: Number(row.id),
-    workspaceId: Number(row.workspace_id),
-    userId: Number(row.user_id),
+    id: normalizeDbRecordId(row.id, { fallback: "" }),
+    workspaceId: normalizeDbRecordId(row.workspace_id, { fallback: "" }),
+    userId: normalizeDbRecordId(row.user_id, { fallback: "" }),
     roleSid: normalizeLowerText(row.role_sid || "member") || "member",
     status: normalizeLowerText(row.status || "active") || "active",
     createdAt: toIsoString(row.created_at),
@@ -29,7 +31,7 @@ function mapMemberSummaryRow(row) {
   }
 
   return {
-    userId: Number(row.user_id),
+    userId: normalizeDbRecordId(row.user_id, { fallback: "" }),
     roleSid: normalizeLowerText(row.role_sid || "member") || "member",
     status: normalizeLowerText(row.status || "active") || "active",
     displayName: normalizeText(row.display_name),
@@ -43,33 +45,45 @@ function createRepository(knex) {
   }
 
   async function findByWorkspaceIdAndUserId(workspaceId, userId, options = {}) {
+    const normalizedWorkspaceId = normalizeRecordId(workspaceId, { fallback: null });
+    const normalizedUserId = normalizeRecordId(userId, { fallback: null });
+    if (!normalizedWorkspaceId || !normalizedUserId) {
+      return null;
+    }
+
     const client = options?.trx || knex;
     const row = await client("workspace_memberships")
-      .where({ workspace_id: Number(workspaceId), user_id: Number(userId) })
+      .where({ workspace_id: normalizedWorkspaceId, user_id: normalizedUserId })
       .first();
     return mapRow(row);
   }
 
   async function ensureOwnerMembership(workspaceId, userId, options = {}) {
+    const normalizedWorkspaceId = normalizeRecordId(workspaceId, { fallback: null });
+    const normalizedUserId = normalizeRecordId(userId, { fallback: null });
+    if (!normalizedWorkspaceId || !normalizedUserId) {
+      throw new TypeError("workspaceMembershipsRepository.ensureOwnerMembership requires workspaceId and userId.");
+    }
+
     const client = options?.trx || knex;
-    const existing = await findByWorkspaceIdAndUserId(workspaceId, userId, { trx: client });
+    const existing = await findByWorkspaceIdAndUserId(normalizedWorkspaceId, normalizedUserId, { trx: client });
     if (existing) {
       if (existing.roleSid !== OWNER_ROLE_ID || existing.status !== "active") {
         await client("workspace_memberships")
-          .where({ workspace_id: Number(workspaceId), user_id: Number(userId) })
+          .where({ workspace_id: normalizedWorkspaceId, user_id: normalizedUserId })
           .update({
             role_sid: OWNER_ROLE_ID,
             status: "active",
             updated_at: nowDb()
           });
       }
-      return findByWorkspaceIdAndUserId(workspaceId, userId, { trx: client });
+      return findByWorkspaceIdAndUserId(normalizedWorkspaceId, normalizedUserId, { trx: client });
     }
 
     try {
       await client("workspace_memberships").insert({
-        workspace_id: Number(workspaceId),
-        user_id: Number(userId),
+        workspace_id: normalizedWorkspaceId,
+        user_id: normalizedUserId,
         role_sid: OWNER_ROLE_ID,
         status: "active",
         created_at: nowDb(),
@@ -81,43 +95,54 @@ function createRepository(knex) {
       }
     }
 
-    return findByWorkspaceIdAndUserId(workspaceId, userId, { trx: client });
+    return findByWorkspaceIdAndUserId(normalizedWorkspaceId, normalizedUserId, { trx: client });
   }
 
   async function upsertMembership(workspaceId, userId, patch = {}, options = {}) {
+    const normalizedWorkspaceId = normalizeRecordId(workspaceId, { fallback: null });
+    const normalizedUserId = normalizeRecordId(userId, { fallback: null });
+    if (!normalizedWorkspaceId || !normalizedUserId) {
+      throw new TypeError("workspaceMembershipsRepository.upsertMembership requires workspaceId and userId.");
+    }
+
     const client = options?.trx || knex;
-    const existing = await findByWorkspaceIdAndUserId(workspaceId, userId, { trx: client });
+    const existing = await findByWorkspaceIdAndUserId(normalizedWorkspaceId, normalizedUserId, { trx: client });
     const roleSid = normalizeLowerText(patch.roleSid || existing?.roleSid || "member") || "member";
     const status = normalizeLowerText(patch.status || existing?.status || "active") || "active";
 
     if (!existing) {
       await client("workspace_memberships").insert({
-        workspace_id: Number(workspaceId),
-        user_id: Number(userId),
+        workspace_id: normalizedWorkspaceId,
+        user_id: normalizedUserId,
         role_sid: roleSid,
         status,
         created_at: nowDb(),
         updated_at: nowDb()
       });
-      return findByWorkspaceIdAndUserId(workspaceId, userId, { trx: client });
+      return findByWorkspaceIdAndUserId(normalizedWorkspaceId, normalizedUserId, { trx: client });
     }
 
     await client("workspace_memberships")
-      .where({ workspace_id: Number(workspaceId), user_id: Number(userId) })
+      .where({ workspace_id: normalizedWorkspaceId, user_id: normalizedUserId })
       .update({
         role_sid: roleSid,
         status,
         updated_at: nowDb()
       });
 
-    return findByWorkspaceIdAndUserId(workspaceId, userId, { trx: client });
+    return findByWorkspaceIdAndUserId(normalizedWorkspaceId, normalizedUserId, { trx: client });
   }
 
   async function listActiveByWorkspaceId(workspaceId, options = {}) {
+    const normalizedWorkspaceId = normalizeRecordId(workspaceId, { fallback: null });
+    if (!normalizedWorkspaceId) {
+      return [];
+    }
+
     const client = options?.trx || knex;
     const rows = await client("workspace_memberships as wm")
       .join("users as up", "up.id", "wm.user_id")
-      .where({ "wm.workspace_id": Number(workspaceId), "wm.status": "active" })
+      .where({ "wm.workspace_id": normalizedWorkspaceId, "wm.status": "active" })
       .orderBy("up.display_name", "asc")
       .select([
         "wm.user_id",
@@ -131,18 +156,23 @@ function createRepository(knex) {
   }
 
   async function listActiveWorkspaceIdsByUserId(userId, options = {}) {
+    const normalizedUserId = normalizeRecordId(userId, { fallback: null });
+    if (!normalizedUserId) {
+      return [];
+    }
+
     const client = options?.trx || knex;
     const rows = await client("workspace_memberships")
       .where({
-        user_id: Number(userId),
+        user_id: normalizedUserId,
         status: "active"
       })
       .select("workspace_id")
       .orderBy("workspace_id", "asc");
 
     return rows
-      .map((row) => Number(row.workspace_id))
-      .filter((workspaceId) => Number.isInteger(workspaceId) && workspaceId > 0);
+      .map((row) => normalizeDbRecordId(row.workspace_id, { fallback: null }))
+      .filter(Boolean);
   }
 
   return Object.freeze({

--- a/packages/users-core/src/server/common/repositories/workspacesRepository.js
+++ b/packages/users-core/src/server/common/repositories/workspacesRepository.js
@@ -1,4 +1,7 @@
+import { resolveInsertedRecordId } from "@jskit-ai/database-runtime/shared";
 import {
+  normalizeDbRecordId,
+  normalizeRecordId,
   normalizeText,
   normalizeLowerText,
   toIsoString,
@@ -13,10 +16,10 @@ function mapRow(row) {
   }
 
   return {
-    id: Number(row.id),
+    id: normalizeDbRecordId(row.id, { fallback: "" }),
     slug: normalizeText(row.slug),
     name: normalizeText(row.name),
-    ownerUserId: Number(row.owner_user_id),
+    ownerUserId: normalizeDbRecordId(row.owner_user_id, { fallback: "" }),
     isPersonal: Boolean(row.is_personal),
     avatarUrl: row.avatar_url ? normalizeText(row.avatar_url) : "",
     createdAt: toIsoString(row.created_at),
@@ -61,9 +64,14 @@ function createRepository(knex) {
   }
 
   async function findById(workspaceId, options = {}) {
+    const normalizedWorkspaceId = normalizeRecordId(workspaceId, { fallback: null });
+    if (!normalizedWorkspaceId) {
+      return null;
+    }
+
     const client = options?.trx || knex;
     const row = await client("workspaces as w")
-      .where({ "w.id": Number(workspaceId) })
+      .where({ "w.id": normalizedWorkspaceId })
       .select(workspaceSelectColumns())
       .first();
     return mapRow(row);
@@ -84,9 +92,14 @@ function createRepository(knex) {
   }
 
   async function findPersonalByOwnerUserId(userId, options = {}) {
+    const normalizedUserId = normalizeRecordId(userId, { fallback: null });
+    if (!normalizedUserId) {
+      return null;
+    }
+
     const client = options?.trx || knex;
     const row = await client("workspaces as w")
-      .where({ "w.owner_user_id": Number(userId), "w.is_personal": 1 })
+      .where({ "w.owner_user_id": normalizedUserId, "w.is_personal": 1 })
       .orderBy("w.id", "asc")
       .select(workspaceSelectColumns())
       .first();
@@ -96,11 +109,15 @@ function createRepository(knex) {
   async function insert(payload = {}, options = {}) {
     const client = options?.trx || knex;
     const source = payload && typeof payload === "object" ? payload : {};
+    const ownerUserId = normalizeRecordId(source.ownerUserId, { fallback: null });
+    if (!ownerUserId) {
+      throw new TypeError("workspacesRepository.insert requires ownerUserId.");
+    }
 
     const insertPayload = {
       slug: normalizeLowerText(source.slug),
       name: normalizeText(source.name),
-      owner_user_id: Number(source.ownerUserId),
+      owner_user_id: ownerUserId,
       is_personal: source.isPersonal ? 1 : 0,
       avatar_url: normalizeText(source.avatarUrl),
       created_at: nowDb(),
@@ -110,8 +127,8 @@ function createRepository(knex) {
 
     try {
       const result = await client("workspaces").insert(insertPayload);
-      const insertedId = Array.isArray(result) ? Number(result[0]) : Number(result);
-      if (Number.isInteger(insertedId) && insertedId > 0) {
+      const insertedId = resolveInsertedRecordId(result, { fallback: null });
+      if (insertedId) {
         return findById(insertedId, { trx: client });
       }
       const bySlug = await findBySlug(insertPayload.slug, { trx: client });
@@ -129,6 +146,11 @@ function createRepository(knex) {
   }
 
   async function updateById(workspaceId, patch = {}, options = {}) {
+    const normalizedWorkspaceId = normalizeRecordId(workspaceId, { fallback: null });
+    if (!normalizedWorkspaceId) {
+      return null;
+    }
+
     const client = options?.trx || knex;
     const source = patch && typeof patch === "object" ? patch : {};
     const dbPatch = {
@@ -142,15 +164,20 @@ function createRepository(knex) {
       dbPatch.avatar_url = normalizeText(source.avatarUrl);
     }
 
-    await client("workspaces").where({ id: Number(workspaceId) }).update(dbPatch);
-    return findById(workspaceId, { trx: client });
+    await client("workspaces").where({ id: normalizedWorkspaceId }).update(dbPatch);
+    return findById(normalizedWorkspaceId, { trx: client });
   }
 
   async function listForUserId(userId, options = {}) {
+    const normalizedUserId = normalizeRecordId(userId, { fallback: null });
+    if (!normalizedUserId) {
+      return [];
+    }
+
     const client = options?.trx || knex;
     const rows = await client("workspace_memberships as wm")
       .join("workspaces as w", "w.id", "wm.workspace_id")
-      .where({ "wm.user_id": Number(userId) })
+      .where({ "wm.user_id": normalizedUserId })
       .whereNull("w.deleted_at")
       .orderBy("w.is_personal", "desc")
       .orderBy("w.id", "asc")

--- a/packages/users-core/src/server/common/services/accountContextService.js
+++ b/packages/users-core/src/server/common/services/accountContextService.js
@@ -1,3 +1,4 @@
+import { normalizeRecordId } from "@jskit-ai/kernel/shared/support/normalize";
 import { normalizeIdentity } from "../repositories/usersRepository.js";
 
 async function resolveUserProfile(usersRepository, user) {
@@ -9,8 +10,8 @@ async function resolveUserProfile(usersRepository, user) {
     }
   }
 
-  const userId = Number(user?.id);
-  if (Number.isInteger(userId) && userId > 0) {
+  const userId = normalizeRecordId(user?.id, { fallback: null });
+  if (userId) {
     const profileById = await usersRepository.findById(userId);
     if (profileById) {
       return profileById;

--- a/packages/users-core/src/server/common/services/authProfileSyncService.js
+++ b/packages/users-core/src/server/common/services/authProfileSyncService.js
@@ -1,3 +1,4 @@
+import { normalizeRecordId } from "@jskit-ai/kernel/shared/support/normalize";
 import { normalizeLowerText, normalizeText } from "@jskit-ai/kernel/shared/actions/textNormalization";
 import { normalizeIdentity } from "../repositories/usersRepository.js";
 
@@ -46,7 +47,7 @@ function profileNeedsUpdate(existing, nextProfile) {
 }
 
 function requireSynchronizedProfile(profile) {
-  if (profile && Number.isFinite(Number(profile.id)) && String(profile.displayName || "").trim()) {
+  if (profile && normalizeRecordId(profile.id, { fallback: null }) && String(profile.displayName || "").trim()) {
     return profile;
   }
 
@@ -118,10 +119,8 @@ function createService({ usersRepository, workspaceProvisioningService = null, u
     if (options?.trx) {
       return runSync(options.trx);
     }
-    if (typeof usersRepository.withTransaction === "function") {
-      return usersRepository.withTransaction((trx) => runSync(trx));
-    }
-    return runSync();
+
+    return usersRepository.withTransaction((trx) => runSync(trx));
   }
 
   return Object.freeze({

--- a/packages/users-core/src/server/common/services/workspaceContextService.js
+++ b/packages/users-core/src/server/common/services/workspaceContextService.js
@@ -11,6 +11,7 @@ import {
   mapWorkspaceSummary
 } from "../formatters/workspaceFormatter.js";
 import { normalizeLowerText, normalizeText } from "@jskit-ai/kernel/shared/actions/textNormalization";
+import { normalizeRecordId } from "@jskit-ai/kernel/shared/support/normalize";
 import { authenticatedUserValidator } from "../validators/authenticatedUserValidator.js";
 
 function toSlugPart(value) {
@@ -237,7 +238,9 @@ function createService({
       normalizedUser.id,
       options
     );
-    const actorOwnsWorkspace = Number(workspace.ownerUserId) === Number(normalizedUser.id);
+    const actorOwnsWorkspace =
+      normalizeRecordId(workspace.ownerUserId, { fallback: null }) ===
+      normalizeRecordId(normalizedUser.id, { fallback: null });
     const membershipIsActive = normalizeLowerText(membership?.status) === "active";
 
     if (!membershipIsActive && actorOwnsWorkspace) {

--- a/packages/users-core/src/server/common/support/realtimeServiceEvents.js
+++ b/packages/users-core/src/server/common/support/realtimeServiceEvents.js
@@ -1,7 +1,8 @@
+import { normalizeRecordId } from "@jskit-ai/kernel/shared/support/normalize";
 import { deepFreeze } from "./deepFreeze.js";
 
 function resolveActorScopedEntityId({ options } = {}) {
-  return Number(options?.context?.actor?.id || 0);
+  return normalizeRecordId(options?.context?.actor?.id, { fallback: "" });
 }
 
 function resolveWorkspaceSlugPayload({ args } = {}) {
@@ -66,7 +67,7 @@ function createWorkspaceEntityAndBootstrapEvents({
       source: "workspace",
       entity: normalizedWorkspaceEntity,
       operation: normalizedWorkspaceOperation,
-      entityId: workspaceEntityId,
+      entityId: (payload = {}) => normalizeRecordId(workspaceEntityId(payload), { fallback: "" }),
       realtime: {
         event: normalizedWorkspaceRealtimeEvent,
         payload: resolveWorkspaceSlugPayload,
@@ -78,7 +79,7 @@ function createWorkspaceEntityAndBootstrapEvents({
       source: "users",
       entity: "bootstrap",
       operation: "updated",
-      entityId: bootstrapEntityId,
+      entityId: (payload = {}) => normalizeRecordId(bootstrapEntityId(payload), { fallback: "" }),
       realtime: {
         event: "users.bootstrap.changed",
         audience: bootstrapAudience

--- a/packages/users-core/src/server/common/validators/authenticatedUserValidator.js
+++ b/packages/users-core/src/server/common/validators/authenticatedUserValidator.js
@@ -1,11 +1,12 @@
 import { Type } from "@fastify/type-provider-typebox";
-import { normalizeObjectInput } from "@jskit-ai/kernel/shared/validators/inputNormalization";
+import { normalizeObjectInput, recordIdInputSchema } from "@jskit-ai/kernel/shared/validators";
 import { normalizeLowerText, normalizeText } from "@jskit-ai/kernel/shared/actions/textNormalization";
+import { normalizeRecordId } from "@jskit-ai/kernel/shared/support/normalize";
 
 function normalizeAuthenticatedUser(input = {}) {
   const source = normalizeObjectInput(input);
-  const id = Number(source.id);
-  if (!Number.isInteger(id) || id < 1) {
+  const id = normalizeRecordId(source.id, { fallback: null });
+  if (!id) {
     return null;
   }
 
@@ -25,7 +26,7 @@ function normalizeAuthenticatedUser(input = {}) {
 const authenticatedUserValidator = Object.freeze({
   schema: Type.Object(
     {
-      id: Type.Integer({ minimum: 1 }),
+      id: recordIdInputSchema,
       email: Type.String({ minLength: 1 }),
       username: Type.Optional(Type.String()),
       displayName: Type.Optional(Type.String()),

--- a/packages/users-core/src/server/consoleSettings/consoleService.js
+++ b/packages/users-core/src/server/consoleSettings/consoleService.js
@@ -1,5 +1,5 @@
 import { AppError } from "@jskit-ai/kernel/server/runtime/errors";
-import { parsePositiveInteger } from "@jskit-ai/kernel/server/runtime";
+import { normalizeRecordId } from "@jskit-ai/kernel/shared/support/normalize";
 
 function createService({ consoleSettingsRepository } = {}) {
   if (!consoleSettingsRepository || typeof consoleSettingsRepository.ensureOwnerUserId !== "function") {
@@ -7,7 +7,7 @@ function createService({ consoleSettingsRepository } = {}) {
   }
 
   async function ensureInitialConsoleMember(userId, options = {}) {
-    const normalizedUserId = parsePositiveInteger(userId);
+    const normalizedUserId = normalizeRecordId(userId, { fallback: null });
     if (!normalizedUserId) {
       throw new AppError(400, "Invalid console user.");
     }
@@ -16,7 +16,7 @@ function createService({ consoleSettingsRepository } = {}) {
   }
 
   async function requireConsoleOwner(context = {}, options = {}) {
-    const actorUserId = parsePositiveInteger(context?.actor?.id);
+    const actorUserId = normalizeRecordId(context?.actor?.id, { fallback: null });
     if (!actorUserId) {
       throw new AppError(401, "Authentication required.");
     }

--- a/packages/users-core/src/server/consoleSettings/consoleSettingsRepository.js
+++ b/packages/users-core/src/server/consoleSettings/consoleSettingsRepository.js
@@ -1,8 +1,9 @@
 import {
+  normalizeDbRecordId,
+  normalizeRecordId,
   nowDb,
   toIsoString
 } from "../common/repositories/repositoryUtils.js";
-import { parsePositiveInteger } from "@jskit-ai/kernel/server/runtime";
 import { normalizeObjectInput } from "@jskit-ai/kernel/shared/validators/inputNormalization";
 import { consoleSettingsFields } from "../../shared/resources/consoleSettingsFields.js";
 
@@ -26,10 +27,10 @@ function mapSingletonRow(row) {
     throw new Error("console_settings singleton row is missing.");
   }
 
-  const ownerUserId = parsePositiveInteger(row.owner_user_id);
+  const ownerUserId = normalizeDbRecordId(row.owner_user_id, { fallback: null });
   return {
-    id: Number(row.id),
-    ownerUserId: ownerUserId || null,
+    id: normalizeDbRecordId(row.id, { fallback: "1" }),
+    ownerUserId,
     settings: mapSettings(row),
     createdAt: toIsoString(row.created_at),
     updatedAt: toIsoString(row.updated_at)
@@ -52,7 +53,7 @@ function createRepository(knex) {
 
   async function ensureOwnerUserId(userId, options = {}) {
     const client = options?.trx || knex;
-    const candidateOwnerUserId = parsePositiveInteger(userId);
+    const candidateOwnerUserId = normalizeRecordId(userId, { fallback: null });
     if (!candidateOwnerUserId) {
       throw new TypeError("consoleSettingsRepository.ensureOwnerUserId requires a positive user id.");
     }

--- a/packages/users-core/src/server/usersBootstrapContributor.js
+++ b/packages/users-core/src/server/usersBootstrapContributor.js
@@ -13,6 +13,7 @@ import {
 import { accountAvatarFormatter } from "./common/formatters/accountAvatarFormatter.js";
 import { authenticatedUserValidator } from "./common/validators/authenticatedUserValidator.js";
 import { userSettingsFields } from "../shared/resources/userSettingsFields.js";
+import { normalizeRecordId } from "@jskit-ai/kernel/shared/support/normalize";
 
 function getOAuthProviderCatalogPayload(authService) {
   if (!authService || typeof authService.getOAuthProviderCatalog !== "function") {
@@ -194,12 +195,15 @@ function createUsersBootstrapContributor({
         const latestProfile = (await usersRepository.findById(normalizedUser.id)) || normalizedUser;
         const userSettings = await userSettingsRepository.ensureForUserId(latestProfile.id);
 
-        let seededConsoleOwnerUserId = 0;
+        let seededConsoleOwnerUserId = null;
         if (
           consoleService &&
           typeof consoleService.ensureInitialConsoleMember === "function"
         ) {
-          seededConsoleOwnerUserId = Number(await consoleService.ensureInitialConsoleMember(latestProfile.id));
+          seededConsoleOwnerUserId = normalizeRecordId(
+            await consoleService.ensureInitialConsoleMember(latestProfile.id),
+            { fallback: null }
+          );
         }
 
         payload = {
@@ -221,7 +225,7 @@ function createUsersBootstrapContributor({
           requestedWorkspace: null,
           permissions: [],
           surfaceAccess: {
-            consoleowner: seededConsoleOwnerUserId > 0 && seededConsoleOwnerUserId === Number(latestProfile.id)
+            consoleowner: Boolean(seededConsoleOwnerUserId) && seededConsoleOwnerUserId === String(latestProfile.id)
           },
           workspaceSettings: null,
           userSettings: mapUserSettingsBootstrap(userSettings),

--- a/packages/users-core/src/server/workspaceBootstrapContributor.js
+++ b/packages/users-core/src/server/workspaceBootstrapContributor.js
@@ -1,4 +1,5 @@
 import { requireServiceMethod } from "@jskit-ai/kernel/shared/actions/actionContributorHelpers";
+import { normalizeRecordId } from "@jskit-ai/kernel/shared/support/normalize";
 import { normalizeLowerText } from "@jskit-ai/kernel/shared/actions/textNormalization";
 import {
   TENANCY_MODE_NONE,
@@ -129,7 +130,10 @@ function createWorkspaceBootstrapContributor({
   return Object.freeze({
     contributorId,
     async contribute({ request = null, query = {}, payload = {} } = {}) {
-      const normalizedUserId = Number(payload?.session?.authenticated === true ? payload?.session?.userId : 0);
+      const normalizedUserId = normalizeRecordId(
+        payload?.session?.authenticated === true ? payload?.session?.userId : null,
+        { fallback: null }
+      );
       const normalizedWorkspaceSlug = resolveBootstrapWorkspaceSlug({ query, request });
       if (!normalizedUserId) {
         if (!normalizedWorkspaceSlug || resolvedTenancyProfile.mode === TENANCY_MODE_NONE) {

--- a/packages/users-core/src/server/workspaceMembers/registerWorkspaceMembers.js
+++ b/packages/users-core/src/server/workspaceMembers/registerWorkspaceMembers.js
@@ -1,4 +1,6 @@
 import { withActionDefaults } from "@jskit-ai/kernel/shared/actions";
+import { normalizeDbRecordId } from "@jskit-ai/database-runtime/shared";
+import { normalizeRecordId } from "@jskit-ai/kernel/shared/support/normalize";
 import { resolveAppConfig } from "@jskit-ai/kernel/server/support";
 import { deepFreeze } from "../common/support/deepFreeze.js";
 import { createService as createWorkspaceMembersService } from "./workspaceMembersService.js";
@@ -23,8 +25,8 @@ const INVITE_RECIPIENT_BOOTSTRAP_AUDIENCE = Object.freeze({
       return [];
     }
 
-    const inviteId = Number(event?.entityId);
-    if (!Number.isInteger(inviteId) || inviteId < 1) {
+    const inviteId = normalizeRecordId(event?.entityId, { fallback: null });
+    if (!inviteId) {
       return [];
     }
 
@@ -33,8 +35,8 @@ const INVITE_RECIPIENT_BOOTSTRAP_AUDIENCE = Object.freeze({
       .where("wi.id", inviteId)
       .first("up.id as user_id");
 
-    const userId = Number(row?.user_id || 0);
-    if (!Number.isInteger(userId) || userId < 1) {
+    const userId = normalizeDbRecordId(row?.user_id, { fallback: null });
+    if (!userId) {
       return [];
     }
 

--- a/packages/users-core/src/server/workspaceMembers/workspaceMembersService.js
+++ b/packages/users-core/src/server/workspaceMembers/workspaceMembersService.js
@@ -1,3 +1,4 @@
+import { normalizeRecordId } from "@jskit-ai/kernel/shared/support/normalize";
 import { buildInviteToken, hashInviteToken } from "@jskit-ai/auth-core/server/inviteTokens";
 import { AppError } from "@jskit-ai/kernel/server/runtime/errors";
 import { OWNER_ROLE_ID, createWorkspaceRoleCatalog, cloneWorkspaceRoleCatalog } from "../../shared/roles.js";
@@ -61,8 +62,11 @@ function createService({
   }
 
   async function updateMemberRole(workspace, payload = {}, options = {}) {
-    const memberUserId = payload.memberUserId;
+    const memberUserId = normalizeRecordId(payload.memberUserId, { fallback: null });
     const roleSid = payload.roleSid;
+    if (!memberUserId) {
+      throw new AppError(400, "Validation failed.");
+    }
     if (!assignableRoleIds.includes(roleSid)) {
       throw new AppError(400, "Validation failed.", {
         details: {
@@ -77,7 +81,7 @@ function createService({
     if (!existingMembership || existingMembership.status !== "active") {
       throw new AppError(404, "Member not found.");
     }
-    if (Number(memberUserId) === Number(workspace.ownerUserId) || existingMembership.roleSid === OWNER_ROLE_ID) {
+    if (memberUserId === normalizeRecordId(workspace.ownerUserId, { fallback: null }) || existingMembership.roleSid === OWNER_ROLE_ID) {
       throw new AppError(409, "Cannot change workspace owner role.");
     }
 
@@ -95,13 +99,16 @@ function createService({
   }
 
   async function removeMember(workspace, payload = {}, options = {}) {
-    const memberUserId = payload.memberUserId;
+    const memberUserId = normalizeRecordId(payload.memberUserId, { fallback: null });
+    if (!memberUserId) {
+      throw new AppError(400, "Validation failed.");
+    }
 
     const existingMembership = await workspaceMembershipsRepository.findByWorkspaceIdAndUserId(workspace.id, memberUserId, options);
     if (!existingMembership || existingMembership.status !== "active") {
       throw new AppError(404, "Member not found.");
     }
-    if (Number(memberUserId) === Number(workspace.ownerUserId) || existingMembership.roleSid === OWNER_ROLE_ID) {
+    if (memberUserId === normalizeRecordId(workspace.ownerUserId, { fallback: null }) || existingMembership.roleSid === OWNER_ROLE_ID) {
       throw new AppError(409, "Cannot remove workspace owner.");
     }
 
@@ -155,13 +162,13 @@ function createService({
         roleSid,
         status: "pending",
         tokenHash,
-        invitedByUserId: Number(user?.id || 0) || null,
+        invitedByUserId: normalizeRecordId(user?.id, { fallback: null }),
         expiresAt: new Date(Date.now() + resolvedInviteExpiresInMs).toISOString()
       },
       options
     );
-    const createdInviteId = Number(createdInvite?.id);
-    if (!Number.isInteger(createdInviteId) || createdInviteId < 1) {
+    const createdInviteId = normalizeRecordId(createdInvite?.id, { fallback: null });
+    if (!createdInviteId) {
       throw new Error("workspaceMembersService.createInvite expected repository to return created invite id.");
     }
 
@@ -174,8 +181,13 @@ function createService({
   }
 
   async function revokeInvite(workspace, inviteId, options = {}) {
+    const normalizedInviteId = normalizeRecordId(inviteId, { fallback: null });
+    if (!normalizedInviteId) {
+      throw new AppError(400, "Validation failed.");
+    }
+
     const invite = await workspaceInvitesRepository.findPendingByIdForWorkspace(
-      inviteId,
+      normalizedInviteId,
       workspace.id,
       options
     );
@@ -183,9 +195,9 @@ function createService({
       throw new AppError(404, "Invite not found.");
     }
 
-    await workspaceInvitesRepository.revokeById(inviteId, options);
-    const revokedInviteId = Number(invite?.id);
-    if (!Number.isInteger(revokedInviteId) || revokedInviteId < 1) {
+    await workspaceInvitesRepository.revokeById(normalizedInviteId, options);
+    const revokedInviteId = normalizeRecordId(invite?.id, { fallback: null });
+    if (!revokedInviteId) {
       throw new Error("workspaceMembersService.revokeInvite expected repository to return pending invite id.");
     }
 

--- a/packages/users-core/src/server/workspacePendingInvitations/registerWorkspacePendingInvitations.js
+++ b/packages/users-core/src/server/workspacePendingInvitations/registerWorkspacePendingInvitations.js
@@ -1,11 +1,12 @@
 import { withActionDefaults } from "@jskit-ai/kernel/shared/actions";
+import { normalizeRecordId } from "@jskit-ai/kernel/shared/support/normalize";
 import { createService } from "./workspacePendingInvitationsService.js";
 import { workspacePendingInvitationsActions } from "./workspacePendingInvitationsActions.js";
 import { deepFreeze } from "../common/support/deepFreeze.js";
 
 function workspaceAudienceFromEntityId({ event } = {}) {
-  const workspaceId = Number(event?.entityId);
-  if (!Number.isInteger(workspaceId) || workspaceId < 1) {
+  const workspaceId = normalizeRecordId(event?.entityId, { fallback: null });
+  if (!workspaceId) {
     return "none";
   }
   return {
@@ -14,7 +15,7 @@ function workspaceAudienceFromEntityId({ event } = {}) {
 }
 
 function actorUserEntityId({ options } = {}) {
-  return Number(options?.context?.actor?.id || 0);
+  return normalizeRecordId(options?.context?.actor?.id, { fallback: "" });
 }
 
 function createActorUserEvent({ source, entity, realtimeEvent }) {
@@ -37,7 +38,7 @@ function createWorkspaceAudienceEvent({ entity, realtimeEvent }) {
     source: "workspace",
     entity,
     operation: "updated",
-    entityId: ({ result }) => result?.workspaceId,
+    entityId: ({ result }) => normalizeRecordId(result?.workspaceId, { fallback: "" }),
     realtime: {
       event: realtimeEvent,
       audience: workspaceAudienceFromEntityId

--- a/packages/users-core/src/server/workspacePendingInvitations/workspacePendingInvitationsService.js
+++ b/packages/users-core/src/server/workspacePendingInvitations/workspacePendingInvitationsService.js
@@ -1,6 +1,7 @@
 import { resolveInviteTokenHash } from "@jskit-ai/auth-core/server/inviteTokens";
 import { AppError } from "@jskit-ai/kernel/server/runtime/errors";
 import { normalizeLowerText, normalizeText } from "@jskit-ai/kernel/shared/actions/textNormalization";
+import { normalizeRecordId } from "@jskit-ai/kernel/shared/support/normalize";
 import { authenticatedUserValidator } from "../common/validators/authenticatedUserValidator.js";
 
 function createService({
@@ -70,8 +71,8 @@ function createService({
   }
 
   function requireWorkspaceIdFromInvite(invite, methodName = "workspacePendingInvitationsService") {
-    const workspaceId = Number(invite?.workspaceId);
-    if (!Number.isInteger(workspaceId) || workspaceId < 1) {
+    const workspaceId = normalizeRecordId(invite?.workspaceId, { fallback: null });
+    if (!workspaceId) {
       throw new Error(`${methodName} expected invite workspace id.`);
     }
     return workspaceId;

--- a/packages/users-core/src/server/workspaceSettings/workspaceSettingsRepository.js
+++ b/packages/users-core/src/server/workspaceSettings/workspaceSettingsRepository.js
@@ -1,4 +1,6 @@
 import {
+  normalizeDbRecordId,
+  normalizeRecordId,
   toIsoString,
   nowDb,
   isDuplicateEntryError
@@ -39,7 +41,7 @@ function createRepository(knex, { defaultInvitesEnabled } = {}) {
     }
 
     const settings = {
-      workspaceId: Number(row.workspace_id)
+      workspaceId: normalizeDbRecordId(row.workspace_id, { fallback: "" })
     };
     for (const field of workspaceSettingsFields) {
       const rawValue = Object.hasOwn(row, field.dbColumn)
@@ -59,24 +61,33 @@ function createRepository(knex, { defaultInvitesEnabled } = {}) {
 
   async function findByWorkspaceId(workspaceId, options = {}) {
     const client = options?.trx || knex;
-    const row = await client("workspace_settings").where({ workspace_id: Number(workspaceId) }).first();
+    const normalizedWorkspaceId = normalizeRecordId(workspaceId, { fallback: null });
+    if (!normalizedWorkspaceId) {
+      return null;
+    }
+
+    const row = await client("workspace_settings").where({ workspace_id: normalizedWorkspaceId }).first();
     return mapRow(row);
   }
 
   async function ensureForWorkspaceId(workspaceId, options = {}) {
     const client = options?.trx || knex;
-    const numericWorkspaceId = Number(workspaceId);
+    const normalizedWorkspaceId = normalizeRecordId(workspaceId, { fallback: null });
+    if (!normalizedWorkspaceId) {
+      throw new TypeError("workspaceSettingsRepository.ensureForWorkspaceId requires a valid workspace id.");
+    }
+
     const seed = resolveWorkspaceSettingsSeed(options?.workspace, {
       defaultInvitesEnabled
     });
-    const existing = await findByWorkspaceId(numericWorkspaceId, { trx: client });
+    const existing = await findByWorkspaceId(normalizedWorkspaceId, { trx: client });
     if (existing) {
       return existing;
     }
 
     try {
       const insertPayload = {
-        workspace_id: numericWorkspaceId,
+        workspace_id: normalizedWorkspaceId,
         created_at: nowDb(),
         updated_at: nowDb()
       };
@@ -90,12 +101,17 @@ function createRepository(knex, { defaultInvitesEnabled } = {}) {
       }
     }
 
-    return findByWorkspaceId(numericWorkspaceId, { trx: client });
+    return findByWorkspaceId(normalizedWorkspaceId, { trx: client });
   }
 
   async function updateSettingsByWorkspaceId(workspaceId, patch = {}, options = {}) {
     const client = options?.trx || knex;
-    const ensured = await ensureForWorkspaceId(workspaceId, {
+    const normalizedWorkspaceId = normalizeRecordId(workspaceId, { fallback: null });
+    if (!normalizedWorkspaceId) {
+      throw new TypeError("workspaceSettingsRepository.updateSettingsByWorkspaceId requires a valid workspace id.");
+    }
+
+    const ensured = await ensureForWorkspaceId(normalizedWorkspaceId, {
       trx: client,
       workspace: options?.workspace
     });
@@ -119,10 +135,10 @@ function createRepository(knex, { defaultInvitesEnabled } = {}) {
       });
     }
 
-    await client("workspace_settings").where({ workspace_id: Number(workspaceId) }).update({
+    await client("workspace_settings").where({ workspace_id: normalizedWorkspaceId }).update({
       ...dbPatch
     });
-    return findByWorkspaceId(workspaceId, { trx: client });
+    return findByWorkspaceId(normalizedWorkspaceId, { trx: client });
   }
 
   return Object.freeze({

--- a/packages/users-core/src/server/workspaceSettings/workspaceSettingsService.js
+++ b/packages/users-core/src/server/workspaceSettings/workspaceSettingsService.js
@@ -1,3 +1,4 @@
+import { normalizeRecordId } from "@jskit-ai/kernel/shared/support/normalize";
 import { normalizeObjectInput } from "@jskit-ai/kernel/shared/validators/inputNormalization";
 import { pickOwnProperties } from "@jskit-ai/kernel/shared/support";
 import {
@@ -33,9 +34,9 @@ function createService({
 
     return {
       workspace: {
-        id: Number(workspace.id),
+        id: normalizeRecordId(workspace.id, { fallback: "" }),
         slug: String(workspace.slug || ""),
-        ownerUserId: Number(workspace.ownerUserId)
+        ownerUserId: normalizeRecordId(workspace.ownerUserId, { fallback: "" })
       },
       settings,
       roleCatalog: cloneWorkspaceRoleCatalog(resolvedRoleCatalog)

--- a/packages/users-core/src/shared/resources/workspaceMembersResource.js
+++ b/packages/users-core/src/shared/resources/workspaceMembersResource.js
@@ -1,16 +1,21 @@
 import { Type } from "@fastify/type-provider-typebox";
 import { normalizeLowerText, normalizeText } from "@jskit-ai/kernel/shared/actions/textNormalization";
-import { normalizeObjectInput } from "@jskit-ai/kernel/shared/validators/inputNormalization";
-import { normalizePositiveInteger } from "@jskit-ai/kernel/shared/support/normalize";
+import {
+  normalizeObjectInput,
+  recordIdSchema,
+  recordIdInputSchema,
+  nullableRecordIdSchema
+} from "@jskit-ai/kernel/shared/validators";
+import { normalizeRecordId } from "@jskit-ai/kernel/shared/support/normalize";
 import { createOperationMessages } from "../operationMessages.js";
 import { createWorkspaceRoleCatalog, OWNER_ROLE_ID } from "../roles.js";
 
 const workspaceSummaryOutputSchema = Type.Object(
   {
-    id: Type.Integer({ minimum: 1 }),
+    id: recordIdSchema,
     slug: Type.String({ minLength: 1 }),
     name: Type.String({ minLength: 1 }),
-    ownerUserId: Type.Integer({ minimum: 1 }),
+    ownerUserId: recordIdSchema,
     avatarUrl: Type.String()
   },
   { additionalProperties: false }
@@ -18,7 +23,7 @@ const workspaceSummaryOutputSchema = Type.Object(
 
 const memberSummaryOutputSchema = Type.Object(
   {
-    userId: Type.Integer({ minimum: 1 }),
+    userId: recordIdSchema,
     roleSid: Type.String({ minLength: 1 }),
     status: Type.String({ minLength: 1 }),
     displayName: Type.String(),
@@ -30,12 +35,12 @@ const memberSummaryOutputSchema = Type.Object(
 
 const inviteSummaryOutputSchema = Type.Object(
   {
-    id: Type.Integer({ minimum: 1 }),
+    id: recordIdSchema,
     email: Type.String({ minLength: 3, format: "email" }),
     roleSid: Type.String({ minLength: 1 }),
     status: Type.String({ minLength: 1 }),
     expiresAt: Type.String({ minLength: 1 }),
-    invitedByUserId: Type.Union([Type.Integer({ minimum: 1 }), Type.Null()])
+    invitedByUserId: nullableRecordIdSchema
   },
   { additionalProperties: false }
 );
@@ -44,26 +49,25 @@ function normalizeWorkspaceAdminSummary(workspace) {
   const source = normalizeObjectInput(workspace);
 
   return {
-    id: Number(source.id),
+    id: normalizeRecordId(source.id, { fallback: "" }),
     slug: normalizeText(source.slug),
     name: normalizeText(source.name),
-    ownerUserId: Number(source.ownerUserId),
+    ownerUserId: normalizeRecordId(source.ownerUserId, { fallback: "" }),
     avatarUrl: normalizeText(source.avatarUrl)
   };
 }
 
 function normalizeMemberSummary(member, workspace) {
   const source = normalizeObjectInput(member);
+  const userId = normalizeRecordId(source.userId, { fallback: "" });
 
   return {
-    userId: Number(source.userId),
+    userId,
     roleSid: normalizeLowerText(source.roleSid || "member") || "member",
     status: normalizeLowerText(source.status || "active") || "active",
     displayName: normalizeText(source.displayName),
     email: normalizeLowerText(source.email),
-    isOwner:
-      Number(source.userId) === Number(workspace.ownerUserId) ||
-      normalizeLowerText(source.roleSid) === OWNER_ROLE_ID
+    isOwner: userId === workspace.ownerUserId || normalizeLowerText(source.roleSid) === OWNER_ROLE_ID
   };
 }
 
@@ -71,12 +75,12 @@ function normalizeInviteSummary(invite) {
   const source = normalizeObjectInput(invite);
 
   return {
-    id: Number(source.id),
+    id: normalizeRecordId(source.id, { fallback: "" }),
     email: normalizeLowerText(source.email),
     roleSid: normalizeLowerText(source.roleSid || "member") || "member",
     status: normalizeLowerText(source.status || "pending") || "pending",
     expiresAt: source.expiresAt,
-    invitedByUserId: source.invitedByUserId == null ? null : Number(source.invitedByUserId)
+    invitedByUserId: source.invitedByUserId == null ? null : normalizeRecordId(source.invitedByUserId, { fallback: null })
   };
 }
 
@@ -176,7 +180,7 @@ const updateMemberRoleBodyValidator = Object.freeze({
 const updateMemberRoleInputValidator = Object.freeze({
   schema: Type.Object(
     {
-      memberUserId: Type.Integer({ minimum: 1 }),
+      memberUserId: recordIdInputSchema,
       roleSid: Type.String({ minLength: 1 })
     },
     { additionalProperties: false }
@@ -185,7 +189,7 @@ const updateMemberRoleInputValidator = Object.freeze({
     const source = normalizeObjectInput(payload);
 
     return {
-      memberUserId: normalizePositiveInteger(source.memberUserId),
+      memberUserId: normalizeRecordId(source.memberUserId, { fallback: "" }),
       roleSid: normalizeLowerText(source.roleSid)
     };
   }
@@ -194,7 +198,7 @@ const updateMemberRoleInputValidator = Object.freeze({
 const removeMemberInputValidator = Object.freeze({
   schema: Type.Object(
     {
-      memberUserId: Type.Integer({ minimum: 1 })
+      memberUserId: recordIdInputSchema
     },
     { additionalProperties: false }
   ),
@@ -202,7 +206,7 @@ const removeMemberInputValidator = Object.freeze({
     const source = normalizeObjectInput(payload);
 
     return {
-      memberUserId: normalizePositiveInteger(source.memberUserId)
+      memberUserId: normalizeRecordId(source.memberUserId, { fallback: "" })
     };
   }
 });
@@ -228,7 +232,7 @@ const createInviteBodyValidator = Object.freeze({
 const revokeInviteInputValidator = Object.freeze({
   schema: Type.Object(
     {
-      inviteId: Type.Integer({ minimum: 1 })
+      inviteId: recordIdInputSchema
     },
     { additionalProperties: false }
   ),
@@ -236,7 +240,7 @@ const revokeInviteInputValidator = Object.freeze({
     const source = normalizeObjectInput(payload);
 
     return {
-      inviteId: normalizePositiveInteger(source.inviteId)
+      inviteId: normalizeRecordId(source.inviteId, { fallback: "" })
     };
   }
 });

--- a/packages/users-core/src/shared/resources/workspacePendingInvitationsResource.js
+++ b/packages/users-core/src/shared/resources/workspacePendingInvitationsResource.js
@@ -2,20 +2,15 @@ import { Type } from "@fastify/type-provider-typebox";
 import { encodeInviteTokenHash } from "@jskit-ai/auth-core/shared/inviteTokens";
 import { normalizeLowerText, normalizeText } from "@jskit-ai/kernel/shared/actions/textNormalization";
 import { createOperationMessages } from "../operationMessages.js";
-import { normalizeObjectInput } from "@jskit-ai/kernel/shared/validators/inputNormalization";
+import { normalizeObjectInput, recordIdSchema } from "@jskit-ai/kernel/shared/validators";
+import { normalizeRecordId } from "@jskit-ai/kernel/shared/support/normalize";
 
 function normalizePendingInvite(invite) {
-  const id = Number(invite?.id);
-  const workspaceId = Number(invite?.workspaceId);
+  const id = normalizeRecordId(invite?.id, { fallback: null });
+  const workspaceId = normalizeRecordId(invite?.workspaceId, { fallback: null });
   const tokenHash = normalizeText(invite?.tokenHash);
 
-  if (!Number.isInteger(id) || id < 1) {
-    return null;
-  }
-  if (!Number.isInteger(workspaceId) || workspaceId < 1) {
-    return null;
-  }
-  if (!tokenHash) {
+  if (!id || !workspaceId || !tokenHash) {
     return null;
   }
 
@@ -39,8 +34,8 @@ function normalizePendingInviteList(invites) {
 const pendingInviteRecordValidator = Object.freeze({
   schema: Type.Object(
     {
-      id: Type.Integer({ minimum: 1 }),
-      workspaceId: Type.Integer({ minimum: 1 }),
+      id: recordIdSchema,
+      workspaceId: recordIdSchema,
       workspaceSlug: Type.String({ minLength: 1 }),
       workspaceName: Type.String({ minLength: 1 }),
       workspaceAvatarUrl: Type.String(),

--- a/packages/users-core/src/shared/resources/workspaceResource.js
+++ b/packages/users-core/src/shared/resources/workspaceResource.js
@@ -2,8 +2,11 @@ import { Type } from "typebox";
 import { normalizeLowerText, normalizeText } from "@jskit-ai/kernel/shared/actions/textNormalization";
 import {
   normalizeObjectInput,
-  createCursorListValidator
+  createCursorListValidator,
+  recordIdSchema,
+  recordIdInputSchema
 } from "@jskit-ai/kernel/shared/validators";
+import { normalizeRecordId } from "@jskit-ai/kernel/shared/support/normalize";
 
 function normalizeWorkspaceAvatarUrl(value) {
   const avatarUrl = normalizeText(value);
@@ -31,7 +34,7 @@ function normalizeWorkspaceInput(payload = {}) {
     normalized.name = normalizeText(source.name);
   }
   if (Object.hasOwn(source, "ownerUserId")) {
-    normalized.ownerUserId = Number(source.ownerUserId);
+    normalized.ownerUserId = normalizeRecordId(source.ownerUserId, { fallback: "" });
   }
   if (Object.hasOwn(source, "avatarUrl")) {
     normalized.avatarUrl = normalizeWorkspaceAvatarUrl(source.avatarUrl);
@@ -47,10 +50,10 @@ function normalizeWorkspaceOutput(payload = {}) {
   const source = normalizeObjectInput(payload);
 
   return {
-    id: Number(source.id),
+    id: normalizeRecordId(source.id, { fallback: "" }),
     slug: normalizeLowerText(source.slug),
     name: normalizeText(source.name),
-    ownerUserId: Number(source.ownerUserId),
+    ownerUserId: normalizeRecordId(source.ownerUserId, { fallback: "" }),
     avatarUrl: normalizeText(source.avatarUrl)
   };
 }
@@ -59,7 +62,7 @@ function normalizeWorkspaceListItemOutput(payload = {}) {
   const source = normalizeObjectInput(payload);
 
   return {
-    id: Number(source.id),
+    id: normalizeRecordId(source.id, { fallback: "" }),
     slug: normalizeLowerText(source.slug),
     name: normalizeText(source.name),
     avatarUrl: normalizeText(source.avatarUrl),
@@ -70,10 +73,10 @@ function normalizeWorkspaceListItemOutput(payload = {}) {
 
 const responseRecordSchema = Type.Object(
   {
-    id: Type.Integer({ minimum: 1 }),
+    id: recordIdSchema,
     slug: Type.String({ minLength: 1 }),
     name: Type.String({ minLength: 1, maxLength: 160 }),
-    ownerUserId: Type.Integer({ minimum: 1 }),
+    ownerUserId: recordIdSchema,
     avatarUrl: Type.String()
   },
   { additionalProperties: false }
@@ -81,7 +84,7 @@ const responseRecordSchema = Type.Object(
 
 const listItemSchema = Type.Object(
   {
-    id: Type.Integer({ minimum: 1 }),
+    id: recordIdSchema,
     slug: Type.String({ minLength: 1 }),
     name: Type.String({ minLength: 1, maxLength: 160 }),
     avatarUrl: Type.String(),
@@ -94,7 +97,8 @@ const listItemSchema = Type.Object(
 const createRequestBodySchema = Type.Object(
   {
     name: Type.String({ minLength: 1, maxLength: 160 }),
-    slug: Type.Optional(Type.String({ minLength: 1, maxLength: 120 }))
+    slug: Type.Optional(Type.String({ minLength: 1, maxLength: 120 })),
+    ownerUserId: Type.Optional(recordIdInputSchema)
   },
   { additionalProperties: false }
 );

--- a/packages/users-core/src/shared/resources/workspaceSettingsResource.js
+++ b/packages/users-core/src/shared/resources/workspaceSettingsResource.js
@@ -3,8 +3,10 @@ import { normalizeText } from "@jskit-ai/kernel/shared/actions/textNormalization
 import {
   normalizeObjectInput,
   createCursorListValidator,
-  normalizeSettingsFieldInput
+  normalizeSettingsFieldInput,
+  recordIdSchema
 } from "@jskit-ai/kernel/shared/validators";
+import { normalizeRecordId } from "@jskit-ai/kernel/shared/support/normalize";
 import { workspaceSettingsFields } from "./workspaceSettingsFields.js";
 import { createWorkspaceRoleCatalog } from "../roles.js";
 
@@ -39,9 +41,9 @@ function buildResponseRecordSchema() {
     {
       workspace: Type.Object(
         {
-          id: Type.Integer({ minimum: 1 }),
+          id: recordIdSchema,
           slug: Type.String({ minLength: 1 }),
-          ownerUserId: Type.Integer({ minimum: 1 })
+          ownerUserId: recordIdSchema
         },
         { additionalProperties: false }
       ),
@@ -98,9 +100,9 @@ function normalizeOutput(payload = {}) {
 
   return {
     workspace: {
-      id: Number(workspace.id),
+      id: normalizeRecordId(workspace.id, { fallback: "" }),
       slug: normalizeText(workspace.slug),
-      ownerUserId: Number(workspace.ownerUserId)
+      ownerUserId: normalizeRecordId(workspace.ownerUserId, { fallback: "" })
     },
     settings: normalizedSettings,
     roleCatalog: hasRoleCatalog ? roleCatalog : createWorkspaceRoleCatalog()

--- a/packages/users-core/templates/migrations/users_core_console_owner.cjs
+++ b/packages/users-core/templates/migrations/users_core_console_owner.cjs
@@ -13,7 +13,7 @@ exports.up = async function up(knex) {
   }
 
   await knex.schema.alterTable("console_settings", (table) => {
-    table.integer("owner_user_id").unsigned().nullable();
+    table.bigInteger("owner_user_id").unsigned().nullable();
   });
 };
 

--- a/packages/users-core/templates/migrations/users_core_generic_initial.cjs
+++ b/packages/users-core/templates/migrations/users_core_generic_initial.cjs
@@ -5,7 +5,7 @@ exports.up = async function up(knex) {
   const hasUsersTable = await knex.schema.hasTable("users");
   if (!hasUsersTable) {
     await knex.schema.createTable("users", (table) => {
-      table.increments("id").primary();
+      table.bigIncrements("id").primary();
       table.string("auth_provider", 64).notNullable();
       table.string("auth_provider_user_sid", 191).notNullable();
       table.string("email", 255).notNullable();
@@ -24,7 +24,7 @@ exports.up = async function up(knex) {
   const hasUserSettingsTable = await knex.schema.hasTable("user_settings");
   if (!hasUserSettingsTable) {
     await knex.schema.createTable("user_settings", (table) => {
-      table.integer("user_id").unsigned().primary().references("id").inTable("users").onDelete("CASCADE");
+      table.bigInteger("user_id").unsigned().primary().references("id").inTable("users").onDelete("CASCADE");
       table.string("theme", 32).notNullable().defaultTo("system");
       table.string("locale", 24).notNullable().defaultTo("en");
       table.string("time_zone", 64).notNullable().defaultTo("UTC");
@@ -45,8 +45,8 @@ exports.up = async function up(knex) {
   const hasConsoleSettingsTable = await knex.schema.hasTable("console_settings");
   if (!hasConsoleSettingsTable) {
     await knex.schema.createTable("console_settings", (table) => {
-      table.integer("id").primary();
-      table.integer("owner_user_id").unsigned().nullable().references("id").inTable("users").onDelete("SET NULL");
+      table.bigInteger("id").primary();
+      table.bigInteger("owner_user_id").unsigned().nullable().references("id").inTable("users").onDelete("SET NULL");
       table.timestamp("created_at", { useTz: false }).notNullable().defaultTo(knex.fn.now());
       table.timestamp("updated_at", { useTz: false }).notNullable().defaultTo(knex.fn.now());
     });

--- a/packages/users-core/templates/migrations/users_core_profile_username.cjs
+++ b/packages/users-core/templates/migrations/users_core_profile_username.cjs
@@ -62,7 +62,7 @@ exports.up = async function up(knex) {
   for (const profile of profiles) {
     const nextUsername = resolveUniqueUsername(usernameBaseFromEmail(profile.email), usedUsernames);
     usedUsernames.add(nextUsername);
-    await knex("users").where({ id: Number(profile.id) }).update({
+    await knex("users").where({ id: profile.id }).update({
       username: nextUsername
     });
   }

--- a/packages/users-core/test/authProfileSyncService.test.js
+++ b/packages/users-core/test/authProfileSyncService.test.js
@@ -15,7 +15,7 @@ test("authProfileSyncService.syncIdentityProfile uses shared transaction for pro
       async upsert(payload, options = {}) {
         calls.push({ step: "upsert", trx: options.trx || null });
         return {
-          id: 13,
+          id: "13",
           authProvider: payload.authProvider,
           authProviderUserSid: payload.authProviderUserSid,
           email: payload.email,
@@ -67,7 +67,7 @@ test("authProfileSyncService.syncIdentityProfile skips write path when profile i
     usersRepository: {
       async findByIdentity() {
         return {
-          id: 7,
+          id: "7",
           authProvider: "supabase",
           authProviderUserSid: "abc-7",
           email: "tony@example.com",
@@ -84,7 +84,7 @@ test("authProfileSyncService.syncIdentityProfile skips write path when profile i
     },
     userSettingsRepository: {
       async ensureForUserId() {
-        return { userId: 7 };
+        return { userId: "7" };
       }
     },
     workspaceProvisioningService: {
@@ -120,7 +120,7 @@ test("authProfileSyncService.findByIdentity normalizes provider identity input",
     },
     userSettingsRepository: {
       async ensureForUserId() {
-        return { userId: 1 };
+        return { userId: "1" };
       }
     }
   });

--- a/packages/users-core/test/avatarStorageService.test.js
+++ b/packages/users-core/test/avatarStorageService.test.js
@@ -18,8 +18,8 @@ function createStorageDouble() {
 }
 
 test("avatarStorageService builds stable storage key by user id", () => {
-  assert.equal(__testables.buildAvatarStorageKey(7), "users/avatars/7/avatar");
-  assert.throws(() => __testables.buildAvatarStorageKey(0), /positive integer user id/);
+  assert.equal(__testables.buildAvatarStorageKey("7"), "users/avatars/7/avatar");
+  assert.throws(() => __testables.buildAvatarStorageKey("0"), /valid user id/);
 });
 
 test("avatarStorageService detects common avatar mime types", () => {
@@ -45,7 +45,7 @@ test("avatarStorageService saves, reads, and deletes avatar bytes", async () => 
   const payload = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
 
   const saved = await avatarStorageService.saveAvatar({
-    userId: 42,
+    userId: "42",
     buffer: payload
   });
   assert.equal(saved.storageKey, "users/avatars/42/avatar");

--- a/packages/users-core/test/consoleService.test.js
+++ b/packages/users-core/test/consoleService.test.js
@@ -10,7 +10,7 @@ function createFixture(initialOwnerUserId = null) {
   const service = createService({
     consoleSettingsRepository: {
       async ensureOwnerUserId(userId) {
-        const normalizedUserId = Number(userId);
+        const normalizedUserId = String(userId || "");
         if (!state.ownerUserId) {
           state.ownerUserId = normalizedUserId;
         }
@@ -25,22 +25,22 @@ function createFixture(initialOwnerUserId = null) {
 test("consoleService seeds the first authenticated user as console owner", async () => {
   const { service, state } = createFixture();
 
-  const firstOwner = await service.ensureInitialConsoleMember(7);
-  const secondAttempt = await service.ensureInitialConsoleMember(9);
+  const firstOwner = await service.ensureInitialConsoleMember("7");
+  const secondAttempt = await service.ensureInitialConsoleMember("9");
 
-  assert.equal(firstOwner, 7);
-  assert.equal(secondAttempt, 7);
-  assert.equal(state.ownerUserId, 7);
+  assert.equal(firstOwner, "7");
+  assert.equal(secondAttempt, "7");
+  assert.equal(state.ownerUserId, "7");
 });
 
 test("consoleService.requireConsoleOwner denies authenticated non-owners", async () => {
-  const { service } = createFixture(7);
+  const { service } = createFixture("7");
 
   await assert.rejects(
     () =>
       service.requireConsoleOwner({
         actor: {
-          id: 9
+          id: "9"
         }
       }),
     (error) => error?.status === 403
@@ -48,7 +48,7 @@ test("consoleService.requireConsoleOwner denies authenticated non-owners", async
 });
 
 test("consoleService.requireConsoleOwner requires authentication", async () => {
-  const { service } = createFixture(7);
+  const { service } = createFixture("7");
 
   await assert.rejects(
     () => service.requireConsoleOwner({}),

--- a/packages/users-core/test/registerServiceRealtimeEvents.test.js
+++ b/packages/users-core/test/registerServiceRealtimeEvents.test.js
@@ -76,7 +76,7 @@ test("workspace register functions publish members/invites/workspace-list realti
   assert.equal(members?.metadata?.events?.removeMember?.[1]?.realtime?.event, "users.bootstrap.changed");
   assert.equal(members?.metadata?.events?.createInvite?.[0]?.realtime?.event, "workspace.invites.changed");
   assert.equal(members?.metadata?.events?.createInvite?.[1]?.realtime?.event, "users.bootstrap.changed");
-  assert.equal(members?.metadata?.events?.createInvite?.[1]?.entityId?.({ result: { createdInviteId: 91 } }), 91);
+  assert.equal(members?.metadata?.events?.createInvite?.[1]?.entityId?.({ result: { createdInviteId: "91" } }), "91");
   assert.equal(members?.metadata?.events?.createInvite?.[1]?.realtime?.audience?.preset, "event_scope");
   assert.equal(typeof members?.metadata?.events?.createInvite?.[1]?.realtime?.audience?.userQuery, "function");
   const createInviteAudienceQueryResult = await members?.metadata?.events?.createInvite?.[1]?.realtime?.audience?.userQuery({
@@ -87,7 +87,7 @@ test("workspace register functions publish members/invites/workspace-list realti
         },
         where(field, value) {
           assert.equal(field, "wi.id");
-          assert.equal(value, 91);
+          assert.equal(value, "91");
           return this;
         },
         async first() {
@@ -98,13 +98,13 @@ test("workspace register functions publish members/invites/workspace-list realti
       };
     },
     event: {
-      entityId: 91
+      entityId: "91"
     }
   });
-  assert.deepEqual(createInviteAudienceQueryResult, [{ userId: 55 }]);
+  assert.deepEqual(createInviteAudienceQueryResult, [{ userId: "55" }]);
   assert.equal(members?.metadata?.events?.revokeInvite?.[0]?.realtime?.event, "workspace.invites.changed");
   assert.equal(members?.metadata?.events?.revokeInvite?.[1]?.realtime?.event, "users.bootstrap.changed");
-  assert.equal(members?.metadata?.events?.revokeInvite?.[1]?.entityId?.({ result: { revokedInviteId: 19 } }), 19);
+  assert.equal(members?.metadata?.events?.revokeInvite?.[1]?.entityId?.({ result: { revokedInviteId: "19" } }), "19");
   assert.equal(members?.metadata?.events?.revokeInvite?.[1]?.realtime?.audience?.preset, "event_scope");
   assert.equal(typeof members?.metadata?.events?.revokeInvite?.[1]?.realtime?.audience?.userQuery, "function");
 
@@ -124,22 +124,22 @@ test("workspace register functions publish members/invites/workspace-list realti
   const acceptedMembersChange = acceptInviteEvents.find(
     (entry) => entry?.realtime?.event === "workspace.members.changed"
   );
-  assert.equal(acceptedMembersChange?.entityId?.({ result: { workspaceId: 9 } }), 9);
+  assert.equal(acceptedMembersChange?.entityId?.({ result: { workspaceId: "9" } }), "9");
   assert.deepEqual(
     acceptedMembersChange?.realtime?.audience?.({
       event: {
-        entityId: 9
+        entityId: "9"
       }
     }),
     {
-      workspaceId: 9
+      workspaceId: "9"
     }
   );
 
   const acceptedInvitesChange = acceptInviteEvents.find(
     (entry) => entry?.realtime?.event === "workspace.invites.changed"
   );
-  assert.equal(acceptedInvitesChange?.entityId?.({ result: { workspaceId: 9 } }), 9);
+  assert.equal(acceptedInvitesChange?.entityId?.({ result: { workspaceId: "9" } }), "9");
 
   const refuseInviteEvents = Array.isArray(pending?.metadata?.events?.refuseInviteByToken)
     ? pending.metadata.events.refuseInviteByToken

--- a/packages/users-core/test/usersBootstrapContributor.test.js
+++ b/packages/users-core/test/usersBootstrapContributor.test.js
@@ -8,7 +8,7 @@ import {
 
 function createAuthenticatedProfile(overrides = {}) {
   return {
-    id: 7,
+    id: "7",
     authProvider: "local",
     authProviderUserSid: "user-7",
     username: "tester",
@@ -34,7 +34,7 @@ function createUserSettings() {
 }
 
 test("users bootstrap contributor seeds the initial console owner and exposes generic app payload", async () => {
-  const profile = createAuthenticatedProfile({ id: 12 });
+  const profile = createAuthenticatedProfile({ id: "12" });
   const consoleOwnerSeeds = [];
   const writtenSessions = [];
   const contributor = createUsersBootstrapContributor({
@@ -64,7 +64,7 @@ test("users bootstrap contributor seeds the initial console owner and exposes ge
     consoleService: {
       async ensureInitialConsoleMember(userId) {
         consoleOwnerSeeds.push(Number(userId));
-        return Number(userId);
+        return String(userId || "");
       }
     }
   });
@@ -92,7 +92,7 @@ test("users bootstrap contributor seeds the initial console owner and exposes ge
     csrfToken: "csrf-1"
   });
   assert.equal(payload.session.authenticated, true);
-  assert.equal(payload.session.userId, 12);
+  assert.equal(payload.session.userId, "12");
   assert.equal(payload.surfaceAccess.consoleowner, true);
   assert.equal(payload.app.features.workspaceSwitching, false);
   assert.deepEqual(payload.session.oauthProviders, [

--- a/packages/users-core/test/workspaceBootstrapContributor.test.js
+++ b/packages/users-core/test/workspaceBootstrapContributor.test.js
@@ -4,7 +4,7 @@ import { createWorkspaceBootstrapContributor } from "../src/server/workspaceBoot
 
 function createAuthenticatedProfile(overrides = {}) {
   return {
-    id: 7,
+    id: "7",
     authProvider: "local",
     authProviderUserSid: "user-7",
     username: "tester",

--- a/packages/users-core/test/workspaceInvitesRepository.test.js
+++ b/packages/users-core/test/workspaceInvitesRepository.test.js
@@ -55,12 +55,12 @@ test("workspaceInvitesRepository.insert normalizes expiresAt ISO input to databa
   const repository = createRepository(knexStub);
 
   await repository.insert({
-    workspaceId: 1,
+    workspaceId: "1",
     email: "invitee@example.com",
     roleSid: "member",
     status: "pending",
     tokenHash: "hash",
-    invitedByUserId: 1,
+    invitedByUserId: "1",
     expiresAt: "2026-03-16T00:26:35.709Z"
   });
 
@@ -106,6 +106,6 @@ test("workspaceInvitesRepository.findPendingByTokenHash reads from invites table
     token_hash: "hash-token",
     status: "pending"
   });
-  assert.equal(invite?.workspaceId, 9);
+  assert.equal(invite?.workspaceId, "9");
   assert.equal(invite?.workspaceSlug, undefined);
 });

--- a/packages/users-core/test/workspaceMembersService.test.js
+++ b/packages/users-core/test/workspaceMembersService.test.js
@@ -7,7 +7,7 @@ function authorizedOptions(permissions = []) {
   return {
     context: {
       actor: {
-        id: 1
+        id: "1"
       },
       permissions
     }
@@ -40,10 +40,10 @@ function createRoleCatalog() {
 
 function createFixture() {
   const workspace = {
-    id: 7,
+    id: "7",
     slug: "tonymobily3",
     name: "TonyMobily3",
-    ownerUserId: 9,
+    ownerUserId: "9",
     avatarUrl: ""
   };
 
@@ -53,7 +53,7 @@ function createFixture() {
         assert.equal(Number(workspaceId), 7);
         return [
           {
-            userId: 11,
+            userId: "11",
             roleSid: "member",
             status: "active",
             displayName: "Alice",
@@ -65,8 +65,8 @@ function createFixture() {
         assert.equal(Number(workspaceId), 7);
         assert.equal(Number(userId), 11);
         return {
-          workspaceId: 7,
-          userId: 11,
+          workspaceId: "7",
+          userId: "11",
           roleSid: "member",
           status: "active"
         };
@@ -112,7 +112,7 @@ test("workspaceMembersService.createInvite uses configured inviteExpiresInMs", a
       async insert(payload) {
         expiresAtValues.push(payload.expiresAt);
         return {
-          id: 31
+          id: "31"
         };
       },
       async listPendingByWorkspaceIdWithWorkspace() {
@@ -130,10 +130,10 @@ test("workspaceMembersService.createInvite uses configured inviteExpiresInMs", a
   const before = Date.now();
   const response = await service.createInvite(
     {
-      id: 7,
-      ownerUserId: 9
+      id: "7",
+      ownerUserId: "9"
     },
-    { id: 11 },
+    { id: "11" },
     {
       email: "alice@example.com",
       roleSid: "member"
@@ -146,7 +146,7 @@ test("workspaceMembersService.createInvite uses configured inviteExpiresInMs", a
   const expiresAt = new Date(expiresAtValues[0]).getTime();
   assert.ok(expiresAt >= before + 30 * 60 * 1000);
   assert.ok(expiresAt <= after + 30 * 60 * 1000);
-  assert.equal(response.createdInviteId, 31);
+  assert.equal(response.createdInviteId, "31");
 });
 
 test("workspaceMembersService.revokeInvite returns the revoked invite id", async () => {
@@ -164,15 +164,15 @@ test("workspaceMembersService.revokeInvite returns the revoked invite id", async
       async expirePendingByWorkspaceIdAndEmail() {},
       async insert() {
         return {
-          id: 1
+          id: "1"
         };
       },
       async findPendingByIdForWorkspace(inviteId, workspaceId) {
         assert.equal(Number(inviteId), 47);
         assert.equal(Number(workspaceId), 7);
         return {
-          id: 47,
-          workspaceId: 7,
+          id: "47",
+          workspaceId: "7",
           status: "pending"
         };
       },
@@ -186,15 +186,15 @@ test("workspaceMembersService.revokeInvite returns the revoked invite id", async
 
   const response = await service.revokeInvite(
     {
-      id: 7,
-      ownerUserId: 9
+      id: "7",
+      ownerUserId: "9"
     },
-    47,
+    "47",
     authorizedOptions(["workspace.invites.revoke"])
   );
 
   assert.equal(revokedInviteId, 47);
-  assert.equal(response.revokedInviteId, 47);
+  assert.equal(response.revokedInviteId, "47");
 });
 
 test("workspaceMembersService rejects invite operations when invitations are disabled", async () => {
@@ -230,8 +230,8 @@ test("workspaceMembersService rejects invite operations when invitations are dis
     () =>
       service.listInvites(
         {
-          id: 7,
-          ownerUserId: 9
+          id: "7",
+          ownerUserId: "9"
         },
         authorizedOptions(["workspace.members.view"])
       ),
@@ -245,10 +245,10 @@ test("workspaceMembersService.listMembers uses the resolved workspace directly",
   const response = await service.listMembers(workspace, authorizedOptions(["workspace.members.view"]));
 
   assert.deepEqual(response.workspace, {
-    id: 7,
+    id: "7",
     slug: "tonymobily3",
     name: "TonyMobily3",
-    ownerUserId: 9,
+    ownerUserId: "9",
     avatarUrl: ""
   });
   assert.equal(response.members.length, 1);
@@ -261,7 +261,7 @@ test("workspaceMembersService.updateMemberRole returns the refreshed member list
   const response = await service.updateMemberRole(
     workspace,
     {
-      memberUserId: 11,
+      memberUserId: "11",
       roleSid: "admin"
     },
     authorizedOptions(["workspace.members.manage"])
@@ -274,10 +274,10 @@ test("workspaceMembersService.updateMemberRole returns the refreshed member list
 test("workspaceMembersService.removeMember marks membership revoked and returns refreshed members", async () => {
   let removed = false;
   const workspace = {
-    id: 7,
+    id: "7",
     slug: "tonymobily3",
     name: "TonyMobily3",
-    ownerUserId: 9,
+    ownerUserId: "9",
     avatarUrl: ""
   };
   const service = createService({
@@ -288,7 +288,7 @@ test("workspaceMembersService.removeMember marks membership revoked and returns 
           ? []
           : [
               {
-                userId: 11,
+                userId: "11",
                 roleSid: "member",
                 status: "active",
                 displayName: "Alice",
@@ -300,8 +300,8 @@ test("workspaceMembersService.removeMember marks membership revoked and returns 
         assert.equal(Number(workspaceId), 7);
         assert.equal(Number(userId), 11);
         return {
-          workspaceId: 7,
-          userId: 11,
+          workspaceId: "7",
+          userId: "11",
           roleSid: "member",
           status: "active"
         };
@@ -334,7 +334,7 @@ test("workspaceMembersService.removeMember marks membership revoked and returns 
   const response = await service.removeMember(
     workspace,
     {
-      memberUserId: 11
+      memberUserId: "11"
     },
     authorizedOptions(["workspace.members.manage"])
   );
@@ -344,10 +344,10 @@ test("workspaceMembersService.removeMember marks membership revoked and returns 
 
 test("workspaceMembersService.removeMember rejects removing the owner", async () => {
   const workspace = {
-    id: 7,
+    id: "7",
     slug: "tonymobily3",
     name: "TonyMobily3",
-    ownerUserId: 9,
+    ownerUserId: "9",
     avatarUrl: ""
   };
   const service = createService({
@@ -359,8 +359,8 @@ test("workspaceMembersService.removeMember rejects removing the owner", async ()
         assert.equal(Number(workspaceId), 7);
         assert.equal(Number(userId), 9);
         return {
-          workspaceId: 7,
-          userId: 9,
+          workspaceId: "7",
+          userId: "9",
           roleSid: "owner",
           status: "active"
         };
@@ -389,7 +389,7 @@ test("workspaceMembersService.removeMember rejects removing the owner", async ()
       service.removeMember(
         workspace,
         {
-          memberUserId: 9
+          memberUserId: "9"
         },
         authorizedOptions(["workspace.members.manage"])
       ),

--- a/packages/users-core/test/workspacePendingInvitationsResource.test.js
+++ b/packages/users-core/test/workspacePendingInvitationsResource.test.js
@@ -9,8 +9,8 @@ test("workspacePendingInvitationsResource output normalizer shapes raw invite ro
   const result = workspacePendingInvitationsResource.operations.list.outputValidator.normalize({
     pendingInvites: [
       {
-        id: 10,
-        workspaceId: 3,
+        id: "10",
+        workspaceId: "3",
         workspaceSlug: "tonymobily3",
         workspaceName: "",
         workspaceAvatarUrl: "",
@@ -24,8 +24,8 @@ test("workspacePendingInvitationsResource output normalizer shapes raw invite ro
 
   assert.deepEqual(result, [
     {
-      id: 10,
-      workspaceId: 3,
+      id: "10",
+      workspaceId: "3",
       workspaceSlug: "tonymobily3",
       workspaceName: "tonymobily3",
       workspaceAvatarUrl: "",

--- a/packages/users-core/test/workspacePendingInvitationsService.test.js
+++ b/packages/users-core/test/workspacePendingInvitationsService.test.js
@@ -59,8 +59,8 @@ test("listPendingInvitesForUser returns raw pending invite rows for the action l
   const { service } = createFixture({
     pendingInvitesByEmail: [
       {
-        id: 10,
-        workspaceId: 1,
+        id: "10",
+        workspaceId: "1",
         workspaceSlug: "tonymobily3",
         workspaceName: "TonyMobily3",
         workspaceAvatarUrl: "",
@@ -73,7 +73,7 @@ test("listPendingInvitesForUser returns raw pending invite rows for the action l
   });
 
   const pendingInvites = await service.listPendingInvitesForUser({
-    id: 7,
+    id: "7",
     email: "chiaramobily@gmail.com"
   });
 
@@ -88,8 +88,8 @@ test("acceptInviteByToken accepts opaque invite token and resolves invite by dec
   const { service, calls } = createFixture({
     inviteByTokenHash: {
       [tokenHash]: {
-        id: 44,
-        workspaceId: 1,
+        id: "44",
+        workspaceId: "1",
         email: "chiaramobily@gmail.com",
         roleSid: "member",
         status: "pending",
@@ -101,7 +101,7 @@ test("acceptInviteByToken accepts opaque invite token and resolves invite by dec
 
   const response = await service.acceptInviteByToken({
     user: {
-      id: 7,
+      id: "7",
       email: "chiaramobily@gmail.com",
       displayName: "Chiara"
     },
@@ -113,7 +113,7 @@ test("acceptInviteByToken accepts opaque invite token and resolves invite by dec
   assert.deepEqual(calls.acceptCalls, [44]);
   assert.deepEqual(calls.revokeCalls, []);
   assert.equal(response.decision, "accepted");
-  assert.equal(response.workspaceId, 1);
+  assert.equal(response.workspaceId, "1");
 });
 
 test("refuseInviteByToken revokes the invite and returns refused", async () => {
@@ -122,8 +122,8 @@ test("refuseInviteByToken revokes the invite and returns refused", async () => {
   const { service, calls } = createFixture({
     inviteByTokenHash: {
       [tokenHash]: {
-        id: 45,
-        workspaceId: 1,
+        id: "45",
+        workspaceId: "1",
         email: "chiaramobily@gmail.com",
         roleSid: "member",
         status: "pending",
@@ -135,7 +135,7 @@ test("refuseInviteByToken revokes the invite and returns refused", async () => {
 
   const response = await service.refuseInviteByToken({
     user: {
-      id: 7,
+      id: "7",
       email: "chiaramobily@gmail.com",
       displayName: "Chiara"
     },
@@ -147,5 +147,5 @@ test("refuseInviteByToken revokes the invite and returns refused", async () => {
   assert.deepEqual(calls.revokeCalls, [45]);
   assert.equal(calls.upsertCalls.length, 0);
   assert.equal(response.decision, "refused");
-  assert.equal(response.workspaceId, 1);
+  assert.equal(response.workspaceId, "1");
 });

--- a/packages/users-core/test/workspaceRouteVisibilityResolver.test.js
+++ b/packages/users-core/test/workspaceRouteVisibilityResolver.test.js
@@ -18,7 +18,7 @@ test("workspace route visibility resolver contributes workspace_user scope and a
         id: "user_42"
       },
       workspace: {
-        id: 11
+        id: "11"
       }
     }
   });
@@ -26,7 +26,7 @@ test("workspace route visibility resolver contributes workspace_user scope and a
   assert.deepEqual(contribution, {
     scopeKind: "workspace_user",
     requiresActorScope: true,
-    scopeOwnerId: 11,
+    scopeOwnerId: "11",
     userId: "user_42"
   });
 });
@@ -44,7 +44,7 @@ test("workspace route visibility resolver keeps workspace-only visibility actor-
     visibility: "workspace",
     context: {
       workspace: {
-        id: 11
+        id: "11"
       }
     }
   });
@@ -52,7 +52,7 @@ test("workspace route visibility resolver keeps workspace-only visibility actor-
   assert.deepEqual(contribution, {
     scopeKind: "workspace",
     requiresActorScope: false,
-    scopeOwnerId: 11
+    scopeOwnerId: "11"
   });
 });
 

--- a/packages/users-core/test/workspaceService.test.js
+++ b/packages/users-core/test/workspaceService.test.js
@@ -28,10 +28,10 @@ function createWorkspaceServiceFixture({
   userWorkspaceRows = null,
   membershipResolver = null,
   personalWorkspace = {
-    id: 1,
+    id: "1",
     slug: "tonymobily3",
     name: "TonyMobily3",
-    ownerUserId: 7,
+    ownerUserId: "7",
     isPersonal: true,
     avatarUrl: ""
   }
@@ -93,7 +93,7 @@ function createWorkspaceServiceFixture({
         }
         return [
           {
-            id: 1,
+            id: "1",
             slug: "tonymobily3",
             name: "TonyMobily3",
             avatarUrl: "",
@@ -101,7 +101,7 @@ function createWorkspaceServiceFixture({
             membershipStatus: "active"
           },
           {
-            id: 2,
+            id: "2",
             slug: "pending-workspace",
             name: "Pending Workspace",
             avatarUrl: "",
@@ -113,12 +113,12 @@ function createWorkspaceServiceFixture({
       async insert(payload) {
         calls.insert += 1;
         insertedPayloads.push(payload);
-        const workspaceId = nextWorkspaceId++;
+        const workspaceId = String(nextWorkspaceId++);
         const inserted = {
           id: workspaceId,
           slug: String(payload.slug || ""),
           name: String(payload.name || ""),
-          ownerUserId: Number(payload.ownerUserId),
+          ownerUserId: String(payload.ownerUserId || ""),
           isPersonal: payload.isPersonal === true,
           avatarUrl: String(payload.avatarUrl || "")
         };
@@ -127,9 +127,9 @@ function createWorkspaceServiceFixture({
       },
       async updateById(workspaceId, patch) {
         calls.updateById += 1;
-        const targetId = Number(workspaceId);
+        const targetId = String(workspaceId || "").trim();
         for (const [slug, workspace] of workspaceBySlug.entries()) {
-          if (Number(workspace.id) !== targetId) {
+          if (String(workspace.id || "").trim() !== targetId) {
             continue;
           }
           const updated = {
@@ -185,7 +185,7 @@ test("workspaceService no longer exposes bootstrap payload assembly", () => {
 test("workspaceService.listWorkspacesForUser returns only accessible workspaces", async () => {
   const { service, calls } = createWorkspaceServiceFixture();
   const workspaces = await service.listWorkspacesForUser({
-    id: 7,
+    id: "7",
     email: "chiaramobily@gmail.com",
     displayName: "Chiara"
   });
@@ -204,7 +204,7 @@ test("workspaceService.listWorkspacesForUser no longer provisions personal works
   });
 
   await service.listWorkspacesForUser({
-    id: 7,
+    id: "7",
     email: "chiaramobily@gmail.com",
     displayName: "Chiara"
   });
@@ -218,7 +218,7 @@ test("workspaceService.listWorkspacesForUser returns all active memberships in p
     tenancyMode: "personal",
     userWorkspaceRows: [
       {
-        id: 1,
+        id: "1",
         slug: "chiaramobily",
         name: "Chiara Personal",
         avatarUrl: "",
@@ -226,7 +226,7 @@ test("workspaceService.listWorkspacesForUser returns all active memberships in p
         membershipStatus: "active"
       },
       {
-        id: 2,
+        id: "2",
         slug: "tonymobily",
         name: "Tony Workspace",
         avatarUrl: "",
@@ -234,7 +234,7 @@ test("workspaceService.listWorkspacesForUser returns all active memberships in p
         membershipStatus: "active"
       },
       {
-        id: 3,
+        id: "3",
         slug: "pending-workspace",
         name: "Pending Workspace",
         avatarUrl: "",
@@ -245,7 +245,7 @@ test("workspaceService.listWorkspacesForUser returns all active memberships in p
   });
 
   const workspaces = await service.listWorkspacesForUser({
-    id: 7,
+    id: "7",
     email: "chiaramobily@gmail.com",
     displayName: "Chiara"
   });
@@ -265,7 +265,7 @@ test("workspaceService.provisionWorkspaceForNewUser provisions personal workspac
   });
 
   const workspace = await service.provisionWorkspaceForNewUser({
-    id: 7,
+    id: "7",
     email: "chiaramobily@gmail.com",
     displayName: "Chiara"
   });
@@ -283,7 +283,7 @@ test("workspaceService.provisionWorkspaceForNewUser is a no-op outside personal 
   });
 
   const result = await service.provisionWorkspaceForNewUser({
-    id: 7,
+    id: "7",
     email: "chiaramobily@gmail.com",
     displayName: "Chiara"
   });
@@ -304,7 +304,7 @@ test("workspaceService.createWorkspaceForAuthenticatedUser creates non-personal 
 
   const workspace = await service.createWorkspaceForAuthenticatedUser(
     {
-      id: 7,
+      id: "7",
       email: "chiaramobily@gmail.com",
       displayName: "Chiara"
     },
@@ -318,7 +318,7 @@ test("workspaceService.createWorkspaceForAuthenticatedUser creates non-personal 
   assert.equal(calls.insert, 1);
   assert.equal(calls.ensureOwnerMembership, 1);
   assert.equal(insertedPayloads[0].isPersonal, false);
-  assert.equal(insertedPayloads[0].ownerUserId, 7);
+  assert.equal(insertedPayloads[0].ownerUserId, "7");
 });
 
 test("workspaceService.createWorkspaceForAuthenticatedUser rejects creation when self-create policy is disabled", async () => {
@@ -330,7 +330,7 @@ test("workspaceService.createWorkspaceForAuthenticatedUser rejects creation when
     () =>
       service.createWorkspaceForAuthenticatedUser(
         {
-          id: 7,
+          id: "7",
           email: "chiaramobily@gmail.com",
           displayName: "Chiara"
         },
@@ -352,7 +352,7 @@ test("workspaceService.resolveWorkspaceContextForUserBySlug returns workspace-no
     () =>
       service.resolveWorkspaceContextForUserBySlug(
         {
-          id: 7,
+          id: "7",
           email: "chiaramobily@gmail.com",
           displayName: "Chiara"
         },
@@ -366,19 +366,19 @@ test("workspaceService.resolveWorkspaceContextForUserBySlug allows personal tena
   const { service } = createWorkspaceServiceFixture({
     tenancyMode: "personal",
     personalWorkspace: {
-      id: 1,
+      id: "1",
       slug: "my-personal",
       name: "My Personal",
-      ownerUserId: 7,
+      ownerUserId: "7",
       isPersonal: true,
       avatarUrl: ""
     },
     additionalWorkspaces: [
       {
-        id: 42,
+        id: "42",
         slug: "team-alpha",
         name: "Team Alpha",
-        ownerUserId: 99,
+        ownerUserId: "99",
         isPersonal: false,
         avatarUrl: ""
       }
@@ -387,7 +387,7 @@ test("workspaceService.resolveWorkspaceContextForUserBySlug allows personal tena
 
   const context = await service.resolveWorkspaceContextForUserBySlug(
     {
-      id: 7,
+      id: "7",
       email: "chiaramobily@gmail.com",
       displayName: "Chiara"
     },
@@ -414,10 +414,10 @@ test("workspaceService.resolveWorkspaceContextForUserBySlug grants owner access 
           return null;
         }
         return {
-          id: 1,
+          id: "1",
           slug: "tonymobily",
           name: "TonyMobily",
-          ownerUserId: 7,
+          ownerUserId: "7",
           isPersonal: true,
           avatarUrl: ""
         };
@@ -458,7 +458,7 @@ test("workspaceService.resolveWorkspaceContextForUserBySlug grants owner access 
 
   const context = await service.resolveWorkspaceContextForUserBySlug(
     {
-      id: 7,
+      id: "7",
       email: "chiaramobily@gmail.com",
       displayName: "Chiara"
     },
@@ -487,7 +487,7 @@ test("workspaceService.resolveWorkspaceContextForUserBySlug resolves permissions
 
   const context = await service.resolveWorkspaceContextForUserBySlug(
     {
-      id: 7,
+      id: "7",
       email: "chiaramobily@gmail.com",
       displayName: "Chiara"
     },
@@ -501,10 +501,10 @@ test("workspaceService.getWorkspaceForAuthenticatedUser resolves workspace from 
   const { service } = createWorkspaceServiceFixture({
     additionalWorkspaces: [
       {
-        id: 42,
+        id: "42",
         slug: "team-alpha",
         name: "Team Alpha",
-        ownerUserId: 99,
+        ownerUserId: "99",
         isPersonal: false,
         avatarUrl: ""
       }
@@ -513,7 +513,7 @@ test("workspaceService.getWorkspaceForAuthenticatedUser resolves workspace from 
 
   const workspace = await service.getWorkspaceForAuthenticatedUser(
     {
-      id: 7,
+      id: "7",
       email: "chiaramobily@gmail.com",
       displayName: "Chiara"
     },
@@ -529,7 +529,7 @@ test("workspaceService.updateWorkspaceForAuthenticatedUser updates workspace pro
 
   const workspace = await service.updateWorkspaceForAuthenticatedUser(
     {
-      id: 7,
+      id: "7",
       email: "chiaramobily@gmail.com",
       displayName: "Chiara"
     },

--- a/packages/users-core/test/workspaceSettingsRepository.test.js
+++ b/packages/users-core/test/workspaceSettingsRepository.test.js
@@ -110,10 +110,10 @@ test("workspaceSettingsRepository.findByWorkspaceId maps the stored row", async 
     defaultInvitesEnabled: createDefaultWorkspaceSettings()
   });
 
-  const record = await repository.findByWorkspaceId(1);
+  const record = await repository.findByWorkspaceId("1");
 
   assert.deepEqual(record, {
-    workspaceId: 1,
+    workspaceId: "1",
     lightPrimaryColor: DEFAULT_WORKSPACE_THEME.light.color,
     lightSecondaryColor: DEFAULT_WORKSPACE_THEME.light.secondaryColor,
     lightSurfaceColor: DEFAULT_WORKSPACE_THEME.light.surfaceColor,
@@ -134,7 +134,7 @@ test("workspaceSettingsRepository.updateSettingsByWorkspaceId updates invitesEna
     defaultInvitesEnabled: createDefaultWorkspaceSettings()
   });
 
-  const updated = await repository.updateSettingsByWorkspaceId(1, {
+  const updated = await repository.updateSettingsByWorkspaceId("1", {
     invitesEnabled: false
   });
 
@@ -149,9 +149,9 @@ test("workspaceSettingsRepository.ensureForWorkspaceId inserts the injected defa
     defaultInvitesEnabled: false
   });
 
-  const record = await repository.ensureForWorkspaceId(5);
+  const record = await repository.ensureForWorkspaceId("5");
 
-  assert.equal(state.insertedRow.workspace_id, 5);
+  assert.equal(state.insertedRow.workspace_id, "5");
   assert.equal(state.insertedRow.light_primary_color, DEFAULT_WORKSPACE_THEME.light.color);
   assert.equal(state.insertedRow.light_secondary_color, DEFAULT_WORKSPACE_THEME.light.secondaryColor);
   assert.equal(state.insertedRow.light_surface_color, DEFAULT_WORKSPACE_THEME.light.surfaceColor);
@@ -176,6 +176,7 @@ test("workspaceSettingsRepository.ensureForWorkspaceId inserts the injected defa
   assert.equal(record.darkSurfaceColor, DEFAULT_WORKSPACE_THEME.dark.surfaceColor);
   assert.equal(record.darkSurfaceVariantColor, DEFAULT_WORKSPACE_THEME.dark.surfaceVariantColor);
   assert.equal(record.invitesEnabled, false);
+  assert.equal(record.workspaceId, "5");
 });
 
 test("workspaceSettingsRepository.updateSettingsByWorkspaceId updates workspace settings columns", async () => {
@@ -184,7 +185,7 @@ test("workspaceSettingsRepository.updateSettingsByWorkspaceId updates workspace 
     defaultInvitesEnabled: true
   });
 
-  const updated = await repository.updateSettingsByWorkspaceId(1, {
+  const updated = await repository.updateSettingsByWorkspaceId("1", {
     lightPrimaryColor: "#123abc"
   });
 

--- a/packages/users-core/test/workspaceSettingsResource.test.js
+++ b/packages/users-core/test/workspaceSettingsResource.test.js
@@ -118,9 +118,9 @@ test("workspace settings output normalizes raw service payloads", () => {
 
   assert.deepEqual(normalized, {
     workspace: {
-      id: 7,
+      id: "7",
       slug: "mercury",
-      ownerUserId: 9
+      ownerUserId: "9"
     },
     settings: {
       lightPrimaryColor: "#0F6B54",

--- a/packages/users-web/src/client/components/MembersAdminClientElement.vue
+++ b/packages/users-web/src/client/components/MembersAdminClientElement.vue
@@ -168,6 +168,7 @@
 <script setup>
 import { computed, toRefs, unref } from "vue";
 import { formatDateTime as formatKernelDateTime } from "@jskit-ai/kernel/shared/support";
+import { normalizeRecordId } from "@jskit-ai/kernel/shared/support/normalize";
 import { requireBoolean, requireFunction, requireRecord } from "../support/contractGuards.js";
 
 const props = defineProps({
@@ -188,11 +189,11 @@ const props = defineProps({
     required: true
   },
   revokeInviteId: {
-    type: Number,
+    type: String,
     required: true
   },
   removeMemberUserId: {
-    type: Number,
+    type: String,
     required: true
   },
   status: {
@@ -352,11 +353,11 @@ function isMemberRemoveLocked(member) {
 }
 
 function isRevokeInviteLoading(inviteId) {
-  return isRevokingInvite.value && revokeInviteId.value === Number(inviteId || 0);
+  return isRevokingInvite.value && revokeInviteId.value === normalizeRecordId(inviteId, { fallback: "" });
 }
 
 function isRemoveMemberLoading(memberUserId) {
-  return isRemovingMember.value && removeMemberUserId.value === Number(memberUserId || 0);
+  return isRemovingMember.value && removeMemberUserId.value === normalizeRecordId(memberUserId, { fallback: "" });
 }
 
 async function onSubmitInvite() {

--- a/packages/users-web/src/client/components/WorkspaceMembersClientElement.vue
+++ b/packages/users-web/src/client/components/WorkspaceMembersClientElement.vue
@@ -21,6 +21,7 @@
 <script setup>
 import { computed, reactive, ref, watch } from "vue";
 import { formatDateTime } from "@jskit-ai/kernel/shared/support";
+import { normalizeRecordId } from "@jskit-ai/kernel/shared/support/normalize";
 import MembersAdminClientElement from "./MembersAdminClientElement.vue";
 import { useCommand } from "../composables/useCommand.js";
 import { useList } from "../composables/records/useList.js";
@@ -61,8 +62,8 @@ const collections = reactive({
 const inviteFeedback = useUiFeedback();
 const membersFeedback = useUiFeedback();
 const teamFeedback = useUiFeedback();
-const revokeInviteId = ref(0);
-const removeMemberUserId = ref(0);
+const revokeInviteId = ref("");
+const removeMemberUserId = ref("");
 
 const { route, currentSurfaceId, workspaceSlugFromRoute, mergePlacementContext } =
   useWorkspaceRouteContext();
@@ -83,7 +84,8 @@ const workspaceInvitesApiPath = computed(() =>
 );
 
 function workspaceMembersPath(memberId) {
-  return `${workspaceMembersApiPath.value}/${Number(memberId || 0)}`;
+  const normalizedMemberId = encodeURIComponent(String(memberId || "").trim());
+  return `${workspaceMembersApiPath.value}/${normalizedMemberId}`;
 }
 
 function workspaceInvitePath(inviteId) {
@@ -145,8 +147,8 @@ function resetViewState() {
   collections.members = [];
   collections.invites = [];
   clearRoleOptions();
-  revokeInviteId.value = 0;
-  removeMemberUserId.value = 0;
+  revokeInviteId.value = "";
+  removeMemberUserId.value = "";
 }
 
 function toRoleTitle(roleSid) {
@@ -223,7 +225,7 @@ function normalizeMembers(entries) {
   return source.map((entry) => {
     const value = entry && typeof entry === "object" ? entry : {};
     return {
-      userId: Number(value.userId || 0),
+      userId: normalizeRecordId(value.userId, { fallback: "" }),
       roleSid: String(value.roleSid || "").trim().toLowerCase(),
       status: String(value.status || "").trim().toLowerCase(),
       displayName: String(value.displayName || "").trim(),
@@ -238,12 +240,12 @@ function normalizeInvites(entries) {
   return source.map((entry) => {
     const value = entry && typeof entry === "object" ? entry : {};
     return {
-      id: Number(value.id || 0),
+      id: normalizeRecordId(value.id, { fallback: "" }),
       email: String(value.email || "").trim().toLowerCase(),
       roleSid: String(value.roleSid || "").trim().toLowerCase(),
       status: String(value.status || "").trim().toLowerCase(),
       expiresAt: value.expiresAt || "",
-      invitedByUserId: value.invitedByUserId == null ? null : Number(value.invitedByUserId)
+      invitedByUserId: normalizeRecordId(value.invitedByUserId, { fallback: null })
     };
   });
 }
@@ -576,7 +578,7 @@ async function submitRevokeInvite(inviteId) {
     return;
   }
 
-  revokeInviteId.value = Number(inviteId || 0);
+  revokeInviteId.value = normalizeRecordId(inviteId, { fallback: "" });
   teamFeedback.clear();
 
   try {
@@ -591,7 +593,7 @@ async function submitRevokeInvite(inviteId) {
   } catch (error) {
     teamFeedback.error(error, "Unable to revoke invite.");
   } finally {
-    revokeInviteId.value = 0;
+    revokeInviteId.value = "";
   }
 }
 
@@ -603,8 +605,8 @@ async function submitMemberRoleUpdate(member, roleSid) {
   membersFeedback.clear();
 
   try {
-    const memberUserId = Number(member?.userId || 0);
-    if (!Number.isInteger(memberUserId) || memberUserId < 1) {
+    const memberUserId = normalizeRecordId(member?.userId, { fallback: null });
+    if (!memberUserId) {
       throw new Error("Member user id is invalid.");
     }
 
@@ -630,12 +632,12 @@ async function submitRemoveMember(member) {
   membersFeedback.clear();
 
   try {
-    const memberUserId = Number(member?.userId || 0);
-    if (!Number.isInteger(memberUserId) || memberUserId < 1) {
+    const memberUserId = normalizeRecordId(member?.userId, { fallback: null });
+    if (!memberUserId) {
       throw new Error("Member user id is invalid.");
     }
 
-    removeMemberUserId.value = memberUserId;
+    removeMemberUserId.value = normalizeRecordId(memberUserId, { fallback: "" });
     await memberRemoveCommand.run({
       memberUserId
     });
@@ -647,7 +649,7 @@ async function submitRemoveMember(member) {
   } catch (error) {
     membersFeedback.error(error, "Unable to remove member.");
   } finally {
-    removeMemberUserId.value = 0;
+    removeMemberUserId.value = "";
   }
 }
 </script>

--- a/packages/users-web/src/client/composables/account-settings/accountSettingsRuntimeHelpers.js
+++ b/packages/users-web/src/client/composables/account-settings/accountSettingsRuntimeHelpers.js
@@ -3,6 +3,7 @@ import {
   normalizeReturnToPath as normalizeSharedReturnToPath,
   resolveAllowedOriginsFromPlacementContext
 } from "@jskit-ai/kernel/shared/support";
+import { normalizeRecordId } from "@jskit-ai/kernel/shared/support/normalize";
 import { normalizeRecord } from "../../support/runtimeNormalization.js";
 
 function normalizeReturnToPath(value, { fallback = "/", accountSettingsPath = "/account", allowedOrigins = [] } = {}) {
@@ -27,9 +28,9 @@ function normalizePendingInvite(entry) {
     return null;
   }
 
-  const id = Number(entry.id);
-  const workspaceId = Number(entry.workspaceId);
-  if (!Number.isInteger(id) || id < 1 || !Number.isInteger(workspaceId) || workspaceId < 1) {
+  const id = normalizeRecordId(entry.id, { fallback: null });
+  const workspaceId = normalizeRecordId(entry.workspaceId, { fallback: null });
+  if (!id || !workspaceId) {
     return null;
   }
 

--- a/packages/users-web/src/client/lib/bootstrap.js
+++ b/packages/users-web/src/client/lib/bootstrap.js
@@ -1,3 +1,5 @@
+import { normalizeRecordId } from "@jskit-ai/kernel/shared/support/normalize";
+
 function buildBootstrapApiPath(workspaceSlug = "") {
   const normalizedWorkspaceSlug = String(workspaceSlug || "").trim();
   if (!normalizedWorkspaceSlug) {
@@ -15,9 +17,9 @@ function normalizeWorkspaceEntry(entry) {
     return null;
   }
 
-  const id = Number(entry.id);
+  const id = normalizeRecordId(entry.id, { fallback: null });
   const slug = String(entry.slug || "").trim();
-  if (!Number.isInteger(id) || id < 1 || !slug) {
+  if (!id || !slug) {
     return null;
   }
 
@@ -69,8 +71,8 @@ function resolvePlacementUserFromBootstrapPayload(payload = {}, currentUser = nu
   const fallbackUser = currentUser && typeof currentUser === "object" ? currentUser : {};
   const nextUser = {};
 
-  const userId = Number(session.userId || fallbackUser.id || 0);
-  if (Number.isInteger(userId) && userId > 0) {
+  const userId = normalizeRecordId(session.userId || fallbackUser.id, { fallback: null });
+  if (userId) {
     nextUser.id = userId;
   }
 

--- a/packages/users-web/test/bootstrap.test.js
+++ b/packages/users-web/test/bootstrap.test.js
@@ -17,7 +17,7 @@ test("resolvePlacementUserFromBootstrapPayload maps profile fields used by place
   const user = resolvePlacementUserFromBootstrapPayload({
     session: {
       authenticated: true,
-      userId: 42
+      userId: "42"
     },
     profile: {
       displayName: "Ada Lovelace",
@@ -29,7 +29,7 @@ test("resolvePlacementUserFromBootstrapPayload maps profile fields used by place
   });
 
   assert.deepEqual(user, {
-    id: 42,
+    id: "42",
     displayName: "Ada Lovelace",
     name: "Ada Lovelace",
     email: "ada@example.com",

--- a/packages/users-web/test/bootstrapPlacementRuntime.test.js
+++ b/packages/users-web/test/bootstrapPlacementRuntime.test.js
@@ -245,7 +245,7 @@ test("bootstrap placement runtime writes user/workspace/permissions into placeme
       return {
         session: {
           authenticated: true,
-          userId: 7
+          userId: "7"
         },
         profile: {
           displayName: "Ada Lovelace",
@@ -260,10 +260,10 @@ test("bootstrap placement runtime writes user/workspace/permissions into placeme
           }
         },
         pendingInvites: [
-          { id: 1, workspaceId: 1, token: "a" },
-          { id: 2, workspaceId: 2, token: "b" }
+          { id: "1", workspaceId: "1", token: "a" },
+          { id: "2", workspaceId: "2", token: "b" }
         ],
-        workspaces: [{ id: 1, slug: "acme", name: "Acme Workspace" }],
+        workspaces: [{ id: "1", slug: "acme", name: "Acme Workspace" }],
         permissions: ["workspace.settings.view"]
       };
     }
@@ -280,7 +280,7 @@ test("bootstrap placement runtime writes user/workspace/permissions into placeme
   assert.equal(runtime.getWorkspaceBootstrapStatus("acme"), WORKSPACE_BOOTSTRAP_STATUS_RESOLVED);
   assert.equal(context.workspaceBootstrapStatuses?.acme, WORKSPACE_BOOTSTRAP_STATUS_RESOLVED);
   assert.deepEqual(context.user, {
-    id: 7,
+    id: "7",
     displayName: "Ada Lovelace",
     name: "Ada Lovelace",
     email: "ada@example.com",
@@ -305,7 +305,7 @@ test("bootstrap placement runtime resolves workspace slug from pathname when sur
       return {
         session: {
           authenticated: true,
-          userId: 1
+          userId: "1"
         },
         profile: {
           displayName: "User",
@@ -314,7 +314,7 @@ test("bootstrap placement runtime resolves workspace slug from pathname when sur
             effectiveUrl: ""
           }
         },
-        workspaces: [{ id: 1, slug: "acme", name: "Acme Workspace" }],
+        workspaces: [{ id: "1", slug: "acme", name: "Acme Workspace" }],
         permissions: ["workspace.settings.view"]
       };
     }
@@ -348,7 +348,7 @@ test("bootstrap placement runtime does not mutate placement auth context", async
       return {
         session: {
           authenticated: true,
-          userId: 9
+          userId: "9"
         },
         profile: {
           displayName: "User",
@@ -357,7 +357,7 @@ test("bootstrap placement runtime does not mutate placement auth context", async
             effectiveUrl: ""
           }
         },
-        workspaces: [{ id: 1, slug: "acme", name: "Workspace" }],
+        workspaces: [{ id: "1", slug: "acme", name: "Workspace" }],
         permissions: []
       };
     }
@@ -387,7 +387,7 @@ test("bootstrap placement runtime refetches on route changes and users.bootstrap
       return {
         session: {
           authenticated: true,
-          userId: 1
+          userId: "1"
         },
         profile: {
           displayName: "User",
@@ -396,7 +396,7 @@ test("bootstrap placement runtime refetches on route changes and users.bootstrap
             effectiveUrl: ""
           }
         },
-        workspaces: [{ id: 1, slug: workspaceSlug || "acme", name: "Workspace" }],
+        workspaces: [{ id: "1", slug: workspaceSlug || "acme", name: "Workspace" }],
         permissions: []
       };
     }
@@ -436,7 +436,7 @@ test("bootstrap placement runtime refetches when auth context changes", async ()
       return {
         session: {
           authenticated: true,
-          userId: 1
+          userId: "1"
         },
         profile: {
           displayName: "User",
@@ -445,7 +445,7 @@ test("bootstrap placement runtime refetches when auth context changes", async ()
             effectiveUrl: ""
           }
         },
-        workspaces: [{ id: 1, slug: workspaceSlug || "acme", name: "Workspace" }],
+        workspaces: [{ id: "1", slug: workspaceSlug || "acme", name: "Workspace" }],
         permissions: []
       };
     }
@@ -535,7 +535,7 @@ test("bootstrap placement runtime reapplies theme when bootstrap payload changes
       return {
         session: {
           authenticated: true,
-          userId: 1
+          userId: "1"
         },
         profile: {
           displayName: "User",
@@ -547,7 +547,7 @@ test("bootstrap placement runtime reapplies theme when bootstrap payload changes
         userSettings: {
           theme: fetchCount === 1 ? "dark" : "light"
         },
-        workspaces: [{ id: 1, slug: workspaceSlug || "acme", name: "Workspace" }],
+        workspaces: [{ id: "1", slug: workspaceSlug || "acme", name: "Workspace" }],
         permissions: []
       };
     }
@@ -575,7 +575,7 @@ test("bootstrap placement runtime applies workspace palette via Vuetify workspac
       return {
         session: {
           authenticated: true,
-          userId: 1
+          userId: "1"
         },
         workspaceSettings: {
           lightPrimaryColor: "#CC3344",
@@ -589,7 +589,7 @@ test("bootstrap placement runtime applies workspace palette via Vuetify workspac
         },
         workspaces: [
           {
-            id: 1,
+            id: "1",
             slug: "acme",
             name: "Acme Workspace"
           }
@@ -630,8 +630,8 @@ test("bootstrap placement runtime marks workspace slug as not_found and clears w
   const placementRuntime = createPlacementRuntimeStub();
   placementRuntime.setContext(
     {
-      workspace: { id: 1, slug: "acme", name: "Acme Workspace" },
-      workspaces: [{ id: 1, slug: "acme", name: "Acme Workspace" }],
+      workspace: { id: "1", slug: "acme", name: "Acme Workspace" },
+      workspaces: [{ id: "1", slug: "acme", name: "Acme Workspace" }],
       permissions: ["workspace.settings.view"]
     },
     { source: "test.seed" }
@@ -680,7 +680,7 @@ test("bootstrap placement runtime updates status per workspace slug across route
       return {
         session: {
           authenticated: true,
-          userId: 1
+          userId: "1"
         },
         profile: {
           displayName: "User",
@@ -689,7 +689,7 @@ test("bootstrap placement runtime updates status per workspace slug across route
             effectiveUrl: ""
           }
         },
-        workspaces: [{ id: 1, slug: workspaceSlug || "acme", name: "Workspace" }],
+        workspaces: [{ id: "1", slug: workspaceSlug || "acme", name: "Workspace" }],
         permissions: []
       };
     }
@@ -721,7 +721,7 @@ test("bootstrap placement runtime uses requestedWorkspace status and keeps globa
       return {
         session: {
           authenticated: true,
-          userId: 4
+          userId: "4"
         },
         profile: {
           displayName: "Chiara",
@@ -730,7 +730,7 @@ test("bootstrap placement runtime uses requestedWorkspace status and keeps globa
             effectiveUrl: ""
           }
         },
-        workspaces: [{ id: 3, slug: "chiaramobily", name: "Chiara Workspace" }],
+        workspaces: [{ id: "3", slug: "chiaramobily", name: "Chiara Workspace" }],
         requestedWorkspace: {
           slug: "tonymobily",
           status: "forbidden"
@@ -763,7 +763,7 @@ test("bootstrap placement runtime uses requestedWorkspace=not_found without forc
       return {
         session: {
           authenticated: true,
-          userId: 1
+          userId: "1"
         },
         profile: {
           displayName: "User",
@@ -772,7 +772,7 @@ test("bootstrap placement runtime uses requestedWorkspace=not_found without forc
             effectiveUrl: ""
           }
         },
-        workspaces: [{ id: 1, slug: "acme", name: "Acme Workspace" }],
+        workspaces: [{ id: "1", slug: "acme", name: "Acme Workspace" }],
         requestedWorkspace: {
           slug: "missing",
           status: "not_found"
@@ -811,9 +811,9 @@ test("bootstrap placement runtime guard wrapper preserves delegated deny outcome
       return {
         session: {
           authenticated: true,
-          userId: 1
+          userId: "1"
         },
-        workspaces: [{ id: 1, slug: "acme", name: "Acme" }],
+        workspaces: [{ id: "1", slug: "acme", name: "Acme" }],
         permissions: []
       };
     }
@@ -854,7 +854,7 @@ test("bootstrap placement runtime guard wrapper blocks forbidden workspace route
       return {
         session: {
           authenticated: true,
-          userId: 1
+          userId: "1"
         },
         workspaces: [],
         permissions: []
@@ -1032,7 +1032,7 @@ test("bootstrap placement runtime enforces surface access policies after bootstr
       return {
         session: {
           authenticated: true,
-          userId: 1
+          userId: "1"
         },
         workspaces: [],
         permissions: [],
@@ -1059,9 +1059,9 @@ test("bootstrap placement runtime captures guard evaluator assignments after ini
       return {
         session: {
           authenticated: true,
-          userId: 1
+          userId: "1"
         },
-        workspaces: [{ id: 1, slug: "acme", name: "Acme" }],
+        workspaces: [{ id: "1", slug: "acme", name: "Acme" }],
         permissions: []
       };
     }

--- a/packages/workspaces-core/templates/migrations/workspaces_core_initial.cjs
+++ b/packages/workspaces-core/templates/migrations/workspaces_core_initial.cjs
@@ -10,10 +10,10 @@ exports.up = async function up(knex) {
   const hasWorkspacesTable = await knex.schema.hasTable("workspaces");
   if (!hasWorkspacesTable) {
     await knex.schema.createTable("workspaces", (table) => {
-      table.increments("id").primary();
+      table.bigIncrements("id").primary();
       table.string("slug", 120).notNullable().unique();
       table.string("name", 160).notNullable();
-      table.integer("owner_user_id").unsigned().notNullable().references("id").inTable("users").onDelete("CASCADE");
+      table.bigInteger("owner_user_id").unsigned().notNullable().references("id").inTable("users").onDelete("CASCADE");
       table.boolean("is_personal").notNullable().defaultTo(true);
       table.string("avatar_url", 512).notNullable().defaultTo("");
       table.timestamp("created_at", { useTz: false }).notNullable().defaultTo(knex.fn.now());
@@ -25,9 +25,9 @@ exports.up = async function up(knex) {
   const hasWorkspaceMembershipsTable = await knex.schema.hasTable("workspace_memberships");
   if (!hasWorkspaceMembershipsTable) {
     await knex.schema.createTable("workspace_memberships", (table) => {
-      table.increments("id").primary();
-      table.integer("workspace_id").unsigned().notNullable().references("id").inTable("workspaces").onDelete("CASCADE");
-      table.integer("user_id").unsigned().notNullable().references("id").inTable("users").onDelete("CASCADE");
+      table.bigIncrements("id").primary();
+      table.bigInteger("workspace_id").unsigned().notNullable().references("id").inTable("workspaces").onDelete("CASCADE");
+      table.bigInteger("user_id").unsigned().notNullable().references("id").inTable("users").onDelete("CASCADE");
       table.string("role_sid", 64).notNullable().defaultTo("member");
       table.string("status", 32).notNullable().defaultTo("active");
       table.timestamp("created_at", { useTz: false }).notNullable().defaultTo(knex.fn.now());
@@ -39,7 +39,7 @@ exports.up = async function up(knex) {
   const hasWorkspaceSettingsTable = await knex.schema.hasTable("workspace_settings");
   if (!hasWorkspaceSettingsTable) {
     await knex.schema.createTable("workspace_settings", (table) => {
-      table.integer("workspace_id").unsigned().primary().references("id").inTable("workspaces").onDelete("CASCADE");
+      table.bigInteger("workspace_id").unsigned().primary().references("id").inTable("workspaces").onDelete("CASCADE");
       table.string("light_primary_color", 7).notNullable().defaultTo("#1867C0");
       table.string("light_secondary_color", 7).notNullable().defaultTo("#48A9A6");
       table.string("light_surface_color", 7).notNullable().defaultTo("#FFFFFF");
@@ -57,13 +57,13 @@ exports.up = async function up(knex) {
   const hasWorkspaceInvitesTable = await knex.schema.hasTable("workspace_invites");
   if (!hasWorkspaceInvitesTable) {
     await knex.schema.createTable("workspace_invites", (table) => {
-      table.increments("id").primary();
-      table.integer("workspace_id").unsigned().notNullable().references("id").inTable("workspaces").onDelete("CASCADE");
+      table.bigIncrements("id").primary();
+      table.bigInteger("workspace_id").unsigned().notNullable().references("id").inTable("workspaces").onDelete("CASCADE");
       table.string("email", 255).notNullable();
       table.string("role_sid", 64).notNullable().defaultTo("member");
       table.string("status", 32).notNullable().defaultTo("pending");
       table.string("token_hash", 191).notNullable();
-      table.integer("invited_by_user_id").unsigned().nullable().references("id").inTable("users").onDelete("SET NULL");
+      table.bigInteger("invited_by_user_id").unsigned().nullable().references("id").inTable("users").onDelete("SET NULL");
       table.timestamp("expires_at", { useTz: false }).nullable();
       table.timestamp("accepted_at", { useTz: false }).nullable();
       table.timestamp("revoked_at", { useTz: false }).nullable();

--- a/packages/workspaces-core/templates/migrations/workspaces_core_workspace_settings_single_name_source.cjs
+++ b/packages/workspaces-core/templates/migrations/workspaces_core_workspace_settings_single_name_source.cjs
@@ -62,7 +62,7 @@ exports.down = async function down(knex) {
     const normalizedName = String(workspaceRow?.name || "").trim() || "Workspace";
     const normalizedAvatarUrl = String(workspaceRow?.avatar_url || "").trim();
     await knex(WORKSPACE_SETTINGS_TABLE)
-      .where({ workspace_id: Number(workspaceRow.id) })
+      .where({ workspace_id: workspaceRow.id })
       .update({
         name: normalizedName,
         avatar_url: normalizedAvatarUrl

--- a/packages/workspaces-core/templates/migrations/workspaces_core_workspaces_drop_color.cjs
+++ b/packages/workspaces-core/templates/migrations/workspaces_core_workspaces_drop_color.cjs
@@ -66,8 +66,8 @@ exports.down = async function down(knex) {
   );
 
   for (const row of workspaceSettingsRows) {
-    const workspaceId = Number(row?.workspace_id || 0);
-    if (!Number.isInteger(workspaceId) || workspaceId < 1) {
+    const workspaceId = row?.workspace_id == null ? "" : String(row.workspace_id).trim();
+    if (!workspaceId) {
       continue;
     }
 


### PR DESCRIPTION
## Summary

This change moves JSKIT record-id handling to a BIGINT-safe string contract above the database boundary.

Exactly what this does:

- makes shared/public record-id validation string-based instead of integer-based
- centralizes canonical record-id text normalization in `normalizeCanonicalRecordIdText()`
- makes `normalizeRecordId()` accept only canonical string / bigint inputs
- keeps DB-edge normalization in `normalizeDbRecordId()` so raw driver results can still be normalized immediately at the repository boundary
- updates shared resources, client helpers, services, repositories, and query-key code to treat record ids as canonical strings
- updates CRUD repository/resource support so record-id fields are detected and normalized as record ids instead of generic integers
- updates CRUD server generation so id / foreign-id style columns generate `recordIdSchema`-based resource fields and `bigIncrements` / `bigInteger` migration columns
- updates runtime migration templates across assistant, users, and workspaces to use BIGINT-compatible primary and foreign key definitions
- updates MySQL Knex connection resolution to enable `supportBigNumbers` + `bigNumberStrings`, so large ids are surfaced as strings instead of lossy JS numbers
- fixes package manifests so packages that now import `@jskit-ai/database-runtime` actually declare that dependency
- refreshes package/kernel inventory docs to reflect the new shared helpers and exports

## Why this shape

The important contract is:

- routes / resources / services / UI / app code use string record ids
- database-runtime is the only layer allowed to normalize raw DB return shapes

That avoids unsafe JS integer handling in app-facing code while keeping the DB adapter boundary practical across dialects and insert-result shapes.

## Verification

- `npm run verify`
- `npm --workspace packages/assistant-core test`
- `npm --workspace packages/crud-core test`
