### PR TITLE
Sync package graph and template metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6176,26 +6176,26 @@
     },
     "packages/agent-docs": {
       "name": "@jskit-ai/agent-docs",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "engines": {
         "node": "20.x"
       }
     },
     "packages/assistant": {
       "name": "@jskit-ai/assistant",
-      "version": "0.1.49",
+      "version": "0.1.50",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.40"
+        "@jskit-ai/kernel": "0.1.41"
       }
     },
     "packages/assistant-core": {
       "name": "@jskit-ai/assistant-core",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.40",
-        "@jskit-ai/http-runtime": "0.1.39",
-        "@jskit-ai/kernel": "0.1.40",
-        "@jskit-ai/users-core": "0.1.50",
+        "@jskit-ai/database-runtime": "0.1.41",
+        "@jskit-ai/http-runtime": "0.1.40",
+        "@jskit-ai/kernel": "0.1.41",
+        "@jskit-ai/users-core": "0.1.51",
         "@tanstack/vue-query": "^5.90.5",
         "dompurify": "^3.3.3",
         "marked": "^17.0.4",
@@ -6273,17 +6273,17 @@
     },
     "packages/assistant-runtime": {
       "name": "@jskit-ai/assistant-runtime",
-      "version": "0.1.11",
+      "version": "0.1.12",
       "dependencies": {
-        "@jskit-ai/assistant-core": "0.1.16",
-        "@jskit-ai/database-runtime": "0.1.40",
-        "@jskit-ai/http-runtime": "0.1.39",
-        "@jskit-ai/kernel": "0.1.40",
-        "@jskit-ai/shell-web": "0.1.39",
-        "@jskit-ai/users-core": "0.1.50",
-        "@jskit-ai/users-web": "0.1.55",
-        "@jskit-ai/workspaces-core": "0.1.16",
-        "@jskit-ai/workspaces-web": "0.1.16",
+        "@jskit-ai/assistant-core": "0.1.17",
+        "@jskit-ai/database-runtime": "0.1.41",
+        "@jskit-ai/http-runtime": "0.1.40",
+        "@jskit-ai/kernel": "0.1.41",
+        "@jskit-ai/shell-web": "0.1.40",
+        "@jskit-ai/users-core": "0.1.51",
+        "@jskit-ai/users-web": "0.1.56",
+        "@jskit-ai/workspaces-core": "0.1.17",
+        "@jskit-ai/workspaces-web": "0.1.17",
         "@tanstack/vue-query": "^5.90.5",
         "vuetify": "^4.0.0"
       }
@@ -6357,34 +6357,34 @@
     },
     "packages/auth-core": {
       "name": "@jskit-ai/auth-core",
-      "version": "0.1.39",
+      "version": "0.1.40",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0",
-        "@jskit-ai/kernel": "0.1.40",
+        "@jskit-ai/kernel": "0.1.41",
         "typebox": "^1.0.81"
       }
     },
     "packages/auth-provider-supabase-core": {
       "name": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.39",
+      "version": "0.1.40",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.39",
-        "@jskit-ai/kernel": "0.1.40",
+        "@jskit-ai/auth-core": "0.1.40",
+        "@jskit-ai/kernel": "0.1.41",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0"
       }
     },
     "packages/auth-web": {
       "name": "@jskit-ai/auth-web",
-      "version": "0.1.41",
+      "version": "0.1.42",
       "dependencies": {
         "@fastify/type-provider-typebox": "^6.1.0",
-        "@jskit-ai/auth-core": "0.1.39",
-        "@jskit-ai/http-runtime": "0.1.39",
-        "@jskit-ai/kernel": "0.1.40",
-        "@jskit-ai/shell-web": "0.1.39",
+        "@jskit-ai/auth-core": "0.1.40",
+        "@jskit-ai/http-runtime": "0.1.40",
+        "@jskit-ai/kernel": "0.1.41",
+        "@jskit-ai/shell-web": "0.1.40",
         "@mdi/js": "^7.4.47",
         "@tanstack/vue-query": "^5.90.5",
         "pinia": "^3.0.4",
@@ -6471,34 +6471,34 @@
     },
     "packages/console-core": {
       "name": "@jskit-ai/console-core",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.40",
-        "@jskit-ai/http-runtime": "0.1.39",
-        "@jskit-ai/kernel": "0.1.40",
-        "@jskit-ai/users-core": "0.1.50",
+        "@jskit-ai/database-runtime": "0.1.41",
+        "@jskit-ai/http-runtime": "0.1.40",
+        "@jskit-ai/kernel": "0.1.41",
+        "@jskit-ai/users-core": "0.1.51",
         "typebox": "^1.0.81"
       }
     },
     "packages/console-web": {
       "name": "@jskit-ai/console-web",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
-        "@jskit-ai/auth-web": "0.1.41",
-        "@jskit-ai/console-core": "0.1.3",
-        "@jskit-ai/shell-web": "0.1.39"
+        "@jskit-ai/auth-web": "0.1.42",
+        "@jskit-ai/console-core": "0.1.4",
+        "@jskit-ai/shell-web": "0.1.40"
       }
     },
     "packages/crud-core": {
       "name": "@jskit-ai/crud-core",
-      "version": "0.1.48",
+      "version": "0.1.49",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.40",
-        "@jskit-ai/kernel": "0.1.40",
-        "@jskit-ai/realtime": "0.1.39",
-        "@jskit-ai/shell-web": "0.1.39",
-        "@jskit-ai/users-core": "0.1.50",
-        "@jskit-ai/users-web": "0.1.55",
+        "@jskit-ai/database-runtime": "0.1.41",
+        "@jskit-ai/kernel": "0.1.41",
+        "@jskit-ai/realtime": "0.1.40",
+        "@jskit-ai/shell-web": "0.1.40",
+        "@jskit-ai/users-core": "0.1.51",
+        "@jskit-ai/users-web": "0.1.56",
         "@tanstack/vue-query": "^5.90.5",
         "typebox": "^1.0.81"
       }
