### PR TITLE
Infer placed-element surface from placement context

### DIFF
--- a/ai-docs/autogen/packages/kernel.md
+++ b/ai-docs/autogen/packages/kernel.md
@@ -1192,8 +1192,10 @@ Exports
 - `toPosixPath`
 - `DEFAULT_PAGE_LINK_COMPONENT_TOKEN`
 - `DEFAULT_SUBPAGE_LINK_COMPONENT_TOKEN`
+- `listSurfacePageRoots`
 - `normalizePagesRelativeTargetFile`
 - `normalizePagesRelativeTargetRoot`
+- `resolveBestSurfaceMatchFromPageFile`
 - `resolvePageTargetDetails`
 - `deriveDefaultSubpagesHost`
 - `resolveNearestParentSubpagesHost`
@@ -1205,8 +1207,10 @@ Exports
 Exports
 - `DEFAULT_PAGE_LINK_COMPONENT_TOKEN`
 - `DEFAULT_SUBPAGE_LINK_COMPONENT_TOKEN`
+- `listSurfacePageRoots(appRoot = "", { context = "page target" } = {})`
 - `normalizePagesRelativeTargetFile(targetFile = "", { context = "page target", label = "target file" } = {})`
 - `normalizePagesRelativeTargetRoot(targetRoot = "", { context = "page target", label = "target root" } = {})`
+- `resolveBestSurfaceMatchFromPageFile(relativePath = "", surfacePageRoots = [], { context = "page target" } = {})`
 - `resolvePageTargetDetails({ appRoot, targetFile = "", context = "page target" } = {})`
 - `deriveDefaultSubpagesHost(pageTarget = {})`
 - `resolveNearestParentSubpagesHost({ appRoot, pageTarget = {}, context = "page target" } = {})`
@@ -1227,10 +1231,8 @@ Local functions
 - `loadPublicConfig(appRoot = "", { context = "page target" } = {})`
 - `normalizeSurfaceAccessPolicyId(value = "")`
 - `resolveSurfaceRequiresAuth(surfaceDefinition = {}, surfaceAccessPolicies = {})`
-- `listSurfacePageRoots(appRoot = "", { context = "page target" } = {})`
 - `deriveSurfaceMatchesFromPageFile(relativePath = "", surfacePageRoots = [])`
 - `compareSurfaceMatchSpecificity(leftMatch = {}, rightMatch = {})`
-- `resolveBestSurfaceMatchFromPageFile(relativePath = "", surfacePageRoots = [], { context = "page target" } = {})`
 - `deriveRouteInfoFromSurfaceRelativeFile(surfaceRelativeFilePath = "", surfaceId = "")`
 - `buildRouteUrlSuffixFromVisibleSegments(segments = [])`
 - `buildAncestorRouteContexts(pageTarget = {})`

--- a/ai-docs/autogen/packages/ui-generator.md
+++ b/ai-docs/autogen/packages/ui-generator.md
@@ -31,6 +31,7 @@ Exports
 - `runGeneratorSubcommand({ appRoot, subcommand = "", args = [], options = {}, dryRun = false } = {})`
 Local functions
 - `renderElementComponentSource(elementName = "")`
+- `resolvePlacedElementSurface({ appRoot, placementTarget = {}, surface = "", context = "ui-generator placed-element" } = {})`
 
 ### `src/server/subcommands/outlet.js`
 Exports

