### PR TITLE
Add agent docs patterns index

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@
   - `packages/agent-docs/guide/agent/`
 - Authored workflow files under these paths are edited directly:
   - `packages/agent-docs/DISTR_AGENT.md`
+  - `packages/agent-docs/patterns/`
   - `packages/agent-docs/workflow/`
   - `packages/agent-docs/templates/`
   - `packages/agent-docs/site/guide/`
@@ -33,3 +34,9 @@ When asked to create or refresh distributed agent docs:
 3. Do not invent behavior or resolve ambiguity by guessing. If the human guide is unclear, keep the uncertainty explicit.
 4. Run `npm run agent-docs:build`.
 5. Review generated outputs in `packages/agent-docs/` like any other tracked artifact.
+
+## JSKIT Patterns
+
+- `packages/agent-docs/patterns/INDEX.md` is the keyword index for recurring JSKIT implementation heuristics and workflow traps.
+- When a request involves JSKIT UI, routing, surfaces, CRUDs, placements, live actions, or similar implementation details, scan the pattern index for matching keywords and read only the relevant pattern files.
+- Keep `AGENTS.md` short. Add recurring JSKIT heuristics to `packages/agent-docs/patterns/`, not as one-off bullets here.

--- a/packages/agent-docs/DISTR_AGENT.md
+++ b/packages/agent-docs/DISTR_AGENT.md
@@ -13,6 +13,7 @@ Use these references on demand:
 
 - `reference/autogen/KERNEL_MAP.md`
 - `reference/autogen/README.md`
+- `patterns/INDEX.md`
 - `guide/agent/index.md`
 - `site/guide/index.md` when compressed guidance is ambiguous or missing nuance
 - `templates/APP_BLUEPRINT.md`
@@ -28,6 +29,7 @@ Core rules:
   - `Why this sticks: ...`
   - `Not doing: ...`
 - Keep that checkpoint compact. Do not expand it into a long preamble unless the developer asks for detail.
+- When a request involves JSKIT UI, routing, surfaces, CRUDs, placements, live actions, or similar implementation details, scan `patterns/INDEX.md` for matching keywords and read only the relevant pattern files.
 - Reuse existing JSKIT helpers and runtime seams before adding new local helpers.
 - A freshly scaffolded JSKIT app can still be in Stage 1. If platform decisions are not settled yet, continue with the initialize workflow before adding runtime packages.
 - Do not treat a missing `config.tenancyMode` line or an untouched minimal scaffold as a final tenancy decision.

