### PR TITLE
docs: refresh initial scaffolding manual

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -128,6 +128,165 @@ html.dark .VPNavScreen {
   background-color: rgba(8, 14, 22, 0.98);
 }
 
+.docs-browser-shot {
+  margin: 1.6rem 0 2rem;
+  overflow: hidden;
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  border-radius: 18px;
+  background: #ffffff;
+  box-shadow: 0 22px 48px rgba(15, 23, 42, 0.12);
+}
+
+.docs-browser-shot__bar {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  padding: 0.85rem 1rem;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+  background:
+    linear-gradient(180deg, rgba(248, 250, 252, 0.98), rgba(241, 245, 249, 0.98));
+}
+
+.docs-browser-shot__dots {
+  display: inline-flex;
+  gap: 0.45rem;
+  flex: 0 0 auto;
+}
+
+.docs-browser-shot__dots span {
+  width: 0.72rem;
+  height: 0.72rem;
+  border-radius: 999px;
+  background: #cbd5e1;
+}
+
+.docs-browser-shot__dots span:nth-child(1) {
+  background: #f87171;
+}
+
+.docs-browser-shot__dots span:nth-child(2) {
+  background: #fbbf24;
+}
+
+.docs-browser-shot__dots span:nth-child(3) {
+  background: #34d399;
+}
+
+.docs-browser-shot__address {
+  min-width: 0;
+  flex: 1 1 auto;
+  overflow: hidden;
+  padding: 0.42rem 0.8rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.94);
+  color: #475569;
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.83rem;
+  line-height: 1.2;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.docs-browser-shot img {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.docs-terminal-tip {
+  margin: 1.5rem 0 1.9rem;
+  overflow: hidden;
+  border: 1px solid rgba(15, 23, 42, 0.14);
+  border-radius: 18px;
+  background: linear-gradient(180deg, #f7fbfa 0%, #eef6f4 100%);
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.09);
+}
+
+.docs-terminal-tip__header {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 0.85rem 1rem;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.1);
+  background: linear-gradient(180deg, rgba(240, 249, 247, 0.98), rgba(230, 242, 239, 0.98));
+}
+
+.docs-terminal-tip__eyebrow {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.24rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(15, 118, 110, 0.12);
+  color: #0f766e;
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.docs-terminal-tip__title {
+  color: #0f172a;
+  font-size: 0.98rem;
+  font-weight: 700;
+}
+
+.docs-terminal-tip__body {
+  padding: 1rem 1.05rem 1.05rem;
+}
+
+.docs-terminal-tip__body > :first-child {
+  margin-top: 0;
+}
+
+.docs-terminal-tip__body > :last-child {
+  margin-bottom: 0;
+}
+
+.docs-terminal-tip__body .language-bash,
+.docs-terminal-tip__body .vp-code-group {
+  margin: 0.85rem 0 1rem;
+}
+
+html.dark .docs-browser-shot {
+  border-color: rgba(148, 163, 184, 0.2);
+  background: #0f172a;
+  box-shadow: 0 24px 54px rgba(2, 6, 23, 0.38);
+}
+
+html.dark .docs-browser-shot__bar {
+  border-bottom-color: rgba(148, 163, 184, 0.16);
+  background:
+    linear-gradient(180deg, rgba(30, 41, 59, 0.98), rgba(15, 23, 42, 0.98));
+}
+
+html.dark .docs-browser-shot__address {
+  border-color: rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.9);
+  color: #cbd5e1;
+}
+
+html.dark .docs-terminal-tip {
+  border-color: rgba(148, 163, 184, 0.24);
+  background: linear-gradient(180deg, #111d2a 0%, #14212f 100%);
+  box-shadow: 0 24px 54px rgba(2, 6, 23, 0.36);
+}
+
+html.dark .docs-terminal-tip__header {
+  border-bottom-color: rgba(148, 163, 184, 0.18);
+  background: linear-gradient(180deg, rgba(24, 37, 52, 0.98), rgba(18, 29, 44, 0.98));
+}
+
+html.dark .docs-terminal-tip__eyebrow {
+  background: rgba(94, 234, 212, 0.14);
+  color: #7dd3fc;
+}
+
+html.dark .docs-terminal-tip__title {
+  color: #f8fafc;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .VPHome .main .name,
   .VPHome .main .text,

--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -1,4 +1,11 @@
 import DefaultTheme from "vitepress/theme";
+import DocsTerminalTip from "./components/DocsTerminalTip.vue";
 import "./custom.css";
 
-export default DefaultTheme;
+export default {
+  ...DefaultTheme,
+  enhanceApp(context) {
+    DefaultTheme.enhanceApp?.(context);
+    context.app.component("DocsTerminalTip", DocsTerminalTip);
+  }
+};

--- a/docs/guide/initial-scaffolding.md
+++ b/docs/guide/initial-scaffolding.md
@@ -1,8 +1,8 @@
 # Initial scaffolding
 
-In this first chapter, we are going to create the smallest useful JSKIT app, install its dependencies, run it locally, and read the scaffold it gives us. The goal is not just to get a screen on the browser. The goal is to understand what the generator produced, which files matter, and why the project already has concepts like surfaces, a local runtime package, and a server even before we add any real features.
+In this first chapter, we are going to create the smallest useful JSKIT app, install its dependencies, run it locally, and read the scaffold it gives us. The goal of this chapter is to explain how to get started with JSKIT and to understand what the generator produced, which files matter, and why the project already has concepts like _surfaces_, a local runtime package, and a server even before we add any real features.
 
-Start in an empty working directory and run:
+Start in a working directory and run:
 
 ```bash
 npx @jskit-ai/create-app exampleapp --tenancy-mode none
@@ -10,9 +10,9 @@ cd exampleapp
 npm install
 ```
 
-The first command creates a new folder called `exampleapp` and fills it with JSKIT's base shell template. The `exampleapp` name is used in a few template replacements, such as the package name and the browser title. The `--tenancy-mode none` flag tells JSKIT to start with the smallest routing model. In this mode, the app is not workspace-aware. That keeps the first scaffold easier to read because there is no workspace slug handling yet.
+The first command creates a new folder called `exampleapp` and fills it with JSKIT's base shell template. The `exampleapp` name is used in a few template replacements, such as the package name and the browser title. The `--tenancy-mode none` flag tells JSKIT to start with the smallest routing model. In this mode, the app is not workspace-aware (more of this later in the guide, when multihoming is introduced). That keeps the first scaffold easier to read because there is no workspace slug handling yet.
 
-The second command that matters is `npm install`. The generator writes files, but it does not download dependencies for you. `npm install` reads `package.json`, creates `node_modules`, writes `package-lock.json`, and makes local commands such as `npx jskit` available inside the app.
+After creating the scaffolding (which comes with a package.json file), you will need to run `npm install` to install dependencies.
 
 Once `npm install` has finished, you can enable Bash completion for the JSKIT CLI. If you only want it for the current shell session, run:
 
@@ -26,7 +26,29 @@ If you want JSKIT completion to keep working in future Bash sessions as well, ru
 npx jskit completion bash --install
 ```
 
-That writes a small loader file into your home directory and updates `~/.bashrc` for you.
+That writes a small loader file into your home directory and updates `~/.bashrc` for you. To activate it in the current shell immediately, run `source ~/.bashrc`.
+
+<DocsTerminalTip title="Try Completion">
+
+Once completion is loaded, you can test it immediately.
+
+If you type:
+
+```bash
+npx jskit li
+```
+
+and press Tab twice, Bash will show completions such as `list`, `list-placements`, and `list-component-tokens`.
+
+If you type:
+
+```bash
+npx jskit add p
+```
+
+and press Tab, JSKIT will complete that subcommand argument to `package`.
+
+</DocsTerminalTip>
 
 To see the app in the browser, the quickest path is:
 
@@ -36,7 +58,20 @@ npm run dev
 
 Then open `http://localhost:5173/` in the browser. The starter screen is intentionally plain. That is a good thing. It proves the shell is wired correctly before we start adding packages.
 
-![Freshly generated `exampleapp` starter screen](/images/guide/initial-scaffolding-home.png)
+<figure class="docs-browser-shot">
+  <div class="docs-browser-shot__bar">
+    <div class="docs-browser-shot__dots" aria-hidden="true">
+      <span></span>
+      <span></span>
+      <span></span>
+    </div>
+    <div class="docs-browser-shot__address">http://localhost:5173/</div>
+  </div>
+  <img
+    src="/images/guide/initial-scaffolding-home.png"
+    alt="Freshly generated exampleapp starter screen in a browser window"
+  />
+</figure>
 
 For the very first page, `npm run dev` is enough because the scaffold does not make any real API calls yet. For normal JSKIT development, though, you will usually keep a second terminal open and run the backend as well:
 
@@ -54,7 +89,9 @@ curl http://localhost:3000/api/health
 
 You should get a small JSON response with `ok: true`.
 
-At this point it is worth slowing down and looking at what the generator actually put on disk. A fresh app has more structure than a plain Vue starter because JSKIT is preparing both a web shell and an application runtime from the beginning. The top-level layout looks roughly like this:
+## Under the hood 
+
+A fresh app has more structure than a plain Vue starter because JSKIT is preparing both a web shell and an application runtime from the beginning. The top-level layout looks roughly like this:
 
 ```text
 exampleapp/
@@ -101,12 +138,16 @@ The most important parts look like this:
 
 There are two details worth noticing immediately. The dependency on `@local/main` points at `file:packages/main`, which means your app already contains its own local JSKIT package. The `verify` script is also useful to notice early, because it shows the default quality gate the scaffold expects you to run later.
 
-The next important place is `config/public.js`. This is the app's shared public configuration. It defines the current tenancy mode, the default surface, and the list of surface definitions. A surface is JSKIT's name for a named slice of the application. In this first scaffold there are two of them:
 
-- `home`, which is the public-facing starter surface
-- `console`, which is reserved for operational tooling
+### App surfaces in JSKIT
 
-Even though we are using `--tenancy-mode none`, surfaces still matter. "None" here means "no workspace routing", not "no surfaces at all". That distinction becomes very important later, so it is worth learning it now.
+A surface is JSKIT's name for a named slice of the application. They are a very important concept in JSKIT, since a surface can be built -- and deployed -- separately from the rest of the system. This is useful if for example you want the end-user interface _not_ to contain _any_ of the symbols/strings of the admin interface.
+
+Surfaces are defined in a very important file in JSKIT: `config/public.js`. This is the app's shared public configuration, used both by client and server. It's called "public" because it _will_ be read by the browser, and therefore it _will_ be available to the world. It defines the current tenancy mode, the default surface, and the list of surface definitions. In this first scaffold there is only one surface:
+
+- `home`, which is the starter surface
+
+Even though we are using `--tenancy-mode none`, more surfaces still matter. "None" here means "no workspace routing", not "no surfaces at all". Every app starts with a single `home` surface, and later packages will expand that topology.
 
 Here is the part of `config/public.js` that sets that up:
 
@@ -131,19 +172,9 @@ config.surfaceDefinitions.home = {
   accessPolicyId: "public",
   origin: ""
 };
-config.surfaceDefinitions.console = {
-  id: "console",
-  label: "Console",
-  pagesRoot: "console",
-  enabled: true,
-  requiresAuth: true,
-  requiresWorkspace: false,
-  accessPolicyId: "console_owner",
-  origin: ""
-};
 ```
 
-Right next to that file is `config/surfaceAccessPolicies.js`. This is where the access rules for surfaces live. The `home` surface uses the `public` policy. The `console` surface uses `console_owner`, which already hints that JSKIT expects some surfaces to be restricted even in a very small app. You do not need to change these policies yet, but you do need to know where they come from, because later packages and generators will extend them.
+Right next to that file is `config/surfaceAccessPolicies.js`. This is where the access rules for surfaces live. In the initial shell, `home` uses the `public` policy. You do not need to change these policies now, but you do need to know where they come from, because later packages will extend them.
 
 The starter policies are small enough to read in one glance:
 
@@ -151,20 +182,11 @@ The starter policies are small enough to read in one glance:
 export const surfaceAccessPolicies = {};
 
 surfaceAccessPolicies.public = {};
-
-surfaceAccessPolicies.authenticated = {
-  requireAuth: true
-};
-
-surfaceAccessPolicies.console_owner = {
-  requireAuth: true,
-  requireFlagsAll: ["console_owner"]
-};
 ```
 
-That tells you a lot. `home` is open. `console` already assumes an authenticated, flagged user. Even the smallest scaffold is already separating public and operational concerns.
+That tells you one thing immediately: `home` is open. More specific policies only appear when later packages add them.
 
-You will also see `config/server.js`. In the base shell it is nearly empty, and that is deliberate. The scaffold is reserving a place for server-side configuration without pretending there are backend features that do not exist yet.
+### The client side
 
 The `src/` directory is the frontend application. `src/main.js` is the real boot file. It creates the Vue app, sets up the router, enables Vuetify, and builds a JSKIT surface runtime from `config/public.js`. That one file is worth reading carefully because it shows the main client-side contract of a JSKIT app: config goes in, the surface-aware router comes out.
 
@@ -174,11 +196,17 @@ The important part looks like this:
 import { createApp } from "vue";
 import { createRouter, createWebHistory } from "vue-router/auto";
 import { routes } from "vue-router/auto-routes";
+import "vuetify/styles";
+import { createVuetify } from "vuetify";
+import * as components from "vuetify/components";
+import * as directives from "vuetify/directives";
+import { aliases as mdiAliases, mdi } from "vuetify/iconsets/mdi-svg";
 import { createSurfaceRuntime } from "@jskit-ai/kernel/shared/surface/runtime";
 import {
   bootstrapClientShellApp,
   createShellRouter
 } from "@jskit-ai/kernel/client";
+import { bootInstalledClientModules } from "virtual:jskit-client-bootstrap";
 import App from "./App.vue";
 import NotFoundView from "./views/NotFound.vue";
 import { config } from "../config/public.js";
@@ -204,11 +232,26 @@ const { router, fallbackRoute } = createShellRouter({
   }
 });
 
+const vuetify = createVuetify({
+  components,
+  directives,
+  theme: {
+    defaultTheme: "light"
+  },
+  icons: {
+    defaultSet: "mdi",
+    aliases: mdiAliases,
+    sets: { mdi }
+  }
+});
+
 void bootstrapClientShellApp({
   createApp,
   rootComponent: App,
   appConfig: config,
+  appPlugins: [vuetify],
   router,
+  bootClientModules: bootInstalledClientModules,
   surfaceRuntime,
   surfaceMode,
   env: import.meta.env,
@@ -216,9 +259,9 @@ void bootstrapClientShellApp({
 });
 ```
 
-The flow is simple once you read it in order. Load config, build the surface runtime, create a surface-aware router, then bootstrap the app with that information.
+The flow is simple once you read it in order. Load config, build the surface runtime, create a surface-aware router, create Vuetify, then bootstrap the app with that information. The last step also gives JSKIT a hook (`bootInstalledClientModules`) to activate client-side modules added later by installed packages.
 
-Inside `src/pages/` you will find both route owners and actual page components. The easy files to notice are `src/pages/home/index.vue` and `src/pages/console/index.vue`, because those are the pages with visible content. The easy files to miss are `src/pages/home.vue` and `src/pages/console.vue`. Those wrapper files contain route metadata that attaches each page tree to a JSKIT surface. When you later add more pages, that surface information is one of the things JSKIT uses to decide where a page belongs.
+Inside `src/pages/` you will find both route owners and actual page components. The easy file to notice is `src/pages/home/index.vue`, because that is the page with visible content. The easy file to miss is `src/pages/home.vue`. That wrapper file contains route metadata that attaches the page tree to a JSKIT surface. When you later add more pages, that surface information is one of the things JSKIT uses to decide where a page belongs.
 
 The wrapper file is tiny, but it is doing an important job:
 
@@ -242,6 +285,9 @@ This is why `src/pages/home/index.vue` becomes part of the `home` surface instea
 
 `src/App.vue` is deliberately small. It is only the outer Vuetify app shell and a `RouterView`. That is another pattern you should get used to in JSKIT: the base scaffold stays thin, and most behavior is pushed toward packages, page files, and runtime providers.
 
+
+### The server side
+
 The backend entry point is `server.js`, with `bin/server.js` acting as the small executable wrapper used by the npm scripts. `server.js` starts Fastify, registers a built-in `/api/health` route, loads the provider runtime, and decides how to serve the frontend. In development, you normally visit the Vite dev server on port `5173`. In a built app, this same server can also serve the compiled frontend.
 
 The core of that startup path looks like this:
@@ -249,6 +295,8 @@ The core of that startup path looks like this:
 ```js
 async function createServer() {
   const app = Fastify({ logger: true });
+  registerTypeBoxFormats();
+  app.setValidatorCompiler(TypeBoxValidatorCompiler);
 
   app.get("/api/health", async () => {
     return {
@@ -258,12 +306,12 @@ async function createServer() {
   });
 
   const runtimeEnv = resolveRuntimeEnv();
+  const appRoot = path.resolve(process.cwd());
   const runtime = await tryCreateProviderRuntimeFromApp({
-    appRoot: path.resolve(process.cwd()),
+    appRoot,
     profile: resolveRuntimeProfileFromSurface({
       surfaceRuntime,
-      serverSurface: runtimeEnv.SERVER_SURFACE,
-      defaultProfile: "app"
+      serverSurface: runtimeEnv.SERVER_SURFACE
     }),
     env: runtimeEnv,
     logger: app.log,
@@ -273,16 +321,21 @@ async function createServer() {
   registerSurfaceRequestConstraint({
     fastify: app,
     surfaceRuntime,
-    serverSurface: runtimeEnv.SERVER_SURFACE
+    serverSurface: runtimeEnv.SERVER_SURFACE,
+    globalUiPaths: resolveGlobalUiPaths(runtime?.globalUiPaths || [])
   });
 
   return app;
 }
 ```
 
-The health route is built in, but the more important idea is that the server is already prepared to load the JSKIT provider runtime from the app itself.
+The health route is built in, but the more important idea is that the server is already prepared to validate HTTP input, load the JSKIT provider runtime from the app itself, and constrain requests by surface.
+
+You will also notice `config/server.js`. In the base shell it is intentionally almost empty. It is there to reserve a clear place for server-side configuration as backend features are added, without pretending the starter app already has server behavior it does not yet need.
 
 The small `server/lib/` directory exists to keep that server boot code tidy. `runtimeEnv.js` reads environment variables such as port and host. `surfaceRuntime.js` builds the same surface runtime that the client uses, so the server and browser agree on what surfaces exist.
+
+### The main package (client and server)
 
 The most unusual part of the scaffold, if you are new to JSKIT, is `packages/main/`. This is the app-local runtime package. It is not there by accident, and it is not just a convenience folder. JSKIT treats your app itself as a local package with a descriptor, client provider hooks, and server provider hooks. That is why the folder contains `package.descriptor.mjs` and a small `src/` tree of its own.
 
@@ -394,8 +447,12 @@ On a brand-new app, the lock file is telling you that only the local app package
 
 That is a useful anchor point. Before you add anything else, JSKIT already knows about exactly one runtime package: the one that belongs to your app.
 
+### Other files and options
+
 The remaining files are easier to understand once you know the core pieces above. `vite.config.mjs` configures the frontend build and the `/api` proxy used during development. `index.html` is the HTML shell Vite uses to mount Vue. `tests/` contains basic smoke tests so the app has a verification path from day one. The `scripts/` directory collects helper scripts for release, updating JSKIT packages, and linking a local JSKIT checkout during framework development.
 
 The `create-app` command also accepts a few other flags that are useful without changing the basic meaning of this chapter's setup. `--title <text>` lets you replace the browser title and other template text with a friendlier app name. `--target <path>` lets you choose a different output directory instead of the default `./exampleapp`. `--tenancy-mode <mode>` can seed `none`, `personal`, or `workspaces`; for this chapter we intentionally use `none` so the first scaffold stays small and non-workspace. `--force` allows writing into a non-empty target directory when you know that is what you want. `--dry-run` prints the planned file writes without touching the filesystem, which is useful when you want to inspect what the generator would do. `-h` or `--help` prints the command help.
+
+## Summary
 
 At the end of this first step, you should have more than a generated folder. You should have a mental map. `src/` is the web app, `server.js` is the runtime server, `config/` defines surfaces and shared behavior, `packages/main/` is your app's own local JSKIT package, and `.jskit/lock.json` records what JSKIT has done to the project. That is the foundation the next chapters will build on.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6444,7 +6444,7 @@
     },
     "packages/console-web": {
       "name": "@jskit-ai/console-web",
-      "version": "0.1.0"
+      "version": "0.1.1"
     },
     "packages/crud-core": {
       "name": "@jskit-ai/crud-core",

--- a/packages/console-web/package.descriptor.mjs
+++ b/packages/console-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-web",
-  version: "0.1.0",
+  version: "0.1.1",
   kind: "runtime",
   description: "Authenticated console surface scaffold and surface policy wiring.",
   dependsOn: [
@@ -42,7 +42,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-web": "0.1.33",
+        "@jskit-ai/auth-web": "0.1.35",
         "@jskit-ai/shell-web": "0.1.33",
         "@jskit-ai/users-core": "0.1.44"
       },

--- a/packages/console-web/package.json
+++ b/packages/console-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/console-web",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "scripts": {
     "test": "node --test"

--- a/tooling/create-app/templates/base-shell/config/surfaceAccessPolicies.js
+++ b/tooling/create-app/templates/base-shell/config/surfaceAccessPolicies.js
@@ -1,7 +1,3 @@
 export const surfaceAccessPolicies = {};
 
 surfaceAccessPolicies.public = {};
-
-surfaceAccessPolicies.authenticated = {
-  requireAuth: true
-};

--- a/tooling/create-app/templates/base-shell/scripts/link-local-jskit-packages.sh
+++ b/tooling/create-app/templates/base-shell/scripts/link-local-jskit-packages.sh
@@ -9,6 +9,7 @@ set -euo pipefail
 
 APP_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SCOPE_DIR="$APP_ROOT/node_modules/@jskit-ai"
+VITE_CACHE_DIR="$APP_ROOT/node_modules/.vite"
 
 is_valid_jskit_repo_root() {
   local candidate_root="$1"
@@ -196,5 +197,10 @@ while IFS=$'\t' read -r package_dir_name source_dir; do
   link_package_bin_entries "$package_dir_name" "$source_dir"
   linked_count=$((linked_count + 1))
 done < <(discover_local_package_map)
+
+if [[ -d "$VITE_CACHE_DIR" ]]; then
+  rm -rf "$VITE_CACHE_DIR"
+  echo "[link-local] cleared Vite cache at $VITE_CACHE_DIR"
+fi
 
 echo "[link-local] done. linked=$linked_count"

--- a/tooling/create-app/templates/base-shell/server.js
+++ b/tooling/create-app/templates/base-shell/server.js
@@ -104,8 +104,7 @@ async function createServer() {
     appRoot,
     profile: resolveRuntimeProfileFromSurface({
       surfaceRuntime,
-      serverSurface: runtimeEnv.SERVER_SURFACE,
-      defaultProfile: "app"
+      serverSurface: runtimeEnv.SERVER_SURFACE
     }),
     env: runtimeEnv,
     logger: app.log,

--- a/tooling/create-app/test/createApp.test.js
+++ b/tooling/create-app/test/createApp.test.js
@@ -68,6 +68,8 @@ test("create-app scaffolds the base shell with placeholder replacements", async 
     await assert.rejects(access(path.join(appRoot, "scripts/copy-local-packages.sh")), /ENOENT/);
     const linkLocalScript = await readFile(path.join(appRoot, "scripts/link-local-jskit-packages.sh"), "utf8");
     assert.doesNotMatch(linkLocalScript, /Development\/current\/jskit-ai/);
+    assert.match(linkLocalScript, /node_modules\/\.vite/);
+    assert.match(linkLocalScript, /cleared Vite cache/);
     await assert.rejects(access(path.join(appRoot, "scripts/dev-bootstrap-jskit.sh")), /ENOENT/);
     await assert.rejects(access(path.join(appRoot, "scripts/just_run_verde")), /ENOENT/);
     await assert.rejects(access(path.join(appRoot, "scripts/verdaccio-reset-and-publish-packages.sh")), /ENOENT/);
@@ -124,6 +126,12 @@ test("create-app scaffolds the base shell with placeholder replacements", async 
     assert.match(publicConfig, /requiresAuth:\s*false/);
     assert.match(publicConfig, /requiresWorkspace:\s*false/);
     assert.match(publicConfig, /origin:\s*""/);
+    const surfaceAccessPoliciesConfig = await readFile(
+      path.join(appRoot, "config/surfaceAccessPolicies.js"),
+      "utf8"
+    );
+    assert.match(surfaceAccessPoliciesConfig, /surfaceAccessPolicies\.public = \{\};/);
+    assert.doesNotMatch(surfaceAccessPoliciesConfig, /surfaceAccessPolicies\.authenticated/);
     const serverConfig = await readFile(path.join(appRoot, "config/server.js"), "utf8");
     assert.match(serverConfig, /export const config = \{\};/);
 
@@ -132,6 +140,7 @@ test("create-app scaffolds the base shell with placeholder replacements", async 
     assert.match(serverJs, /globalUiPaths:\s*resolveGlobalUiPaths\(runtime\?\.globalUiPaths\s*\|\|\s*\[\]\)/);
     assert.match(serverJs, /registerTypeBoxFormats\(\);/);
     assert.match(serverJs, /app\.setValidatorCompiler\(TypeBoxValidatorCompiler\);/);
+    assert.doesNotMatch(serverJs, /defaultProfile:\s*"app"/);
 
     const appVue = await readFile(path.join(appRoot, "src/App.vue"), "utf8");
     assert.match(appVue, /<RouterView \/>/);


### PR DESCRIPTION
## Summary
- refresh the initial scaffolding chapter to match the current scaffold and docs presentation
- keep create-app scaffold/tests aligned with the current surface and server defaults
- include the current console-web/package-lock version updates already in the worktree

## Verification
- create-app test suite passes
- docs build passes
