### PR TITLE
Hide ids from default generated CRUD lists

### DIFF
--- a/packages/crud-ui-generator/src/server/buildTemplateContext.js
+++ b/packages/crud-ui-generator/src/server/buildTemplateContext.js
@@ -24,6 +24,7 @@ import {
   buildListRowColumns,
   buildViewColumns,
   buildFormColumns,
+  resolveRecordIdFieldKey,
   renderObjectPushLines,
   resolveRecordChangedEventName,
   resolveRecordIdExpression
@@ -233,14 +234,20 @@ function filterDisplayFields(selectedFieldKeys, fields) {
   });
 }
 
-function filterDefaultHiddenListFields(selectedFieldKeys, fields) {
+function filterDefaultHiddenListFields(selectedFieldKeys, fields, { recordIdFieldKey = "" } = {}) {
   const selectedFields = Array.isArray(selectedFieldKeys) ? selectedFieldKeys : [];
   const availableFields = Array.isArray(fields) ? fields : [];
   if (selectedFields.length > 0) {
     return availableFields;
   }
 
-  return availableFields.filter((field) => !DEFAULT_LIST_HIDDEN_FIELD_KEYS.has(normalizeText(field?.key)));
+  const hiddenFieldKeys = new Set(DEFAULT_LIST_HIDDEN_FIELD_KEYS);
+  const normalizedRecordIdFieldKey = normalizeText(recordIdFieldKey);
+  if (normalizedRecordIdFieldKey) {
+    hiddenFieldKeys.add(normalizedRecordIdFieldKey);
+  }
+
+  return availableFields.filter((field) => !hiddenFieldKeys.has(normalizeText(field?.key)));
 }
 
 function ensureFields(fields, fallbackFields = createFieldDefinitions({})) {
@@ -408,10 +415,16 @@ async function buildUiTemplateContext({ appRoot, options } = {}) {
     validateDisplayFieldsForOperation(selectedDisplayFields, editFieldsAll, "patch");
   }
 
+  const listRecordIdFieldKey = hasListOperation
+    ? resolveRecordIdFieldKey(listFieldsAll)
+    : "";
+
   const listFields = hasListOperation
     ? filterDisplayFields(
       selectedDisplayFields,
-      filterDefaultHiddenListFields(selectedDisplayFields, ensureFields(listFieldsAll))
+      filterDefaultHiddenListFields(selectedDisplayFields, ensureFields(listFieldsAll), {
+        recordIdFieldKey: listRecordIdFieldKey
+      })
     )
     : createFieldDefinitions({});
   const viewFields = hasViewOperation

--- a/packages/crud-ui-generator/src/server/resourceSupport.js
+++ b/packages/crud-ui-generator/src/server/resourceSupport.js
@@ -885,6 +885,20 @@ function buildFormColumns(fields = []) {
     .join("\n");
 }
 
+function resolveRecordIdFieldKey(fields = []) {
+  const normalizedFields = Array.isArray(fields) ? fields : [];
+  const preferred =
+    normalizedFields.find((field) => normalizeText(field?.key).toLowerCase() === "id") ||
+    normalizedFields.find((field) => {
+      const key = normalizeText(field?.key).toLowerCase();
+      return key.endsWith("id") || key.endsWith("_id") || key.endsWith("-id");
+    }) ||
+    normalizedFields[0] ||
+    { key: "id" };
+
+  return normalizeText(preferred?.key) || "id";
+}
+
 function renderObjectPushLines(arrayName, entries = []) {
   const normalizedArrayName = normalizeText(arrayName);
   if (!normalizedArrayName) {
@@ -903,17 +917,7 @@ function renderObjectPushLines(arrayName, entries = []) {
 }
 
 function resolveRecordIdExpression(fields = []) {
-  const normalizedFields = Array.isArray(fields) ? fields : [];
-  const preferred =
-    normalizedFields.find((field) => normalizeText(field?.key).toLowerCase() === "id") ||
-    normalizedFields.find((field) => {
-      const key = normalizeText(field?.key).toLowerCase();
-      return key.endsWith("id") || key.endsWith("_id") || key.endsWith("-id");
-    }) ||
-    normalizedFields[0] ||
-    { key: "id" };
-
-  return toAccessorExpression("item", preferred.key);
+  return toAccessorExpression("item", resolveRecordIdFieldKey(fields));
 }
 
 export {
@@ -936,6 +940,7 @@ export {
   buildListRowColumns,
   buildViewColumns,
   buildFormColumns,
+  resolveRecordIdFieldKey,
   renderObjectPushLines,
   resolveCrudRecordChangedEvent as resolveRecordChangedEventName,
   resolveRecordIdExpression

--- a/packages/crud-ui-generator/test/buildTemplateContext.test.js
+++ b/packages/crud-ui-generator/test/buildTemplateContext.test.js
@@ -255,12 +255,15 @@ test("buildUiTemplateContext derives CRUD placeholders from the explicit target-
     assert.equal(context.__JSKIT_UI_HAS_VIEW_ROUTE__, "true");
     assert.equal(context.__JSKIT_UI_HAS_NEW_ROUTE__, "true");
     assert.equal(context.__JSKIT_UI_HAS_EDIT_ROUTE__, "true");
+    assert.doesNotMatch(context.__JSKIT_UI_LIST_HEADER_COLUMNS__, /Id/);
+    assert.doesNotMatch(context.__JSKIT_UI_LIST_ROW_COLUMNS__, /record\.id/);
     assert.match(context.__JSKIT_UI_LIST_HEADER_COLUMNS__, /First Name/);
     assert.match(context.__JSKIT_UI_LIST_ROW_COLUMNS__, /record\.firstName/);
     assert.match(context.__JSKIT_UI_VIEW_COLUMNS__, /view\.record\?\.firstName/);
     assert.match(context.__JSKIT_UI_CREATE_FORM_COLUMNS__, /formRuntime\.form\.firstName/);
     assert.match(context.__JSKIT_UI_EDIT_FORM_COLUMNS__, /formRuntime\.form\.email/);
     assert.equal(context.__JSKIT_UI_RECORD_CHANGED_EVENT__, "\"customers.record.changed\"");
+    assert.equal(context.__JSKIT_UI_LIST_RECORD_ID_EXPR__, "item.id");
     assert.equal(context.__JSKIT_UI_VIEW_TITLE_FALLBACK_FIELD_KEY__, "\"firstName\"");
   });
 });
@@ -303,6 +306,23 @@ test("buildUiTemplateContext filters rendered fields when display-fields is prov
     assert.match(context.__JSKIT_UI_VIEW_COLUMNS__, /view\.record\?\.firstName/);
     assert.match(context.__JSKIT_UI_VIEW_COLUMNS__, /view\.record\?\.email/);
     assert.doesNotMatch(context.__JSKIT_UI_VIEW_COLUMNS__, /view\.record\?\.vip/);
+  });
+});
+
+test("buildUiTemplateContext keeps an explicitly requested id display field", async () => {
+  await withTempApp(async (appRoot) => {
+    await writeResource(appRoot, RESOURCE_FILE, FULL_RESOURCE_SOURCE);
+
+    const context = await buildUiTemplateContext({
+      appRoot,
+      options: createOptions({
+        operations: "list,view",
+        "display-fields": "id,firstName"
+      })
+    });
+
+    assert.match(context.__JSKIT_UI_LIST_HEADER_COLUMNS__, /Id/);
+    assert.match(context.__JSKIT_UI_LIST_ROW_COLUMNS__, /record\.id/);
   });
 });
 