--- a/packages/agent-docs/package.json
+++ b/packages/agent-docs/package.json
@@ -6,6 +6,7 @@
   "files": [
     "DISTR_AGENT.md",
     "guide",
+    "patterns",
     "reference",
     "skills",
     "templates",

--- a/packages/agent-docs/patterns/INDEX.md
+++ b/packages/agent-docs/patterns/INDEX.md
@@ -1,0 +1,30 @@
+# JSKIT Patterns Index
+
+Use this index as the first stop for recurring JSKIT implementation heuristics and workflow traps.
+
+How to use it:
+
+- Match the user request against the keywords below.
+- Open only the relevant pattern files.
+- Use patterns as implementation guidance, not as permission to skip normal scoping or user clarification.
+
+## Keyword Map
+
+- tabs, menu items, icons, shell links, profile links, subpage tabs, placements
+  - `placements.md`
+- surfaces, app/admin/home/console, "which surface", route ownership, placement visibility
+  - `surfaces.md`
+- child crud, nested crud, embedded list, subroute, separate page, parent/child layout
+  - `child-cruds.md`
+- CRUD links, record placeholders, `paths.page()`, `resolveViewUrl`, `resolveEditUrl`, `resolveParams`
+  - `crud-links.md`
+- live actions, checkbox, toggle, patch button, inline action, `useCommand()`
+  - `live-actions.md`
+
+## Current Patterns
+
+- [placements.md](./placements.md)
+- [surfaces.md](./surfaces.md)
+- [child-cruds.md](./child-cruds.md)
+- [crud-links.md](./crud-links.md)
+- [live-actions.md](./live-actions.md)

--- a/packages/agent-docs/patterns/child-cruds.md
+++ b/packages/agent-docs/patterns/child-cruds.md
@@ -1,0 +1,30 @@
+# Child CRUD Layout Patterns
+
+Use when:
+
+- planning nested CRUDs
+- adding records under a parent record
+- deciding whether child records need their own page or stay inside the parent view
+
+Rules:
+
+- Before generating a child CRUD, ask how the user wants the child records laid out.
+- Do not assume one layout pattern by default.
+
+Clarify these options:
+
+- embedded in the parent view
+  - often a list rendered directly inside the parent page
+- embedded as child subroutes
+  - the parent page becomes a routed container or subpage host
+- totally separate route/page
+  - the child list/view/edit flow lives in its own route area
+
+Why this matters:
+
+- the answer changes route structure, placements, host containers, and which generator flow fits best
+- child CRUD layout mistakes are expensive to unwind later
+
+Avoid:
+
+- generating nested CRUD routes before the parent/child layout is agreed

--- a/packages/agent-docs/patterns/crud-links.md
+++ b/packages/agent-docs/patterns/crud-links.md
@@ -1,0 +1,36 @@
+# CRUD Link Resolution Patterns
+
+Use when:
+
+- customizing generated CRUD pages
+- wiring buttons or links on list/view/edit pages
+- building nested CRUD links
+
+Rules:
+
+- Use `paths.page()` for surface-aware navigation that only needs surface params.
+- Do not use `paths.page()` with CRUD record placeholders such as `:contactId`, `:addressId`, `:todoListId`, or `:todoItemId` in CRUD-bound route suffixes.
+- For CRUD-bound links, use the runtime that owns the current CRUD scope.
+
+Prefer:
+
+- list pages
+  - `records.resolveViewUrl(record)`
+  - `records.resolveEditUrl(record)`
+  - `records.resolveParams(template, extraParams)`
+- view pages
+  - `view.listUrl`
+  - `view.editUrl`
+  - `view.resolveParams(template, extraParams)`
+- add/edit pages
+  - `formRuntime.addEdit.resolveParams(template, extraParams)`
+
+Scope rule:
+
+- Use the runtime anchored to the record that owns the action.
+- On a parent record view with nested child routes, parent actions should still resolve from the parent `view` runtime even while a child route is active.
+
+Avoid:
+
+- `paths.page("/lists/:todoListId/items/new")`
+- `paths.page("/lists/:todoListId/edit")`

--- a/packages/agent-docs/patterns/live-actions.md
+++ b/packages/agent-docs/patterns/live-actions.md
@@ -1,0 +1,33 @@
+# Live Action Patterns
+
+Use when:
+
+- wiring checkboxes
+- toggles
+- archive/delete/reopen/publish actions
+- small inline PATCH/POST/DELETE actions
+
+Rules:
+
+- Prefer `useCommand()` for live actions.
+- Prefer form runtimes such as `useCrudAddEdit()` or `useAddEdit()` for real forms.
+- Prefer `useCrudList()` and `useCrudView()` for routed CRUD loading and URL resolution.
+
+Good live-action pattern:
+
+- build a narrow payload
+- call `command.run()`
+- disable only the busy control while the command is running
+- invalidate the relevant query key on success
+- keep derived business rules on the server
+
+Examples:
+
+- checkbox toggles
+- inline status changes
+- quick destructive or publish/unpublish actions
+
+Avoid:
+
+- manually hand-rolling fetch logic for a standard live action when `useCommand()` fits
+- pushing derived write rules into the client just because the action is small

--- a/packages/agent-docs/patterns/placements.md
+++ b/packages/agent-docs/patterns/placements.md
@@ -1,0 +1,28 @@
+# Placement Patterns
+
+Use when:
+
+- changing tab icons
+- changing menu link icons or labels
+- moving shell links
+- changing profile or settings menu entries
+- debugging why a visible link does not match the page component
+
+Check first:
+
+- app `src/placement.js`
+- package placement contributions
+- linked component token props
+
+Rules:
+
+- In JSKIT, tab-like links and shell/menu entries are often placement-owned, not page-owned.
+- When asked to change a tab or menu icon, inspect placement metadata before editing page components.
+- Look at placement `props`, especially fields such as `icon`, `prependIcon`, `appendIcon`, or props passed into the linked component token.
+- If the visible entry is contributed by a package, update the owning package placement contribution instead of patching a local page component.
+- If the request is really about where a link appears, check the placement `target`, `surfaces`, `order`, and `when` fields before changing UI markup.
+
+Avoid:
+
+- editing the routed page just to change a shell/tab/menu icon that is actually placement-owned
+- assuming a rendered tab label/icon lives in the page component

--- a/packages/agent-docs/patterns/surfaces.md
+++ b/packages/agent-docs/patterns/surfaces.md
@@ -1,0 +1,30 @@
+# Surface Patterns
+
+Use when:
+
+- adding a new screen or feature
+- generating pages
+- adding menu entries or widgets
+- deciding whether something belongs in `home`, `app`, `admin`, `console`, or another surface
+
+Check first:
+
+- the blueprint surface plan
+- existing route roots under `src/pages`
+- placement visibility by `surfaces`
+
+Rules:
+
+- Always ask which surface the feature belongs to before generating routes, placements, or related UI.
+- Do not silently default new functionality to `app`.
+- Surface choice is architectural, not cosmetic. It controls routes, access, placement visibility, and often data ownership expectations.
+- When a link or widget should only appear on certain surfaces, use placement `surfaces` first and keep runtime `when` conditions for behavior-specific gating.
+
+Ask explicitly about:
+
+- route pages
+- menu entries
+- top-left/top-right widgets
+- settings pages
+- CRUD screens
+- helper components that only make sense on one surface

--- a/packages/agent-docs/templates/app/AGENTS.md
+++ b/packages/agent-docs/templates/app/AGENTS.md
@@ -15,6 +15,7 @@ Use these references on demand:
 
 - `node_modules/@jskit-ai/agent-docs/reference/autogen/KERNEL_MAP.md`
 - `node_modules/@jskit-ai/agent-docs/reference/autogen/README.md`
+- `node_modules/@jskit-ai/agent-docs/patterns/INDEX.md`
 - `node_modules/@jskit-ai/agent-docs/guide/agent/index.md`
 - `node_modules/@jskit-ai/agent-docs/site/guide/index.md` when compressed guidance is ambiguous or missing nuance
 - `node_modules/@jskit-ai/agent-docs/templates/APP_BLUEPRINT.md`
@@ -30,6 +31,7 @@ Core rules:
   - `Why this sticks: ...`
   - `Not doing: ...`
 - Keep that checkpoint compact. Do not expand it into a long preamble unless the developer asks for detail.
+- When a request involves JSKIT UI, routing, surfaces, CRUDs, placements, live actions, or similar implementation details, scan `node_modules/@jskit-ai/agent-docs/patterns/INDEX.md` for matching keywords and read only the relevant pattern files.
 - Reuse existing JSKIT helpers and runtime seams before adding new local helpers.
 - A freshly scaffolded JSKIT app can still be in Stage 1. If the app was just created and platform decisions are not settled yet, continue with the initialize workflow before adding runtime packages.
 - Do not treat a missing `config.tenancyMode` line or an untouched minimal scaffold as a final tenancy decision.


### PR DESCRIPTION
## Summary
- add packaged JSKIT implementation pattern notes under agent-docs/patterns
- wire the new patterns index into AGENTS and distributed agent references
- publish the patterns directory in the agent-docs package

## Notes
- not running repo-wide verify in this PR flow
- not waiting for GitHub checks