### PR TITLE
Add shell-web starter general settings page

### DIFF
--- a/ai-docs/autogen/packages/shell-web.md
+++ b/ai-docs/autogen/packages/shell-web.md
@@ -315,6 +315,10 @@ Exports
 Exports
 - None
 
+### `templates/src/pages/home/settings/general/index.vue`
+Exports
+- None
+
 ### `templates/src/pages/home/settings/index.vue`
 Exports
 - None

--- a/docs/STRUCTURE.md
+++ b/docs/STRUCTURE.md
@@ -14,9 +14,8 @@ npm install
 
 (show placements)
 
-- Improve look, maybe put a settings menu on the left in jskit
-- Read after src/placement.js becomes the placement registry
 - Explain that shell-web OVERWRITES things, and only if they are actually unchanged
+- Read after "src/placement.js becomes the placement registry"
 
 # AUTHENTICATION
 
@@ -53,7 +52,7 @@ npm run db:migrate
 
 # MORE GENERATORS
 
-(Show cruds and multihoming config)
+(Show cruds and multihoming config, and different roles)
 
 # REALTIME
 

--- a/packages/shell-web/package.descriptor.mjs
+++ b/packages/shell-web/package.descriptor.mjs
@@ -99,6 +99,14 @@ export default Object.freeze({
             order: 100,
             componentToken: "local.main.ui.surface-aware-menu-link-item",
             source: "templates/src/placement.js"
+          },
+          {
+            id: "shell-web.home.settings.general",
+            target: "home-settings:primary-menu",
+            surfaces: ["home"],
+            order: 100,
+            componentToken: "local.main.ui.surface-aware-menu-link-item",
+            source: "templates/src/placement.js"
           }
         ]
       }
@@ -275,9 +283,18 @@ export default Object.freeze({
         toSurface: "home",
         toSurfacePath: "settings/index.vue",
         ownership: "app",
-        reason: "Install shell-driven home settings landing page with a tiny browser-local shell preference example.",
+        reason: "Install shell-driven home settings redirect so the starter settings shell lands on a real child page.",
         category: "shell-web",
         id: "shell-web-page-home-settings"
+      },
+      {
+        from: "templates/src/pages/home/settings/general/index.vue",
+        toSurface: "home",
+        toSurfacePath: "settings/general/index.vue",
+        ownership: "app",
+        reason: "Install shell-driven general settings child page with a tiny browser-local shell preference example.",
+        category: "shell-web",
+        id: "shell-web-page-home-settings-general"
       }
     ]
   }

--- a/packages/shell-web/templates/src/pages/home/settings/general/index.vue
+++ b/packages/shell-web/templates/src/pages/home/settings/general/index.vue
@@ -1,0 +1,37 @@
+<script setup>
+import { computed } from "vue";
+import { useShellLayoutState } from "@jskit-ai/shell-web/client/composables/useShellLayoutState";
+
+const { drawerDefaultOpen, setDrawerDefaultOpen } = useShellLayoutState();
+
+const drawerDefaultOpenModel = computed({
+  get() {
+    return drawerDefaultOpen.value;
+  },
+  set(value) {
+    setDrawerDefaultOpen(Boolean(value));
+  }
+});
+</script>
+
+<template>
+  <section class="d-flex flex-column ga-4">
+    <div>
+      <h2 class="text-h6 mb-2">General</h2>
+      <p class="text-body-2 text-medium-emphasis mb-0">These starter settings live in this browser only.</p>
+    </div>
+
+    <v-switch
+      v-model="drawerDefaultOpenModel"
+      color="primary"
+      inset
+      hide-details="auto"
+      label="Open navigation drawer by default"
+    />
+
+    <p class="text-body-2 text-medium-emphasis mb-0">
+      This tiny example exists to prove that shell-level settings can work without auth or a database. Real apps will
+      usually replace it.
+    </p>
+  </section>
+</template>

--- a/packages/shell-web/templates/src/pages/home/settings/index.vue
+++ b/packages/shell-web/templates/src/pages/home/settings/index.vue
@@ -1,37 +1,5 @@
 <script setup>
-import { computed } from "vue";
-import { useShellLayoutState } from "@jskit-ai/shell-web/client/composables/useShellLayoutState";
-
-const { drawerDefaultOpen, setDrawerDefaultOpen } = useShellLayoutState();
-
-const drawerDefaultOpenModel = computed({
-  get() {
-    return drawerDefaultOpen.value;
-  },
-  set(value) {
-    setDrawerDefaultOpen(Boolean(value));
-  }
+definePage({
+  redirect: (to) => `${String(to.path || "").replace(/\/$/, "")}/general`
 });
 </script>
-
-<template>
-  <section class="d-flex flex-column ga-4">
-    <div>
-      <h2 class="text-h6 mb-2">Shell settings</h2>
-      <p class="text-body-2 text-medium-emphasis mb-0">These starter settings live in this browser only.</p>
-    </div>
-
-    <v-switch
-      v-model="drawerDefaultOpenModel"
-      color="primary"
-      inset
-      hide-details="auto"
-      label="Open navigation drawer by default"
-    />
-
-    <p class="text-body-2 text-medium-emphasis mb-0">
-      This tiny example exists to prove that shell-level settings can work without auth or a database. Real apps will
-      usually replace it.
-    </p>
-  </section>
-</template>

--- a/packages/shell-web/templates/src/placement.js
+++ b/packages/shell-web/templates/src/placement.js
@@ -39,3 +39,18 @@ addPlacement({
     nonWorkspaceSuffix: "/settings"
   }
 });
+
+addPlacement({
+  id: "shell-web.home.settings.general",
+  target: "home-settings:primary-menu",
+  surfaces: ["home"],
+  order: 100,
+  componentToken: "local.main.ui.surface-aware-menu-link-item",
+  props: {
+    label: "General",
+    surface: "home",
+    workspaceSuffix: "/settings/general",
+    nonWorkspaceSuffix: "/settings/general",
+    to: "./general"
+  }
+});

--- a/packages/shell-web/test/settingsPlacementContract.test.js
+++ b/packages/shell-web/test/settingsPlacementContract.test.js
@@ -39,8 +39,19 @@ test("shell-web home settings template exposes surface-derived settings outlets"
   assert.match(source, /<RouterView \/>/);
 });
 
