### PR TITLE
Make generated page links auth-aware by surface

### DIFF
--- a/packages/assistant/src/server/pageSupport.js
+++ b/packages/assistant/src/server/pageSupport.js
@@ -60,6 +60,7 @@ async function resolveAssistantPageGenerationContext({
     linkComponentToken: String(linkTarget.componentToken || ""),
     linkWorkspaceSuffix: pageTarget.routeUrlSuffix,
     linkNonWorkspaceSuffix: pageTarget.routeUrlSuffix,
+    linkWhenLine: String(linkTarget.whenLine || ""),
     linkToPropLine: resolveLinkToPropLine(linkTarget.linkTo)
   });
 }
@@ -84,7 +85,7 @@ function renderAssistantPageLinkPlacementBlock({
     `      workspaceSuffix: "${String(generationContext?.linkWorkspaceSuffix || "")}",\n` +
     `      nonWorkspaceSuffix: "${String(generationContext?.linkNonWorkspaceSuffix || "")}",\n` +
     `${String(generationContext?.linkToPropLine || "")}    },\n` +
-    "    when: ({ auth }) => Boolean(auth?.authenticated)\n" +
+    `${String(generationContext?.linkWhenLine || "")}` +
     "  });\n" +
     "}\n"
   );

--- a/packages/assistant/test/subcommands.test.js
+++ b/packages/assistant/test/subcommands.test.js
@@ -25,11 +25,12 @@ function toPagePath(targetFile = "") {
   return path.join("src/pages", targetFile);
 }
 
-async function writeAppFixture(appRoot) {
+async function writeAppFixture(appRoot, { configSource = "" } = {}) {
   await writeFileInApp(
     appRoot,
     "config/public.js",
-    `export const config = {
+    configSource ||
+      `export const config = {
   surfaceDefinitions: {
     admin: {
       id: "admin",
@@ -140,6 +141,41 @@ test("assistant settings-page subcommand uses the target assistant surface and i
     assert.match(placementSource, /componentToken: "local\.main\.ui\.tab-link-item"/);
     assert.match(placementSource, /to: "\.\/assistant"/);
     assert.match(placementSource, /label: "Assistant"/);
+  });
+});
+
+test("assistant page subcommand omits the auth guard for a public surface link", async () => {
+  await withTempApp(async (appRoot) => {
+    await writeAppFixture(appRoot, {
+      configSource: `export const config = {
+  surfaceAccessPolicies: {
+    public: {}
+  },
+  surfaceDefinitions: {
+    home: {
+      id: "home",
+      pagesRoot: "home",
+      enabled: true,
+      requiresWorkspace: false,
+      accessPolicyId: "public"
+    }
+  },
+  assistantSurfaces: {}
+};
+`
+    });
+
+    const targetFile = "home/assistant/index.vue";
+    await runPageSubcommand({
+      appRoot,
+      subcommand: "page",
+      args: [targetFile],
+      options: {}
+    });
+
+    const placementSource = await readFile(path.join(appRoot, "src", "placement.js"), "utf8");
+    assert.match(placementSource, /id: "ui-generator\.page\.home\.assistant\.link"/);
+    assert.doesNotMatch(placementSource, /when: \(\{ auth \}\) => Boolean\(auth\?\.authenticated\)/);
   });
 });
 

--- a/packages/crud-ui-generator/package.descriptor.mjs
+++ b/packages/crud-ui-generator/package.descriptor.mjs
@@ -351,7 +351,7 @@ export default Object.freeze({
         position: "bottom",
         skipIfContains: "__JSKIT_UI_MENU_MARKER__",
         value:
-          "\n// __JSKIT_UI_MENU_MARKER__\n{\n  addPlacement({\n    id: \"__JSKIT_UI_MENU_PLACEMENT_ID__\",\n    target: \"__JSKIT_UI_MENU_PLACEMENT_TARGET__\",\n    surfaces: [\"__JSKIT_UI_SURFACE_ID__\"],\n    order: 155,\n    componentToken: \"__JSKIT_UI_MENU_COMPONENT_TOKEN__\",\n    props: {\n      label: \"__JSKIT_UI_MENU_LABEL__\",\n      surface: \"__JSKIT_UI_SURFACE_ID__\",\n      workspaceSuffix: \"__JSKIT_UI_MENU_WORKSPACE_SUFFIX__\",\n      nonWorkspaceSuffix: \"__JSKIT_UI_MENU_NON_WORKSPACE_SUFFIX__\",\n__JSKIT_UI_MENU_TO_PROP_LINE__    },\n    when: ({ auth }) => Boolean(auth?.authenticated)\n  });\n}\n",
+          "\n// __JSKIT_UI_MENU_MARKER__\n{\n  addPlacement({\n    id: \"__JSKIT_UI_MENU_PLACEMENT_ID__\",\n    target: \"__JSKIT_UI_MENU_PLACEMENT_TARGET__\",\n    surfaces: [\"__JSKIT_UI_SURFACE_ID__\"],\n    order: 155,\n    componentToken: \"__JSKIT_UI_MENU_COMPONENT_TOKEN__\",\n    props: {\n      label: \"__JSKIT_UI_MENU_LABEL__\",\n      surface: \"__JSKIT_UI_SURFACE_ID__\",\n      workspaceSuffix: \"__JSKIT_UI_MENU_WORKSPACE_SUFFIX__\",\n      nonWorkspaceSuffix: \"__JSKIT_UI_MENU_NON_WORKSPACE_SUFFIX__\",\n__JSKIT_UI_MENU_TO_PROP_LINE__    },\n__JSKIT_UI_MENU_WHEN_LINE__  });\n}\n",
         reason: "Append generated CRUD list-page placement.",
         category: "crud-ui-generator",
         id: "crud-ui-placement-menu",

--- a/packages/crud-ui-generator/src/server/buildTemplateContext.js
+++ b/packages/crud-ui-generator/src/server/buildTemplateContext.js
@@ -496,6 +496,7 @@ async function buildUiTemplateContext({ appRoot, options } = {}) {
     __JSKIT_UI_MENU_COMPONENT_TOKEN__: String(pageLinkTarget?.componentToken || ""),
     __JSKIT_UI_MENU_WORKSPACE_SUFFIX__: String(pageLinkTarget?.pageTarget?.routeUrlSuffix || ""),
     __JSKIT_UI_MENU_NON_WORKSPACE_SUFFIX__: String(pageLinkTarget?.pageTarget?.routeUrlSuffix || ""),
+    __JSKIT_UI_MENU_WHEN_LINE__: String(pageLinkTarget?.whenLine || ""),
     __JSKIT_UI_MENU_TO_PROP_LINE__: resolveMenuToPropLine(pageLinkTarget?.linkTo || ""),
     __JSKIT_UI_MENU_LABEL__: pageTarget.defaultName
   };

--- a/packages/crud-ui-generator/test/buildTemplateContext.test.js
+++ b/packages/crud-ui-generator/test/buildTemplateContext.test.js
@@ -255,6 +255,7 @@ test("buildUiTemplateContext derives CRUD placeholders from the explicit target-
     assert.equal(context.__JSKIT_UI_HAS_VIEW_ROUTE__, "true");
     assert.equal(context.__JSKIT_UI_HAS_NEW_ROUTE__, "true");
     assert.equal(context.__JSKIT_UI_HAS_EDIT_ROUTE__, "true");
+    assert.equal(context.__JSKIT_UI_MENU_WHEN_LINE__, "");
     assert.doesNotMatch(context.__JSKIT_UI_LIST_HEADER_COLUMNS__, /Id/);
     assert.doesNotMatch(context.__JSKIT_UI_LIST_ROW_COLUMNS__, /record\.id/);
     assert.match(context.__JSKIT_UI_LIST_HEADER_COLUMNS__, /First Name/);
@@ -265,6 +266,36 @@ test("buildUiTemplateContext derives CRUD placeholders from the explicit target-
     assert.equal(context.__JSKIT_UI_RECORD_CHANGED_EVENT__, "\"customers.record.changed\"");
     assert.equal(context.__JSKIT_UI_LIST_RECORD_ID_EXPR__, "item.id");
     assert.equal(context.__JSKIT_UI_VIEW_TITLE_FALLBACK_FIELD_KEY__, "\"firstName\"");
+  });
+});
+
+test("buildUiTemplateContext derives menu auth visibility from the target surface policy", async () => {
+  await withTempApp(async (appRoot) => {
+    await writeFile(
+      path.join(appRoot, "config", "public.js"),
+      `export const config = {
+  surfaceAccessPolicies: {
+    authenticated: {
+      requireAuth: true
+    }
+  },
+  surfaceDefinitions: {
+    app: { id: "app", pagesRoot: "app", enabled: true, accessPolicyId: "authenticated" }
+  }
+};
+`,
+      "utf8"
+    );
+    await writeResource(appRoot, RESOURCE_FILE, FULL_RESOURCE_SOURCE);
+
+    const context = await buildUiTemplateContext({
+      appRoot,
+      options: createOptions({
+        "target-root": "app/customers"
+      })
+    });
+
+    assert.equal(context.__JSKIT_UI_MENU_WHEN_LINE__, "    when: ({ auth }) => Boolean(auth?.authenticated)\n");
   });
 });
 

--- a/packages/kernel/server/support/pageTargets.js
+++ b/packages/kernel/server/support/pageTargets.js
@@ -192,9 +192,29 @@ async function loadPublicConfig(appRoot = "", { context = "page target" } = {}) 
   }
 }
 
+function normalizeSurfaceAccessPolicyId(value = "") {
+  return normalizeText(value).toLowerCase();
+}
+
+function resolveSurfaceRequiresAuth(surfaceDefinition = {}, surfaceAccessPolicies = {}) {
+  const normalizedDefinition = normalizeObject(surfaceDefinition);
+  const normalizedPolicies = normalizeObject(surfaceAccessPolicies);
+  const accessPolicyId = normalizeSurfaceAccessPolicyId(normalizedDefinition.accessPolicyId);
+  const configuredPolicy = accessPolicyId
+    ? normalizeObject(normalizedPolicies[accessPolicyId])
+    : {};
+
+  if (Object.hasOwn(configuredPolicy, "requireAuth")) {
+    return configuredPolicy.requireAuth === true;
+  }
+
+  return normalizedDefinition.requiresAuth === true;
+}
+
 async function listSurfacePageRoots(appRoot = "", { context = "page target" } = {}) {
   const config = await loadPublicConfig(appRoot, { context });
   const surfaceDefinitions = normalizeObject(config.surfaceDefinitions);
+  const surfaceAccessPolicies = normalizeObject(config.surfaceAccessPolicies);
 
   return Object.freeze(
     Object.entries(surfaceDefinitions)
@@ -207,7 +227,8 @@ async function listSurfacePageRoots(appRoot = "", { context = "page target" } = 
 
         return Object.freeze({
           id: surfaceId,
-          pagesRoot: normalizeSurfacePagesRoot(definition.pagesRoot)
+          pagesRoot: normalizeSurfacePagesRoot(definition.pagesRoot),
+          requiresAuth: resolveSurfaceRequiresAuth(definition, surfaceAccessPolicies)
         });
       })
       .filter(Boolean)
@@ -228,6 +249,7 @@ function deriveSurfaceMatchesFromPageFile(relativePath = "", surfacePageRoots = 
         return Object.freeze({
           surfaceId: normalizeSurfaceId(surface?.id),
           pagesRoot,
+          requiresAuth: surface?.requiresAuth === true,
           surfaceRelativeFilePath: pagePathWithinPagesRoot
         });
       }
@@ -240,6 +262,7 @@ function deriveSurfaceMatchesFromPageFile(relativePath = "", surfacePageRoots = 
       return Object.freeze({
         surfaceId: normalizeSurfaceId(surface?.id),
         pagesRoot,
+        requiresAuth: surface?.requiresAuth === true,
         surfaceRelativeFilePath: pagePathWithinPagesRoot.slice(requiredPrefix.length)
       });
     })
@@ -455,6 +478,7 @@ async function resolvePageTargetDetails({
     }),
     surfaceId: surfaceMatch.surfaceId,
     surfacePagesRoot: surfaceMatch.pagesRoot,
+    surfaceRequiresAuth: surfaceMatch.requiresAuth === true,
     surfaceRelativeFilePath: surfaceMatch.surfaceRelativeFilePath,
     ...routeInfo
   });
