### PR TITLE
Accept src/pages-prefixed generator targets

### DIFF
--- a/packages/assistant/test/subcommands.test.js
+++ b/packages/assistant/test/subcommands.test.js
@@ -301,19 +301,20 @@ test("assistant settings-page subcommand requires the target assistant surface o
   });
 });
 
-test("assistant page subcommand rejects target files with a src/pages prefix", async () => {
+test("assistant page subcommand accepts target files with a src/pages prefix", async () => {
   await withTempApp(async (appRoot) => {
     await writeAppFixture(appRoot);
 
-    await assert.rejects(
-      () =>
-        runPageSubcommand({
-          appRoot,
-          subcommand: "page",
-          args: ["src/pages/w/[workspaceSlug]/admin/assistant/index.vue"],
-          options: {}
-        }),
-      /must be relative to src\/pages\/, without the src\/pages\/ prefix/
-    );
+    const targetFile = "src/pages/w/[workspaceSlug]/admin/assistant/index.vue";
+    const result = await runPageSubcommand({
+      appRoot,
+      subcommand: "page",
+      args: [targetFile],
+      options: {}
+    });
+
+    assert.deepEqual(result.touchedFiles, [targetFile, "src/placement.js"]);
+    const pageSource = await readFile(path.join(appRoot, targetFile), "utf8");
+    assert.match(pageSource, /<AssistantSurfaceClientElement surface-id="admin" \/>/);
   });
 });

--- a/packages/crud-ui-generator/test/buildTemplateContext.test.js
+++ b/packages/crud-ui-generator/test/buildTemplateContext.test.js
@@ -471,20 +471,19 @@ test("buildUiTemplateContext honors explicit link-placement override", async () 
   });
 });
 
