### PR TITLE
Fix workspace home menu labels

### DIFF
--- a/packages/agent-docs/guide/agent/generators/advanced-cruds.md
+++ b/packages/agent-docs/guide/agent/generators/advanced-cruds.md
@@ -509,6 +509,110 @@ The safe mental model is:
 - use `paths.page()` to get to the right surface
 - use CRUD runtime resolvers to move around inside the CRUD
 
+### Live actions and `useCommand()`
+
+There is one more client-side pattern worth naming explicitly:
+
+Use `useCommand()` for live actions such as:
+
+- checkboxes that toggle a record field
+- archive / publish / reopen buttons
+- delete buttons
+- small one-click PATCH / POST / DELETE actions that are not full forms
+
+This is the pattern the `todo` app uses for "mark item done".
+
+The page renders a checkbox like this:
+
+```vue
+<v-checkbox-btn
+  :model-value="item.done"
+  :disabled="!canUpdateItem || isItemBusy(item.id)"
+  @update:model-value="toggleItem(item, $event)"
+/>
+```
+
+Then the page wires a command:
+
+```js
+const itemPatchModel = reactive({
+  id: "",
+  patch: {}
+});
+
+const updateItemCommand = useCommand({
+  model: itemPatchModel,
+  apiSuffix: ({ model }) => `/todo-items/${model?.id || ""}`,
+  writeMethod: "PATCH",
+  runPermissions: ["crud.todo_items.update"],
+  suppressSuccessMessage: true,
+  fallbackRunError: "Unable to update item.",
+  buildRawPayload(model) {
+    return model.patch;
+  },
+  async onRunSuccess(_payload, context = {}) {
+    if (context.queryClient) {
+      await context.queryClient.invalidateQueries({
+        queryKey: ["ui-generator", "todo_items"]
+      });
+    }
+  }
+});
+
+async function toggleItem(item = {}, nextValue = false) {
+  itemPatchModel.id = String(item.id || "");
+  itemPatchModel.patch = {
+    done: Boolean(nextValue)
+  };
+
+  await updateItemCommand.run();
+}
+```
+
+That gives you a clean action pipeline:
+
+1. the UI captures the click
+2. the page writes a tiny action model
+3. `useCommand()` resolves the correct scoped API path for the current route/surface
+4. it sends the request through the standard HTTP runtime
+5. on success, it invalidates the relevant query keys so the list/view refreshes
+
+So yes: for this class of interaction, `useCommand()` is the right helper.
+
+Use this rule of thumb:
+
+- `useCommand()`
+  - for live actions
+  - button clicks
+  - toggles
+  - small PATCH/POST/DELETE interactions
+- `useAddEdit()` / `useCrudAddEdit()`
+  - for real forms
+  - create/edit screens
+  - save/cancel flows
+- `useCrudList()` / `useCrudView()`
+  - for routed list/view loading and CRUD URL resolution
+
+Best practices for live CRUD actions:
+
+- keep the payload narrow
+  - send the field change you mean, not a whole copied record
+- disable the control while the command for that record is running
+  - `todo` does this with `isItemBusy(item.id)`
+- invalidate the relevant list/view query keys on success
+  - do not hand-maintain parallel local record copies unless you really need optimistic UI
+- suppress success toasts for high-frequency actions when they would become noisy
+  - a checkbox toggle usually does not need "Saved." every time
+- keep business rules on the server
+  - in `todo`, the client sends `{ done: true|false }`
+  - the server service decides how `completedAt` should be set or cleared
+
+The safe mental model is:
+
+- use form runtimes for forms
+- use command runtimes for actions
+- keep the server as the source of truth for derived state
+
 ### `_components/CrudAddEditForm.vue`
 
 This is the shared rendering shell for the add/edit form.

--- a/packages/agent-docs/guide/agent/generators/crud-generators.md
+++ b/packages/agent-docs/guide/agent/generators/crud-generators.md
@@ -513,6 +513,27 @@ The host page then renders the comment list directly, usually with lower-level C
 - `useCrudAddEdit()`
 - `useCrudView()` when needed
 
