### PR TITLE
Remove built-in settings landing pages

### DIFF
--- a/packages/shell-web/package.descriptor.mjs
+++ b/packages/shell-web/package.descriptor.mjs
@@ -245,7 +245,7 @@ export default Object.freeze({
         from: "templates/src/pages/home/settings/index.vue",
         toSurface: "home",
         toSurfacePath: "settings/index.vue",
-        reason: "Install shell-driven home settings landing page scaffold.",
+        reason: "Install shell-driven home settings index stub scaffold for app-owned landing or redirect behavior.",
         category: "shell-web",
         id: "shell-web-page-home-settings"
       },

--- a/packages/shell-web/templates/src/pages/home/settings/index.vue
+++ b/packages/shell-web/templates/src/pages/home/settings/index.vue
@@ -1,8 +1,8 @@
-<template>
-  <v-sheet rounded="lg" border class="pa-6">
-    <h2 class="text-h6 mb-2">Settings</h2>
-    <p class="text-body-2 text-medium-emphasis mb-0">
-      Select a settings section from the menu.
-    </p>
-  </v-sheet>
-</template>
+<script setup>
+// To redirect this settings shell to a child page, uncomment and edit the example below.
+// definePage({
+//   redirect: (to) => `${to.path}/your_child_segment`
+// });
+</script>
+
+<template />

--- a/packages/shell-web/test/settingsPlacementContract.test.js
+++ b/packages/shell-web/test/settingsPlacementContract.test.js
@@ -27,6 +27,14 @@ test("shell-web home settings template exposes surface-derived settings outlets"
 
   assert.match(source, /target="home-settings:primary-menu"/);
   assert.match(source, /default-link-component-token="local\.main\.ui\.surface-aware-menu-link-item"/);
+  assert.match(source, /<RouterView \/>/);
+});
+
+test("shell-web home settings index template is a simple developer-owned stub", async () => {
+  const source = await readFile(path.join(PACKAGE_DIR, "templates", "src", "pages", "home", "settings", "index.vue"), "utf8");
+
+  assert.match(source, /definePage/);
+  assert.match(source, /your_child_segment/);
 });
 
 test("shell-web descriptor metadata advertises home settings outlets and installs the scaffold page", () => {
@@ -55,7 +63,7 @@ test("shell-web descriptor metadata advertises home settings outlets and install
     from: "templates/src/pages/home/settings/index.vue",
     toSurface: "home",
     toSurfacePath: "settings/index.vue",
-    reason: "Install shell-driven home settings landing page scaffold.",
+    reason: "Install shell-driven home settings index stub scaffold for app-owned landing or redirect behavior.",
     category: "shell-web",
     id: "shell-web-page-home-settings"
   });

--- a/packages/users-web/package.descriptor.mjs
+++ b/packages/users-web/package.descriptor.mjs
@@ -54,14 +54,6 @@ export default Object.freeze({
           summary: "Exports profile settings client element scaffold component."
         },
         {
-          subpath: "./client/components/ConsoleSettingsClientElement",
-          summary: "Exports console settings landing-page client element."
-        },
-        {
-          subpath: "./client/components/WorkspaceSettingsClientElement",
-          summary: "Exports workspace settings client element."
-        },
-        {
           subpath: "./client/composables/useAddEdit",
           summary: "Exports add/edit operation composable."
         },
@@ -184,15 +176,6 @@ export default Object.freeze({
             componentToken: "local.main.ui.surface-aware-menu-link-item",
             when: "auth.authenticated === true",
             source: "mutations.text#users-web-home-tools-placement"
-          },
-          {
-            id: "users.home.settings.general",
-            target: "home-settings:primary-menu",
-            surfaces: ["home"],
-            order: 100,
-            componentToken: "local.main.ui.surface-aware-menu-link-item",
-            when: "auth.authenticated === true",
-            source: "mutations.text#users-web-home-settings-general-placement"
           }
         ]
       }
@@ -276,7 +259,7 @@ export default Object.freeze({
         from: "templates/src/pages/console/settings/index.vue",
         toSurface: "console",
         toSurfacePath: "settings/index.vue",
-        reason: "Install console settings landing page scaffold for users-web console UI.",
+        reason: "Install console settings index stub scaffold for app-owned landing or redirect behavior.",
         category: "users-web",
         id: "users-web-page-console-settings"
       }
@@ -347,17 +330,6 @@ export default Object.freeze({
         reason: "Append users-web home tools widget and settings menu placements into app-owned placement registry.",
         category: "users-web",
         id: "users-web-home-tools-placement"
-      },
-      {
-        op: "append-text",
-        file: "src/placement.js",
-        position: "bottom",
-        skipIfContains: "id: \"users.home.settings.general\"",
-        value:
-          "\naddPlacement({\n  id: \"users.home.settings.general\",\n  target: \"home-settings:primary-menu\",\n  surfaces: [\"home\"],\n  order: 100,\n  componentToken: \"local.main.ui.surface-aware-menu-link-item\",\n  props: {\n    label: \"General\",\n    surface: \"home\",\n    workspaceSuffix: \"/settings\",\n    nonWorkspaceSuffix: \"/settings\"\n  },\n  when: ({ auth }) => Boolean(auth?.authenticated)\n});\n",
-        reason: "Append users-web home settings general-page placement into app-owned placement registry.",
-        category: "users-web",
-        id: "users-web-home-settings-general-placement"
       }
     ]
   }

--- a/packages/users-web/package.json
+++ b/packages/users-web/package.json
@@ -8,8 +8,6 @@
   "exports": {
     "./client": "./src/client/index.js",
     "./client/providers/UsersWorkspacesClientProvider": "./src/client/providers/UsersWorkspacesClientProvider.js",
-    "./client/components/ConsoleSettingsClientElement": "./src/client/components/ConsoleSettingsClientElement.vue",
-    "./client/components/WorkspaceSettingsClientElement": "./src/client/components/WorkspaceSettingsClientElement.vue",
     "./client/components/WorkspaceMembersClientElement": "./src/client/components/WorkspaceMembersClientElement.vue",
     "./client/composables/useAddEdit": "./src/client/composables/records/useAddEdit.js",
     "./client/composables/useCrudAddEdit": "./src/client/composables/records/useCrudAddEdit.js",

--- a/packages/users-web/src/client/index.js
+++ b/packages/users-web/src/client/index.js
@@ -2,8 +2,6 @@ import { UsersWebClientProvider } from "./providers/UsersWebClientProvider.js";
 
 export { UsersWebClientProvider } from "./providers/UsersWebClientProvider.js";
 export { UsersWorkspacesClientProvider } from "./providers/UsersWorkspacesClientProvider.js";
-export { default as ConsoleSettingsClientElement } from "./components/ConsoleSettingsClientElement.vue";
-export { default as WorkspaceSettingsClientElement } from "./components/WorkspaceSettingsClientElement.vue";
 
 const clientProviders = Object.freeze([UsersWebClientProvider]);
 

--- a/packages/users-web/src/client/providers/UsersWorkspacesClientProvider.js
+++ b/packages/users-web/src/client/providers/UsersWorkspacesClientProvider.js
@@ -3,7 +3,6 @@ import UsersWorkspaceToolsWidget from "../components/UsersWorkspaceToolsWidget.v
 import UsersWorkspaceSettingsMenuItem from "../components/UsersWorkspaceSettingsMenuItem.vue";
 import UsersWorkspaceMembersMenuItem from "../components/UsersWorkspaceMembersMenuItem.vue";
 import MembersAdminClientElement from "../components/MembersAdminClientElement.vue";
-import WorkspaceSettingsClientElement from "../components/WorkspaceSettingsClientElement.vue";
 
 class UsersWorkspacesClientProvider {
   static id = "workspaces.web.client";
@@ -19,7 +18,6 @@ class UsersWorkspacesClientProvider {
     app.singleton("users.web.workspace-settings.menu-item", () => UsersWorkspaceSettingsMenuItem);
     app.singleton("users.web.workspace-members.menu-item", () => UsersWorkspaceMembersMenuItem);
     app.singleton("users.web.members-admin.element", () => MembersAdminClientElement);
-    app.singleton("users.web.workspace-settings.element", () => WorkspaceSettingsClientElement);
   }
 }
 

--- a/packages/users-web/templates/src/pages/console/settings/index.vue
+++ b/packages/users-web/templates/src/pages/console/settings/index.vue
@@ -1,7 +1,8 @@
 <script setup>
-import ConsoleSettingsClientElement from "@jskit-ai/users-web/client/components/ConsoleSettingsClientElement";
+// To redirect this settings shell to a child page, uncomment and edit the example below.
+// definePage({
+//   redirect: (to) => `${to.path}/your_child_segment`
+// });
 </script>
 
-<template>
-  <ConsoleSettingsClientElement />
-</template>
+<template />

--- a/packages/users-web/test/settingsPlacementContract.test.js
+++ b/packages/users-web/test/settingsPlacementContract.test.js
@@ -30,6 +30,13 @@ function findTextMutation(id) {
     : null;
 }
 
+function findFileMutation(id) {
+  const fileMutations = descriptor?.mutations?.files;
+  return Array.isArray(fileMutations)
+    ? fileMutations.find((entry) => String(entry?.id || "").trim() === id) || null
+    : null;
+}
+
 function expectContribution(id, expected = {}) {
   const contribution = findContribution(id);
   assert.ok(contribution, `Expected contribution "${id}".`);
@@ -69,6 +76,14 @@ test("users-web console settings template exposes surface-derived settings outle
 
   assert.match(source, /target="console-settings:primary-menu"/);
   assert.match(source, /default-link-component-token="local\.main\.ui\.surface-aware-menu-link-item"/);
+  assert.match(source, /<RouterView \/>/);
+});
+
+test("users-web console settings index template is a simple developer-owned stub", async () => {
+  const source = await readFile(path.join(PACKAGE_DIR, "templates", "src", "pages", "console", "settings", "index.vue"), "utf8");
+
+  assert.match(source, /definePage/);
+  assert.match(source, /your_child_segment/);
 });
 
 test("users-web descriptor metadata advertises console settings outlets with standard positions", () => {
@@ -84,6 +99,14 @@ test("users-web descriptor metadata advertises console settings outlets with sta
       }
     ]
   );
+  assert.deepEqual(findFileMutation("users-web-page-console-settings"), {
+    from: "templates/src/pages/console/settings/index.vue",
+    toSurface: "console",
+    toSurfacePath: "settings/index.vue",
+    reason: "Install console settings index stub scaffold for app-owned landing or redirect behavior.",
+    category: "users-web",
+    id: "users-web-page-console-settings"
+  });
 });
 
 test("users-web home tools widget exposes home-tools outlet", async () => {
@@ -152,15 +175,7 @@ test("users-web descriptor metadata advertises home tools outlet and standard ho
     when: "auth.authenticated === true",
     source: "mutations.text#users-web-home-tools-placement"
   });
-
-  expectContribution("users.home.settings.general", {
-    target: "home-settings:primary-menu",
-    surfaces: ["home"],
-    order: 100,
-    componentToken: "local.main.ui.surface-aware-menu-link-item",
-    when: "auth.authenticated === true",
-    source: "mutations.text#users-web-home-settings-general-placement"
-  });
+  assert.equal(findContribution("users.home.settings.general"), null);
 
   expectTextMutation("users-web-home-tools-placement", {
     reason: "Append users-web home tools widget and settings menu placements into app-owned placement registry.",
@@ -205,17 +220,4 @@ test("users-web descriptor metadata advertises home tools outlet and standard ho
     ]
   });
 
-  expectTextMutation("users-web-home-settings-general-placement", {
-    reason: "Append users-web home settings general-page placement into app-owned placement registry.",
-    category: "users-web",
-    skipIfContains: 'id: "users.home.settings.general"',
-    snippets: [
-      'id: "users.home.settings.general"',
-      'target: "home-settings:primary-menu"',
-      'componentToken: "local.main.ui.surface-aware-menu-link-item"',
-      'label: "General"',
-      'workspaceSuffix: "/settings"',
-      'nonWorkspaceSuffix: "/settings"'
-    ]
-  });
 });