@@ -6572,68 +6572,68 @@
     },
     "packages/crud-server-generator": {
       "name": "@jskit-ai/crud-server-generator",
-      "version": "0.1.48",
+      "version": "0.1.49",
       "dependencies": {
         "@babel/parser": "^7.29.2",
-        "@jskit-ai/crud-core": "0.1.48",
-        "@jskit-ai/database-runtime": "0.1.40",
-        "@jskit-ai/http-runtime": "0.1.39",
-        "@jskit-ai/kernel": "0.1.40",
-        "@jskit-ai/users-core": "0.1.50",
+        "@jskit-ai/crud-core": "0.1.49",
+        "@jskit-ai/database-runtime": "0.1.41",
+        "@jskit-ai/http-runtime": "0.1.40",
+        "@jskit-ai/kernel": "0.1.41",
+        "@jskit-ai/users-core": "0.1.51",
         "recast": "^0.23.11",
         "typebox": "^1.0.81"
       }
     },
     "packages/crud-ui-generator": {
       "name": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.23",
+      "version": "0.1.24",
       "dependencies": {
-        "@jskit-ai/crud-core": "0.1.48",
-        "@jskit-ai/kernel": "0.1.40"
+        "@jskit-ai/crud-core": "0.1.49",
+        "@jskit-ai/kernel": "0.1.41"
       }
     },
     "packages/database-runtime": {
       "name": "@jskit-ai/database-runtime",
-      "version": "0.1.40",
+      "version": "0.1.41",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.40"
+        "@jskit-ai/kernel": "0.1.41"
       }
     },
     "packages/database-runtime-mysql": {
       "name": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.39",
+      "version": "0.1.40",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.40"
+        "@jskit-ai/database-runtime": "0.1.41"
       }
     },
     "packages/database-runtime-postgres": {
       "name": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.39",
+      "version": "0.1.40",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.40"
+        "@jskit-ai/database-runtime": "0.1.41"
       }
     },
     "packages/http-runtime": {
       "name": "@jskit-ai/http-runtime",
-      "version": "0.1.39",
+      "version": "0.1.40",
       "dependencies": {
         "@fastify/type-provider-typebox": "^6.1.0",
-        "@jskit-ai/kernel": "0.1.40",
+        "@jskit-ai/kernel": "0.1.41",
         "typebox": "^1.0.81"
       }
     },
     "packages/kernel": {
       "name": "@jskit-ai/kernel",
-      "version": "0.1.40",
+      "version": "0.1.41",
       "dependencies": {
         "typebox": "^1.0.81"
       }
     },
     "packages/realtime": {
       "name": "@jskit-ai/realtime",
-      "version": "0.1.39",
+      "version": "0.1.40",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.40",
+        "@jskit-ai/kernel": "0.1.41",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",
@@ -6642,9 +6642,9 @@
     },
     "packages/shell-web": {
       "name": "@jskit-ai/shell-web",
-      "version": "0.1.39",
+      "version": "0.1.40",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.40",
+        "@jskit-ai/kernel": "0.1.41",
         "@mdi/js": "^7.4.47",
         "@tanstack/vue-query": "^5.90.5",
         "pinia": "^3.0.4",
@@ -6710,25 +6710,25 @@
     },
     "packages/storage-runtime": {
       "name": "@jskit-ai/storage-runtime",
-      "version": "0.1.39",
+      "version": "0.1.40",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.40",
+        "@jskit-ai/kernel": "0.1.41",
         "unstorage": "^1.17.3"
       }
     },
     "packages/ui-generator": {
       "name": "@jskit-ai/ui-generator",
-      "version": "0.1.23",
+      "version": "0.1.24",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.40",
-        "@jskit-ai/shell-web": "0.1.39"
+        "@jskit-ai/kernel": "0.1.41",
+        "@jskit-ai/shell-web": "0.1.40"
       }
     },
     "packages/uploads-image-web": {
       "name": "@jskit-ai/uploads-image-web",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "dependencies": {
-        "@jskit-ai/uploads-runtime": "0.1.18",
+        "@jskit-ai/uploads-runtime": "0.1.19",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",
@@ -6738,35 +6738,35 @@
     },
     "packages/uploads-runtime": {
       "name": "@jskit-ai/uploads-runtime",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "dependencies": {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.40"
+        "@jskit-ai/kernel": "0.1.41"
       }
     },
     "packages/users-core": {
       "name": "@jskit-ai/users-core",
-      "version": "0.1.50",
+      "version": "0.1.51",
       "dependencies": {
         "@fastify/type-provider-typebox": "^6.1.0",
-        "@jskit-ai/auth-core": "0.1.39",
-        "@jskit-ai/database-runtime": "0.1.40",
-        "@jskit-ai/http-runtime": "0.1.39",
-        "@jskit-ai/kernel": "0.1.40",
-        "@jskit-ai/uploads-runtime": "0.1.18",
+        "@jskit-ai/auth-core": "0.1.40",
+        "@jskit-ai/database-runtime": "0.1.41",
+        "@jskit-ai/http-runtime": "0.1.40",
+        "@jskit-ai/kernel": "0.1.41",
+        "@jskit-ai/uploads-runtime": "0.1.19",
         "typebox": "^1.0.81"
       }
     },
     "packages/users-web": {
       "name": "@jskit-ai/users-web",
-      "version": "0.1.55",
+      "version": "0.1.56",
       "dependencies": {
-        "@jskit-ai/http-runtime": "0.1.39",
-        "@jskit-ai/kernel": "0.1.40",
-        "@jskit-ai/realtime": "0.1.39",
-        "@jskit-ai/shell-web": "0.1.39",
-        "@jskit-ai/uploads-image-web": "0.1.18",
-        "@jskit-ai/users-core": "0.1.50",
+        "@jskit-ai/http-runtime": "0.1.40",
+        "@jskit-ai/kernel": "0.1.41",
+        "@jskit-ai/realtime": "0.1.40",
+        "@jskit-ai/shell-web": "0.1.40",
+        "@jskit-ai/uploads-image-web": "0.1.19",
+        "@jskit-ai/users-core": "0.1.51",
         "@mdi/js": "^7.4.47",
         "@tanstack/vue-query": "5.92.12",
         "vuetify": "^4.0.0"
@@ -6841,27 +6841,27 @@
     },
     "packages/workspaces-core": {
       "name": "@jskit-ai/workspaces-core",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "dependencies": {
         "@fastify/type-provider-typebox": "^6.1.0",
-        "@jskit-ai/auth-core": "0.1.39",
-        "@jskit-ai/database-runtime": "0.1.40",
-        "@jskit-ai/http-runtime": "0.1.39",
-        "@jskit-ai/kernel": "0.1.40",
-        "@jskit-ai/users-core": "0.1.50",
+        "@jskit-ai/auth-core": "0.1.40",
+        "@jskit-ai/database-runtime": "0.1.41",
+        "@jskit-ai/http-runtime": "0.1.40",
+        "@jskit-ai/kernel": "0.1.41",
+        "@jskit-ai/users-core": "0.1.51",
         "typebox": "^1.0.81"
       }
     },
     "packages/workspaces-web": {
       "name": "@jskit-ai/workspaces-web",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "dependencies": {
-        "@jskit-ai/http-runtime": "0.1.39",
-        "@jskit-ai/kernel": "0.1.40",
-        "@jskit-ai/shell-web": "0.1.39",
-        "@jskit-ai/users-core": "0.1.50",
-        "@jskit-ai/users-web": "0.1.55",
-        "@jskit-ai/workspaces-core": "0.1.16",
+        "@jskit-ai/http-runtime": "0.1.40",
+        "@jskit-ai/kernel": "0.1.41",
+        "@jskit-ai/shell-web": "0.1.40",
+        "@jskit-ai/users-core": "0.1.51",
+        "@jskit-ai/users-web": "0.1.56",
+        "@jskit-ai/workspaces-core": "0.1.17",
         "@mdi/js": "^7.4.47",
         "@tanstack/vue-query": "5.92.12",
         "vuetify": "^4.0.0"
@@ -6936,7 +6936,7 @@
     },
     "tooling/config-eslint": {
       "name": "@jskit-ai/config-eslint",
-      "version": "0.1.39",
+      "version": "0.1.40",
       "dependencies": {
         "@eslint/js": "^9.39.1",
         "eslint-plugin-vue": "^10.5.1",
@@ -6954,7 +6954,7 @@
     },
     "tooling/create-app": {
       "name": "@jskit-ai/create-app",
-      "version": "0.1.47",
+      "version": "0.1.48",
       "bin": {
         "jskit-create-app": "bin/jskit-create-app.js"
       },
@@ -6964,18 +6964,18 @@
     },
     "tooling/jskit-catalog": {
       "name": "@jskit-ai/jskit-catalog",
-      "version": "0.1.48",
+      "version": "0.1.49",
       "engines": {
         "node": "20.x"
       }
     },
     "tooling/jskit-cli": {
       "name": "@jskit-ai/jskit-cli",
-      "version": "0.2.49",
+      "version": "0.2.50",
       "dependencies": {
-        "@jskit-ai/jskit-catalog": "0.1.48",
-        "@jskit-ai/kernel": "0.1.40",
-        "@jskit-ai/shell-web": "0.1.39"
+        "@jskit-ai/jskit-catalog": "0.1.49",
+        "@jskit-ai/kernel": "0.1.41",
+        "@jskit-ai/shell-web": "0.1.40"
       },
       "bin": {
         "jskit": "bin/jskit.js"

--- a/packages/agent-docs/package.json
+++ b/packages/agent-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/agent-docs",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Distributed JSKIT agent workflows, guides, and generated reference maps.",
   "type": "module",
   "files": [

--- a/packages/agent-docs/templates/app/AGENTS.md
+++ b/packages/agent-docs/templates/app/AGENTS.md
@@ -1,0 +1,33 @@
+# App Agent Instructions
+
+Use this file as the app-facing instruction entrypoint.
+
+Read these workflow files in order:
+
+1. `node_modules/@jskit-ai/agent-docs/workflow/app-state.md`
+2. `node_modules/@jskit-ai/agent-docs/workflow/bootstrap.md` if the workspace is empty or no JSKIT app exists yet
+3. `node_modules/@jskit-ai/agent-docs/workflow/scoping.md`
+4. `node_modules/@jskit-ai/agent-docs/workflow/feature-delivery.md`
+5. `node_modules/@jskit-ai/agent-docs/workflow/review.md`
+
+Use these references on demand:
+
+- `node_modules/@jskit-ai/agent-docs/reference/autogen/KERNEL_MAP.md`
+- `node_modules/@jskit-ai/agent-docs/reference/autogen/README.md`
+- `node_modules/@jskit-ai/agent-docs/guide/agent/index.md`
+- `node_modules/@jskit-ai/agent-docs/guide/human/index.md` when compressed guidance is ambiguous or missing nuance
+- `node_modules/@jskit-ai/agent-docs/templates/APP_BLUEPRINT.md`
+
+Core rules:
+
+- Inspect the workspace before assuming a JSKIT app exists.
+- Reuse existing JSKIT helpers and runtime seams before adding new local helpers.
+- Do not implement app features before the blueprint has the database, surfaces, ownership model, and route/screen plan written down.
+- Use the compressed guide first for speed; fall back to the human guide when a workflow trap, migration caveat, or architectural boundary needs exact wording.
+- Treat generated reference maps and guide copies as vendor reference. Do not edit them manually.
+
+If dependencies are not installed yet:
+
+- install dependencies so `node_modules/@jskit-ai/agent-docs/` exists
+- inspect the workspace before assuming a JSKIT app already exists
+- if the workspace is empty and the user wants a new app, start with the initialize workflow at a high level first

--- a/packages/assistant-core/package.descriptor.mjs
+++ b/packages/assistant-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-core",
-  version: "0.1.16",
+  version: "0.1.17",
   kind: "runtime",
   description: "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
   dependsOn: [
@@ -45,9 +45,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/http-runtime": "0.1.39",
-        "@jskit-ai/kernel": "0.1.40",
-        "@jskit-ai/users-core": "0.1.50",
+        "@jskit-ai/http-runtime": "0.1.40",
+        "@jskit-ai/kernel": "0.1.41",
+        "@jskit-ai/users-core": "0.1.51",
         "@tanstack/vue-query": "^5.90.5",
         "dompurify": "^3.3.3",
         "marked": "^17.0.4",

--- a/packages/assistant-core/package.json
+++ b/packages/assistant-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-core",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,10 +11,10 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.40",
-    "@jskit-ai/http-runtime": "0.1.39",
-    "@jskit-ai/kernel": "0.1.40",
-    "@jskit-ai/users-core": "0.1.50",
+    "@jskit-ai/database-runtime": "0.1.41",
+    "@jskit-ai/http-runtime": "0.1.40",
+    "@jskit-ai/kernel": "0.1.41",
+    "@jskit-ai/users-core": "0.1.51",
     "@tanstack/vue-query": "^5.90.5",
     "dompurify": "^3.3.3",
     "marked": "^17.0.4",

--- a/packages/assistant-runtime/package.descriptor.mjs
+++ b/packages/assistant-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-runtime",
-  version: "0.1.11",
+  version: "0.1.12",
   kind: "runtime",
   description: "Shared assistant runtime with per-surface assistant registration.",
   dependsOn: [
@@ -78,15 +78,15 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/assistant-core": "0.1.16",
-        "@jskit-ai/database-runtime": "0.1.40",
-        "@jskit-ai/http-runtime": "0.1.39",
-        "@jskit-ai/kernel": "0.1.40",
-        "@jskit-ai/shell-web": "0.1.39",
-        "@jskit-ai/users-core": "0.1.50",
-        "@jskit-ai/users-web": "0.1.55",
-        "@jskit-ai/workspaces-core": "0.1.16",
-        "@jskit-ai/workspaces-web": "0.1.16",
+        "@jskit-ai/assistant-core": "0.1.17",
+        "@jskit-ai/database-runtime": "0.1.41",
+        "@jskit-ai/http-runtime": "0.1.40",
+        "@jskit-ai/kernel": "0.1.41",
+        "@jskit-ai/shell-web": "0.1.40",
+        "@jskit-ai/users-core": "0.1.51",
+        "@jskit-ai/users-web": "0.1.56",
+        "@jskit-ai/workspaces-core": "0.1.17",
+        "@jskit-ai/workspaces-web": "0.1.17",
         "@tanstack/vue-query": "^5.90.5",
         "vuetify": "^4.0.0"
       },

--- a/packages/assistant-runtime/package.json
+++ b/packages/assistant-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-runtime",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "type": "module",
   "exports": {
     "./client": "./src/client/index.js",
@@ -8,15 +8,15 @@
     "./server/actionIds": "./src/server/actionIds.js"
   },
   "dependencies": {
-    "@jskit-ai/assistant-core": "0.1.16",
-    "@jskit-ai/database-runtime": "0.1.40",
-    "@jskit-ai/http-runtime": "0.1.39",
-    "@jskit-ai/kernel": "0.1.40",
-    "@jskit-ai/shell-web": "0.1.39",
-    "@jskit-ai/users-core": "0.1.50",
-    "@jskit-ai/users-web": "0.1.55",
-    "@jskit-ai/workspaces-core": "0.1.16",
-    "@jskit-ai/workspaces-web": "0.1.16",
+    "@jskit-ai/assistant-core": "0.1.17",
+    "@jskit-ai/database-runtime": "0.1.41",
+    "@jskit-ai/http-runtime": "0.1.40",
+    "@jskit-ai/kernel": "0.1.41",
+    "@jskit-ai/shell-web": "0.1.40",
+    "@jskit-ai/users-core": "0.1.51",
+    "@jskit-ai/users-web": "0.1.56",
+    "@jskit-ai/workspaces-core": "0.1.17",
+    "@jskit-ai/workspaces-web": "0.1.17",
     "@tanstack/vue-query": "^5.90.5",
     "vuetify": "^4.0.0"
   }

--- a/packages/assistant/package.descriptor.mjs
+++ b/packages/assistant/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant",
-  version: "0.1.49",
+  version: "0.1.50",
   kind: "generator",
   description: "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
   options: {

--- a/packages/assistant/package.json
+++ b/packages/assistant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant",
-  "version": "0.1.49",
+  "version": "0.1.50",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.40"
+    "@jskit-ai/kernel": "0.1.41"
   }
 }

--- a/packages/auth-core/package.descriptor.mjs
+++ b/packages/auth-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-core",
-  "version": "0.1.39",
+  "version": "0.1.40",
   "kind": "runtime",
   "dependsOn": [
     "@jskit-ai/value-app-config-shared"
@@ -69,7 +69,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.40",
+        "@jskit-ai/kernel": "0.1.41",
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0"

--- a/packages/auth-core/package.json
+++ b/packages/auth-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-core",
-  "version": "0.1.39",
+  "version": "0.1.40",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -43,7 +43,7 @@
     "./shared/commands/authSessionReadCommand": "./src/shared/commands/authSessionReadCommand.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.40",
+    "@jskit-ai/kernel": "0.1.41",
     "@fastify/cookie": "^11.0.2",
     "@fastify/csrf-protection": "^7.1.0",
     "@fastify/rate-limit": "^10.3.0",

--- a/packages/auth-provider-supabase-core/package.descriptor.mjs
+++ b/packages/auth-provider-supabase-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.39",
+  "version": "0.1.40",
   "kind": "runtime",
   "options": {
     "auth-supabase-url": {
@@ -83,8 +83,8 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/auth-core": "0.1.39",
-        "@jskit-ai/kernel": "0.1.40",
+        "@jskit-ai/auth-core": "0.1.40",
+        "@jskit-ai/kernel": "0.1.41",
         "dotenv": "^16.4.5",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0"

--- a/packages/auth-provider-supabase-core/package.json
+++ b/packages/auth-provider-supabase-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.39",
+  "version": "0.1.40",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,8 +12,8 @@
     "./client": "./src/client/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.39",
-    "@jskit-ai/kernel": "0.1.40",
+    "@jskit-ai/auth-core": "0.1.40",
+    "@jskit-ai/kernel": "0.1.41",
     "jose": "^6.1.0",
     "@supabase/supabase-js": "^2.57.4"
   }

--- a/packages/auth-web/package.descriptor.mjs
+++ b/packages/auth-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-web",
-  "version": "0.1.41",
+  "version": "0.1.42",
   "kind": "runtime",
   "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
   "dependsOn": [
@@ -220,10 +220,10 @@ export default Object.freeze({
         "@tanstack/vue-query": "5.92.12",
         "@mdi/js": "^7.4.47",
         "@fastify/type-provider-typebox": "^6.1.0",
-        "@jskit-ai/auth-core": "0.1.39",
-        "@jskit-ai/http-runtime": "0.1.39",
-        "@jskit-ai/kernel": "0.1.40",
-        "@jskit-ai/shell-web": "0.1.39",
+        "@jskit-ai/auth-core": "0.1.40",
+        "@jskit-ai/http-runtime": "0.1.40",
+        "@jskit-ai/kernel": "0.1.41",
+        "@jskit-ai/shell-web": "0.1.40",
         "vuetify": "^4.0.0"
       },
       "dev": {}

--- a/packages/auth-web/package.json
+++ b/packages/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-web",
-  "version": "0.1.41",
+  "version": "0.1.42",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -18,13 +18,13 @@
   },
   "dependencies": {
     "@tanstack/vue-query": "^5.90.5",
-    "@jskit-ai/auth-core": "0.1.39",
+    "@jskit-ai/auth-core": "0.1.40",
     "@mdi/js": "^7.4.47",
     "@fastify/type-provider-typebox": "^6.1.0",
-    "@jskit-ai/kernel": "0.1.40",
-    "@jskit-ai/shell-web": "0.1.39",
+    "@jskit-ai/kernel": "0.1.41",
+    "@jskit-ai/shell-web": "0.1.40",
     "pinia": "^3.0.4",
     "vuetify": "^4.0.0",
-    "@jskit-ai/http-runtime": "0.1.39"
+    "@jskit-ai/http-runtime": "0.1.40"
   }
 }

--- a/packages/console-core/package.descriptor.mjs
+++ b/packages/console-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-core",
-  version: "0.1.3",
+  version: "0.1.4",
   kind: "runtime",
   description: "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
   dependsOn: [
@@ -72,10 +72,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.40",
-        "@jskit-ai/http-runtime": "0.1.39",
-        "@jskit-ai/kernel": "0.1.40",
-        "@jskit-ai/users-core": "0.1.50",
+        "@jskit-ai/database-runtime": "0.1.41",
+        "@jskit-ai/http-runtime": "0.1.40",
+        "@jskit-ai/kernel": "0.1.41",
+        "@jskit-ai/users-core": "0.1.51",
         "typebox": "^1.0.81"
       },
       dev: {}

--- a/packages/console-core/package.json
+++ b/packages/console-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/console-core",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,10 +9,10 @@
     "./shared/resources/consoleSettingsFields": "./src/shared/resources/consoleSettingsFields.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.40",
-    "@jskit-ai/http-runtime": "0.1.39",
-    "@jskit-ai/kernel": "0.1.40",
-    "@jskit-ai/users-core": "0.1.50",
+    "@jskit-ai/database-runtime": "0.1.41",
+    "@jskit-ai/http-runtime": "0.1.40",
+    "@jskit-ai/kernel": "0.1.41",
+    "@jskit-ai/users-core": "0.1.51",
     "typebox": "^1.0.81"
   }
 }

--- a/packages/console-web/package.descriptor.mjs
+++ b/packages/console-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-web",
-  version: "0.1.8",
+  version: "0.1.9",
   kind: "runtime",
   description: "Authenticated console surface scaffold and surface policy wiring.",
   dependsOn: [
@@ -65,9 +65,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-web": "0.1.41",
-        "@jskit-ai/console-core": "0.1.3",
-        "@jskit-ai/shell-web": "0.1.39",
+        "@jskit-ai/auth-web": "0.1.42",
+        "@jskit-ai/console-core": "0.1.4",
+        "@jskit-ai/shell-web": "0.1.40",
       },
       dev: {}
     },

--- a/packages/console-web/package.json
+++ b/packages/console-web/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/console-web",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-web": "0.1.41",
-    "@jskit-ai/console-core": "0.1.3",
-    "@jskit-ai/shell-web": "0.1.39"
+    "@jskit-ai/auth-web": "0.1.42",
+    "@jskit-ai/console-core": "0.1.4",
+    "@jskit-ai/shell-web": "0.1.40"
   }
 }

--- a/packages/crud-core/package.descriptor.mjs
+++ b/packages/crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-core",
-  version: "0.1.48",
+  version: "0.1.49",
   kind: "runtime",
   description: "Shared CRUD helpers used by CRUD modules.",
   dependsOn: [
@@ -26,7 +26,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/crud-core": "0.1.48"
+        "@jskit-ai/crud-core": "0.1.49"
       },
       dev: {}
     },

--- a/packages/crud-core/package.json
+++ b/packages/crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-core",
-  "version": "0.1.48",
+  "version": "0.1.49",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -26,12 +26,12 @@
   },
   "dependencies": {
     "@tanstack/vue-query": "^5.90.5",
-    "@jskit-ai/database-runtime": "0.1.40",
-    "@jskit-ai/kernel": "0.1.40",
-    "@jskit-ai/realtime": "0.1.39",
-    "@jskit-ai/shell-web": "0.1.39",
-    "@jskit-ai/users-core": "0.1.50",
-    "@jskit-ai/users-web": "0.1.55",
+    "@jskit-ai/database-runtime": "0.1.41",
+    "@jskit-ai/kernel": "0.1.41",
+    "@jskit-ai/realtime": "0.1.40",
+    "@jskit-ai/shell-web": "0.1.40",
+    "@jskit-ai/users-core": "0.1.51",
+    "@jskit-ai/users-web": "0.1.56",
     "typebox": "^1.0.81"
   }
 }

--- a/packages/crud-server-generator/package.descriptor.mjs
+++ b/packages/crud-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-server-generator",
-  version: "0.1.48",
+  version: "0.1.49",
   kind: "generator",
   description: "CRUD server generator with routes, actions, and persistence scaffolding.",
   options: {
@@ -151,13 +151,13 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.39",
-        "@jskit-ai/crud-core": "0.1.48",
-        "@jskit-ai/database-runtime": "0.1.40",
-        "@jskit-ai/http-runtime": "0.1.39",
-        "@jskit-ai/kernel": "0.1.40",
-        "@jskit-ai/realtime": "0.1.39",
-        "@jskit-ai/users-core": "0.1.50",
+        "@jskit-ai/auth-core": "0.1.40",
+        "@jskit-ai/crud-core": "0.1.49",
+        "@jskit-ai/database-runtime": "0.1.41",
+        "@jskit-ai/http-runtime": "0.1.40",
+        "@jskit-ai/kernel": "0.1.41",
+        "@jskit-ai/realtime": "0.1.40",
+        "@jskit-ai/users-core": "0.1.51",
         "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}",
         "typebox": "^1.0.81"
       },

--- a/packages/crud-server-generator/package.json
+++ b/packages/crud-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-server-generator",
-  "version": "0.1.48",
+  "version": "0.1.49",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,11 +13,11 @@
   },
   "dependencies": {
     "@babel/parser": "^7.29.2",
-    "@jskit-ai/crud-core": "0.1.48",
-    "@jskit-ai/database-runtime": "0.1.40",
-    "@jskit-ai/http-runtime": "0.1.39",
-    "@jskit-ai/kernel": "0.1.40",
-    "@jskit-ai/users-core": "0.1.50",
+    "@jskit-ai/crud-core": "0.1.49",
+    "@jskit-ai/database-runtime": "0.1.41",
+    "@jskit-ai/http-runtime": "0.1.40",
+    "@jskit-ai/kernel": "0.1.41",
+    "@jskit-ai/users-core": "0.1.51",
     "recast": "^0.23.11",
     "typebox": "^1.0.81"
   }

