### PR TITLE
Track VitePress theme components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,6 @@ data/
 *.swp
 .jscpd/*
 !.jscpd/baseline.json
-.vitepress**
+docs/.vitepress/cache/
+docs/.vitepress/dist/
 .aider*

--- a/docs/.vitepress/theme/components/DocsInDepth.vue
+++ b/docs/.vitepress/theme/components/DocsInDepth.vue
@@ -1,0 +1,37 @@
+<template>
+  <aside :class="['docs-in-depth', { 'is-open': open }]" :style="{ '--docs-in-depth-preview-height': previewHeight }">
+    <button
+      class="docs-in-depth__toggle"
+      type="button"
+      :aria-expanded="open ? 'true' : 'false'"
+      @click="open = !open"
+    >
+      <span class="docs-in-depth__title">{{ title }}</span>
+      <span class="docs-in-depth__state">{{ open ? "Hide details" : "Show details" }}</span>
+      <span class="docs-in-depth__chevron" aria-hidden="true">⌄</span>
+    </button>
+
+    <div class="docs-in-depth__frame">
+      <div class="docs-in-depth__content">
+        <slot />
+      </div>
+    </div>
+  </aside>
+</template>
+
+<script setup>
+import { ref } from "vue";
+
+defineProps({
+  title: {
+    type: String,
+    default: "In depth"
+  },
+  previewHeight: {
+    type: String,
+    default: "14rem"
+  }
+});
+
+const open = ref(false);
+</script>

--- a/docs/.vitepress/theme/components/DocsTerminalTip.vue
+++ b/docs/.vitepress/theme/components/DocsTerminalTip.vue
@@ -1,0 +1,24 @@
+<template>
+  <aside class="docs-terminal-tip">
+    <div class="docs-terminal-tip__header">
+      <span class="docs-terminal-tip__eyebrow">{{ label }}</span>
+      <strong class="docs-terminal-tip__title">{{ title }}</strong>
+    </div>
+    <div class="docs-terminal-tip__body">
+      <slot />
+    </div>
+  </aside>
+</template>
+
+<script setup>
+defineProps({
+  label: {
+    type: String,
+    default: "Terminal"
+  },
+  title: {
+    type: String,
+    default: "Try This"
+  }
+});
+</script>


### PR DESCRIPTION
## Summary
- stop ignoring the whole docs/.vitepress tree and ignore only generated cache/dist output
- add the tracked VitePress theme components imported by the docs theme

## Verification
- npm run docs:build