### PR TITLE
Centralize fresh module imports in kernel support

### DIFF
--- a/agent-index/packages/auth-web.md
+++ b/agent-index/packages/auth-web.md
@@ -85,6 +85,14 @@ Exports
 - `routeComponents`
 - `clientProviders`
 
+### `src/client/lib/profileMenuLinkTarget.js`
+Exports
+- `appendAccountReturnToIfNeeded(target = "", { placementContext = null, currentFullPath = "", currentPath = "", currentHref = "" } = {})`
+- `resolveAccountSettingsPathFromPlacementContext(contextValue = null)`
+Local functions
+- `resolvePathnameFromLinkTarget(target = "")`
+- `resolveFallbackReturnTo({ currentFullPath = "", currentPath = "", currentHref = "", absolute = false } = {})`
+
 ### `src/client/lib/returnToPath.js`
 Exports
 - `normalizeAuthReturnToPath(value, fallback = "/", { allowedOrigins = [] } = {})`
@@ -157,6 +165,8 @@ Local functions
 ### `src/client/views/AuthProfileMenuLinkItem.vue`
 Exports
 - None
+Local functions
+- `resolveWindowHref()`
 
 ### `src/client/views/AuthProfileWidget.vue`
 Exports

--- a/agent-index/packages/crud-server-generator.md
+++ b/agent-index/packages/crud-server-generator.md
@@ -24,6 +24,7 @@ Exports
 - `renderInputNormalizer(column)`
 - `renderOutputNormalizerExpression(column)`
 - `buildFieldMetaEntries({ outputColumns = [], writableColumns = [], snapshot = {} } = {})`
+- `resolveCrudGenerationSurfaceId({ appRoot, options } = {})`
 - `__testables`
 Local functions
 - `resolveGlobalScaffoldCache()`
@@ -36,7 +37,10 @@ Local functions
 - `loadEnvFromApp(appRoot)`
 - `createAppRequire(appRoot)`
 - `importModuleFromApp(appRequire, moduleId, contextLabel)`
-- `resolveCrudPermissionGenerationConfig({ appRoot, options } = {})`
+- `resolveCrudSurfaceRequiresWorkspace({ appRoot, options, surface = "" } = {})`
+- `loadCrudAppConfig(appRoot = "")`
+- `resolveSurfaceDefinitions(appConfig = {})`
+- `resolveDefaultCrudSurfaceIdFromAppConfig(appConfig = {})`
 - `resolveKnexFactory(moduleNamespace)`
 - `resolveMysqlSnapshotFromDatabase({ appRoot, tableName, idColumn } = {})`
 - `resolveColumnKey(column, idColumn)`
@@ -73,10 +77,17 @@ Local functions
 - `renderResourceFieldMetaPushLines(entries = [])`
 - `renderRepositoryListConfigLines(snapshot = {})`
 - `buildCrudPermissionIds(namespace = "")`
+- `normalizeCrudOperation(operation = "", context = "CRUD operation")`
 - `renderRoleCatalogPermissionGrants(namespace = "", { requiresNamedPermissions = true } = {})`
 - `renderActionPermissionSupport(namespace = "", { requiresNamedPermissions = true } = {})`
 - `renderActionPermissionExpression(operation = "", { requiresNamedPermissions = true } = {})`
-- `buildReplacementsFromSnapshot({ namespace = "", snapshot, resolvedOwnershipFilter, requiresNamedPermissions = true })`
+- `renderRouteWorkspaceSupportImports({ surfaceRequiresWorkspace = true } = {})`
+- `renderActionWorkspaceValidatorImport({ surfaceRequiresWorkspace = true } = {})`
+- `renderRouteParamsValidatorLine(operation = "", { surfaceRequiresWorkspace = true } = {})`
+- `renderRouteInputLines(operation = "", { surfaceRequiresWorkspace = true } = {})`
+- `renderActionInputValidatorExpression(operation = "", { surfaceRequiresWorkspace = true } = {})`
+- `buildReplacementsFromSnapshot({ namespace = "", snapshot, resolvedOwnershipFilter, surfaceRequiresWorkspace = true, surfaceId = "" })`
+- `resolveCrudGenerationTableName(options = {})`
 - `createCacheKey({ appRoot, options })`
 - `buildCrudTemplateContext(input = {})`
 
@@ -170,7 +181,7 @@ Exports
 
 ### `templates/src/local-package/server/registerRoutes.js`
 Exports
-- `registerRoutes(app, { routeOwnershipFilter = "public", routeSurface = "", routeSurfaceRequiresWorkspace = false, routeRelativePath = "" } = {})`
+- `registerRoutes(app, { routeOwnershipFilter = "public", routeSurface = "", routeRelativePath = "" } = {})`
 
 ### `templates/src/local-package/server/repository.js`
 Exports
@@ -200,8 +211,9 @@ Exports
 ### `test-support/templateServerFixture.js`
 Exports
 - `resource`
-- `createTemplateServerFixture()`
+- `createTemplateServerFixture(options = {})`
 Local functions