--- a/packages/crud-ui-generator/package.descriptor.mjs
+++ b/packages/crud-ui-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-ui-generator",
-  version: "0.1.23",
+  version: "0.1.24",
   kind: "generator",
   description: "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
   options: {
@@ -168,7 +168,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.55"
+        "@jskit-ai/users-web": "0.1.56"
       },
       dev: {}
     },

--- a/packages/crud-ui-generator/package.json
+++ b/packages/crud-ui-generator/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/crud-ui-generator",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/crud-core": "0.1.48",
-    "@jskit-ai/kernel": "0.1.40"
+    "@jskit-ai/crud-core": "0.1.49",
+    "@jskit-ai/kernel": "0.1.41"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/database-runtime-mysql/package.descriptor.mjs
+++ b/packages/database-runtime-mysql/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-mysql",
-  version: "0.1.39",
+  version: "0.1.40",
   kind: "runtime",
   options: {
     "db-host": {
@@ -91,7 +91,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.40",
+        "@jskit-ai/database-runtime": "0.1.41",
         "mysql2": "^3.11.2"
       },
       dev: {}

--- a/packages/database-runtime-mysql/package.json
+++ b/packages/database-runtime-mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-mysql",
-  "version": "0.1.39",
+  "version": "0.1.40",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,6 +12,6 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.40"
+    "@jskit-ai/database-runtime": "0.1.41"
   }
 }

