### PR TITLE
Add shared auth composable and docs notes

### DIFF
--- a/docs/STRUCTURE.md
+++ b/docs/STRUCTURE.md
@@ -24,11 +24,33 @@ npm install
 
 # DATABASE LAYER
 
+    SUPABASE_URL=...
+    SUPABASE_KEY=...
+ 
+    npx @jskit-ai/create-app exampleapp --tenancy-mode none
+    cd exampleapp
+    npm install
+ 
+    npx jskit add package shell-web
+    npx jskit add package auth-provider-supabase-core \
+      --auth-supabase-url "$SUPABASE_URL" \
+      --auth-supabase-publishable-key "$SUPABASE_KEY" \
+      --app-public-url "http://localhost:5173"
+ 
+    npx jskit add bundle auth-base
+    npm install
+
+
+
 npx jskit add package database-runtime-mysql
-npx jskit add package users-web
 npm install
 
 (Show what is added, and explain the consequences to authentication)
+
+# USERS
+
+npx jskit add package users-web
+(What changes with logging in)
 
 # CONSOLE
 
@@ -58,11 +80,6 @@ npm install
 npm run db:migrate
 
 # ASSISTANT
-
-
-
-
-
 
 
 * Prep

--- a/docs/guide/authentication.md
+++ b/docs/guide/authentication.md
@@ -200,21 +200,295 @@ config.auth = {
 };
 ```
 
-That is why the login card in this chapter does not show buttons like `Continue with Google`. If later you enable a provider in Supabase and list it in `config.auth.oauth.providers`, the same screen can render those buttons automatically.
+That is why the login card in this chapter does not show buttons like `Continue with Google`.
+
+To turn on Google later, there are two separate setup steps.
+
+First, configure Google and Supabase:
+
+1. In Google Auth Platform, create a **Web application** OAuth client.
+2. Add your browser URLs as **Authorized JavaScript origins**.
+3. In Supabase, open the Google provider settings and copy the provider callback URL shown there.
+4. Add that Supabase callback URL as an **Authorized redirect URI** on the Google OAuth client.
+5. Back in Supabase, paste the Google **Client ID** and **Client Secret** into the Google provider settings and enable the provider.
+6. Make sure Supabase's **Site URL** and **Redirect URLs** still match the real browser URL your app uses.
+
+Then tell JSKIT to expose the provider in the login UI:
+
+```js
+config.auth = {
+  oauth: {
+    providers: ["google"],
+    defaultProvider: "google"
+  }
+};
+```
+
+`providers` controls which OAuth buttons the stock login screen is allowed to render. `defaultProvider` tells JSKIT which provider to prefer when it needs a default choice. If the provider is configured in Supabase but missing from this list, the button still does not appear in the JSKIT login screen.
 
 <DocsTerminalTip label="Important" title="What Works Without A Database">
-Authentication works at this stage because Supabase stores the real identity data, passwords, and sessions.
+Authentication is already real in this chapter because Supabase is still the source of truth for the important auth data:
 
-What does **not** exist yet is JSKIT's database-backed users layer. Until later chapters install the database and users packages, the app-side profile mirror and user-settings storage use standalone in-memory fallbacks. That means:
+- the real auth user record
+- the password hash and password-reset state
+- the OTP and OAuth flows
+- the access and refresh tokens that JSKIT writes into cookies
 
-- auth itself is real
-- Supabase still stores the real auth user, password state, and session state
-- app-owned mirrored profile/settings data is not persistent yet
-- restarting the local server clears that JSKIT-side in-memory mirror
-- there is still no account surface, no user settings UI, and no workspace membership model
+What is missing is JSKIT's own database-backed users layer. In no-database mode, the auth provider switches to **standalone in-memory fallbacks** for the app-side data it normally mirrors into JSKIT tables.
 
-So this chapter gives you real authentication, but not yet the full app user model.
+Concretely, that means:
+
+- JSKIT still creates a local profile mirror for each authenticated Supabase user.
+- But that mirror lives only in the Node process, not in a database table.
+- That temporary mirror stores only a small app-side profile shape:
+  - `id`
+  - `authProvider`
+  - `authProviderUserSid`
+  - `email`
+  - `displayName`
+- JSKIT also keeps a tiny in-memory user-settings record for auth-related flags such as:
+  - `passwordSignInEnabled`
+  - `passwordSetupRequired`
+
+So the behavior is:
+
+- register a user -> the real user is created in Supabase
+- sign in -> Supabase still verifies credentials and returns the real session
+- JSKIT then mirrors just enough profile data into memory so the app can work
+- restart the local server -> that JSKIT-side mirror and those fallback settings are cleared
+
+The browser session is a different thing. In the normal case, a server restart does **not** log the browser out. The browser still has the auth cookies, so on the next request JSKIT can read those cookies, validate or refresh the Supabase session, and rebuild the temporary mirror.
+
+That last point is the important difference. A restart does **not** delete the Supabase user. It does **not** erase the real password. It does **not** erase the real auth session in Supabase itself. What it clears is only the app's temporary in-memory mirror. On the next authenticated request, JSKIT rebuilds that mirror from the Supabase user or token claims.
+
+So without a database, you still get:
+
+- real login
+- real logout
+- real registration
+- real password reset requests
+- real OTP and OAuth flows
+- real session cookies
+
+But you do **not** get:
+
+- persistent JSKIT-side user rows
+- persistent JSKIT-side user settings
+- account/profile persistence beyond what Supabase itself stores
+- workspace membership, user preferences, or the later users/workspaces data model
+
+So this chapter gives you real authentication, but only a temporary app-side user mirror. The full persistent JSKIT user model comes later with the database and users layers.
 </DocsTerminalTip>
+
+## Using auth in your own app
+
+The most important thing this chapter gives you is not just a login page. It gives you three real app-building tools:
+
+- a route-level auth guard
+- auth-aware placement predicates
+- a client-side auth composable you can read in your own components
+
+Those are different tools, and they do different jobs.
+
+- A route guard protects a URL.
+- A placement predicate controls whether a menu entry or widget is visible.
+- The auth composable lets your component react to the current session state.
+
+That separation matters. Protecting a route does **not** automatically hide a menu entry, and hiding a menu entry does **not** protect a route.
+
+### Start with a normal public page
+
+Generate a simple page under the public `home` surface:
+
+```bash
+npx jskit generate ui-generator page home/reports/index.vue --name "Reports"
+```
+
+At this point the page is still public, because `home` is a public surface. JSKIT creates:
+
+- `src/pages/home/reports/index.vue`
+- a new menu placement in `src/placement.js`
+
+The placement entry is just a normal shell link:
+
+```js
+addPlacement({
+  id: "ui-generator.page.home.reports.link",
+  target: "shell-layout:primary-menu",
+  surfaces: ["home"],
+  order: 155,
+  componentToken: "local.main.ui.surface-aware-menu-link-item",
+  props: {
+    label: "Reports",
+    surface: "home",
+    workspaceSuffix: "/reports",
+    nonWorkspaceSuffix: "/reports"
+  }
+});
+```
+
+And the page file itself is a normal page scaffold:
+
+```vue
+<template>
+  <section class="pa-4">
+    <h1 class="text-h5 mb-2">Reports</h1>
+    <p class="text-body-2 text-medium-emphasis">Replace this scaffold with your page implementation.</p>
+  </section>
+</template>
+```
+
+So immediately after generation:
+
+- the `Reports` menu entry is visible to everyone
+- `/home/reports` is reachable by everyone
+
+### Gate the page behind login
+
+To make the route require login, add a route guard block to `src/pages/home/reports/index.vue`:
+
+```vue
+<route lang="json">
+{
+  "meta": {
+    "guard": {
+      "policy": "authenticated"
+    }
+  }
+}
+</route>
+
+<template>
+  <section class="pa-4">
+    <h1 class="text-h5 mb-2">Reports</h1>
+    <p class="text-body-2 text-medium-emphasis">Replace this scaffold with your page implementation.</p>
+  </section>
+</template>
+```
+
+That one change protects the route itself. If a signed-out user tries to visit `/home/reports`, the auth guard runtime redirects them to the login route instead of letting the page render.
+
+The redirect also keeps the requested target. In practice the browser ends up on a login URL shaped like this:
+
+```text
+/auth/login?returnTo=%2Fhome%2Freports
+```
+
+So after login, JSKIT can send the user back to the page they originally asked for.
+
+### Hide the menu entry when signed out
+
+The route is now protected, but the drawer link is still visible. That is expected. Route protection and shell visibility are separate concerns.
+
+To hide the `Reports` menu entry until the user is logged in, update the placement entry in `src/placement.js`:
+
+```js
+addPlacement({
+  id: "ui-generator.page.home.reports.link",
+  target: "shell-layout:primary-menu",
+  surfaces: ["home"],
+  order: 155,
+  componentToken: "local.main.ui.surface-aware-menu-link-item",
+  props: {
+    label: "Reports",
+    surface: "home",
+    workspaceSuffix: "/reports",
+    nonWorkspaceSuffix: "/reports"
+  },
+  // Added: only show this menu entry when the current auth context is authenticated.
+  when: ({ auth }) => Boolean(auth?.authenticated)
+});
+```
+
+The only new part is the `when(...)` line. That predicate is evaluated by the shell placement runtime using the auth context that `auth-web` injects from `/api/session`.
+
+So the behavior now becomes:
+
+- signed out:
+  - the `Reports` drawer entry disappears
+  - visiting `/home/reports` manually still redirects to `/auth/login`
+- signed in:
+  - the `Reports` drawer entry appears
+  - `/home/reports` renders normally
+
+This is the most important pattern to understand: use the guard to protect the route, and use the placement `when(...)` function to control whether the shell exposes a link to it.
+
+### Read auth state in your own page code
+
+Sometimes you do not want to redirect or hide a menu entry. You just want the page to react differently when a user is logged in.
+
+For that, use `useAuth()` from `auth-web`. It gives your component a shared reactive auth object built on top of the underlying auth runtime, so normal Vue code can read the session state without manually wiring subscriptions.
+
+Here is a small example that changes `src/pages/home/index.vue` so it shows a success message when the session is authenticated:
+
+```vue
+<script setup>
+import { useAuth } from "@jskit-ai/auth-web/client";
+
+const { authenticated } = useAuth();
+</script>
+
+<template>
+  <section class="pa-4">
+    <v-alert v-if="authenticated" type="success" variant="tonal" class="mb-4">
+      You are logged in!
+    </v-alert>
+
+    <h1 class="text-h5 mb-2">Home</h1>
+    <p class="text-body-2 text-medium-emphasis">Replace this scaffold with your page implementation.</p>
+  </section>
+</template>
+```
+
+The important thing about that snippet is how little it needs to know. `authenticated` is already a reactive Vue ref, so the banner updates automatically when the session changes.
+
+`useAuth()` also gives you the rest of the surfaced auth state and the lower-level runtime methods when you need them:
+
+- `state`
+- `authenticated`
+- `username`
+- `oauthProviders`
+- `oauthDefaultProvider`
+- `initialize()`
+- `refresh()`
+- `getState()`
+- `subscribe()`
+- `runtime`
+
+If you need one of those methods, keep the whole auth object instead of only destructuring a single ref:
+
+```vue
+<script setup>
+import { useAuth } from "@jskit-ai/auth-web/client";
+
+const auth = useAuth();
+
+async function refreshSession() {
+  await auth.refresh();
+  console.log(auth.getState());
+}
+</script>
+```
+
+So this is not just useful for a demo banner. It is the same mechanism you would use for:
+
+- guest vs authenticated copy
+- showing a call-to-action only for signed-out users
+- enabling a tool panel only for authenticated users
+- rendering a user-specific welcome message
+
+### The three auth tools, side by side
+
+By this point the surfaced auth API should be clearer:
+
+- route file meta:
+  - use `"policy": "authenticated"` when the page itself must be protected
+- placement entry:
+  - use `when: ({ auth }) => Boolean(auth?.authenticated)` when shell UI should only appear for signed-in users
+- component code:
+  - use `useAuth()` when the page needs to react to auth state directly
+
+That is the real development payoff of this chapter. The login system is not just a screen. It gives the app a reusable auth state model that routing, shell placements, and component code can all use.
 
 ## Under the hood
 
@@ -361,6 +635,67 @@ So the auth story in this chapter is spread across clear responsibilities:
 - `src/placement.js` makes auth visible in the shell
 
 That is a very JSKIT-style pattern. The installed package brings the runtime behavior, but the app still owns the important seams where routing and UI get attached.
+
+### The runtime behind `useAuth()`
+
+`useAuth()` is the app-facing Vue layer, but it is not inventing a second auth system. It is a thin reactive wrapper around the lower-level auth guard runtime that `auth-web` boots on startup.
+
+That lower-level runtime already has a small, concrete contract:
+
+- `initialize()`
+- `refresh()`
+- `getState()`
+- `subscribe()`
+
+`auth-web` initializes that runtime once, injects it into Vue, and then exposes `useAuth()` as the normal component-facing API. That is why the main example earlier could stay so small.
+
+If you strip the composable away and write the same `You are logged in!` example directly against the runtime, it looks like this:
+
+```vue
+<script setup>
+import { computed, onBeforeUnmount, onMounted, ref } from "vue";
+import { useAuthGuardRuntime } from "@jskit-ai/auth-web/client";
+
+const authGuardRuntime = useAuthGuardRuntime({
+  required: true
+});
+const authState = ref(authGuardRuntime.getState());
+let unsubscribe = null;
+
+const isAuthenticated = computed(() => authState.value?.authenticated === true);
+
+onMounted(() => {
+  unsubscribe = authGuardRuntime.subscribe((nextState) => {
+    authState.value = nextState;
+  });
+});
+
+onBeforeUnmount(() => {
+  if (typeof unsubscribe === "function") {
+    unsubscribe();
+  }
+});
+</script>
+
+<template>
+  <section class="pa-4">
+    <v-alert v-if="isAuthenticated" type="success" variant="tonal" class="mb-4">
+      You are logged in!
+    </v-alert>
+
+    <h1 class="text-h5 mb-2">Home</h1>
+    <p class="text-body-2 text-medium-emphasis">Replace this scaffold with your page implementation.</p>
+  </section>
+</template>
+```
+
+That code works, and it shows exactly what `useAuth()` is wrapping:
+
+- `getState()` gives the first auth snapshot immediately
+- `subscribe(...)` keeps that snapshot updated later
+- the component turns that imperative runtime into normal Vue refs and computeds
+
+For ordinary Vue component code there is usually no advantage to writing it this way. `useAuth()` already gives you the same surfaced information plus the same runtime methods when you need them. The direct runtime version is mainly worth knowing so you understand the lower-level contract that `auth-web` itself is building on.
 
 ### Who actually talks to whom
 

--- a/packages/auth-web/src/client/composables/useAuth.js
+++ b/packages/auth-web/src/client/composables/useAuth.js
@@ -1,0 +1,96 @@
+import { computed, inject, readonly, shallowRef } from "vue";
+import { isAuthGuardRuntime } from "../runtime/authGuardRuntime.js";
+import {
+  EMPTY_AUTH_GUARD_RUNTIME,
+  EMPTY_AUTH_GUARD_STATE,
+  useAuthGuardRuntime
+} from "../runtime/inject.js";
+
+const AUTH_STATE_INJECTION_KEY = "jskit.auth-web.state.client";
+const authStoreCache = new WeakMap();
+
+function isReadonlyRef(value) {
+  return Boolean(value && typeof value === "object" && "value" in value);
+}
+
+function isAuthStore(value) {
+  return Boolean(
+    value &&
+      typeof value === "object" &&
+      isReadonlyRef(value.state) &&
+      isReadonlyRef(value.authenticated) &&
+      isReadonlyRef(value.username) &&
+      isReadonlyRef(value.oauthProviders) &&
+      isReadonlyRef(value.oauthDefaultProvider) &&
+      typeof value.initialize === "function" &&
+      typeof value.refresh === "function" &&
+      typeof value.getState === "function" &&
+      typeof value.subscribe === "function" &&
+      isAuthGuardRuntime(value.runtime)
+  );
+}
+
+function normalizeAuthStateValue(nextState) {
+  if (!nextState || typeof nextState !== "object") {
+    return EMPTY_AUTH_GUARD_STATE;
+  }
+  return nextState;
+}
+
+function createAuthStore({ runtime = EMPTY_AUTH_GUARD_RUNTIME } = {}) {
+  if (!isAuthGuardRuntime(runtime) || typeof runtime.subscribe !== "function") {
+    throw new TypeError("createAuthStore requires an auth guard runtime with subscribe().");
+  }
+
+  const cachedStore = authStoreCache.get(runtime);
+  if (cachedStore) {
+    return cachedStore;
+  }
+
+  const state = shallowRef(normalizeAuthStateValue(runtime.getState()));
+
+  runtime.subscribe((nextState) => {
+    state.value = normalizeAuthStateValue(nextState);
+  });
+
+  const store = Object.freeze({
+    runtime,
+    state: readonly(state),
+    authenticated: computed(() => state.value.authenticated === true),
+    username: computed(() => String(state.value.username || "")),
+    oauthProviders: computed(() => state.value.oauthProviders || EMPTY_AUTH_GUARD_STATE.oauthProviders),
+    oauthDefaultProvider: computed(() => String(state.value.oauthDefaultProvider || "")),
+    async initialize(options = {}) {
+      return runtime.initialize(options);
+    },
+    async refresh(options = {}) {
+      return runtime.refresh(options);
+    },
+    getState() {
+      return state.value;
+    },
+    subscribe(listener) {
+      return runtime.subscribe(listener);
+    }
+  });
+
+  authStoreCache.set(runtime, store);
+  return store;
+}
+
+function useAuth({ required = false } = {}) {
+  const injectedStore = inject(AUTH_STATE_INJECTION_KEY, null);
+  if (isAuthStore(injectedStore)) {
+    return injectedStore;
+  }
+
+  const runtime = useAuthGuardRuntime({ required });
+  return createAuthStore({ runtime });
+}
+
+export {
+  AUTH_STATE_INJECTION_KEY,
+  createAuthStore,
+  isAuthStore,
+  useAuth
+};

--- a/packages/auth-web/src/client/index.js
+++ b/packages/auth-web/src/client/index.js
@@ -7,6 +7,8 @@ export { default as DefaultLoginView } from "./views/DefaultLoginView.vue";
 export { default as DefaultSignOutView } from "./views/DefaultSignOutView.vue";
 export { default as AuthProfileWidget } from "./views/AuthProfileWidget.vue";
 export { default as AuthProfileMenuLinkItem } from "./views/AuthProfileMenuLinkItem.vue";
+export { useAuth } from "./composables/useAuth.js";
+export { useAuthGuardRuntime } from "./runtime/inject.js";
 
 const routeComponents = Object.freeze({
   "auth-login": DefaultLoginView,

--- a/packages/auth-web/src/client/providers/AuthWebClientProvider.js
+++ b/packages/auth-web/src/client/providers/AuthWebClientProvider.js
@@ -2,7 +2,9 @@ import DefaultLoginView from "../views/DefaultLoginView.vue";
 import AuthProfileWidget from "../views/AuthProfileWidget.vue";
 import AuthProfileMenuLinkItem from "../views/AuthProfileMenuLinkItem.vue";
 import { createAuthGuardRuntime } from "../runtime/authGuardRuntime.js";
+import { AUTH_GUARD_RUNTIME_INJECTION_KEY } from "../runtime/inject.js";
 import { useLoginView } from "../runtime/useLoginView.js";
+import { AUTH_STATE_INJECTION_KEY, createAuthStore } from "../composables/useAuth.js";
 import { resolveSurfaceNavigationTargetFromPlacementContext } from "@jskit-ai/shell-web/client/placement";
 
 class AuthWebClientProvider {
@@ -43,6 +45,9 @@ class AuthWebClientProvider {
 
     const authGuardRuntime = app.make("runtime.auth-guard.client");
     await authGuardRuntime.initialize();
+    const authStore = createAuthStore({
+      runtime: authGuardRuntime
+    });
 
     if (!app.has("jskit.client.vue.app")) {
       return;
@@ -53,7 +58,8 @@ class AuthWebClientProvider {
       return;
     }
 
-    vueApp.provide("jskit.auth-web.runtime.auth-guard.client", authGuardRuntime);
+    vueApp.provide(AUTH_GUARD_RUNTIME_INJECTION_KEY, authGuardRuntime);
+    vueApp.provide(AUTH_STATE_INJECTION_KEY, authStore);
   }
 }
 

--- a/packages/auth-web/src/client/runtime/inject.js
+++ b/packages/auth-web/src/client/runtime/inject.js
@@ -1,6 +1,8 @@
 import { inject } from "vue";
 import { isAuthGuardRuntime } from "./authGuardRuntime.js";
 
+const AUTH_GUARD_RUNTIME_INJECTION_KEY = "jskit.auth-web.runtime.auth-guard.client";
+
 const EMPTY_AUTH_GUARD_STATE = Object.freeze({
   authenticated: false,
   username: "",
@@ -24,7 +26,7 @@ const EMPTY_AUTH_GUARD_RUNTIME = Object.freeze({
 });
 
 function useAuthGuardRuntime({ required = false } = {}) {
-  const runtime = inject("jskit.auth-web.runtime.auth-guard.client", null);
+  const runtime = inject(AUTH_GUARD_RUNTIME_INJECTION_KEY, null);
   if (isAuthGuardRuntime(runtime)) {
     return runtime;
   }
@@ -37,6 +39,8 @@ function useAuthGuardRuntime({ required = false } = {}) {
 }
 
 export {
+  AUTH_GUARD_RUNTIME_INJECTION_KEY,
+  EMPTY_AUTH_GUARD_STATE,
   EMPTY_AUTH_GUARD_RUNTIME,
   useAuthGuardRuntime
 };

--- a/packages/auth-web/src/client/views/AuthProfileWidget.vue
+++ b/packages/auth-web/src/client/views/AuthProfileWidget.vue
@@ -1,15 +1,14 @@
 <script setup>
-import { computed, onBeforeUnmount, onMounted, ref } from "vue";
+import { computed } from "vue";
 import ShellOutlet from "@jskit-ai/shell-web/client/components/ShellOutlet";
 import { useWebPlacementContext } from "@jskit-ai/shell-web/client/placement";
-import { useAuthGuardRuntime } from "../runtime/inject.js";
+import { useAuth } from "../composables/useAuth.js";
 
-const authGuardRuntime = useAuthGuardRuntime({
+const auth = useAuth({
   required: true
 });
-const authState = ref(authGuardRuntime.getState());
+const authState = auth.state;
 const { context: shellPlacementContext } = useWebPlacementContext();
-let unsubscribe = null;
 
 const shellUser = computed(() => {
   const user = shellPlacementContext.value?.user;
@@ -61,19 +60,6 @@ const placementContext = computed(() => {
     auth: authState.value,
     user: shellUser.value
   };
-});
-
-onMounted(() => {
-  unsubscribe = authGuardRuntime.subscribe((nextState) => {
-    authState.value = nextState;
-  });
-});
-
-onBeforeUnmount(() => {
-  if (typeof unsubscribe === "function") {
-    unsubscribe();
-    unsubscribe = null;
-  }
 });
 </script>
 

--- a/packages/auth-web/test/clientBoot.test.js
+++ b/packages/auth-web/test/clientBoot.test.js
@@ -6,6 +6,8 @@ import test from "node:test";
 test("auth-web client index defines provider-based client routes surface", () => {
   const source = readFileSync(fileURLToPath(new URL("../src/client/index.js", import.meta.url)), "utf8");
 
+  assert.equal(source.includes('export { useAuth } from "./composables/useAuth.js";'), true);
+  assert.equal(source.includes('export { useAuthGuardRuntime } from "./runtime/inject.js";'), true);
   assert.equal(source.includes("const routeComponents = Object.freeze({"), true);
   assert.equal(source.includes('"auth-login": DefaultLoginView'), true);
   assert.equal(source.includes('"auth-signout": DefaultSignOutView'), true);

--- a/packages/auth-web/test/useAuth.test.js
+++ b/packages/auth-web/test/useAuth.test.js
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createSSRApp } from "vue";
+import { createAuthStore, useAuth } from "../src/client/composables/useAuth.js";
+import { AUTH_GUARD_RUNTIME_INJECTION_KEY, useAuthGuardRuntime } from "../src/client/runtime/inject.js";
+
+function createAuthRuntimeStub(initialState = {}) {
+  let state = Object.freeze({
+    authenticated: Boolean(initialState.authenticated),
+    username: String(initialState.username || ""),
+    oauthDefaultProvider: String(initialState.oauthDefaultProvider || ""),
+    oauthProviders: Array.isArray(initialState.oauthProviders)
+      ? Object.freeze([...initialState.oauthProviders])
+      : Object.freeze([])
+  });
+  const listeners = new Set();
+
+  return {
+    async initialize() {
+      return state;
+    },
+    async refresh() {
+      return state;
+    },
+    getState() {
+      return state;
+    },
+    subscribe(listener) {
+      if (typeof listener === "function") {
+        listeners.add(listener);
+      }
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    push(nextState = {}) {
+      state = Object.freeze({
+        authenticated: Boolean(nextState.authenticated),
+        username: String(nextState.username || ""),
+        oauthDefaultProvider: String(nextState.oauthDefaultProvider || ""),
+        oauthProviders: Array.isArray(nextState.oauthProviders)
+          ? Object.freeze([...nextState.oauthProviders])
+          : Object.freeze([])
+      });
+
+      for (const listener of listeners) {
+        listener(state);
+      }
+    }
+  };
+}
+
+test("createAuthStore exposes reactive auth refs and direct runtime methods", async () => {
+  const runtime = createAuthRuntimeStub({
+    authenticated: false,
+    username: ""
+  });
+
+  const auth = createAuthStore({
+    runtime
+  });
+
+  assert.equal(auth.runtime, runtime);
+  assert.equal(auth.authenticated.value, false);
+  assert.equal(auth.username.value, "");
+  assert.deepEqual(auth.oauthProviders.value, []);
+  assert.equal(auth.oauthDefaultProvider.value, "");
+  assert.equal(auth.getState().authenticated, false);
+  assert.equal(await auth.refresh(), runtime.getState());
+
+  runtime.push({
+    authenticated: true,
+    username: "ada",
+    oauthProviders: [{ id: "google", label: "Google" }],
+    oauthDefaultProvider: "google"
+  });
+
+  assert.equal(auth.authenticated.value, true);
+  assert.equal(auth.username.value, "ada");
+  assert.deepEqual(auth.oauthProviders.value, [{ id: "google", label: "Google" }]);
+  assert.equal(auth.oauthDefaultProvider.value, "google");
+  assert.equal(auth.getState().authenticated, true);
+
+  let observedState = null;
+  const unsubscribe = auth.subscribe((nextState) => {
+    observedState = nextState;
+  });
+
+  runtime.push({
+    authenticated: true,
+    username: "grace"
+  });
+
+  assert.equal(observedState?.username, "grace");
+  unsubscribe();
+});
+
+test("useAuth reuses the same shared store injected from the runtime", () => {
+  const runtime = createAuthRuntimeStub({
+    authenticated: true,
+    username: "ada"
+  });
+  const app = createSSRApp({});
+  app.provide(AUTH_GUARD_RUNTIME_INJECTION_KEY, runtime);
+
+  const runtimeFromInjection = app.runWithContext(() => useAuthGuardRuntime({ required: true }));
+  const authFromFirstCall = app.runWithContext(() => useAuth({ required: true }));
+  const authFromSecondCall = app.runWithContext(() => useAuth({ required: true }));
+
+  assert.equal(runtimeFromInjection, runtime);
+  assert.equal(authFromFirstCall, authFromSecondCall);
+  assert.equal(authFromFirstCall.runtime, runtime);
+  assert.equal(authFromFirstCall.authenticated.value, true);
+  assert.equal(authFromFirstCall.username.value, "ada");
+});


### PR DESCRIPTION
## Summary
- add a shared auth composable in auth-web and wire it through the client runtime
- update the auth profile widget and client provider to use the shared auth access point
- expand the authentication docs and structure notes to cover the new behavior

## Verification
- npm --workspace packages/auth-web test
- npm run docs:build