-- `applyTemplateReplacements(sourceText = "")`
+- `buildTemplateReplacements({ surfaceRequiresWorkspace = true, requiresNamedPermissions = surfaceRequiresWorkspace === true, surfaceId = surfaceRequiresWorkspace ? "admin" : "home" } = {})`
+- `applyTemplateReplacements(sourceText = "", options = {})`
 - `buildResourceStubSource()`
-- `renderServerTemplateFile(targetServerDirectory, fileName)`
+- `renderServerTemplateFile(targetServerDirectory, fileName, options)`

--- a/agent-index/packages/crud-ui-generator.md
+++ b/agent-index/packages/crud-ui-generator.md
@@ -31,7 +31,7 @@ Local functions
 - `parseDisplayFieldsOption(options)`
 - `validateDisplayFieldsForOperation(selectedFieldKeys, fields, operationName)`
 - `filterDisplayFields(selectedFieldKeys, fields)`
-- `filterDefaultHiddenListFields(selectedFieldKeys, fields)`
+- `filterDefaultHiddenListFields(selectedFieldKeys, fields, { recordIdFieldKey = "" } = {})`
 - `ensureFields(fields, fallbackFields = createFieldDefinitions({}))`
 - `resolveViewTitleFallbackFieldKey(fields = [])`
 - `resolveResourceNamespace(resource = {}, pageTarget = {}, options = {})`
@@ -61,6 +61,7 @@ Exports
 - `buildListRowColumns(fields = [])`
 - `buildViewColumns(fields = [])`
 - `buildFormColumns(fields = [])`
+- `resolveRecordIdFieldKey(fields = [])`
 - `renderObjectPushLines(arrayName, entries = [])`
 - `resolveRecordChangedEventName`
 - `resolveRecordIdExpression(fields = [])`

--- a/agent-index/packages/kernel.md
+++ b/agent-index/packages/kernel.md
@@ -332,6 +332,8 @@ Exports
 - `discoverShellOutletTargetsFromVueSource(source = "", { context = "shell layout" } = {})`
 - `findShellOutletTargetById(targets = [], targetId = "")`
 - `normalizeShellOutletTargetId(value = "")`
+- `normalizeShellOutletTargetRecord(value = {}, { context = "shell layout" } = {})`
+- `resolveShellOutletTargetParts({ target = "" } = {})`
 Local functions
 - `parseTagAttributes(attributesSource = "")`
 - `isDefaultAttributeEnabled(value)`
@@ -1174,11 +1176,18 @@ Local functions
 Exports
 - `defaultMissingHandler(_request, reply)`
 
+### `server/support/importFreshModuleFromAbsolutePath.js`
+Exports
+- `importFreshModuleFromAbsolutePath(absolutePath)`
+Local functions
+- `nextFreshImportToken()`
+
 ### `server/support/index.js`
 Exports
 - `symlinkSafeRequire`
 - `resolveAppConfig`
 - `loadAppConfigFromModuleUrl`
+- `importFreshModuleFromAbsolutePath`
 - `resolveRequiredAppRoot`
 - `toPosixPath`
 - `DEFAULT_PAGE_LINK_COMPONENT_TOKEN`
@@ -1216,6 +1225,8 @@ Local functions
 - `normalizePlacementIdSegment(value = "")`
 - `humanizePageSegment(value = "", fallback = "Page")`
 - `loadPublicConfig(appRoot = "", { context = "page target" } = {})`
+- `normalizeSurfaceAccessPolicyId(value = "")`
+- `resolveSurfaceRequiresAuth(surfaceDefinition = {}, surfaceAccessPolicies = {})`
 - `listSurfacePageRoots(appRoot = "", { context = "page target" } = {})`
 - `deriveSurfaceMatchesFromPageFile(relativePath = "", surfacePageRoots = [])`
 - `compareSurfaceMatchSpecificity(leftMatch = {}, rightMatch = {})`
@@ -1230,6 +1241,7 @@ Local functions
 - `resolveRelativeLinkToFromNearestIndexOwner(pageTarget = {})`
 - `resolveInferredPageLinkTo({ explicitLinkTo = "", pageTarget = {}, parentHost = null, placementTarget = null } = {})`
 - `resolveInferredPageLinkComponentToken({ explicitComponentToken = "", parentHost = null, placementTarget = null, defaultComponentToken = DEFAULT_PAGE_LINK_COMPONENT_TOKEN, subpageComponentToken = DEFAULT_SUBPAGE_LINK_COMPONENT_TOKEN } = {})`
+- `renderPageLinkWhenLine(pageTarget = {})`
 
 ### `server/support/path.js`
 Exports
@@ -1253,6 +1265,8 @@ Local functions
 - `collectVueFilePaths(rootDirectoryPath)`
 - `readInstalledPackageStates(appRoot)`
 - `normalizePackageOutletTarget({ packageId = "", outlet = {}, descriptorPath = "" } = {})`
+- `loadOutletDefaultOverrides(appRoot = "")`
+- `applyOutletDefaultOverrides(target = {}, outletDefaultOverrides = {})`
 - `collectInstalledPackageOutletTargets(appRoot)`
 
 ### `server/support/SupportCoreServiceProvider.js`