--- a/packages/workspaces-web/package.descriptor.mjs
+++ b/packages/workspaces-web/package.descriptor.mjs
@@ -45,8 +45,7 @@ export default Object.freeze({
           "users.web.workspace.tools.widget",
           "users.web.workspace-settings.menu-item",
           "users.web.workspace-members.menu-item",
-          "users.web.members-admin.element",
-          "users.web.workspace-settings.element"
+          "users.web.members-admin.element"
         ]
       }
     },
@@ -103,14 +102,6 @@ export default Object.freeze({
             componentToken: "users.web.workspace-members.menu-item",
             source: "mutations.text#users-web-placement-block"
           },
-          {
-            id: "users.workspace.settings.general",
-            target: "admin-settings:primary-menu",
-            surfaces: ["admin"],
-            order: 100,
-            componentToken: "local.main.ui.surface-aware-menu-link-item",
-            source: "mutations.text#users-web-workspace-settings-general-placement"
-          }
         ]
       }
     }
@@ -238,7 +229,7 @@ export default Object.freeze({
         from: "templates/src/pages/admin/workspace/settings/index.vue",
         toSurface: "admin",
         toSurfacePath: "workspace/settings/index.vue",
-        reason: "Install workspace settings landing page scaffold for workspaces-web workspace admin UI.",
+        reason: "Install workspace settings index stub scaffold for app-owned landing or redirect behavior.",
         category: "workspaces-web",
         id: "users-web-page-admin-workspace-settings",
         when: {
@@ -282,21 +273,6 @@ export default Object.freeze({
         reason: "Bind app-owned account pending invites cue component token into local main client provider registry.",
         category: "workspaces-web",
         id: "users-web-main-client-provider-account-invites-register"
-      },
-      {
-        op: "append-text",
-        file: "src/placement.js",
-        position: "bottom",
-        skipIfContains: "id: \"users.workspace.settings.general\"",
-        value:
-          "\naddPlacement({\n  id: \"users.workspace.settings.general\",\n  target: \"admin-settings:primary-menu\",\n  surfaces: [\"admin\"],\n  order: 100,\n  componentToken: \"local.main.ui.surface-aware-menu-link-item\",\n  props: {\n    label: \"General\",\n    surface: \"admin\",\n    workspaceSuffix: \"/workspace/settings\",\n    nonWorkspaceSuffix: \"/workspace/settings\"\n  },\n  when: ({ auth }) => Boolean(auth?.authenticated)\n});\n",
-        reason: "Append workspace settings general-page placement into app-owned placement registry.",
-        category: "workspaces-web",
-        id: "users-web-workspace-settings-general-placement",
-        when: {
-          config: "tenancyMode",
-          in: ["personal", "workspaces"]
-        }
       }
     ]
   }

--- a/packages/workspaces-web/templates/src/pages/admin/workspace/settings/index.vue
+++ b/packages/workspaces-web/templates/src/pages/admin/workspace/settings/index.vue
@@ -1,7 +1,8 @@
 <script setup>
-import WorkspaceSettingsClientElement from "@jskit-ai/users-web/client/components/WorkspaceSettingsClientElement";
+// To redirect this settings shell to a child page, uncomment and edit the example below.
+// definePage({
+//   redirect: (to) => `${to.path}/your_child_segment`
+// });
 </script>
 
-<template>
-  <WorkspaceSettingsClientElement />
-</template>
+<template />

--- a/packages/workspaces-web/test/settingsPlacementContract.test.js
+++ b/packages/workspaces-web/test/settingsPlacementContract.test.js
@@ -22,6 +22,13 @@ function findContribution(id) {
     : null;
 }
 
+function findFileMutation(id) {
+  const fileMutations = descriptor?.mutations?.files;
+  return Array.isArray(fileMutations)
+    ? fileMutations.find((entry) => String(entry?.id || "").trim() === id) || null
+    : null;
+}
+
 test("workspaces-web admin settings template exposes surface-derived settings outlets", async () => {
   const source = await readFile(
     path.join(PACKAGE_DIR, "templates", "src", "pages", "admin", "workspace", "settings.vue"),
@@ -30,9 +37,20 @@ test("workspaces-web admin settings template exposes surface-derived settings ou
 
   assert.match(source, /target="admin-settings:primary-menu"/);
   assert.match(source, /default-link-component-token="local\.main\.ui\.surface-aware-menu-link-item"/);
+  assert.match(source, /<RouterView \/>/);
 });
 
-test("workspaces-web descriptor metadata advertises admin settings outlets and general-page placement on the derived host", () => {
+test("workspaces-web admin settings index template is a simple developer-owned stub", async () => {
+  const source = await readFile(
+    path.join(PACKAGE_DIR, "templates", "src", "pages", "admin", "workspace", "settings", "index.vue"),
+    "utf8"
+  );
+
+  assert.match(source, /definePage/);
+  assert.match(source, /your_child_segment/);
+});
+
+test("workspaces-web descriptor metadata advertises admin settings outlets", () => {
   assert.deepEqual(
     readSettingsOutlets(),
     [
@@ -44,13 +62,17 @@ test("workspaces-web descriptor metadata advertises admin settings outlets and g
       }
     ]
   );
-
-  assert.deepEqual(findContribution("users.workspace.settings.general"), {
-    id: "users.workspace.settings.general",
-    target: "admin-settings:primary-menu",
-    surfaces: ["admin"],
-    order: 100,
-    componentToken: "local.main.ui.surface-aware-menu-link-item",
-    source: "mutations.text#users-web-workspace-settings-general-placement"
+  assert.equal(findContribution("users.workspace.settings.general"), null);
+  assert.deepEqual(findFileMutation("users-web-page-admin-workspace-settings"), {
+    from: "templates/src/pages/admin/workspace/settings/index.vue",
+    toSurface: "admin",
+    toSurfacePath: "workspace/settings/index.vue",
+    reason: "Install workspace settings index stub scaffold for app-owned landing or redirect behavior.",
+    category: "workspaces-web",
+    id: "users-web-page-admin-workspace-settings",
+    when: {
+      config: "tenancyMode",
+      in: ["personal", "workspaces"]
+    }
   });
 });

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -2788,7 +2788,7 @@
               "from": "templates/src/pages/home/settings/index.vue",
               "toSurface": "home",
               "toSurfacePath": "settings/index.vue",
-              "reason": "Install shell-driven home settings landing page scaffold.",
+              "reason": "Install shell-driven home settings index stub scaffold for app-owned landing or redirect behavior.",
               "category": "shell-web",
               "id": "shell-web-page-home-settings"
             },
@@ -3681,14 +3681,6 @@
                 "summary": "Exports profile settings client element scaffold component."
               },
               {
-                "subpath": "./client/components/ConsoleSettingsClientElement",
-                "summary": "Exports console settings landing-page client element."
-              },
-              {
-                "subpath": "./client/components/WorkspaceSettingsClientElement",
-                "summary": "Exports workspace settings client element."
-              },
-              {
                 "subpath": "./client/composables/useAddEdit",
                 "summary": "Exports add/edit operation composable."
               },
@@ -3829,17 +3821,6 @@
                   "componentToken": "local.main.ui.surface-aware-menu-link-item",
                   "when": "auth.authenticated === true",
                   "source": "mutations.text#users-web-home-tools-placement"
-                },
-                {
-                  "id": "users.home.settings.general",
-                  "target": "home-settings:primary-menu",
-                  "surfaces": [
-                    "home"
-                  ],
-                  "order": 100,
-                  "componentToken": "local.main.ui.surface-aware-menu-link-item",
-                  "when": "auth.authenticated === true",
-                  "source": "mutations.text#users-web-home-settings-general-placement"
                 }
               ]
             }
@@ -3923,7 +3904,7 @@
               "from": "templates/src/pages/console/settings/index.vue",
               "toSurface": "console",
               "toSurfacePath": "settings/index.vue",
-              "reason": "Install console settings landing page scaffold for users-web console UI.",
+              "reason": "Install console settings index stub scaffold for app-owned landing or redirect behavior.",
               "category": "users-web",
               "id": "users-web-page-console-settings"
             }
@@ -3988,16 +3969,6 @@
               "reason": "Append users-web home tools widget and settings menu placements into app-owned placement registry.",
               "category": "users-web",
               "id": "users-web-home-tools-placement"
-            },
-            {
-              "op": "append-text",
-              "file": "src/placement.js",
-              "position": "bottom",
-              "skipIfContains": "id: \"users.home.settings.general\"",
-              "value": "\naddPlacement({\n  id: \"users.home.settings.general\",\n  target: \"home-settings:primary-menu\",\n  surfaces: [\"home\"],\n  order: 100,\n  componentToken: \"local.main.ui.surface-aware-menu-link-item\",\n  props: {\n    label: \"General\",\n    surface: \"home\",\n    workspaceSuffix: \"/settings\",\n    nonWorkspaceSuffix: \"/settings\"\n  },\n  when: ({ auth }) => Boolean(auth?.authenticated)\n});\n",
-              "reason": "Append users-web home settings general-page placement into app-owned placement registry.",
-              "category": "users-web",
-              "id": "users-web-home-settings-general-placement"
             }
           ]
         }
