### PR TITLE
Refresh agent-docs site homepage and add AI-focused landing pages

### DIFF
--- a/packages/agent-docs/site/.vitepress/config.mjs
+++ b/packages/agent-docs/site/.vitepress/config.mjs
@@ -12,6 +12,8 @@ export default defineConfig({
   themeConfig: {
     siteTitle: "JSKIT",
     nav: [
+      { text: "AI Ready", link: "/ai-ready" },
+      { text: "Vibe Guide", link: "/vibe-guide" },
       { text: "Guide", link: "/guide/" },
       { text: "GitHub", link: "https://github.com/mobily-enterprises/jskit-ai" }
     ],

--- a/packages/agent-docs/site/.vitepress/theme/custom.css
+++ b/packages/agent-docs/site/.vitepress/theme/custom.css
@@ -1,4 +1,4 @@
-@import url("https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;800&family=Bricolage+Grotesque:wght@700;800&family=IBM+Plex+Mono:wght@400;500;600&display=swap");
 
 :root {
   --vp-font-family-base: "Archivo", "Avenir Next", "Trebuchet MS", sans-serif;
@@ -126,6 +126,791 @@ html.dark .VPNavBar .VPNavBarMenuLink:hover {
 
 html.dark .VPNavScreen {
   background-color: rgba(8, 14, 22, 0.98);
+}
+
+.why-jskit-page {
+  --why-bg: #f6f6ef;
+  --why-panel: rgba(255, 255, 255, 0.82);
+  --why-panel-strong: #fffdf8;
+  --why-text: #131313;
+  --why-muted: #5b5b53;
+  --why-line: rgba(19, 19, 19, 0.12);
+  --why-teal: #0f766e;
+  --why-ink: #0f172a;
+  --why-clay: #c96b32;
+  --why-mustard: #d9a400;
+  --why-paper-shadow: 0 28px 70px rgba(28, 25, 23, 0.08);
+  color: var(--why-text);
+  background:
+    radial-gradient(1100px 500px at 0% 0%, rgba(15, 118, 110, 0.11), transparent 58%),
+    radial-gradient(900px 460px at 100% 8%, rgba(201, 107, 50, 0.11), transparent 54%),
+    linear-gradient(180deg, #f8f6ef 0%, #fdfcf8 48%, #f3efe5 100%);
+  border: 1px solid rgba(19, 19, 19, 0.04);
+  border-radius: 36px;
+  width: min(1180px, calc(100vw - 2rem));
+  max-width: none;
+  position: relative;
+  left: 50%;
+  margin: 0.5rem 0 2rem;
+  padding: 1.1rem;
+  overflow: hidden;
+  transform: translateX(-50%);
+}
+
+.why-jskit-page section {
+  position: relative;
+  overflow: hidden;
+  border-radius: 28px;
+  margin: 0 0 1rem;
+}
+
+.why-jskit-hero,
+.why-jskit-wall,
+.why-jskit-close {
+  padding: 1.6rem;
+}
+
+.why-jskit-kicker {
+  margin: 0 0 0.75rem;
+  color: var(--why-teal);
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.79rem;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.why-jskit-hero {
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.9), rgba(251, 247, 236, 0.96)),
+    linear-gradient(180deg, rgba(15, 118, 110, 0.06), transparent);
+  border: 1px solid rgba(19, 19, 19, 0.08);
+  box-shadow: var(--why-paper-shadow);
+}
+
+.why-jskit-title-stack {
+  display: grid;
+  gap: 0.1em;
+  margin-bottom: 1rem;
+  line-height: 0.88;
+  font-family: "Bricolage Grotesque", var(--vp-font-family-base);
+  font-size: clamp(3.6rem, 12vw, 8.6rem);
+  font-weight: 800;
+  letter-spacing: -0.08em;
+}
+
+.why-jskit-title-stack div:nth-child(1) {
+  color: #0f172a;
+}
+
+.why-jskit-title-stack div:nth-child(2) {
+  color: var(--why-clay);
+  padding-left: 0.45em;
+}
+
+.why-jskit-title-stack div:nth-child(3) {
+  color: #8f8a7e;
+  padding-left: 0.12em;
+}
+
+.why-jskit-title-stack div:nth-child(4) {
+  color: var(--why-teal);
+}
+
+.why-jskit-lead {
+  max-width: 56rem;
+  margin: 0;
+  font-size: clamp(1.18rem, 2vw, 1.55rem);
+  line-height: 1.55;
+}
+
+.why-jskit-signal-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+  margin-top: 1.4rem;
+}
+
+.why-jskit-signal-row span {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.45rem 0.78rem;
+  border: 1px solid rgba(19, 19, 19, 0.1);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.7);
+  color: var(--why-ink);
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.8rem;
+  text-transform: lowercase;
+}
+
+.why-jskit-quote-band {
+  padding: 1.2rem 1.5rem;
+  background: linear-gradient(90deg, rgba(15, 118, 110, 0.92), rgba(19, 78, 74, 0.92));
+  color: #effffb;
+}
+
+.why-jskit-quote-band p {
+  margin: 0;
+  font-size: clamp(1.35rem, 3vw, 2.25rem);
+  font-weight: 700;
+  line-height: 1.15;
+}
+
+.why-jskit-quote-band span {
+  display: block;
+  color: #abfaec;
+}
+
+.why-jskit-grid {
+  display: grid;
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.why-jskit-card {
+  grid-column: span 4;
+  padding: 1.25rem;
+  background: var(--why-panel);
+  border: 1px solid var(--why-line);
+  box-shadow: var(--why-paper-shadow);
+  backdrop-filter: blur(14px);
+}
+
+.why-jskit-card--xl {
+  grid-column: span 8;
+}
+
+.why-jskit-card--wide {
+  grid-column: span 8;
+}
+
+.why-jskit-card--accent {
+  background:
+    linear-gradient(180deg, rgba(242, 248, 247, 0.96), rgba(254, 251, 246, 0.96));
+}
+
+.why-jskit-card-label {
+  margin: 0 0 0.75rem;
+  color: var(--why-muted);
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.76rem;
+  letter-spacing: 0.15em;
+}
+
+.why-jskit-card h2,
+.why-jskit-bento-card h2,
+.why-jskit-wall h2 {
+  margin: 0 0 0.7rem;
+  font-size: clamp(1.2rem, 2vw, 1.95rem);
+  line-height: 1.05;
+  letter-spacing: -0.04em;
+}
+
+.why-jskit-card p,
+.why-jskit-bento-card p,
+.why-jskit-wall p,
+.why-jskit-wall li {
+  margin: 0;
+  color: var(--why-muted);
+  line-height: 1.6;
+}
+
+.why-jskit-wall {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  gap: 1rem;
+  background: linear-gradient(135deg, #121212, #1d2d2a 70%, #7f4822 140%);
+  color: #fffdf8;
+}
+
+.why-jskit-wall h2 {
+  margin-bottom: 0.8rem;
+  color: #fffdf8;
+  font-size: clamp(2rem, 4vw, 3.8rem);
+}
+
+.why-jskit-wall h2 span {
+  display: block;
+  color: #8ff1e0;
+  font-size: 1.1em;
+}
+
+.why-jskit-wall p,
+.why-jskit-wall li {
+  color: rgba(255, 253, 248, 0.82);
+}
+
+.why-jskit-wall-list {
+  align-self: end;
+  padding: 1.1rem 1.15rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.06);
+  backdrop-filter: blur(12px);
+}
+
+.why-jskit-wall-list ul {
+  margin: 0.9rem 0 0;
+  padding-left: 1.1rem;
+}
+
+.why-jskit-ai-ready {
+  padding: 1.4rem;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.9), rgba(247, 244, 235, 0.96)),
+    radial-gradient(900px 380px at 15% 0%, rgba(15, 118, 110, 0.1), transparent 58%),
+    radial-gradient(700px 300px at 100% 100%, rgba(201, 107, 50, 0.08), transparent 52%);
+  border: 1px solid rgba(19, 19, 19, 0.08);
+  box-shadow: var(--why-paper-shadow);
+}
+
+.why-jskit-ai-ready-head {
+  display: grid;
+  grid-template-columns: 1.15fr 1fr;
+  gap: 1rem;
+  align-items: end;
+  margin-bottom: 1.15rem;
+}
+
+.why-jskit-ai-ready-title {
+  display: grid;
+  line-height: 0.86;
+  font-family: "Bricolage Grotesque", var(--vp-font-family-base);
+  font-size: clamp(3.1rem, 9vw, 7rem);
+  font-weight: 800;
+  letter-spacing: -0.08em;
+}
+
+.why-jskit-ai-ready-title span:first-child {
+  color: var(--why-clay);
+}
+
+.why-jskit-ai-ready-title span:last-child {
+  color: var(--why-teal);
+  padding-left: 0.18em;
+}
+
+.why-jskit-ai-ready-lead {
+  max-width: 34rem;
+  margin: 0;
+  align-self: center;
+  font-size: 1.05rem;
+  line-height: 1.65;
+}
+
+.why-jskit-ai-ready-grid {
+  display: grid;
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.why-jskit-ai-ready-card {
+  grid-column: span 4;
+  padding: 1.15rem;
+  border: 1px solid rgba(19, 19, 19, 0.08);
+  border-radius: 22px;
+  background: rgba(255, 255, 255, 0.76);
+  box-shadow: 0 16px 38px rgba(28, 25, 23, 0.06);
+  backdrop-filter: blur(10px);
+}
+
+.why-jskit-ai-ready-card--hero {
+  grid-column: span 8;
+  background:
+    linear-gradient(145deg, rgba(15, 118, 110, 0.1), rgba(255, 255, 255, 0.82) 52%),
+    rgba(255, 255, 255, 0.84);
+}
+
+.why-jskit-ai-ready-card h2 {
+  margin: 0 0 0.65rem;
+  font-size: clamp(1.15rem, 1.8vw, 1.8rem);
+  line-height: 1.08;
+  letter-spacing: -0.04em;
+}
+
+.why-jskit-ai-ready-card p {
+  margin: 0;
+  color: var(--why-muted);
+  line-height: 1.6;
+}
+
+.why-jskit-ai-ready-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+  margin-top: 1.1rem;
+}
+
+.why-jskit-ai-ready-strip div {
+  padding: 0.54rem 0.8rem;
+  border-radius: 999px;
+  border: 1px solid rgba(19, 19, 19, 0.08);
+  background: rgba(255, 255, 255, 0.72);
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.78rem;
+  color: var(--why-ink);
+  text-transform: lowercase;
+}
+
+.why-jskit-ai-ready-note {
+  margin-top: 1rem;
+  padding: 1rem 1.1rem;
+  border-radius: 22px;
+  background: linear-gradient(90deg, rgba(15, 118, 110, 0.92), rgba(11, 94, 89, 0.92));
+  color: #effffb;
+}
+
+.why-jskit-ai-ready-note p {
+  margin: 0;
+  font-size: clamp(1rem, 2vw, 1.35rem);
+  line-height: 1.35;
+}
+
+.why-jskit-ai-ready-note strong {
+  color: #ffffff;
+}
+
+.vibe-guide-page {
+  width: min(980px, calc(100vw - 2rem));
+}
+
+.vibe-guide-intro,
+.vibe-guide-section,
+.vibe-guide-close {
+  padding: 1.35rem 1.45rem;
+  border: 1px solid rgba(19, 19, 19, 0.08);
+  background: rgba(255, 255, 255, 0.86);
+  box-shadow: var(--why-paper-shadow);
+}
+
+.vibe-guide-intro {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.92), rgba(250, 247, 239, 0.98)),
+    radial-gradient(760px 280px at 100% 0%, rgba(15, 118, 110, 0.08), transparent 58%);
+}
+
+.vibe-guide-intro h1,
+.vibe-guide-section h2 {
+  margin: 0 0 0.7rem;
+  font-size: clamp(1.8rem, 3.2vw, 3.2rem);
+  line-height: 1;
+  letter-spacing: -0.05em;
+}
+
+.vibe-guide-section h2 {
+  font-size: clamp(1.35rem, 2.4vw, 2.25rem);
+}
+
+.vibe-guide-intro-lead,
+.vibe-guide-section > p {
+  margin: 0;
+  color: var(--why-muted);
+  line-height: 1.68;
+}
+
+.vibe-guide-inline-note {
+  margin: 0.95rem 0 0;
+  padding: 0.85rem 1rem;
+  border-left: 4px solid rgba(15, 118, 110, 0.5);
+  border-radius: 0 14px 14px 0;
+  background: rgba(15, 118, 110, 0.08);
+  color: var(--why-ink);
+  line-height: 1.62;
+}
+
+.vibe-guide-checklist,
+.vibe-guide-service-grid,
+.vibe-guide-cheatsheet-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.vibe-guide-checklist {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin-top: 0.85rem;
+}
+
+.vibe-guide-service-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-top: 0.85rem;
+}
+
+.vibe-guide-panel,
+.vibe-guide-cheatsheet-card {
+  padding: 1rem 1.05rem;
+  border-radius: 18px;
+  border: 1px solid rgba(19, 19, 19, 0.08);
+  background: rgba(255, 255, 255, 0.78);
+}
+
+.vibe-guide-panel h3,
+.vibe-guide-cheatsheet-card h3 {
+  margin: 0 0 0.6rem;
+  font-size: 1.05rem;
+  line-height: 1.2;
+}
+
+.vibe-guide-panel p,
+.vibe-guide-panel li,
+.vibe-guide-cheatsheet-card p,
+.vibe-guide-bullets li {
+  color: var(--why-muted);
+  line-height: 1.64;
+}
+
+.vibe-guide-panel p,
+.vibe-guide-cheatsheet-card p {
+  margin: 0;
+}
+
+.vibe-guide-panel ul,
+.vibe-guide-panel ol,
+.vibe-guide-bullets {
+  margin: 0.75rem 0 0;
+  padding-left: 1.15rem;
+}
+
+.vibe-guide-panel li + li,
+.vibe-guide-bullets li + li {
+  margin-top: 0.25rem;
+}
+
+.vibe-guide-command {
+  margin: 0.9rem 0 0;
+  padding: 0.95rem 1rem;
+  overflow-x: auto;
+  border-radius: 14px;
+  border: 1px solid rgba(15, 118, 110, 0.16);
+  background: linear-gradient(180deg, #132226, #0f1b1f);
+  color: #d7fffa;
+}
+
+.vibe-guide-command code {
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.9rem;
+  white-space: pre;
+}
+
+.vibe-guide-section--muted {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.88), rgba(254, 248, 239, 0.96)),
+    radial-gradient(600px 260px at 50% 0%, rgba(15, 118, 110, 0.08), transparent 58%);
+}
+
+.vibe-guide-cheatsheet-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-top: 0.85rem;
+}
+
+.vibe-guide-cheatsheet-card code {
+  font-size: 0.88rem;
+}
+
+.why-jskit-bento {
+  display: grid;
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.why-jskit-bento-card {
+  grid-column: span 4;
+  padding: 1.25rem;
+  background: var(--why-panel-strong);
+  border: 1px dashed rgba(19, 19, 19, 0.14);
+  box-shadow: var(--why-paper-shadow);
+}
+
+.why-jskit-bento-card--big {
+  grid-column: span 5;
+}
+
+.why-jskit-bento-card--quote {
+  grid-column: span 3;
+  display: flex;
+  align-items: center;
+  background: linear-gradient(160deg, #f0a22e, #f7d15f);
+  color: #271800;
+}
+
+.why-jskit-bento-card--quote p {
+  color: #271800;
+  font-size: 1.22rem;
+  font-weight: 700;
+  line-height: 1.15;
+}
+
+.why-jskit-bento-card--quote span {
+  display: block;
+  margin-top: 0.45rem;
+}
+
+.why-jskit-bento-card ul {
+  margin: 0.7rem 0 0;
+  padding-left: 1.1rem;
+}
+
+.why-jskit-close {
+  text-align: center;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.88), rgba(254, 248, 239, 0.96)),
+    radial-gradient(500px 300px at 50% 10%, rgba(15, 118, 110, 0.12), transparent 60%);
+  border: 1px solid rgba(19, 19, 19, 0.08);
+  box-shadow: var(--why-paper-shadow);
+}
+
+.why-jskit-close-top,
+.why-jskit-close-bottom {
+  margin: 0;
+  color: var(--why-muted);
+}
+
+.why-jskit-close h2 {
+  margin: 0.35rem 0 0.55rem;
+  font-size: clamp(2.5rem, 5vw, 5.2rem);
+  line-height: 0.95;
+  letter-spacing: -0.08em;
+}
+
+.why-jskit-close-actions {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+  margin-top: 1.35rem;
+}
+
+.why-jskit-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 12rem;
+  padding: 0.86rem 1.15rem;
+  border-radius: 999px;
+  font-weight: 700;
+  text-decoration: none;
+  transition: transform 180ms ease, box-shadow 180ms ease, background-color 180ms ease;
+}
+
+.why-jskit-button:hover {
+  transform: translateY(-2px);
+}
+
+.why-jskit-button--primary {
+  background: var(--why-teal);
+  color: #f8fffd;
+  box-shadow: 0 18px 36px rgba(15, 118, 110, 0.24);
+}
+
+.why-jskit-button--ghost {
+  border: 1px solid rgba(19, 19, 19, 0.12);
+  color: var(--why-ink);
+  background: rgba(255, 255, 255, 0.8);
+}
+
+.why-jskit-page section {
+  opacity: 0;
+  transform: translateY(20px);
+  animation: whyPageRise 720ms ease forwards;
+}
+
+.why-jskit-page section:nth-child(2) { animation-delay: 70ms; }
+.why-jskit-page section:nth-child(3) { animation-delay: 120ms; }
+.why-jskit-page section:nth-child(4) { animation-delay: 180ms; }
+.why-jskit-page section:nth-child(5) { animation-delay: 230ms; }
+.why-jskit-page section:nth-child(6) { animation-delay: 280ms; }
+
+@keyframes whyPageRise {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+html.dark .why-jskit-page {
+  --why-panel: rgba(15, 23, 30, 0.76);
+  --why-panel-strong: rgba(17, 24, 31, 0.9);
+  --why-text: #f8fafc;
+  --why-muted: #cbd5e1;
+  --why-line: rgba(248, 250, 252, 0.12);
+  --why-paper-shadow: 0 30px 80px rgba(2, 8, 23, 0.34);
+  background:
+    radial-gradient(1200px 500px at 0% 0%, rgba(15, 118, 110, 0.18), transparent 58%),
+    radial-gradient(800px 420px at 100% 5%, rgba(201, 107, 50, 0.16), transparent 50%),
+    linear-gradient(180deg, #091017 0%, #081018 45%, #0c1218 100%);
+}
+
+html.dark .why-jskit-hero,
+html.dark .why-jskit-close {
+  background:
+    linear-gradient(180deg, rgba(15, 23, 30, 0.88), rgba(11, 18, 27, 0.96)),
+    linear-gradient(180deg, rgba(15, 118, 110, 0.09), transparent);
+}
+
+html.dark .why-jskit-card--accent {
+  background:
+    linear-gradient(180deg, rgba(18, 32, 36, 0.96), rgba(19, 26, 35, 0.96)),
+    linear-gradient(135deg, rgba(45, 212, 191, 0.08), rgba(251, 146, 60, 0.06));
+}
+
+html.dark .why-jskit-title-stack div:nth-child(1) {
+  color: #f8fafc;
+}
+
+html.dark .why-jskit-title-stack div:nth-child(2) {
+  color: #fdba74;
+}
+
+html.dark .why-jskit-title-stack div:nth-child(3) {
+  color: #7dd3c7;
+}
+
+html.dark .why-jskit-title-stack div:nth-child(4) {
+  color: #5eead4;
+}
+
+html.dark .why-jskit-quote-band {
+  background: linear-gradient(90deg, rgba(20, 184, 166, 0.88), rgba(14, 165, 233, 0.88));
+  color: #081018;
+}
+
+html.dark .why-jskit-quote-band span {
+  color: #ecfeff;
+}
+
+html.dark .why-jskit-signal-row span,
+html.dark .why-jskit-button--ghost {
+  background: rgba(15, 23, 30, 0.72);
+  color: #f8fafc;
+  border-color: rgba(248, 250, 252, 0.12);
+}
+
+html.dark .why-jskit-wall {
+  background: linear-gradient(135deg, #0f172a, #0c2430 70%, #5f3417 140%);
+}
+
+html.dark .why-jskit-ai-ready {
+  background:
+    linear-gradient(180deg, rgba(14, 20, 29, 0.95), rgba(10, 16, 24, 0.98)),
+    radial-gradient(900px 360px at 20% 0%, rgba(45, 212, 191, 0.14), transparent 56%),
+    radial-gradient(800px 360px at 100% 100%, rgba(251, 146, 60, 0.12), transparent 52%);
+}
+
+html.dark .why-jskit-ai-ready-card {
+  background: rgba(13, 20, 28, 0.8);
+  border-color: rgba(248, 250, 252, 0.1);
+}
+
+html.dark .why-jskit-ai-ready-card--hero {
+  background:
+    linear-gradient(145deg, rgba(45, 212, 191, 0.1), rgba(13, 20, 28, 0.82) 52%),
+    rgba(13, 20, 28, 0.84);
+}
+
+html.dark .why-jskit-ai-ready-title span:first-child {
+  color: #fdba74;
+}
+
+html.dark .why-jskit-ai-ready-title span:last-child {
+  color: #5eead4;
+}
+
+html.dark .why-jskit-ai-ready-strip div {
+  background: rgba(15, 23, 30, 0.78);
+  border-color: rgba(248, 250, 252, 0.1);
+  color: #f8fafc;
+}
+
+html.dark .why-jskit-ai-ready-note {
+  background: linear-gradient(90deg, rgba(20, 184, 166, 0.9), rgba(14, 165, 233, 0.9));
+  color: #081018;
+}
+
+html.dark .why-jskit-ai-ready-note strong {
+  color: #081018;
+}
+
+html.dark .vibe-guide-intro,
+html.dark .vibe-guide-section,
+html.dark .vibe-guide-close {
+  background:
+    linear-gradient(180deg, rgba(14, 20, 29, 0.95), rgba(10, 16, 24, 0.98)),
+    radial-gradient(900px 340px at 10% 0%, rgba(45, 212, 191, 0.12), transparent 56%),
+    radial-gradient(700px 280px at 100% 100%, rgba(251, 146, 60, 0.1), transparent 52%);
+}
+
+html.dark .vibe-guide-inline-note {
+  background: rgba(45, 212, 191, 0.08);
+  border-left-color: rgba(94, 234, 212, 0.5);
+  color: #e2fdf8;
+}
+
+html.dark .vibe-guide-panel,
+html.dark .vibe-guide-cheatsheet-card {
+  background: rgba(13, 20, 28, 0.82);
+  border-color: rgba(248, 250, 252, 0.1);
+}
+
+html.dark .vibe-guide-command {
+  border-color: rgba(94, 234, 212, 0.18);
+  background: linear-gradient(180deg, #091317, #071015);
+}
+
+html.dark .why-jskit-bento-card--quote {
+  background: linear-gradient(160deg, #f59e0b, #facc15);
+}
+
+@media (max-width: 960px) {
+  .why-jskit-grid,
+  .why-jskit-bento,
+  .why-jskit-ai-ready-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .why-jskit-card,
+  .why-jskit-card--xl,
+  .why-jskit-card--wide,
+  .why-jskit-card--accent,
+  .why-jskit-bento-card,
+  .why-jskit-bento-card--big,
+  .why-jskit-bento-card--quote,
+  .why-jskit-ai-ready-card,
+  .why-jskit-ai-ready-card--hero {
+    grid-column: auto;
+  }
+
+  .why-jskit-wall {
+    grid-template-columns: 1fr;
+  }
+
+  .vibe-guide-checklist,
+  .vibe-guide-service-grid,
+  .vibe-guide-cheatsheet-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .why-jskit-page {
+    border-radius: 24px;
+    padding: 0.65rem;
+  }
+
+  .why-jskit-hero,
+  .why-jskit-wall,
+  .why-jskit-close,
+  .why-jskit-card,
+  .why-jskit-bento-card,
+  .why-jskit-quote-band,
+  .vibe-guide-intro,
+  .vibe-guide-section,
+  .vibe-guide-close {
+    padding: 1rem;
+  }
 }
 
 .docs-browser-shot {

--- a/packages/agent-docs/site/ai-ready.md
+++ b/packages/agent-docs/site/ai-ready.md
@@ -1,0 +1,132 @@
+---
+title: AI Ready
+description: Why JSKIT-AI works unusually well with AI agents.
+---
+
+<div class="why-jskit-page">
+
+<section class="why-jskit-hero">
+  <p class="why-jskit-kicker">AI Ready</p>
+  <div class="why-jskit-ai-ready-title">
+    <span>AI</span>
+    <span>READY</span>
+  </div>
+  <p class="why-jskit-lead">
+    JSKIT-AI is not “AI ready” because it says the word AI a lot.
+    It is AI ready because the framework gives the agent
+    <strong>structure</strong>,
+    <strong>memory</strong>,
+    <strong>reference material</strong>,
+    and <strong>review gates</strong>.
+  </p>
+  <div class="why-jskit-signal-row">
+    <span>predictable structure</span>
+    <span>function indexes</span>
+    <span>agents instructions</span>
+    <span>blueprints</span>
+    <span>workboards</span>
+    <span>deslop</span>
+    <span>review gates</span>
+  </div>
+</section>
+
+<section class="why-jskit-quote-band">
+  <p>
+    AI is only as good as the shape around it.
+    <span>JSKIT-AI gives that shape to the agent before it writes code.</span>
+  </p>
+</section>
+
+<section class="why-jskit-ai-ready">
+  <div class="why-jskit-ai-ready-head">
+    <p class="why-jskit-kicker">What makes it work</p>
+    <div class="why-jskit-ai-ready-title">
+      <span>LESS</span>
+      <span>CHAOS</span>
+    </div>
+    <p class="why-jskit-ai-ready-lead">
+      Most repos ask an AI to invent the working model of the app while it is coding.
+      JSKIT-AI gives that model to the agent up front.
+    </p>
+  </div>
+
+  <div class="why-jskit-ai-ready-grid">
+    <article class="why-jskit-ai-ready-card why-jskit-ai-ready-card--hero">
+      <p class="why-jskit-card-label">A</p>
+      <h2>The app itself is structured for AI</h2>
+      <p>
+        Surfaces, packages, routes, placements, and package-owned workflows give the agent a
+        predictable map of the application instead of a blank custom codebase with no boundaries.
+      </p>
+    </article>
+    <article class="why-jskit-ai-ready-card">
+      <p class="why-jskit-card-label">B</p>
+      <h2>Pre-built docs and function indexes</h2>
+      <p>
+        The agent gets AI-friendly guides, distributed workflow docs, and generated reference maps
+        so it can find what already exists before inventing another helper.
+      </p>
+    </article>
+    <article class="why-jskit-ai-ready-card">
+      <p class="why-jskit-card-label">C</p>
+      <h2>Detailed AGENTS instructions</h2>
+      <p>
+        The workflow is not left to chance. The instructions force visible checkpoints, scoping,
+        chunked delivery, review passes, and alignment with documented JSKIT best practices.
+      </p>
+    </article>
+    <article class="why-jskit-ai-ready-card">
+      <p class="why-jskit-card-label">D</p>
+      <h2>Blueprint + workboard memory</h2>
+      <p>
+        The agent is pushed to write down the app blueprint and the current workboard, so important
+        decisions do not disappear into chat history.
+      </p>
+    </article>
+    <article class="why-jskit-ai-ready-card">
+      <p class="why-jskit-card-label">E</p>
+      <h2>Package-owned defaults reduce guessing</h2>
+      <p>
+        JSKIT teaches the agent to assume standard package-owned workflows first and ask only about
+        overrides, instead of redesigning baseline behavior from scratch every time.
+      </p>
+    </article>
+    <article class="why-jskit-ai-ready-card">
+      <p class="why-jskit-card-label">F</p>
+      <h2>Generators reduce random hand-wiring</h2>
+      <p>
+        Server scaffolds, CRUD scaffolds, and UI generators keep the agent inside repeatable
+        patterns instead of encouraging improvised local architecture.
+      </p>
+    </article>
+  </div>
+  <div class="why-jskit-ai-ready-strip">
+    <div>less guessing</div>
+    <div>less repetition</div>
+    <div>less slop</div>
+    <div>more reuse</div>
+    <div>more review</div>
+    <div>more correct structure</div>
+  </div>
+  <div class="why-jskit-ai-ready-note">
+    <p>
+      The result is simple:
+      <strong>the AI is not improvising against chaos.</strong>
+      It is building inside a framework that already expects discipline.
+    </p>
+  </div>
+</section>
+
+<section class="why-jskit-close">
+  <p class="why-jskit-close-top">Structure for the app. Structure for the agent. Structure for the work.</p>
+  <h2>That is what makes AI usable.</h2>
+  <p class="why-jskit-close-bottom">
+    JSKIT-AI does not just make code generation possible. It makes it governable.
+  </p>
+  <div class="why-jskit-close-actions">
+    <a class="why-jskit-button why-jskit-button--primary" href="/">Back to home</a>
+    <a class="why-jskit-button why-jskit-button--ghost" href="/guide/">Read the guide</a>
+  </div>
+</section>
+
+</div>

--- a/packages/agent-docs/site/index.md
+++ b/packages/agent-docs/site/index.md
@@ -1,15 +1,212 @@
 ---
-layout: home
-
-hero:
-  name: JSKIT
-  text: A Full-Stack Framework for Real Apps
-  tagline: JSKIT generates the app, server, UI, CRUDs, and routing so you can focus on features.
-  actions:
-    - theme: brand
-      text: Read the guide
-      link: /guide/
-    - theme: brand
-      text: GitHub Repository
-      link: https://github.com/mobily-enterprises/jskit-ai
+title: Why JSKIT-AI
+description: Why JSKIT-AI is more than a stack.
 ---
+
+<div class="why-jskit-page">
+
+<section class="why-jskit-hero">
+  <p class="why-jskit-kicker">Why JSKIT-AI</p>
+  <div class="why-jskit-title-stack">
+    <div>NOT</div>
+    <div>JUST</div>
+    <div>A</div>
+    <div>STACK.</div>
+  </div>
+  <p class="why-jskit-lead">
+    JSKIT-AI does not stop at <code>Vue + Fastify + DB</code>. It gives you the
+    <strong>app shape</strong>, the <strong>package model</strong>, the
+    <strong>extension seams</strong>, the <strong>scaffolding workflows</strong>,
+    and the <strong>AI process</strong> to use all of it properly.
+  </p>
+  <div class="why-jskit-signal-row">
+    <span>surfaces</span>
+    <span>packages</span>
+    <span>workspaces</span>
+    <span>cruds</span>
+    <span>console</span>
+    <span>review</span>
+    <span>ai workflow</span>
+  </div>
+</section>
+
+<section class="why-jskit-quote-band">
+  <p>
+    Most tools give you primitives.
+    <span>JSKIT-AI gives you an application architecture.</span>
+  </p>
+</section>
+
+<section class="why-jskit-grid">
+  <article class="why-jskit-card why-jskit-card--xl">
+    <p class="why-jskit-card-label">01</p>
+    <h2>A real app architecture from day one</h2>
+    <p>
+      JSKIT starts with surfaces, routing structure, app-owned packages, and extension seams
+      instead of a blank project folder and a pile of conventions you have to invent yourself.
+    </p>
+  </article>
+
+  <article class="why-jskit-card">
+    <p class="why-jskit-card-label">02</p>
+    <h2>Installable product capabilities</h2>
+    <p>
+      Auth, users, console, workspaces, uploads, realtime, assistant, storage, and CRUD are
+      first-class JSKIT packages, not one-off integrations.
+    </p>
+  </article>
+
+  <article class="why-jskit-card">
+    <p class="why-jskit-card-label">03</p>
+    <h2>A package system that changes the app for you</h2>
+    <p>
+      Adding a JSKIT package does not just add dependencies. It can scaffold routes, config,
+      placements, runtime wiring, and app-owned files in the right places.
+    </p>
+  </article>
+
+  <article class="why-jskit-card why-jskit-card--accent">
+    <p class="why-jskit-card-label">04</p>
+    <h2>Multi-surface application structure</h2>
+    <p>
+      Public, auth, account, app, admin, and workspace-aware surfaces are already part of the
+      framework, so the app grows into a coherent shape instead of becoming a routing mess.
+    </p>
+  </article>
+
+  <article class="why-jskit-card">
+    <p class="why-jskit-card-label">05</p>
+    <h2>Workspace and multi-homing support</h2>
+    <p>
+      Personal workspaces, multi-workspace apps, membership, invites, selectors, and
+      workspace-aware navigation are already solved as framework concerns.
+    </p>
+  </article>
+
+  <article class="why-jskit-card">
+    <p class="why-jskit-card-label">06</p>
+    <h2>CRUDs that are part of the system</h2>
+    <p>
+      CRUD generators understand ownership, routing, resources, lookups, and UI structure.
+      You are not generating a table in isolation. You are extending the application model.
+    </p>
+  </article>
+  
+  <article class="why-jskit-card">
+    <p class="why-jskit-card-label">07</p>
+    <h2>A shell and placement model that stays sane</h2>
+    <p>
+      Features plug into known shell locations and extension points instead of hardcoding layout
+      logic across random pages.
+    </p>
+  </article>
+
+  <article class="why-jskit-card why-jskit-card--wide">
+    <p class="why-jskit-card-label">08</p>
+    <h2>Built-in seams for growth</h2>
+    <p>
+      Packages extend the app through stable boundaries, so new capability does not mean
+      collapsing into custom glue code. The architecture expects growth.
+    </p>
+  </article>
+</section>
+
+<section class="why-jskit-wall">
+  <div class="why-jskit-wall-copy">
+    <p class="why-jskit-kicker">This is the difference</p>
+    <h2>
+      You are not assembling
+      <span>an architecture</span>
+      out of loose parts.
+    </h2>
+    <p>
+      You are starting from one that already exists.
+    </p>
+  </div>
+  <div class="why-jskit-wall-list">
+    <div>
+      <strong>JSKIT gives you:</strong>
+    </div>
+    <ul>
+      <li>the app shape</li>
+      <li>the package model</li>
+      <li>the extension system</li>
+      <li>the scaffolding workflows</li>
+      <li>the workspace model</li>
+      <li>the CRUD model</li>
+      <li>the AI workflow to use all of it properly</li>
+    </ul>
+  </div>
+</section>
+
+<section class="why-jskit-bento">
+  <article class="why-jskit-bento-card why-jskit-bento-card--big">
+    <p class="why-jskit-kicker">What comes built in</p>
+    <h2>Structure for real apps</h2>
+    <ul>
+      <li>app-owned packages</li>
+      <li>surface-aware routing</li>
+      <li>account and admin areas</li>
+      <li>workspace-aware app structure</li>
+      <li>package-owned workflows</li>
+    </ul>
+  </article>
+
+  <article class="why-jskit-bento-card">
+    <p class="why-jskit-kicker">Speed</p>
+    <h2>Feature acceleration</h2>
+    <ul>
+      <li>CRUD server scaffolding</li>
+      <li>CRUD UI scaffolding</li>
+      <li>nested CRUD support</li>
+      <li>relationship-aware lookups</li>
+    </ul>
+  </article>
+
+  <article class="why-jskit-bento-card">
+    <p class="why-jskit-kicker">Product primitives</p>
+    <h2>Not one-off integrations</h2>
+    <ul>
+      <li>auth and users</li>
+      <li>console surfaces</li>
+      <li>uploads and storage</li>
+      <li>realtime</li>
+      <li>assistant</li>
+    </ul>
+  </article>
+
+  <article class="why-jskit-bento-card why-jskit-bento-card--quote">
+    <p>
+      “Framework value” is not the libraries.
+      <span>It is the shape they are forced into.</span>
+    </p>
+  </article>
+
+  <article class="why-jskit-bento-card">
+    <p class="why-jskit-kicker">Discipline</p>
+    <h2>AI that builds inside the framework</h2>
+    <ul>
+      <li>blueprinting before code</li>
+      <li>workboards for substantial work</li>
+      <li>chunked delivery</li>
+      <li>deslop passes</li>
+      <li>JSKIT audits</li>
+      <li>UI review against Material + Vuetify</li>
+    </ul>
+  </article>
+</section>
+
+<section class="why-jskit-close">
+  <p class="why-jskit-close-top">Less blank-page architecture. Less integration drift. Less AI slop.</p>
+  <h2>More app. Faster.</h2>
+  <p class="why-jskit-close-bottom">
+    JSKIT-AI gives you the hard parts that usually get rebuilt badly every single time.
+  </p>
+  <div class="why-jskit-close-actions">
+    <a class="why-jskit-button why-jskit-button--primary" href="/guide/">Read the guide</a>
+    <a class="why-jskit-button why-jskit-button--ghost" href="/vibe-guide">Vibe Guide</a>
+    <a class="why-jskit-button why-jskit-button--ghost" href="/ai-ready">See AI Ready</a>
+  </div>
+</section>
+
+</div>

--- a/packages/agent-docs/site/vibe-guide.md
+++ b/packages/agent-docs/site/vibe-guide.md
@@ -1,0 +1,167 @@
+---
+title: Vibe Guide
+description: How to vibe an app with JSKIT-AI, even if you are not a developer.
+---
+
+<div class="why-jskit-page vibe-guide-page">
+<section class="vibe-guide-intro">
+  <p class="why-jskit-kicker">Vibe Guide</p>
+  <h1>How to vibe an app with JSKIT-AI</h1>
+  <p class="vibe-guide-intro-lead">
+    This page is for people who are comfortable around computers but are not developers.
+    The AI can do a lot of the building, but you still need to set up the outside pieces and
+    answer the right questions clearly.
+  </p>
+  <p class="vibe-guide-inline-note">
+    <strong>Important:</strong> start by seeding a real JSKIT app. Without that scaffold, the AI
+    does not have the packaged instructions, docs, and structure it expects.
+  </p>
+</section>
+
+<section class="vibe-guide-section">
+  <h2>Before you start</h2>
+  <div class="vibe-guide-checklist">
+    <article class="vibe-guide-panel">
+      <h3>You should be comfortable with</h3>
+      <ul>
+        <li>running commands in a terminal</li>
+        <li>creating a MySQL or Postgres database</li>
+        <li>creating a Supabase project and copying a couple of values</li>
+        <li>creating an API key if your app will include an assistant</li>
+      </ul>
+    </article>
+    <article class="vibe-guide-panel">
+      <h3>You will probably need</h3>
+      <ul>
+        <li>a development database, not a production one</li>
+        <li>your Supabase project URL and publishable key</li>
+        <li>an assistant API key if the app will have AI features</li>
+        <li>the patience to answer setup questions properly before asking for features</li>
+      </ul>
+    </article>
+  </div>
+</section>
+
+<section class="vibe-guide-section">
+  <h2>Step 1. Seed the app with AI instructions</h2>
+  <p>
+    This is mandatory. It creates the app scaffold and installs the files that tell the AI how to
+    work inside a JSKIT app.
+  </p>
+  <pre class="vibe-guide-command"><code>npx @jskit-ai/create-app exampleapp --tenancy-mode none
+cd exampleapp
+npm install</code></pre>
+  <p class="vibe-guide-inline-note">
+    Use <code>none</code> here as the neutral starting point. The AI can later decide whether the
+    app should stay simple or move to personal workspaces or full multi-homing.
+  </p>
+</section>
+
+<section class="vibe-guide-section">
+  <h2>Step 2. Prepare the external services</h2>
+  <div class="vibe-guide-service-grid">
+    <article class="vibe-guide-panel">
+      <h3>Create a database</h3>
+      <p>JSKIT works with MySQL or Postgres.</p>
+      <ul>
+        <li>create the database</li>
+        <li>create or choose a database user</li>
+        <li>save the username, password, and database name</li>
+        <li>also keep host and port if they are not the usual local defaults</li>
+      </ul>
+    </article>
+    <article class="vibe-guide-panel">
+      <h3>Create a Supabase project if the app will have login</h3>
+      <ol>
+        <li>Go to <code>supabase.com</code> and create an account.</li>
+        <li>Create a new project.</li>
+        <li>Open the project dashboard.</li>
+        <li>Go to <code>Settings</code> → <code>API</code>.</li>
+        <li>Copy the Project URL.</li>
+        <li>Copy the publishable key.</li>
+      </ol>
+      <p>The AI will usually ask for <code>AUTH_SUPABASE_URL</code> and <code>AUTH_SUPABASE_PUBLISHABLE_KEY</code>.</p>
+    </article>
+    <article class="vibe-guide-panel">
+      <h3>Create an assistant API token if needed</h3>
+      <p>Skip this if the app does not need an assistant.</p>
+      <ul>
+        <li>recommended provider: <strong>DeepSeek</strong></li>
+        <li>create an API key in the provider dashboard</li>
+        <li>keep it ready before you start asking for assistant features</li>
+      </ul>
+    </article>
+  </div>
+</section>
+
+<section class="vibe-guide-section">
+  <h2>Step 3. Run Codex or Claude from inside the app folder</h2>
+  <p>Start your AI only after the app exists and <code>npm install</code> has finished.</p>
+  <pre class="vibe-guide-command"><code>codex
+claude</code></pre>
+  <p class="vibe-guide-inline-note">
+    Run one of them, not both. The important part is that you start inside the seeded app folder.
+  </p>
+</section>
+
+<section class="vibe-guide-section">
+  <h2>Step 4. Answer the setup questions clearly</h2>
+  <p>The AI will ask structural questions before it starts building. That is the right behavior.</p>
+  <ul class="vibe-guide-bullets">
+    <li>Is this a simple app or a workspace / multi-homing app?</li>
+    <li>Does it need login?</li>
+    <li>Does it need a database right away?</li>
+    <li>Does it need an assistant?</li>
+    <li>Is it an internal tool, a customer app, or something else?</li>
+  </ul>
+</section>
+
+<section class="vibe-guide-section">
+  <h2>Step 5. Ask for features one chunk at a time</h2>
+  <p>
+    Once setup is done, start building the real app. The best results come when you ask for one
+    feature or one CRUD at a time and let the AI scope it before coding.
+  </p>
+  <ul class="vibe-guide-bullets">
+    <li>start with the main screens and data model</li>
+    <li>let the AI ask follow-up questions</li>
+    <li>approve the scope before implementation</li>
+    <li>then grow the app chunk by chunk</li>
+  </ul>
+  <p class="vibe-guide-inline-note">
+    “Build my whole startup in one go” is the bad vibe. “Let’s do the task list CRUD, then the
+    dashboard, then the reminders flow” is the good vibe.
+  </p>
+</section>
+
+<section class="vibe-guide-section vibe-guide-section--muted">
+  <h2>Keep these values ready</h2>
+  <div class="vibe-guide-cheatsheet-grid">
+    <article class="vibe-guide-cheatsheet-card">
+      <h3>Database</h3>
+      <p><code>DB_NAME</code> · <code>DB_USER</code> · <code>DB_PASSWORD</code></p>
+      <p><code>DB_HOST</code> and <code>DB_PORT</code> only if not default.</p>
+    </article>
+    <article class="vibe-guide-cheatsheet-card">
+      <h3>Supabase</h3>
+      <p><code>AUTH_SUPABASE_URL</code></p>
+      <p><code>AUTH_SUPABASE_PUBLISHABLE_KEY</code></p>
+    </article>
+    <article class="vibe-guide-cheatsheet-card">
+      <h3>Assistant</h3>
+      <p>Your assistant provider API key.</p>
+      <p>Recommended first stop: <strong>DeepSeek</strong>.</p>
+    </article>
+  </div>
+</section>
+
+<section class="why-jskit-close vibe-guide-close">
+  <p class="why-jskit-close-top">You do not need to be a developer. You do need to be prepared.</p>
+  <h2>Seed it, answer clearly, then build.</h2>
+  <div class="why-jskit-close-actions">
+    <a class="why-jskit-button why-jskit-button--ghost" href="/">Back to home</a>
+    <a class="why-jskit-button why-jskit-button--primary" href="/guide/">Read the guide</a>
+    <a class="why-jskit-button why-jskit-button--ghost" href="/ai-ready">See AI Ready</a>
+  </div>
+</section>
+</div>


### PR DESCRIPTION
- Replace the default VitePress home hero with a custom `Why JSKIT-AI` homepage that explains JSKIT’s package model, surfaces, workspaces, CRUD system, and AI workflow.
- Add a new `AI Ready` page describing why JSKIT works well with agents: predictable app structure, packaged docs/reference maps, `AGENTS.md` guidance, blueprint/workboard memory, package-owned defaults, and generators.
- Add a new `Vibe Guide` page aimed at non-developers, covering the seed-app flow, required external setup, Supabase/database prep, and how to work with Codex or Claude chunk-by-chunk.
- Extend the site nav with direct links to `AI Ready` and `Vibe Guide`, while making the homepage the main JSKIT-AI positioning page.
- Introduce a large custom theme layer for these landing-style docs pages, including responsive layouts, CTA blocks, and dark-mode variants.
- Keep the docs site entrypoints connected: homepage CTAs point into the guide, Vibe Guide, and AI Ready instead of leaving the site as a generic docs landing page.