--- a/agent-index/packages/shell-web.md
+++ b/agent-index/packages/shell-web.md
@@ -29,11 +29,23 @@ Local functions
 Exports
 - None
 
+### `src/client/components/ShellMenuLinkItem.vue`
+Exports
+- None
+
 ### `src/client/components/ShellOutlet.vue`
 Exports
 - None
 
 ### `src/client/components/ShellOutletMenuWidget.vue`
+Exports
+- None
+
+### `src/client/components/ShellSurfaceAwareMenuLinkItem.vue`
+Exports
+- None
+
+### `src/client/components/ShellTabLinkItem.vue`
 Exports
 - None
 
@@ -104,8 +116,20 @@ Exports
 - `ShellOutlet`
 - `ShellOutletMenuWidget`
 - `ShellErrorHost`
+- `ShellMenuLinkItem`
+- `ShellSurfaceAwareMenuLinkItem`
+- `ShellTabLinkItem`
 - `useShellLayoutState`
 - `clientProviders`
+
+### `src/client/lib/menuIcons.js`
+Exports
+- `resolveMenuLinkIcon({ icon = "", label = "", to = "" } = {})`
+- `resolveSurfaceSwitchIcon(surfaceId = "", explicitIcon = "")`
+Local functions
+- `resolveExplicitIconValue(explicitIcon = "")`
+- `normalizePathname(value = "")`
+- `resolveSurfaceSwitchIdFromLabel(label = "")`
 
 ### `src/client/navigation/linkResolver.js`
 Exports
@@ -192,14 +216,12 @@ Exports
 - `isRenderableComponent(value)`
 - `normalizeSurface(value)`
 - `normalizePlacementSurface(value, { strict = false, source = "placement" } = {})`
-- `normalizePlacementHost(value, { strict = false, source = "placement" } = {})`
-- `normalizePlacementPosition(value, { strict = false, source = "placement" } = {})`
+- `normalizePlacementTarget(value, { strict = false, source = "placement" } = {})`
 - `normalizePlacementSurfaces(value, { strict = false, source = "placement" } = {})`
 - `normalizePlacementDefinition(value, { strict = false, source = "placement" } = {})`
 - `definePlacement(value = {})`
 Local functions
 - `isValidSurfaceIdToken(value = "")`
-- `isValidPlacementHostOrPositionToken(value = "")`
 - `toInteger(value, fallback = 1000)`
 
 ### `src/client/providers/ShellWebClientProvider.js`
@@ -215,9 +237,62 @@ Local functions
 - `installVueErrorBridge(vueApp, errorRuntime, logger)`
 - `installRouterErrorBridge(app, errorRuntime, logger)`
 
+### `src/client/support/menuLinkTarget.js`
+Exports
+- `normalizeMenuLinkPathname(pathname = "")`
+- `resolveMenuLinkTarget({ to = "", surface = "", currentSurfaceId = "", placementContext = null, workspaceSuffix = "/", nonWorkspaceSuffix = "/", routeParams = {}, resolvePagePath = null } = {})`
+Local functions
+- `resolveMenuLinkSurfaceId(surface = "", fallbackSurfaceId = "")`
+- `interpolateBracketParams(pathTemplate = "", params = {})`
+- `isRelativeMenuLinkTarget(target = "")`
+- `surfaceRequiresWorkspaceFromPlacementContext(contextValue = null, surfaceId = "")`
+
+### `src/server/support/localLinkItemScaffolds.js`
+Exports
+- `LOCAL_LINK_ITEM_COMPONENT_DEFINITIONS`
+- `LOCAL_LINK_ITEM_COMPONENT_TOKENS`
+- `findLocalLinkItemDefinition(componentToken = "")`
+- `readLocalLinkItemComponentSource(componentTokenOrDefinition = "")`
+- `resolveLocalLinkItemTemplateAbsolutePath(componentTokenOrDefinition = "")`
+Local functions
+- `createLocalLinkItemDefinition({ token = "", componentFile = "", componentName = "", templateFile = "" } = {})`
+- `resolveLocalLinkItemDefinition(componentTokenOrDefinition = "")`
+
 ### templates
 
+### `templates/expected-existing/src/App.vue`
+Exports
+- None
+
+### `templates/expected-existing/src/pages/console.vue`
+Exports
+- None
+
+### `templates/expected-existing/src/pages/console/index.vue`
+Exports
+- None
+
+### `templates/expected-existing/src/pages/home.vue`
+Exports
+- None
+
+### `templates/expected-existing/src/pages/home/index.vue`
+Exports
+- None
+
 ### `templates/src/App.vue`
+Exports
+- None
+
+### `templates/src/components/menus/MenuLinkItem.vue`
+Exports
+- None
+
+### `templates/src/components/menus/SurfaceAwareMenuLinkItem.vue`
+Exports
+- None
+
+### `templates/src/components/menus/TabLinkItem.vue`
 Exports
 - None
 