--- a/packages/database-runtime-postgres/package.descriptor.mjs
+++ b/packages/database-runtime-postgres/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-postgres",
-  version: "0.1.39",
+  version: "0.1.40",
   kind: "runtime",
   options: {
     "db-host": {
@@ -91,7 +91,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.40",
+        "@jskit-ai/database-runtime": "0.1.41",
         "pg": "^8.13.1"
       },
       dev: {}

--- a/packages/database-runtime-postgres/package.json
+++ b/packages/database-runtime-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-postgres",
-  "version": "0.1.39",
+  "version": "0.1.40",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,6 +12,6 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.40"
+    "@jskit-ai/database-runtime": "0.1.41"
   }
 }

--- a/packages/database-runtime/package.descriptor.mjs
+++ b/packages/database-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime",
-  version: "0.1.40",
+  version: "0.1.41",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -58,7 +58,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.40",
+        "@jskit-ai/kernel": "0.1.41",
         "dotenv": "^16.4.5",
         "knex": "^3.1.0"
       },

--- a/packages/database-runtime/package.json
+++ b/packages/database-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime",
-  "version": "0.1.40",
+  "version": "0.1.41",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -25,6 +25,6 @@
     "./shared/transactions": "./src/shared/transactions.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.40"
+    "@jskit-ai/kernel": "0.1.41"
   }
 }

