### PR TITLE
Handle app-owned scaffold claims in package installs

### DIFF
--- a/packages/shell-web/package.descriptor.mjs
+++ b/packages/shell-web/package.descriptor.mjs
@@ -171,6 +171,8 @@ export default Object.freeze({
       {
         from: "templates/src/App.vue",
         to: "src/App.vue",
+        ownership: "app",
+        expectedExistingFrom: "templates/expected-existing/src/App.vue",
         reason: "Install full-width shell app root with shell-web error host and edge-to-edge layout.",
         category: "shell-web",
         id: "shell-web-app-root"
@@ -178,6 +180,7 @@ export default Object.freeze({
       {
         from: "templates/src/components/ShellLayout.vue",
         to: "src/components/ShellLayout.vue",
+        ownership: "app",
         reason: "Install app-owned shell layout component so apps can customize structure and slots.",
         category: "shell-web",
         id: "shell-web-component-shell-layout"
@@ -185,6 +188,7 @@ export default Object.freeze({
       {
         from: "templates/src/components/menus/MenuLinkItem.vue",
         to: "src/components/menus/MenuLinkItem.vue",
+        ownership: "app",
         reason: "Install app-owned shell menu link-item scaffold for local placement customization.",
         category: "shell-web",
         id: "shell-web-component-menu-link-item"
@@ -192,6 +196,7 @@ export default Object.freeze({
       {
         from: "templates/src/components/menus/SurfaceAwareMenuLinkItem.vue",
         to: "src/components/menus/SurfaceAwareMenuLinkItem.vue",
+        ownership: "app",
         reason: "Install app-owned surface-aware shell menu link-item scaffold for local placement customization.",
         category: "shell-web",
         id: "shell-web-component-surface-aware-menu-link-item"
@@ -199,6 +204,7 @@ export default Object.freeze({
       {
         from: "templates/src/components/menus/TabLinkItem.vue",
         to: "src/components/menus/TabLinkItem.vue",
+        ownership: "app",
         reason: "Install app-owned shell tab link-item scaffold for local placement customization.",
         category: "shell-web",
         id: "shell-web-component-tab-link-item"
@@ -206,6 +212,7 @@ export default Object.freeze({
       {
         from: "templates/src/error.js",
         to: "src/error.js",
+        ownership: "app",
         reason: "Install app-owned error runtime policy and presenter config scaffold.",
         category: "shell-web",
         id: "shell-web-error-config"
@@ -213,6 +220,7 @@ export default Object.freeze({
       {
         from: "templates/src/placement.js",
         to: "src/placement.js",
+        ownership: "app",
         reason: "Install app-owned placement registry scaffold used by shell-web placement runtime.",
         category: "shell-web",
         id: "shell-web-placement-registry"
@@ -221,6 +229,8 @@ export default Object.freeze({
         from: "templates/src/pages/home.vue",
         toSurface: "home",
         toSurfaceRoot: true,
+        ownership: "app",
+        expectedExistingFrom: "templates/expected-existing/src/pages/home.vue",
         reason: "Install shell-driven home wrapper page.",
         category: "shell-web",
         id: "shell-web-page-home-wrapper"
@@ -229,6 +239,8 @@ export default Object.freeze({
         from: "templates/src/pages/home/index.vue",
         toSurface: "home",
         toSurfacePath: "index.vue",
+        ownership: "app",
+        expectedExistingFrom: "templates/expected-existing/src/pages/home/index.vue",
         reason: "Install shell-driven home surface starter page.",
         category: "shell-web",
         id: "shell-web-page-home"
@@ -237,6 +249,7 @@ export default Object.freeze({
         from: "templates/src/pages/home/settings.vue",
         toSurface: "home",
         toSurfacePath: "settings.vue",
+        ownership: "app",
         reason: "Install shell-driven home settings shell route with section navigation.",
         category: "shell-web",
         id: "shell-web-page-home-settings-shell"
@@ -245,6 +258,7 @@ export default Object.freeze({
         from: "templates/src/pages/home/settings/index.vue",
         toSurface: "home",
         toSurfacePath: "settings/index.vue",
+        ownership: "app",
         reason: "Install shell-driven home settings index stub scaffold for app-owned landing or redirect behavior.",
         category: "shell-web",
         id: "shell-web-page-home-settings"
@@ -253,6 +267,8 @@ export default Object.freeze({
         from: "templates/src/pages/console.vue",
         toSurface: "console",
         toSurfaceRoot: true,
+        ownership: "app",
+        expectedExistingFrom: "templates/expected-existing/src/pages/console.vue",
         reason: "Install shell-driven console wrapper page.",
         category: "shell-web",
         id: "shell-web-page-console-wrapper"
@@ -261,6 +277,8 @@ export default Object.freeze({
         from: "templates/src/pages/console/index.vue",
         toSurface: "console",
         toSurfacePath: "index.vue",
+        ownership: "app",
+        expectedExistingFrom: "templates/expected-existing/src/pages/console/index.vue",
         reason: "Install shell-driven console page starter.",
         category: "shell-web",
         id: "shell-web-page-console"

--- a/packages/shell-web/templates/expected-existing/src/App.vue
+++ b/packages/shell-web/templates/expected-existing/src/App.vue
@@ -1,0 +1,13 @@
+<template>
+  <v-app>
+    <v-main>
+      <v-container class="py-10 py-md-14">
+        <v-row justify="center">
+          <v-col cols="12" sm="11" md="10" lg="8" xl="7">
+            <RouterView />
+          </v-col>
+        </v-row>
+      </v-container>
+    </v-main>
+  </v-app>
+</template>

--- a/packages/shell-web/templates/expected-existing/src/pages/console.vue
+++ b/packages/shell-web/templates/expected-existing/src/pages/console.vue
@@ -1,0 +1,13 @@
+<route lang="json">
+{
+  "meta": {
+    "jskit": {
+      "surface": "console"
+    }
+  }
+}
+</route>
+
+<template>
+  <RouterView />
+</template>

--- a/packages/shell-web/templates/expected-existing/src/pages/console/index.vue
+++ b/packages/shell-web/templates/expected-existing/src/pages/console/index.vue
@@ -1,0 +1,12 @@
+<template>
+  <v-card class="mx-auto" max-width="960" rounded="xl" border elevation="1">
+    <v-card-item class="px-6 py-5 px-md-8 py-md-7">
+      <v-card-title class="text-h4">console</v-card-title>
+      <v-card-subtitle class="text-subtitle-1 mt-2">operations surface</v-card-subtitle>
+    </v-card-item>
+    <v-divider />
+    <v-card-text class="px-6 py-5 px-md-8 py-md-7 text-body-1 text-medium-emphasis">
+      This surface is intended for operational tooling.
+    </v-card-text>
+  </v-card>
+</template>

--- a/packages/shell-web/templates/expected-existing/src/pages/home.vue
+++ b/packages/shell-web/templates/expected-existing/src/pages/home.vue
@@ -1,0 +1,13 @@
+<route lang="json">
+{
+  "meta": {
+    "jskit": {
+      "surface": "home"
+    }
+  }
+}
+</route>
+
+<template>
+  <RouterView />
+</template>

--- a/packages/shell-web/templates/expected-existing/src/pages/home/index.vue
+++ b/packages/shell-web/templates/expected-existing/src/pages/home/index.vue
@@ -1,0 +1,12 @@
+<template>
+  <v-card class="mx-auto" max-width="960" rounded="xl" border elevation="1">
+    <v-card-item class="px-6 py-5 px-md-8 py-md-7">
+      <v-card-title class="text-h4">welcome</v-card-title>
+      <v-card-subtitle class="text-subtitle-1 mt-2">starter app</v-card-subtitle>
+    </v-card-item>
+    <v-divider />
+    <v-card-text class="px-6 py-5 px-md-8 py-md-7 text-body-1 text-medium-emphasis">
+      Start by adding packages and pages to this app.
+    </v-card-text>
+  </v-card>
+</template>

--- a/packages/shell-web/test/bootstrapClaimContract.test.js
+++ b/packages/shell-web/test/bootstrapClaimContract.test.js
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import test from "node:test";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import descriptor from "../package.descriptor.mjs";
+
+const TEST_DIRECTORY = path.dirname(fileURLToPath(import.meta.url));
+const PACKAGE_DIR = path.resolve(TEST_DIRECTORY, "..");
+const CREATE_APP_TEMPLATE_DIR = path.resolve(PACKAGE_DIR, "..", "..", "tooling", "create-app", "templates", "base-shell");
+
+function findFileMutation(id) {
+  const files = descriptor?.mutations?.files;
+  return Array.isArray(files)
+    ? files.find((entry) => String(entry?.id || "").trim() === id) || null
+    : null;
+}
+
+test("shell-web claims starter shell files as app-owned scaffolds", () => {
+  assert.deepEqual(findFileMutation("shell-web-app-root"), {
+    from: "templates/src/App.vue",
+    to: "src/App.vue",
+    ownership: "app",
+    expectedExistingFrom: "templates/expected-existing/src/App.vue",
+    reason: "Install full-width shell app root with shell-web error host and edge-to-edge layout.",
+    category: "shell-web",
+    id: "shell-web-app-root"
+  });
+  assert.deepEqual(findFileMutation("shell-web-page-home-wrapper"), {
+    from: "templates/src/pages/home.vue",
+    toSurface: "home",
+    toSurfaceRoot: true,
+    ownership: "app",
+    expectedExistingFrom: "templates/expected-existing/src/pages/home.vue",
+    reason: "Install shell-driven home wrapper page.",
+    category: "shell-web",
+    id: "shell-web-page-home-wrapper"
+  });
+  assert.deepEqual(findFileMutation("shell-web-page-home"), {
+    from: "templates/src/pages/home/index.vue",
+    toSurface: "home",
+    toSurfacePath: "index.vue",
+    ownership: "app",
+    expectedExistingFrom: "templates/expected-existing/src/pages/home/index.vue",
+    reason: "Install shell-driven home surface starter page.",
+    category: "shell-web",
+    id: "shell-web-page-home"
+  });
+  assert.deepEqual(findFileMutation("shell-web-page-console-wrapper"), {
+    from: "templates/src/pages/console.vue",
+    toSurface: "console",
+    toSurfaceRoot: true,
+    ownership: "app",
+    expectedExistingFrom: "templates/expected-existing/src/pages/console.vue",
+    reason: "Install shell-driven console wrapper page.",
+    category: "shell-web",
+    id: "shell-web-page-console-wrapper"
+  });
+  assert.deepEqual(findFileMutation("shell-web-page-console"), {
+    from: "templates/src/pages/console/index.vue",
+    toSurface: "console",
+    toSurfacePath: "index.vue",
+    ownership: "app",
+    expectedExistingFrom: "templates/expected-existing/src/pages/console/index.vue",
+    reason: "Install shell-driven console page starter.",
+    category: "shell-web",
+    id: "shell-web-page-console"
+  });
+});
+
+test("shell-web expected-existing starter files stay aligned with create-app base-shell", async () => {
+  const comparedFiles = [
+    "src/App.vue",
+    "src/pages/home.vue",
+    "src/pages/home/index.vue",
+    "src/pages/console.vue",
+    "src/pages/console/index.vue"
+  ];
+
+  for (const relativeFile of comparedFiles) {
+    const shellWebExpectedSource = await readFile(
+      path.join(PACKAGE_DIR, "templates", "expected-existing", relativeFile),
+      "utf8"
+    );
+    const createAppSource = await readFile(path.join(CREATE_APP_TEMPLATE_DIR, relativeFile), "utf8");
+    assert.equal(shellWebExpectedSource, createAppSource, relativeFile);
+  }
+});

--- a/packages/shell-web/test/linkItemScaffoldContract.test.js
+++ b/packages/shell-web/test/linkItemScaffoldContract.test.js
@@ -73,6 +73,7 @@ test("shell-web scaffolds app-owned local link-item wrappers under src/component
   assert.deepEqual(findFileMutation("shell-web-component-menu-link-item"), {
     from: "templates/src/components/menus/MenuLinkItem.vue",
     to: "src/components/menus/MenuLinkItem.vue",
+    ownership: "app",
     reason: "Install app-owned shell menu link-item scaffold for local placement customization.",
     category: "shell-web",
     id: "shell-web-component-menu-link-item"
@@ -80,6 +81,7 @@ test("shell-web scaffolds app-owned local link-item wrappers under src/component
   assert.deepEqual(findFileMutation("shell-web-component-surface-aware-menu-link-item"), {
     from: "templates/src/components/menus/SurfaceAwareMenuLinkItem.vue",
     to: "src/components/menus/SurfaceAwareMenuLinkItem.vue",
+    ownership: "app",
     reason: "Install app-owned surface-aware shell menu link-item scaffold for local placement customization.",
     category: "shell-web",
     id: "shell-web-component-surface-aware-menu-link-item"
@@ -87,6 +89,7 @@ test("shell-web scaffolds app-owned local link-item wrappers under src/component
   assert.deepEqual(findFileMutation("shell-web-component-tab-link-item"), {
     from: "templates/src/components/menus/TabLinkItem.vue",
     to: "src/components/menus/TabLinkItem.vue",
+    ownership: "app",
     reason: "Install app-owned shell tab link-item scaffold for local placement customization.",
     category: "shell-web",
     id: "shell-web-component-tab-link-item"

--- a/packages/shell-web/test/settingsPlacementContract.test.js
+++ b/packages/shell-web/test/settingsPlacementContract.test.js
@@ -54,6 +54,7 @@ test("shell-web descriptor metadata advertises home settings outlets and install
     from: "templates/src/pages/home/settings.vue",
     toSurface: "home",
     toSurfacePath: "settings.vue",
+    ownership: "app",
     reason: "Install shell-driven home settings shell route with section navigation.",
     category: "shell-web",
     id: "shell-web-page-home-settings-shell"
@@ -63,6 +64,7 @@ test("shell-web descriptor metadata advertises home settings outlets and install
     from: "templates/src/pages/home/settings/index.vue",
     toSurface: "home",
     toSurfacePath: "settings/index.vue",
+    ownership: "app",
     reason: "Install shell-driven home settings index stub scaffold for app-owned landing or redirect behavior.",
     category: "shell-web",
     id: "shell-web-page-home-settings"

--- a/tooling/create-app/src/server/index.js
+++ b/tooling/create-app/src/server/index.js
@@ -48,12 +48,15 @@ function normalizeTenancyMode(value, { showUsage = true } = {}) {
   );
 }
 
-function buildInitialBundleCommands(initialBundles) {
+function buildInitialSetupCommands(initialBundles) {
   const normalizedPreset = normalizeInitialBundlesPreset(initialBundles, { showUsage: false });
 
   const commands = [];
   if (normalizedPreset === "auth") {
-    commands.push("npx jskit add auth-base");
+    commands.push(
+      "npx jskit add package auth-provider-supabase-core --auth-supabase-url \"https://YOUR-PROJECT.supabase.co\" --auth-supabase-publishable-key \"sb_publishable_...\" --app-public-url \"http://localhost:5173\""
+    );
+    commands.push("npx jskit add bundle auth-base");
   }
 
   return commands;
@@ -555,7 +558,7 @@ export async function createApp({
     template: String(template),
     initialBundles: resolvedInitialBundles,
     tenancyMode: resolvedTenancyMode,
-    selectedBundleCommands: buildInitialBundleCommands(resolvedInitialBundles),
+    selectedSetupCommands: buildInitialSetupCommands(resolvedInitialBundles),
     targetDirectory,
     dryRun,
     touchedFiles
@@ -626,15 +629,16 @@ export async function runCli(
       stdout.write("- npm run dev\n");
 
       stdout.write("\n");
-      if (result.selectedBundleCommands.length > 0) {
-        stdout.write(`Initial framework bundle commands (${result.initialBundles}):\n`);
-        for (const command of result.selectedBundleCommands) {
+      if (result.selectedSetupCommands.length > 0) {
+        stdout.write(`Initial framework setup commands (${result.initialBundles}):\n`);
+        for (const command of result.selectedSetupCommands) {
           stdout.write(`- ${command}\n`);
         }
       } else {
         stdout.write("First of all run npm install.:\n");
         stdout.write("Then add framework capabilities:\n");
-        stdout.write("- npx jskit add auth-base\n");
+        stdout.write("- npx jskit add package auth-provider-supabase-core --auth-supabase-url \"https://YOUR-PROJECT.supabase.co\" --auth-supabase-publishable-key \"sb_publishable_...\" --app-public-url \"http://localhost:5173\"\n");
+        stdout.write("- npx jskit add bundle auth-base\n");
         stdout.write("- npx jskit list\n");
         stdout.write("Run server and client to see it in action:\n");
         stdout.write("- npm run dev\n");

--- a/tooling/create-app/templates/base-shell/README.md
+++ b/tooling/create-app/templates/base-shell/README.md
@@ -35,5 +35,10 @@ App configuration files:
 ## Add Capabilities
 
 ```bash
-npx jskit add auth-base
+npx jskit add package auth-provider-supabase-core \
+  --auth-supabase-url "https://YOUR-PROJECT.supabase.co" \
+  --auth-supabase-publishable-key "sb_publishable_..." \
+  --app-public-url "http://localhost:5173"
+
+npx jskit add bundle auth-base
 ```

--- a/tooling/create-app/test/createApp.test.js
+++ b/tooling/create-app/test/createApp.test.js
@@ -74,7 +74,9 @@ test("create-app scaffolds the base shell with placeholder replacements", async 
     const readme = await readFile(path.join(appRoot, "README.md"), "utf8");
     assert.match(readme, /^# Sample App$/m);
     assert.match(readme, /npm run dev/);
-    assert.match(readme, /npx jskit add auth-base/);
+    assert.match(readme, /npx jskit add package auth-provider-supabase-core/);
+    assert.match(readme, /--auth-supabase-url "https:\/\/YOUR-PROJECT\.supabase\.co"/);
+    assert.match(readme, /npx jskit add bundle auth-base/);
     assert.doesNotMatch(readme, /-w apps/);
 
     const appJson = JSON.parse(await readFile(path.join(appRoot, "app.json"), "utf8"));
@@ -240,7 +242,8 @@ test("create-app scaffolds the base shell with placeholder replacements", async 
     assert.doesNotMatch(viteConfig, /^\s*beforeWriteFiles:\s*reparentNestedChildrenToIndexOwners/m);
     assert.match(viteConfig, /nestedChildren deprecated/);
 
-    assert.match(result.stdout, /npx jskit add auth-base/);
+    assert.match(result.stdout, /npx jskit add package auth-provider-supabase-core/);
+    assert.match(result.stdout, /npx jskit add bundle auth-base/);
   });
 });
 
@@ -309,8 +312,9 @@ test("create-app interactive flow captures initial bundle selection in guidance"
     assert.equal(exitCode, 0, stderr);
     assert.deepEqual(answers, []);
     assert.ok(askedPrompts.length >= 7);
-    assert.match(stdout, /Initial framework bundle commands \(auth\):/);
-    assert.match(stdout, /npx jskit add auth-base/);
+    assert.match(stdout, /Initial framework setup commands \(auth\):/);
+    assert.match(stdout, /npx jskit add package auth-provider-supabase-core/);
+    assert.match(stdout, /npx jskit add bundle auth-base/);
 
     const publicConfig = await readFile(path.join(cwd, "interactive-app/config/public.js"), "utf8");
     assert.match(publicConfig, /config\.tenancyMode = "workspaces";/);

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -2714,6 +2714,8 @@
             {
               "from": "templates/src/App.vue",
               "to": "src/App.vue",
+              "ownership": "app",
+              "expectedExistingFrom": "templates/expected-existing/src/App.vue",
               "reason": "Install full-width shell app root with shell-web error host and edge-to-edge layout.",
               "category": "shell-web",
               "id": "shell-web-app-root"
@@ -2721,6 +2723,7 @@
             {
               "from": "templates/src/components/ShellLayout.vue",
               "to": "src/components/ShellLayout.vue",
+              "ownership": "app",
               "reason": "Install app-owned shell layout component so apps can customize structure and slots.",
               "category": "shell-web",
               "id": "shell-web-component-shell-layout"
@@ -2728,6 +2731,7 @@
             {
               "from": "templates/src/components/menus/MenuLinkItem.vue",
               "to": "src/components/menus/MenuLinkItem.vue",
+              "ownership": "app",
               "reason": "Install app-owned shell menu link-item scaffold for local placement customization.",
               "category": "shell-web",
               "id": "shell-web-component-menu-link-item"
@@ -2735,6 +2739,7 @@
             {
               "from": "templates/src/components/menus/SurfaceAwareMenuLinkItem.vue",
               "to": "src/components/menus/SurfaceAwareMenuLinkItem.vue",
+              "ownership": "app",
               "reason": "Install app-owned surface-aware shell menu link-item scaffold for local placement customization.",
               "category": "shell-web",
               "id": "shell-web-component-surface-aware-menu-link-item"
@@ -2742,6 +2747,7 @@
             {
               "from": "templates/src/components/menus/TabLinkItem.vue",
               "to": "src/components/menus/TabLinkItem.vue",
+              "ownership": "app",
               "reason": "Install app-owned shell tab link-item scaffold for local placement customization.",
               "category": "shell-web",
               "id": "shell-web-component-tab-link-item"
@@ -2749,6 +2755,7 @@
             {
               "from": "templates/src/error.js",
               "to": "src/error.js",
+              "ownership": "app",
               "reason": "Install app-owned error runtime policy and presenter config scaffold.",
               "category": "shell-web",
               "id": "shell-web-error-config"
@@ -2756,6 +2763,7 @@
             {
               "from": "templates/src/placement.js",
               "to": "src/placement.js",
+              "ownership": "app",
               "reason": "Install app-owned placement registry scaffold used by shell-web placement runtime.",
               "category": "shell-web",
               "id": "shell-web-placement-registry"
@@ -2764,6 +2772,8 @@
               "from": "templates/src/pages/home.vue",
               "toSurface": "home",
               "toSurfaceRoot": true,
+              "ownership": "app",
+              "expectedExistingFrom": "templates/expected-existing/src/pages/home.vue",
               "reason": "Install shell-driven home wrapper page.",
               "category": "shell-web",
               "id": "shell-web-page-home-wrapper"
@@ -2772,6 +2782,8 @@
               "from": "templates/src/pages/home/index.vue",
               "toSurface": "home",
               "toSurfacePath": "index.vue",
+              "ownership": "app",
+              "expectedExistingFrom": "templates/expected-existing/src/pages/home/index.vue",
               "reason": "Install shell-driven home surface starter page.",
               "category": "shell-web",
               "id": "shell-web-page-home"
@@ -2780,6 +2792,7 @@
               "from": "templates/src/pages/home/settings.vue",
               "toSurface": "home",
               "toSurfacePath": "settings.vue",
+              "ownership": "app",
               "reason": "Install shell-driven home settings shell route with section navigation.",
               "category": "shell-web",
               "id": "shell-web-page-home-settings-shell"
@@ -2788,6 +2801,7 @@
               "from": "templates/src/pages/home/settings/index.vue",
               "toSurface": "home",
               "toSurfacePath": "settings/index.vue",
+              "ownership": "app",
               "reason": "Install shell-driven home settings index stub scaffold for app-owned landing or redirect behavior.",
               "category": "shell-web",
               "id": "shell-web-page-home-settings"
@@ -2796,6 +2810,8 @@
               "from": "templates/src/pages/console.vue",
               "toSurface": "console",
               "toSurfaceRoot": true,
+              "ownership": "app",
+              "expectedExistingFrom": "templates/expected-existing/src/pages/console.vue",
               "reason": "Install shell-driven console wrapper page.",
               "category": "shell-web",
               "id": "shell-web-page-console-wrapper"
@@ -2804,6 +2820,8 @@
               "from": "templates/src/pages/console/index.vue",
               "toSurface": "console",
               "toSurfacePath": "index.vue",
+              "ownership": "app",
+              "expectedExistingFrom": "templates/expected-existing/src/pages/console/index.vue",
               "reason": "Install shell-driven console page starter.",
               "category": "shell-web",
               "id": "shell-web-page-console"

--- a/tooling/jskit-cli/src/server/cliRuntime/descriptorValidation.js
+++ b/tooling/jskit-cli/src/server/cliRuntime/descriptorValidation.js
@@ -24,12 +24,27 @@ function normalizePackageKind(rawValue, descriptorPath) {
   return normalized;
 }
 
-function validateInstallMigrationMutationShape(descriptor, descriptorPath) {
+function validateFileMutationShape(descriptor, descriptorPath) {
   const packageId = String(ensureObject(descriptor).packageId || "").trim() || "unknown-package";
   const mutations = ensureObject(ensureObject(descriptor).mutations);
   const files = ensureArray(mutations.files);
   for (const fileMutation of files) {
     const normalized = normalizeFileMutationRecord(fileMutation);
+    if (normalized.ownership !== "package" && normalized.ownership !== "app") {
+      throw createCliError(
+        `Invalid package descriptor at ${descriptorPath}: files mutation in ${packageId} has unsupported ownership "${normalized.ownership}". Expected "package" or "app".`
+      );
+    }
+    if (normalized.expectedExistingFrom && normalized.op !== "copy-file") {
+      throw createCliError(
+        `Invalid package descriptor at ${descriptorPath}: files mutation in ${packageId} can only use "expectedExistingFrom" with copy-file.`
+      );
+    }
+    if (normalized.expectedExistingFrom && normalized.ownership !== "app") {
+      throw createCliError(
+        `Invalid package descriptor at ${descriptorPath}: files mutation in ${packageId} can only use "expectedExistingFrom" when ownership is "app".`
+      );
+    }
     if (normalized.op !== "install-migration") {
       continue;
     }
@@ -69,7 +84,7 @@ function validatePackageDescriptorShape(descriptor, descriptorPath) {
     );
   }
 
-  validateInstallMigrationMutationShape(normalized, descriptorPath);
+  validateFileMutationShape(normalized, descriptorPath);
 
   return {
     ...normalized,
@@ -99,7 +114,7 @@ function validateAppLocalPackageDescriptorShape(descriptor, descriptorPath, { ex
     throw createCliError(`Invalid app-local package descriptor at ${descriptorPath}: missing version.`);
   }
 
-  validateInstallMigrationMutationShape(normalized, descriptorPath);
+  validateFileMutationShape(normalized, descriptorPath);
 
   return {
     ...normalized,

--- a/tooling/jskit-cli/src/server/cliRuntime/mutationApplication.js
+++ b/tooling/jskit-cli/src/server/cliRuntime/mutationApplication.js
@@ -1,6 +1,6 @@
 export {
   applyFileMutations,
-  preflightFileMutationTemplateContexts
+  prepareFileMutations
 } from "./mutations/fileMutations.js";
 
 export {

--- a/tooling/jskit-cli/src/server/cliRuntime/mutationWhen.js
+++ b/tooling/jskit-cli/src/server/cliRuntime/mutationWhen.js
@@ -41,6 +41,8 @@ function normalizeFileMutationRecord(value) {
     toSurfaceRoot: record.toSurfaceRoot === true,
     toDir: String(record.toDir || "").trim(),
     extension: normalizeMutationExtension(record.extension),
+    ownership: String(record.ownership || "").trim().toLowerCase() || "package",
+    expectedExistingFrom: String(record.expectedExistingFrom || "").trim(),
     preserveOnRemove: record.preserveOnRemove === true,
     id: String(record.id || "").trim(),
     category: String(record.category || "").trim(),

--- a/tooling/jskit-cli/src/server/cliRuntime/mutations/fileMutations.js
+++ b/tooling/jskit-cli/src/server/cliRuntime/mutations/fileMutations.js
@@ -1,5 +1,6 @@
 import {
-  readFile
+  mkdir,
+  writeFile
 } from "node:fs/promises";
 import path from "node:path";
 import { createCliError } from "../../shared/cliError.js";
@@ -20,35 +21,32 @@ import {
   resolveAppRelativePathWithinRoot
 } from "../ioAndMigrations.js";
 import {
-  copyTemplateFile,
   interpolateFileMutationRecord,
+  renderTemplateFile,
   resolveTemplateContextReplacementsForMutation
 } from "./templateContext.js";
 import { resolveSurfaceTargetPathsForMutation } from "./surfaceTargets.js";
 import { applyInstallMigrationMutation } from "./installMigrationMutation.js";
 
-async function applyFileMutations(
+async function prepareFileMutations(
   packageEntry,
   options,
   appRoot,
   fileMutations,
-  managedFiles,
-  managedMigrations,
-  touchedFiles,
-  warnings = [],
-  precomputedTemplateContextByMutationIndex = null
+  existingManagedFiles = []
 ) {
   const mutationList = ensureArray(fileMutations);
-  const managedMigrationById = new Map();
-  for (const managedMigrationValue of ensureArray(managedMigrations)) {
-    const managedMigration = ensureObject(managedMigrationValue);
-    const migrationId = String(managedMigration.id || "").trim();
-    if (!migrationId) {
+  const existingManagedFilesByPath = new Map();
+  for (const managedFileValue of ensureArray(existingManagedFiles)) {
+    const managedFile = ensureObject(managedFileValue);
+    const managedPath = String(managedFile.path || "").trim();
+    if (!managedPath) {
       continue;
     }
-    managedMigrationById.set(migrationId, managedMigration);
+    existingManagedFilesByPath.set(managedPath, managedFile);
   }
 
+  const preparedMutations = [];
   for (const [mutationIndex, mutationValue] of mutationList.entries()) {
     const normalizedMutation = normalizeFileMutationRecord(mutationValue);
     const requiresConfigContext = Boolean(normalizedMutation.when?.config || normalizedMutation.toSurface);
@@ -65,139 +63,16 @@ async function applyFileMutations(
     }
 
     const mutation = interpolateFileMutationRecord(normalizedMutation, options, packageEntry.packageId);
-    const operation = mutation.op || "copy-file";
-
-    if (operation === "install-migration") {
-      await applyInstallMigrationMutation({
-        packageEntry,
-        mutation,
-        rawMutation: mutationValue,
-        mutationIndex,
-        options,
-        appRoot,
-        managedMigrations,
-        managedMigrationById,
-        touchedFiles,
-        warnings,
-        precomputedTemplateContextByMutationIndex
-      });
-      continue;
-    }
-
-    if (operation !== "copy-file") {
-      throw createCliError(`Unsupported files mutation op \"${operation}\" in ${packageEntry.packageId}.`);
-    }
-
-    const from = mutation.from;
-    const to = mutation.to;
-    const toSurface = mutation.toSurface;
-    if (to && toSurface) {
-      throw createCliError(
-        `Invalid files mutation in ${packageEntry.packageId}: "to" and "toSurface" cannot both be set.`
-      );
-    }
-    if (!from || (!to && !toSurface)) {
-      throw createCliError(
-        `Invalid files mutation in ${packageEntry.packageId}: "from" plus one destination ("to" or "toSurface") are required.`
-      );
-    }
-
-    const sourcePath = path.join(packageEntry.rootDir, from);
-    if (!(await fileExists(sourcePath))) {
-      throw createCliError(`Missing template source ${sourcePath} for ${packageEntry.packageId}.`);
-    }
-
-    const targetPaths = toSurface
-      ? resolveSurfaceTargetPathsForMutation({
-          appRoot,
-          packageId: packageEntry.packageId,
-          mutation,
-          configContext
-        })
-      : [resolveAppRelativePathWithinRoot(appRoot, to, `${packageEntry.packageId} files mutation.to`).absolutePath];
-    const hasPrecomputedTemplateContext =
-      precomputedTemplateContextByMutationIndex instanceof Map &&
-      precomputedTemplateContextByMutationIndex.has(mutationIndex);
-    const templateContextReplacements = hasPrecomputedTemplateContext
-      ? precomputedTemplateContextByMutationIndex.get(mutationIndex)
-      : await resolveTemplateContextReplacementsForMutation({
-          packageEntry,
-          mutation,
-          options,
-          appRoot,
-          sourcePath,
-          targetPaths
-        });
-
-    for (const targetPath of targetPaths) {
-      const previous = await readFileBufferIfExists(targetPath);
-      await copyTemplateFile(
-        sourcePath,
-        targetPath,
-        options,
-        packageEntry.packageId,
-        `${mutation.id || to || from}.source`,
-        templateContextReplacements
-      );
-      const nextBuffer = await readFile(targetPath);
-
-      managedFiles.push({
-        path: normalizeRelativePath(appRoot, targetPath),
-        hash: hashBuffer(nextBuffer),
-        hadPrevious: previous.exists,
-        previousContentBase64: previous.exists ? previous.buffer.toString("base64") : "",
-        preserveOnRemove: mutation.preserveOnRemove,
-        reason: mutation.reason,
-        category: mutation.category,
-        id: mutation.id
-      });
-      touchedFiles.add(normalizeRelativePath(appRoot, targetPath));
-    }
-  }
-}
-
-async function preflightFileMutationTemplateContexts(
-  packageEntry,
-  options,
-  appRoot,
-  fileMutations
-) {
-  const mutationList = ensureArray(fileMutations);
-  const replacementsByMutationIndex = new Map();
-
-  for (const [mutationIndex, mutationValue] of mutationList.entries()) {
-    const normalizedMutation = normalizeFileMutationRecord(mutationValue);
-    const requiresConfigContext = Boolean(normalizedMutation.when?.config || normalizedMutation.toSurface);
-    const configContext = requiresConfigContext ? await loadMutationWhenConfigContext(appRoot) : {};
-    if (
-      !shouldApplyMutationWhen(normalizedMutation.when, {
-        options,
-        configContext,
-        packageId: packageEntry.packageId,
-        mutationContext: "files mutation"
-      })
-    ) {
-      continue;
-    }
-
-    const mutation = interpolateFileMutationRecord(normalizedMutation, options, packageEntry.packageId);
-    const templateContext = ensureObject(mutation.templateContext);
-    if (Object.keys(templateContext).length < 1) {
-      continue;
-    }
-
     const operation = mutation.op || "copy-file";
     if (operation !== "copy-file" && operation !== "install-migration") {
-      continue;
+      throw createCliError(`Unsupported files mutation op "${operation}" in ${packageEntry.packageId}.`);
     }
 
     const from = mutation.from;
     const to = mutation.to;
     const toSurface = mutation.toSurface;
     if (!from) {
-      throw createCliError(
-        `Invalid files mutation in ${packageEntry.packageId}: "from" is required.`
-      );
+      throw createCliError(`Invalid files mutation in ${packageEntry.packageId}: "from" is required.`);
     }
     if (operation === "copy-file") {
       if (to && toSurface) {
@@ -227,7 +102,7 @@ async function preflightFileMutationTemplateContexts(
           })
         : [resolveAppRelativePathWithinRoot(appRoot, to, `${packageEntry.packageId} files mutation.to`).absolutePath]
       : [path.join(appRoot, mutation.toDir || "migrations")];
-    const replacements = await resolveTemplateContextReplacementsForMutation({
+    const templateContextReplacements = await resolveTemplateContextReplacementsForMutation({
       packageEntry,
       mutation,
       options,
@@ -236,13 +111,183 @@ async function preflightFileMutationTemplateContexts(
       targetPaths,
       mutationContext: "files mutation"
     });
-    replacementsByMutationIndex.set(mutationIndex, replacements);
+    const interpolationKey = `${mutation.id || to || from}.source`;
+    const renderedSourceContent = await renderTemplateFile(
+      sourcePath,
+      options,
+      packageEntry.packageId,
+      interpolationKey,
+      templateContextReplacements
+    );
+
+    if (operation === "copy-file" && mutation.ownership === "app") {
+      const renderedSourceBuffer = Buffer.from(renderedSourceContent, "utf8");
+      const renderedSourceHash = hashBuffer(renderedSourceBuffer);
+      let expectedExistingHash = "";
+      if (mutation.expectedExistingFrom) {
+        const expectedExistingPath = path.join(packageEntry.rootDir, mutation.expectedExistingFrom);
+        if (!(await fileExists(expectedExistingPath))) {
+          throw createCliError(
+            `Missing expected existing source ${expectedExistingPath} for ${packageEntry.packageId}.`
+          );
+        }
+        const expectedExistingContent = await renderTemplateFile(
+          expectedExistingPath,
+          options,
+          packageEntry.packageId,
+          `${mutation.id || to || from}.expectedExisting`,
+          templateContextReplacements
+        );
+        expectedExistingHash = hashBuffer(Buffer.from(expectedExistingContent, "utf8"));
+      }
+
+      for (const targetPath of targetPaths) {
+        const relativeTargetPath = normalizeRelativePath(appRoot, targetPath);
+        if (existingManagedFilesByPath.has(relativeTargetPath)) {
+          const existing = await readFileBufferIfExists(targetPath);
+          if (!existing.exists) {
+            throw createCliError(
+              `${packageEntry.packageId}: app-owned file ${relativeTargetPath} is managed in lock but missing on disk. Restore it before updating, or remove and re-add the package intentionally.`
+            );
+          }
+          continue;
+        }
+
+        const existing = await readFileBufferIfExists(targetPath);
+        if (!existing.exists) {
+          continue;
+        }
+
+        const existingHash = hashBuffer(existing.buffer);
+        if (existingHash === renderedSourceHash) {
+          continue;
+        }
+        if (expectedExistingHash && existingHash === expectedExistingHash) {
+          continue;
+        }
+
+        const expectedSourceLabel = mutation.expectedExistingFrom
+          ? ` or match ${mutation.expectedExistingFrom}`
+          : "";
+        throw createCliError(
+          `${packageEntry.packageId}: app-owned file ${relativeTargetPath} already exists and cannot be claimed. It must already match the rendered scaffold${expectedSourceLabel}.`
+        );
+      }
+    }
+
+    preparedMutations.push({
+      mutationIndex,
+      mutation,
+      operation,
+      sourcePath,
+      targetPaths,
+      renderedSourceContent
+    });
   }
 
-  return replacementsByMutationIndex;
+  return preparedMutations;
+}
+
+async function applyFileMutations(
+  packageEntry,
+  appRoot,
+  preparedMutations,
+  managedFiles,
+  managedMigrations,
+  touchedFiles,
+  warnings = [],
+  existingManagedFiles = []
+) {
+  const existingManagedFilesByPath = new Map();
+  for (const managedFileValue of ensureArray(existingManagedFiles)) {
+    const managedFile = ensureObject(managedFileValue);
+    const managedPath = String(managedFile.path || "").trim();
+    if (!managedPath) {
+      continue;
+    }
+    existingManagedFilesByPath.set(managedPath, managedFile);
+  }
+
+  const managedMigrationById = new Map();
+  for (const managedMigrationValue of ensureArray(managedMigrations)) {
+    const managedMigration = ensureObject(managedMigrationValue);
+    const migrationId = String(managedMigration.id || "").trim();
+    if (!migrationId) {
+      continue;
+    }
+    managedMigrationById.set(migrationId, managedMigration);
+  }
+
+  for (const preparedMutation of ensureArray(preparedMutations)) {
+    const mutation = ensureObject(preparedMutation.mutation);
+    const operation = String(preparedMutation.operation || "").trim() || "copy-file";
+    if (operation === "install-migration") {
+      await applyInstallMigrationMutation({
+        packageEntry,
+        preparedMutation,
+        appRoot,
+        managedMigrations,
+        managedMigrationById,
+        touchedFiles,
+        warnings
+      });
+      continue;
+    }
+
+    const renderedSourceContent = String(preparedMutation.renderedSourceContent || "");
+    const renderedSourceBuffer = Buffer.from(renderedSourceContent, "utf8");
+    const renderedSourceHash = hashBuffer(renderedSourceBuffer);
+
+    for (const targetPath of ensureArray(preparedMutation.targetPaths)) {
+      const relativeTargetPath = normalizeRelativePath(appRoot, targetPath);
+      const previous = await readFileBufferIfExists(targetPath);
+      const existingManaged = existingManagedFilesByPath.get(relativeTargetPath);
+
+      if (mutation.ownership === "app" && existingManaged) {
+        managedFiles.push({
+          ...existingManaged,
+          path: relativeTargetPath,
+          preserveOnRemove: mutation.preserveOnRemove,
+          reason: mutation.reason || String(existingManaged.reason || ""),
+          category: mutation.category || String(existingManaged.category || ""),
+          id: mutation.id || String(existingManaged.id || "")
+        });
+        continue;
+      }
+
+      if (mutation.ownership === "app" && previous.exists && hashBuffer(previous.buffer) === renderedSourceHash) {
+        managedFiles.push({
+          path: relativeTargetPath,
+          hash: renderedSourceHash,
+          hadPrevious: true,
+          previousContentBase64: previous.buffer.toString("base64"),
+          preserveOnRemove: mutation.preserveOnRemove,
+          reason: mutation.reason,
+          category: mutation.category,
+          id: mutation.id
+        });
+        continue;
+      }
+
+      await mkdir(path.dirname(targetPath), { recursive: true });
+      await writeFile(targetPath, renderedSourceContent, "utf8");
+
+      managedFiles.push({
+        path: relativeTargetPath,
+        hash: renderedSourceHash,
+        hadPrevious: previous.exists,
+        previousContentBase64: previous.exists ? previous.buffer.toString("base64") : "",
+        preserveOnRemove: mutation.preserveOnRemove,
+        reason: mutation.reason,
+        category: mutation.category,
+        id: mutation.id
+      });
+      touchedFiles.add(relativeTargetPath);
+    }
+  }
 }
 
 export {
   applyFileMutations,
-  preflightFileMutationTemplateContexts
+  prepareFileMutations
 };

--- a/tooling/jskit-cli/src/server/cliRuntime/mutations/installMigrationMutation.js
+++ b/tooling/jskit-cli/src/server/cliRuntime/mutations/installMigrationMutation.js
@@ -6,7 +6,6 @@ import {
 import path from "node:path";
 import { createCliError } from "../../shared/cliError.js";
 import { ensureObject } from "../../shared/collectionUtils.js";
-import { interpolateOptionValue } from "../../shared/optionInterpolation.js";
 import {
   hashBuffer,
   normalizeMigrationExtension,
@@ -19,25 +18,18 @@ import {
   fileExists
 } from "../ioAndMigrations.js";
 import { normalizeRelativePosixPath } from "../localPackageSupport.js";
-import {
-  applyTemplateContextReplacements,
-  resolveTemplateContextReplacementsForMutation
-} from "./templateContext.js";
 
 async function applyInstallMigrationMutation({
   packageEntry,
-  mutation,
-  rawMutation,
-  mutationIndex,
-  options,
+  preparedMutation,
   appRoot,
   managedMigrations,
   managedMigrationById,
   touchedFiles,
-  warnings,
-  precomputedTemplateContextByMutationIndex
+  warnings
 } = {}) {
-  if (Object.hasOwn(ensureObject(rawMutation), "preserveOnRemove")) {
+  const mutation = ensureObject(preparedMutation?.mutation);
+  if (mutation.preserveOnRemove === true) {
     warnings.push(
       `${packageEntry.packageId}: install-migration ignores preserveOnRemove (migrations are always preserved on remove).`
     );
@@ -45,36 +37,17 @@ async function applyInstallMigrationMutation({
 
   const from = mutation.from;
   const toDir = mutation.toDir || "migrations";
+  const sourcePath = String(preparedMutation?.sourcePath || "").trim();
+  const renderedSourceContent = preparedMutation?.renderedSourceContent;
   if (!from) {
     throw createCliError(`Invalid install-migration mutation in ${packageEntry.packageId}: \"from\" is required.`);
   }
-  const migrationId = normalizeMigrationId(mutation.id, packageEntry.packageId);
-
-  const sourcePath = path.join(packageEntry.rootDir, from);
-  if (!(await fileExists(sourcePath))) {
-    throw createCliError(`Missing migration template source ${sourcePath} for ${packageEntry.packageId}.`);
+  if (!sourcePath) {
+    throw createCliError(`Invalid install-migration mutation in ${packageEntry.packageId}: missing prepared source path.`);
   }
-
-  const hasPrecomputedTemplateContext =
-    precomputedTemplateContextByMutationIndex instanceof Map &&
-    precomputedTemplateContextByMutationIndex.has(mutationIndex);
-  const templateContextReplacements = hasPrecomputedTemplateContext
-    ? precomputedTemplateContextByMutationIndex.get(mutationIndex)
-    : await resolveTemplateContextReplacementsForMutation({
-        packageEntry,
-        mutation,
-        options,
-        appRoot,
-        sourcePath,
-        targetPaths: [path.join(appRoot, toDir)]
-      });
-
-  const sourceContent = await readFile(sourcePath, "utf8");
-  let renderedSourceContent = sourceContent.includes("${")
-    ? interpolateOptionValue(sourceContent, options, packageEntry.packageId, `${mutation.id || from}.source`)
-    : sourceContent;
-  if (templateContextReplacements) {
-    renderedSourceContent = applyTemplateContextReplacements(renderedSourceContent, templateContextReplacements);
+  const migrationId = normalizeMigrationId(mutation.id, packageEntry.packageId);
+  if (typeof renderedSourceContent !== "string") {
+    throw createCliError(`Invalid install-migration mutation in ${packageEntry.packageId}: missing rendered migration source.`);
   }
   const sourceExtension = normalizeMigrationExtension(path.extname(from), ".cjs");
   const extension = normalizeMigrationExtension(mutation.extension, sourceExtension);

--- a/tooling/jskit-cli/src/server/cliRuntime/mutations/templateContext.js
+++ b/tooling/jskit-cli/src/server/cliRuntime/mutations/templateContext.js
@@ -1,9 +1,4 @@
-import {
-  mkdir,
-  readFile,
-  writeFile
-} from "node:fs/promises";
-import path from "node:path";
+import { readFile } from "node:fs/promises";
 import { pathToFileURL } from "node:url";
 import { createCliError } from "../../shared/cliError.js";
 import {
@@ -31,6 +26,8 @@ function interpolateFileMutationRecord(mutation, options, packageId) {
     toSurfacePath: interpolate(mutation.toSurfacePath, "toSurfacePath"),
     toDir: interpolate(mutation.toDir, "toDir"),
     extension: interpolate(mutation.extension, "extension"),
+    ownership: interpolate(mutation.ownership, "ownership"),
+    expectedExistingFrom: interpolate(mutation.expectedExistingFrom, "expectedExistingFrom"),
     id: interpolate(mutation.id, "id"),
     category: interpolate(mutation.category, "category"),
     reason: interpolate(mutation.reason, "reason"),
@@ -55,9 +52,8 @@ function applyTemplateContextReplacements(sourceContent, replacements) {
   return output;
 }
 
-async function copyTemplateFile(
+async function renderTemplateFile(
   sourcePath,
-  targetPath,
   options,
   packageId,
   interpolationKey,
@@ -70,9 +66,7 @@ async function copyTemplateFile(
   if (templateContextReplacements) {
     renderedContent = applyTemplateContextReplacements(renderedContent, templateContextReplacements);
   }
-
-  await mkdir(path.dirname(targetPath), { recursive: true });
-  await writeFile(targetPath, renderedContent, "utf8");
+  return renderedContent;
 }
 
 async function resolveTemplateContextReplacementsForMutation({
@@ -165,7 +159,7 @@ async function resolveTemplateContextReplacementsForMutation({
 
 export {
   applyTemplateContextReplacements,
-  copyTemplateFile,
   interpolateFileMutationRecord,
+  renderTemplateFile,
   resolveTemplateContextReplacementsForMutation
 };

--- a/tooling/jskit-cli/src/server/cliRuntime/packageInstallFlow.js
+++ b/tooling/jskit-cli/src/server/cliRuntime/packageInstallFlow.js
@@ -32,7 +32,7 @@ import {
 import {
   applyFileMutations,
   applyTextMutations,
-  preflightFileMutationTemplateContexts,
+  prepareFileMutations,
   resolvePositioningMutations
 } from "./mutationApplication.js";
 function createManagedRecordBase(packageEntry, options) {
@@ -138,15 +138,23 @@ async function applyPackagePositioning({
   const positioningMutations = resolvePositioningMutations(mutations);
   const appliedManagedFiles = [];
   const appliedManagedText = {};
+  const preparedFileMutations = await prepareFileMutations(
+    packageEntryForMutations,
+    packageOptions,
+    appRoot,
+    positioningMutations.files,
+    nextManaged.files
+  );
   if (positioningMutations.files.length > 0) {
     await applyFileMutations(
       packageEntryForMutations,
-      packageOptions,
       appRoot,
-      positioningMutations.files,
+      preparedFileMutations,
       appliedManagedFiles,
       [],
-      touchedFiles
+      touchedFiles,
+      [],
+      nextManaged.files
     );
   }
   if (positioningMutations.text.length > 0) {
@@ -236,17 +244,24 @@ async function applyPackageMigrationsOnly({
     return operation === "install-migration";
   });
   const mutationWarnings = [];
+  const preparedFileMutations = await prepareFileMutations(
+    packageEntryForMutations,
+    packageOptions,
+    appRoot,
+    migrationFileMutations,
+    nextManaged.files
+  );
 
   if (migrationFileMutations.length > 0) {
     await applyFileMutations(
       packageEntryForMutations,
-      packageOptions,
       appRoot,
-      migrationFileMutations,
+      preparedFileMutations,
       [],
       nextManaged.migrations,
       touchedFiles,
-      mutationWarnings
+      mutationWarnings,
+      nextManaged.files
     );
   }
 
@@ -280,15 +295,6 @@ async function applyPackageInstall({
 }) {
   const existingInstall = ensureObject(lock.installedPackages[packageEntry.packageId]);
   const existingManaged = ensureObject(existingInstall.managed);
-  await removeManagedViteProxyEntries({
-    appRoot,
-    packageId: packageEntry.packageId,
-    managedViteChanges: ensureObject(existingManaged.vite),
-    touchedFiles
-  });
-
-  const managedRecord = createManagedRecordBase(packageEntry, packageOptions);
-  managedRecord.managed.migrations = cloneManagedArray(existingManaged.migrations);
   const generatorPackage = isGeneratorPackageEntry(packageEntry);
   const mutationWarnings = [];
   const mutations = ensureObject(packageEntry.descriptor.mutations);
@@ -306,12 +312,22 @@ async function applyPackageInstall({
           rootDir: templateRoot
         };
 
-  const precomputedTemplateContextByMutationIndex = await preflightFileMutationTemplateContexts(
+  const preparedFileMutations = await prepareFileMutations(
     packageEntryForMutations,
     packageOptions,
     appRoot,
-    fileMutations
+    fileMutations,
+    ensureArray(existingManaged.files)
   );
+  await removeManagedViteProxyEntries({
+    appRoot,
+    packageId: packageEntry.packageId,
+    managedViteChanges: ensureObject(existingManaged.vite),
+    touchedFiles
+  });
+
+  const managedRecord = createManagedRecordBase(packageEntry, packageOptions);
+  managedRecord.managed.migrations = cloneManagedArray(existingManaged.migrations);
 
   const mutationDependencies = ensureObject(mutations.dependencies);
   const runtimeDependencies = ensureObject(mutationDependencies.runtime);
@@ -416,14 +432,13 @@ async function applyPackageInstall({
 
   await applyFileMutations(
     packageEntryForMutations,
-    packageOptions,
     appRoot,
-    fileMutations,
+    preparedFileMutations,
     managedRecord.managed.files,
     managedRecord.managed.migrations,
     touchedFiles,
     mutationWarnings,
-    precomputedTemplateContextByMutationIndex
+    ensureArray(existingManaged.files)
   );
 
   await applyTextMutations(

--- a/tooling/jskit-cli/test/appOwnedFileMutation.test.js
+++ b/tooling/jskit-cli/test/appOwnedFileMutation.test.js
@@ -1,0 +1,214 @@
+import assert from "node:assert/strict";
+import { access, constants as fsConstants, mkdir, readFile, unlink, writeFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import test from "node:test";
+import { withTempDir } from "../../testUtils/tempDir.mjs";
+import { createCliRunner } from "../../testUtils/runCli.js";
+
+const CLI_PATH = fileURLToPath(new URL("../bin/jskit.js", import.meta.url));
+const runCli = createCliRunner(CLI_PATH);
+
+async function createMinimalApp(appRoot, { name = "tmp-app" } = {}) {
+  await mkdir(appRoot, { recursive: true });
+  await writeFile(
+    path.join(appRoot, "package.json"),
+    `${JSON.stringify(
+      {
+        name,
+        version: "0.1.0",
+        private: true,
+        type: "module"
+      },
+      null,
+      2
+    )}\n`,
+    "utf8"
+  );
+}
+
+async function fileExists(absolutePath) {
+  try {
+    await access(absolutePath, fsConstants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function createAppOwnedClaimPackage(
+  appRoot,
+  {
+    version = "0.1.0",
+    expectedExistingContent = "starter-shell\n",
+    replacementContent = "claimed-shell\n"
+  } = {}
+) {
+  const packageRoot = path.join(appRoot, "packages", "claim-feature");
+  await mkdir(path.join(packageRoot, "src", "server"), { recursive: true });
+  await mkdir(path.join(packageRoot, "templates"), { recursive: true });
+
+  await writeFile(
+    path.join(packageRoot, "package.json"),
+    `${JSON.stringify(
+      {
+        name: "@demo/claim-feature",
+        version,
+        type: "module"
+      },
+      null,
+      2
+    )}\n`,
+    "utf8"
+  );
+
+  await writeFile(
+    path.join(packageRoot, "src", "server", "Provider.js"),
+    "class Provider { static id = \"demo.claim\"; register() {} boot() {} }\nexport { Provider };\n",
+    "utf8"
+  );
+
+  await writeFile(path.join(packageRoot, "templates", "expected-existing.txt"), expectedExistingContent, "utf8");
+  await writeFile(path.join(packageRoot, "templates", "replacement.txt"), replacementContent, "utf8");
+
+  await writeFile(
+    path.join(packageRoot, "package.descriptor.mjs"),
+    `export default Object.freeze({
+  packageId: "@demo/claim-feature",
+  version: "${version}",
+  kind: "runtime",
+  runtime: {
+    server: {
+      providers: [{ entrypoint: "src/server/Provider.js", export: "Provider" }]
+    },
+    client: {
+      providers: []
+    }
+  },
+  mutations: {
+    dependencies: {
+      runtime: {},
+      dev: {}
+    },
+    files: [
+      {
+        from: "templates/replacement.txt",
+        to: "src/App.vue",
+        ownership: "app",
+        expectedExistingFrom: "templates/expected-existing.txt",
+        reason: "Claim app shell scaffold.",
+        category: "demo",
+        id: "demo-app-shell"
+      }
+    ]
+  }
+});
+`,
+    "utf8"
+  );
+}
+
+test("add package claims an app-owned file from the expected baseline and preserves it on update", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "app-owned-claim-app");
+    await createMinimalApp(appRoot, { name: "app-owned-claim-app" });
+    await mkdir(path.join(appRoot, "src"), { recursive: true });
+    await writeFile(path.join(appRoot, "src", "App.vue"), "starter-shell\n", "utf8");
+
+    await createAppOwnedClaimPackage(appRoot, {
+      version: "0.1.0",
+      expectedExistingContent: "starter-shell\n",
+      replacementContent: "claimed-shell-v1\n"
+    });
+
+    const addResult = runCli({
+      cwd: appRoot,
+      args: ["add", "package", "@demo/claim-feature"]
+    });
+    assert.equal(addResult.status, 0, String(addResult.stderr || ""));
+    assert.equal(await readFile(path.join(appRoot, "src", "App.vue"), "utf8"), "claimed-shell-v1\n");
+
+    const lockAfterAdd = JSON.parse(await readFile(path.join(appRoot, ".jskit", "lock.json"), "utf8"));
+    assert.equal(lockAfterAdd.installedPackages["@demo/claim-feature"].managed.files[0].path, "src/App.vue");
+
+    await createAppOwnedClaimPackage(appRoot, {
+      version: "0.2.0",
+      expectedExistingContent: "starter-shell\n",
+      replacementContent: "claimed-shell-v2\n"
+    });
+
+    const updateResult = runCli({
+      cwd: appRoot,
+      args: ["update", "package", "@demo/claim-feature"]
+    });
+    assert.equal(updateResult.status, 0, String(updateResult.stderr || ""));
+    assert.equal(await readFile(path.join(appRoot, "src", "App.vue"), "utf8"), "claimed-shell-v1\n");
+  });
+});
+
+test("add package fails before any writes when an app-owned file cannot be claimed", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "app-owned-claim-failure-app");
+    await createMinimalApp(appRoot, { name: "app-owned-claim-failure-app" });
+    await mkdir(path.join(appRoot, "src"), { recursive: true });
+    await writeFile(path.join(appRoot, "src", "App.vue"), "custom-app-shell\n", "utf8");
+    await createAppOwnedClaimPackage(appRoot, {
+      expectedExistingContent: "starter-shell\n",
+      replacementContent: "claimed-shell\n"
+    });
+
+    const addResult = runCli({
+      cwd: appRoot,
+      args: ["add", "package", "@demo/claim-feature"]
+    });
+    assert.notEqual(addResult.status, 0);
+    assert.match(String(addResult.stderr || ""), /cannot be claimed/i);
+
+    assert.equal(await readFile(path.join(appRoot, "src", "App.vue"), "utf8"), "custom-app-shell\n");
+
+    const appPackageJson = JSON.parse(await readFile(path.join(appRoot, "package.json"), "utf8"));
+    assert.equal(appPackageJson.dependencies, undefined);
+    assert.equal(await fileExists(path.join(appRoot, ".jskit", "lock.json")), false);
+  });
+});
+
+test("update package fails when a managed app-owned file is missing on disk", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "app-owned-missing-file-app");
+    await createMinimalApp(appRoot, { name: "app-owned-missing-file-app" });
+    await mkdir(path.join(appRoot, "src"), { recursive: true });
+    await writeFile(path.join(appRoot, "src", "App.vue"), "starter-shell\n", "utf8");
+
+    await createAppOwnedClaimPackage(appRoot, {
+      version: "0.1.0",
+      expectedExistingContent: "starter-shell\n",
+      replacementContent: "claimed-shell-v1\n"
+    });
+
+    const addResult = runCli({
+      cwd: appRoot,
+      args: ["add", "package", "@demo/claim-feature"]
+    });
+    assert.equal(addResult.status, 0, String(addResult.stderr || ""));
+
+    const lockPath = path.join(appRoot, ".jskit", "lock.json");
+    const lockAfterAdd = await readFile(lockPath, "utf8");
+
+    await unlink(path.join(appRoot, "src", "App.vue"));
+
+    await createAppOwnedClaimPackage(appRoot, {
+      version: "0.2.0",
+      expectedExistingContent: "starter-shell\n",
+      replacementContent: "claimed-shell-v2\n"
+    });
+
+    const updateResult = runCli({
+      cwd: appRoot,
+      args: ["update", "package", "@demo/claim-feature"]
+    });
+    assert.equal(updateResult.status, 1);
+    assert.match(String(updateResult.stderr || ""), /managed in lock but missing on disk/i);
+    assert.equal(await fileExists(path.join(appRoot, "src", "App.vue")), false);
+    assert.equal(await readFile(lockPath, "utf8"), lockAfterAdd);
+  });
+});

--- a/tooling/jskit-cli/test/optionMutationInterpolation.test.js
+++ b/tooling/jskit-cli/test/optionMutationInterpolation.test.js
@@ -388,6 +388,83 @@ test("update package fails when an install-migration source changes for the same
   });
 });
 
+test("add package allows empty rendered install-migration files", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "empty-migration-app");
+    await createMinimalApp(appRoot, { name: "empty-migration-app" });
+
+    const packageRoot = path.join(appRoot, "packages", "empty-migration");
+    await mkdir(path.join(packageRoot, "src", "server"), { recursive: true });
+    await mkdir(path.join(packageRoot, "templates"), { recursive: true });
+
+    await writeFile(
+      path.join(packageRoot, "package.json"),
+      `${JSON.stringify(
+        {
+          name: "@demo/empty-migration",
+          version: "0.1.0",
+          type: "module"
+        },
+        null,
+        2
+      )}\n`,
+      "utf8"
+    );
+
+    await writeFile(
+      path.join(packageRoot, "src", "server", "Provider.js"),
+      "class Provider { static id = \"demo.empty.migration\"; register() {} boot() {} }\nexport { Provider };\n",
+      "utf8"
+    );
+    await writeFile(path.join(packageRoot, "templates", "migration.cjs"), "", "utf8");
+
+    await writeFile(
+      path.join(packageRoot, "package.descriptor.mjs"),
+      `export default Object.freeze({
+  packageId: "@demo/empty-migration",
+  version: "0.1.0",
+  kind: "runtime",
+  runtime: {
+    server: {
+      providers: [{ entrypoint: "src/server/Provider.js", export: "Provider" }]
+    },
+    client: {
+      providers: []
+    }
+  },
+  mutations: {
+    dependencies: {
+      runtime: {},
+      dev: {}
+    },
+    files: [
+      {
+        op: "install-migration",
+        from: "templates/migration.cjs",
+        toDir: "migrations",
+        extension: ".cjs",
+        id: "demo-empty-migration"
+      }
+    ]
+  }
+});\n`,
+      "utf8"
+    );
+
+    const addResult = runCli({
+      cwd: appRoot,
+      args: ["add", "package", "@demo/empty-migration"]
+    });
+    assert.equal(addResult.status, 0, String(addResult.stderr || ""));
+
+    const migrationFiles = (await readdir(path.join(appRoot, "migrations")))
+      .filter((entry) => /^\d{14}_demo-empty-migration\.cjs$/.test(entry))
+      .sort();
+    assert.equal(migrationFiles.length, 1);
+    assert.equal(await readFile(path.join(appRoot, "migrations", migrationFiles[0]), "utf8"), "");
+  });
+});
+
 test("remove then re-add package reuses existing timestamped migration by id", async () => {
   await withTempDir(async (cwd) => {
     const appRoot = path.join(cwd, "migration-readd-app");


### PR DESCRIPTION
## Summary
- mark shell-web starter files as app-owned scaffolds with expected-existing baselines
- teach jskit-cli file/install mutations to claim app-owned files safely and preserve managed files on update
- update create-app auth setup guidance and related catalog/tests

## Verification
- npm run verify