--- a/agent-index/packages/ui-generator.md
+++ b/agent-index/packages/ui-generator.md
@@ -36,11 +36,11 @@ Local functions
 Exports
 - `runGeneratorSubcommand({ appRoot, subcommand = "", args = [], options = {}, dryRun = false } = {})`
 Local functions
-- `hasShellOutletTarget(source = "", { host = "", position = "" } = {})`
+- `hasShellOutletTarget(source = "", { target = "" } = {})`
 - `applyScriptImports(source = "")`
-- `createOutletBlock({ host = "", position = "" } = {})`
+- `createOutletBlock({ target = "" } = {})`
 - `findLastTemplateCloseTag(source = "")`
-- `applyOutletTemplateBlock(source = "", { host = "", position = "" } = {})`
+- `applyOutletTemplateBlock(source = "", { target = "" } = {})`
 
 ### `src/server/subcommands/page.js`
 Exports
@@ -60,17 +60,16 @@ Exports
 - `deriveDefaultSubpagesHost`
 - `renderPlainPageSource(pageTitle = "")`
 - `ensureSubpagesSupportScaffold({ appRoot, componentDirectory = DEFAULT_COMPONENT_DIRECTORY, dryRun = false } = {})`
-- `applySubpagesUpgradeToPageSource(source = "", { host = "", position = DEFAULT_SUBPAGES_POSITION, title = "", subtitle = "", sectionContainerComponentImportPath = "/src/components/SectionContainerShell.vue", preserveExistingContent = true } = {})`
-- `upgradePageFileToSubpages({ appRoot, targetFile, host = "", position = DEFAULT_SUBPAGES_POSITION, title = "", subtitle = "", componentDirectory = DEFAULT_COMPONENT_DIRECTORY, preserveExistingContent = true, dryRun = false } = {})`
+- `applySubpagesUpgradeToPageSource(source = "", { target = "", title = "", subtitle = "", sectionContainerComponentImportPath = "/src/components/SectionContainerShell.vue", preserveExistingContent = true } = {})`
+- `upgradePageFileToSubpages({ appRoot, targetFile, target = "", title = "", subtitle = "", componentDirectory = DEFAULT_COMPONENT_DIRECTORY, preserveExistingContent = true, dryRun = false } = {})`
 Local functions
 - `trimEdgeBlankLines(source = "")`
 - `renderSectionContainerShellSource()`
-- `renderTabLinkItemSource()`
 - `findTemplateBlock(source = "")`
 - `unwrapSectionContainerShell(source = "")`
 - `stripExistingSubpagesStructure(source = "")`
 - `renderSectionContainerOpenTag({ title = "", subtitle = "" } = {})`
-- `renderSubpagesTemplate({ bodyContent = "", title = "", subtitle = "", host = "", position = DEFAULT_SUBPAGES_POSITION } = {})`
+- `renderSubpagesTemplate({ bodyContent = "", title = "", subtitle = "", target = "" } = {})`
 - `applySubpagesScriptImports(source = "", { sectionContainerComponentImportPath = "" } = {})`
 - `hasExistingSubpagesRouting(source = "")`
 
@@ -83,8 +82,7 @@ Exports
 - `toPascalCase(value = "")`
 - `requireOption(options = {}, optionName = "", { context = "ui-generator" } = {})`
 - `requireSinglePositionalTargetFile(args = [], { context = "ui-generator" } = {})`
-- `normalizeExplicitOutletTargetId(value = "")`
-- `resolveOutletTargetId(rawTarget = "", { context = "ui-generator", optionName = "target", defaultPosition = "" } = {})`
+- `resolveOutletTargetId(rawTarget = "", { context = "ui-generator", optionName = "target" } = {})`
 - `rejectUnexpectedOptions(options = {}, allowedOptionNames = [], { context = "ui-generator" } = {})`
 - `resolvePathWithinApp(appRoot, targetPath, { context = "ui-generator" } = {})`
 - `ensureTrailingNewline(value = "")`

--- a/agent-index/packages/users-web.md
+++ b/agent-index/packages/users-web.md
@@ -496,8 +496,6 @@ Local functions
 Exports
 - `UsersWebClientProvider`
 - `UsersWorkspacesClientProvider`
-- `ConsoleSettingsClientElement`
-- `WorkspaceSettingsClientElement`
 - `clientProviders`
 
 ### `src/client/lib/bootstrap.js`
@@ -693,6 +691,12 @@ Exports
 ### `src/client/support/workspaceQueryKeys.js`
 Exports
 - `buildWorkspaceQueryKey(kind = "", surfaceId = "", workspaceSlug = "")`
+
+### `src/shared/toolsOutletContracts.js`
+Exports
+- `DEFAULT_TOOLS_LINK_COMPONENT_TOKEN`
+- `HOME_TOOLS_OUTLET`
+- `WORKSPACE_TOOLS_OUTLET`
 
 ### templates
 

--- a/agent-index/tooling/create-app.md
+++ b/agent-index/tooling/create-app.md
@@ -39,7 +39,7 @@ Local functions
 - `toAppTitle(appName)`
 - `normalizeInitialBundlesPreset(value, { showUsage = true } = {})`
 - `normalizeTenancyMode(value, { showUsage = true } = {})`