+There is one more runtime worth knowing about early:
+
+- `useCommand()`
+
+Use it for live actions that are **not** full forms, such as:
+
+- checkbox toggles
+- archive / reopen buttons
+- quick PATCH / POST / DELETE actions on one record
+
+So the practical split is:
+
+- `useCrudList()` / `useCrudView()`
+  - routed list/view loading
+- `useCrudAddEdit()`
+  - real create/edit forms
+- `useCommand()`
+  - live actions inside the page
+
+The `todo` app uses that last pattern for "mark item done" checkboxes. The deeper best-practices explanation is in [Advanced CRUDs](/guide/generators/advanced-cruds).
+
 That is the same general pattern already used in the real app for embedded child records like pet notes: the record list lives inside the main view page, while routed child pages handle the operations that still deserve their own URLs.
 
 This pattern is useful when the child records are supporting detail rather than a destination in their own right.

--- a/packages/agent-docs/guide/human/generators/advanced-cruds.md
+++ b/packages/agent-docs/guide/human/generators/advanced-cruds.md
@@ -507,6 +507,110 @@ The safe mental model is:
 - use `paths.page()` to get to the right surface
 - use CRUD runtime resolvers to move around inside the CRUD
 
+### Live actions and `useCommand()`
+
+There is one more client-side pattern worth naming explicitly:
+
+Use `useCommand()` for live actions such as:
+
+- checkboxes that toggle a record field
+- archive / publish / reopen buttons
+- delete buttons
+- small one-click PATCH / POST / DELETE actions that are not full forms
+
+This is the pattern the `todo` app uses for "mark item done".
+
+The page renders a checkbox like this:
+
+```vue
+<v-checkbox-btn
+  :model-value="item.done"
+  :disabled="!canUpdateItem || isItemBusy(item.id)"
+  @update:model-value="toggleItem(item, $event)"
+/>
+```
+
+Then the page wires a command:
+
+```js
+const itemPatchModel = reactive({
+  id: "",
+  patch: {}
+});
+
+const updateItemCommand = useCommand({
+  model: itemPatchModel,
+  apiSuffix: ({ model }) => `/todo-items/${model?.id || ""}`,
+  writeMethod: "PATCH",
+  runPermissions: ["crud.todo_items.update"],
+  suppressSuccessMessage: true,
+  fallbackRunError: "Unable to update item.",
+  buildRawPayload(model) {
+    return model.patch;
+  },
+  async onRunSuccess(_payload, context = {}) {
+    if (context.queryClient) {
+      await context.queryClient.invalidateQueries({
+        queryKey: ["ui-generator", "todo_items"]
+      });
+    }
+  }
+});
+
+async function toggleItem(item = {}, nextValue = false) {
+  itemPatchModel.id = String(item.id || "");
+  itemPatchModel.patch = {
+    done: Boolean(nextValue)
+  };
+
+  await updateItemCommand.run();
+}
+```
+
+That gives you a clean action pipeline:
+
+1. the UI captures the click
+2. the page writes a tiny action model
+3. `useCommand()` resolves the correct scoped API path for the current route/surface
+4. it sends the request through the standard HTTP runtime
+5. on success, it invalidates the relevant query keys so the list/view refreshes
+
+So yes: for this class of interaction, `useCommand()` is the right helper.
+
+Use this rule of thumb:
+
+- `useCommand()`
+  - for live actions
+  - button clicks
+  - toggles
+  - small PATCH/POST/DELETE interactions
+- `useAddEdit()` / `useCrudAddEdit()`
+  - for real forms
+  - create/edit screens
+  - save/cancel flows
+- `useCrudList()` / `useCrudView()`
+  - for routed list/view loading and CRUD URL resolution
+
+Best practices for live CRUD actions:
+
+- keep the payload narrow
+  - send the field change you mean, not a whole copied record
+- disable the control while the command for that record is running
+  - `todo` does this with `isItemBusy(item.id)`
+- invalidate the relevant list/view query keys on success
+  - do not hand-maintain parallel local record copies unless you really need optimistic UI
+- suppress success toasts for high-frequency actions when they would become noisy
+  - a checkbox toggle usually does not need "Saved." every time
+- keep business rules on the server
+  - in `todo`, the client sends `{ done: true|false }`
+  - the server service decides how `completedAt` should be set or cleared
+
+The safe mental model is:
+
+- use form runtimes for forms
+- use command runtimes for actions
+- keep the server as the source of truth for derived state
+
 ### `_components/CrudAddEditForm.vue`
 
 This is the shared rendering shell for the add/edit form.