@@ -612,6 +636,14 @@ function resolveInferredPageLinkComponentToken({
   return normalizeText(defaultComponentToken) || DEFAULT_PAGE_LINK_COMPONENT_TOKEN;
 }
 
+function renderPageLinkWhenLine(pageTarget = {}) {
+  if (pageTarget?.surfaceRequiresAuth !== true) {
+    return "";
+  }
+
+  return "    when: ({ auth }) => Boolean(auth?.authenticated)\n";
+}
+
 async function resolvePageLinkTargetDetails({
   appRoot,
   targetFile = "",
@@ -650,6 +682,7 @@ async function resolvePageLinkTargetDetails({
       defaultComponentToken,
       subpageComponentToken
     }),
+    whenLine: renderPageLinkWhenLine(resolvedPageTarget),
     linkTo: resolveInferredPageLinkTo({
       explicitLinkTo: linkTo,
       pageTarget: resolvedPageTarget,

--- a/packages/kernel/server/support/pageTargets.test.js
+++ b/packages/kernel/server/support/pageTargets.test.js
@@ -132,6 +132,41 @@ test("resolvePageTargetDetails chooses the most specific matching surface pagesR
   });
 });
 
+test("resolvePageTargetDetails derives surface auth requirement from surface access policy", async () => {
+  await withTempApp(async (appRoot) => {
+    await writeConfig(
+      appRoot,
+      `export const config = {
+  surfaceAccessPolicies: {
+    public: {},
+    authenticated: {
+      requireAuth: true
+    }
+  },
+  surfaceDefinitions: {
+    home: { id: "home", pagesRoot: "home", enabled: true, accessPolicyId: "public" },
+    app: { id: "app", pagesRoot: "app", enabled: true, accessPolicyId: "authenticated" }
+  }
+};
+`
+    );
+
+    const publicPageTarget = await resolvePageTargetDetails({
+      appRoot,
+      targetFile: "home/index.vue",
+      context: "page target"
+    });
+    const authenticatedPageTarget = await resolvePageTargetDetails({
+      appRoot,
+      targetFile: "app/index.vue",
+      context: "page target"
+    });
+
+    assert.equal(publicPageTarget.surfaceRequiresAuth, false);
+    assert.equal(authenticatedPageTarget.surfaceRequiresAuth, true);
+  });
+});
+
 test("resolvePageTargetDetails rejects duplicate matching surface pagesRoot definitions", async () => {
   await withTempApp(async (appRoot) => {
     await writeConfig(
@@ -215,6 +250,35 @@ test("resolvePageLinkTargetDetails falls back to the app default placement targe
     assert.equal(details.placementTarget.id, "shell-layout:primary-menu");
     assert.equal(details.componentToken, "local.main.ui.surface-aware-menu-link-item");
     assert.equal(details.linkTo, "");
+    assert.equal(details.whenLine, "");
+  });
+});
+
+test("resolvePageLinkTargetDetails emits an auth guard when the surface policy requires auth", async () => {
+  await withTempApp(async (appRoot) => {
+    await writeConfig(
+      appRoot,
+      `export const config = {
+  surfaceAccessPolicies: {
+    authenticated: {
+      requireAuth: true
+    }
+  },
+  surfaceDefinitions: {
+    app: { id: "app", pagesRoot: "app", enabled: true, accessPolicyId: "authenticated" }
+  }
+};
+`
+    );
+    await writeShellLayout(appRoot);
+
+    const details = await resolvePageLinkTargetDetails({
+      appRoot,
+      targetFile: "app/reports/index.vue",
+      context: "page target"
+    });
+
+    assert.equal(details.whenLine, "    when: ({ auth }) => Boolean(auth?.authenticated)\n");
   });
 });
 

--- a/packages/ui-generator/src/server/buildTemplateContext.js
+++ b/packages/ui-generator/src/server/buildTemplateContext.js
@@ -36,6 +36,7 @@ async function buildUiPageTemplateContext({
     __JSKIT_UI_LINK_COMPONENT_TOKEN__: String(linkTarget.componentToken || ""),
     __JSKIT_UI_LINK_WORKSPACE_SUFFIX__: pageTarget.routeUrlSuffix,
     __JSKIT_UI_LINK_NON_WORKSPACE_SUFFIX__: pageTarget.routeUrlSuffix,
+    __JSKIT_UI_LINK_WHEN_LINE__: String(linkTarget.whenLine || ""),
     __JSKIT_UI_LINK_TO_PROP_LINE__: resolveLinkToPropLine(linkTarget.linkTo)
   };
 }

--- a/packages/ui-generator/src/server/subcommands/page.js
+++ b/packages/ui-generator/src/server/subcommands/page.js
@@ -35,7 +35,7 @@ function renderPageLinkPlacementBlock({
     `      workspaceSuffix: "${context.__JSKIT_UI_LINK_WORKSPACE_SUFFIX__}",\n` +
     `      nonWorkspaceSuffix: "${context.__JSKIT_UI_LINK_NON_WORKSPACE_SUFFIX__}",\n` +
     `${context.__JSKIT_UI_LINK_TO_PROP_LINE__}    },\n` +
-    "    when: ({ auth }) => Boolean(auth?.authenticated)\n" +
+    `${String(context.__JSKIT_UI_LINK_WHEN_LINE__ || "")}` +
     "  });\n" +
     "}\n"
   );

--- a/packages/ui-generator/test/buildTemplateContext.test.js
+++ b/packages/ui-generator/test/buildTemplateContext.test.js
@@ -65,8 +65,37 @@ test("buildUiPageTemplateContext resolves link placement from default app ShellO
     assert.equal(context.__JSKIT_UI_LINK_COMPONENT_TOKEN__, "local.main.ui.surface-aware-menu-link-item");
     assert.equal(context.__JSKIT_UI_LINK_WORKSPACE_SUFFIX__, "/reports");
     assert.equal(context.__JSKIT_UI_LINK_NON_WORKSPACE_SUFFIX__, "/reports");
+    assert.equal(context.__JSKIT_UI_LINK_WHEN_LINE__, "");
     assert.equal(context.__JSKIT_UI_LINK_TO_PROP_LINE__, "");
     assert.equal(context.__JSKIT_UI_LINK_PLACEMENT_ID__, "ui-generator.page.admin.reports.link");
+  });
+});
+
+test("buildUiPageTemplateContext derives an auth guard from an authenticated surface policy", async () => {
+  await withTempApp(async (appRoot) => {
+    await writeConfig(
+      appRoot,
+      `export const config = {
+  surfaceAccessPolicies: {
+    authenticated: {
+      requireAuth: true
+    }
+  },
+  surfaceDefinitions: {
+    app: { id: "app", pagesRoot: "app", enabled: true, accessPolicyId: "authenticated" }
+  }
+};
+`
+    );
+    await writeShellLayout(appRoot);
+
+    const context = await buildUiPageTemplateContext({
+      appRoot,
+      targetFile: "app/reports/index.vue",
+      options: {}
+    });
+
+    assert.equal(context.__JSKIT_UI_LINK_WHEN_LINE__, "    when: ({ auth }) => Boolean(auth?.authenticated)\n");
   });
 });
 

--- a/packages/ui-generator/test/pageSubcommand.test.js
+++ b/packages/ui-generator/test/pageSubcommand.test.js
@@ -113,6 +113,36 @@ test("ui-generator page subcommand creates a file route and derives label from t
   });
 });
 
