### PR TITLE
Regenerate config-eslint AI docs

### DIFF
--- a/ai-docs/autogen/tooling/config-eslint.md
+++ b/ai-docs/autogen/tooling/config-eslint.md
@@ -43,10 +43,6 @@ Exports
 Exports
 - `nodeConfig`
 
-### `package.descriptor.mjs`
-Exports
-- None
-
 ### `vue.js`
 Exports
 - `vueConfig`


### PR DESCRIPTION
## Summary
- regenerate the stale `ai-docs/autogen/tooling/config-eslint.md` file after the `config-eslint` descriptor/test cleanup

## Why
The previous merged PR left one generated AI doc out of date, which caused the `verify` workflow to fail on `generated:check`.

This follow-up only brings the generated docs back in sync with the current source tree.

## Testing
- `npm run generated:check`