--- a/packages/http-runtime/package.descriptor.mjs
+++ b/packages/http-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/http-runtime",
-  "version": "0.1.39",
+  "version": "0.1.40",
   "kind": "runtime",
   "dependsOn": [],
   "capabilities": {
@@ -67,7 +67,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.40",
+        "@jskit-ai/kernel": "0.1.41",
         "@fastify/type-provider-typebox": "^6.1.0",
         "typebox": "^1.0.81"
       },

--- a/packages/http-runtime/package.json
+++ b/packages/http-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/http-runtime",
-  "version": "0.1.39",
+  "version": "0.1.40",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -17,7 +17,7 @@
     "./shared/validators/operationValidation": "./src/shared/validators/operationValidation.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.40",
+    "@jskit-ai/kernel": "0.1.41",
     "@fastify/type-provider-typebox": "^6.1.0",
     "typebox": "^1.0.81"
   }

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/kernel",
-  "version": "0.1.40",
+  "version": "0.1.41",
   "type": "module",
   "dependencies": {
     "typebox": "^1.0.81"

--- a/packages/realtime/package.descriptor.mjs
+++ b/packages/realtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/realtime",
-  version: "0.1.39",
+  version: "0.1.40",
   kind: "runtime",
   description: "Thin, generic realtime runtime wrappers for socket.io server and client.",
   options: {
@@ -94,7 +94,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.40",
+        "@jskit-ai/kernel": "0.1.41",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/realtime",
-  "version": "0.1.39",
+  "version": "0.1.40",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@socket.io/redis-adapter": "^8.3.0",
-    "@jskit-ai/kernel": "0.1.40",
+    "@jskit-ai/kernel": "0.1.41",
     "redis": "^5.8.2",
     "socket.io": "^4.8.3",
     "socket.io-client": "^4.8.3"

--- a/packages/shell-web/package.descriptor.mjs
+++ b/packages/shell-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/shell-web",
-  version: "0.1.39",
+  version: "0.1.40",
   kind: "runtime",
   description: "Web shell layout runtime with outlet-based placement contributions.",
   dependsOn: [],
@@ -117,7 +117,7 @@ export default Object.freeze({
       runtime: {
         "@mdi/js": "^7.4.47",
         "@tanstack/vue-query": "^5.90.5",
-        "@jskit-ai/kernel": "0.1.40",
+        "@jskit-ai/kernel": "0.1.41",
         "vuetify": "^4.0.0"
       },
       dev: {}

--- a/packages/shell-web/package.json
+++ b/packages/shell-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/shell-web",
-  "version": "0.1.39",
+  "version": "0.1.40",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -24,7 +24,7 @@
   "dependencies": {
     "@mdi/js": "^7.4.47",
     "@tanstack/vue-query": "^5.90.5",
-    "@jskit-ai/kernel": "0.1.40",
+    "@jskit-ai/kernel": "0.1.41",
     "pinia": "^3.0.4",
     "vuetify": "^4.0.0"
   }

--- a/packages/storage-runtime/package.descriptor.mjs
+++ b/packages/storage-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/storage-runtime",
-  version: "0.1.39",
+  version: "0.1.40",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -50,7 +50,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.40",
+        "@jskit-ai/kernel": "0.1.41",
         "unstorage": "^1.17.3"
       },
       dev: {}

--- a/packages/storage-runtime/package.json
+++ b/packages/storage-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/storage-runtime",
-  "version": "0.1.39",
+  "version": "0.1.40",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./server/providers/StorageRuntimeServiceProvider": "./src/server/providers/StorageRuntimeServiceProvider.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.40",
+    "@jskit-ai/kernel": "0.1.41",
     "unstorage": "^1.17.3"
   }
 }

--- a/packages/ui-generator/package.descriptor.mjs
+++ b/packages/ui-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/ui-generator",
-  version: "0.1.23",
+  version: "0.1.24",
   kind: "generator",
   description: "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
   options: {
@@ -278,7 +278,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.55"
+        "@jskit-ai/users-web": "0.1.56"
       },
       dev: {}
     },

--- a/packages/ui-generator/package.json
+++ b/packages/ui-generator/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/ui-generator",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.40",
-    "@jskit-ai/shell-web": "0.1.39"
+    "@jskit-ai/kernel": "0.1.41",
+    "@jskit-ai/shell-web": "0.1.40"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/uploads-image-web/package.descriptor.mjs
+++ b/packages/uploads-image-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-image-web",
-  version: "0.1.18",
+  version: "0.1.19",
   kind: "runtime",
   description: "Reusable client-side image upload runtime with pre-upload image editing.",
   dependsOn: [
@@ -65,7 +65,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/uploads-runtime": "0.1.18",
+        "@jskit-ai/uploads-runtime": "0.1.19",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-image-web/package.json
+++ b/packages/uploads-image-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-image-web",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,7 +13,7 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/uploads-runtime": "0.1.18",
+    "@jskit-ai/uploads-runtime": "0.1.19",
     "@uppy/compressor": "^3.1.0",
     "@uppy/core": "^5.2.0",
     "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-runtime/package.descriptor.mjs
+++ b/packages/uploads-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-runtime",
-  version: "0.1.18",
+  version: "0.1.19",
   kind: "runtime",
   description: "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
   dependsOn: [
@@ -71,7 +71,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.40"
+        "@jskit-ai/kernel": "0.1.41"
       },
       dev: {}
     },

--- a/packages/uploads-runtime/package.json
+++ b/packages/uploads-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-runtime",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,6 +16,6 @@
   },
   "dependencies": {
     "@fastify/multipart": "^9.4.0",
-    "@jskit-ai/kernel": "0.1.40"
+    "@jskit-ai/kernel": "0.1.41"
   }
 }

--- a/packages/users-core/package.descriptor.mjs
+++ b/packages/users-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-core",
-  version: "0.1.50",
+  version: "0.1.51",
   kind: "runtime",
   description: "Users/account runtime plus HTTP routes for account features.",
   dependsOn: [
@@ -128,11 +128,11 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.39",
-        "@jskit-ai/database-runtime": "0.1.40",
-        "@jskit-ai/http-runtime": "0.1.39",
-        "@jskit-ai/kernel": "0.1.40",
-        "@jskit-ai/uploads-runtime": "0.1.18",
+        "@jskit-ai/auth-core": "0.1.40",
+        "@jskit-ai/database-runtime": "0.1.41",
+        "@jskit-ai/http-runtime": "0.1.40",
+        "@jskit-ai/kernel": "0.1.41",
+        "@jskit-ai/uploads-runtime": "0.1.19",
         "@fastify/type-provider-typebox": "^6.1.0",
         typebox: "^1.0.81"
       },