+test("ui-generator page subcommand omits the auth guard for public surface links", async () => {
+  await withTempApp(async (appRoot) => {
+    await writeAppFixture(appRoot, {
+      configSource: `export const config = {
+  surfaceAccessPolicies: {
+    public: {}
+  },
+  surfaceDefinitions: {
+    home: { id: "home", pagesRoot: "home", enabled: true, accessPolicyId: "public" }
+  }
+};
+`
+    });
+
+    const targetFile = "home/reports/index.vue";
+    await runGeneratorSubcommand({
+      appRoot,
+      subcommand: "page",
+      args: [targetFile],
+      options: {
+        name: "Reports"
+      }
+    });
+
+    const placementSource = await readFile(path.join(appRoot, "src", "placement.js"), "utf8");
+    assert.match(placementSource, /id: "ui-generator\.page\.home\.reports\.link"/);
+    assert.doesNotMatch(placementSource, /when: \(\{ auth \}\) => Boolean\(auth\?\.authenticated\)/);
+  });
+});
+
 test("ui-generator page subcommand supports link placement options", async () => {
   await withTempApp(async (appRoot) => {
     await writeAppFixture(appRoot);

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -1853,7 +1853,7 @@
               "file": "src/placement.js",
               "position": "bottom",
               "skipIfContains": "__JSKIT_UI_MENU_MARKER__",
-              "value": "\n// __JSKIT_UI_MENU_MARKER__\n{\n  addPlacement({\n    id: \"__JSKIT_UI_MENU_PLACEMENT_ID__\",\n    target: \"__JSKIT_UI_MENU_PLACEMENT_TARGET__\",\n    surfaces: [\"__JSKIT_UI_SURFACE_ID__\"],\n    order: 155,\n    componentToken: \"__JSKIT_UI_MENU_COMPONENT_TOKEN__\",\n    props: {\n      label: \"__JSKIT_UI_MENU_LABEL__\",\n      surface: \"__JSKIT_UI_SURFACE_ID__\",\n      workspaceSuffix: \"__JSKIT_UI_MENU_WORKSPACE_SUFFIX__\",\n      nonWorkspaceSuffix: \"__JSKIT_UI_MENU_NON_WORKSPACE_SUFFIX__\",\n__JSKIT_UI_MENU_TO_PROP_LINE__    },\n    when: ({ auth }) => Boolean(auth?.authenticated)\n  });\n}\n",
+              "value": "\n// __JSKIT_UI_MENU_MARKER__\n{\n  addPlacement({\n    id: \"__JSKIT_UI_MENU_PLACEMENT_ID__\",\n    target: \"__JSKIT_UI_MENU_PLACEMENT_TARGET__\",\n    surfaces: [\"__JSKIT_UI_SURFACE_ID__\"],\n    order: 155,\n    componentToken: \"__JSKIT_UI_MENU_COMPONENT_TOKEN__\",\n    props: {\n      label: \"__JSKIT_UI_MENU_LABEL__\",\n      surface: \"__JSKIT_UI_SURFACE_ID__\",\n      workspaceSuffix: \"__JSKIT_UI_MENU_WORKSPACE_SUFFIX__\",\n      nonWorkspaceSuffix: \"__JSKIT_UI_MENU_NON_WORKSPACE_SUFFIX__\",\n__JSKIT_UI_MENU_TO_PROP_LINE__    },\n__JSKIT_UI_MENU_WHEN_LINE__  });\n}\n",
               "reason": "Append generated CRUD list-page placement.",
               "category": "crud-ui-generator",
               "id": "crud-ui-placement-menu",


### PR DESCRIPTION
## Summary
- resolve page target auth requirements from surface definitions and access policies
- emit auth-gated link placement `when` clauses only for surfaces that actually require auth
- cover the new behavior across assistant, ui-generator, crud-ui-generator, and kernel tests

## Verification
- skipped on request