### PR TITLE
Make CRUD generator permissions surface-aware

### DIFF
--- a/packages/crud-server-generator/package.descriptor.mjs
+++ b/packages/crud-server-generator/package.descriptor.mjs
@@ -208,7 +208,11 @@ export default Object.freeze({
         to: "packages/${option:namespace|kebab}/src/server/actions.js",
         reason: "Install app-local CRUD action definitions.",
         category: "crud",
-        id: "crud-local-package-server-actions-${option:namespace|snake}"
+        id: "crud-local-package-server-actions-${option:namespace|snake}",
+        templateContext: {
+          entrypoint: "src/server/buildTemplateContext.js",
+          export: "buildTemplateContext"
+        }
       },
       {
         from: "templates/src/local-package/server/actionIds.js",
@@ -278,11 +282,14 @@ export default Object.freeze({
         file: "config/roles.js",
         position: "bottom",
         skipIfContains: "\"crud.${option:namespace|snake}.list\"",
-        value:
-          "\nroleCatalog.roles.member.permissions.push(\n  \"crud.${option:namespace|snake}.list\",\n  \"crud.${option:namespace|snake}.view\",\n  \"crud.${option:namespace|snake}.create\",\n  \"crud.${option:namespace|snake}.update\",\n  \"crud.${option:namespace|snake}.delete\"\n);\n",
+        value: "__JSKIT_CRUD_ROLE_CATALOG_PERMISSION_GRANTS__",
         reason: "Grant generated CRUD action permissions to the default member role in the app-owned role catalog.",
         category: "crud",
-        id: "crud-role-catalog-permissions-${option:namespace|snake}"
+        id: "crud-role-catalog-permissions-${option:namespace|snake}",
+        templateContext: {
+          entrypoint: "src/server/buildTemplateContext.js",
+          export: "buildTemplateContext"
+        }
       }
     ]
   }

--- a/packages/crud-server-generator/src/server/buildTemplateContext.js
+++ b/packages/crud-server-generator/src/server/buildTemplateContext.js
@@ -8,7 +8,9 @@ import {
   resolveKnexConnectionFromEnvironment,
   toKnexClientId
 } from "@jskit-ai/database-runtime/shared";
+import { resolveCrudSurfacePolicyFromAppConfig } from "@jskit-ai/crud-core/server/crudModuleConfig";
 import { checkCrudLookupFormControl } from "@jskit-ai/crud-core/shared/crudFieldMetaSupport";
+import { loadAppConfigFromModuleUrl, resolveRequiredAppRoot } from "@jskit-ai/kernel/server/support";
 import { normalizeCrudLookupNamespace } from "@jskit-ai/kernel/shared/support/crudLookup";
 import { toCamelCase, toSnakeCase } from "@jskit-ai/kernel/shared/support/stringCase";
 
@@ -22,6 +24,7 @@ const OWNERSHIP_FILTER_VALUES = new Set([
   "workspace_user"
 ]);
 const MYSQL_CLIENT_ID = "mysql2";
+const CRUD_PERMISSION_OPERATIONS = Object.freeze(["list", "view", "create", "update", "delete"]);
 
 function resolveGlobalScaffoldCache() {
   const globalObject = globalThis;
@@ -193,6 +196,40 @@ async function importModuleFromApp(appRequire, moduleId, contextLabel) {
       `${contextLabel} failed loading "${moduleId}": ${String(error?.message || error || "unknown error")}`
     );
   }
+}
+
+async function resolveCrudPermissionGenerationConfig({
+  appRoot,
+  options
+} = {}) {
+  const namespace = normalizeText(options?.namespace);
+  const surface = normalizeText(options?.surface);
+  if (!namespace) {
+    throw new Error('crud template context requires option "namespace".');
+  }
+  if (!surface) {
+    throw new Error('crud template context requires option "surface".');
+  }
+
+  const resolvedAppRoot = resolveRequiredAppRoot(appRoot, {
+    context: "crud template context"
+  });
+  const appConfig = await loadAppConfigFromModuleUrl({
+    moduleUrl: pathToFileURL(path.join(resolvedAppRoot, "config", "public.js")).href
+  });
+  const crudPolicy = resolveCrudSurfacePolicyFromAppConfig(
+    {
+      namespace,
+      surface,
+      ownershipFilter: options?.["ownership-filter"]
+    },
+    appConfig,
+    {
+      context: "crud template context"
+    }
+  );
+
+  return crudPolicy?.surfaceDefinition?.requiresWorkspace === true;
 }
 
 function resolveKnexFactory(moduleNamespace) {
@@ -1231,9 +1268,79 @@ function renderRepositoryListConfigLines(snapshot = {}) {
   ].join("\n");
 }
 
