### PR TITLE
tooling(create-app): remove stale post-create guidance

### DIFF
--- a/tooling/create-app/src/server/index.js
+++ b/tooling/create-app/src/server/index.js
@@ -628,22 +628,12 @@ export async function runCli(
       stdout.write("- npm install\n");
       stdout.write("- npm run dev\n");
 
-      stdout.write("\n");
       if (result.selectedSetupCommands.length > 0) {
+        stdout.write("\n");
         stdout.write(`Initial framework setup commands (${result.initialBundles}):\n`);
         for (const command of result.selectedSetupCommands) {
           stdout.write(`- ${command}\n`);
         }
-      } else {
-        stdout.write("First of all run npm install.:\n");
-        stdout.write("Then add framework capabilities:\n");
-        stdout.write("- npx jskit add package auth-provider-supabase-core --auth-supabase-url \"https://YOUR-PROJECT.supabase.co\" --auth-supabase-publishable-key \"sb_publishable_...\" --app-public-url \"http://localhost:5173\"\n");
-        stdout.write("- npx jskit add bundle auth-base\n");
-        stdout.write("- npx jskit list\n");
-        stdout.write("Run server and client to see it in action:\n");
-        stdout.write("- npm run dev\n");
-        stdout.write("- npx run server\n");
-       
       }
     }
 

--- a/tooling/create-app/test/createApp.test.js
+++ b/tooling/create-app/test/createApp.test.js
@@ -236,8 +236,9 @@ test("create-app scaffolds the base shell with placeholder replacements", async 
     assert.doesNotMatch(viteConfig, /^\s*beforeWriteFiles:\s*reparentNestedChildrenToIndexOwners/m);
     assert.match(viteConfig, /nestedChildren deprecated/);
 
-    assert.match(result.stdout, /npx jskit add package auth-provider-supabase-core/);
-    assert.match(result.stdout, /npx jskit add bundle auth-base/);
+    assert.doesNotMatch(result.stdout, /Then add framework capabilities:/);
+    assert.doesNotMatch(result.stdout, /npx jskit add package auth-provider-supabase-core/);
+    assert.doesNotMatch(result.stdout, /npx jskit add bundle auth-base/);
   });
 });
 


### PR DESCRIPTION
## Summary
- remove the stale fallback capability checklist from default create-app output
- keep explicit initial setup guidance only when setup bundles were actually selected
- update create-app tests to prove the old canned output no longer appears

## Verification
- `npm --workspace tooling/create-app test`

## Excluded Local Changes
- `install.txt`
- `docs/STRUCTURE.md`