--- a/packages/kernel/server/support/index.js
+++ b/packages/kernel/server/support/index.js
@@ -6,8 +6,10 @@ export { resolveRequiredAppRoot, toPosixPath } from "./path.js";
 export {
   DEFAULT_PAGE_LINK_COMPONENT_TOKEN,
   DEFAULT_SUBPAGE_LINK_COMPONENT_TOKEN,
+  listSurfacePageRoots,
   normalizePagesRelativeTargetFile,
   normalizePagesRelativeTargetRoot,
+  resolveBestSurfaceMatchFromPageFile,
   resolvePageTargetDetails,
   deriveDefaultSubpagesHost,
   resolveNearestParentSubpagesHost,

--- a/packages/kernel/server/support/pageTargets.js
+++ b/packages/kernel/server/support/pageTargets.js
@@ -695,8 +695,10 @@ async function resolvePageLinkTargetDetails({
 export {
   DEFAULT_PAGE_LINK_COMPONENT_TOKEN,
   DEFAULT_SUBPAGE_LINK_COMPONENT_TOKEN,
+  listSurfacePageRoots,
   normalizePagesRelativeTargetFile,
   normalizePagesRelativeTargetRoot,
+  resolveBestSurfaceMatchFromPageFile,
   resolvePageTargetDetails,
   deriveDefaultSubpagesHost,
   resolveNearestParentSubpagesHost,

--- a/packages/ui-generator/package.descriptor.mjs
+++ b/packages/ui-generator/package.descriptor.mjs
@@ -19,7 +19,7 @@ export default Object.freeze({
       validationType: "enabled-surface-id",
       defaultFromConfig: "surfaceDefaultId",
       promptLabel: "Target surface",
-      promptHint: "Used by the placed-element subcommand. Must match an enabled surface id."
+      promptHint: "Optional. Used when JSKIT cannot infer the target surface from placement or app topology."
     },
     path: {
       required: false,
@@ -152,9 +152,11 @@ export default Object.freeze({
         export: "runGeneratorSubcommand",
         description: "Create a Vue component file under the chosen component directory (default: src/components) and add a placement entry that renders it.",
         optionNames: ["name", "surface", "path", "placement", "force"],
-        requiredOptionNames: ["name", "surface"],
+        requiredOptionNames: ["name"],
         notes: [
           "If --placement is omitted, the placed element is added at shell-layout:top-right.",
+          "If the placement target belongs to a page-owned outlet, JSKIT infers the surface automatically.",
+          "If the target is shared and the app has multiple enabled surfaces, pass --surface explicitly.",
           "If the component file already exists, rerun with --force to overwrite it."
         ],
         examples: [
@@ -162,8 +164,7 @@ export default Object.freeze({
             label: "Common usage",
             lines: [
               "npx jskit generate ui-generator placed-element \\",
-              "  --name \"Alerts Widget\" \\",
-              "  --surface admin"
+              "  --name \"Alerts Widget\""
             ]
           },
           {

--- a/packages/ui-generator/src/server/subcommands/element.js
+++ b/packages/ui-generator/src/server/subcommands/element.js
@@ -1,9 +1,12 @@
 import path from "node:path";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import {
+  listSurfacePageRoots,
+  resolveBestSurfaceMatchFromPageFile,
   resolveShellOutletPlacementTargetFromApp,
   toPosixPath
 } from "@jskit-ai/kernel/server/support";
+import { normalizeSurfaceId } from "@jskit-ai/kernel/shared/surface";
 import { normalizeBoolean, normalizeText } from "@jskit-ai/kernel/shared/support/normalize";
 import {
   DEFAULT_COMPONENT_DIRECTORY,
@@ -31,6 +34,47 @@ function renderElementComponentSource(elementName = "") {
 `;
 }
 
+async function resolvePlacedElementSurface({
+  appRoot,
+  placementTarget = {},
+  surface = "",
+  context = "ui-generator placed-element"
+} = {}) {
+  const explicitSurface = normalizeSurfaceId(surface);
+  const inferredSurfaceMatch = await resolveBestSurfaceMatchFromPageFile(
+    String(placementTarget?.sourcePath || ""),
+    await listSurfacePageRoots(appRoot, { context }),
+    { context }
+  );
+  const inferredSurface = normalizeSurfaceId(inferredSurfaceMatch?.surfaceId);
+
+  if (explicitSurface) {
+    if (inferredSurface && explicitSurface !== inferredSurface) {
+      throw new Error(
+        `${context} target "${normalizeText(placementTarget?.id) || "<unknown>"}" belongs to surface "${inferredSurface}", ` +
+        `so --surface ${explicitSurface} is invalid.`
+      );
+    }
+    return explicitSurface;
+  }
+
+  if (inferredSurface) {
+    return inferredSurface;
+  }
+
+  const surfacePageRoots = await listSurfacePageRoots(appRoot, { context });
+  if (surfacePageRoots.length === 1) {
+    return normalizeSurfaceId(surfacePageRoots[0]?.id);
+  }
+
+  const targetId = normalizeText(placementTarget?.id) || "<unknown>";
+  const enabledSurfaceIds = surfacePageRoots.map((entry) => normalizeSurfaceId(entry?.id)).filter(Boolean);
+  throw new Error(
+    `${context} could not infer a surface for placement target "${targetId}". ` +
+    `Pass --surface explicitly. Enabled surfaces: ${enabledSurfaceIds.join(", ") || "<none>"}.`
+  );
+}
+
 async function runGeneratorSubcommand({
   appRoot,
   subcommand = "",
@@ -50,7 +94,6 @@ async function runGeneratorSubcommand({
   });
 
   const name = requireOption(options, "name", { context: "ui-generator placed-element" });
-  const surface = requireOption(options, "surface", { context: "ui-generator placed-element" }).toLowerCase();
   const componentDirectory = normalizeText(options.path) || DEFAULT_COMPONENT_DIRECTORY;
   const forceOverwrite = Object.prototype.hasOwnProperty.call(options, "force")
     ? normalizeBoolean(options.force)
@@ -76,6 +119,12 @@ async function runGeneratorSubcommand({
     appRoot,
     context: "ui-generator",
     placement: options?.placement || DEFAULT_ELEMENT_PLACEMENT
+  });
+  const surface = await resolvePlacedElementSurface({
+    appRoot,
+    placementTarget,
+    surface: options?.surface,
+    context: "ui-generator placed-element"
   });
 
   const touchedFiles = new Set();

--- a/packages/ui-generator/test/elementSubcommand.test.js
+++ b/packages/ui-generator/test/elementSubcommand.test.js
@@ -15,9 +15,26 @@ async function withTempApp(run) {
 }
 
 async function writeAppFixture(appRoot) {
+  await mkdir(path.join(appRoot, "config"), { recursive: true });
   await mkdir(path.join(appRoot, "src", "components"), { recursive: true });
   await mkdir(path.join(appRoot, "src", "pages", "admin", "workspace", "settings"), { recursive: true });
   await mkdir(path.join(appRoot, "packages", "main", "src", "client", "providers"), { recursive: true });
+
+  await writeFile(
+    path.join(appRoot, "config", "public.js"),
+    `export const config = {
+  surfaceDefaultId: "admin",
+  surfaceDefinitions: {
+    admin: {
+      id: "admin",
+      pagesRoot: "admin/workspace",
+      enabled: true
+    }
+  }
+};
+`,
+    "utf8"
+  );
 
   await writeFile(
     path.join(appRoot, "src", "components", "ShellLayout.vue"),
@@ -120,6 +137,101 @@ test("ui-generator placed-element subcommand supports explicit placement overrid
 
     const placementSource = await readFile(path.join(appRoot, "src", "placement.js"), "utf8");
     assert.match(placementSource, /target: "shell-layout:primary-menu"/);
+  });
+});
+
+test("ui-generator placed-element infers surface from a page-owned placement target", async () => {
+  await withTempApp(async (appRoot) => {
+    await writeAppFixture(appRoot);
+
+    await runGeneratorSubcommand({
+      appRoot,
+      subcommand: "placed-element",
+      options: {
+        name: "Ops Panel",
+        placement: "admin-settings:forms"
+      }
+    });
+
+    const placementSource = await readFile(path.join(appRoot, "src", "placement.js"), "utf8");
+    assert.match(placementSource, /target: "admin-settings:forms"/);
+    assert.match(placementSource, /surfaces: \["admin"\]/);
+  });
+});
+
+test("ui-generator placed-element infers the only enabled surface for shared shell targets", async () => {
+  await withTempApp(async (appRoot) => {
+    await writeAppFixture(appRoot);
+
+    await runGeneratorSubcommand({
+      appRoot,
+      subcommand: "placed-element",
+      options: {
+        name: "Ops Panel"
+      }
+    });
+
+    const placementSource = await readFile(path.join(appRoot, "src", "placement.js"), "utf8");
+    assert.match(placementSource, /target: "shell-layout:top-right"/);
+    assert.match(placementSource, /surfaces: \["admin"\]/);
+  });
+});
+
+test("ui-generator placed-element requires explicit surface when a shared shell target is ambiguous", async () => {
+  await withTempApp(async (appRoot) => {
+    await writeAppFixture(appRoot);
+    await writeFile(
+      path.join(appRoot, "config", "public.js"),
+      `export const config = {
+  surfaceDefaultId: "admin",
+  surfaceDefinitions: {
+    admin: {
+      id: "admin",
+      pagesRoot: "admin/workspace",
+      enabled: true
+    },
+    console: {
+      id: "console",
+      pagesRoot: "console",
+      enabled: true
+    }
+  }
+};
+`,
+      "utf8"
+    );
+
+    await assert.rejects(
+      () =>
+        runGeneratorSubcommand({
+          appRoot,
+          subcommand: "placed-element",
+          options: {
+            name: "Ops Panel"
+          }
+        }),
+      /could not infer a surface for placement target "shell-layout:top-right". Pass --surface explicitly/
+    );
+  });
+});
+
+test("ui-generator placed-element rejects explicit surfaces that conflict with page-owned targets", async () => {
+  await withTempApp(async (appRoot) => {
+    await writeAppFixture(appRoot);
+
+    await assert.rejects(
+      () =>
+        runGeneratorSubcommand({
+          appRoot,
+          subcommand: "placed-element",
+          options: {
+            name: "Ops Panel",
+            placement: "admin-settings:forms",
+            surface: "console"
+          }
+        }),
+      /target "admin-settings:forms" belongs to surface "admin", so --surface console is invalid/
+    );
   });
 });
 

--- a/packages/ui-generator/test/packageDescriptor.test.js
+++ b/packages/ui-generator/test/packageDescriptor.test.js
@@ -6,5 +6,6 @@ test("ui-generator surface options validate against enabled surface ids", () => 
   assert.equal(descriptor.kind, "generator");
   assert.equal(descriptor.options?.surface?.validationType, "enabled-surface-id");
   assert.equal(descriptor.metadata?.generatorSubcommands?.["placed-element"]?.optionNames?.includes("surface"), true);
+  assert.equal(descriptor.metadata?.generatorSubcommands?.["placed-element"]?.requiredOptionNames?.includes("surface"), false);
   assert.equal(descriptor.metadata?.generatorSubcommands?.page?.optionNames?.includes("force"), true);
 });

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -3026,7 +3026,7 @@
             "validationType": "enabled-surface-id",
             "defaultFromConfig": "surfaceDefaultId",
             "promptLabel": "Target surface",
-            "promptHint": "Used by the placed-element subcommand. Must match an enabled surface id."
+            "promptHint": "Optional. Used when JSKIT cannot infer the target surface from placement or app topology."
           },
           "path": {
             "required": false,
@@ -3172,11 +3172,12 @@
                 "force"
               ],
               "requiredOptionNames": [
-                "name",
-                "surface"
+                "name"
               ],
               "notes": [
                 "If --placement is omitted, the placed element is added at shell-layout:top-right.",
+                "If the placement target belongs to a page-owned outlet, JSKIT infers the surface automatically.",
+                "If the target is shared and the app has multiple enabled surfaces, pass --surface explicitly.",
                 "If the component file already exists, rerun with --force to overwrite it."
               ],
               "examples": [
@@ -3184,8 +3185,7 @@
                   "label": "Common usage",
                   "lines": [
                     "npx jskit generate ui-generator placed-element \\",
-                    "  --name \"Alerts Widget\" \\",
-                    "  --surface admin"
+                    "  --name \"Alerts Widget\""
                   ]
                 },
                 {

--- a/tooling/jskit-cli/test/uiElementGeneratorPackage.test.js
+++ b/tooling/jskit-cli/test/uiElementGeneratorPackage.test.js
@@ -569,8 +569,6 @@ test("generate @jskit-ai/ui-generator placed-element scaffolds component token r
         "placed-element",
         "--name",
         "Ops Panel",
-        "--surface",
-        "admin",
         "--path",
         "src/widgets"
       ]
@@ -610,8 +608,6 @@ test("generate @jskit-ai/ui-generator placed-element supports explicit placement
         "placed-element",
         "--name",
         "Ops Panel",
-        "--surface",
-        "admin",
         "--placement",
         "shell-layout:primary-menu"
       ]


### PR DESCRIPTION
## Summary
- let `ui-generator placed-element` infer `--surface` from page-owned placement targets when possible
- fall back to the only enabled surface for shared shell targets, and require `--surface` only when the target is ambiguous
- update tests, catalog metadata, and generated docs for the new behavior

## Verification
- `node --test packages/ui-generator/test/elementSubcommand.test.js packages/ui-generator/test/packageDescriptor.test.js tooling/jskit-cli/test/uiElementGeneratorPackage.test.js`