--- a/packages/users-core/package.json
+++ b/packages/users-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-core",
-  "version": "0.1.50",
+  "version": "0.1.51",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,11 +13,11 @@
     "./shared/resources/userSettingsResource": "./src/shared/resources/userSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.39",
-    "@jskit-ai/database-runtime": "0.1.40",
-    "@jskit-ai/http-runtime": "0.1.39",
-    "@jskit-ai/kernel": "0.1.40",
-    "@jskit-ai/uploads-runtime": "0.1.18",
+    "@jskit-ai/auth-core": "0.1.40",
+    "@jskit-ai/database-runtime": "0.1.41",
+    "@jskit-ai/http-runtime": "0.1.40",
+    "@jskit-ai/kernel": "0.1.41",
+    "@jskit-ai/uploads-runtime": "0.1.19",
     "@fastify/type-provider-typebox": "^6.1.0",
     "typebox": "^1.0.81"
   }

--- a/packages/users-web/package.descriptor.mjs
+++ b/packages/users-web/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { HOME_TOOLS_OUTLET } from "./src/shared/toolsOutletContracts.js";
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-web",
-  version: "0.1.55",
+  version: "0.1.56",
   kind: "runtime",
   description: "Users web module: account/profile UI plus shared users web widgets.",
   dependsOn: [
@@ -142,12 +142,12 @@ export default Object.freeze({
       runtime: {
         "@tanstack/vue-query": "5.92.12",
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/http-runtime": "0.1.39",
-        "@jskit-ai/realtime": "0.1.39",
-        "@jskit-ai/kernel": "0.1.40",
-        "@jskit-ai/shell-web": "0.1.39",
-        "@jskit-ai/uploads-image-web": "0.1.18",
-        "@jskit-ai/users-core": "0.1.50",
+        "@jskit-ai/http-runtime": "0.1.40",
+        "@jskit-ai/realtime": "0.1.40",
+        "@jskit-ai/kernel": "0.1.41",
+        "@jskit-ai/shell-web": "0.1.40",
+        "@jskit-ai/uploads-image-web": "0.1.19",
+        "@jskit-ai/users-core": "0.1.51",
         vuetify: "^4.0.0"
       },
       dev: {}

--- a/packages/users-web/package.json
+++ b/packages/users-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-web",
-  "version": "0.1.55",
+  "version": "0.1.56",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -31,12 +31,12 @@
   "dependencies": {
     "@tanstack/vue-query": "5.92.12",
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/http-runtime": "0.1.39",
-    "@jskit-ai/kernel": "0.1.40",
-    "@jskit-ai/realtime": "0.1.39",
-    "@jskit-ai/shell-web": "0.1.39",
-    "@jskit-ai/uploads-image-web": "0.1.18",
-    "@jskit-ai/users-core": "0.1.50",
+    "@jskit-ai/http-runtime": "0.1.40",
+    "@jskit-ai/kernel": "0.1.41",
+    "@jskit-ai/realtime": "0.1.40",
+    "@jskit-ai/shell-web": "0.1.40",
+    "@jskit-ai/uploads-image-web": "0.1.19",
+    "@jskit-ai/users-core": "0.1.51",
     "vuetify": "^4.0.0"
   }
 }

--- a/packages/workspaces-core/package.descriptor.mjs
+++ b/packages/workspaces-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-core",
-  version: "0.1.16",
+  version: "0.1.17",
   kind: "runtime",
   description: "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
   dependsOn: [
@@ -110,7 +110,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-core": "0.1.50"
+        "@jskit-ai/users-core": "0.1.51"
       },
       dev: {}
     },

--- a/packages/workspaces-core/package.json
+++ b/packages/workspaces-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-core",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -19,11 +19,11 @@
   },
   "dependencies": {
     "@fastify/type-provider-typebox": "^6.1.0",
-    "@jskit-ai/auth-core": "0.1.39",
-    "@jskit-ai/database-runtime": "0.1.40",
-    "@jskit-ai/http-runtime": "0.1.39",
-    "@jskit-ai/kernel": "0.1.40",
-    "@jskit-ai/users-core": "0.1.50",
+    "@jskit-ai/auth-core": "0.1.40",
+    "@jskit-ai/database-runtime": "0.1.41",
+    "@jskit-ai/http-runtime": "0.1.40",
+    "@jskit-ai/kernel": "0.1.41",
+    "@jskit-ai/users-core": "0.1.51",
     "typebox": "^1.0.81"
   }
 }

--- a/packages/workspaces-web/package.descriptor.mjs
+++ b/packages/workspaces-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-web",
-  version: "0.1.16",
+  version: "0.1.17",
   kind: "runtime",
   description: "Workspace web module: workspace selector, tools widget, workspace surfaces, and members/settings UI.",
   dependsOn: [
@@ -129,8 +129,8 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/workspaces-core": "0.1.16",
-        "@jskit-ai/users-web": "0.1.55",
+        "@jskit-ai/workspaces-core": "0.1.17",
+        "@jskit-ai/users-web": "0.1.56",
         "vuetify": "^4.0.0"
       },
       dev: {}

--- a/packages/workspaces-web/package.json
+++ b/packages/workspaces-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-web",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -14,12 +14,12 @@
   "dependencies": {
     "@tanstack/vue-query": "5.92.12",
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/http-runtime": "0.1.39",
-    "@jskit-ai/kernel": "0.1.40",
-    "@jskit-ai/shell-web": "0.1.39",
-    "@jskit-ai/users-core": "0.1.50",
-    "@jskit-ai/users-web": "0.1.55",
-    "@jskit-ai/workspaces-core": "0.1.16",
+    "@jskit-ai/http-runtime": "0.1.40",
+    "@jskit-ai/kernel": "0.1.41",
+    "@jskit-ai/shell-web": "0.1.40",
+    "@jskit-ai/users-core": "0.1.51",
+    "@jskit-ai/users-web": "0.1.56",
+    "@jskit-ai/workspaces-core": "0.1.17",
     "vuetify": "^4.0.0"
   }
 }

