### PR TITLE
Add home shell link and shared tools menu widget

### DIFF
--- a/agent-index/packages/shell-web.md
+++ b/agent-index/packages/shell-web.md
@@ -33,6 +33,10 @@ Exports
 Exports
 - None
 
+### `src/client/components/ShellOutletMenuWidget.vue`
+Exports
+- None
+
 ### `src/client/composables/useShellLayoutState.js`
 Exports
 - `useShellLayoutState(props = {})`
@@ -98,6 +102,7 @@ Exports
 - `ShellWebClientProvider`
 - `ShellLayout`
 - `ShellOutlet`
+- `ShellOutletMenuWidget`
 - `ShellErrorHost`
 - `useShellLayoutState`
 - `clientProviders`

--- a/agent-index/packages/users-web.md
+++ b/agent-index/packages/users-web.md
@@ -41,6 +41,10 @@ Local functions
 - `onAvatarReplace()`
 - `onAvatarRemove()`
 
+### `src/client/components/UsersHomeToolsWidget.vue`
+Exports
+- None
+
 ### `src/client/components/UsersProfileSurfaceSwitchMenuItem.vue`
 Exports
 - None

--- a/packages/shell-web/package.descriptor.mjs
+++ b/packages/shell-web/package.descriptor.mjs
@@ -30,7 +30,7 @@ export default Object.freeze({
       surfaces: [
         {
           subpath: "./client",
-          summary: "Exports shell layout/outlet/error-host components and ShellWebClientProvider."
+          summary: "Exports shell layout/outlet/outlet-menu/error-host components and ShellWebClientProvider."
         },
         {
           subpath: "./client/placement",
@@ -92,6 +92,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
+        "@mdi/js": "^7.4.47",
         "@tanstack/vue-query": "^5.90.5",
         "@jskit-ai/kernel": "0.1.33",
         "vuetify": "^4.0.0"

--- a/packages/shell-web/package.json
+++ b/packages/shell-web/package.json
@@ -12,11 +12,13 @@
     "./client/navigation/linkResolver": "./src/client/navigation/linkResolver.js",
     "./client/components/ShellLayout": "./src/client/components/ShellLayout.vue",
     "./client/components/ShellOutlet": "./src/client/components/ShellOutlet.vue",
+    "./client/components/ShellOutletMenuWidget": "./src/client/components/ShellOutletMenuWidget.vue",
     "./client/components/ShellErrorHost": "./src/client/components/ShellErrorHost.vue",
     "./client/composables/useShellLayoutState": "./src/client/composables/useShellLayoutState.js",
     "./client/providers/ShellWebClientProvider": "./src/client/providers/ShellWebClientProvider.js"
   },
   "dependencies": {
+    "@mdi/js": "^7.4.47",
     "@tanstack/vue-query": "^5.90.5",
     "@jskit-ai/kernel": "0.1.33",
     "vuetify": "^4.0.0"

--- a/packages/shell-web/src/client/components/ShellOutletMenuWidget.vue
+++ b/packages/shell-web/src/client/components/ShellOutletMenuWidget.vue
@@ -1,0 +1,54 @@
+<script setup>
+import { mdiCogOutline } from "@mdi/js";
+import ShellOutlet from "./ShellOutlet.vue";
+
+const props = defineProps({
+  host: {
+    type: String,
+    default: ""
+  },
+  position: {
+    type: String,
+    default: "primary-menu"
+  },
+  icon: {
+    type: String,
+    default: mdiCogOutline
+  },
+  ariaLabel: {
+    type: String,
+    default: "Tools"
+  },
+  location: {
+    type: String,
+    default: "bottom end"
+  },
+  offset: {
+    type: [Number, String],
+    default: 10
+  },
+  minWidth: {
+    type: [Number, String],
+    default: 220
+  }
+});
+</script>
+
+<template>
+  <v-menu :location="props.location" :offset="props.offset" eager>
+    <template #activator="{ props: activatorProps }">
+      <v-btn
+        v-bind="activatorProps"
+        icon
+        variant="text"
+        :aria-label="props.ariaLabel"
+      >
+        <v-icon :icon="props.icon" />
+      </v-btn>
+    </template>
+
+    <v-list :min-width="props.minWidth" density="comfortable" class="py-1">
+      <ShellOutlet :host="props.host" :position="props.position" />
+    </v-list>
+  </v-menu>
+</template>

--- a/packages/shell-web/src/client/index.js
+++ b/packages/shell-web/src/client/index.js
@@ -8,6 +8,7 @@ export {
 
 export { default as ShellLayout } from "./components/ShellLayout.vue";
 export { default as ShellOutlet } from "./components/ShellOutlet.vue";
+export { default as ShellOutletMenuWidget } from "./components/ShellOutletMenuWidget.vue";
 export { default as ShellErrorHost } from "./components/ShellErrorHost.vue";
 export { useShellLayoutState } from "./composables/useShellLayoutState.js";
 

--- a/packages/shell-web/test/outletMenuWidgetContract.test.js
+++ b/packages/shell-web/test/outletMenuWidgetContract.test.js
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import test from "node:test";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+const TEST_DIRECTORY = path.dirname(fileURLToPath(import.meta.url));
+const PACKAGE_DIR = path.resolve(TEST_DIRECTORY, "..");
+
+test("shell-web outlet menu widget exposes a configurable nested outlet", async () => {
+  const source = await readFile(
+    path.join(PACKAGE_DIR, "src", "client", "components", "ShellOutletMenuWidget.vue"),
+    "utf8"
+  );
+
+  assert.match(source, /import \{ mdiCogOutline \} from "@mdi\/js";/);
+  assert.match(source, /<ShellOutlet :host="props\.host" :position="props\.position" \/>/);
+  assert.match(source, /default: mdiCogOutline/);
+  assert.doesNotMatch(source, /mdi-[a-z0-9-]+/);
+});
+
+test("shell-web exports the outlet menu widget from both client index and package exports", async () => {
+  const clientIndexSource = await readFile(path.join(PACKAGE_DIR, "src", "client", "index.js"), "utf8");
+  assert.match(clientIndexSource, /export \{ default as ShellOutletMenuWidget \} from "\.\/components\/ShellOutletMenuWidget\.vue";/);
+
+  const packageJson = JSON.parse(await readFile(path.join(PACKAGE_DIR, "package.json"), "utf8"));
+  assert.equal(
+    packageJson?.exports?.["./client/components/ShellOutletMenuWidget"],
+    "./src/client/components/ShellOutletMenuWidget.vue"
+  );
+});

--- a/packages/users-web/package.descriptor.mjs
+++ b/packages/users-web/package.descriptor.mjs
@@ -98,6 +98,7 @@ export default Object.freeze({
           "users.web.shell.menu-link-item",
           "users.web.shell.surface-aware-menu-link-item",
           "users.web.profile.menu.surface-switch-item",
+          "users.web.home.tools.widget",
           "users.web.profile.element",
           "users.web.bootstrap-placement.runtime"
         ]
@@ -106,6 +107,12 @@ export default Object.freeze({
     ui: {
       placements: {
         outlets: [
+          {
+            host: "home-tools",
+            position: "primary-menu",
+            surfaces: ["home"],
+            source: "src/client/components/UsersHomeToolsWidget.vue"
+          },
           {
             host: "console-settings",
             position: "primary-menu",
@@ -135,6 +142,16 @@ export default Object.freeze({
             source: "mutations.text#users-web-profile-settings-placement"
           },
           {
+            id: "users.home.menu.home",
+            host: "shell-layout",
+            position: "primary-menu",
+            surfaces: ["*"],
+            order: 50,
+            componentToken: "users.web.shell.surface-aware-menu-link-item",
+            when: "auth.authenticated === true",
+            source: "mutations.text#users-web-home-shell-menu-placement"
+          },
+          {
             id: "users.console.menu.settings",
             host: "shell-layout",
             position: "primary-menu",
@@ -143,6 +160,36 @@ export default Object.freeze({
             componentToken: "users.web.shell.menu-link-item",
             when: "auth.authenticated === true",
             source: "mutations.text#users-web-console-settings-placement"
+          },
+          {
+            id: "users.home.tools.widget",
+            host: "shell-layout",
+            position: "top-right",
+            surfaces: ["home"],
+            order: 900,
+            componentToken: "users.web.home.tools.widget",
+            when: "auth.authenticated === true",
+            source: "mutations.text#users-web-home-tools-placement"
+          },
+          {
+            id: "users.home.menu.settings",
+            host: "home-tools",
+            position: "primary-menu",
+            surfaces: ["home"],
+            order: 100,
+            componentToken: "users.web.shell.surface-aware-menu-link-item",
+            when: "auth.authenticated === true",
+            source: "mutations.text#users-web-home-tools-placement"
+          },
+          {
+            id: "users.home.settings.general",
+            host: "home-settings",
+            position: "primary-menu",
+            surfaces: ["home"],
+            order: 100,
+            componentToken: "users.web.shell.surface-aware-menu-link-item",
+            when: "auth.authenticated === true",
+            source: "mutations.text#users-web-home-settings-general-placement"
           }
         ]
       }
@@ -269,12 +316,45 @@ export default Object.freeze({
         op: "append-text",
         file: "src/placement.js",
         position: "bottom",
+        skipIfContains: "id: \"users.home.menu.home\"",
+        value:
+          "\naddPlacement({\n  id: \"users.home.menu.home\",\n  host: \"shell-layout\",\n  position: \"primary-menu\",\n  surfaces: [\"*\"],\n  order: 50,\n  componentToken: \"users.web.shell.surface-aware-menu-link-item\",\n  props: {\n    label: \"Home\",\n    surface: \"home\",\n    workspaceSuffix: \"/\",\n    nonWorkspaceSuffix: \"/\"\n  },\n  when: ({ auth }) => Boolean(auth?.authenticated)\n});\n",
+        reason: "Append users-web home shell menu placement into app-owned placement registry.",
+        category: "users-web",
+        id: "users-web-home-shell-menu-placement"
+      },
+      {
+        op: "append-text",
+        file: "src/placement.js",
+        position: "bottom",
         skipIfContains: "id: \"users.console.menu.settings\"",
         value:
           "\naddPlacement({\n  id: \"users.console.menu.settings\",\n  host: \"shell-layout\",\n  position: \"primary-menu\",\n  surfaces: [\"console\"],\n  order: 100,\n  componentToken: \"users.web.shell.menu-link-item\",\n  props: {\n    label: \"Settings\",\n    to: \"/console/settings\",\n    icon: \"mdi-cog-outline\"\n  },\n  when: ({ auth }) => Boolean(auth?.authenticated)\n});\n",
         reason: "Append users-web console settings menu placement into app-owned placement registry.",
         category: "users-web",
         id: "users-web-console-settings-placement"
+      },
+      {
+        op: "append-text",
+        file: "src/placement.js",
+        position: "bottom",
+        skipIfContains: "id: \"users.home.tools.widget\"",
+        value:
+          "\naddPlacement({\n  id: \"users.home.tools.widget\",\n  host: \"shell-layout\",\n  position: \"top-right\",\n  surfaces: [\"home\"],\n  order: 900,\n  componentToken: \"users.web.home.tools.widget\",\n  when: ({ auth }) => Boolean(auth?.authenticated)\n});\n\naddPlacement({\n  id: \"users.home.menu.settings\",\n  host: \"home-tools\",\n  position: \"primary-menu\",\n  surfaces: [\"home\"],\n  order: 100,\n  componentToken: \"users.web.shell.surface-aware-menu-link-item\",\n  props: {\n    label: \"Settings\",\n    surface: \"home\",\n    workspaceSuffix: \"/settings\",\n    nonWorkspaceSuffix: \"/settings\"\n  },\n  when: ({ auth }) => Boolean(auth?.authenticated)\n});\n",
+        reason: "Append users-web home tools widget and settings menu placements into app-owned placement registry.",
+        category: "users-web",
+        id: "users-web-home-tools-placement"
+      },
+      {
+        op: "append-text",
+        file: "src/placement.js",
+        position: "bottom",
+        skipIfContains: "id: \"users.home.settings.general\"",
+        value:
+          "\naddPlacement({\n  id: \"users.home.settings.general\",\n  host: \"home-settings\",\n  position: \"primary-menu\",\n  surfaces: [\"home\"],\n  order: 100,\n  componentToken: \"users.web.shell.surface-aware-menu-link-item\",\n  props: {\n    label: \"General\",\n    surface: \"home\",\n    workspaceSuffix: \"/settings\",\n    nonWorkspaceSuffix: \"/settings\"\n  },\n  when: ({ auth }) => Boolean(auth?.authenticated)\n});\n",
+        reason: "Append users-web home settings general-page placement into app-owned placement registry.",
+        category: "users-web",
+        id: "users-web-home-settings-general-placement"
       }
     ]
   }

--- a/packages/users-web/src/client/components/UsersHomeToolsWidget.vue
+++ b/packages/users-web/src/client/components/UsersHomeToolsWidget.vue
@@ -4,8 +4,8 @@ import ShellOutletMenuWidget from "@jskit-ai/shell-web/client/components/ShellOu
 
 <template>
   <ShellOutletMenuWidget
-    host="workspace-tools"
+    host="home-tools"
     position="primary-menu"
-    aria-label="Workspace tools"
+    aria-label="Home tools"
   />
 </template>

--- a/packages/users-web/src/client/providers/UsersWebClientProvider.js
+++ b/packages/users-web/src/client/providers/UsersWebClientProvider.js
@@ -1,6 +1,7 @@
 import UsersShellMenuLinkItem from "../components/UsersShellMenuLinkItem.vue";
 import UsersSurfaceAwareMenuLinkItem from "../components/UsersSurfaceAwareMenuLinkItem.vue";
 import UsersProfileSurfaceSwitchMenuItem from "../components/UsersProfileSurfaceSwitchMenuItem.vue";
+import UsersHomeToolsWidget from "../components/UsersHomeToolsWidget.vue";
 import ProfileClientElement from "../components/ProfileClientElement.vue";
 import {
   createBootstrapPlacementRuntime
@@ -18,6 +19,7 @@ class UsersWebClientProvider {
     app.singleton("users.web.shell.menu-link-item", () => UsersShellMenuLinkItem);
     app.singleton("users.web.shell.surface-aware-menu-link-item", () => UsersSurfaceAwareMenuLinkItem);
     app.singleton("users.web.profile.menu.surface-switch-item", () => UsersProfileSurfaceSwitchMenuItem);
+    app.singleton("users.web.home.tools.widget", () => UsersHomeToolsWidget);
     app.singleton("users.web.profile.element", () => ProfileClientElement);
     app.singleton("users.web.bootstrap-placement.runtime", (scope) => createBootstrapPlacementRuntime({ app: scope }));
   }

--- a/packages/users-web/test/settingsPlacementContract.test.js
+++ b/packages/users-web/test/settingsPlacementContract.test.js
@@ -8,11 +8,60 @@ import descriptor from "../package.descriptor.mjs";
 const TEST_DIRECTORY = path.dirname(fileURLToPath(import.meta.url));
 const PACKAGE_DIR = path.resolve(TEST_DIRECTORY, "..");
 
-function readSettingsOutlets() {
+function readOutlets(host = "") {
   const outlets = descriptor?.metadata?.ui?.placements?.outlets;
+  const normalizedHost = String(host || "").trim();
   return Array.isArray(outlets)
-    ? outlets.filter((entry) => String(entry?.host || "").trim() === "console-settings")
+    ? outlets.filter((entry) => String(entry?.host || "").trim() === normalizedHost)
     : [];
+}
+
+function findContribution(id) {
+  const contributions = descriptor?.metadata?.ui?.placements?.contributions;
+  return Array.isArray(contributions)
+    ? contributions.find((entry) => String(entry?.id || "").trim() === id) || null
+    : null;
+}
+
+function findTextMutation(id) {
+  const textMutations = descriptor?.mutations?.text;
+  return Array.isArray(textMutations)
+    ? textMutations.find((entry) => String(entry?.id || "").trim() === id) || null
+    : null;
+}
+
+function expectContribution(id, expected = {}) {
+  const contribution = findContribution(id);
+  assert.ok(contribution, `Expected contribution "${id}".`);
+
+  for (const [key, value] of Object.entries(expected)) {
+    assert.deepEqual(contribution[key], value);
+  }
+}
+
+function expectTextMutation(id, { reason = "", category = "", skipIfContains = "", snippets = [] } = {}) {
+  const mutation = findTextMutation(id);
+  assert.ok(mutation, `Expected text mutation "${id}".`);
+  assert.equal(mutation.op, "append-text");
+  assert.equal(mutation.file, "src/placement.js");
+  assert.equal(mutation.position, "bottom");
+  assert.equal(mutation.id, id);
+
+  if (reason) {
+    assert.equal(mutation.reason, reason);
+  }
+
+  if (category) {
+    assert.equal(mutation.category, category);
+  }
+
+  if (skipIfContains) {
+    assert.equal(mutation.skipIfContains, skipIfContains);
+  }
+
+  for (const snippet of snippets) {
+    assert.ok(mutation.value.includes(snippet), `Expected mutation "${id}" to include "${snippet}".`);
+  }
 }
 
 test("users-web console settings template exposes surface-derived settings outlets", async () => {
@@ -22,7 +71,7 @@ test("users-web console settings template exposes surface-derived settings outle
 });
 
 test("users-web descriptor metadata advertises console settings outlets with standard positions", () => {
-  const outlets = readSettingsOutlets();
+  const outlets = readOutlets("console-settings");
   assert.deepEqual(
     outlets,
     [
@@ -34,4 +83,110 @@ test("users-web descriptor metadata advertises console settings outlets with sta
       }
     ]
   );
+});
+
+test("users-web home tools widget exposes home-tools outlet", async () => {
+  const source = await readFile(path.join(PACKAGE_DIR, "src", "client", "components", "UsersHomeToolsWidget.vue"), "utf8");
+
+  assert.match(source, /<ShellOutletMenuWidget/);
+  assert.match(source, /host="home-tools"/);
+  assert.match(source, /position="primary-menu"/);
+});
+
+test("users-web descriptor metadata advertises home tools outlet and standard home settings placements", () => {
+  assert.deepEqual(
+    readOutlets("home-tools"),
+    [
+      {
+        host: "home-tools",
+        position: "primary-menu",
+        surfaces: ["home"],
+        source: "src/client/components/UsersHomeToolsWidget.vue"
+      }
+    ]
+  );
+
+  expectContribution("users.home.menu.home", {
+    host: "shell-layout",
+    position: "primary-menu",
+    surfaces: ["*"],
+    order: 50,
+    componentToken: "users.web.shell.surface-aware-menu-link-item",
+    when: "auth.authenticated === true",
+    source: "mutations.text#users-web-home-shell-menu-placement"
+  });
+
+  expectContribution("users.home.tools.widget", {
+    host: "shell-layout",
+    position: "top-right",
+    surfaces: ["home"],
+    order: 900,
+    componentToken: "users.web.home.tools.widget",
+    when: "auth.authenticated === true",
+    source: "mutations.text#users-web-home-tools-placement"
+  });
+
+  expectContribution("users.home.menu.settings", {
+    host: "home-tools",
+    position: "primary-menu",
+    surfaces: ["home"],
+    order: 100,
+    componentToken: "users.web.shell.surface-aware-menu-link-item",
+    when: "auth.authenticated === true",
+    source: "mutations.text#users-web-home-tools-placement"
+  });
+
+  expectContribution("users.home.settings.general", {
+    host: "home-settings",
+    position: "primary-menu",
+    surfaces: ["home"],
+    order: 100,
+    componentToken: "users.web.shell.surface-aware-menu-link-item",
+    when: "auth.authenticated === true",
+    source: "mutations.text#users-web-home-settings-general-placement"
+  });
+
+  expectTextMutation("users-web-home-tools-placement", {
+    reason: "Append users-web home tools widget and settings menu placements into app-owned placement registry.",
+    category: "users-web",
+    skipIfContains: 'id: "users.home.tools.widget"',
+    snippets: [
+      'id: "users.home.tools.widget"',
+      'componentToken: "users.web.home.tools.widget"',
+      'id: "users.home.menu.settings"',
+      'host: "home-tools"',
+      'componentToken: "users.web.shell.surface-aware-menu-link-item"',
+      'workspaceSuffix: "/settings"',
+      'nonWorkspaceSuffix: "/settings"'
+    ]
+  });
+
+  expectTextMutation("users-web-home-shell-menu-placement", {
+    reason: "Append users-web home shell menu placement into app-owned placement registry.",
+    category: "users-web",
+    skipIfContains: 'id: "users.home.menu.home"',
+    snippets: [
+      'id: "users.home.menu.home"',
+      'host: "shell-layout"',
+      'componentToken: "users.web.shell.surface-aware-menu-link-item"',
+      'label: "Home"',
+      'surface: "home"',
+      'workspaceSuffix: "/"',
+      'nonWorkspaceSuffix: "/"'
+    ]
+  });
+
+  expectTextMutation("users-web-home-settings-general-placement", {
+    reason: "Append users-web home settings general-page placement into app-owned placement registry.",
+    category: "users-web",
+    skipIfContains: 'id: "users.home.settings.general"',
+    snippets: [
+      'id: "users.home.settings.general"',
+      'host: "home-settings"',
+      'componentToken: "users.web.shell.surface-aware-menu-link-item"',
+      'label: "General"',
+      'workspaceSuffix: "/settings"',
+      'nonWorkspaceSuffix: "/settings"'
+    ]
+  });
 });

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -2554,7 +2554,7 @@
             "surfaces": [
               {
                 "subpath": "./client",
-                "summary": "Exports shell layout/outlet/error-host components and ShellWebClientProvider."
+                "summary": "Exports shell layout/outlet/outlet-menu/error-host components and ShellWebClientProvider."
               },
               {
                 "subpath": "./client/placement",
@@ -2626,6 +2626,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
+              "@mdi/js": "^7.4.47",
               "@tanstack/vue-query": "^5.90.5",
               "@jskit-ai/kernel": "0.1.33",
               "vuetify": "^4.0.0"
@@ -3640,6 +3641,7 @@
                 "users.web.shell.menu-link-item",
                 "users.web.shell.surface-aware-menu-link-item",
                 "users.web.profile.menu.surface-switch-item",
+                "users.web.home.tools.widget",
                 "users.web.profile.element",
                 "users.web.bootstrap-placement.runtime"
               ]
@@ -3648,6 +3650,14 @@
           "ui": {
             "placements": {
               "outlets": [
+                {
+                  "host": "home-tools",
+                  "position": "primary-menu",
+                  "surfaces": [
+                    "home"
+                  ],
+                  "source": "src/client/components/UsersHomeToolsWidget.vue"
+                },
                 {
                   "host": "console-settings",
                   "position": "primary-menu",
@@ -3683,6 +3693,18 @@
                   "source": "mutations.text#users-web-profile-settings-placement"
                 },
                 {
+                  "id": "users.home.menu.home",
+                  "host": "shell-layout",
+                  "position": "primary-menu",
+                  "surfaces": [
+                    "*"
+                  ],
+                  "order": 50,
+                  "componentToken": "users.web.shell.surface-aware-menu-link-item",
+                  "when": "auth.authenticated === true",
+                  "source": "mutations.text#users-web-home-shell-menu-placement"
+                },
+                {
                   "id": "users.console.menu.settings",
                   "host": "shell-layout",
                   "position": "primary-menu",
@@ -3693,6 +3715,42 @@
                   "componentToken": "users.web.shell.menu-link-item",
                   "when": "auth.authenticated === true",
                   "source": "mutations.text#users-web-console-settings-placement"
+                },
+                {
+                  "id": "users.home.tools.widget",
+                  "host": "shell-layout",
+                  "position": "top-right",
+                  "surfaces": [
+                    "home"
+                  ],
+                  "order": 900,
+                  "componentToken": "users.web.home.tools.widget",
+                  "when": "auth.authenticated === true",
+                  "source": "mutations.text#users-web-home-tools-placement"
+                },
+                {
+                  "id": "users.home.menu.settings",
+                  "host": "home-tools",
+                  "position": "primary-menu",
+                  "surfaces": [
+                    "home"
+                  ],
+                  "order": 100,
+                  "componentToken": "users.web.shell.surface-aware-menu-link-item",
+                  "when": "auth.authenticated === true",
+                  "source": "mutations.text#users-web-home-tools-placement"
+                },
+                {
+                  "id": "users.home.settings.general",
+                  "host": "home-settings",
+                  "position": "primary-menu",
+                  "surfaces": [
+                    "home"
+                  ],
+                  "order": 100,
+                  "componentToken": "users.web.shell.surface-aware-menu-link-item",
+                  "when": "auth.authenticated === true",
+                  "source": "mutations.text#users-web-home-settings-general-placement"
                 }
               ]
             }
@@ -3816,11 +3874,41 @@
               "op": "append-text",
               "file": "src/placement.js",
               "position": "bottom",
+              "skipIfContains": "id: \"users.home.menu.home\"",
+              "value": "\naddPlacement({\n  id: \"users.home.menu.home\",\n  host: \"shell-layout\",\n  position: \"primary-menu\",\n  surfaces: [\"*\"],\n  order: 50,\n  componentToken: \"users.web.shell.surface-aware-menu-link-item\",\n  props: {\n    label: \"Home\",\n    surface: \"home\",\n    workspaceSuffix: \"/\",\n    nonWorkspaceSuffix: \"/\"\n  },\n  when: ({ auth }) => Boolean(auth?.authenticated)\n});\n",
+              "reason": "Append users-web home shell menu placement into app-owned placement registry.",
+              "category": "users-web",
+              "id": "users-web-home-shell-menu-placement"
+            },
+            {
+              "op": "append-text",
+              "file": "src/placement.js",
+              "position": "bottom",
               "skipIfContains": "id: \"users.console.menu.settings\"",
               "value": "\naddPlacement({\n  id: \"users.console.menu.settings\",\n  host: \"shell-layout\",\n  position: \"primary-menu\",\n  surfaces: [\"console\"],\n  order: 100,\n  componentToken: \"users.web.shell.menu-link-item\",\n  props: {\n    label: \"Settings\",\n    to: \"/console/settings\",\n    icon: \"mdi-cog-outline\"\n  },\n  when: ({ auth }) => Boolean(auth?.authenticated)\n});\n",
               "reason": "Append users-web console settings menu placement into app-owned placement registry.",
               "category": "users-web",
               "id": "users-web-console-settings-placement"
+            },
+            {
+              "op": "append-text",
+              "file": "src/placement.js",
+              "position": "bottom",
+              "skipIfContains": "id: \"users.home.tools.widget\"",
+              "value": "\naddPlacement({\n  id: \"users.home.tools.widget\",\n  host: \"shell-layout\",\n  position: \"top-right\",\n  surfaces: [\"home\"],\n  order: 900,\n  componentToken: \"users.web.home.tools.widget\",\n  when: ({ auth }) => Boolean(auth?.authenticated)\n});\n\naddPlacement({\n  id: \"users.home.menu.settings\",\n  host: \"home-tools\",\n  position: \"primary-menu\",\n  surfaces: [\"home\"],\n  order: 100,\n  componentToken: \"users.web.shell.surface-aware-menu-link-item\",\n  props: {\n    label: \"Settings\",\n    surface: \"home\",\n    workspaceSuffix: \"/settings\",\n    nonWorkspaceSuffix: \"/settings\"\n  },\n  when: ({ auth }) => Boolean(auth?.authenticated)\n});\n",
+              "reason": "Append users-web home tools widget and settings menu placements into app-owned placement registry.",
+              "category": "users-web",
+              "id": "users-web-home-tools-placement"
+            },
+            {
+              "op": "append-text",
+              "file": "src/placement.js",
+              "position": "bottom",
+              "skipIfContains": "id: \"users.home.settings.general\"",
+              "value": "\naddPlacement({\n  id: \"users.home.settings.general\",\n  host: \"home-settings\",\n  position: \"primary-menu\",\n  surfaces: [\"home\"],\n  order: 100,\n  componentToken: \"users.web.shell.surface-aware-menu-link-item\",\n  props: {\n    label: \"General\",\n    surface: \"home\",\n    workspaceSuffix: \"/settings\",\n    nonWorkspaceSuffix: \"/settings\"\n  },\n  when: ({ auth }) => Boolean(auth?.authenticated)\n});\n",
+              "reason": "Append users-web home settings general-page placement into app-owned placement registry.",
+              "category": "users-web",
+              "id": "users-web-home-settings-general-placement"
             }
           ]
         }


### PR DESCRIPTION
## Summary
- add a reusable shell outlet menu widget and use it for home/workspace tools menus
- switch the shared tools activator icon to a cog-safe mdi svg path
- seed a default authenticated Home shell link through users-web for installed apps

## Verification
- npm run verify
- npm --workspace packages/users-web test