-test("shell-web settings landing page exposes a tiny browser-local drawer preference", async () => {
+test("shell-web settings landing page redirects to the starter child page", async () => {
   const source = await readFile(path.join(PACKAGE_DIR, "templates", "src", "pages", "home", "settings", "index.vue"), "utf8");
+
+  assert.match(source, /definePage/);
+  assert.match(source, /redirect:/);
+  assert.match(source, /\/general/);
+});
+
+test("shell-web settings general child page exposes a tiny browser-local drawer preference", async () => {
+  const source = await readFile(
+    path.join(PACKAGE_DIR, "templates", "src", "pages", "home", "settings", "general", "index.vue"),
+    "utf8"
+  );
 
   assert.match(source, /useShellLayoutState/);
   assert.match(source, /drawerDefaultOpen/);
@@ -59,6 +70,11 @@ test("shell-web placement template seeds default Home and Settings drawer naviga
   assert.match(source, /id: "shell-web\.home\.menu\.settings"/);
   assert.match(source, /label: "Settings"/);
   assert.match(source, /nonWorkspaceSuffix: "\/settings"/);
+  assert.match(source, /id: "shell-web\.home\.settings\.general"/);
+  assert.match(source, /target: "home-settings:primary-menu"/);
+  assert.match(source, /label: "General"/);
+  assert.match(source, /nonWorkspaceSuffix: "\/settings\/general"/);
+  assert.match(source, /to: "\.\/general"/);
 });
 
 test("shell-web descriptor metadata advertises home settings outlets, default drawer links, and installs the scaffold page", () => {
@@ -96,6 +112,20 @@ test("shell-web descriptor metadata advertises home settings outlets, default dr
     ]
   );
 
+  assert.deepEqual(
+    readContributions("home-settings:primary-menu"),
+    [
+      {
+        id: "shell-web.home.settings.general",
+        target: "home-settings:primary-menu",
+        surfaces: ["home"],
+        order: 100,
+        componentToken: "local.main.ui.surface-aware-menu-link-item",
+        source: "templates/src/placement.js"
+      }
+    ]
+  );
+
   assert.deepEqual(findFileMutation("shell-web-page-home-settings-shell"), {
     from: "templates/src/pages/home/settings.vue",
     toSurface: "home",
@@ -111,9 +141,19 @@ test("shell-web descriptor metadata advertises home settings outlets, default dr
     toSurface: "home",
     toSurfacePath: "settings/index.vue",
     ownership: "app",
-    reason: "Install shell-driven home settings landing page with a tiny browser-local shell preference example.",
+    reason: "Install shell-driven home settings redirect so the starter settings shell lands on a real child page.",
     category: "shell-web",
     id: "shell-web-page-home-settings"
+  });
+
+  assert.deepEqual(findFileMutation("shell-web-page-home-settings-general"), {
+    from: "templates/src/pages/home/settings/general/index.vue",
+    toSurface: "home",
+    toSurfacePath: "settings/general/index.vue",
+    ownership: "app",
+    reason: "Install shell-driven general settings child page with a tiny browser-local shell preference example.",
+    category: "shell-web",
+    id: "shell-web-page-home-settings-general"
   });
 });
 

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -2771,6 +2771,16 @@
                   "order": 100,
                   "componentToken": "local.main.ui.surface-aware-menu-link-item",
                   "source": "templates/src/placement.js"
+                },
+                {
+                  "id": "shell-web.home.settings.general",
+                  "target": "home-settings:primary-menu",
+                  "surfaces": [
+                    "home"
+                  ],
+                  "order": 100,
+                  "componentToken": "local.main.ui.surface-aware-menu-link-item",
+                  "source": "templates/src/placement.js"
                 }
               ]
             }
@@ -2947,9 +2957,18 @@
               "toSurface": "home",
               "toSurfacePath": "settings/index.vue",
               "ownership": "app",
-              "reason": "Install shell-driven home settings landing page with a tiny browser-local shell preference example.",
+              "reason": "Install shell-driven home settings redirect so the starter settings shell lands on a real child page.",
               "category": "shell-web",
               "id": "shell-web-page-home-settings"
+            },
+            {
+              "from": "templates/src/pages/home/settings/general/index.vue",
+              "toSurface": "home",
+              "toSurfacePath": "settings/general/index.vue",
+              "ownership": "app",
+              "reason": "Install shell-driven general settings child page with a tiny browser-local shell preference example.",
+              "category": "shell-web",
+              "id": "shell-web-page-home-settings-general"
             }
           ]
         }


### PR DESCRIPTION
## Summary
- turn the shell-web settings landing page into a redirect to a real starter child page
- add a starter `general` settings child page that hosts the browser-local drawer preference example
- seed the matching settings menu placement and update shell-web catalog/docs/contracts

## Verification
- `node --test packages/shell-web/test/settingsPlacementContract.test.js`