-test("buildUiTemplateContext rejects target-roots with a src/pages prefix", async () => {
+test("buildUiTemplateContext accepts target-roots with a src/pages prefix", async () => {
   await withTempApp(async (appRoot) => {
     await writeResource(appRoot, RESOURCE_FILE, FULL_RESOURCE_SOURCE);
 
-    await assert.rejects(
-      () =>
-        buildUiTemplateContext({
-          appRoot,
-          options: createOptions({
-            "target-root": "src/pages/admin/customers"
-          })
-        }),
-      /must be relative to src\/pages\/, without the src\/pages\/ prefix/
-    );
+    const context = await buildUiTemplateContext({
+      appRoot,
+      options: createOptions({
+        "target-root": "src/pages/admin/customers"
+      })
+    });
+
+    assert.equal(context.__JSKIT_UI_SURFACE_ID__, "admin");
+    assert.equal(context.__JSKIT_UI_MENU_PLACEMENT_ID__, "ui-generator.page.admin.customers.link");
   });
 });
 

--- a/packages/kernel/server/support/pageTargets.js
+++ b/packages/kernel/server/support/pageTargets.js
@@ -65,17 +65,17 @@ function resolvePagesRelativeAppPath(
   if (isAbsolutePathInput(normalizedValue)) {
     throw new Error(`${context} ${label} must be relative to src/pages/: ${normalizedValue}.`);
   }
-  if (
-    normalizedValue === "src/pages" ||
-    normalizedValue.startsWith(PAGE_ROOT_PREFIX)
-  ) {
+  if (normalizedValue === "src/pages" || normalizedValue === PAGE_ROOT_PREFIX) {
     throw new Error(
-      `${context} ${label} must be relative to src/pages/, without the src/pages/ prefix: ${normalizedValue}.`
+      `${context} ${label} must include a path under src/pages/: ${normalizedValue}.`
     );
+  }
+  if (normalizedValue.startsWith(PAGE_ROOT_PREFIX)) {
+    return normalizedValue;
   }
   if (normalizedValue.startsWith("src/")) {
     throw new Error(
-      `${context} ${label} must be relative to src/pages/, without a leading src/ segment: ${normalizedValue}.`
+      `${context} ${label} must be relative to src/pages/ or start with src/pages/: ${normalizedValue}.`
     );
   }
 

--- a/packages/kernel/server/support/pageTargets.test.js
+++ b/packages/kernel/server/support/pageTargets.test.js
@@ -192,7 +192,7 @@ test("resolvePageTargetDetails rejects duplicate matching surface pagesRoot defi
   });
 });
 
-test("resolvePageTargetDetails rejects target files with a src/pages prefix", async () => {
+test("resolvePageTargetDetails accepts target files with a src/pages prefix", async () => {
   await withTempApp(async (appRoot) => {
     await writeConfig(
       appRoot,
@@ -204,26 +204,25 @@ test("resolvePageTargetDetails rejects target files with a src/pages prefix", as
 `
     );
 
-    await assert.rejects(
-      () =>
-        resolvePageTargetDetails({
-          appRoot,
-          targetFile: "src/pages/admin/reports/index.vue",
-          context: "page target"
-        }),
-      /must be relative to src\/pages\/, without the src\/pages\/ prefix/
-    );
+    const details = await resolvePageTargetDetails({
+      appRoot,
+      targetFile: "src/pages/admin/reports/index.vue",
+      context: "page target"
+    });
+
+    assert.equal(details.targetFilePath.relativePath, "src/pages/admin/reports/index.vue");
+    assert.equal(details.surfaceId, "admin");
+    assert.equal(details.routeUrlSuffix, "/reports");
   });
 });
 
-test("normalizePagesRelativeTargetRoot rejects route roots with a src/pages prefix", () => {
-  assert.throws(
-    () =>
-      normalizePagesRelativeTargetRoot("src/pages/admin/customers", {
-        context: "crud-ui-generator",
-        label: 'option "target-root"'
-      }),
-    /must be relative to src\/pages\/, without the src\/pages\/ prefix/
+test("normalizePagesRelativeTargetRoot accepts route roots with a src/pages prefix", () => {
+  assert.equal(
+    normalizePagesRelativeTargetRoot("src/pages/admin/customers", {
+      context: "crud-ui-generator",
+      label: 'option "target-root"'
+    }),
+    "src/pages/admin/customers"
   );
 });
 

--- a/packages/ui-generator/test/buildTemplateContext.test.js
+++ b/packages/ui-generator/test/buildTemplateContext.test.js
@@ -498,8 +498,32 @@ test("buildUiPageTemplateContext rejects target files with a leading src segment
           targetFile: "src/components/ReportsPanel.vue",
           options: {}
         }),
-      /must be relative to src\/pages\/, without a leading src\/ segment/
+      /must be relative to src\/pages\/ or start with src\/pages\/:/
     );
+  });
+});
+
+test("buildUiPageTemplateContext accepts target files with a src/pages prefix", async () => {
+  await withTempApp(async (appRoot) => {
+    await writeConfig(
+      appRoot,
+      `export const config = {
+  surfaceDefinitions: {
+    admin: { id: "admin", pagesRoot: "admin", enabled: true }
+  }
+};
+`
+    );
+    await writeShellLayout(appRoot);
+
+    const context = await buildUiPageTemplateContext({
+      appRoot,
+      targetFile: "src/pages/admin/reports/index.vue",
+      options: {}
+    });
+
+    assert.equal(context.__JSKIT_UI_LINK_PLACEMENT_ID__, "ui-generator.page.admin.reports.link");
+    assert.equal(context.__JSKIT_UI_LINK_WORKSPACE_SUFFIX__, "/reports");
   });
 });
 

--- a/packages/ui-generator/test/pageSubcommand.test.js
+++ b/packages/ui-generator/test/pageSubcommand.test.js
@@ -297,7 +297,28 @@ test("ui-generator page subcommand rejects unsupported options", async () => {
   });
 });
 
-test("ui-generator page subcommand rejects target files with a src/pages prefix", async () => {
+test("ui-generator page subcommand accepts target files with a src/pages prefix", async () => {
+  await withTempApp(async (appRoot) => {
+    await writeAppFixture(appRoot);
+
+    const targetFile = "src/pages/w/[workspaceSlug]/admin/practice/index.vue";
+    const result = await runGeneratorSubcommand({
+      appRoot,
+      subcommand: "page",
+      args: [targetFile],
+      options: {}
+    });
+
+    assert.deepEqual(result.touchedFiles, [targetFile, "src/placement.js"]);
+    const pageSource = await readFile(path.join(appRoot, targetFile), "utf8");
+    assert.match(pageSource, /Practice/);
+    const placementSource = await readFile(path.join(appRoot, "src", "placement.js"), "utf8");
+    assert.match(placementSource, /id: "ui-generator\.page\.admin\.practice\.link"/);
+    assert.match(placementSource, /workspaceSuffix: "\/practice"/);
+  });
+});
+
+test("ui-generator page subcommand still rejects non-page src targets", async () => {
   await withTempApp(async (appRoot) => {
     await writeAppFixture(appRoot);
 
@@ -305,10 +326,10 @@ test("ui-generator page subcommand rejects target files with a src/pages prefix"
       runGeneratorSubcommand({
         appRoot,
         subcommand: "page",
-        args: ["src/pages/w/[workspaceSlug]/admin/practice/index.vue"],
+        args: ["src/components/PracticePanel.vue"],
         options: {}
       }),
-      /must be relative to src\/pages\/, without the src\/pages\/ prefix/
+      /must be relative to src\/pages\/ or start with src\/pages\/:/
     );
   });
 });

--- a/tooling/jskit-cli/test/uiGeneratorPackage.test.js
+++ b/tooling/jskit-cli/test/uiGeneratorPackage.test.js
@@ -654,7 +654,7 @@ test("generate @jskit-ai/crud-ui-generator overwrites existing generated files w
   });
 });
 
-test("generate @jskit-ai/crud-ui-generator rejects route roots with a src/pages prefix", async () => {
+test("generate @jskit-ai/crud-ui-generator accepts route roots with a src/pages prefix", async () => {
   await withTempDir(async (cwd) => {
     const appRoot = path.join(cwd, "crud-ui-invalid-target-root");
     await createMinimalApp(appRoot, { name: "crud-ui-invalid-target-root" });
@@ -675,8 +675,9 @@ test("generate @jskit-ai/crud-ui-generator rejects route roots with a src/pages 
       ]
     });
 
-    assert.equal(result.status, 1);
-    assert.match(String(result.stderr || ""), /must be relative to src\/pages\/, without the src\/pages\/ prefix/);
+    assert.equal(result.status, 0, String(result.stderr || ""));
+    const listPageSource = await readFile(path.join(appRoot, "src/pages/admin/products/index.vue"), "utf8");
+    assert.match(listPageSource, /Manage Customers\./);
   });
 });
 


### PR DESCRIPTION
## Summary
- allow page and target-root inputs that already start with `src/pages/`
- keep rejecting non-page `src/...` paths so the constraint stays explicit
- update assistant, ui-generator, crud-ui-generator, kernel, and CLI generator tests to reflect the accepted input form

## Verification
- npm run verify