--- a/packages/agent-docs/guide/human/generators/crud-generators.md
+++ b/packages/agent-docs/guide/human/generators/crud-generators.md
@@ -511,6 +511,27 @@ The host page then renders the comment list directly, usually with lower-level C
 - `useCrudAddEdit()`
 - `useCrudView()` when needed
 
+There is one more runtime worth knowing about early:
+
+- `useCommand()`
+
+Use it for live actions that are **not** full forms, such as:
+
+- checkbox toggles
+- archive / reopen buttons
+- quick PATCH / POST / DELETE actions on one record
+
+So the practical split is:
+
+- `useCrudList()` / `useCrudView()`
+  - routed list/view loading
+- `useCrudAddEdit()`
+  - real create/edit forms
+- `useCommand()`
+  - live actions inside the page
+
+The `todo` app uses that last pattern for "mark item done" checkboxes. The deeper best-practices explanation is in [Advanced CRUDs](/guide/generators/advanced-cruds).
+
 That is the same general pattern already used in the real app for embedded child records like pet notes: the record list lives inside the main view page, while routed child pages handle the operations that still deserve their own URLs.
 
 This pattern is useful when the child records are supporting detail rather than a destination in their own right.

--- a/packages/shell-web/package.descriptor.mjs
+++ b/packages/shell-web/package.descriptor.mjs
@@ -87,7 +87,7 @@ export default Object.freeze({
           {
             id: "shell-web.home.menu.home",
             target: "shell-layout:primary-menu",
-            surfaces: ["*"],
+            surfaces: ["home"],
             order: 50,
             componentToken: "local.main.ui.surface-aware-menu-link-item",
             source: "templates/src/placement.js"

--- a/packages/shell-web/templates/src/placement.js
+++ b/packages/shell-web/templates/src/placement.js
@@ -14,7 +14,7 @@ export default function getPlacements() {
 addPlacement({
   id: "shell-web.home.menu.home",
   target: "shell-layout:primary-menu",
-  surfaces: ["*"],
+  surfaces: ["home"],
   order: 50,
   componentToken: "local.main.ui.surface-aware-menu-link-item",
   props: {

--- a/packages/shell-web/test/settingsPlacementContract.test.js
+++ b/packages/shell-web/test/settingsPlacementContract.test.js
@@ -65,6 +65,7 @@ test("shell-web placement template seeds default Home and Settings drawer naviga
 
   assert.match(source, /id: "shell-web\.home\.menu\.home"/);
   assert.match(source, /target: "shell-layout:primary-menu"/);
+  assert.match(source, /surfaces: \["home"\]/);
   assert.match(source, /label: "Home"/);
   assert.match(source, /unscopedSuffix: "\/"/);
   assert.match(source, /id: "shell-web\.home\.menu\.settings"/);
@@ -96,7 +97,7 @@ test("shell-web descriptor metadata advertises home settings outlets, default dr
       {
         id: "shell-web.home.menu.home",
         target: "shell-layout:primary-menu",
-        surfaces: ["*"],
+        surfaces: ["home"],
         order: 50,
         componentToken: "local.main.ui.surface-aware-menu-link-item",
         source: "templates/src/placement.js"

--- a/packages/workspaces-web/package.descriptor.mjs
+++ b/packages/workspaces-web/package.descriptor.mjs
@@ -72,6 +72,24 @@ export default Object.freeze({
         ],
         contributions: [
           {
+            id: "workspaces.workspace.menu.app",
+            target: "shell-layout:primary-menu",
+            surfaces: ["app"],
+            order: 50,
+            componentToken: "local.main.ui.surface-aware-menu-link-item",
+            when: "auth.authenticated === true",
+            source: "mutations.text#workspaces-web-placement-block"
+          },
+          {
+            id: "workspaces.workspace.menu.admin",
+            target: "shell-layout:primary-menu",
+            surfaces: ["admin"],
+            order: 60,
+            componentToken: "local.main.ui.surface-aware-menu-link-item",
+            when: "auth.authenticated === true",
+            source: "mutations.text#workspaces-web-placement-block"
+          },
+          {
             id: "workspaces.profile.menu.surface-switch",
             target: "auth-profile-menu:primary-menu",
             surfaces: ["*"],
@@ -280,7 +298,7 @@ export default Object.freeze({
         file: "src/placement.js",
         position: "bottom",
         skipIfContains: "id: \"workspaces.workspace.selector\"",
-        value: "\naddPlacement({\n  id: \"workspaces.workspace.selector\",\n  target: \"shell-layout:top-left\",\n  surfaces: [\"*\"],\n  order: 200,\n  componentToken: \"workspaces.web.workspace.selector\",\n  props: {\n    allowOnNonWorkspaceSurface: true,\n    targetSurfaceId: \"app\"\n  },\n  when: ({ auth }) => {\n    return Boolean(auth?.authenticated);\n  }\n});\n\naddPlacement({\n  id: \"workspaces.account.invites.cue\",\n  target: \"shell-layout:top-right\",\n  surfaces: [\"*\"],\n  order: 850,\n  componentToken: \"local.main.account.pending-invites.cue\",\n  when: ({ auth }) => Boolean(auth?.authenticated)\n});\n\naddPlacement({\n  id: \"workspaces.workspace.tools.widget\",\n  target: \"shell-layout:top-right\",\n  surfaces: [\"admin\"],\n  order: 900,\n  componentToken: \"workspaces.web.workspace.tools.widget\"\n});\n\naddPlacement({\n  id: \"workspaces.workspace.menu.workspace-settings\",\n  target: \"workspace-tools:primary-menu\",\n  surfaces: [\"admin\"],\n  order: 100,\n  componentToken: \"workspaces.web.workspace-settings.menu-item\"\n});\n\naddPlacement({\n  id: \"workspaces.workspace.menu.members\",\n  target: \"workspace-tools:primary-menu\",\n  surfaces: [\"admin\"],\n  order: 200,\n  componentToken: \"workspaces.web.workspace-members.menu-item\"\n});\n",
+        value: "\naddPlacement({\n  id: \"workspaces.workspace.menu.app\",\n  target: \"shell-layout:primary-menu\",\n  surfaces: [\"app\"],\n  order: 50,\n  componentToken: \"local.main.ui.surface-aware-menu-link-item\",\n  props: {\n    label: \"Home\",\n    surface: \"app\",\n    scopedSuffix: \"/\",\n    unscopedSuffix: \"/\",\n    exact: true\n  },\n  when: ({ auth }) => Boolean(auth?.authenticated)\n});\n\naddPlacement({\n  id: \"workspaces.workspace.menu.admin\",\n  target: \"shell-layout:primary-menu\",\n  surfaces: [\"admin\"],\n  order: 60,\n  componentToken: \"local.main.ui.surface-aware-menu-link-item\",\n  props: {\n    label: \"Home\",\n    surface: \"admin\",\n    scopedSuffix: \"/\",\n    unscopedSuffix: \"/\",\n    exact: true\n  },\n  when: ({ auth }) => Boolean(auth?.authenticated)\n});\n\naddPlacement({\n  id: \"workspaces.workspace.selector\",\n  target: \"shell-layout:top-left\",\n  surfaces: [\"*\"],\n  order: 200,\n  componentToken: \"workspaces.web.workspace.selector\",\n  props: {\n    allowOnNonWorkspaceSurface: true,\n    targetSurfaceId: \"app\"\n  },\n  when: ({ auth }) => {\n    return Boolean(auth?.authenticated);\n  }\n});\n\naddPlacement({\n  id: \"workspaces.account.invites.cue\",\n  target: \"shell-layout:top-right\",\n  surfaces: [\"*\"],\n  order: 850,\n  componentToken: \"local.main.account.pending-invites.cue\",\n  when: ({ auth }) => Boolean(auth?.authenticated)\n});\n\naddPlacement({\n  id: \"workspaces.workspace.tools.widget\",\n  target: \"shell-layout:top-right\",\n  surfaces: [\"admin\"],\n  order: 900,\n  componentToken: \"workspaces.web.workspace.tools.widget\"\n});\n\naddPlacement({\n  id: \"workspaces.workspace.menu.workspace-settings\",\n  target: \"workspace-tools:primary-menu\",\n  surfaces: [\"admin\"],\n  order: 100,\n  componentToken: \"workspaces.web.workspace-settings.menu-item\"\n});\n\naddPlacement({\n  id: \"workspaces.workspace.menu.members\",\n  target: \"workspace-tools:primary-menu\",\n  surfaces: [\"admin\"],\n  order: 200,\n  componentToken: \"workspaces.web.workspace-members.menu-item\"\n});\n",
         reason: "Append workspace placement entries into app-owned placement registry.",
         category: "workspaces-web",
         id: "workspaces-web-placement-block",

--- a/packages/workspaces-web/test/settingsPlacementContract.test.js
+++ b/packages/workspaces-web/test/settingsPlacementContract.test.js
@@ -22,6 +22,13 @@ function findContribution(id) {
     : null;
 }
 
+function findTextMutation(id) {
+  const textMutations = descriptor?.mutations?.text;
+  return Array.isArray(textMutations)
+    ? textMutations.find((entry) => String(entry?.id || "").trim() === id) || null
+    : null;
+}
+
 function findFileMutation(id) {
   const fileMutations = descriptor?.mutations?.files;
   return Array.isArray(fileMutations)
@@ -63,6 +70,26 @@ test("workspaces-web descriptor metadata advertises admin settings outlets", () 
     ]
   );
   assert.equal(findContribution("workspaces.workspace.settings.general"), null);
+  assert.deepEqual(findContribution("workspaces.workspace.menu.app"), {
+    id: "workspaces.workspace.menu.app",
+    target: "shell-layout:primary-menu",
+    surfaces: ["app"],
+    order: 50,
+    componentToken: "local.main.ui.surface-aware-menu-link-item",
+    when: "auth.authenticated === true",
+    source: "mutations.text#workspaces-web-placement-block"
+  });
+  assert.deepEqual(findContribution("workspaces.workspace.menu.admin"), {
+    id: "workspaces.workspace.menu.admin",
+    target: "shell-layout:primary-menu",
+    surfaces: ["admin"],
+    order: 60,
+    componentToken: "local.main.ui.surface-aware-menu-link-item",
+    when: "auth.authenticated === true",
+    source: "mutations.text#workspaces-web-placement-block"
+  });
+  assert.match(findTextMutation("workspaces-web-placement-block")?.value || "", /id: "workspaces\.workspace\.menu\.app"[\s\S]*surfaces: \["app"\][\s\S]*label: "Home"/);
+  assert.match(findTextMutation("workspaces-web-placement-block")?.value || "", /id: "workspaces\.workspace\.menu\.admin"[\s\S]*surfaces: \["admin"\][\s\S]*label: "Home"/);
   assert.deepEqual(findContribution("workspaces.profile.menu.surface-switch"), {
     id: "workspaces.profile.menu.surface-switch",
     target: "auth-profile-menu:primary-menu",


### PR DESCRIPTION
## Summary
- scope shell and workspace root menu entries to the surfaces they belong to
- relabel workspace root menu entries to `Home`
- publish the staged CRUD guide additions around `useCommand()`

## Notes
- not running repo-wide verify in this PR flow
- not waiting for GitHub checks