@@ -4356,8 +4327,7 @@
                 "users.web.workspace.tools.widget",
                 "users.web.workspace-settings.menu-item",
                 "users.web.workspace-members.menu-item",
-                "users.web.members-admin.element",
-                "users.web.workspace-settings.element"
+                "users.web.members-admin.element"
               ]
             }
           },
@@ -4425,16 +4395,6 @@
                   "order": 200,
                   "componentToken": "users.web.workspace-members.menu-item",
                   "source": "mutations.text#users-web-placement-block"
-                },
-                {
-                  "id": "users.workspace.settings.general",
-                  "target": "admin-settings:primary-menu",
-                  "surfaces": [
-                    "admin"
-                  ],
-                  "order": 100,
-                  "componentToken": "local.main.ui.surface-aware-menu-link-item",
-                  "source": "mutations.text#users-web-workspace-settings-general-placement"
                 }
               ]
             }
@@ -4587,7 +4547,7 @@
               "from": "templates/src/pages/admin/workspace/settings/index.vue",
               "toSurface": "admin",
               "toSurfacePath": "workspace/settings/index.vue",
-              "reason": "Install workspace settings landing page scaffold for workspaces-web workspace admin UI.",
+              "reason": "Install workspace settings index stub scaffold for app-owned landing or redirect behavior.",
               "category": "workspaces-web",
               "id": "users-web-page-admin-workspace-settings",
               "when": {
@@ -4636,23 +4596,6 @@
               "reason": "Bind app-owned account pending invites cue component token into local main client provider registry.",
               "category": "workspaces-web",
               "id": "users-web-main-client-provider-account-invites-register"
-            },
-            {
-              "op": "append-text",
-              "file": "src/placement.js",
-              "position": "bottom",
-              "skipIfContains": "id: \"users.workspace.settings.general\"",
-              "value": "\naddPlacement({\n  id: \"users.workspace.settings.general\",\n  target: \"admin-settings:primary-menu\",\n  surfaces: [\"admin\"],\n  order: 100,\n  componentToken: \"local.main.ui.surface-aware-menu-link-item\",\n  props: {\n    label: \"General\",\n    surface: \"admin\",\n    workspaceSuffix: \"/workspace/settings\",\n    nonWorkspaceSuffix: \"/workspace/settings\"\n  },\n  when: ({ auth }) => Boolean(auth?.authenticated)\n});\n",
-              "reason": "Append workspace settings general-page placement into app-owned placement registry.",
-              "category": "workspaces-web",
-              "id": "users-web-workspace-settings-general-placement",
-              "when": {
-                "config": "tenancyMode",
-                "in": [
-                  "personal",
-                  "workspaces"
-                ]
-              }
             }
           ]
         }


### PR DESCRIPTION
## Summary
- turn the generated home, console, and workspace settings index pages into simple developer-owned stubs
- remove built-in General settings placements from users-web and workspaces-web
- drop the old users-web client exports/registration that were only supporting those built-in landing pages

## Verification
- npm run verify