### PR TITLE
Remove legacy top-level CLI aliases

### DIFF
--- a/tooling/jskit-cli/src/server/core/commandCatalog.js
+++ b/tooling/jskit-cli/src/server/core/commandCatalog.js
@@ -159,7 +159,7 @@ const COMMAND_DESCRIPTORS = Object.freeze({
   }),
   generate: Object.freeze({
     command: "generate",
-    aliases: Object.freeze(["gen"]),
+    aliases: Object.freeze([]),
     showInOverview: true,
     summary: "Run a generator package (or generator subcommand).",
     minimalUse: "jskit generate <generatorId>",
@@ -212,7 +212,7 @@ const COMMAND_DESCRIPTORS = Object.freeze({
   }),
   list: Object.freeze({
     command: "list",
-    aliases: Object.freeze(["ls"]),
+    aliases: Object.freeze([]),
     showInOverview: true,
     summary: "List bundles, runtime packages, or generator packages.",
     minimalUse: "jskit list",
@@ -236,7 +236,7 @@ const COMMAND_DESCRIPTORS = Object.freeze({
   }),
   "list-placements": Object.freeze({
     command: "list-placements",
-    aliases: Object.freeze(["lp"]),
+    aliases: Object.freeze([]),
     showInOverview: true,
     summary: "List discovered UI placement targets.",
     minimalUse: "jskit list-placements",
@@ -255,7 +255,7 @@ const COMMAND_DESCRIPTORS = Object.freeze({
   }),
   "list-component-tokens": Object.freeze({
     command: "list-component-tokens",
-    aliases: Object.freeze(["lct", "list-link-items", "lpct", "list-placement-component-tokens"]),
+    aliases: Object.freeze([]),
     showInOverview: true,
     summary: "List available placement component tokens.",
     minimalUse: "jskit list-component-tokens",
@@ -285,7 +285,7 @@ const COMMAND_DESCRIPTORS = Object.freeze({
   }),
   show: Object.freeze({
     command: "show",
-    aliases: Object.freeze(["view"]),
+    aliases: Object.freeze([]),
     showInOverview: true,
     summary: "Show detailed metadata for a bundle or package.",
     minimalUse: "jskit show <id>",
@@ -296,7 +296,6 @@ const COMMAND_DESCRIPTORS = Object.freeze({
       })
     ]),
     defaults: Object.freeze([
-      "view is an alias of show.",
       "Basic output is compact; --details expands capability and runtime sections.",
       "--debug-exports implies --details."
     ]),

--- a/tooling/jskit-cli/test/completionCommand.test.js
+++ b/tooling/jskit-cli/test/completionCommand.test.js
@@ -58,6 +58,27 @@ test("completion bash prints an installable bash completion script", () => {
   assert.match(stdout, /complete -o bashdefault -o default -F _jskit_completion jskit/);
 });
 
+test("completion bash __complete__ lists only canonical top-level commands", () => {
+  const result = runCli({
+    args: ["completion", "bash", "__complete__", "2", "--", "npx", "jskit", ""]
+  });
+
+  assert.equal(result.status, 0, String(result.stderr || ""));
+  const completions = String(result.stdout || "").trim().split(/\r?\n/u).filter(Boolean);
+  assert.ok(completions.includes("generate"));
+  assert.ok(completions.includes("list"));
+  assert.ok(completions.includes("list-component-tokens"));
+  assert.ok(completions.includes("show"));
+  assert.ok(!completions.includes("gen"));
+  assert.ok(!completions.includes("ls"));
+  assert.ok(!completions.includes("lp"));
+  assert.ok(!completions.includes("lct"));
+  assert.ok(!completions.includes("lpct"));
+  assert.ok(!completions.includes("list-link-items"));
+  assert.ok(!completions.includes("list-placement-component-tokens"));
+  assert.ok(!completions.includes("view"));
+});
+
 test("completion bash --install writes a short loader file and updates bashrc", async () => {
   await withTempDir(async (cwd) => {
     const homeRoot = path.join(cwd, "home");

--- a/tooling/jskit-cli/test/helpUsage.test.js
+++ b/tooling/jskit-cli/test/helpUsage.test.js
@@ -48,6 +48,23 @@ test("jskit help completion prints completion command help", () => {
   assert.match(stdout, /source <\(npx jskit completion bash\)/);
 });
 
+test("legacy alias commands are rejected as unknown commands", () => {
+  for (const alias of [
+    "gen",
+    "ls",
+    "lp",
+    "lct",
+    "lpct",
+    "list-link-items",
+    "list-placement-component-tokens",
+    "view"
+  ]) {
+    const result = runCli({ args: [alias] });
+    assert.equal(result.status, 1, `expected ${alias} to fail`);
+    assert.match(String(result.stderr || ""), new RegExp(`Unknown command: ${alias.replace(/[.*+?^${}()|[\\]\\\\]/g, "\\\\$&")}`));
+  }
+});
+
 test("jskit generate with no params lists available generators", () => {
   const result = runCli({ args: ["generate"] });
   assert.equal(result.status, 0, String(result.stderr || ""));


### PR DESCRIPTION
## Summary
- remove legacy top-level command aliases from the CLI command catalog
- keep completion output limited to canonical top-level commands
- add tests that reject removed aliases as unknown commands

## Verification
- not run (per request)