### PR TITLE
Support exact matching for home menu links

### DIFF
--- a/packages/shell-web/src/client/components/ShellMenuLinkItem.vue
+++ b/packages/shell-web/src/client/components/ShellMenuLinkItem.vue
@@ -22,6 +22,10 @@ const props = defineProps({
   disabled: {
     type: Boolean,
     default: false
+  },
+  exact: {
+    type: Boolean,
+    default: false
   }
 });
 
@@ -62,5 +66,6 @@ const resolvedIcon = computed(() =>
     :href="resolvedTarget.sameOrigin ? undefined : resolvedTarget.href"
     :prepend-icon="resolvedIcon || undefined"
     :disabled="props.disabled"
+    :exact="props.exact"
   />
 </template>

--- a/packages/shell-web/src/client/components/ShellSurfaceAwareMenuLinkItem.vue
+++ b/packages/shell-web/src/client/components/ShellSurfaceAwareMenuLinkItem.vue
@@ -38,6 +38,10 @@ const props = defineProps({
   disabled: {
     type: Boolean,
     default: false
+  },
+  exact: {
+    type: Boolean,
+    default: false
   }
 });
 
@@ -107,5 +111,6 @@ const resolvedIcon = computed(() =>
     :href="resolvedTarget.sameOrigin ? undefined : resolvedTarget.href"
     :prepend-icon="resolvedIcon || undefined"
     :disabled="props.disabled"
+    :exact="props.exact"
   />
 </template>

--- a/packages/shell-web/templates/src/components/menus/MenuLinkItem.vue
+++ b/packages/shell-web/templates/src/components/menus/MenuLinkItem.vue
@@ -17,6 +17,10 @@ const props = defineProps({
   disabled: {
     type: Boolean,
     default: false
+  },
+  exact: {
+    type: Boolean,
+    default: false
   }
 });
 </script>

--- a/packages/shell-web/templates/src/components/menus/SurfaceAwareMenuLinkItem.vue
+++ b/packages/shell-web/templates/src/components/menus/SurfaceAwareMenuLinkItem.vue
@@ -29,6 +29,10 @@ const props = defineProps({
   disabled: {
     type: Boolean,
     default: false
+  },
+  exact: {
+    type: Boolean,
+    default: false
   }
 });
 </script>

--- a/packages/shell-web/test/linkItemScaffoldContract.test.js
+++ b/packages/shell-web/test/linkItemScaffoldContract.test.js
@@ -69,6 +69,8 @@ test("shell-web scaffolds app-owned local link-item wrappers under src/component
   assert.match(menuWrapperSource, /@jskit-ai\/shell-web\/client\/components\/ShellMenuLinkItem/);
   assert.match(surfaceAwareWrapperSource, /@jskit-ai\/shell-web\/client\/components\/ShellSurfaceAwareMenuLinkItem/);
   assert.match(tabWrapperSource, /@jskit-ai\/shell-web\/client\/components\/ShellTabLinkItem/);
+  assert.match(menuWrapperSource, /exact:\s*\{/);
+  assert.match(surfaceAwareWrapperSource, /exact:\s*\{/);
 
   assert.deepEqual(findFileMutation("shell-web-component-menu-link-item"), {
     from: "templates/src/components/menus/MenuLinkItem.vue",
@@ -125,6 +127,22 @@ test("shell-web scaffolds app-owned local link-item wrappers under src/component
   );
   assert.equal(findLocalLinkItemDefinition("local.main.ui.tab-link-item")?.componentName, "TabLinkItem");
   assert.equal(await readLocalLinkItemComponentSource("local.main.ui.tab-link-item"), tabWrapperSource);
+});
+
+test("shell-web generic menu link items support exact route matching", async () => {
+  const shellMenuSource = await readFile(
+    path.join(PACKAGE_DIR, "src", "client", "components", "ShellMenuLinkItem.vue"),
+    "utf8"
+  );
+  const shellSurfaceAwareSource = await readFile(
+    path.join(PACKAGE_DIR, "src", "client", "components", "ShellSurfaceAwareMenuLinkItem.vue"),
+    "utf8"
+  );
+
+  assert.match(shellMenuSource, /exact:\s*\{/);
+  assert.match(shellMenuSource, /:exact="props\.exact"/);
+  assert.match(shellSurfaceAwareSource, /exact:\s*\{/);
+  assert.match(shellSurfaceAwareSource, /:exact="props\.exact"/);
 });
 
 test("shell-web binds the local link-item wrapper tokens into MainClientProvider", () => {

--- a/packages/users-web/package.descriptor.mjs
+++ b/packages/users-web/package.descriptor.mjs
@@ -304,7 +304,7 @@ export default Object.freeze({
         position: "bottom",
         skipIfContains: "id: \"users.home.menu.home\"",
         value:
-          "\naddPlacement({\n  id: \"users.home.menu.home\",\n  target: \"shell-layout:primary-menu\",\n  surfaces: [\"*\"],\n  order: 50,\n  componentToken: \"local.main.ui.surface-aware-menu-link-item\",\n  props: {\n    label: \"Home\",\n    surface: \"home\",\n    workspaceSuffix: \"/\",\n    nonWorkspaceSuffix: \"/\"\n  },\n  when: ({ auth }) => Boolean(auth?.authenticated)\n});\n",
+          "\naddPlacement({\n  id: \"users.home.menu.home\",\n  target: \"shell-layout:primary-menu\",\n  surfaces: [\"*\"],\n  order: 50,\n  componentToken: \"local.main.ui.surface-aware-menu-link-item\",\n  props: {\n    label: \"Home\",\n    surface: \"home\",\n    workspaceSuffix: \"/\",\n    nonWorkspaceSuffix: \"/\",\n    exact: true\n  },\n  when: ({ auth }) => Boolean(auth?.authenticated)\n});\n",
         reason: "Append users-web home shell menu placement into app-owned placement registry.",
         category: "users-web",
         id: "users-web-home-shell-menu-placement"

--- a/packages/users-web/test/settingsPlacementContract.test.js
+++ b/packages/users-web/test/settingsPlacementContract.test.js
@@ -216,7 +216,8 @@ test("users-web descriptor metadata advertises home tools outlet and standard ho
       'label: "Home"',
       'surface: "home"',
       'workspaceSuffix: "/"',
-      'nonWorkspaceSuffix: "/"'
+      'nonWorkspaceSuffix: "/"',
+      'exact: true'
     ]
   });
 

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -3971,7 +3971,7 @@
               "file": "src/placement.js",
               "position": "bottom",
               "skipIfContains": "id: \"users.home.menu.home\"",
-              "value": "\naddPlacement({\n  id: \"users.home.menu.home\",\n  target: \"shell-layout:primary-menu\",\n  surfaces: [\"*\"],\n  order: 50,\n  componentToken: \"local.main.ui.surface-aware-menu-link-item\",\n  props: {\n    label: \"Home\",\n    surface: \"home\",\n    workspaceSuffix: \"/\",\n    nonWorkspaceSuffix: \"/\"\n  },\n  when: ({ auth }) => Boolean(auth?.authenticated)\n});\n",
+              "value": "\naddPlacement({\n  id: \"users.home.menu.home\",\n  target: \"shell-layout:primary-menu\",\n  surfaces: [\"*\"],\n  order: 50,\n  componentToken: \"local.main.ui.surface-aware-menu-link-item\",\n  props: {\n    label: \"Home\",\n    surface: \"home\",\n    workspaceSuffix: \"/\",\n    nonWorkspaceSuffix: \"/\",\n    exact: true\n  },\n  when: ({ auth }) => Boolean(auth?.authenticated)\n});\n",
               "reason": "Append users-web home shell menu placement into app-owned placement registry.",
               "category": "users-web",
               "id": "users-web-home-shell-menu-placement"


### PR DESCRIPTION
## Summary
- add exact matching support to shell-web menu link components and scaffolds
- mark the users-web Home placement as an exact match
- update catalog and contract coverage for the exact Home link behavior

## Verification
- npm run verify