### PR TITLE
Refresh docs homepage hero copy

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3,8 +3,8 @@ layout: home
 
 hero:
   name: JSKIT
-  text: Documentation Reset
-  tagline: Fresh documentation is being rebuilt from the current codebase.
+  text: A Full-Stack Framework for Real Apps
+  tagline: JSKIT generates the app, server, UI, CRUDs, and routing so you can focus on features.
   actions:
     - theme: brand
       text: GitHub Repository


### PR DESCRIPTION
## Summary
- update the docs homepage hero headline
- replace the temporary reset tagline with framework-focused copy

## Verification
- npm run docs:build