--- a/tooling/jskit-cli/test/uiGeneratorPackage.test.js
+++ b/tooling/jskit-cli/test/uiGeneratorPackage.test.js
@@ -281,6 +281,8 @@ test("generate @jskit-ai/crud-ui-generator crud scaffolds CRUD pages at an expli
     assert.match(listPageSource, /const UI_LIST_API_URL = "\/customers";/);
     assert.match(listPageSource, /const UI_RECORD_ID_PARAM = "customerId";/);
     assert.match(listPageSource, /"ui-generator", "customers", "list"/);
+    assert.doesNotMatch(listPageSource, /<th>Id<\/th>/);
+    assert.doesNotMatch(listPageSource, /<td>\{\{ record\.id \}\}<\/td>/);
 
     const newPageSource = await readFile(paths.newPagePath, "utf8");
     assert.match(newPageSource, /import CrudAddEditForm from "\.\/_components\/CrudAddEditForm\.vue";/);
@@ -375,6 +377,7 @@ test("generate @jskit-ai/crud-ui-generator applies display-fields filters to gen
     const listPageSource = await readFile(path.join(appRoot, "src/pages/admin/ops/customers-ui/index.vue"), "utf8");
     assert.match(listPageSource, /<th>First Name<\/th>/);
     assert.match(listPageSource, /<th>Email<\/th>/);
+    assert.doesNotMatch(listPageSource, /<th>Id<\/th>/);
     assert.doesNotMatch(listPageSource, /<th>Vip<\/th>/);
   });
 });


### PR DESCRIPTION
## Summary
- stop default CRUD UI list scaffolds from rendering the record id column
- keep explicit display field overrides able to include the id column when requested
- cover the new default and explicit override behavior in generator and CLI tests

## Verification
- npm run verify