### PR TITLE
Add CLI completion and descriptor-backed enum options

### DIFF
--- a/packages/crud-server-generator/package.descriptor.mjs
+++ b/packages/crud-server-generator/package.descriptor.mjs
@@ -23,6 +23,8 @@ export default Object.freeze({
       required: true,
       inputType: "text",
       defaultValue: "auto",
+      validationType: "enum",
+      allowedValues: ["auto", "public", "user", "workspace", "workspace_user"],
       promptLabel: "Ownership filter",
       promptHint: "auto | public | user | workspace | workspace_user"
     },

--- a/packages/crud-server-generator/src/server/buildTemplateContext.js
+++ b/packages/crud-server-generator/src/server/buildTemplateContext.js
@@ -17,18 +17,42 @@ import {
 } from "@jskit-ai/kernel/server/support";
 import { normalizeCrudLookupNamespace } from "@jskit-ai/kernel/shared/support/crudLookup";
 import { toCamelCase, toSnakeCase } from "@jskit-ai/kernel/shared/support/stringCase";
+import descriptor from "../../package.descriptor.mjs";
 
 const DEFAULT_ID_COLUMN = "id";
-const OWNERSHIP_FILTER_AUTO = "auto";
-const OWNERSHIP_FILTER_VALUES = new Set([
-  OWNERSHIP_FILTER_AUTO,
-  "public",
-  "user",
-  "workspace",
-  "workspace_user"
-]);
+const DEFAULT_OWNERSHIP_FILTER_VALUES = Object.freeze(["auto", "public", "user", "workspace", "workspace_user"]);
 const MYSQL_CLIENT_ID = "mysql2";
 const CRUD_PERMISSION_OPERATIONS = Object.freeze(["list", "view", "create", "update", "delete"]);
+
+function resolveAllowedValues(schema = {}, fallbackValues = []) {
+  const resolvedValues = [];
+  const seen = new Set();
+  for (const rawValue of Array.isArray(schema?.allowedValues) ? schema.allowedValues : []) {
+    const value = normalizeText(typeof rawValue === "string" ? rawValue : rawValue?.value).toLowerCase();
+    if (!value || seen.has(value)) {
+      continue;
+    }
+    seen.add(value);
+    resolvedValues.push(value);
+  }
+  if (resolvedValues.length > 0) {
+    return Object.freeze(resolvedValues);
+  }
+  return Object.freeze(
+    (Array.isArray(fallbackValues) ? fallbackValues : [])
+      .map((value) => normalizeText(value).toLowerCase())
+      .filter(Boolean)
+  );
+}
+
+const OWNERSHIP_FILTER_ALLOWED_VALUES = resolveAllowedValues(
+  descriptor?.options?.["ownership-filter"],
+  DEFAULT_OWNERSHIP_FILTER_VALUES
+);
+const OWNERSHIP_FILTER_AUTO = normalizeText(
+  descriptor?.options?.["ownership-filter"]?.defaultValue
+).toLowerCase() || "auto";
+const OWNERSHIP_FILTER_VALUES = new Set(OWNERSHIP_FILTER_ALLOWED_VALUES);
 
 function resolveGlobalScaffoldCache() {
   const globalObject = globalThis;
@@ -61,7 +85,7 @@ function normalizeRequestedOwnershipFilter(value, { strict = false } = {}) {
   }
   if (strict) {
     throw new Error(
-      `Invalid ownership filter "${normalized || String(value || "")}". Use: auto, public, user, workspace, workspace_user.`
+      `Invalid ownership filter "${normalized || String(value || "")}". Use: ${OWNERSHIP_FILTER_ALLOWED_VALUES.join(", ")}.`
     );
   }
   return OWNERSHIP_FILTER_AUTO;

--- a/packages/crud-server-generator/test/packageDescriptor.test.js
+++ b/packages/crud-server-generator/test/packageDescriptor.test.js
@@ -6,6 +6,11 @@ test("crud-server-generator surface option validates against enabled surface ids
   assert.equal(descriptor.kind, "generator");
   assert.equal(descriptor.options?.surface?.validationType, "enabled-surface-id");
   assert.equal(descriptor.options?.surface?.required, false);
+  assert.equal(descriptor.options?.["ownership-filter"]?.validationType, "enum");
+  assert.deepEqual(
+    descriptor.options?.["ownership-filter"]?.allowedValues,
+    ["auto", "public", "user", "workspace", "workspace_user"]
+  );
   assert.equal(descriptor.options?.["table-name"]?.required, false);
   assert.equal(
     descriptor.options?.["table-name"]?.defaultFromOptionTemplate,

--- a/packages/crud-ui-generator/package.descriptor.mjs
+++ b/packages/crud-ui-generator/package.descriptor.mjs
@@ -24,6 +24,8 @@ export default Object.freeze({
       required: false,
       inputType: "text",
       defaultValue: "list,view,new,edit",
+      validationType: "csv-enum",
+      allowedValues: ["list", "view", "new", "edit"],
       promptLabel: "Operations",
       promptHint: "Optional comma-separated values from: list, view, new, edit. Defaults to all four."
     },

--- a/packages/crud-ui-generator/src/server/buildTemplateContext.js
+++ b/packages/crud-ui-generator/src/server/buildTemplateContext.js
@@ -29,9 +29,33 @@ import {
   resolveRecordChangedEventName,
   resolveRecordIdExpression
 } from "./resourceSupport.js";
+import descriptor from "../../package.descriptor.mjs";
 
-const ALLOWED_OPERATIONS = new Set(["list", "view", "new", "edit"]);
-const DEFAULT_OPERATIONS = "list,view,new,edit";
+const DEFAULT_ALLOWED_OPERATIONS = Object.freeze(["list", "view", "new", "edit"]);
+function resolveAllowedValues(schema = {}, fallbackValues = []) {
+  const resolvedValues = [];
+  const seen = new Set();
+  for (const rawValue of Array.isArray(schema?.allowedValues) ? schema.allowedValues : []) {
+    const value = normalizeText(typeof rawValue === "string" ? rawValue : rawValue?.value).toLowerCase();
+    if (!value || seen.has(value)) {
+      continue;
+    }
+    seen.add(value);
+    resolvedValues.push(value);
+  }
+  if (resolvedValues.length > 0) {
+    return Object.freeze(resolvedValues);
+  }
+  return Object.freeze(
+    (Array.isArray(fallbackValues) ? fallbackValues : [])
+      .map((value) => normalizeText(value).toLowerCase())
+      .filter(Boolean)
+  );
+}
+
+const OPERATION_VALUES = resolveAllowedValues(descriptor?.options?.operations, DEFAULT_ALLOWED_OPERATIONS);
+const ALLOWED_OPERATIONS = new Set(OPERATION_VALUES);
+const DEFAULT_OPERATIONS = normalizeText(descriptor?.options?.operations?.defaultValue) || OPERATION_VALUES.join(",");
 const DEFAULT_LIST_HIDDEN_FIELD_KEYS = new Set(["createdAt", "updatedAt"]);
 const DEFAULT_FORM_COMPONENT_FILE = "CrudAddEditForm.vue";
 const DEFAULT_FORM_FIELDS_FILE = "CrudAddEditFormFields.js";
@@ -161,7 +185,7 @@ function parseOperationsOption(options) {
   const unique = new Set();
   for (const operation of operations) {
     if (!ALLOWED_OPERATIONS.has(operation)) {
-      throw new Error('crud-ui-generator option "operations" supports only: list, view, new, edit.');
+      throw new Error(`crud-ui-generator option "operations" supports only: ${OPERATION_VALUES.join(", ")}.`);
     }
     unique.add(operation);
   }

--- a/packages/crud-ui-generator/test/packageDescriptor.test.js
+++ b/packages/crud-ui-generator/test/packageDescriptor.test.js
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import descriptor from "../package.descriptor.mjs";
+
+test("crud-ui-generator operations option exposes structured csv-enum metadata", () => {
+  assert.equal(descriptor.kind, "generator");
+  assert.equal(descriptor.options?.operations?.validationType, "csv-enum");
+  assert.deepEqual(
+    descriptor.options?.operations?.allowedValues,
+    ["list", "view", "new", "edit"]
+  );
+  assert.equal(descriptor.options?.operations?.defaultValue, "list,view,new,edit");
+  assert.equal(descriptor.metadata?.generatorSubcommands?.crud?.optionNames?.includes("operations"), true);
+});

--- a/tooling/jskit-cli/src/server/cliRuntime/completion.js
+++ b/tooling/jskit-cli/src/server/cliRuntime/completion.js
@@ -1,0 +1,1177 @@
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { access, readdir, readFile } from "node:fs/promises";
+import {
+  COMMAND_IDS,
+  isKnownCommandName,
+  resolveCommandAlias,
+  resolveCommandDescriptor
+} from "../core/commandCatalog.js";
+
+const WRAPPER_COMMANDS = new Set(["npx", "jsx"]);
+const KNOWN_GENERATE_FLAG_OPTIONS = Object.freeze(["dry-run", "run-npm-install", "json", "verbose"]);
+const BOOLEAN_OPTION_NAMES = new Set([
+  "dry-run",
+  "run-npm-install",
+  "full",
+  "expanded",
+  "details",
+  "debug-exports",
+  "check-di-labels",
+  "verbose",
+  "json",
+  "all",
+  "help",
+  "force"
+]);
+const LIST_MODES = Object.freeze(["bundles", "packages", "generators"]);
+const ADD_TARGET_TYPES = Object.freeze(["package", "bundle"]);
+const POSITION_TARGET_TYPES = Object.freeze(["element"]);
+const UPDATE_TARGET_TYPES = Object.freeze(["package"]);
+const REMOVE_TARGET_TYPES = Object.freeze(["package"]);
+const MIGRATION_SCOPES = Object.freeze(["all", "changed", "package"]);
+
+function normalizeText(value = "") {
+  return String(value || "").trim();
+}
+
+function toPosix(value = "") {
+  return String(value || "").replaceAll(path.sep, "/");
+}
+
+function uniqueSorted(values = []) {
+  return [...new Set((Array.isArray(values) ? values : []).filter(Boolean))].sort((left, right) =>
+    String(left).localeCompare(String(right))
+  );
+}
+
+function filterByPrefix(values = [], prefix = "") {
+  const normalizedPrefix = String(prefix || "");
+  if (!normalizedPrefix) {
+    return uniqueSorted(values);
+  }
+  return uniqueSorted(values).filter((value) => String(value || "").startsWith(normalizedPrefix));
+}
+
+function resolveAllowedValues(schema = {}) {
+  const values = [];
+  const seen = new Set();
+  for (const rawValue of Array.isArray(schema?.allowedValues) ? schema.allowedValues : []) {
+    const value = normalizeText(typeof rawValue === "string" ? rawValue : rawValue?.value);
+    if (!value) {
+      continue;
+    }
+    const normalizedKey = value.toLowerCase();
+    if (seen.has(normalizedKey)) {
+      continue;
+    }
+    seen.add(normalizedKey);
+    values.push(value);
+  }
+  return Object.freeze(values);
+}
+
+function ensureTrailingSlash(value = "") {
+  const normalized = toPosix(value).replace(/\/+$/g, "");
+  if (!normalized) {
+    return "";
+  }
+  return `${normalized}/`;
+}
+
+async function pathExists(targetPath) {
+  try {
+    await access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readJsonFile(filePath) {
+  const source = await readFile(filePath, "utf8");
+  return JSON.parse(source);
+}
+
+async function safeReaddir(directoryPath) {
+  try {
+    return await readdir(directoryPath, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+}
+
+async function walkDirectory(rootPath, { includeDirectories = false, includeFiles = true, fileFilter = null } = {}) {
+  const entries = [];
+
+  async function visit(directoryPath) {
+    const children = await safeReaddir(directoryPath);
+    for (const child of children) {
+      if (child.name.startsWith(".")) {
+        continue;
+      }
+      const absolutePath = path.join(directoryPath, child.name);
+      if (child.isDirectory()) {
+        if (includeDirectories) {
+          entries.push(absolutePath);
+        }
+        await visit(absolutePath);
+        continue;
+      }
+      if (!includeFiles) {
+        continue;
+      }
+      if (typeof fileFilter === "function" && fileFilter(absolutePath) !== true) {
+        continue;
+      }
+      entries.push(absolutePath);
+    }
+  }
+
+  if (await pathExists(rootPath)) {
+    await visit(rootPath);
+  }
+
+  return entries;
+}
+
+async function importDefaultModule(modulePath) {
+  const moduleUrl = `${pathToFileURL(modulePath).href}?mtime=${Date.now()}`;
+  const imported = await import(moduleUrl);
+  return imported?.default;
+}
+
+async function loadCommandCatalog() {
+  return {
+    COMMAND_IDS,
+    isKnownCommandName,
+    resolveCommandAlias,
+    resolveCommandDescriptor
+  };
+}
+
+function isDirectoryLike(entry) {
+  return Boolean(entry && (entry.isDirectory() || entry.isSymbolicLink()));
+}
+
+async function discoverDescriptorPackages(appRoot) {
+  const packageDirs = [];
+
+  for (const entry of await safeReaddir(path.join(appRoot, "packages"))) {
+    if (isDirectoryLike(entry)) {
+      packageDirs.push(path.join(appRoot, "packages", entry.name));
+    }
+  }
+
+  for (const entry of await safeReaddir(path.join(appRoot, "node_modules", "@jskit-ai"))) {
+    if (isDirectoryLike(entry)) {
+      packageDirs.push(path.join(appRoot, "node_modules", "@jskit-ai", entry.name));
+    }
+  }
+
+  const discovered = [];
+  for (const packageDir of packageDirs) {
+    const descriptorPath = path.join(packageDir, "package.descriptor.mjs");
+    if (!(await pathExists(descriptorPath))) {
+      continue;
+    }
+    try {
+      const descriptor = await importDefaultModule(descriptorPath);
+      const packageJsonPath = path.join(packageDir, "package.json");
+      const packageJson = (await pathExists(packageJsonPath)) ? await readJsonFile(packageJsonPath) : {};
+      const packageId = normalizeText(descriptor?.packageId || packageJson?.name || path.basename(packageDir));
+      if (!packageId) {
+        continue;
+      }
+      discovered.push(
+        Object.freeze({
+          packageDir,
+          packageId,
+          descriptor: descriptor && typeof descriptor === "object" ? descriptor : {}
+        })
+      );
+    } catch {
+      // Ignore malformed descriptors during completion discovery.
+    }
+  }
+
+  return uniqueSorted(discovered.map((entry) => entry.packageId)).map((packageId) =>
+    discovered.find((entry) => entry.packageId === packageId)
+  );
+}
+
+async function discoverBundleIds(appRoot) {
+  const bundleDescriptorPaths = [];
+
+  for (const packageDir of [
+    ...((await safeReaddir(path.join(appRoot, "packages"))).filter((entry) => isDirectoryLike(entry)).map((entry) =>
+      path.join(appRoot, "packages", entry.name)
+    )),
+    ...((await safeReaddir(path.join(appRoot, "node_modules", "@jskit-ai"))).filter((entry) => isDirectoryLike(entry)).map((entry) =>
+      path.join(appRoot, "node_modules", "@jskit-ai", entry.name)
+    ))
+  ]) {
+    const bundlesDir = path.join(packageDir, "bundles");
+    for (const entry of await safeReaddir(bundlesDir)) {
+      if (!entry.isDirectory()) {
+        continue;
+      }
+      const descriptorPath = path.join(bundlesDir, entry.name, "bundle.descriptor.mjs");
+      if (await pathExists(descriptorPath)) {
+        bundleDescriptorPaths.push(descriptorPath);
+      }
+    }
+  }
+
+  const bundleIds = [];
+  for (const descriptorPath of bundleDescriptorPaths) {
+    try {
+      const descriptor = await importDefaultModule(descriptorPath);
+      const bundleId = normalizeText(descriptor?.bundleId);
+      if (bundleId) {
+        bundleIds.push(bundleId);
+      }
+    } catch {
+      // Ignore malformed bundle descriptors.
+    }
+  }
+
+  return uniqueSorted(bundleIds);
+}
+
+function toShortPackageId(packageId = "") {
+  const normalized = normalizeText(packageId);
+  if (!normalized.startsWith("@jskit-ai/")) {
+    return normalized;
+  }
+  return normalized.slice("@jskit-ai/".length);
+}
+
+async function discoverGenerators(appRoot) {
+  const packages = await discoverDescriptorPackages(appRoot);
+  const generators = [];
+  for (const entry of packages) {
+    if (normalizeText(entry?.descriptor?.kind) !== "generator") {
+      continue;
+    }
+    const shortId = toShortPackageId(entry.packageId);
+    generators.push(
+      Object.freeze({
+        packageId: entry.packageId,
+        shortId,
+        descriptor: entry.descriptor
+      })
+    );
+  }
+  return generators.sort((left, right) => left.shortId.localeCompare(right.shortId));
+}
+
+async function discoverRuntimePackages(appRoot) {
+  const packages = await discoverDescriptorPackages(appRoot);
+  const runtimeIds = [];
+  for (const entry of packages) {
+    if (normalizeText(entry?.descriptor?.kind) === "generator") {
+      continue;
+    }
+    runtimeIds.push(entry.packageId);
+    if (entry.packageId.startsWith("@jskit-ai/")) {
+      runtimeIds.push(toShortPackageId(entry.packageId));
+    }
+  }
+  return uniqueSorted(runtimeIds);
+}
+
+async function discoverResourceFiles(appRoot) {
+  const sharedFiles = [];
+  for (const packageDir of await safeReaddir(path.join(appRoot, "packages"))) {
+    if (!packageDir.isDirectory()) {
+      continue;
+    }
+    const sharedDir = path.join(appRoot, "packages", packageDir.name, "src", "shared");
+    for (const fileEntry of await safeReaddir(sharedDir)) {
+      if (!fileEntry.isFile()) {
+        continue;
+      }
+      if (!/Resource\.js$/u.test(fileEntry.name)) {
+        continue;
+      }
+      sharedFiles.push(toPosix(path.relative(appRoot, path.join(sharedDir, fileEntry.name))));
+    }
+  }
+  return uniqueSorted(sharedFiles);
+}
+
+async function discoverSurfaces(appRoot) {
+  const pagesRoot = path.join(appRoot, "src", "pages");
+  const surfaces = [];
+  for (const entry of await safeReaddir(pagesRoot)) {
+    if (entry.isDirectory()) {
+      surfaces.push(entry.name);
+      continue;
+    }
+    if (entry.isFile() && entry.name.endsWith(".vue")) {
+      surfaces.push(entry.name.slice(0, -".vue".length));
+    }
+  }
+  return uniqueSorted(surfaces);
+}
+
+function extractMatches(source = "", patterns = []) {
+  const values = [];
+  for (const pattern of patterns) {
+    for (const match of String(source || "").matchAll(pattern)) {
+      const value = normalizeText(match?.[1]);
+      if (value) {
+        values.push(value);
+      }
+    }
+  }
+  return values;
+}
+
+async function discoverPlacementTargets(appRoot) {
+  const placementValues = [];
+  const placementSourcePath = path.join(appRoot, "src", "placement.js");
+  if (await pathExists(placementSourcePath)) {
+    const source = await readFile(placementSourcePath, "utf8");
+    placementValues.push(...extractMatches(source, [/\btarget\s*:\s*["']([^"']+)["']/g]));
+    for (const match of source.matchAll(/\bhost\s*:\s*["']([^"']+)["']\s*,\s*\n?\s*position\s*:\s*["']([^"']+)["']/g)) {
+      const host = normalizeText(match?.[1]);
+      const position = normalizeText(match?.[2]);
+      if (host && position) {
+        placementValues.push(`${host}:${position}`);
+      }
+    }
+  }
+
+  const sourceFiles = await walkDirectory(path.join(appRoot, "src"), {
+    includeFiles: true,
+    includeDirectories: false,
+    fileFilter: (filePath) => /\.(vue|js|mjs)$/u.test(filePath)
+  });
+  for (const filePath of sourceFiles) {
+    const source = await readFile(filePath, "utf8");
+    placementValues.push(...extractMatches(source, [/\btarget\s*=\s*["']([^"']+)["']/g]));
+    for (const match of source.matchAll(/\bhost\s*=\s*["']([^"']+)["']\s+position\s*=\s*["']([^"']+)["']/g)) {
+      const host = normalizeText(match?.[1]);
+      const position = normalizeText(match?.[2]);
+      if (host && position) {
+        placementValues.push(`${host}:${position}`);
+      }
+    }
+  }
+
+  return uniqueSorted(placementValues);
+}
+
+async function discoverComponentTokens(appRoot) {
+  const tokens = [];
+  for (const filePath of [
+    path.join(appRoot, "src", "placement.js"),
+    ...((await walkDirectory(path.join(appRoot, "src"), {
+      includeFiles: true,
+      includeDirectories: false,
+      fileFilter: (candidate) => /\.(vue|js|mjs)$/u.test(candidate)
+    })) || []),
+    ...((await walkDirectory(path.join(appRoot, "packages"), {
+      includeFiles: true,
+      includeDirectories: false,
+      fileFilter: (candidate) => /\.(vue|js|mjs)$/u.test(candidate)
+    })) || [])
+  ]) {
+    if (!(await pathExists(filePath))) {
+      continue;
+    }
+    const source = await readFile(filePath, "utf8");
+    tokens.push(...extractMatches(source, [
+      /\bcomponentToken\s*:\s*["']([^"']+)["']/g,
+      /\bdefault-link-component-token\s*=\s*["']([^"']+)["']/g,
+      /registerMainClientComponent\(\s*["']([^"']+)["']/g
+    ]));
+  }
+  return uniqueSorted(tokens);
+}
+
+function isRouteLikeRelativePath(relativePath = "") {
+  return !toPosix(relativePath)
+    .split("/")
+    .filter(Boolean)
+    .some((segment) => segment.startsWith("_"));
+}
+
+async function discoverPagesRelativeDirectories(appRoot) {
+  const pagesRoot = path.join(appRoot, "src", "pages");
+  const directories = await walkDirectory(pagesRoot, {
+    includeDirectories: true,
+    includeFiles: false
+  });
+  return uniqueSorted(
+    directories
+      .map((directoryPath) => path.relative(pagesRoot, directoryPath))
+      .filter(Boolean)
+      .filter((relativePath) => isRouteLikeRelativePath(relativePath))
+      .map((relativePath) => ensureTrailingSlash(relativePath))
+  );
+}
+
+async function discoverPagesRelativeFiles(appRoot) {
+  const pagesRoot = path.join(appRoot, "src", "pages");
+  const files = await walkDirectory(pagesRoot, {
+    includeDirectories: false,
+    includeFiles: true,
+    fileFilter: (filePath) => filePath.endsWith(".vue")
+  });
+  return uniqueSorted(
+    files
+      .map((filePath) => path.relative(pagesRoot, filePath))
+      .filter((relativePath) => isRouteLikeRelativePath(relativePath))
+      .map((relativePath) => toPosix(relativePath))
+  );
+}
+
+async function discoverAppVueFiles(appRoot) {
+  const srcRoot = path.join(appRoot, "src");
+  const files = await walkDirectory(srcRoot, {
+    includeDirectories: false,
+    includeFiles: true,
+    fileFilter: (filePath) => filePath.endsWith(".vue")
+  });
+  return uniqueSorted(files.map((filePath) => toPosix(path.relative(appRoot, filePath))));
+}
+
+function buildOptionSuggestions(optionNames = [], { current = "", seenOptionNames = new Set() } = {}) {
+  const suggestions = [];
+  for (const optionName of optionNames) {
+    if (!optionName) {
+      continue;
+    }
+    if (seenOptionNames.has(optionName) && !BOOLEAN_OPTION_NAMES.has(optionName)) {
+      continue;
+    }
+    suggestions.push(`--${optionName}`);
+  }
+  return filterByPrefix(suggestions, current);
+}
+
+function parseOptionToken(token = "") {
+  const normalized = String(token || "");
+  if (!normalized.startsWith("--")) {
+    return null;
+  }
+  const withoutPrefix = normalized.slice(2);
+  if (!withoutPrefix) {
+    return null;
+  }
+  const equalsIndex = withoutPrefix.indexOf("=");
+  if (equalsIndex < 0) {
+    return {
+      name: withoutPrefix,
+      value: "",
+      hasInlineValue: false
+    };
+  }
+  return {
+    name: withoutPrefix.slice(0, equalsIndex),
+    value: withoutPrefix.slice(equalsIndex + 1),
+    hasInlineValue: true
+  };
+}
+
+function parseContextTokens(tokens = [], optionMeta = {}) {
+  const positionals = [];
+  const seenOptionNames = new Set();
+  const optionValues = new Map();
+  let expectValueFor = "";
+
+  for (const token of Array.isArray(tokens) ? tokens : []) {
+    if (expectValueFor) {
+      optionValues.set(expectValueFor, token);
+      seenOptionNames.add(expectValueFor);
+      expectValueFor = "";
+      continue;
+    }
+
+    const parsedOption = parseOptionToken(token);
+    if (parsedOption) {
+      const optionName = normalizeText(parsedOption.name);
+      if (!optionName) {
+        continue;
+      }
+      const meta = optionMeta[optionName] || {};
+      seenOptionNames.add(optionName);
+      if (parsedOption.hasInlineValue) {
+        optionValues.set(optionName, parsedOption.value);
+        continue;
+      }
+      if (normalizeText(meta.inputType) === "flag" || BOOLEAN_OPTION_NAMES.has(optionName)) {
+        optionValues.set(optionName, "true");
+        continue;
+      }
+      expectValueFor = optionName;
+      continue;
+    }
+
+    positionals.push(token);
+  }
+
+  return Object.freeze({
+    positionals: Object.freeze(positionals),
+    optionValues,
+    seenOptionNames,
+    expectValueFor
+  });
+}
+
+function resolveCurrentOptionValueRequest({ currentToken = "", previousToken = "", optionMeta = {} } = {}) {
+  const previousOption = parseOptionToken(previousToken);
+  if (previousOption && !previousOption.hasInlineValue) {
+    const meta = optionMeta[previousOption.name] || {};
+    if (normalizeText(meta.inputType) !== "flag" && !BOOLEAN_OPTION_NAMES.has(previousOption.name)) {
+      return {
+        optionName: previousOption.name,
+        valuePrefix: currentToken,
+        includeOptionPrefix: false
+      };
+    }
+  }
+
+  const currentOption = parseOptionToken(currentToken);
+  if (currentOption && currentOption.hasInlineValue) {
+    const meta = optionMeta[currentOption.name] || {};
+    if (normalizeText(meta.inputType) !== "flag" && !BOOLEAN_OPTION_NAMES.has(currentOption.name)) {
+      return {
+        optionName: currentOption.name,
+        valuePrefix: currentOption.value,
+        includeOptionPrefix: true
+      };
+    }
+  }
+
+  return null;
+}
+
+function completeCommaSeparatedValues({ currentValue = "", allowedValues = [] } = {}) {
+  const source = String(currentValue || "");
+  const segments = source.split(",");
+  segments.pop();
+  const used = new Set(segments.map((entry) => normalizeText(entry)).filter(Boolean));
+  const prefix = segments.length > 0 ? `${segments.join(",")},` : "";
+
+  return filterByPrefix(
+    allowedValues.filter((value) => !used.has(value)).map((value) => `${prefix}${value}`),
+    source
+  );
+}
+
+function extractBracketParams(value = "") {
+  return [...String(value || "").matchAll(/\[([^\]/]+)\]/g)].map((match) => normalizeText(match?.[1])).filter(Boolean);
+}
+
+async function completeOptionValue({
+  appRoot,
+  optionName = "",
+  valuePrefix = "",
+  includeOptionPrefix = false,
+  parseState,
+  currentGenerator = "",
+  optionMeta = {}
+} = {}) {
+  const normalizedOptionName = normalizeText(optionName);
+  const descriptorOption = optionMeta?.descriptorOption || {};
+  const validationType = normalizeText(descriptorOption?.validationType).toLowerCase();
+  const allowedValues = resolveAllowedValues(descriptorOption);
+  let suggestions = [];
+
+  if (normalizedOptionName === "resource-file") {
+    suggestions = await discoverResourceFiles(appRoot);
+  } else if (["link-placement", "placement", "target"].includes(normalizedOptionName)) {
+    suggestions = await discoverPlacementTargets(appRoot);
+  } else if (normalizedOptionName === "link-component-token") {
+    suggestions = await discoverComponentTokens(appRoot);
+  } else if (normalizedOptionName === "surface") {
+    suggestions = await discoverSurfaces(appRoot);
+  } else if (validationType === "csv-enum" && allowedValues.length > 0) {
+    suggestions = completeCommaSeparatedValues({
+      currentValue: valuePrefix,
+      allowedValues
+    });
+  } else if (validationType === "enum" && allowedValues.length > 0) {
+    suggestions = allowedValues;
+  } else if (normalizedOptionName === "display-fields") {
+    const resourceFile = normalizeText(parseState?.optionValues?.get("resource-file"));
+    const fields = await discoverResourceDisplayFields(appRoot, resourceFile);
+    suggestions = completeCommaSeparatedValues({
+      currentValue: valuePrefix,
+      allowedValues: fields
+    });
+  } else if (normalizedOptionName === "prefix") {
+    const tokens = await discoverComponentTokens(appRoot);
+    const prefixes = new Set();
+    for (const token of tokens) {
+      const segments = String(token || "").split(".").filter(Boolean);
+      let currentPrefix = "";
+      for (const segment of segments.slice(0, -1)) {
+        currentPrefix = currentPrefix ? `${currentPrefix}.${segment}` : segment;
+        prefixes.add(`${currentPrefix}.`);
+      }
+    }
+    suggestions = [...prefixes];
+  } else if (normalizedOptionName === "id-param") {
+    const dynamicParams = new Set(["recordId"]);
+    for (const positional of parseState?.positionals || []) {
+      for (const param of extractBracketParams(positional)) {
+        dynamicParams.add(param);
+      }
+    }
+    suggestions = [...dynamicParams];
+  } else if (normalizedOptionName === "table-name" && currentGenerator === "crud-server-generator") {
+    suggestions = [];
+  }
+
+  suggestions = filterByPrefix(suggestions, valuePrefix);
+  if (!includeOptionPrefix) {
+    return suggestions;
+  }
+  return suggestions.map((value) => `--${normalizedOptionName}=${value}`);
+}
+
+async function discoverResourceDisplayFields(appRoot, resourceFile = "") {
+  const normalizedPath = normalizeText(resourceFile);
+  if (!normalizedPath) {
+    return [];
+  }
+
+  const absolutePath = path.resolve(appRoot, normalizedPath);
+  if (!absolutePath.startsWith(`${appRoot}${path.sep}`) && absolutePath !== appRoot) {
+    return [];
+  }
+  if (!(await pathExists(absolutePath))) {
+    return [];
+  }
+
+  try {
+    const imported = await import(`${pathToFileURL(absolutePath).href}?mtime=${Date.now()}`);
+    const resource = imported?.resource;
+    if (!resource || typeof resource !== "object") {
+      return [];
+    }
+    const fieldKeys = new Set();
+
+    const outputSchemaProperties = resource?.operations?.view?.outputValidator?.schema?.properties;
+    if (outputSchemaProperties && typeof outputSchemaProperties === "object") {
+      for (const key of Object.keys(outputSchemaProperties)) {
+        if (key === resource?.contract?.lookup?.containerKey) {
+          continue;
+        }
+        fieldKeys.add(key);
+      }
+    }
+
+    for (const fieldMeta of Array.isArray(resource?.fieldMeta) ? resource.fieldMeta : []) {
+      const key = normalizeText(fieldMeta?.key);
+      if (key) {
+        fieldKeys.add(key);
+      }
+    }
+
+    return uniqueSorted([...fieldKeys]);
+  } catch {
+    return [];
+  }
+}
+
+async function completeRelativeDirectoryRoot(appRoot, current = "") {
+  return filterByPrefix(await discoverPagesRelativeDirectories(appRoot), current);
+}
+
+async function completeRelativePageTargetFile(appRoot, current = "") {
+  return filterByPrefix(
+    [...(await discoverPagesRelativeDirectories(appRoot)), ...(await discoverPagesRelativeFiles(appRoot))],
+    current
+  );
+}
+
+async function completeAppVueFile(appRoot, current = "") {
+  return filterByPrefix(await discoverAppVueFiles(appRoot), current);
+}
+
+function normalizeCompletionInvocation(words = [], cword = 0) {
+  const rawWords = (Array.isArray(words) ? words : []).map((value) => String(value ?? ""));
+  let currentIndex = Number(cword);
+  if (!Number.isInteger(currentIndex)) {
+    currentIndex = Math.max(rawWords.length - 1, 0);
+  }
+
+  if (rawWords.length < 1) {
+    return {
+      words: ["jskit"],
+      cword: 0,
+      wrapperOnly: false
+    };
+  }
+
+  if (WRAPPER_COMMANDS.has(rawWords[0])) {
+    const jskitIndex = rawWords.findIndex((token, index) => index > 0 && ["jskit", "@jskit-ai/jskit-cli"].includes(token));
+    if (jskitIndex < 0) {
+      return {
+        words: rawWords,
+        cword: currentIndex,
+        wrapperOnly: true
+      };
+    }
+    const normalizedWords = rawWords.slice(jskitIndex);
+    return {
+      words: normalizedWords,
+      cword: Math.max(0, currentIndex - jskitIndex),
+      wrapperOnly: false
+    };
+  }
+
+  return {
+    words: rawWords[0] === "@jskit-ai/jskit-cli" ? ["jskit", ...rawWords.slice(1)] : rawWords,
+    cword: currentIndex,
+    wrapperOnly: false
+  };
+}
+
+function buildTopLevelCommandMetadata(catalogModule) {
+  const commands = new Set();
+  for (const commandId of catalogModule.COMMAND_IDS || []) {
+    const descriptor = catalogModule.resolveCommandDescriptor(commandId);
+    if (!descriptor) {
+      continue;
+    }
+    commands.add(descriptor.command);
+    for (const alias of Array.isArray(descriptor.aliases) ? descriptor.aliases : []) {
+      commands.add(alias);
+    }
+  }
+  commands.add("help");
+  return uniqueSorted([...commands]);
+}
+
+function buildCommandOptionMeta(command = "", catalogModule) {
+  const descriptor = catalogModule.resolveCommandDescriptor(command);
+  if (!descriptor) {
+    return {};
+  }
+
+  const optionMeta = {};
+  for (const flagKey of Array.isArray(descriptor.allowedFlagKeys) ? descriptor.allowedFlagKeys : []) {
+    const labels = {
+      dryRun: "dry-run",
+      runNpmInstall: "run-npm-install",
+      full: "full",
+      expanded: "expanded",
+      details: "details",
+      debugExports: "debug-exports",
+      checkDiLabels: "check-di-labels",
+      verbose: "verbose",
+      json: "json",
+      all: "all"
+    };
+    const optionName = labels[flagKey];
+    if (optionName) {
+      optionMeta[optionName] = { inputType: "flag" };
+    }
+  }
+  for (const optionName of Array.isArray(descriptor.allowedValueOptionNames) ? descriptor.allowedValueOptionNames : []) {
+    optionMeta[optionName] = { inputType: "text" };
+  }
+  optionMeta.help = { inputType: "flag" };
+  return optionMeta;
+}
+
+function buildGeneratorLookup(generators = []) {
+  const lookup = new Map();
+  for (const generator of generators) {
+    lookup.set(generator.shortId, generator);
+    lookup.set(generator.packageId, generator);
+  }
+  return lookup;
+}
+
+function buildGeneratorOptionMeta(generator = null, subcommandName = "") {
+  const optionMeta = {};
+  for (const optionName of KNOWN_GENERATE_FLAG_OPTIONS) {
+    optionMeta[optionName] = { inputType: "flag" };
+  }
+  optionMeta.help = { inputType: "flag" };
+
+  const descriptorOptions = generator?.descriptor?.options && typeof generator.descriptor.options === "object"
+    ? generator.descriptor.options
+    : {};
+  const subcommand = generator?.descriptor?.metadata?.generatorSubcommands?.[subcommandName] || {};
+  for (const optionName of Array.isArray(subcommand.optionNames) ? subcommand.optionNames : []) {
+    const descriptorOption = descriptorOptions?.[optionName] || {};
+    optionMeta[optionName] = {
+      inputType: normalizeText(descriptorOption.inputType) || (BOOLEAN_OPTION_NAMES.has(optionName) ? "flag" : "text"),
+      descriptorOption
+    };
+  }
+  return optionMeta;
+}
+
+function resolveImplicitGeneratorSubcommand(generator = null, tokensAfterGenerator = [], currentToken = "") {
+  const metadata = generator?.descriptor?.metadata || {};
+  const subcommands = metadata.generatorSubcommands && typeof metadata.generatorSubcommands === "object"
+    ? metadata.generatorSubcommands
+    : {};
+  const tokenList = Array.isArray(tokensAfterGenerator) ? tokensAfterGenerator : [];
+  const firstToken = normalizeText(tokenList[0]);
+
+  if (firstToken && !firstToken.startsWith("-") && firstToken !== "help" && Object.hasOwn(subcommands, firstToken)) {
+    return {
+      subcommandName: firstToken,
+      explicit: true,
+      offset: 1
+    };
+  }
+
+  const primarySubcommand = normalizeText(metadata.generatorPrimarySubcommand);
+  if (!primarySubcommand || !Object.hasOwn(subcommands, primarySubcommand)) {
+    return {
+      subcommandName: "",
+      explicit: false,
+      offset: 0
+    };
+  }
+
+  const hasOptionUsage = tokenList.some((token) => String(token || "").startsWith("--")) || String(currentToken || "").startsWith("--");
+  if (!hasOptionUsage) {
+    return {
+      subcommandName: "",
+      explicit: false,
+      offset: 0
+    };
+  }
+
+  return {
+    subcommandName: primarySubcommand,
+    explicit: false,
+    offset: 0
+  };
+}
+
+async function completeGenericContext({
+  appRoot,
+  currentToken = "",
+  previousToken = "",
+  optionMeta = {},
+  positionalArgs = [],
+  tokensBeforeCurrent = [],
+  optionNames = [],
+  positionalCompleter = null,
+  generatorName = "",
+  subcommandName = ""
+} = {}) {
+  const parseState = parseContextTokens(tokensBeforeCurrent, optionMeta);
+  const optionValueRequest = resolveCurrentOptionValueRequest({
+    currentToken,
+    previousToken,
+    optionMeta
+  });
+  if (optionValueRequest) {
+    return completeOptionValue({
+      appRoot,
+      optionName: optionValueRequest.optionName,
+      valuePrefix: optionValueRequest.valuePrefix,
+      includeOptionPrefix: optionValueRequest.includeOptionPrefix,
+      parseState,
+      currentSubcommand: subcommandName,
+      currentGenerator: generatorName,
+      optionMeta: optionMeta[optionValueRequest.optionName] || {}
+    });
+  }
+
+  if (String(currentToken || "").startsWith("--")) {
+    return buildOptionSuggestions(optionNames, {
+      current: currentToken,
+      seenOptionNames: parseState.seenOptionNames
+    });
+  }
+
+  const positionalIndex = parseState.positionals.length;
+  const suggestions = [];
+  if (typeof positionalCompleter === "function") {
+    suggestions.push(
+      ...(await positionalCompleter({
+        positionalIndex,
+        currentToken,
+        parseState,
+        positionalArgs,
+        appRoot,
+        generatorName,
+        subcommandName
+      }))
+    );
+  }
+
+  if (!currentToken) {
+    suggestions.push(
+      ...buildOptionSuggestions(optionNames, {
+        current: currentToken,
+        seenOptionNames: parseState.seenOptionNames
+      })
+    );
+  }
+
+  return uniqueSorted(suggestions);
+}
+
+async function completeTopLevel({ currentToken = "", catalogModule }) {
+  const commandSuggestions = buildTopLevelCommandMetadata(catalogModule);
+  if (String(currentToken || "").startsWith("-")) {
+    return filterByPrefix(["--help"], currentToken);
+  }
+  return filterByPrefix([...commandSuggestions, "--help"], currentToken);
+}
+
+async function completeGenerateCommand({ appRoot, words, cword, catalogModule }) {
+  const currentToken = words[cword] ?? "";
+  const previousToken = words[cword - 1] ?? "";
+  const generators = await discoverGenerators(appRoot);
+  const generatorLookup = buildGeneratorLookup(generators);
+
+  if (cword <= 2) {
+    const generatorIds = uniqueSorted(
+      generators.flatMap((generator) => [generator.shortId, generator.packageId])
+    );
+    if (String(currentToken || "").startsWith("-")) {
+      return buildOptionSuggestions(KNOWN_GENERATE_FLAG_OPTIONS, {
+        current: currentToken,
+        seenOptionNames: parseContextTokens(words.slice(2, cword), buildCommandOptionMeta("generate", catalogModule)).seenOptionNames
+      });
+    }
+    return filterByPrefix([...generatorIds, ...KNOWN_GENERATE_FLAG_OPTIONS.map((name) => `--${name}`)], currentToken);
+  }
+
+  const generatorToken = normalizeText(words[2]);
+  const generator = generatorLookup.get(generatorToken);
+  if (!generator) {
+    return [];
+  }
+
+  const generatorContext = resolveImplicitGeneratorSubcommand(generator, words.slice(3, cword), currentToken);
+  const metadata = generator?.descriptor?.metadata || {};
+  const subcommands = metadata.generatorSubcommands && typeof metadata.generatorSubcommands === "object"
+    ? metadata.generatorSubcommands
+    : {};
+
+  if (!generatorContext.subcommandName && cword <= 3) {
+    const subcommandNames = uniqueSorted([...Object.keys(subcommands), "help"]);
+    if (String(currentToken || "").startsWith("-")) {
+      return buildOptionSuggestions(KNOWN_GENERATE_FLAG_OPTIONS, {
+        current: currentToken,
+        seenOptionNames: parseContextTokens(words.slice(3, cword), buildCommandOptionMeta("generate", catalogModule)).seenOptionNames
+      });
+    }
+    return filterByPrefix([...subcommandNames, ...KNOWN_GENERATE_FLAG_OPTIONS.map((name) => `--${name}`)], currentToken);
+  }
+
+  if (!generatorContext.subcommandName) {
+    return filterByPrefix(uniqueSorted([...Object.keys(subcommands), "help"]), currentToken);
+  }
+
+  const subcommandName = generatorContext.subcommandName;
+  const subcommand = subcommands[subcommandName] || {};
+  const optionMeta = buildGeneratorOptionMeta(generator, subcommandName);
+  const optionNames = uniqueSorted(Object.keys(optionMeta));
+  const tokensBeforeCurrent = words.slice(3 + generatorContext.offset, cword);
+
+  return completeGenericContext({
+    appRoot,
+    currentToken,
+    previousToken,
+    optionMeta,
+    positionalArgs: Array.isArray(subcommand.positionalArgs) ? subcommand.positionalArgs : [],
+    tokensBeforeCurrent,
+    optionNames,
+    generatorName: generator.shortId,
+    subcommandName,
+    positionalCompleter: async ({ positionalIndex, currentToken: currentPositional }) => {
+      if (currentToken === "help" || previousToken === "help") {
+        return [];
+      }
+      if (generator.shortId === "crud-ui-generator" && subcommandName === "crud" && positionalIndex === 0) {
+        return completeRelativeDirectoryRoot(appRoot, currentPositional);
+      }
+      if (generator.shortId === "crud-ui-generator" && subcommandName === "field") {
+        if (positionalIndex === 1) {
+          return filterByPrefix(await discoverResourceFiles(appRoot), currentPositional);
+        }
+      }
+      if (generator.shortId === "crud-server-generator" && subcommandName === "scaffold-field" && positionalIndex === 1) {
+        return filterByPrefix(await discoverResourceFiles(appRoot), currentPositional);
+      }
+      if (generator.shortId === "ui-generator" && ["page", "add-subpages"].includes(subcommandName) && positionalIndex === 0) {
+        return completeRelativePageTargetFile(appRoot, currentPositional);
+      }
+      if (generator.shortId === "ui-generator" && subcommandName === "outlet" && positionalIndex === 0) {
+        return completeAppVueFile(appRoot, currentPositional);
+      }
+      return [];
+    }
+  });
+}
+
+async function completeCommand({ appRoot, words, cword, catalogModule }) {
+  const currentToken = words[cword] ?? "";
+  const commandToken = normalizeText(words[1]);
+  const command = catalogModule.resolveCommandAlias(commandToken);
+  const previousToken = words[cword - 1] ?? "";
+
+  if (!command || !catalogModule.isKnownCommandName(command)) {
+    return completeTopLevel({ appRoot, currentToken, catalogModule });
+  }
+
+  if (command === "generate") {
+    return completeGenerateCommand({ appRoot, words, cword, catalogModule });
+  }
+
+  const optionMeta = buildCommandOptionMeta(command, catalogModule);
+  const optionNames = uniqueSorted(Object.keys(optionMeta));
+  const tokensBeforeCurrent = words.slice(2, cword);
+
+  return completeGenericContext({
+    appRoot,
+    currentToken,
+    previousToken,
+    optionMeta,
+    tokensBeforeCurrent,
+    optionNames,
+    positionalCompleter: async ({ positionalIndex, currentToken: positionalCurrent, parseState }) => {
+      if (command === "help" && positionalIndex === 0) {
+        return filterByPrefix(buildTopLevelCommandMetadata(catalogModule), positionalCurrent);
+      }
+      if (command === "create" && positionalIndex === 0) {
+        return filterByPrefix(["package"], positionalCurrent);
+      }
+      if (command === "add") {
+        if (positionalIndex === 0) {
+          return filterByPrefix(ADD_TARGET_TYPES, positionalCurrent);
+        }
+        if (positionalIndex === 1) {
+          if (parseState.positionals[0] === "package") {
+            return filterByPrefix(await discoverRuntimePackages(appRoot), positionalCurrent);
+          }
+          if (parseState.positionals[0] === "bundle") {
+            return filterByPrefix(await discoverBundleIds(appRoot), positionalCurrent);
+          }
+        }
+      }
+      if (command === "list" && positionalIndex === 0) {
+        return filterByPrefix(LIST_MODES, positionalCurrent);
+      }
+      if (command === "show" && positionalIndex === 0) {
+        return filterByPrefix(
+          [...(await discoverRuntimePackages(appRoot)), ...(await discoverBundleIds(appRoot))],
+          positionalCurrent
+        );
+      }
+      if (command === "migrations") {
+        if (positionalIndex === 0) {
+          return filterByPrefix(MIGRATION_SCOPES, positionalCurrent);
+        }
+        if (positionalIndex === 1 && parseState.positionals[0] === "package") {
+          return filterByPrefix(await discoverRuntimePackages(appRoot), positionalCurrent);
+        }
+      }
+      if (command === "position") {
+        if (positionalIndex === 0) {
+          return filterByPrefix(POSITION_TARGET_TYPES, positionalCurrent);
+        }
+        if (positionalIndex === 1 && parseState.positionals[0] === "element") {
+          return filterByPrefix(await discoverRuntimePackages(appRoot), positionalCurrent);
+        }
+      }
+      if (command === "update") {
+        if (positionalIndex === 0) {
+          return filterByPrefix(UPDATE_TARGET_TYPES, positionalCurrent);
+        }
+        if (positionalIndex === 1 && parseState.positionals[0] === "package") {
+          return filterByPrefix(await discoverRuntimePackages(appRoot), positionalCurrent);
+        }
+      }
+      if (command === "remove") {
+        if (positionalIndex === 0) {
+          return filterByPrefix(REMOVE_TARGET_TYPES, positionalCurrent);
+        }
+        if (positionalIndex === 1 && parseState.positionals[0] === "package") {
+          return filterByPrefix(await discoverRuntimePackages(appRoot), positionalCurrent);
+        }
+      }
+      return [];
+    }
+  });
+}
+
+async function getCompletions({ appRoot = process.cwd(), words = [], cword = 0 } = {}) {
+  const normalized = normalizeCompletionInvocation(words, cword);
+  const currentToken = normalized.words[normalized.cword] ?? "";
+
+  if (normalized.wrapperOnly) {
+    return filterByPrefix(["jskit"], currentToken);
+  }
+
+  if (normalized.words[0] !== "jskit") {
+    return filterByPrefix(["jskit"], currentToken);
+  }
+
+  const catalogModule = await loadCommandCatalog(appRoot);
+  if (normalized.cword <= 1) {
+    return completeTopLevel({ appRoot, currentToken, catalogModule });
+  }
+
+  return completeCommand({
+    appRoot,
+    words: normalized.words,
+    cword: normalized.cword,
+    catalogModule
+  });
+}
+
+function renderBashCompletionScript() {
+  return `# shellcheck shell=bash
+
+_jskit_completion() {
+  local first_word="\${COMP_WORDS[0]}"
+  local second_word="\${COMP_WORDS[1]}"
+
+  if [[ "$first_word" == "npx" || "$first_word" == "jsx" ]]; then
+    if (( COMP_CWORD == 1 )); then
+      COMPREPLY=( $(compgen -W "jskit" -- "\${COMP_WORDS[COMP_CWORD]}") )
+      return 0
+    fi
+    if [[ "$second_word" != "jskit" && "$second_word" != "@jskit-ai/jskit-cli" ]]; then
+      return 1
+    fi
+  elif [[ "$first_word" != "jskit" ]]; then
+    return 1
+  fi
+
+  mapfile -t COMPREPLY < <(
+    npx jskit completion bash __complete__ "$COMP_CWORD" -- "\${COMP_WORDS[@]}"
+  ) || return 1
+
+  if ((\${#COMPREPLY[@]} == 0)); then
+    return 1
+  fi
+
+  return 0
+}
+complete -o bashdefault -o default -F _jskit_completion npx
+complete -o bashdefault -o default -F _jskit_completion jsx
+complete -o bashdefault -o default -F _jskit_completion jskit
+`;
+}
+
+export {
+  discoverPlacementTargets,
+  discoverResourceDisplayFields,
+  discoverResourceFiles,
+  discoverSurfaces,
+  getCompletions,
+  normalizeCompletionInvocation,
+  renderBashCompletionScript
+};

--- a/tooling/jskit-cli/src/server/cliRuntime/packageOptions.js
+++ b/tooling/jskit-cli/src/server/cliRuntime/packageOptions.js
@@ -17,6 +17,8 @@ import { loadMutationWhenConfigContext } from "./ioAndMigrations.js";
 const WORKSPACE_VISIBILITY_LEVELS = Object.freeze(["workspace", "workspace_user"]);
 const WORKSPACE_VISIBILITY_SET = new Set(WORKSPACE_VISIBILITY_LEVELS);
 const OPTION_VALIDATION_ENABLED_SURFACE_ID = "enabled-surface-id";
+const OPTION_VALIDATION_ENUM = "enum";
+const OPTION_VALIDATION_CSV_ENUM = "csv-enum";
 const OPTION_NORMALIZATION_PAGES_RELATIVE_TARGET_ROOT = "pages-relative-target-root";
 
 function normalizeSurfaceIdForMutation(value = "") {
@@ -153,6 +155,114 @@ function resolveSchemaValidatedOptionNames(packageEntry = {}, validationType = "
   ];
 }
 
+function resolveAllowedValuesForSchema(schema = {}) {
+  const values = [];
+  const seen = new Set();
+  for (const rawValue of Array.isArray(schema?.allowedValues) ? schema.allowedValues : []) {
+    const value = String(
+      typeof rawValue === "string"
+        ? rawValue
+        : ensureObject(rawValue).value
+    ).trim();
+    if (!value || seen.has(value.toLowerCase())) {
+      continue;
+    }
+    seen.add(value.toLowerCase());
+    values.push(value);
+  }
+  return Object.freeze(values);
+}
+
+function parseCsvEnumOptionValues(value = "") {
+  return String(value || "")
+    .split(",")
+    .map((entry) => String(entry || "").trim())
+    .filter(Boolean);
+}
+
+function validateEnumOptionValues({
+  packageEntry,
+  resolvedOptions = {},
+  optionNames = null
+} = {}) {
+  const validatedOptionNames = resolveSchemaValidatedOptionNames(
+    packageEntry,
+    OPTION_VALIDATION_ENUM,
+    { optionNames }
+  );
+  if (validatedOptionNames.length < 1) {
+    return;
+  }
+
+  const packageId = String(packageEntry?.packageId || "").trim() || "unknown-package";
+  const optionSchemas = ensureObject(packageEntry?.descriptor?.options);
+  for (const optionName of validatedOptionNames) {
+    const schema = ensureObject(optionSchemas[optionName]);
+    const value = String(resolvedOptions?.[optionName] || "").trim();
+    if (!value) {
+      continue;
+    }
+
+    const allowedValues = resolveAllowedValuesForSchema(schema);
+    if (allowedValues.length < 1) {
+      continue;
+    }
+    const allowedValueSet = new Set(allowedValues.map((entry) => entry.toLowerCase()));
+    if (!allowedValueSet.has(value.toLowerCase())) {
+      throw createCliError(
+        `Invalid option for package ${packageId}: --${optionName} must be one of: ${allowedValues.join(", ")}.`
+      );
+    }
+  }
+}
+
+function validateCsvEnumOptionValues({
+  packageEntry,
+  resolvedOptions = {},
+  optionNames = null
+} = {}) {
+  const validatedOptionNames = resolveSchemaValidatedOptionNames(
+    packageEntry,
+    OPTION_VALIDATION_CSV_ENUM,
+    { optionNames }
+  );
+  if (validatedOptionNames.length < 1) {
+    return;
+  }
+
+  const packageId = String(packageEntry?.packageId || "").trim() || "unknown-package";
+  const optionSchemas = ensureObject(packageEntry?.descriptor?.options);
+  for (const optionName of validatedOptionNames) {
+    const schema = ensureObject(optionSchemas[optionName]);
+    const value = String(resolvedOptions?.[optionName] || "").trim();
+    if (!value) {
+      continue;
+    }
+
+    const allowedValues = resolveAllowedValuesForSchema(schema);
+    if (allowedValues.length < 1) {
+      continue;
+    }
+    const allowedValueSet = new Set(allowedValues.map((entry) => entry.toLowerCase()));
+    const providedValues = parseCsvEnumOptionValues(value);
+    if (providedValues.length < 1) {
+      throw createCliError(
+        `Invalid option for package ${packageId}: --${optionName} must include at least one value from: ${allowedValues.join(", ")}.`
+      );
+    }
+    const invalidValues = [
+      ...new Set(
+        providedValues.filter((entry) => !allowedValueSet.has(entry.toLowerCase()))
+      )
+    ];
+    if (invalidValues.length > 0) {
+      throw createCliError(
+        `Invalid option for package ${packageId}: --${optionName} includes unsupported value(s): ${invalidValues.join(", ")}. Allowed values: ${allowedValues.join(", ")}.`
+      );
+    }
+  }
+}
+
 function validateEnabledSurfaceOptionValues({
   packageEntry,
   resolvedOptions = {},
@@ -254,6 +364,12 @@ async function validateResolvedOptionPolicies({
 
 function resolvePromptChoicesForOption({ schema = {}, configContext = {} } = {}) {
   const validationType = normalizeResolvedOptionValue(schema.validationType);
+  if (validationType === OPTION_VALIDATION_ENUM) {
+    return resolveAllowedValuesForSchema(schema).map((value) => Object.freeze({
+      value,
+      label: value
+    }));
+  }
   if (validationType !== OPTION_VALIDATION_ENABLED_SURFACE_ID) {
     return [];
   }
@@ -275,9 +391,16 @@ async function validateOptionValuesForPackage({
   appRoot = "",
   optionNames = null
 } = {}) {
-  if (!appRoot) {
-    return;
-  }
+  validateEnumOptionValues({
+    packageEntry,
+    resolvedOptions,
+    optionNames
+  });
+  validateCsvEnumOptionValues({
+    packageEntry,
+    resolvedOptions,
+    optionNames
+  });
 
   const validatedOptionNames = resolveSchemaValidatedOptionNames(
     packageEntry,
@@ -285,6 +408,9 @@ async function validateOptionValuesForPackage({
     { optionNames }
   );
   if (validatedOptionNames.length < 1) {
+    return;
+  }
+  if (!appRoot) {
     return;
   }
 

--- a/tooling/jskit-cli/src/server/commandHandlers/completion.js
+++ b/tooling/jskit-cli/src/server/commandHandlers/completion.js
@@ -1,0 +1,129 @@
+import os from "node:os";
+import path from "node:path";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import {
+  getCompletions,
+  renderBashCompletionScript
+} from "../cliRuntime/completion.js";
+
+const INSTALL_MARKER_BEGIN = "# >>> jskit completion >>>";
+const INSTALL_MARKER_END = "# <<< jskit completion <<<";
+
+function resolveInstallBlock(relativeCompletionPath = "") {
+  return [
+    INSTALL_MARKER_BEGIN,
+    `if [ -f "$HOME/${relativeCompletionPath}" ]; then`,
+    `  source "$HOME/${relativeCompletionPath}"`,
+    "fi",
+    INSTALL_MARKER_END
+  ].join("\n");
+}
+
+async function readTextFileIfExists(filePath = "") {
+  try {
+    return await readFile(filePath, "utf8");
+  } catch (error) {
+    if (String(error?.code || "").trim().toUpperCase() === "ENOENT") {
+      return "";
+    }
+    throw error;
+  }
+}
+
+async function installBashCompletion() {
+  const homeDirectory = os.homedir();
+  const completionRelativePath = ".jskit/completion/bash/jskit.bash";
+  const completionAbsolutePath = path.join(homeDirectory, completionRelativePath);
+  const bashrcAbsolutePath = path.join(homeDirectory, ".bashrc");
+  const installBlock = resolveInstallBlock(completionRelativePath);
+
+  await mkdir(path.dirname(completionAbsolutePath), { recursive: true });
+  await writeFile(completionAbsolutePath, renderBashCompletionScript(), "utf8");
+
+  const existingBashrc = await readTextFileIfExists(bashrcAbsolutePath);
+  const markerPattern = new RegExp(
+    `${INSTALL_MARKER_BEGIN.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}[\\s\\S]*?${INSTALL_MARKER_END.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`,
+    "u"
+  );
+  const normalizedExisting = String(existingBashrc || "");
+  const nextBashrc = markerPattern.test(normalizedExisting)
+    ? normalizedExisting.replace(markerPattern, installBlock)
+    : `${normalizedExisting.replace(/\s*$/u, "")}${normalizedExisting.trim() ? "\n\n" : ""}${installBlock}\n`;
+
+  if (nextBashrc !== normalizedExisting) {
+    await writeFile(bashrcAbsolutePath, nextBashrc, "utf8");
+  }
+
+  return {
+    completionAbsolutePath,
+    bashrcAbsolutePath
+  };
+}
+
+function createCompletionCommands(ctx = {}) {
+  const {
+    createCliError,
+    resolveAppRootFromCwd
+  } = ctx;
+
+  async function commandCompletion({ positional = [], options = {}, cwd = "", stdout }) {
+    const shell = String(positional[0] || "").trim().toLowerCase();
+    if (shell !== "bash") {
+      throw createCliError(`Unsupported completion shell: ${shell || "<empty>"}.`, { showUsage: true });
+    }
+
+    const installRequested = String(options?.inlineOptions?.install || "").trim().toLowerCase() === "true";
+    const mode = String(positional[1] || "").trim();
+    if (installRequested && mode) {
+      throw createCliError("jskit completion bash --install does not accept internal completion mode arguments.", {
+        showUsage: true
+      });
+    }
+
+    if (installRequested) {
+      const {
+        completionAbsolutePath,
+        bashrcAbsolutePath
+      } = await installBashCompletion();
+      stdout.write(`Installed Bash completion to ${completionAbsolutePath}.\n`);
+      stdout.write(`Updated ${bashrcAbsolutePath}.\n`);
+      stdout.write("Run: source ~/.bashrc\n");
+      return 0;
+    }
+
+    if (!mode) {
+      stdout.write(renderBashCompletionScript());
+      return 0;
+    }
+
+    if (mode !== "__complete__") {
+      throw createCliError(`Unknown completion mode: ${mode}.`, { showUsage: true });
+    }
+
+    const rawCword = Number.parseInt(String(positional[2] || "0"), 10);
+    const words = positional.slice(3).map((value) => String(value ?? ""));
+
+    let appRoot = String(cwd || process.cwd());
+    try {
+      appRoot = await resolveAppRootFromCwd(appRoot);
+    } catch {
+      // Fall back to cwd so top-level completion still works outside an app root.
+    }
+
+    const completions = await getCompletions({
+      appRoot,
+      words,
+      cword: Number.isInteger(rawCword) ? rawCword : 0
+    });
+    if (completions.length > 0) {
+      stdout.write(`${completions.join("\n")}\n`);
+    }
+    return 0;
+  }
+
+  return {
+    commandCompletion
+  };
+}
+
+export { createCompletionCommands };

--- a/tooling/jskit-cli/src/server/commandHandlers/packageCommands/discoverabilityHelp.js
+++ b/tooling/jskit-cli/src/server/commandHandlers/packageCommands/discoverabilityHelp.js
@@ -54,10 +54,15 @@ function buildPackageOptionRows(packageEntry = {}) {
 
   for (const optionName of sortStrings(Object.keys(optionSchemas))) {
     const schema = ensureObject(optionSchemas[optionName]);
+    const allowedValues = ensureArray(schema.allowedValues)
+      .map((value) => String(typeof value === "string" ? value : ensureObject(value).value || "").trim())
+      .filter(Boolean);
     rows.push(Object.freeze({
       name: optionName,
       required: schema.required === true,
       inputType: String(schema.inputType || "text").trim() || "text",
+      validationType: String(schema.validationType || "").trim(),
+      allowedValues,
       defaultValue: String(schema.defaultValue || "").trim(),
       allowEmpty: schema.allowEmpty === true,
       promptLabel: String(schema.promptLabel || "").trim(),
@@ -326,9 +331,12 @@ function formatOptionSummary(optionRow = {}, { color = null } = {}) {
     ? `; default: ${optionRow.defaultValue}`
     : optionalDefaultSuffix;
   const allowEmptySuffix = optionRow.allowEmpty ? "; allow-empty" : "";
+  const allowedValuesHint = Array.isArray(optionRow.allowedValues) && optionRow.allowedValues.length > 0
+    ? `Allowed values: ${optionRow.allowedValues.join(", ")}.`
+    : "";
   const labelParts = [
     String(optionRow.helpLabel || "").trim() || String(optionRow.promptLabel || "").trim(),
-    String(optionRow.helpHint || "").trim() || String(optionRow.promptHint || "").trim()
+    String(optionRow.helpHint || "").trim() || String(optionRow.promptHint || "").trim() || allowedValuesHint
   ].filter(Boolean);
   const label = labelParts.join(". ");
   const normalizedInputType = String(optionRow.inputType || "").trim().toLowerCase();

--- a/tooling/jskit-cli/src/server/core/argParser.js
+++ b/tooling/jskit-cli/src/server/core/argParser.js
@@ -56,6 +56,11 @@ function parseArgs(argv, { createCliError } = {}) {
   while (args.length > 0) {
     const token = String(args.shift() || "");
 
+    if (token === "--") {
+      positional.push(...args.map((value) => String(value || "")));
+      break;
+    }
+
     if (token === "--dry-run") {
       options.dryRun = true;
       continue;
@@ -102,6 +107,10 @@ function parseArgs(argv, { createCliError } = {}) {
     }
     if (token === "--force") {
       options.inlineOptions.force = "true";
+      continue;
+    }
+    if (token === "--install") {
+      options.inlineOptions.install = "true";
       continue;
     }
 

--- a/tooling/jskit-cli/src/server/core/commandCatalog.js
+++ b/tooling/jskit-cli/src/server/core/commandCatalog.js
@@ -76,6 +76,31 @@ const COMMAND_DESCRIPTORS = Object.freeze({
     inlineOptionMode: "none",
     allowedValueOptionNames: Object.freeze([])
   }),
+  completion: Object.freeze({
+    command: "completion",
+    aliases: Object.freeze([]),
+    showInOverview: true,
+    summary: "Print shell completion script support.",
+    minimalUse: "jskit completion bash",
+    parameters: Object.freeze([
+      Object.freeze({
+        name: "<shell>",
+        description: "Shell name. Currently only bash is supported."
+      })
+    ]),
+    defaults: Object.freeze([
+      "Prints a shell completion script to stdout.",
+      "Use --install to write a small Bash loader file and wire ~/.bashrc automatically.",
+      "Use source <(npx jskit completion bash) to enable completion in the current shell.",
+      "The internal __complete__ mode is reserved for the generated shell function."
+    ]),
+    fullUse: "jskit completion bash [--install]",
+    showHelpOnBareInvocation: true,
+    handlerName: "commandCompletion",
+    allowedFlagKeys: Object.freeze([]),
+    inlineOptionMode: "enumerated",
+    allowedValueOptionNames: Object.freeze(["install"])
+  }),
   create: Object.freeze({
     command: "create",
     aliases: Object.freeze([]),

--- a/tooling/jskit-cli/src/server/core/createCommandHandlers.js
+++ b/tooling/jskit-cli/src/server/core/createCommandHandlers.js
@@ -3,6 +3,7 @@ import { createListCommands } from "../commandHandlers/list.js";
 import { createShowCommand } from "../commandHandlers/show.js";
 import { createPackageCommands } from "../commandHandlers/package.js";
 import { createHealthCommands } from "../commandHandlers/health.js";
+import { createCompletionCommands } from "../commandHandlers/completion.js";
 
 function createCommandHandlers(deps = {}) {
   const shared = createCommandHandlerShared(deps);
@@ -23,11 +24,13 @@ function createCommandHandlers(deps = {}) {
     commandRemove
   } = createPackageCommands(commandContext);
   const { commandDoctor, commandLintDescriptors } = createHealthCommands(commandContext);
+  const { commandCompletion } = createCompletionCommands(commandContext);
 
   return {
     commandList,
     commandListPlacements,
     commandListLinkItems,
+    commandCompletion,
     commandShow,
     commandCreate,
     commandAdd,

--- a/tooling/jskit-cli/test/completionCommand.test.js
+++ b/tooling/jskit-cli/test/completionCommand.test.js
@@ -1,0 +1,232 @@
+import assert from "node:assert/strict";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import test from "node:test";
+import { withTempDir } from "../../testUtils/tempDir.mjs";
+import { createCliRunner } from "../../testUtils/runCli.js";
+
+const CLI_PATH = fileURLToPath(new URL("../bin/jskit.js", import.meta.url));
+const runCli = createCliRunner(CLI_PATH);
+
+async function createMinimalApp(appRoot, { name = "tmp-app" } = {}) {
+  await mkdir(path.join(appRoot, "src", "pages"), { recursive: true });
+  await writeFile(
+    path.join(appRoot, "package.json"),
+    `${JSON.stringify(
+      {
+        name,
+        version: "0.1.0",
+        private: true,
+        type: "module"
+      },
+      null,
+      2
+    )}\n`,
+    "utf8"
+  );
+}
+
+async function writeGeneratorPackage(appRoot, packageName, descriptorSource) {
+  const packageRoot = path.join(appRoot, "packages", packageName);
+  await mkdir(packageRoot, { recursive: true });
+  await writeFile(
+    path.join(packageRoot, "package.json"),
+    `${JSON.stringify(
+      {
+        name: `@jskit-ai/${packageName}`,
+        version: "0.1.0",
+        type: "module"
+      },
+      null,
+      2
+    )}\n`,
+    "utf8"
+  );
+  await writeFile(path.join(packageRoot, "package.descriptor.mjs"), descriptorSource, "utf8");
+}
+
+test("completion bash prints an installable bash completion script", () => {
+  const result = runCli({ args: ["completion", "bash"] });
+
+  assert.equal(result.status, 0, String(result.stderr || ""));
+  const stdout = String(result.stdout || "");
+  assert.match(stdout, /_jskit_completion\(\)/);
+  assert.match(stdout, /compgen -W "jskit"/);
+  assert.match(stdout, /npx jskit completion bash __complete__/);
+  assert.match(stdout, /complete -o bashdefault -o default -F _jskit_completion npx/);
+  assert.match(stdout, /complete -o bashdefault -o default -F _jskit_completion jskit/);
+});
+
+test("completion bash --install writes a short loader file and updates bashrc", async () => {
+  await withTempDir(async (cwd) => {
+    const homeRoot = path.join(cwd, "home");
+    await mkdir(homeRoot, { recursive: true });
+
+    const result = runCli({
+      cwd,
+      args: ["completion", "bash", "--install"],
+      env: {
+        HOME: homeRoot
+      }
+    });
+
+    assert.equal(result.status, 0, String(result.stderr || ""));
+    const completionFile = path.join(homeRoot, ".jskit", "completion", "bash", "jskit.bash");
+    const bashrcFile = path.join(homeRoot, ".bashrc");
+    const completionScript = await readFile(completionFile, "utf8");
+    const bashrc = await readFile(bashrcFile, "utf8");
+
+    assert.match(completionScript, /_jskit_completion\(\)/);
+    assert.match(completionScript, /npx jskit completion bash __complete__/);
+    assert.match(bashrc, /# >>> jskit completion >>>/);
+    assert.match(bashrc, /\.jskit\/completion\/bash\/jskit\.bash/);
+    assert.match(String(result.stdout || ""), /Run: source ~\/\.bashrc/);
+  });
+});
+
+test("completion bash __complete__ resolves descriptor-backed values from the current app", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "completion-app");
+    await createMinimalApp(appRoot, { name: "completion-app" });
+
+    await writeGeneratorPackage(
+      appRoot,
+      "crud-ui-generator",
+      `export default Object.freeze({
+  packageVersion: 1,
+  packageId: "@jskit-ai/crud-ui-generator",
+  version: "0.1.0",
+  kind: "generator",
+  options: {
+    "resource-file": { inputType: "text" },
+    operations: {
+      inputType: "text",
+      validationType: "csv-enum",
+      allowedValues: ["list", "view", "new", "edit"]
+    }
+  },
+  dependsOn: [],
+  capabilities: { provides: [], requires: [] },
+  runtime: { server: { providers: [] }, client: { providers: [] } },
+  metadata: {
+    generatorPrimarySubcommand: "crud",
+    generatorSubcommands: {
+      crud: {
+        optionNames: ["resource-file", "operations"],
+        requiredOptionNames: ["resource-file"]
+      }
+    }
+  },
+  mutations: { dependencies: { runtime: {}, dev: {} }, packageJson: { scripts: {} }, procfile: {}, files: [], text: [] }
+});\n`
+    );
+
+    await writeGeneratorPackage(
+      appRoot,
+      "crud-server-generator",
+      `export default Object.freeze({
+  packageVersion: 1,
+  packageId: "@jskit-ai/crud-server-generator",
+  version: "0.1.0",
+  kind: "generator",
+  options: {
+    "ownership-filter": {
+      inputType: "text",
+      validationType: "enum",
+      allowedValues: ["auto", "public", "user", "workspace", "workspace_user"]
+    }
+  },
+  dependsOn: [],
+  capabilities: { provides: [], requires: [] },
+  runtime: { server: { providers: [] }, client: { providers: [] } },
+  metadata: {
+    generatorPrimarySubcommand: "scaffold",
+    generatorSubcommands: {
+      scaffold: {
+        optionNames: ["ownership-filter"]
+      }
+    }
+  },
+  mutations: { dependencies: { runtime: {}, dev: {} }, packageJson: { scripts: {} }, procfile: {}, files: [], text: [] }
+});\n`
+    );
+
+    const resourceDir = path.join(appRoot, "packages", "widgets", "src", "shared");
+    await mkdir(resourceDir, { recursive: true });
+    await writeFile(
+      path.join(resourceDir, "widgetResource.js"),
+      "export const resource = {};\n",
+      "utf8"
+    );
+
+    const operationsResult = runCli({
+      cwd: appRoot,
+      args: [
+        "completion",
+        "bash",
+        "__complete__",
+        "6",
+        "--",
+        "npx",
+        "jskit",
+        "generate",
+        "crud-ui-generator",
+        "crud",
+        "--operations",
+        ""
+      ]
+    });
+    assert.equal(operationsResult.status, 0, String(operationsResult.stderr || ""));
+    assert.deepEqual(
+      String(operationsResult.stdout || "").trim().split(/\r?\n/u).filter(Boolean),
+      ["edit", "list", "new", "view"]
+    );
+
+    const resourceFileResult = runCli({
+      cwd: appRoot,
+      args: [
+        "completion",
+        "bash",
+        "__complete__",
+        "6",
+        "--",
+        "npx",
+        "jskit",
+        "generate",
+        "crud-ui-generator",
+        "crud",
+        "--resource-file",
+        ""
+      ]
+    });
+    assert.equal(resourceFileResult.status, 0, String(resourceFileResult.stderr || ""));
+    assert.deepEqual(
+      String(resourceFileResult.stdout || "").trim().split(/\r?\n/u).filter(Boolean),
+      ["packages/widgets/src/shared/widgetResource.js"]
+    );
+
+    const ownershipResult = runCli({
+      cwd: appRoot,
+      args: [
+        "completion",
+        "bash",
+        "__complete__",
+        "6",
+        "--",
+        "npx",
+        "jskit",
+        "generate",
+        "crud-server-generator",
+        "scaffold",
+        "--ownership-filter",
+        ""
+      ]
+    });
+    assert.equal(ownershipResult.status, 0, String(ownershipResult.stderr || ""));
+    assert.deepEqual(
+      String(ownershipResult.stdout || "").trim().split(/\r?\n/u).filter(Boolean),
+      ["auto", "public", "user", "workspace", "workspace_user"]
+    );
+  });
+});

--- a/tooling/jskit-cli/test/helpUsage.test.js
+++ b/tooling/jskit-cli/test/helpUsage.test.js
@@ -31,9 +31,21 @@ test("jskit with no args prints top-level command overview", () => {
   assertMaxLineLength(stdout);
   assert.match(stdout, /JSKit CLI/);
   assert.match(stdout, /Available commands:/);
+  assert.match(stdout, /completion\s+Print shell completion script support/);
   assert.match(stdout, /generate\s+Run a generator package/);
   assert.match(stdout, /list-placements\s+List discovered UI placement targets/);
   assert.match(stdout, /list-component-tokens\s+List available placement component tokens/);
+});
+
+test("jskit help completion prints completion command help", () => {
+  const result = runCli({ args: ["help", "completion"] });
+  assert.equal(result.status, 0, String(result.stderr || ""));
+  const stdout = String(result.stdout || "");
+  assertMaxLineLength(stdout);
+  assert.match(stdout, /Command: completion/);
+  assert.match(stdout, /jskit completion bash \[--install\]/);
+  assert.match(stdout, /--install/);
+  assert.match(stdout, /source <\(npx jskit completion bash\)/);
 });
 
 test("jskit generate with no params lists available generators", () => {

--- a/tooling/jskit-cli/test/packageOptionEnumValidation.test.js
+++ b/tooling/jskit-cli/test/packageOptionEnumValidation.test.js
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { PassThrough, Writable } from "node:stream";
+import {
+  resolvePackageOptions,
+  validateInlineOptionValuesForPackage
+} from "../src/server/cliRuntime/packageOptions.js";
+
+class CaptureOutput extends Writable {
+  constructor() {
+    super();
+    this.isTTY = true;
+    this.chunks = [];
+  }
+
+  _write(chunk, encoding, callback) {
+    this.chunks.push(Buffer.from(chunk).toString("utf8"));
+    callback();
+  }
+
+  toString() {
+    return this.chunks.join("");
+  }
+}
+
+test("validateInlineOptionValuesForPackage accepts enum and csv-enum values from descriptor metadata", async () => {
+  const packageEntry = {
+    packageId: "@demo/enum-generator",
+    descriptor: {
+      options: {
+        "ownership-filter": {
+          validationType: "enum",
+          allowedValues: ["auto", "public", "user"]
+        },
+        operations: {
+          validationType: "csv-enum",
+          allowedValues: ["list", "view", "edit"]
+        }
+      }
+    }
+  };
+
+  await validateInlineOptionValuesForPackage(packageEntry, {
+    "ownership-filter": "USER",
+    operations: "list,EDIT"
+  });
+});
+
+test("validateInlineOptionValuesForPackage rejects unsupported enum and csv-enum values", async () => {
+  const packageEntry = {
+    packageId: "@demo/enum-generator",
+    descriptor: {
+      options: {
+        "ownership-filter": {
+          validationType: "enum",
+          allowedValues: ["auto", "public", "user"]
+        },
+        operations: {
+          validationType: "csv-enum",
+          allowedValues: ["list", "view", "edit"]
+        }
+      }
+    }
+  };
+
+  await assert.rejects(
+    () => validateInlineOptionValuesForPackage(packageEntry, { "ownership-filter": "workspace" }),
+    /--ownership-filter must be one of: auto, public, user\./
+  );
+  await assert.rejects(
+    () => validateInlineOptionValuesForPackage(packageEntry, { operations: "list,delete" }),
+    /--operations includes unsupported value\(s\): delete\. Allowed values: list, view, edit\./
+  );
+});
+
+test("resolvePackageOptions offers descriptor-backed choices for required enum options", async () => {
+  const stdin = new PassThrough();
+  stdin.isTTY = true;
+  const stdout = new CaptureOutput();
+  stdin.end("2\n");
+
+  const packageEntry = {
+    packageId: "@demo/enum-generator",
+    descriptor: {
+      options: {
+        "ownership-filter": {
+          required: true,
+          inputType: "text",
+          validationType: "enum",
+          allowedValues: ["auto", "public", "user"],
+          promptLabel: "Ownership filter"
+        }
+      }
+    }
+  };
+
+  const resolved = await resolvePackageOptions(packageEntry, {}, { stdin, stdout }, {});
+
+  assert.equal(resolved["ownership-filter"], "public");
+  const output = stdout.toString();
+  assert.match(output, /Ownership filter/);
+  assert.match(output, /1\) auto/);
+  assert.match(output, /2\) public/);
+  assert.match(output, /3\) user/);
+});


### PR DESCRIPTION
## Summary
- add a `completion` command with Bash completion support for commands, generators, options, and descriptor-backed values
- support `enum` and `csv-enum` option validation and help rendering from package descriptor metadata
- move generator ownership/operations allowed values to descriptor metadata and consume them from runtime/tests

## Verification
- npm run verify