-- `buildInitialBundleCommands(initialBundles)`
+- `buildInitialSetupCommands(initialBundles)`
 - `validateAppName(appName, { showUsage = true } = {})`
 - `parseOptionWithValue(argv, index, optionName)`
 - `parseCliArgs(argv)`

--- a/agent-index/tooling/jskit-cli.md
+++ b/agent-index/tooling/jskit-cli.md
@@ -60,7 +60,7 @@ Exports
 - `isGeneratorPackageEntry(packageEntry)`
 Local functions
 - `normalizePackageKind(rawValue, descriptorPath)`
-- `validateInstallMigrationMutationShape(descriptor, descriptorPath)`
+- `validateFileMutationShape(descriptor, descriptorPath)`
 
 ### `src/server/cliRuntime/ioAndMigrations.js`
 Exports
@@ -104,18 +104,18 @@ Local functions
 ### `src/server/cliRuntime/mutationApplication.js`
 Exports
 - `applyFileMutations`
-- `preflightFileMutationTemplateContexts`
+- `prepareFileMutations`
 - `applyTextMutations`
 - `resolvePositioningMutations`
 
 ### `src/server/cliRuntime/mutations/fileMutations.js`
 Exports
-- `applyFileMutations(packageEntry, options, appRoot, fileMutations, managedFiles, managedMigrations, touchedFiles, warnings = [], precomputedTemplateContextByMutationIndex = null)`
-- `preflightFileMutationTemplateContexts(packageEntry, options, appRoot, fileMutations)`
+- `applyFileMutations(packageEntry, appRoot, preparedMutations, managedFiles, managedMigrations, touchedFiles, warnings = [], existingManagedFiles = [])`
+- `prepareFileMutations(packageEntry, options, appRoot, fileMutations, existingManagedFiles = [])`
 
 ### `src/server/cliRuntime/mutations/installMigrationMutation.js`
 Exports
-- `applyInstallMigrationMutation({ packageEntry, mutation, rawMutation, mutationIndex, options, appRoot, managedMigrations, managedMigrationById, touchedFiles, warnings, precomputedTemplateContextByMutationIndex } = {})`
+- `applyInstallMigrationMutation({ packageEntry, preparedMutation, appRoot, managedMigrations, managedMigrationById, touchedFiles, warnings } = {})`
 
 ### `src/server/cliRuntime/mutations/mutationPathUtils.js`
 Exports
@@ -132,8 +132,8 @@ Local functions
 ### `src/server/cliRuntime/mutations/templateContext.js`
 Exports
 - `applyTemplateContextReplacements(sourceContent, replacements)`
-- `copyTemplateFile(sourcePath, targetPath, options, packageId, interpolationKey, templateContextReplacements = null)`
 - `interpolateFileMutationRecord(mutation, options, packageId)`
+- `renderTemplateFile(sourcePath, options, packageId, interpolationKey, templateContextReplacements = null)`
 - `resolveTemplateContextReplacementsForMutation({ packageEntry, mutation, options, appRoot, sourcePath, targetPaths, mutationContext = "files mutation" } = {})`
 
 ### `src/server/cliRuntime/mutations/textMutations.js`
@@ -302,6 +302,8 @@ Exports
 ### `src/server/commandHandlers/packageCommands/add.js`
 Exports
 - `runPackageAddCommand(ctx = {}, { positional, options, cwd, io })`
+Local functions
+- `collectPlacementComponentTokensFromManagedRecords(installedPackageRecords = [])`
 
 ### `src/server/commandHandlers/packageCommands/create.js`
 Exports
@@ -342,6 +344,7 @@ Exports
 - `runPackageGenerateCommand(ctx = {}, { positional, options, cwd, io }, { runCommandAdd })`
 Local functions
 - `resolveGeneratorSubcommandDefinitionMetadata(packageEntry = {}, subcommandName = "")`
+- `resolveSubcommandRequiresShellWeb(packageEntry = {}, subcommandName = "")`
 - `mapDescriptorBackedSubcommandArgsToInlineOptions(packageEntry = {}, subcommandName = "", subcommandArgs = [], inlineOptions = {}, createCliError)`
 - `resolveSubcommandRequiresInput(packageEntry = {}, subcommandName = "")`
 - `collectUnexpectedGeneratorSubcommandOptionNames(packageEntry = {}, subcommandName = "", inlineOptions = {})`
@@ -363,21 +366,22 @@ Exports
 
 ### `src/server/commandHandlers/packageCommands/tabLinkItemProvisioning.js`
 Exports
+- `LOCAL_LINK_ITEM_COMPONENT_TOKENS`
 - `TAB_LINK_COMPONENT_TOKEN`
