### PR TITLE
Add docs homepage guide CTA

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,9 @@ hero:
   tagline: JSKIT generates the app, server, UI, CRUDs, and routing so you can focus on features.
   actions:
     - theme: brand
+      text: Read the guide
+      link: /guide/initial-scaffolding
+    - theme: brand
       text: GitHub Repository
       link: https://github.com/mobily-enterprises/jskit-ai
 ---


### PR DESCRIPTION
## Summary
- add a direct Read the guide CTA to the docs homepage hero
- point the CTA at the initial scaffolding guide

## Verification
- npm run docs:build