--- a/tooling/config-eslint/package.json
+++ b/tooling/config-eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/config-eslint",
-  "version": "0.1.39",
+  "version": "0.1.40",
   "description": "Shared flat ESLint presets for JSKIT projects.",
   "type": "module",
   "files": [

--- a/tooling/create-app/package.descriptor.mjs
+++ b/tooling/create-app/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/create-app",
-  "version": "0.1.47",
+  "version": "0.1.48",
   "dependsOn": [],
   "capabilities": {
     "provides": [

--- a/tooling/create-app/package.json
+++ b/tooling/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/create-app",
-  "version": "0.1.47",
+  "version": "0.1.48",
   "description": "Scaffold minimal JSKIT app shells.",
   "type": "module",
   "files": [

--- a/tooling/create-app/templates/base-shell/AGENTS.md
+++ b/tooling/create-app/templates/base-shell/AGENTS.md
@@ -1,12 +1,10 @@
 # App Agent Wrapper
 
-Primary instructions live in:
+Read and follow:
 
-- `node_modules/@jskit-ai/agent-docs/DISTR_AGENT.md`
+- `node_modules/@jskit-ai/agent-docs/templates/app/AGENTS.md`
 
-Read that file first and follow the workflow docs it references before planning, scaffolding, or editing code.
-
-Fallback if the package is not installed yet:
+If that file does not exist yet:
 
 - install dependencies so `node_modules/@jskit-ai/agent-docs/` exists
 - inspect the workspace before assuming a JSKIT app already exists

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -6,11 +6,11 @@
   "packages": [
     {
       "packageId": "@jskit-ai/assistant",
-      "version": "0.1.49",
+      "version": "0.1.50",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant",
-        "version": "0.1.49",
+        "version": "0.1.50",
         "kind": "generator",
         "description": "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
         "options": {
@@ -356,11 +356,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-core",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-core",
-        "version": "0.1.16",
+        "version": "0.1.17",
         "kind": "runtime",
         "description": "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
         "dependsOn": [
@@ -406,9 +406,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/http-runtime": "0.1.39",
-              "@jskit-ai/kernel": "0.1.40",
-              "@jskit-ai/users-core": "0.1.50",
+              "@jskit-ai/http-runtime": "0.1.40",
+              "@jskit-ai/kernel": "0.1.41",
+              "@jskit-ai/users-core": "0.1.51",
               "@tanstack/vue-query": "^5.90.5",
               "dompurify": "^3.3.3",
               "marked": "^17.0.4",
@@ -429,11 +429,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-runtime",
-      "version": "0.1.11",
+      "version": "0.1.12",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-runtime",
-        "version": "0.1.11",
+        "version": "0.1.12",
         "kind": "runtime",
         "description": "Shared assistant runtime with per-surface assistant registration.",
         "dependsOn": [
@@ -512,15 +512,15 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/assistant-core": "0.1.16",
-              "@jskit-ai/database-runtime": "0.1.40",
-              "@jskit-ai/http-runtime": "0.1.39",
-              "@jskit-ai/kernel": "0.1.40",
-              "@jskit-ai/shell-web": "0.1.39",
-              "@jskit-ai/users-core": "0.1.50",
-              "@jskit-ai/users-web": "0.1.55",
-              "@jskit-ai/workspaces-core": "0.1.16",
-              "@jskit-ai/workspaces-web": "0.1.16",
+              "@jskit-ai/assistant-core": "0.1.17",
+              "@jskit-ai/database-runtime": "0.1.41",
+              "@jskit-ai/http-runtime": "0.1.40",
+              "@jskit-ai/kernel": "0.1.41",
+              "@jskit-ai/shell-web": "0.1.40",
+              "@jskit-ai/users-core": "0.1.51",
+              "@jskit-ai/users-web": "0.1.56",
+              "@jskit-ai/workspaces-core": "0.1.17",
+              "@jskit-ai/workspaces-web": "0.1.17",
               "@tanstack/vue-query": "^5.90.5",
               "vuetify": "^4.0.0"
             },
@@ -577,11 +577,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-core",
-      "version": "0.1.39",
+      "version": "0.1.40",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-core",
-        "version": "0.1.39",
+        "version": "0.1.40",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/value-app-config-shared"
@@ -649,7 +649,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.40",
+              "@jskit-ai/kernel": "0.1.41",
               "@fastify/cookie": "^11.0.2",
               "@fastify/csrf-protection": "^7.1.0",
               "@fastify/rate-limit": "^10.3.0"
@@ -667,11 +667,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.39",
+      "version": "0.1.40",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-supabase-core",
-        "version": "0.1.39",
+        "version": "0.1.40",
         "kind": "runtime",
         "options": {
           "auth-supabase-url": {
@@ -753,8 +753,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.39",
-              "@jskit-ai/kernel": "0.1.40",
+              "@jskit-ai/auth-core": "0.1.40",
+              "@jskit-ai/kernel": "0.1.41",
               "dotenv": "^16.4.5",
               "@supabase/supabase-js": "^2.57.4",
               "jose": "^6.1.0"
@@ -819,11 +819,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-web",
-      "version": "0.1.41",
+      "version": "0.1.42",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-web",
-        "version": "0.1.41",
+        "version": "0.1.42",
         "kind": "runtime",
         "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
         "dependsOn": [
@@ -1050,10 +1050,10 @@
               "@tanstack/vue-query": "5.92.12",
               "@mdi/js": "^7.4.47",
               "@fastify/type-provider-typebox": "^6.1.0",
-              "@jskit-ai/auth-core": "0.1.39",
-              "@jskit-ai/http-runtime": "0.1.39",
-              "@jskit-ai/kernel": "0.1.40",
-              "@jskit-ai/shell-web": "0.1.39",
+              "@jskit-ai/auth-core": "0.1.40",
+              "@jskit-ai/http-runtime": "0.1.40",
+              "@jskit-ai/kernel": "0.1.41",
+              "@jskit-ai/shell-web": "0.1.40",
               "vuetify": "^4.0.0"
             },
             "dev": {}
@@ -1123,11 +1123,11 @@
     },
     {
       "packageId": "@jskit-ai/console-core",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-core",
-        "version": "0.1.3",
+        "version": "0.1.4",
         "kind": "runtime",
         "description": "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
         "dependsOn": [
@@ -1198,10 +1198,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.40",
-              "@jskit-ai/http-runtime": "0.1.39",
-              "@jskit-ai/kernel": "0.1.40",
-              "@jskit-ai/users-core": "0.1.50",
+              "@jskit-ai/database-runtime": "0.1.41",
+              "@jskit-ai/http-runtime": "0.1.40",
+              "@jskit-ai/kernel": "0.1.41",
+              "@jskit-ai/users-core": "0.1.51",
               "typebox": "^1.0.81"
             },
             "dev": {}
@@ -1246,11 +1246,11 @@
     },
     {
       "packageId": "@jskit-ai/console-web",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-web",
-        "version": "0.1.8",
+        "version": "0.1.9",
         "kind": "runtime",
         "description": "Authenticated console surface scaffold and surface policy wiring.",
         "dependsOn": [
@@ -1318,9 +1318,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-web": "0.1.41",
-              "@jskit-ai/console-core": "0.1.3",
-              "@jskit-ai/shell-web": "0.1.39"
+              "@jskit-ai/auth-web": "0.1.42",
+              "@jskit-ai/console-core": "0.1.4",
+              "@jskit-ai/shell-web": "0.1.40"
             },
             "dev": {}
           },
@@ -1407,11 +1407,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-core",
-      "version": "0.1.48",
+      "version": "0.1.49",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-core",
-        "version": "0.1.48",
+        "version": "0.1.49",
         "kind": "runtime",
         "description": "Shared CRUD helpers used by CRUD modules.",
         "dependsOn": [
@@ -1438,7 +1438,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/crud-core": "0.1.48"
+              "@jskit-ai/crud-core": "0.1.49"
             },
             "dev": {}
           },
@@ -1452,11 +1452,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-server-generator",
-      "version": "0.1.48",
+      "version": "0.1.49",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-server-generator",
-        "version": "0.1.48",
+        "version": "0.1.49",
         "kind": "generator",
         "description": "CRUD server generator with routes, actions, and persistence scaffolding.",
         "options": {
@@ -1614,13 +1614,13 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.39",
-              "@jskit-ai/crud-core": "0.1.48",
-              "@jskit-ai/database-runtime": "0.1.40",
-              "@jskit-ai/http-runtime": "0.1.39",
-              "@jskit-ai/kernel": "0.1.40",
-              "@jskit-ai/realtime": "0.1.39",
-              "@jskit-ai/users-core": "0.1.50",
+              "@jskit-ai/auth-core": "0.1.40",
+              "@jskit-ai/crud-core": "0.1.49",
+              "@jskit-ai/database-runtime": "0.1.41",
+              "@jskit-ai/http-runtime": "0.1.40",
+              "@jskit-ai/kernel": "0.1.41",
+              "@jskit-ai/realtime": "0.1.40",
+              "@jskit-ai/users-core": "0.1.51",
               "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}",
               "typebox": "^1.0.81"
             },
@@ -1767,11 +1767,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.23",
+      "version": "0.1.24",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-ui-generator",
-        "version": "0.1.23",
+        "version": "0.1.24",
         "kind": "generator",
         "description": "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
         "options": {
@@ -1946,7 +1946,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.55"
+              "@jskit-ai/users-web": "0.1.56"
             },
             "dev": {}
           },
@@ -2179,11 +2179,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime",
-      "version": "0.1.40",
+      "version": "0.1.41",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime",
-        "version": "0.1.40",
+        "version": "0.1.41",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -2240,7 +2240,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.40",
+              "@jskit-ai/kernel": "0.1.41",
               "dotenv": "^16.4.5",
               "knex": "^3.1.0"
             },
@@ -2275,11 +2275,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.39",
+      "version": "0.1.40",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-mysql",
-        "version": "0.1.39",
+        "version": "0.1.40",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -2369,7 +2369,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.40",
+              "@jskit-ai/database-runtime": "0.1.41",
               "mysql2": "^3.11.2"
             },
             "dev": {}
@@ -2440,11 +2440,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.39",
+      "version": "0.1.40",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-postgres",
-        "version": "0.1.39",
+        "version": "0.1.40",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -2534,7 +2534,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.40",
+              "@jskit-ai/database-runtime": "0.1.41",
               "pg": "^8.13.1"
             },
             "dev": {}
@@ -2605,11 +2605,11 @@
     },
     {
       "packageId": "@jskit-ai/http-runtime",
-      "version": "0.1.39",
+      "version": "0.1.40",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/http-runtime",
-        "version": "0.1.39",
+        "version": "0.1.40",
         "kind": "runtime",
         "dependsOn": [],
         "capabilities": {
@@ -2675,7 +2675,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.40",
+              "@jskit-ai/kernel": "0.1.41",
               "@fastify/type-provider-typebox": "^6.1.0",
               "typebox": "^1.0.81"
             },
@@ -2691,11 +2691,11 @@
     },
     {
       "packageId": "@jskit-ai/realtime",
-      "version": "0.1.39",
+      "version": "0.1.40",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/realtime",
-        "version": "0.1.39",
+        "version": "0.1.40",
         "kind": "runtime",
         "description": "Thin, generic realtime runtime wrappers for socket.io server and client.",
         "options": {
@@ -2790,7 +2790,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.40",
+              "@jskit-ai/kernel": "0.1.41",
               "@socket.io/redis-adapter": "^8.3.0",
               "redis": "^5.8.2",
               "socket.io": "^4.8.3",
@@ -2839,11 +2839,11 @@
     },
     {
       "packageId": "@jskit-ai/shell-web",
-      "version": "0.1.39",
+      "version": "0.1.40",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/shell-web",
-        "version": "0.1.39",
+        "version": "0.1.40",
         "kind": "runtime",
         "description": "Web shell layout runtime with outlet-based placement contributions.",
         "dependsOn": [],
@@ -2975,7 +2975,7 @@
             "runtime": {
               "@mdi/js": "^7.4.47",
               "@tanstack/vue-query": "^5.90.5",
-              "@jskit-ai/kernel": "0.1.40",
+              "@jskit-ai/kernel": "0.1.41",
               "vuetify": "^4.0.0"
             },
             "dev": {}
@@ -3160,11 +3160,11 @@
     },
     {
       "packageId": "@jskit-ai/storage-runtime",
-      "version": "0.1.39",
+      "version": "0.1.40",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/storage-runtime",
-        "version": "0.1.39",
+        "version": "0.1.40",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -3213,7 +3213,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.40",
+              "@jskit-ai/kernel": "0.1.41",
               "unstorage": "^1.17.3"
             },
             "dev": {}
@@ -3229,11 +3229,11 @@
     },
     {
       "packageId": "@jskit-ai/ui-generator",
-      "version": "0.1.23",
+      "version": "0.1.24",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/ui-generator",
-        "version": "0.1.23",
+        "version": "0.1.24",
         "kind": "generator",
         "description": "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
         "options": {
@@ -3532,7 +3532,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.55"
+              "@jskit-ai/users-web": "0.1.56"
             },
             "dev": {}
           },
@@ -3547,11 +3547,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-image-web",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-image-web",
-        "version": "0.1.18",
+        "version": "0.1.19",
         "kind": "runtime",
         "description": "Reusable client-side image upload runtime with pre-upload image editing.",
         "dependsOn": [
@@ -3615,7 +3615,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/uploads-runtime": "0.1.18",
+              "@jskit-ai/uploads-runtime": "0.1.19",
               "@uppy/compressor": "^3.1.0",
               "@uppy/core": "^5.2.0",
               "@uppy/dashboard": "^5.1.1",
@@ -3635,11 +3635,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-runtime",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-runtime",
-        "version": "0.1.18",
+        "version": "0.1.19",
         "kind": "runtime",
         "description": "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
         "dependsOn": [
@@ -3709,7 +3709,7 @@
           "dependencies": {
             "runtime": {
               "@fastify/multipart": "^9.4.0",
-              "@jskit-ai/kernel": "0.1.40"
+              "@jskit-ai/kernel": "0.1.41"
             },
             "dev": {}
           },
@@ -3724,11 +3724,11 @@
     },
     {
       "packageId": "@jskit-ai/users-core",
-      "version": "0.1.50",
+      "version": "0.1.51",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-core",
-        "version": "0.1.50",
+        "version": "0.1.51",
         "kind": "runtime",
         "description": "Users/account runtime plus HTTP routes for account features.",
         "dependsOn": [
@@ -3854,11 +3854,11 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.39",
-              "@jskit-ai/database-runtime": "0.1.40",
-              "@jskit-ai/http-runtime": "0.1.39",
-              "@jskit-ai/kernel": "0.1.40",
-              "@jskit-ai/uploads-runtime": "0.1.18",
+              "@jskit-ai/auth-core": "0.1.40",
+              "@jskit-ai/database-runtime": "0.1.41",
+              "@jskit-ai/http-runtime": "0.1.40",
+              "@jskit-ai/kernel": "0.1.41",
+              "@jskit-ai/uploads-runtime": "0.1.19",
               "@fastify/type-provider-typebox": "^6.1.0",
               "typebox": "^1.0.81"
             },
@@ -3942,11 +3942,11 @@
     },
     {
       "packageId": "@jskit-ai/users-web",
-      "version": "0.1.55",
+      "version": "0.1.56",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-web",
-        "version": "0.1.55",
+        "version": "0.1.56",
         "kind": "runtime",
         "description": "Users web module: account/profile UI plus shared users web widgets.",
         "dependsOn": [
@@ -4093,12 +4093,12 @@
             "runtime": {
               "@tanstack/vue-query": "5.92.12",
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/http-runtime": "0.1.39",
-              "@jskit-ai/realtime": "0.1.39",
-              "@jskit-ai/kernel": "0.1.40",
-              "@jskit-ai/shell-web": "0.1.39",
-              "@jskit-ai/uploads-image-web": "0.1.18",
-              "@jskit-ai/users-core": "0.1.50",
+              "@jskit-ai/http-runtime": "0.1.40",
+              "@jskit-ai/realtime": "0.1.40",
+              "@jskit-ai/kernel": "0.1.41",
+              "@jskit-ai/shell-web": "0.1.40",
+              "@jskit-ai/uploads-image-web": "0.1.19",
+              "@jskit-ai/users-core": "0.1.51",
               "vuetify": "^4.0.0"
             },
             "dev": {}
@@ -4185,11 +4185,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-core",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-core",
-        "version": "0.1.16",
+        "version": "0.1.17",
         "kind": "runtime",
         "description": "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
         "dependsOn": [
@@ -4298,7 +4298,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-core": "0.1.50"
+              "@jskit-ai/users-core": "0.1.51"
             },
             "dev": {}
           },
@@ -4488,11 +4488,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-web",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-web",
-        "version": "0.1.16",
+        "version": "0.1.17",
         "kind": "runtime",
         "description": "Workspace web module: workspace selector, tools widget, workspace surfaces, and members/settings UI.",
         "dependsOn": [
@@ -4634,8 +4634,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/workspaces-core": "0.1.16",
-              "@jskit-ai/users-web": "0.1.55",
+              "@jskit-ai/workspaces-core": "0.1.17",
+              "@jskit-ai/users-web": "0.1.56",
               "vuetify": "^4.0.0"
             },
             "dev": {}

--- a/tooling/jskit-catalog/package.json
+++ b/tooling/jskit-catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-catalog",
-  "version": "0.1.48",
+  "version": "0.1.49",
   "description": "Published metadata catalog for JSKIT package descriptors.",
   "type": "module",
   "files": [

--- a/tooling/jskit-cli/package.json
+++ b/tooling/jskit-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-cli",
-  "version": "0.2.49",
+  "version": "0.2.50",
   "description": "Bundle and package orchestration CLI for JSKIT apps.",
   "type": "module",
   "files": [
@@ -20,9 +20,9 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/jskit-catalog": "0.1.48",
-    "@jskit-ai/kernel": "0.1.40",
-    "@jskit-ai/shell-web": "0.1.39"
+    "@jskit-ai/jskit-catalog": "0.1.49",
+    "@jskit-ai/kernel": "0.1.41",
+    "@jskit-ai/shell-web": "0.1.40"
   },
   "engines": {
     "node": "20.x"


### PR DESCRIPTION
## Summary
- bump package and tooling versions across the monorepo for the latest package graph
- sync inter-package dependency versions in `package.json` and `package.descriptor.mjs`
- refresh `tooling/jskit-catalog/catalog/packages.json`, `package-lock.json`, and the new `packages/agent-docs/templates/app/AGENTS.md` template payload so shipped metadata matches the repo state

## Why
- the repo had another coordinated local release-sync change set that was not yet committed or merged
- manifests, descriptors, catalog output, lockfile state, and shipped templates need to move together to keep package metadata portable and consistent

## Testing
- not run (per request)