+- `collectProvisionableLocalPlacementComponentTokensFromApp({ appRoot = "" } = {})`
+- `resolveProvisionableLocalPlacementComponentTokens({ appRoot = "", componentTokens = [] } = {})`
+- `ensureLocalMainPlacementComponentProvisioning({ appRoot = "", createCliError, dryRun = false, touchedFiles = new Set(), componentTokens = [] } = {})`
 - `ensureLocalMainTabLinkItemProvisioning({ appRoot = "", createCliError, dryRun = false, touchedFiles = new Set() } = {})`
 Local functions
 - `toPosixPath(value = "")`
 - `ensureTrailingNewline(value = "")`
 - `insertImportIfMissing(source = "", importLine = "")`
 - `insertBeforeClassDeclaration(source = "", line = "", { className = "", contextFile = "" } = {})`
-- `renderTabLinkItemSource()`
-- `normalizePathname(pathname = "")`
-- `interpolateBracketParams(pathTemplate = "", params = {})`
 - `readUtf8FileIfExists(absolutePath = "")`
-- `ensureTabLinkItemComponentFile({ appRoot = "", dryRun = false, touchedFiles = new Set() } = {})`
-- `hasTabLinkItemTokenRegistration(providerSource = "")`
-- `loadMainClientProviderSource({ appRoot = "", createCliError } = {})`
-- `ensureTabLinkItemProviderRegistration({ appRoot = "", createCliError, dryRun = false, touchedFiles = new Set() } = {})`
+- `ensureProvisionedComponentFile(definition, { appRoot = "", dryRun = false, touchedFiles = new Set() } = {})`
+- `hasProvisionedTokenRegistration(providerSource = "", componentToken = "")`
+- `loadMainClientProviderSource({ appRoot = "", createCliError, componentToken = "" } = {})`
+- `ensureProvisionedProviderRegistration(definition, { appRoot = "", createCliError, dryRun = false, touchedFiles = new Set() } = {})`
 
 ### `src/server/commandHandlers/packageCommands/update.js`
 Exports

--- a/agents/KERNEL_MAP.md
+++ b/agents/KERNEL_MAP.md
@@ -158,6 +158,8 @@ Exports
 - `discoverShellOutletTargetsFromVueSource(source = "", { context = "shell layout" } = {})`
 - `findShellOutletTargetById(targets = [], targetId = "")`
 - `normalizeShellOutletTargetId(value = "")`
+- `normalizeShellOutletTargetRecord(value = {}, { context = "shell layout" } = {})`
+- `resolveShellOutletTargetParts({ target = "" } = {})`
 Local functions
 - `parseTagAttributes(attributesSource = "")`
 - `isDefaultAttributeEnabled(value)`

--- a/packages/crud-server-generator/src/server/buildTemplateContext.js
+++ b/packages/crud-server-generator/src/server/buildTemplateContext.js
@@ -10,7 +10,11 @@ import {
 } from "@jskit-ai/database-runtime/shared";
 import { resolveCrudSurfacePolicyFromAppConfig } from "@jskit-ai/crud-core/server/crudModuleConfig";
 import { checkCrudLookupFormControl } from "@jskit-ai/crud-core/shared/crudFieldMetaSupport";
-import { loadAppConfigFromModuleUrl, resolveRequiredAppRoot } from "@jskit-ai/kernel/server/support";
+import {
+  importFreshModuleFromAbsolutePath,
+  loadAppConfigFromModuleUrl,
+  resolveRequiredAppRoot
+} from "@jskit-ai/kernel/server/support";
 import { normalizeCrudLookupNamespace } from "@jskit-ai/kernel/shared/support/crudLookup";
 import { toCamelCase, toSnakeCase } from "@jskit-ai/kernel/shared/support/stringCase";
 