+function buildCrudPermissionIds(namespace = "") {
+  const permissionNamespace = toSnakeCase(namespace);
+  if (!permissionNamespace) {
+    return null;
+  }
+
+  return Object.freeze(
+    Object.fromEntries(
+      CRUD_PERMISSION_OPERATIONS.map((operation) => [operation, `crud.${permissionNamespace}.${operation}`])
+    )
+  );
+}
+
+function renderRoleCatalogPermissionGrants(namespace = "", { requiresNamedPermissions = true } = {}) {
+  const permissionIds = buildCrudPermissionIds(namespace);
+  if (!requiresNamedPermissions || !permissionIds) {
+    return "";
+  }
+
+  return [
+    "roleCatalog.roles.member.permissions.push(",
+    `  ${JSON.stringify(permissionIds.list)},`,
+    `  ${JSON.stringify(permissionIds.view)},`,
+    `  ${JSON.stringify(permissionIds.create)},`,
+    `  ${JSON.stringify(permissionIds.update)},`,
+    `  ${JSON.stringify(permissionIds.delete)}`,
+    ");"
+  ].join("\n");
+}
+
+function renderActionPermissionSupport(namespace = "", { requiresNamedPermissions = true } = {}) {
+  if (!requiresNamedPermissions) {
+    return [
+      "const authenticatedPermission = Object.freeze({",
+      '  require: "authenticated"',
+      "});"
+    ].join("\n");
+  }
+
+  const permissionIds = buildCrudPermissionIds(namespace);
+  if (!permissionIds) {
+    return "";
+  }
+
+  return [
+    "const actionPermissions = Object.freeze({",
+    `  list: ${JSON.stringify(permissionIds.list)},`,
+    `  view: ${JSON.stringify(permissionIds.view)},`,
+    `  create: ${JSON.stringify(permissionIds.create)},`,
+    `  update: ${JSON.stringify(permissionIds.update)},`,
+    `  delete: ${JSON.stringify(permissionIds.delete)}`,
+    "});"
+  ].join("\n");
+}
+
+function renderActionPermissionExpression(operation = "", { requiresNamedPermissions = true } = {}) {
+  const normalizedOperation = normalizeText(operation).toLowerCase();
+  if (!CRUD_PERMISSION_OPERATIONS.includes(normalizedOperation)) {
+    throw new Error(`Unknown CRUD permission operation "${normalizedOperation || String(operation || "")}".`);
+  }
+
+  if (!requiresNamedPermissions) {
+    return "authenticatedPermission";
+  }
+
+  return `{ require: "all", permissions: [actionPermissions.${normalizedOperation}] }`;
+}
+
 function buildReplacementsFromSnapshot({
+  namespace = "",
   snapshot,
-  resolvedOwnershipFilter
+  resolvedOwnershipFilter,
+  requiresNamedPermissions = true
 }) {
   const scaffoldColumns = resolveScaffoldColumns(snapshot);
   const outputColumns = scaffoldColumns.filter((column) => !column.isOwnerColumn);
@@ -1276,6 +1383,27 @@ function buildReplacementsFromSnapshot({
     __JSKIT_CRUD_TABLE_NAME__: JSON.stringify(snapshot.tableName),
     __JSKIT_CRUD_ID_COLUMN__: JSON.stringify(snapshot.idColumn || DEFAULT_ID_COLUMN),
     __JSKIT_CRUD_RESOLVED_OWNERSHIP_FILTER__: resolvedOwnershipFilter,
+    __JSKIT_CRUD_ACTION_PERMISSION_SUPPORT__: renderActionPermissionSupport(namespace, {
+      requiresNamedPermissions
+    }),
+    __JSKIT_CRUD_LIST_ACTION_PERMISSION__: renderActionPermissionExpression("list", {
+      requiresNamedPermissions
+    }),
+    __JSKIT_CRUD_VIEW_ACTION_PERMISSION__: renderActionPermissionExpression("view", {
+      requiresNamedPermissions
+    }),
+    __JSKIT_CRUD_CREATE_ACTION_PERMISSION__: renderActionPermissionExpression("create", {
+      requiresNamedPermissions
+    }),
+    __JSKIT_CRUD_UPDATE_ACTION_PERMISSION__: renderActionPermissionExpression("update", {
+      requiresNamedPermissions
+    }),
+    __JSKIT_CRUD_DELETE_ACTION_PERMISSION__: renderActionPermissionExpression("delete", {
+      requiresNamedPermissions
+    }),
+    __JSKIT_CRUD_ROLE_CATALOG_PERMISSION_GRANTS__: renderRoleCatalogPermissionGrants(namespace, {
+      requiresNamedPermissions
+    }),
     __JSKIT_CRUD_RESOURCE_VALIDATORS_IMPORT__: renderResourceValidatorsImport({
       needsHtmlTimeSchemas,
       needsRecordIdSchemas
@@ -1339,6 +1467,7 @@ function createCacheKey({ appRoot, options }) {
     appRoot: path.resolve(String(appRoot || "")),
     options: {
       namespace: normalizeText(options?.namespace),
+      surface: normalizeText(options?.surface),
       ownershipFilter: normalizeText(options?.["ownership-filter"]),
       tableName: normalizeText(options?.["table-name"]),
       idColumn: normalizeText(options?.["id-column"])
@@ -1373,10 +1502,16 @@ async function buildCrudTemplateContext(input = {}) {
       enforceTableColumns: true
     }
   );
+  const requiresNamedPermissions = await resolveCrudPermissionGenerationConfig({
+    appRoot,
+    options
+  });
 
   return buildReplacementsFromSnapshot({
+    namespace,
     snapshot,
-    resolvedOwnershipFilter
+    resolvedOwnershipFilter,
+    requiresNamedPermissions
   });
 }
 
@@ -1409,7 +1544,12 @@ const __testables = Object.freeze({
   renderInputNormalizer,
   renderOutputNormalizerExpression,
   resolveGenerationSnapshot,
-  buildFieldMetaEntries
+  buildFieldMetaEntries,
+  resolveCrudPermissionGenerationConfig,
+  buildCrudPermissionIds,
+  renderRoleCatalogPermissionGrants,
+  renderActionPermissionSupport,
+  renderActionPermissionExpression
 });
 
 export {

--- a/packages/crud-server-generator/templates/src/local-package/server/actions.js
+++ b/packages/crud-server-generator/templates/src/local-package/server/actions.js
@@ -14,13 +14,7 @@ import { LIST_CONFIG } from "./listConfig.js";
 
 const listCursorPaginationQueryValidator = createCrudCursorPaginationQueryValidator(LIST_CONFIG);
 const listParentFilterQueryValidator = createCrudParentFilterQueryValidator(resource);
-const actionPermissions = Object.freeze({
-  list: "crud.${option:namespace|snake}.list",
-  view: "crud.${option:namespace|snake}.view",
-  create: "crud.${option:namespace|snake}.create",
-  update: "crud.${option:namespace|snake}.update",
-  delete: "crud.${option:namespace|snake}.delete"
-});
+__JSKIT_CRUD_ACTION_PERMISSION_SUPPORT__
 
 function requireActionSurface(surface = "") {
   const normalizedSurface = String(surface || "").trim().toLowerCase();
@@ -41,10 +35,7 @@ function createActions({ surface = "" } = {}) {
       kind: "query",
       channels: ["api", "automation", "internal"],
       surfaces: [actionSurface],
-      permission: {
-        require: "all",
-        permissions: [actionPermissions.list]
-      },
+      permission: __JSKIT_CRUD_LIST_ACTION_PERMISSION__,
       inputValidator: [
         workspaceSlugParamsValidator,
         listCursorPaginationQueryValidator,
@@ -71,10 +62,7 @@ function createActions({ surface = "" } = {}) {
       kind: "query",
       channels: ["api", "automation", "internal"],
       surfaces: [actionSurface],
-      permission: {
-        require: "all",
-        permissions: [actionPermissions.view]
-      },
+      permission: __JSKIT_CRUD_VIEW_ACTION_PERMISSION__,
       inputValidator: [workspaceSlugParamsValidator, recordIdParamsValidator, lookupIncludeQueryValidator],
       outputValidator: resource.operations.view.outputValidator,
       idempotency: "none",
@@ -96,10 +84,7 @@ function createActions({ surface = "" } = {}) {
       kind: "command",
       channels: ["api", "automation", "internal"],
       surfaces: [actionSurface],
-      permission: {
-        require: "all",
-        permissions: [actionPermissions.create]
-      },
+      permission: __JSKIT_CRUD_CREATE_ACTION_PERMISSION__,
       inputValidator: [
         workspaceSlugParamsValidator,
         {
@@ -125,10 +110,7 @@ function createActions({ surface = "" } = {}) {
       kind: "command",
       channels: ["api", "automation", "internal"],
       surfaces: [actionSurface],
-      permission: {
-        require: "all",
-        permissions: [actionPermissions.update]
-      },
+      permission: __JSKIT_CRUD_UPDATE_ACTION_PERMISSION__,
       inputValidator: [
         workspaceSlugParamsValidator,
         recordIdParamsValidator,
@@ -155,10 +137,7 @@ function createActions({ surface = "" } = {}) {
       kind: "command",
       channels: ["api", "automation", "internal"],
       surfaces: [actionSurface],
-      permission: {
-        require: "all",
-        permissions: [actionPermissions.delete]
-      },
+      permission: __JSKIT_CRUD_DELETE_ACTION_PERMISSION__,
       inputValidator: [workspaceSlugParamsValidator, recordIdParamsValidator],
       outputValidator: resource.operations.delete.outputValidator,
       idempotency: "optional",

--- a/packages/crud-server-generator/test-support/templateServerFixture.js
+++ b/packages/crud-server-generator/test-support/templateServerFixture.js
@@ -20,6 +20,23 @@ const TEMPLATE_REPLACEMENTS = Object.freeze([
   ["${option:namespace|pascal}", CRUD_NAMESPACE.pascal],
   ["__JSKIT_CRUD_ID_COLUMN__", JSON.stringify("id")],
   [
+    "__JSKIT_CRUD_ACTION_PERMISSION_SUPPORT__",
+    [
+      "const actionPermissions = Object.freeze({",
+      '  list: "crud.customers.list",',
+      '  view: "crud.customers.view",',
+      '  create: "crud.customers.create",',
+      '  update: "crud.customers.update",',
+      '  delete: "crud.customers.delete"',
+      "});"
+    ].join("\n")
+  ],
+  ["__JSKIT_CRUD_LIST_ACTION_PERMISSION__", '{ require: "all", permissions: [actionPermissions.list] }'],
+  ["__JSKIT_CRUD_VIEW_ACTION_PERMISSION__", '{ require: "all", permissions: [actionPermissions.view] }'],
+  ["__JSKIT_CRUD_CREATE_ACTION_PERMISSION__", '{ require: "all", permissions: [actionPermissions.create] }'],
+  ["__JSKIT_CRUD_UPDATE_ACTION_PERMISSION__", '{ require: "all", permissions: [actionPermissions.update] }'],
+  ["__JSKIT_CRUD_DELETE_ACTION_PERMISSION__", '{ require: "all", permissions: [actionPermissions.delete] }'],
+  [
     "__JSKIT_CRUD_LIST_CONFIG_LINES__",
     [
       "  // defaultLimit: 20,",

--- a/packages/crud-server-generator/test/buildTemplateContext.test.js
+++ b/packages/crud-server-generator/test/buildTemplateContext.test.js
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
-import { readFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
@@ -152,6 +153,22 @@ function createSnapshot({
   });
 }
 
+async function withTempApp(run, publicConfigSource) {
+  const appRoot = await mkdtemp(path.join(tmpdir(), "crud-server-generator-"));
+  try {
+    await mkdir(path.join(appRoot, "config"), { recursive: true });
+    await writeFile(
+      path.join(appRoot, "package.json"),
+      `${JSON.stringify({ name: "crud-server-generator-test-app", private: true, type: "module" }, null, 2)}\n`,
+      "utf8"
+    );
+    await writeFile(path.join(appRoot, "config", "public.js"), publicConfigSource, "utf8");
+    return await run(appRoot);
+  } finally {
+    await rm(appRoot, { recursive: true, force: true });
+  }
+}
+
 test("resolveOwnershipFilterForGeneration infers ownership filter for table introspection mode", () => {
   const snapshotBoth = createSnapshot({
     hasWorkspaceIdColumn: true,
@@ -241,6 +258,26 @@ test("buildReplacementsFromSnapshot builds deterministic template replacement pa
   assert.equal(replacements.__JSKIT_CRUD_TABLE_NAME__, "\"contacts\"");
   assert.equal(replacements.__JSKIT_CRUD_ID_COLUMN__, "\"id\"");
   assert.equal(replacements.__JSKIT_CRUD_RESOLVED_OWNERSHIP_FILTER__, "workspace_user");
+  assert.match(
+    replacements.__JSKIT_CRUD_ACTION_PERMISSION_SUPPORT__,
+    /const actionPermissions = Object\.freeze\(\{/
+  );
+  assert.match(
+    replacements.__JSKIT_CRUD_ACTION_PERMISSION_SUPPORT__,
+    /"crud\.contacts\.delete"/
+  );
+  assert.equal(
+    replacements.__JSKIT_CRUD_LIST_ACTION_PERMISSION__,
+    '{ require: "all", permissions: [actionPermissions.list] }'
+  );
+  assert.match(
+    replacements.__JSKIT_CRUD_ROLE_CATALOG_PERMISSION_GRANTS__,
+    /roleCatalog\.roles\.member\.permissions\.push\(/
+  );
+  assert.match(
+    replacements.__JSKIT_CRUD_ROLE_CATALOG_PERMISSION_GRANTS__,
+    /"crud\.contacts\.delete"/
+  );
   assert.match(replacements.__JSKIT_CRUD_MIGRATION_COLUMN_LINES__, /table\.bigIncrements\("id"\)/);
   assert.match(replacements.__JSKIT_CRUD_MIGRATION_COLUMN_LINES__, /table\.string\("first_name", 160\)/);
   assert.equal(replacements.__JSKIT_CRUD_RESOURCE_FIELD_META_PUSH_LINES__, "");
@@ -280,6 +317,63 @@ test("buildReplacementsFromSnapshot builds deterministic template replacement pa
   );
   assert.equal(replacements.__JSKIT_CRUD_RESOURCE_CREATE_REQUIRED_FIELDS__, "[\"firstName\"]");
   assert.equal(replacements.__JSKIT_CRUD_MIGRATION_FOREIGN_KEY_LINES__, "");
+});
+
+test("buildReplacementsFromSnapshot omits named permissions and role grants when disabled", () => {
+  const replacements = __testables.buildReplacementsFromSnapshot({
+    namespace: "contacts",
+    snapshot: createSnapshot({
+      hasWorkspaceIdColumn: false,
+      hasUserIdColumn: false
+    }),
+    resolvedOwnershipFilter: "public",
+    requiresNamedPermissions: false
+  });
+
+  assert.match(
+    replacements.__JSKIT_CRUD_ACTION_PERMISSION_SUPPORT__,
+    /const authenticatedPermission = Object\.freeze\(\{/
+  );
+  assert.equal(replacements.__JSKIT_CRUD_LIST_ACTION_PERMISSION__, "authenticatedPermission");
+  assert.equal(replacements.__JSKIT_CRUD_DELETE_ACTION_PERMISSION__, "authenticatedPermission");
+  assert.equal(replacements.__JSKIT_CRUD_ROLE_CATALOG_PERMISSION_GRANTS__, "");
+});
+
+test("resolveCrudPermissionGenerationConfig follows surface workspace requirements from app config", async () => {
+  await withTempApp(
+    async (appRoot) => {
+      assert.equal(
+        await __testables.resolveCrudPermissionGenerationConfig({
+          appRoot,
+          options: {
+            namespace: "contacts",
+            surface: "home",
+            "ownership-filter": "auto"
+          }
+        }),
+        false
+      );
+
+      assert.equal(
+        await __testables.resolveCrudPermissionGenerationConfig({
+          appRoot,
+          options: {
+            namespace: "contacts",
+            surface: "admin",
+            "ownership-filter": "auto"
+          }
+        }),
+        true
+      );
+    },
+    `export const config = {
+  surfaceDefinitions: {
+    home: { id: "home", enabled: true, requiresAuth: true, requiresWorkspace: false },
+    admin: { id: "admin", enabled: true, requiresAuth: true, requiresWorkspace: true }
+  }
+};
+`
+  );
 });
 
 test("buildReplacementsFromSnapshot omits default list ordering when created_at is absent", () => {
@@ -336,6 +430,7 @@ test("buildReplacementsFromSnapshot renders append-only field meta entries from 
   };
 
   const replacements = __testables.buildReplacementsFromSnapshot({
+    namespace: "contacts",
     snapshot,
     resolvedOwnershipFilter: "workspace_user"
   });
@@ -380,6 +475,7 @@ test("buildReplacementsFromSnapshot renders enum field meta options as select co
   };
 
   const replacements = __testables.buildReplacementsFromSnapshot({
+    namespace: "contacts",
     snapshot,
     resolvedOwnershipFilter: "public"
   });
@@ -493,6 +589,7 @@ test("buildReplacementsFromSnapshot preserves custom collations, hash unique ind
     hasUserIdColumn: false
   });
   const replacements = __testables.buildReplacementsFromSnapshot({
+    namespace: "services",
     snapshot: {
       ...snapshot,
       columns: Object.freeze([
@@ -668,6 +765,10 @@ test("crud actions and routes templates share LIST_CONFIG for cursor validation"
   assert.match(actionsTemplateSource, /createCrudCursorPaginationQueryValidator/);
   assert.match(actionsTemplateSource, /import \{ LIST_CONFIG \} from "\.\/listConfig\.js";/);
   assert.match(actionsTemplateSource, /const listCursorPaginationQueryValidator = createCrudCursorPaginationQueryValidator\(LIST_CONFIG\);/);
+  assert.match(actionsTemplateSource, /__JSKIT_CRUD_ACTION_PERMISSION_SUPPORT__/);
+  assert.match(actionsTemplateSource, /__JSKIT_CRUD_LIST_ACTION_PERMISSION__/);
+  assert.doesNotMatch(actionsTemplateSource, /ACTIONS_REQUIRE_NAMED_PERMISSIONS/);
+  assert.doesNotMatch(actionsTemplateSource, /createActionPermission/);
   assert.match(registerRoutesTemplateSource, /createCrudCursorPaginationQueryValidator/);
   assert.match(registerRoutesTemplateSource, /import \{ LIST_CONFIG \} from "\.\/listConfig\.js";/);
   assert.match(registerRoutesTemplateSource, /const listCursorPaginationQueryValidator = createCrudCursorPaginationQueryValidator\(LIST_CONFIG\);/);
@@ -738,6 +839,7 @@ test("buildReplacementsFromSnapshot uses shared framework time schemas in genera
     enumValues: Object.freeze([])
   });
   const replacements = __testables.buildReplacementsFromSnapshot({
+    namespace: "opening-hours",
     snapshot: {
       ...snapshot,
       columns: Object.freeze([...snapshot.columns, timeColumn])

--- a/packages/crud-server-generator/test/crudServerGuards.test.js
+++ b/packages/crud-server-generator/test/crudServerGuards.test.js
@@ -1,7 +1,6 @@
 import test, { after } from "node:test";
 import assert from "node:assert/strict";
 import { createTemplateServerFixture } from "../test-support/templateServerFixture.js";
-import descriptor from "../package.descriptor.mjs";
 
 const fixture = await createTemplateServerFixture();
 const { createActions } = await fixture.importServerModule("actions.js");
@@ -66,25 +65,6 @@ test("template createActions requires namespaced CRUD permissions by default", (
       { require: "all", permissions: ["crud.customers.create"] },
       { require: "all", permissions: ["crud.customers.update"] },
       { require: "all", permissions: ["crud.customers.delete"] }
-    ]
-  );
-});
-
-test("crud generator appends member role grants for generated CRUD permissions", () => {
-  assert.deepEqual(
-    descriptor.mutations.text,
-    [
-      {
-        op: "append-text",
-        file: "config/roles.js",
-        position: "bottom",
-        skipIfContains: "\"crud.${option:namespace|snake}.list\"",
-        value:
-          "\nroleCatalog.roles.member.permissions.push(\n  \"crud.${option:namespace|snake}.list\",\n  \"crud.${option:namespace|snake}.view\",\n  \"crud.${option:namespace|snake}.create\",\n  \"crud.${option:namespace|snake}.update\",\n  \"crud.${option:namespace|snake}.delete\"\n);\n",
-        reason: "Grant generated CRUD action permissions to the default member role in the app-owned role catalog.",
-        category: "crud",
-        id: "crud-role-catalog-permissions-${option:namespace|snake}"
-      }
     ]
   );
 });

--- a/packages/crud-server-generator/test/packageDescriptor.test.js
+++ b/packages/crud-server-generator/test/packageDescriptor.test.js
@@ -24,3 +24,22 @@ test("crud-server-generator installs listConfig alongside server templates", () 
     export: "buildTemplateContext"
   });
 });
+
+test("crud-server-generator wires action and role mutations through template context", () => {
+  const files = descriptor.mutations?.files || [];
+  const actionsTemplate = files.find((entry) => entry.from === "templates/src/local-package/server/actions.js");
+  const roleGrantMutation = (descriptor.mutations?.text || []).find((entry) => entry.file === "config/roles.js");
+
+  assert.ok(actionsTemplate);
+  assert.deepEqual(actionsTemplate.templateContext, {
+    entrypoint: "src/server/buildTemplateContext.js",
+    export: "buildTemplateContext"
+  });
+
+  assert.ok(roleGrantMutation);
+  assert.equal(roleGrantMutation.value, "__JSKIT_CRUD_ROLE_CATALOG_PERMISSION_GRANTS__");
+  assert.deepEqual(roleGrantMutation.templateContext, {
+    entrypoint: "src/server/buildTemplateContext.js",
+    export: "buildTemplateContext"
+  });
+});

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -1376,7 +1376,11 @@
               "to": "packages/${option:namespace|kebab}/src/server/actions.js",
               "reason": "Install app-local CRUD action definitions.",
               "category": "crud",
-              "id": "crud-local-package-server-actions-${option:namespace|snake}"
+              "id": "crud-local-package-server-actions-${option:namespace|snake}",
+              "templateContext": {
+                "entrypoint": "src/server/buildTemplateContext.js",
+                "export": "buildTemplateContext"
+              }
             },
             {
               "from": "templates/src/local-package/server/actionIds.js",
@@ -1446,10 +1450,14 @@
               "file": "config/roles.js",
               "position": "bottom",
               "skipIfContains": "\"crud.${option:namespace|snake}.list\"",
-              "value": "\nroleCatalog.roles.member.permissions.push(\n  \"crud.${option:namespace|snake}.list\",\n  \"crud.${option:namespace|snake}.view\",\n  \"crud.${option:namespace|snake}.create\",\n  \"crud.${option:namespace|snake}.update\",\n  \"crud.${option:namespace|snake}.delete\"\n);\n",
+              "value": "__JSKIT_CRUD_ROLE_CATALOG_PERMISSION_GRANTS__",
               "reason": "Grant generated CRUD action permissions to the default member role in the app-owned role catalog.",
               "category": "crud",
-              "id": "crud-role-catalog-permissions-${option:namespace|snake}"
+              "id": "crud-role-catalog-permissions-${option:namespace|snake}",
+              "templateContext": {
+                "entrypoint": "src/server/buildTemplateContext.js",
+                "export": "buildTemplateContext"
+              }
             }
           ]
         }


### PR DESCRIPTION
## Summary
- route CRUD action template permissions through template context instead of hard-coded strings
- generate named CRUD permissions only for workspace-required surfaces and fall back to authenticated access otherwise
- cover the new permission-generation behavior in descriptor and template-context tests

## Verification
- npm run verify