### PR TITLE
Preserve placement source order for equal priorities

### DIFF
--- a/packages/shell-web/src/client/placement/runtime.js
+++ b/packages/shell-web/src/client/placement/runtime.js
@@ -85,13 +85,19 @@ function normalizePlacementList(placements, context = {}) {
     byId.set(placement.id, placement);
   }
 
-  return [...byId.values()].sort((left, right) => {
-    const orderCompare = left.order - right.order;
-    if (orderCompare !== 0) {
-      return orderCompare;
-    }
-    return left.id.localeCompare(right.id);
-  });
+  return [...byId.values()]
+    .map((placement, index) => ({
+      placement,
+      index
+    }))
+    .sort((left, right) => {
+      const orderCompare = left.placement.order - right.placement.order;
+      if (orderCompare !== 0) {
+        return orderCompare;
+      }
+      return left.index - right.index;
+    })
+    .map((entry) => entry.placement);
 }
 
 function matchesSurface(placementSurfaces, requestedSurface) {

--- a/packages/shell-web/test/placementRuntime.test.js
+++ b/packages/shell-web/test/placementRuntime.test.js
@@ -78,6 +78,37 @@ test("web placement runtime filters by surface/host/position, resolves component
   assert.deepEqual(adminTopRight.map((entry) => entry.id), ["test.profile"]);
 });
 
+test("web placement runtime preserves source order when placements share the same order", () => {
+  const app = createAppStub({
+    tokens: {
+      "component.beta": () => null,
+      "component.alpha": () => null
+    }
+  });
+
+  const runtime = createWebPlacementRuntime({ app });
+  runtime.replacePlacements([
+    definePlacement({
+      id: "test.beta",
+      target: "home-settings:primary-menu",
+      surfaces: ["app"],
+      order: 155,
+      componentToken: "component.beta"
+    }),
+    definePlacement({
+      id: "test.alpha",
+      target: "home-settings:primary-menu",
+      surfaces: ["app"],
+      order: 155,
+      componentToken: "component.alpha"
+    })
+  ]);
+  runtime.setContext(createPlacementContext());
+
+  const menu = runtime.getPlacements({ surface: "app", target: "home-settings:primary-menu" });
+  assert.deepEqual(menu.map((entry) => entry.id), ["test.beta", "test.alpha"]);
+});
+
 test("web placement runtime applies context contributors and placement when() predicates", () => {
   const app = createAppStub({
     tokens: {


### PR DESCRIPTION
## Summary
- keep `shell-web` placement runtime ordering stable when multiple placements share the same `order`
- sort equal-priority placements by their source sequence instead of by id
- cover the behavior with a placement runtime test

## Verification
- npm run verify