@@ -190,7 +194,7 @@ async function importModuleFromApp(appRequire, moduleId, contextLabel) {
   }
 
   try {
-    return await import(`${pathToFileURL(resolvedPath).href}?t=${Date.now()}_${Math.random()}`);
+    return await importFreshModuleFromAbsolutePath(resolvedPath);
   } catch (error) {
     throw new Error(
       `${contextLabel} failed loading "${moduleId}": ${String(error?.message || error || "unknown error")}`

--- a/packages/crud-server-generator/test-support/templateServerFixture.js
+++ b/packages/crud-server-generator/test-support/templateServerFixture.js
@@ -1,6 +1,7 @@
 import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
+import { importFreshModuleFromAbsolutePath } from "@jskit-ai/kernel/server/support";
 
 const testSupportDirectory = path.dirname(fileURLToPath(import.meta.url));
 const packageRoot = path.resolve(testSupportDirectory, "..");
@@ -270,8 +271,7 @@ async function createTemplateServerFixture(options = {}) {
 
   async function importServerModule(fileName) {
     const absolutePath = path.join(serverRoot, fileName);
-    const href = pathToFileURL(absolutePath).href;
-    return import(`${href}?t=${Date.now()}_${Math.random()}`);
+    return importFreshModuleFromAbsolutePath(absolutePath);
   }
 
   async function cleanup() {

--- a/packages/crud-ui-generator/src/server/resourceSupport.js
+++ b/packages/crud-ui-generator/src/server/resourceSupport.js
@@ -1,10 +1,10 @@
 import path from "node:path";
-import { pathToFileURL } from "node:url";
 import { resolveCrudRecordChangedEvent } from "@jskit-ai/crud-core/shared/crudNamespaceSupport";
 import {
   checkCrudLookupFormControl,
   isCrudRuntimeOutputOnlyFieldKey
 } from "@jskit-ai/crud-core/shared/crudFieldMetaSupport";
+import { importFreshModuleFromAbsolutePath } from "@jskit-ai/kernel/server/support";
 import {
   normalizeCrudLookupApiPath,
   normalizeCrudLookupNamespace,
@@ -64,7 +64,7 @@ async function loadResourceDefinition({
 
   let moduleNamespace = null;
   try {
-    moduleNamespace = await import(`${pathToFileURL(resourceModulePath).href}?t=${Date.now()}_${Math.random()}`);
+    moduleNamespace = await importFreshModuleFromAbsolutePath(resourceModulePath);
   } catch (error) {
     throw new Error(
       `${context} could not load resource file "${resourceFile}": ${String(error?.message || error || "unknown error")}`

--- a/packages/kernel/server/support/importFreshModuleFromAbsolutePath.js
+++ b/packages/kernel/server/support/importFreshModuleFromAbsolutePath.js
@@ -1,0 +1,23 @@
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+let freshImportCounter = 0;
+
+function nextFreshImportToken() {
+  freshImportCounter += 1;
+  return String(freshImportCounter);
+}
+
+async function importFreshModuleFromAbsolutePath(absolutePath) {
+  const normalizedPath = String(absolutePath || "").trim();
+  if (!normalizedPath || !path.isAbsolute(normalizedPath)) {
+    throw new Error("importFreshModuleFromAbsolutePath requires an absolute path.");
+  }
+
+  const resolvedPath = path.resolve(normalizedPath);
+  const moduleUrl = pathToFileURL(resolvedPath);
+  moduleUrl.searchParams.set("jskit_fresh", nextFreshImportToken());
+  return import(moduleUrl.href);
+}
+
+export { importFreshModuleFromAbsolutePath };

--- a/packages/kernel/server/support/importFreshModuleFromAbsolutePath.test.js
+++ b/packages/kernel/server/support/importFreshModuleFromAbsolutePath.test.js
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { tmpdir } from "node:os";
+import test from "node:test";
+import { importFreshModuleFromAbsolutePath } from "./importFreshModuleFromAbsolutePath.js";
+
+test("importFreshModuleFromAbsolutePath requires an absolute path", async () => {
+  await assert.rejects(
+    () => importFreshModuleFromAbsolutePath("relative/module.js"),
+    /requires an absolute path/
+  );
+});
+
+test("importFreshModuleFromAbsolutePath re-evaluates a module on each call", async () => {
+  const tempRoot = await mkdtemp(path.join(tmpdir(), "jskit-import-fresh-module-"));
+  const modulePath = path.join(tempRoot, "counter.mjs");
+  const counterKey = "__jskitKernelImportFreshCounter";
+  delete globalThis[counterKey];
+
+  await writeFile(
+    modulePath,
+    `globalThis.${counterKey} = Number(globalThis.${counterKey} || 0) + 1;
+export const loadCount = globalThis.${counterKey};
+`,
+    "utf8"
+  );
+
+  const first = await importFreshModuleFromAbsolutePath(modulePath);
+  const second = await importFreshModuleFromAbsolutePath(modulePath);
+
+  assert.equal(first.loadCount, 1);
+  assert.equal(second.loadCount, 2);
+
+  delete globalThis[counterKey];
+});

--- a/packages/kernel/server/support/index.js
+++ b/packages/kernel/server/support/index.js
@@ -1,6 +1,7 @@
 export { symlinkSafeRequire } from "./symlinkSafeRequire.js";
 export { resolveAppConfig } from "./appConfig.js";
 export { loadAppConfigFromModuleUrl } from "./appConfigFiles.js";
+export { importFreshModuleFromAbsolutePath } from "./importFreshModuleFromAbsolutePath.js";
 export { resolveRequiredAppRoot, toPosixPath } from "./path.js";
 export {
   DEFAULT_PAGE_LINK_COMPONENT_TOKEN,

--- a/tooling/jskit-cli/src/server/cliRuntime/ioAndMigrations.js
+++ b/tooling/jskit-cli/src/server/cliRuntime/ioAndMigrations.js
@@ -8,7 +8,7 @@ import {
   writeFile
 } from "node:fs/promises";
 import path from "node:path";
-import { pathToFileURL } from "node:url";
+import { importFreshModuleFromAbsolutePath } from "@jskit-ai/kernel/server/support";
 import { createCliError } from "../shared/cliError.js";
 import {
   ensureArray,
@@ -325,7 +325,7 @@ async function loadAppConfigModuleConfig(appRoot, relativePath) {
 
   let moduleNamespace = null;
   try {
-    moduleNamespace = await import(`${pathToFileURL(absolutePath).href}?t=${Date.now()}_${Math.random()}`);
+    moduleNamespace = await importFreshModuleFromAbsolutePath(absolutePath);
   } catch (error) {
     throw createCliError(
       `Unable to load ${relativePath}: ${String(error?.message || error || "unknown error")}`

--- a/tooling/jskit-cli/src/server/cliRuntime/mutations/templateContext.js
+++ b/tooling/jskit-cli/src/server/cliRuntime/mutations/templateContext.js
@@ -1,5 +1,5 @@
 import { readFile } from "node:fs/promises";
-import { pathToFileURL } from "node:url";
+import { importFreshModuleFromAbsolutePath } from "@jskit-ai/kernel/server/support";
 import { createCliError } from "../../shared/cliError.js";
 import {
   ensureArray,
@@ -105,7 +105,7 @@ async function resolveTemplateContextReplacementsForMutation({
 
   let moduleNamespace = null;
   try {
-    moduleNamespace = await import(`${pathToFileURL(absoluteEntrypointPath).href}?t=${Date.now()}_${Math.random()}`);
+    moduleNamespace = await importFreshModuleFromAbsolutePath(absoluteEntrypointPath);
   } catch (error) {
     throw createCliError(
       `Unable to load templateContext entrypoint ${entrypoint} for ${packageEntry.packageId}: ${String(error?.message || error || "unknown error")}`

--- a/tooling/jskit-cli/src/server/cliRuntime/packageRegistries.js
+++ b/tooling/jskit-cli/src/server/cliRuntime/packageRegistries.js
@@ -1,6 +1,7 @@
 import { readdir } from "node:fs/promises";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import { importFreshModuleFromAbsolutePath } from "@jskit-ai/kernel/server/support";
 import { createCliError } from "../shared/cliError.js";
 import {
   ensureArray,
@@ -92,7 +93,7 @@ async function loadAppLocalPackageRegistry(appRoot) {
       throw createCliError(`Invalid app-local package at ${normalizeRelativePath(appRoot, packageRoot)}: package.json missing name.`);
     }
 
-    const descriptorModule = await import(pathToFileURL(descriptorPath).href + `?t=${Date.now()}_${Math.random()}`);
+    const descriptorModule = await importFreshModuleFromAbsolutePath(descriptorPath);
     const descriptor = validateAppLocalPackageDescriptorShape(descriptorModule?.default, descriptorPath, {
       expectedPackageId: packageId,
       fallbackVersion: String(packageJson?.version || "").trim()
@@ -207,7 +208,7 @@ async function loadInstalledNodeModulePackageEntry({ appRoot, packageId }) {
     return null;
   }
 
-  const descriptorModule = await import(pathToFileURL(descriptorPath).href + `?t=${Date.now()}_${Math.random()}`);
+  const descriptorModule = await importFreshModuleFromAbsolutePath(descriptorPath);
   const descriptor = validateAppLocalPackageDescriptorShape(descriptorModule?.default, descriptorPath, {
     expectedPackageId: resolvedPackageId,
     fallbackVersion: String(packageJson?.version || "").trim()

--- a/tooling/jskit-cli/src/server/commandHandlers/list.js
+++ b/tooling/jskit-cli/src/server/commandHandlers/list.js
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { readdir, readFile } from "node:fs/promises";
-import { pathToFileURL } from "node:url";
+import { importFreshModuleFromAbsolutePath } from "@jskit-ai/kernel/server/support";
 import {
   ensureArray,
   ensureObject,
@@ -72,7 +72,7 @@ async function resolveDescriptorFromLockEntry({ appRoot = "", packageId = "", in
 
   let descriptorModule = null;
   try {
-    descriptorModule = await import(`${pathToFileURL(descriptorAbsolutePath).href}?t=${Date.now()}_${Math.random()}`);
+    descriptorModule = await importFreshModuleFromAbsolutePath(descriptorAbsolutePath);
   } catch {
     return null;
   }

--- a/tooling/jskit-cli/src/server/commandHandlers/shared.js
+++ b/tooling/jskit-cli/src/server/commandHandlers/shared.js
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { pathToFileURL } from "node:url";
+import { importFreshModuleFromAbsolutePath } from "@jskit-ai/kernel/server/support";
 import {
   ensureArray,
   ensureObject,
@@ -246,7 +246,7 @@ function createCommandHandlerShared(ctx = {}) {
 
     let moduleNamespace = null;
     try {
-      moduleNamespace = await import(`${pathToFileURL(entrypointPath).href}?t=${Date.now()}_${Math.random()}`);
+      moduleNamespace = await importFreshModuleFromAbsolutePath(entrypointPath);
     } catch (error) {
       throw createCliError(
         `Unable to load generator subcommand entrypoint ${normalizeRelativePath(appRoot, entrypointPath)}: ${String(error?.message || error || "unknown error")}`


### PR DESCRIPTION
## Summary
- add a shared kernel helper for fresh-loading modules from absolute paths
- switch CLI and generator/template loaders away from ad-hoc `Date.now()`/`Math.random()` cache busting
- regenerate agent inventory docs to reflect the new helper/export surface

## Verification
- skipped on request