### PR TITLE
Publish docs from verify workflow

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -27,3 +27,43 @@ jobs:
 
       - name: Run verify
         run: npm run verify
+
+  deploy-docs:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: verify
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build docs
+        run: npm run docs:build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/.vitepress/dist
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+

--- a/packages/ui-generator/test/addSubpagesSubcommand.test.js
+++ b/packages/ui-generator/test/addSubpagesSubcommand.test.js
@@ -313,18 +313,27 @@ test("ui-generator add-subpages validates target format", async () => {
   });
 });
 
-test("ui-generator add-subpages rejects target files with a src/pages prefix", async () => {
+test("ui-generator add-subpages accepts target files with a src/pages prefix", async () => {
   await withTempApp(async (appRoot) => {
     await writeAppFixture(appRoot);
 
-    await assert.rejects(
-      runGeneratorSubcommand({
-        appRoot,
-        subcommand: "add-subpages",
-        args: ["src/pages/w/[workspaceSlug]/admin/practice/index.vue"],
-        options: {}
-      }),
-      /must be relative to src\/pages\/, without the src\/pages\/ prefix/
+    const bareTargetFile = "w/[workspaceSlug]/admin/practice/index.vue";
+    const targetFile = `src/pages/${bareTargetFile}`;
+    await writePageFile(appRoot, bareTargetFile);
+
+    const result = await runGeneratorSubcommand({
+      appRoot,
+      subcommand: "add-subpages",
+      args: [targetFile],
+      options: {}
+    });
+
+    assert.ok(result.touchedFiles.includes(targetFile));
+    const pageSource = await readFile(path.join(appRoot, targetFile), "utf8");
+    assert.match(
+      pageSource,
+      /<ShellOutlet target="practice:sub-pages" default-link-component-token="local\.main\.ui\.tab-link-item" \/>/
     );
+    assert.match(pageSource, /<RouterView \/>/);
   });
 });


### PR DESCRIPTION
## Summary
- add a GitHub Pages deploy job that publishes the VitePress site after verify passes on main
- update the stale ui-generator add-subpages test to match the current src/pages contract

## Verification
- npm run verify