### PR TITLE
Require shell-web for page-style generator commands

### DIFF
--- a/packages/assistant/package.descriptor.mjs
+++ b/packages/assistant/package.descriptor.mjs
@@ -158,6 +158,7 @@ export default Object.freeze({
         ]
       },
       page: {
+        requiresShellWeb: true,
         entrypoint: "src/server/subcommands/page.js",
         export: "runGeneratorSubcommand",
         description: "Create an assistant runtime page at an explicit target file relative to src/pages/.",
@@ -194,6 +195,7 @@ export default Object.freeze({
         ]
       },
       "settings-page": {
+        requiresShellWeb: true,
         entrypoint: "src/server/subcommands/settingsPage.js",
         export: "runGeneratorSubcommand",
         description: "Create an assistant settings page at an explicit target file relative to src/pages/.",

--- a/packages/crud-ui-generator/package.descriptor.mjs
+++ b/packages/crud-ui-generator/package.descriptor.mjs
@@ -88,6 +88,7 @@ export default Object.freeze({
     generatorPrimarySubcommand: "crud",
     generatorSubcommands: {
       crud: {
+        requiresShellWeb: true,
         description: "Create CRUD pages at an explicit route root relative to src/pages/.",
         longDescription: [
           "CRUD generation follows the same page-placement model as `ui-generator page`.",
@@ -144,6 +145,7 @@ export default Object.freeze({
         ]
       },
       field: {
+        requiresShellWeb: true,
         entrypoint: "src/server/subcommands/addField.js",
         export: "runGeneratorSubcommand"
       }

--- a/packages/ui-generator/package.descriptor.mjs
+++ b/packages/ui-generator/package.descriptor.mjs
@@ -104,6 +104,7 @@ export default Object.freeze({
     generatorPrimarySubcommand: "page",
     generatorSubcommands: {
       page: {
+        requiresShellWeb: true,
         entrypoint: "src/server/subcommands/page.js",
         export: "runGeneratorSubcommand",
         description: "Create a route page at an explicit target file and add a link placement entry for it.",
@@ -146,6 +147,7 @@ export default Object.freeze({
         ]
       },
       "placed-element": {
+        requiresShellWeb: true,
         entrypoint: "src/server/subcommands/element.js",
         export: "runGeneratorSubcommand",
         description: "Create a Vue component file under the chosen component directory (default: src/components) and add a placement entry that renders it.",
@@ -178,6 +180,7 @@ export default Object.freeze({
         ]
       },
       "add-subpages": {
+        requiresShellWeb: true,
         entrypoint: "src/server/subcommands/addSubpages.js",
         export: "runGeneratorSubcommand",
         description: "Upgrade an existing page into a routed subpage host with SectionContainerShell, ShellOutlet, and RouterView.",
@@ -217,6 +220,7 @@ export default Object.freeze({
         ]
       },
       outlet: {
+        requiresShellWeb: true,
         entrypoint: "src/server/subcommands/outlet.js",
         export: "runGeneratorSubcommand",
         description: "Inject a generic ShellOutlet block into an existing Vue page/component.",

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -171,6 +171,7 @@
               ]
             },
             "page": {
+              "requiresShellWeb": true,
               "entrypoint": "src/server/subcommands/page.js",
               "export": "runGeneratorSubcommand",
               "description": "Create an assistant runtime page at an explicit target file relative to src/pages/.",
@@ -213,6 +214,7 @@
               ]
             },
             "settings-page": {
+              "requiresShellWeb": true,
               "entrypoint": "src/server/subcommands/settingsPage.js",
               "export": "runGeneratorSubcommand",
               "description": "Create an assistant settings page at an explicit target file relative to src/pages/.",
@@ -1559,6 +1561,7 @@
           "generatorPrimarySubcommand": "crud",
           "generatorSubcommands": {
             "crud": {
+              "requiresShellWeb": true,
               "description": "Create CRUD pages at an explicit route root relative to src/pages/.",
               "longDescription": [
                 "CRUD generation follows the same page-placement model as `ui-generator page`.",
@@ -1617,6 +1620,7 @@
               ]
             },
             "field": {
+              "requiresShellWeb": true,
               "entrypoint": "src/server/subcommands/addField.js",
               "export": "runGeneratorSubcommand"
             }
@@ -3007,6 +3011,7 @@
           "generatorPrimarySubcommand": "page",
           "generatorSubcommands": {
             "page": {
+              "requiresShellWeb": true,
               "entrypoint": "src/server/subcommands/page.js",
               "export": "runGeneratorSubcommand",
               "description": "Create a route page at an explicit target file and add a link placement entry for it.",
@@ -3055,6 +3060,7 @@
               ]
             },
             "placed-element": {
+              "requiresShellWeb": true,
               "entrypoint": "src/server/subcommands/element.js",
               "export": "runGeneratorSubcommand",
               "description": "Create a Vue component file under the chosen component directory (default: src/components) and add a placement entry that renders it.",
@@ -3096,6 +3102,7 @@
               ]
             },
             "add-subpages": {
+              "requiresShellWeb": true,
               "entrypoint": "src/server/subcommands/addSubpages.js",
               "export": "runGeneratorSubcommand",
               "description": "Upgrade an existing page into a routed subpage host with SectionContainerShell, ShellOutlet, and RouterView.",
@@ -3140,6 +3147,7 @@
               ]
             },
             "outlet": {
+              "requiresShellWeb": true,
               "entrypoint": "src/server/subcommands/outlet.js",
               "export": "runGeneratorSubcommand",
               "description": "Inject a generic ShellOutlet block into an existing Vue page/component.",

--- a/tooling/jskit-cli/src/server/commandHandlers/packageCommands/generate.js
+++ b/tooling/jskit-cli/src/server/commandHandlers/packageCommands/generate.js
@@ -7,6 +7,8 @@ import {
 } from "./discoverabilityHelp.js";
 import { interpolateOptionValue } from "../../shared/optionInterpolation.js";
 
+const SHELL_WEB_PACKAGE_ID = "@jskit-ai/shell-web";
+
 function resolveGeneratorSubcommandDefinitionMetadata(packageEntry = {}, subcommandName = "") {
   const descriptor = packageEntry?.descriptor && typeof packageEntry.descriptor === "object"
     ? packageEntry.descriptor
@@ -25,6 +27,10 @@ function resolveGeneratorSubcommandDefinitionMetadata(packageEntry = {}, subcomm
   }
   const definition = subcommands[normalizedSubcommandName];
   return definition && typeof definition === "object" ? definition : {};
+}
+
+function resolveSubcommandRequiresShellWeb(packageEntry = {}, subcommandName = "") {
+  return resolveGeneratorSubcommandDefinitionMetadata(packageEntry, subcommandName)?.requiresShellWeb === true;
 }
 
 function mapDescriptorBackedSubcommandArgsToInlineOptions(
@@ -199,6 +205,7 @@ async function runPackageGenerateCommand(
     resolvePackageKind,
     resolveGeneratorPrimarySubcommand,
     hasGeneratorSubcommandDefinition,
+    loadLockFile,
     readdir,
     validateInlineOptionValuesForPackage,
     runGeneratorSubcommand,
@@ -360,6 +367,15 @@ async function runPackageGenerateCommand(
       appRoot,
       optionNames: validatedOptionNames
     });
+    if (resolveSubcommandRequiresShellWeb(packageEntry, normalizedSubcommandName)) {
+      const { lock } = await loadLockFile(appRoot);
+      if (!lock?.installedPackages?.[SHELL_WEB_PACKAGE_ID]) {
+        const commandLabel = `${String(targetId || resolvedPackageId || "").trim() || resolvedPackageId} ${normalizedSubcommandName}`.trim();
+        throw createCliError(
+          `Generator command ${commandLabel} requires ${SHELL_WEB_PACKAGE_ID} to be installed in this app. Run: npx jskit add package shell-web`
+        );
+      }
+    }
 
     const primarySubcommand = resolveGeneratorPrimarySubcommand(packageEntry);
     if (

--- a/tooling/jskit-cli/test/assistantPackage.test.js
+++ b/tooling/jskit-cli/test/assistantPackage.test.js
@@ -5,6 +5,7 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 import { withTempDir } from "../../testUtils/tempDir.mjs";
 import { createCliRunner } from "../../testUtils/runCli.js";
+import { writeInstalledPackagesLock } from "./testLock.js";
 
 const CLI_PATH = fileURLToPath(new URL("../bin/jskit.js", import.meta.url));
 const REPO_ROOT = fileURLToPath(new URL("../../../", import.meta.url));
@@ -115,6 +116,13 @@ export default MainClientProvider;
 `,
     "utf8"
   );
+
+  await writeInstalledPackagesLock(appRoot, {
+    "@jskit-ai/shell-web": {
+      packageId: "@jskit-ai/shell-web",
+      version: "0.1.0"
+    }
+  });
 }
 
 async function installAssistantGenerator(appRoot) {

--- a/tooling/jskit-cli/test/generatorSubcommand.test.js
+++ b/tooling/jskit-cli/test/generatorSubcommand.test.js
@@ -5,6 +5,7 @@ import path from "node:path";
 import test from "node:test";
 import { withTempDir } from "../../testUtils/tempDir.mjs";
 import { createCliRunner } from "../../testUtils/runCli.js";
+import { writeInstalledPackagesLock } from "./testLock.js";
 
 const CLI_PATH = fileURLToPath(new URL("../bin/jskit.js", import.meta.url));
 const runCli = createCliRunner(CLI_PATH);
@@ -36,7 +37,7 @@ async function createMinimalApp(appRoot, { name = "tmp-app" } = {}) {
   );
 }
 
-async function writeGeneratorPackage(appRoot) {
+async function writeGeneratorPackage(appRoot, { requiresShellWeb = false } = {}) {
   const packageRoot = path.join(appRoot, "packages", "demo-generator");
   await mkdir(path.join(packageRoot, "src", "server", "subcommands"), { recursive: true });
 
@@ -80,6 +81,7 @@ async function writeGeneratorPackage(appRoot) {
     generatorPrimarySubcommand: "ping",
     generatorSubcommands: {
       ping: {
+        requiresShellWeb: ${requiresShellWeb ? "true" : "false"},
         entrypoint: "src/server/subcommands/ping.js",
         export: "runGeneratorSubcommand"
       }
@@ -159,5 +161,46 @@ test("generate <packageId> with no subcommand shows generator help instead of ex
     assert.equal(result.status, 0, String(result.stderr || ""));
     assert.match(String(result.stdout || ""), /Generator help: @demo\/generator/);
     assert.equal(await fileExists(path.join(appRoot, "tmp", "generator-subcommand.txt")), false);
+  });
+});
+
+test("generate <packageId> <subcommand> fails when the subcommand requires shell-web and it is not installed", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "generator-subcommand-shell-gate-app");
+    await createMinimalApp(appRoot, { name: "generator-subcommand-shell-gate-app" });
+    await writeGeneratorPackage(appRoot, { requiresShellWeb: true });
+
+    const result = runCli({
+      cwd: appRoot,
+      args: ["generate", "@demo/generator", "ping", "a", "b"]
+    });
+
+    assert.equal(result.status, 1);
+    assert.match(String(result.stderr || ""), /requires @jskit-ai\/shell-web to be installed in this app/i);
+    assert.equal(await fileExists(path.join(appRoot, "tmp", "generator-subcommand.txt")), false);
+  });
+});
+
+test("generate <packageId> <subcommand> runs when the subcommand requires shell-web and shell-web is installed", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "generator-subcommand-shell-ready-app");
+    await createMinimalApp(appRoot, { name: "generator-subcommand-shell-ready-app" });
+    await writeGeneratorPackage(appRoot, { requiresShellWeb: true });
+    await writeInstalledPackagesLock(appRoot, {
+      "@jskit-ai/shell-web": {
+        packageId: "@jskit-ai/shell-web",
+        version: "0.1.0"
+      }
+    });
+
+    const result = runCli({
+      cwd: appRoot,
+      args: ["generate", "@demo/generator", "ping", "a", "b"]
+    });
+
+    assert.equal(result.status, 0, String(result.stderr || ""));
+    assert.match(String(result.stdout || ""), /Generated with @demo\/generator \(ping\)/);
+    const output = await readFile(path.join(appRoot, "tmp", "generator-subcommand.txt"), "utf8");
+    assert.equal(output, "ping:a,b");
   });
 });

--- a/tooling/jskit-cli/test/testLock.js
+++ b/tooling/jskit-cli/test/testLock.js
@@ -1,0 +1,21 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+async function writeInstalledPackagesLock(appRoot, installedPackages = {}) {
+  const lockDirectory = path.join(appRoot, ".jskit");
+  await mkdir(lockDirectory, { recursive: true });
+  await writeFile(
+    path.join(lockDirectory, "lock.json"),
+    `${JSON.stringify(
+      {
+        lockVersion: 1,
+        installedPackages
+      },
+      null,
+      2
+    )}\n`,
+    "utf8"
+  );
+}
+
+export { writeInstalledPackagesLock };

--- a/tooling/jskit-cli/test/uiElementGeneratorPackage.test.js
+++ b/tooling/jskit-cli/test/uiElementGeneratorPackage.test.js
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 import { readLocalLinkItemComponentSource } from "@jskit-ai/shell-web/server/support/localLinkItemScaffolds";
 import { withTempDir } from "../../testUtils/tempDir.mjs";
 import { createCliRunner } from "../../testUtils/runCli.js";
+import { writeInstalledPackagesLock } from "./testLock.js";
 
 const CLI_PATH = fileURLToPath(new URL("../bin/jskit.js", import.meta.url));
 const REPO_ROOT = fileURLToPath(new URL("../../../", import.meta.url));
@@ -130,6 +131,13 @@ export {
 `,
     "utf8"
   );
+
+  await writeInstalledPackagesLock(appRoot, {
+    "@jskit-ai/shell-web": {
+      packageId: "@jskit-ai/shell-web",
+      version: "0.1.0"
+    }
+  });
 }
 
 async function installUiGeneratorPackage(appRoot) {
@@ -199,6 +207,31 @@ test("generate @jskit-ai/ui-generator page scaffolds page and menu placement", a
   });
 });
 
+test("generate @jskit-ai/ui-generator page requires shell-web to be installed in lock", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "ui-element-generator-shell-gate");
+    await createMinimalApp(appRoot, { name: "ui-element-generator-shell-gate" });
+    await writeInstalledPackagesLock(appRoot, {});
+    await installUiGeneratorPackage(appRoot);
+
+    const result = runCli({
+      cwd: appRoot,
+      args: [
+        "generate",
+        "@jskit-ai/ui-generator",
+        "page",
+        "admin/reports-dashboard/index.vue",
+        "--name",
+        "Reports Dashboard"
+      ]
+    });
+
+    assert.equal(result.status, 1);
+    assert.match(String(result.stderr || ""), /requires @jskit-ai\/shell-web to be installed in this app/i);
+    assert.equal(await fileExists(path.join(appRoot, "src", "pages", "admin", "reports-dashboard", "index.vue")), false);
+  });
+});
+
 test("generate @jskit-ai/ui-generator with no subcommand shows generator help without mutating app deps", async () => {
   await withTempDir(async (cwd) => {
     const appRoot = path.join(cwd, "ui-element-generator-primary-help");
@@ -224,6 +257,8 @@ test("generate @jskit-ai/ui-generator with no subcommand shows generator help wi
       "utf8"
     );
     const packageJsonBefore = await readFile(packageJsonPath, "utf8");
+    const lockPath = path.join(appRoot, ".jskit", "lock.json");
+    const lockBefore = await readFile(lockPath, "utf8");
 
     const result = runCli({
       cwd: appRoot,
@@ -236,7 +271,7 @@ test("generate @jskit-ai/ui-generator with no subcommand shows generator help wi
 
     const packageJsonAfter = await readFile(packageJsonPath, "utf8");
     assert.equal(packageJsonAfter, packageJsonBefore);
-    assert.equal(await fileExists(path.join(appRoot, ".jskit", "lock.json")), false);
+    assert.equal(await readFile(lockPath, "utf8"), lockBefore);
   });
 });
 

--- a/tooling/jskit-cli/test/uiGeneratorPackage.test.js
+++ b/tooling/jskit-cli/test/uiGeneratorPackage.test.js
@@ -5,6 +5,7 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 import { withTempDir } from "../../testUtils/tempDir.mjs";
 import { createCliRunner } from "../../testUtils/runCli.js";
+import { writeInstalledPackagesLock } from "./testLock.js";
 
 const CLI_PATH = fileURLToPath(new URL("../bin/jskit.js", import.meta.url));
 const REPO_ROOT = fileURLToPath(new URL("../../../", import.meta.url));
@@ -116,6 +117,13 @@ export {
 `,
     "utf8"
   );
+
+  await writeInstalledPackagesLock(appRoot, {
+    "@jskit-ai/shell-web": {
+      packageId: "@jskit-ai/shell-web",
+      version: "0.1.0"
+    }
+  });
 }
 
 async function installCrudUiGeneratorPackage(appRoot) {
@@ -561,6 +569,8 @@ test("generate @jskit-ai/crud-ui-generator refuses a non-empty existing target r
 `,
       "utf8"
     );
+    const lockPath = path.join(appRoot, ".jskit", "lock.json");
+    const lockBefore = await readFile(lockPath, "utf8");
 
     const result = runCli({
       cwd: appRoot,
@@ -581,7 +591,7 @@ test("generate @jskit-ai/crud-ui-generator refuses a non-empty existing target r
       String(result.stderr || ""),
       /crud-ui-generator crud will not overwrite existing target root src\/pages\/admin\/products\. Re-run with --force to overwrite it\./
     );
-    assert.equal(await fileExists(path.join(appRoot, ".jskit", "lock.json")), false);
+    assert.equal(await readFile(lockPath, "utf8"), lockBefore);
 
     const listPageSource = await readFile(path.join(appRoot, "src/pages/admin/products/index.vue"), "utf8");
     assert.match(listPageSource, /custom products page/);


### PR DESCRIPTION
## Summary
- mark page/placement-style generator subcommands as requiring `@jskit-ai/shell-web`
- enforce that requirement in `jskit generate` by checking the app lock before execution
- cover the shell-web gate with shared lock helpers and generator package tests

## Verification
- npm run verify