### PR TITLE
Decouple assistant workspace scope and fix nullable CRUD booleans

### DIFF
--- a/packages/agent-docs/reference/autogen/packages/assistant-runtime.md
+++ b/packages/agent-docs/reference/autogen/packages/assistant-runtime.md
@@ -55,6 +55,13 @@ Exports
 Exports
 - `AssistantClientProvider`
 
+### `src/client/support/workspaceScopeSupport.js`
+Exports
+- `EMPTY_WORKSPACE_WEB_SCOPE_SUPPORT`
+- `WORKSPACES_WEB_SCOPE_SUPPORT_INJECTION_KEY`
+- `isWorkspaceWebScopeSupport(value)`
+- `useWorkspaceWebScopeSupport({ required = false } = {})`
+
 ### `src/server/actionIds.js`
 Exports
 - `actionIds`
@@ -79,16 +86,16 @@ Exports
 Exports
 - `registerRoutes(app)`
 Local functions
-- `buildRouteParamsValidator(requiresWorkspace)`
-- `buildConversationMessagesRouteParamsValidator(requiresWorkspace)`
-- `readWorkspaceInput(request, requiresWorkspace)`
+- `buildRouteParamsValidator(requiresWorkspace, workspaceScopeSupport = null)`
+- `buildConversationMessagesRouteParamsValidator(requiresWorkspace, workspaceScopeSupport = null)`
+- `readWorkspaceInput(request, requiresWorkspace, workspaceScopeSupport = null)`
 - `requireAssistantSurface(appConfig = {}, targetSurfaceId = "")`
 - `requireHostSurfaceId(request)`
 - `shouldExposeAppErrorDetails(errorCode = "")`
 - `sendPreStreamErrorResponse(reply, error)`
-- `resolveRouteRequestState(request, { resolveCurrentAppConfig = () => ({}), kind = "runtime", requiresWorkspace = false } = {})`
-- `registerSettingsRoutes(router, resolveCurrentAppConfig, { requiresWorkspace = false } = {})`
-- `registerRuntimeRoutes(router, resolveCurrentAppConfig, { requiresWorkspace = false } = {})`
+- `resolveRouteRequestState(request, { resolveCurrentAppConfig = () => ({}), kind = "runtime", requiresWorkspace = false, workspaceScopeSupport = null } = {})`
+- `registerSettingsRoutes(router, resolveCurrentAppConfig, { requiresWorkspace = false, workspaceScopeSupport = null } = {})`
+- `registerRuntimeRoutes(router, resolveCurrentAppConfig, { requiresWorkspace = false, workspaceScopeSupport = null } = {})`
 
 ### `src/server/repositories/assistantConfigRepository.js`
 Exports
@@ -128,11 +135,11 @@ Local functions
 
 ### `src/server/services/assistantConfigService.js`
 Exports
-- `createService({ assistantConfigRepository, consoleService = null, appConfig = {}, resolveAppConfig = null } = {})`
+- `createService({ assistantConfigRepository, consoleService = null, appConfig = {}, resolveAppConfig = null, workspaceScopeSupport = null } = {})`
 
 ### `src/server/services/chatService.js`
 Exports
-- `createChatService({ aiClientFactory, transcriptService, serviceToolCatalog, assistantConfigService, appConfig = {}, resolveAppConfig = null } = {})`
+- `createChatService({ aiClientFactory, transcriptService, serviceToolCatalog, assistantConfigService, appConfig = {}, resolveAppConfig = null, workspaceScopeSupport = null } = {})`
 Local functions
 - `normalizeConversationId(value)`
 - `normalizeHistory(history = [])`
@@ -182,6 +189,12 @@ Exports
 Local functions
 - `buildCatalogOptions(appConfig = {}, surfaceId = "")`
 - `requireContextSurfaceId(context = {})`
+
+### `src/server/support/workspaceScopeSupport.js`
+Exports
+- `WORKSPACES_SERVER_SCOPE_SUPPORT_TOKEN`
+- `isWorkspaceServerScopeSupport(value)`
+- `resolveWorkspaceServerScopeSupport(scope = null, { required = false, caller = "assistant-runtime" } = {})`
 
 ### `src/shared/assistantRuntimeConfig.js`
 Exports

--- a/packages/agent-docs/reference/autogen/packages/crud-ui-generator.md
+++ b/packages/agent-docs/reference/autogen/packages/crud-ui-generator.md
@@ -82,6 +82,7 @@ Local functions
 - `toLookupRelation(fieldMetaMap = {}, fieldKey = "", { lookupContainerKey = "lookups" } = {})`
 - `resolveFormInputType(fieldType, fieldFormat)`
 - `resolveFormFieldComponent(fieldType, relation = null)`
+- `buildDefaultNullableBooleanOptions()`
 - `toPositiveInteger(value)`
 - `toAccessorExpression(baseName, fieldKey)`
 - `toOptionalAccessorExpression(baseName, fieldKey)`

--- a/packages/agent-docs/reference/autogen/packages/users-web.md
+++ b/packages/agent-docs/reference/autogen/packages/users-web.md
@@ -104,6 +104,7 @@ Local functions
 - `resolveStableFieldErrorList(fieldKey, message)`
 - `resolveFormFieldType(field = {})`
 - `resolveFormFieldFormat(field = {})`
+- `isNullableFormField(field = {})`
 - `padDateTimePart(value)`
 - `normalizeTimeWhitespace(value)`
 - `toTimeInputValue(value)`

--- a/packages/agent-docs/reference/autogen/packages/workspaces-core.md
+++ b/packages/agent-docs/reference/autogen/packages/workspaces-core.md
@@ -154,6 +154,10 @@ Exports
 - `readWorkspaceSlugFromRouteParams(params = {})`
 - `buildWorkspaceInputFromRouteParams(params = {})`
 
+### `src/server/support/workspaceServerScopeSupport.js`
+Exports
+- `createWorkspaceServerScopeSupport()`
+
 ### `src/server/workspaceBootstrapContributor.js`
 Exports
 - `createWorkspaceBootstrapContributor({ workspaceService, workspacePendingInvitationsService, usersRepository, workspaceInvitationsEnabled = false, appConfig = {}, tenancyProfile = null } = {})`

--- a/packages/agent-docs/reference/autogen/packages/workspaces-web.md
+++ b/packages/agent-docs/reference/autogen/packages/workspaces-web.md
@@ -313,6 +313,14 @@ Exports
 Exports
 - `buildWorkspaceQueryKey(kind = "", surfaceId = "", workspaceSlug = "")`
 
+### `src/client/support/workspaceScopeSupport.js`
+Exports
+- `WORKSPACES_WEB_SCOPE_SUPPORT_INJECTION_KEY`
+- `createWorkspaceScopeSupport()`
+- `readWorkspaceRouteScope(routeContext = {})`
+Local functions
+- `unwrapRefValue(value)`
+
 ### `src/shared/toolsOutletContracts.js`
 Exports
 - `DEFAULT_TOOLS_LINK_COMPONENT_TOKEN`

--- a/packages/assistant-runtime/package.descriptor.mjs
+++ b/packages/assistant-runtime/package.descriptor.mjs
@@ -10,9 +10,7 @@ export default Object.freeze({
     "@jskit-ai/http-runtime",
     "@jskit-ai/shell-web",
     "@jskit-ai/users-core",
-    "@jskit-ai/users-web",
-    "@jskit-ai/workspaces-core",
-    "@jskit-ai/workspaces-web"
+    "@jskit-ai/users-web"
   ],
   capabilities: {
     provides: ["assistant.runtime"],
@@ -22,9 +20,7 @@ export default Object.freeze({
       "auth.policy",
       "runtime.http-client",
       "users.core",
-      "users.web",
-      "workspaces.core",
-      "workspaces.web"
+      "users.web"
     ]
   },
   runtime: {
@@ -85,8 +81,6 @@ export default Object.freeze({
         "@jskit-ai/shell-web": "0.1.42",
         "@jskit-ai/users-core": "0.1.53",
         "@jskit-ai/users-web": "0.1.58",
-        "@jskit-ai/workspaces-core": "0.1.19",
-        "@jskit-ai/workspaces-web": "0.1.19",
         "@tanstack/vue-query": "^5.90.5",
         "vuetify": "^4.0.0"
       },

--- a/packages/assistant-runtime/package.json
+++ b/packages/assistant-runtime/package.json
@@ -15,8 +15,6 @@
     "@jskit-ai/shell-web": "0.1.42",
     "@jskit-ai/users-core": "0.1.53",
     "@jskit-ai/users-web": "0.1.58",
-    "@jskit-ai/workspaces-core": "0.1.19",
-    "@jskit-ai/workspaces-web": "0.1.19",
     "@tanstack/vue-query": "^5.90.5",
     "vuetify": "^4.0.0"
   }

--- a/packages/assistant-runtime/src/client/components/AssistantSettingsClientElement.vue
+++ b/packages/assistant-runtime/src/client/components/AssistantSettingsClientElement.vue
@@ -30,8 +30,9 @@ import { validateOperationSection } from "@jskit-ai/http-runtime/shared/validato
 import { assistantHttpClient, createAssistantApi, AssistantSettingsFormCard } from "@jskit-ai/assistant-core/client";
 import { assistantConfigResource, assistantSettingsQueryKey, buildAssistantApiPath } from "@jskit-ai/assistant-core/shared";
 import { useShellWebErrorRuntime } from "@jskit-ai/shell-web/client/error";
-import { useWorkspaceRouteContext } from "@jskit-ai/workspaces-web/client/composables/useWorkspaceRouteContext";
+import { useSurfaceRouteContext } from "@jskit-ai/users-web/client/composables/useSurfaceRouteContext";
 import { resolveAssistantSurfaceConfig } from "../../shared/assistantSurfaces.js";
+import { useWorkspaceWebScopeSupport } from "../support/workspaceScopeSupport.js";
 
 const props = defineProps({
   targetSurfaceId: {
@@ -51,14 +52,17 @@ const fieldErrors = reactive({
 const errorRuntime = useShellWebErrorRuntime();
 const queryClient = useQueryClient();
 const appConfig = getClientAppConfig();
-const { placementContext, currentSurfaceId, workspaceSlugFromRoute } = useWorkspaceRouteContext();
+const routeContext = useSurfaceRouteContext();
+const workspaceScopeSupport = useWorkspaceWebScopeSupport();
+const { placementContext, currentSurfaceId } = routeContext;
 
 const assistantSurface = computed(() => resolveAssistantSurfaceConfig(appConfig, props.targetSurfaceId));
 const placementSnapshot = computed(() => normalizeObject(placementContext.value));
+const routeScope = computed(() => workspaceScopeSupport.readRouteScope(routeContext));
 const scope = computed(() => {
   const settingsRequiresWorkspace = assistantSurface.value?.settingsSurfaceRequiresWorkspace === true;
   const workspaceSlug = settingsRequiresWorkspace
-    ? normalizeText(workspaceSlugFromRoute.value).toLowerCase()
+    ? normalizeText(routeScope.value.workspaceSlug).toLowerCase()
     : "";
 
   return {
@@ -154,6 +158,10 @@ const loadError = computed(() => {
   }
 
   if (assistantSurface.value?.settingsSurfaceRequiresWorkspace) {
+    if (workspaceScopeSupport.available !== true) {
+      return "Workspace support is not available for this assistant surface.";
+    }
+
     return "Select a workspace to configure assistant settings.";
   }
 

--- a/packages/assistant-runtime/src/client/composables/useAssistantRuntime.js
+++ b/packages/assistant-runtime/src/client/composables/useAssistantRuntime.js
@@ -21,8 +21,9 @@ import {
 } from "@jskit-ai/assistant-core/client";
 import { useShellWebErrorRuntime } from "@jskit-ai/shell-web/client/error";
 import { usePagedCollection } from "@jskit-ai/users-web/client/composables/usePagedCollection";
-import { useWorkspaceRouteContext } from "@jskit-ai/workspaces-web/client/composables/useWorkspaceRouteContext";
+import { useSurfaceRouteContext } from "@jskit-ai/users-web/client/composables/useSurfaceRouteContext";
 import { resolveAssistantSurfaceConfig } from "../../shared/assistantSurfaces.js";
+import { useWorkspaceWebScopeSupport } from "../support/workspaceScopeSupport.js";
 
 const DEFAULT_STREAM_TIMEOUT_MS = 120_000;
 const DEFAULT_HISTORY_PAGE_SIZE = 20;
@@ -234,7 +235,9 @@ function useAssistantRuntime({ api = null, surfaceId = "" } = {}) {
   const runtimePolicy = resolveRuntimePolicy();
   const queryClient = useQueryClient();
   const errorRuntime = useShellWebErrorRuntime();
-  const { placementContext, currentSurfaceId, workspaceSlugFromRoute } = useWorkspaceRouteContext();
+  const routeContext = useSurfaceRouteContext();
+  const workspaceScopeSupport = useWorkspaceWebScopeSupport();
+  const { placementContext, currentSurfaceId } = routeContext;
   const appConfig = getClientAppConfig();
 
   const messages = ref([]);
@@ -250,9 +253,10 @@ function useAssistantRuntime({ api = null, surfaceId = "" } = {}) {
   const assistantSurface = computed(() =>
     resolveAssistantSurfaceConfig(appConfig, surfaceId)
   );
+  const routeScope = computed(() => workspaceScopeSupport.readRouteScope(routeContext));
   const runtimeScope = computed(() => {
     const workspaceSlug = assistantSurface.value?.runtimeSurfaceRequiresWorkspace
-      ? normalizeText(workspaceSlugFromRoute.value).toLowerCase()
+      ? normalizeText(routeScope.value.workspaceSlug).toLowerCase()
       : "";
 
     return {

--- a/packages/assistant-runtime/src/client/support/workspaceScopeSupport.js
+++ b/packages/assistant-runtime/src/client/support/workspaceScopeSupport.js
@@ -1,0 +1,38 @@
+import { inject } from "vue";
+
+const WORKSPACES_WEB_SCOPE_SUPPORT_INJECTION_KEY = "jskit.workspaces.web.scope-support";
+
+const EMPTY_ROUTE_SCOPE = Object.freeze({
+  workspaceSlug: ""
+});
+
+const EMPTY_WORKSPACE_WEB_SCOPE_SUPPORT = Object.freeze({
+  available: false,
+  readRouteScope() {
+    return EMPTY_ROUTE_SCOPE;
+  }
+});
+
+function isWorkspaceWebScopeSupport(value) {
+  return Boolean(value && typeof value.readRouteScope === "function");
+}
+
+function useWorkspaceWebScopeSupport({ required = false } = {}) {
+  const support = inject(WORKSPACES_WEB_SCOPE_SUPPORT_INJECTION_KEY, null);
+  if (isWorkspaceWebScopeSupport(support)) {
+    return support;
+  }
+
+  if (required) {
+    throw new Error("Workspace web scope support is not available in Vue injection context.");
+  }
+
+  return EMPTY_WORKSPACE_WEB_SCOPE_SUPPORT;
+}
+
+export {
+  EMPTY_WORKSPACE_WEB_SCOPE_SUPPORT,
+  WORKSPACES_WEB_SCOPE_SUPPORT_INJECTION_KEY,
+  isWorkspaceWebScopeSupport,
+  useWorkspaceWebScopeSupport
+};

--- a/packages/assistant-runtime/src/server/AssistantProvider.js
+++ b/packages/assistant-runtime/src/server/AssistantProvider.js
@@ -12,6 +12,7 @@ import { createChatService } from "./services/chatService.js";
 import { createTranscriptService } from "./services/transcriptService.js";
 import { resolveAssistantAiConfig } from "./support/assistantServerConfig.js";
 import { createSurfaceAwareToolCatalog } from "./support/createSurfaceAwareToolCatalog.js";
+import { resolveWorkspaceServerScopeSupport } from "./support/workspaceScopeSupport.js";
 
 function resolveGlobalAssistantConfig(scope) {
   const appConfig = resolveAppConfig(scope);
@@ -108,7 +109,8 @@ class AssistantProvider {
         createAssistantConfigService({
           assistantConfigRepository: scope.make("assistant.config.repository"),
           consoleService: scope.has("consoleService") ? scope.make("consoleService") : null,
-          resolveAppConfig: resolveCurrentAppConfig
+          resolveAppConfig: resolveCurrentAppConfig,
+          workspaceScopeSupport: resolveWorkspaceServerScopeSupport(scope)
         })
     );
 
@@ -129,7 +131,8 @@ class AssistantProvider {
           transcriptService: scope.make("assistant.transcript.service"),
           serviceToolCatalog: scope.make("assistant.service.tool-catalog"),
           assistantConfigService: scope.make("assistant.config.service"),
-          resolveAppConfig: resolveCurrentAppConfig
+          resolveAppConfig: resolveCurrentAppConfig,
+          workspaceScopeSupport: resolveWorkspaceServerScopeSupport(scope)
         })
     );
 

--- a/packages/assistant-runtime/src/server/registerRoutes.js
+++ b/packages/assistant-runtime/src/server/registerRoutes.js
@@ -2,8 +2,6 @@ import { AppError } from "@jskit-ai/kernel/server/runtime";
 import { resolveAppConfig } from "@jskit-ai/kernel/server/support";
 import { normalizeSurfaceId } from "@jskit-ai/kernel/shared/surface/registry";
 import { withStandardErrorResponses } from "@jskit-ai/http-runtime/shared/validators/errorResponses";
-import { buildWorkspaceInputFromRouteParams } from "@jskit-ai/workspaces-core/server/support/workspaceRouteInput";
-import { workspaceSlugParamsValidator } from "@jskit-ai/workspaces-core/server/validators/routeParamsValidator";
 import {
   assistantConfigResource,
   assistantResource,
@@ -18,17 +16,22 @@ import {
 import { resolveAssistantSurfaceConfig } from "../shared/assistantSurfaces.js";
 import { actionIds } from "./actionIds.js";
 import { assistantSurfaceRouteParamsValidator } from "./inputValidators.js";
+import { resolveWorkspaceServerScopeSupport } from "./support/workspaceScopeSupport.js";
 
-function buildRouteParamsValidator(requiresWorkspace) {
+function buildRouteParamsValidator(requiresWorkspace, workspaceScopeSupport = null) {
   if (requiresWorkspace === true) {
-    return [workspaceSlugParamsValidator, assistantSurfaceRouteParamsValidator];
+    if (!workspaceScopeSupport) {
+      throw new Error("Assistant workspace routes require workspace server scope support.");
+    }
+
+    return [workspaceScopeSupport.paramsValidator, assistantSurfaceRouteParamsValidator];
   }
 
   return assistantSurfaceRouteParamsValidator;
 }
 
-function buildConversationMessagesRouteParamsValidator(requiresWorkspace) {
-  const validators = buildRouteParamsValidator(requiresWorkspace);
+function buildConversationMessagesRouteParamsValidator(requiresWorkspace, workspaceScopeSupport = null) {
+  const validators = buildRouteParamsValidator(requiresWorkspace, workspaceScopeSupport);
   if (Array.isArray(validators)) {
     return validators.concat(assistantResource.operations.conversationMessagesList.paramsValidator);
   }
@@ -36,12 +39,16 @@ function buildConversationMessagesRouteParamsValidator(requiresWorkspace) {
   return [validators, assistantResource.operations.conversationMessagesList.paramsValidator];
 }
 
-function readWorkspaceInput(request, requiresWorkspace) {
+function readWorkspaceInput(request, requiresWorkspace, workspaceScopeSupport = null) {
   if (requiresWorkspace !== true) {
     return {};
   }
 
-  return buildWorkspaceInputFromRouteParams(request?.input?.params);
+  if (!workspaceScopeSupport) {
+    throw new Error("Assistant workspace routes require workspace server scope support.");
+  }
+
+  return workspaceScopeSupport.buildInputFromRouteParams(request?.input?.params);
 }
 
 function requireAssistantSurface(appConfig = {}, targetSurfaceId = "") {
@@ -102,7 +109,15 @@ function sendPreStreamErrorResponse(reply, error) {
   });
 }
 
-function resolveRouteRequestState(request, { resolveCurrentAppConfig = () => ({}), kind = "runtime", requiresWorkspace = false } = {}) {
+function resolveRouteRequestState(
+  request,
+  {
+    resolveCurrentAppConfig = () => ({}),
+    kind = "runtime",
+    requiresWorkspace = false,
+    workspaceScopeSupport = null
+  } = {}
+) {
   const appConfig = resolveCurrentAppConfig();
   const targetSurfaceId = normalizeSurfaceId(request?.input?.params?.surfaceId);
   const assistantSurface = requireAssistantSurface(appConfig, targetSurfaceId);
@@ -126,18 +141,22 @@ function resolveRouteRequestState(request, { resolveCurrentAppConfig = () => ({}
     hostSurfaceId,
     actionInput: Object.freeze({
       targetSurfaceId: assistantSurface.targetSurfaceId,
-      ...readWorkspaceInput(request, requiresWorkspace)
+      ...readWorkspaceInput(request, requiresWorkspace, workspaceScopeSupport)
     })
   });
 }
 
-function registerSettingsRoutes(router, resolveCurrentAppConfig, { requiresWorkspace = false } = {}) {
+function registerSettingsRoutes(
+  router,
+  resolveCurrentAppConfig,
+  { requiresWorkspace = false, workspaceScopeSupport = null } = {}
+) {
   const routeBase = resolveAssistantApiBasePath({
     requiresWorkspace
   });
   const visibility = requiresWorkspace ? "workspace" : "public";
   const routePath = `${routeBase}/:surfaceId/settings`;
-  const paramsValidator = buildRouteParamsValidator(requiresWorkspace);
+  const paramsValidator = buildRouteParamsValidator(requiresWorkspace, workspaceScopeSupport);
 
   router.register(
     "GET",
@@ -158,7 +177,8 @@ function registerSettingsRoutes(router, resolveCurrentAppConfig, { requiresWorks
       const routeState = resolveRouteRequestState(request, {
         resolveCurrentAppConfig,
         kind: "settings",
-        requiresWorkspace
+        requiresWorkspace,
+        workspaceScopeSupport
       });
 
       const response = await request.executeAction({
@@ -198,7 +218,8 @@ function registerSettingsRoutes(router, resolveCurrentAppConfig, { requiresWorks
       const routeState = resolveRouteRequestState(request, {
         resolveCurrentAppConfig,
         kind: "settings",
-        requiresWorkspace
+        requiresWorkspace,
+        workspaceScopeSupport
       });
 
       const response = await request.executeAction({
@@ -217,13 +238,17 @@ function registerSettingsRoutes(router, resolveCurrentAppConfig, { requiresWorks
   );
 }
 
-function registerRuntimeRoutes(router, resolveCurrentAppConfig, { requiresWorkspace = false } = {}) {
+function registerRuntimeRoutes(
+  router,
+  resolveCurrentAppConfig,
+  { requiresWorkspace = false, workspaceScopeSupport = null } = {}
+) {
   const routeBase = resolveAssistantApiBasePath({
     requiresWorkspace
   });
   const visibility = requiresWorkspace ? "workspace" : "public";
   const surfaceRouteBase = `${routeBase}/:surfaceId`;
-  const paramsValidator = buildRouteParamsValidator(requiresWorkspace);
+  const paramsValidator = buildRouteParamsValidator(requiresWorkspace, workspaceScopeSupport);
 
   router.register(
     "POST",
@@ -242,7 +267,8 @@ function registerRuntimeRoutes(router, resolveCurrentAppConfig, { requiresWorksp
       const routeState = resolveRouteRequestState(request, {
         resolveCurrentAppConfig,
         kind: "runtime",
-        requiresWorkspace
+        requiresWorkspace,
+        workspaceScopeSupport
       });
       const abortController = new AbortController();
       const requestBody = request?.input?.body && typeof request.input.body === "object" ? request.input.body : {};
@@ -367,7 +393,8 @@ function registerRuntimeRoutes(router, resolveCurrentAppConfig, { requiresWorksp
       const routeState = resolveRouteRequestState(request, {
         resolveCurrentAppConfig,
         kind: "runtime",
-        requiresWorkspace
+        requiresWorkspace,
+        workspaceScopeSupport
       });
 
       const response = await request.executeAction({
@@ -391,7 +418,7 @@ function registerRuntimeRoutes(router, resolveCurrentAppConfig, { requiresWorksp
     {
       auth: "required",
       visibility,
-      paramsValidator: buildConversationMessagesRouteParamsValidator(requiresWorkspace),
+      paramsValidator: buildConversationMessagesRouteParamsValidator(requiresWorkspace, workspaceScopeSupport),
       meta: {
         tags: ["assistant"],
         summary: "List assistant conversation messages."
@@ -405,7 +432,8 @@ function registerRuntimeRoutes(router, resolveCurrentAppConfig, { requiresWorksp
       const routeState = resolveRouteRequestState(request, {
         resolveCurrentAppConfig,
         kind: "runtime",
-        requiresWorkspace
+        requiresWorkspace,
+        workspaceScopeSupport
       });
 
       const response = await request.executeAction({
@@ -432,19 +460,25 @@ function registerRoutes(app) {
 
   const router = app.make("jskit.http.router");
   const resolveCurrentAppConfig = () => resolveAppConfig(app);
+  const workspaceScopeSupport = resolveWorkspaceServerScopeSupport(app);
 
   registerSettingsRoutes(router, resolveCurrentAppConfig, {
     requiresWorkspace: false
   });
-  registerSettingsRoutes(router, resolveCurrentAppConfig, {
-    requiresWorkspace: true
-  });
   registerRuntimeRoutes(router, resolveCurrentAppConfig, {
     requiresWorkspace: false
   });
-  registerRuntimeRoutes(router, resolveCurrentAppConfig, {
-    requiresWorkspace: true
-  });
+
+  if (workspaceScopeSupport) {
+    registerSettingsRoutes(router, resolveCurrentAppConfig, {
+      requiresWorkspace: true,
+      workspaceScopeSupport
+    });
+    registerRuntimeRoutes(router, resolveCurrentAppConfig, {
+      requiresWorkspace: true,
+      workspaceScopeSupport
+    });
+  }
 }
 
 export { registerRoutes };

--- a/packages/assistant-runtime/src/server/services/assistantConfigService.js
+++ b/packages/assistant-runtime/src/server/services/assistantConfigService.js
@@ -1,9 +1,14 @@
 import { AppError, requireAuth } from "@jskit-ai/kernel/server/runtime";
 import { normalizeObject, normalizeRecordId } from "@jskit-ai/kernel/shared/support/normalize";
-import { resolveWorkspace } from "@jskit-ai/workspaces-core/server/support/resolveWorkspace";
 import { resolveAssistantSurfaceConfig } from "../../shared/assistantSurfaces.js";
 
-function createService({ assistantConfigRepository, consoleService = null, appConfig = {}, resolveAppConfig = null } = {}) {
+function createService({
+  assistantConfigRepository,
+  consoleService = null,
+  appConfig = {},
+  resolveAppConfig = null,
+  workspaceScopeSupport = null
+} = {}) {
   if (!assistantConfigRepository || typeof assistantConfigRepository.findByScope !== "function") {
     throw new Error("assistantConfigService requires assistantConfigRepository.findByScope().");
   }
@@ -63,7 +68,11 @@ function createService({ assistantConfigRepository, consoleService = null, appCo
       return null;
     }
 
-    const resolvedWorkspace = workspace || resolveWorkspace(context, input);
+    if (!workspaceScopeSupport || typeof workspaceScopeSupport.resolveWorkspace !== "function") {
+      throw new Error("assistant.config.service requires workspace server scope support for workspace-scoped settings.");
+    }
+
+    const resolvedWorkspace = workspace || workspaceScopeSupport.resolveWorkspace(context, input);
     const workspaceId = normalizeRecordId(resolvedWorkspace?.id, { fallback: null });
     if (!workspaceId) {
       throw new AppError(409, "Workspace selection required.");

--- a/packages/assistant-runtime/src/server/services/chatService.js
+++ b/packages/assistant-runtime/src/server/services/chatService.js
@@ -1,6 +1,5 @@
 import { AppError } from "@jskit-ai/kernel/server/runtime";
 import { normalizeObject, normalizeRecordId, normalizeText } from "@jskit-ai/kernel/shared/support/normalize";
-import { resolveWorkspace } from "@jskit-ai/workspaces-core/server/support/resolveWorkspace";
 import { resolveWorkspaceSlug } from "@jskit-ai/assistant-core/server";
 import {
   ASSISTANT_STREAM_EVENT_TYPES
@@ -553,7 +552,8 @@ function createChatService({
   serviceToolCatalog,
   assistantConfigService,
   appConfig = {},
-  resolveAppConfig = null
+  resolveAppConfig = null,
+  workspaceScopeSupport = null
 } = {}) {
   if (!aiClientFactory || typeof aiClientFactory.resolveClient !== "function" || !transcriptService || !serviceToolCatalog || !assistantConfigService) {
     throw new Error(
@@ -564,6 +564,18 @@ function createChatService({
   const resolveCurrentAppConfig =
     typeof resolveAppConfig === "function" ? resolveAppConfig : () => appConfig;
 
+  function resolveRuntimeWorkspace(assistantSurface, context = {}, input = {}) {
+    if (assistantSurface?.runtimeSurfaceRequiresWorkspace !== true) {
+      return null;
+    }
+
+    if (!workspaceScopeSupport || typeof workspaceScopeSupport.resolveWorkspace !== "function") {
+      throw new Error("assistant.chat.service requires workspace server scope support for workspace-scoped assistant surfaces.");
+    }
+
+    return workspaceScopeSupport.resolveWorkspace(context, input);
+  }
+
   async function streamChat(payload = {}, options = {}) {
     const assistantSurface = requireAssistantSurface(resolveCurrentAppConfig(), payload?.targetSurfaceId);
     const aiClient = aiClientFactory.resolveClient(assistantSurface.targetSurfaceId);
@@ -573,9 +585,7 @@ function createChatService({
 
     const context = normalizeObject(options.context);
     const assistantContext = buildAssistantActionContext(context, assistantSurface);
-    const workspace = assistantSurface.runtimeSurfaceRequiresWorkspace
-      ? resolveWorkspace(assistantContext, payload)
-      : null;
+    const workspace = resolveRuntimeWorkspace(assistantSurface, assistantContext, payload);
     const source = normalizeStreamInput(payload);
     const streamWriter = options.streamWriter;
     if (!hasStreamWriter(streamWriter)) {
@@ -1010,9 +1020,7 @@ function createChatService({
     const assistantSurface = requireAssistantSurface(resolveCurrentAppConfig(), options?.input?.targetSurfaceId);
     const context = normalizeObject(options.context);
     const assistantContext = buildAssistantActionContext(context, assistantSurface);
-    const workspace = assistantSurface.runtimeSurfaceRequiresWorkspace
-      ? resolveWorkspace(assistantContext, options.input || {})
-      : null;
+    const workspace = resolveRuntimeWorkspace(assistantSurface, assistantContext, options.input || {});
     return transcriptService.listConversationsForUser(assistantSurface, workspace, assistantContext.actor, query, {
       context: assistantContext
     });
@@ -1022,9 +1030,7 @@ function createChatService({
     const assistantSurface = requireAssistantSurface(resolveCurrentAppConfig(), options?.input?.targetSurfaceId);
     const context = normalizeObject(options.context);
     const assistantContext = buildAssistantActionContext(context, assistantSurface);
-    const workspace = assistantSurface.runtimeSurfaceRequiresWorkspace
-      ? resolveWorkspace(assistantContext, options.input || {})
-      : null;
+    const workspace = resolveRuntimeWorkspace(assistantSurface, assistantContext, options.input || {});
     return transcriptService.getConversationMessagesForUser(
       assistantSurface,
       workspace,

--- a/packages/assistant-runtime/src/server/support/workspaceScopeSupport.js
+++ b/packages/assistant-runtime/src/server/support/workspaceScopeSupport.js
@@ -1,0 +1,35 @@
+const WORKSPACES_SERVER_SCOPE_SUPPORT_TOKEN = "workspaces.server.scope-support";
+
+function isWorkspaceServerScopeSupport(value) {
+  return Boolean(
+    value &&
+      value.available === true &&
+      value.paramsValidator &&
+      typeof value.paramsValidator.normalize === "function" &&
+      typeof value.buildInputFromRouteParams === "function" &&
+      typeof value.resolveWorkspace === "function"
+  );
+}
+
+function resolveWorkspaceServerScopeSupport(scope = null, { required = false, caller = "assistant-runtime" } = {}) {
+  const support =
+    scope && typeof scope.has === "function" && typeof scope.make === "function" && scope.has(WORKSPACES_SERVER_SCOPE_SUPPORT_TOKEN)
+      ? scope.make(WORKSPACES_SERVER_SCOPE_SUPPORT_TOKEN)
+      : null;
+
+  if (isWorkspaceServerScopeSupport(support)) {
+    return support;
+  }
+
+  if (required) {
+    throw new Error(`${caller} requires ${WORKSPACES_SERVER_SCOPE_SUPPORT_TOKEN} for workspace-scoped assistant surfaces.`);
+  }
+
+  return null;
+}
+
+export {
+  WORKSPACES_SERVER_SCOPE_SUPPORT_TOKEN,
+  isWorkspaceServerScopeSupport,
+  resolveWorkspaceServerScopeSupport
+};

--- a/packages/assistant-runtime/test/lazyAppConfig.test.js
+++ b/packages/assistant-runtime/test/lazyAppConfig.test.js
@@ -23,6 +23,26 @@ function createAssistantAppConfig() {
   };
 }
 
+function createWorkspaceServerScopeSupport() {
+  return Object.freeze({
+    available: true,
+    paramsValidator: Object.freeze({
+      normalize(value = {}) {
+        return {
+          workspaceSlug: String(value?.workspaceSlug || "").trim().toLowerCase()
+        };
+      }
+    }),
+    buildInputFromRouteParams(params = {}) {
+      const workspaceSlug = String(params?.workspaceSlug || "").trim().toLowerCase();
+      return workspaceSlug ? { workspaceSlug } : {};
+    },
+    resolveWorkspace(context = {}, input = {}) {
+      return input.workspace || context.workspace || null;
+    }
+  });
+}
+
 test("registerRoutes resolves appConfig lazily when handlers run", async () => {
   const routes = [];
   let currentAppConfig = null;
@@ -41,10 +61,16 @@ test("registerRoutes resolves appConfig lazily when handlers run", async () => {
       if (token === "appConfig") {
         return currentAppConfig;
       }
+      if (token === "workspaces.server.scope-support") {
+        return createWorkspaceServerScopeSupport();
+      }
       throw new Error(`Unexpected token: ${token}`);
     },
     has(token) {
-      return token === "appConfig" ? Boolean(currentAppConfig) : token === "jskit.http.router";
+      return (
+        (token === "appConfig" ? Boolean(currentAppConfig) : token === "jskit.http.router") ||
+        token === "workspaces.server.scope-support"
+      );
     }
   };
 
@@ -126,10 +152,16 @@ test("registerRoutes returns clear AppError payload for pre-stream assistant fai
       if (token === "appConfig") {
         return currentAppConfig;
       }
+      if (token === "workspaces.server.scope-support") {
+        return createWorkspaceServerScopeSupport();
+      }
       throw new Error(`Unexpected token: ${token}`);
     },
     has(token) {
-      return token === "appConfig" ? Boolean(currentAppConfig) : token === "jskit.http.router";
+      return (
+        (token === "appConfig" ? Boolean(currentAppConfig) : token === "jskit.http.router") ||
+        token === "workspaces.server.scope-support"
+      );
     }
   };
 
@@ -216,7 +248,8 @@ test("chat service resolves appConfig lazily when conversations are listed", asy
     },
     serviceToolCatalog: {},
     assistantConfigService: {},
-    resolveAppConfig: () => currentAppConfig
+    resolveAppConfig: () => currentAppConfig,
+    workspaceScopeSupport: createWorkspaceServerScopeSupport()
   });
 
   currentAppConfig = createAssistantAppConfig();
@@ -245,4 +278,77 @@ test("chat service resolves appConfig lazily when conversations are listed", asy
 
   assert.equal(response.assistantSurface.targetSurfaceId, "admin");
   assert.equal(response.workspace.slug, "dogandgroom");
+});
+
+test("chat service rejects workspace-scoped assistant surfaces when workspace support is unavailable", async () => {
+  const chatService = createChatService({
+    aiClientFactory: {
+      resolveClient() {
+        throw new Error("resolveClient should not be called when listing conversations.");
+      }
+    },
+    transcriptService: {
+      async listConversationsForUser() {
+        throw new Error("listConversationsForUser should not be called without workspace support.");
+      }
+    },
+    serviceToolCatalog: {},
+    assistantConfigService: {},
+    resolveAppConfig: () => createAssistantAppConfig()
+  });
+
+  await assert.rejects(
+    () =>
+      chatService.listConversations(
+        {
+          limit: 20
+        },
+        {
+          input: {
+            targetSurfaceId: "admin",
+            workspaceSlug: "dogandgroom"
+          },
+          context: {
+            actor: {
+              authenticated: true,
+              userId: 42
+            }
+          }
+        }
+      ),
+    /workspace server scope support/
+  );
+});
+
+test("registerRoutes omits workspace assistant routes when workspace scope support is unavailable", () => {
+  const routes = [];
+  const app = {
+    make(token) {
+      if (token === "jskit.http.router") {
+        return {
+          register(method, path, options, handler) {
+            routes.push({ method, path, options, handler });
+          }
+        };
+      }
+      if (token === "appConfig") {
+        return createAssistantAppConfig();
+      }
+      throw new Error(`Unexpected token: ${token}`);
+    },
+    has(token) {
+      return token === "jskit.http.router" || token === "appConfig";
+    }
+  };
+
+  registerRoutes(app);
+
+  assert.equal(
+    routes.some((entry) => entry.path.startsWith("/api/w/:workspaceSlug/assistant/")),
+    false
+  );
+  assert.equal(
+    routes.some((entry) => entry.path.startsWith("/api/assistant/")),
+    true
+  );
 });

--- a/packages/assistant-runtime/test/packageDescriptor.test.js
+++ b/packages/assistant-runtime/test/packageDescriptor.test.js
@@ -15,6 +15,10 @@ function findFileMutation(id) {
 test("assistant-runtime descriptor registers runtime providers and initializes assistant config roots", () => {
   assert.equal(descriptor.kind, "runtime");
   assert.equal(descriptor.packageId, "@jskit-ai/assistant-runtime");
+  assert.equal(descriptor.dependsOn.includes("@jskit-ai/workspaces-core"), false);
+  assert.equal(descriptor.dependsOn.includes("@jskit-ai/workspaces-web"), false);
+  assert.equal(descriptor.capabilities?.requires?.includes("workspaces.core"), false);
+  assert.equal(descriptor.capabilities?.requires?.includes("workspaces.web"), false);
   assert.equal(descriptor.runtime?.server?.providers?.[0]?.entrypoint, "src/server/AssistantProvider.js");
   assert.equal(descriptor.runtime?.client?.providers?.[0]?.entrypoint, "src/client/providers/AssistantClientProvider.js");
 

--- a/packages/crud-ui-generator/src/server/resourceSupport.js
+++ b/packages/crud-ui-generator/src/server/resourceSupport.js
@@ -570,6 +570,14 @@ function resolveFormFieldComponent(fieldType, relation = null) {
   return "text";
 }
 
+function buildDefaultNullableBooleanOptions() {
+  return [
+    { label: "Unset", value: null },
+    { label: "Yes", value: true },
+    { label: "No", value: false }
+  ];
+}
+
 function toPositiveInteger(value) {
   const parsed = Number(value);
   return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
@@ -638,7 +646,17 @@ function createFormFieldDefinitions(
         `resource form field "${key}" defines schema enum values but is missing resource.fieldMeta["${key}"].ui.options.`
       );
     }
-    const selectOptions = relation ? [] : fieldUiOptions;
+    const selectOptions = relation
+      ? []
+      : (
+          fieldUiOptions.length > 0
+            ? fieldUiOptions
+            : (
+                schemaType.type === "boolean" && schemaType.nullable === true
+                  ? buildDefaultNullableBooleanOptions()
+                  : []
+              )
+        );
     const lookupFormControl = relation
       ? checkCrudLookupFormControl(fieldMetaMap?.[key]?.ui?.formControl, {
           context: `resource.fieldMeta["${key}"].ui.formControl`,

--- a/packages/crud-ui-generator/test/buildTemplateContext.test.js
+++ b/packages/crud-ui-generator/test/buildTemplateContext.test.js
@@ -126,6 +126,70 @@ const resource = {
 export { resource };
 `;
 
+const NULLABLE_BOOLEAN_RESOURCE_SOURCE = `const customerRecordSchema = {
+  type: "object",
+  properties: {
+    id: { type: "integer" },
+    firstName: { type: "string" },
+    reviewPassed: { type: ["boolean", "null"] }
+  },
+  additionalProperties: false
+};
+
+const customerBodySchema = {
+  type: "object",
+  properties: {
+    firstName: { type: "string", maxLength: 120 },
+    reviewPassed: { type: ["boolean", "null"] }
+  },
+  additionalProperties: false
+};
+
+const resource = {
+  resource: "customers",
+  operations: {
+    list: {
+      outputValidator: {
+        schema: {
+          type: "object",
+          properties: {
+            items: {
+              type: "array",
+              items: customerRecordSchema
+            },
+            nextCursor: { type: ["string", "null"] }
+          },
+          additionalProperties: false
+        }
+      }
+    },
+    view: {
+      outputValidator: {
+        schema: customerRecordSchema
+      }
+    },
+    create: {
+      bodyValidator: {
+        schema: customerBodySchema
+      },
+      outputValidator: {
+        schema: customerRecordSchema
+      }
+    },
+    patch: {
+      bodyValidator: {
+        schema: customerBodySchema
+      },
+      outputValidator: {
+        schema: customerRecordSchema
+      }
+    }
+  }
+};
+
+export { resource };
+`;
+
 const LOOKUP_RESOURCE_SOURCE = `const recordSchema = {
   type: "object",
   properties: {
@@ -266,6 +330,38 @@ test("buildUiTemplateContext derives CRUD placeholders from the explicit target-
     assert.equal(context.__JSKIT_UI_RECORD_CHANGED_EVENT__, "\"customers.record.changed\"");
     assert.equal(context.__JSKIT_UI_LIST_RECORD_ID_EXPR__, "item.id");
     assert.equal(context.__JSKIT_UI_VIEW_TITLE_FALLBACK_FIELD_KEY__, "\"firstName\"");
+  });
+});
+
+test("buildUiTemplateContext keeps non-nullable booleans as switches", async () => {
+  await withTempApp(async (appRoot) => {
+    await writeResource(appRoot, RESOURCE_FILE, FULL_RESOURCE_SOURCE);
+
+    const context = await buildUiTemplateContext({
+      appRoot,
+      options: createOptions()
+    });
+
+    assert.match(context.__JSKIT_UI_CREATE_FORM_COLUMNS__, /<v-switch/);
+    assert.match(context.__JSKIT_UI_CREATE_FORM_COLUMNS__, /formRuntime\.form\.vip/);
+  });
+});
+
+test("buildUiTemplateContext renders nullable booleans as tri-state selects by default", async () => {
+  await withTempApp(async (appRoot) => {
+    await writeResource(appRoot, RESOURCE_FILE, NULLABLE_BOOLEAN_RESOURCE_SOURCE);
+
+    const context = await buildUiTemplateContext({
+      appRoot,
+      options: createOptions()
+    });
+
+    assert.match(context.__JSKIT_UI_CREATE_FORM_FIELDS__, /"key":"reviewPassed"/);
+    assert.match(context.__JSKIT_UI_CREATE_FORM_FIELDS__, /"component":"select"/);
+    assert.match(context.__JSKIT_UI_CREATE_FORM_FIELDS__, /"nullable":true/);
+    assert.match(context.__JSKIT_UI_CREATE_FORM_FIELDS__, /"options":\[\{"label":"Unset","value":null\},\{"label":"Yes","value":true\},\{"label":"No","value":false\}\]/);
+    assert.match(context.__JSKIT_UI_CREATE_FORM_COLUMNS__, /<v-select/);
+    assert.doesNotMatch(context.__JSKIT_UI_CREATE_FORM_COLUMNS__, /<v-switch/);
   });
 });
 

--- a/packages/users-web/src/client/composables/crud/crudSchemaFormHelpers.js
+++ b/packages/users-web/src/client/composables/crud/crudSchemaFormHelpers.js
@@ -48,6 +48,10 @@ function resolveFormFieldFormat(field = {}) {
   return String(field.format || "").trim().toLowerCase();
 }
 
+function isNullableFormField(field = {}) {
+  return field?.nullable === true;
+}
+
 function padDateTimePart(value) {
   return String(value).padStart(2, "0");
 }
@@ -132,7 +136,7 @@ function resolveFormFieldInitialValue(field = {}) {
 
   const fieldType = resolveFormFieldType(field);
   if (fieldType === "boolean") {
-    return false;
+    return isNullableFormField(field) ? null : false;
   }
 
   return "";
@@ -176,7 +180,9 @@ function buildCrudFormPayload(fields = [], model = {}) {
     const rawValue = sourceModel[fieldKey];
 
     if (fieldType === "boolean") {
-      payload[fieldKey] = Boolean(rawValue);
+      payload[fieldKey] = rawValue == null && isNullableFormField(field)
+        ? null
+        : Boolean(rawValue);
       continue;
     }
 
@@ -258,7 +264,9 @@ function applyCrudPayloadToForm(fields = [], model = {}, payload = {}) {
     const rawValue = sourcePayload[fieldKey];
 
     if (fieldType === "boolean") {
-      targetModel[fieldKey] = Boolean(rawValue);
+      targetModel[fieldKey] = rawValue == null && isNullableFormField(field)
+        ? null
+        : Boolean(rawValue);
       continue;
     }
 

--- a/packages/users-web/test/useCrudAddEdit.test.js
+++ b/packages/users-web/test/useCrudAddEdit.test.js
@@ -29,13 +29,27 @@ test("createCrudFormModel resolves defaults and supports explicit initial values
   const model = createCrudFormModel([
     { key: "name", type: "string" },
     { key: "active", type: "boolean" },
+    { key: "reviewed", type: "boolean", nullable: true },
     { key: "role", type: "string", initialValue: "member" }
   ]);
 
   assert.deepEqual(model, {
     name: "",
     active: false,
+    reviewed: null,
     role: "member"
+  });
+});
+
+test("createCrudFormModel preserves explicit boolean defaults for nullable fields", () => {
+  const model = createCrudFormModel([
+    { key: "reviewed", type: "boolean", nullable: true, initialValue: false },
+    { key: "approved", type: "boolean", nullable: true, defaultValue: true }
+  ]);
+
+  assert.deepEqual(model, {
+    reviewed: false,
+    approved: true
   });
 });
 
@@ -100,12 +114,14 @@ test("buildCrudFormPayload normalizes time fields to canonical HH:MM", () => {
 test("buildCrudFormPayload serializes cleared nullable typed fields as null", () => {
   const payload = buildCrudFormPayload(
     [
+      { key: "reviewed", type: "boolean", nullable: true },
       { key: "serviceId", type: "integer", nullable: true },
       { key: "fromDate", type: "string", format: "date", nullable: true },
       { key: "scheduledAt", type: "string", format: "date-time", nullable: true },
       { key: "fromTime", type: "string", format: "time", nullable: true }
     ],
     {
+      reviewed: null,
       serviceId: null,
       fromDate: "",
       scheduledAt: "",
@@ -114,11 +130,46 @@ test("buildCrudFormPayload serializes cleared nullable typed fields as null", ()
   );
 
   assert.deepEqual(payload, {
+    reviewed: null,
     serviceId: null,
     fromDate: null,
     scheduledAt: null,
     fromTime: null
   });
+});
+
+test("buildCrudFormPayload preserves nullable booleans while keeping non-nullable booleans binary", () => {
+  const fields = [
+    { key: "active", type: "boolean" },
+    { key: "reviewed", type: "boolean", nullable: true },
+    { key: "approved", type: "boolean", nullable: true }
+  ];
+
+  assert.deepEqual(
+    buildCrudFormPayload(fields, {
+      active: null,
+      reviewed: null,
+      approved: true
+    }),
+    {
+      active: false,
+      reviewed: null,
+      approved: true
+    }
+  );
+
+  assert.deepEqual(
+    buildCrudFormPayload(fields, {
+      active: 1,
+      reviewed: 0,
+      approved: false
+    }),
+    {
+      active: true,
+      reviewed: false,
+      approved: false
+    }
+  );
 });
 
 test("applyCrudPayloadToForm normalizes time fields for form inputs", () => {
@@ -146,18 +197,21 @@ test("applyCrudPayloadToForm maps payload values into reactive form model", () =
   const form = reactive({
     name: "",
     active: false,
+    reviewed: null,
     age: ""
   });
   applyCrudPayloadToForm(
     [
       { key: "name", type: "string" },
       { key: "active", type: "boolean" },
+      { key: "reviewed", type: "boolean", nullable: true },
       { key: "age", type: "integer" }
     ],
     form,
     {
       name: "Grace",
       active: 1,
+      reviewed: null,
       age: 33
     }
   );
@@ -165,7 +219,33 @@ test("applyCrudPayloadToForm maps payload values into reactive form model", () =
   assert.deepEqual(form, {
     name: "Grace",
     active: true,
+    reviewed: null,
     age: "33"
+  });
+});
+
+test("applyCrudPayloadToForm preserves nullable boolean payload values", () => {
+  const fields = [
+    { key: "active", type: "boolean" },
+    { key: "reviewed", type: "boolean", nullable: true },
+    { key: "approved", type: "boolean", nullable: true }
+  ];
+  const form = reactive({
+    active: false,
+    reviewed: null,
+    approved: null
+  });
+
+  applyCrudPayloadToForm(fields, form, {
+    active: null,
+    reviewed: null,
+    approved: true
+  });
+
+  assert.deepEqual(form, {
+    active: false,
+    reviewed: null,
+    approved: true
   });
 });
 

--- a/packages/workspaces-core/package.descriptor.mjs
+++ b/packages/workspaces-core/package.descriptor.mjs
@@ -38,7 +38,9 @@ export default Object.freeze({
         }
       ],
       containerTokens: {
-        server: [],
+        server: [
+          "workspaces.server.scope-support"
+        ],
         client: []
       }
     },

--- a/packages/workspaces-core/package.json
+++ b/packages/workspaces-core/package.json
@@ -8,7 +8,6 @@
   "exports": {
     "./server/WorkspacesCoreServiceProvider": "./src/server/WorkspacesCoreServiceProvider.js",
     "./server/validators/routeParamsValidator": "./src/server/common/validators/routeParamsValidator.js",
-    "./server/support/resolveWorkspace": "./src/server/support/resolveWorkspace.js",
     "./server/support/workspaceRouteInput": "./src/server/support/workspaceRouteInput.js",
     "./shared/settings": "./src/shared/settings.js",
     "./shared/tenancyProfile": "./src/shared/tenancyProfile.js",

--- a/packages/workspaces-core/src/server/registerWorkspaceCore.js
+++ b/packages/workspaces-core/src/server/registerWorkspaceCore.js
@@ -14,6 +14,7 @@ import {
   registerWorkspaceActionSurfaceSources,
   resolveWorkspaceSurfaceIdsFromAppConfig
 } from "./support/workspaceActionSurfaces.js";
+import { createWorkspaceServerScopeSupport } from "./support/workspaceServerScopeSupport.js";
 
 
 function registerWorkspaceCore(app) {
@@ -57,6 +58,7 @@ function registerWorkspaceCore(app) {
       tenancyProfile
     }).enabled;
   });
+  app.singleton("workspaces.server.scope-support", () => createWorkspaceServerScopeSupport());
 
   registerProfileSyncLifecycleContributor(app, "workspaces.core.profileSyncLifecycleContributor", (scope) => {
     const workspaceService = scope.make("workspaces.service");

--- a/packages/workspaces-core/src/server/support/workspaceServerScopeSupport.js
+++ b/packages/workspaces-core/src/server/support/workspaceServerScopeSupport.js
@@ -1,0 +1,18 @@
+import { workspaceSlugParamsValidator } from "../common/validators/routeParamsValidator.js";
+import { buildWorkspaceInputFromRouteParams } from "./workspaceRouteInput.js";
+import { resolveWorkspace } from "./resolveWorkspace.js";
+
+function createWorkspaceServerScopeSupport() {
+  return Object.freeze({
+    available: true,
+    paramsValidator: workspaceSlugParamsValidator,
+    buildInputFromRouteParams(params = {}) {
+      return buildWorkspaceInputFromRouteParams(params);
+    },
+    resolveWorkspace(context = {}, input = {}) {
+      return resolveWorkspace(context, input);
+    }
+  });
+}
+
+export { createWorkspaceServerScopeSupport };

--- a/packages/workspaces-core/test/workspaceServerScopeSupport.test.js
+++ b/packages/workspaces-core/test/workspaceServerScopeSupport.test.js
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createWorkspaceServerScopeSupport } from "../src/server/support/workspaceServerScopeSupport.js";
+import { registerWorkspaceCore } from "../src/server/registerWorkspaceCore.js";
+
+test("workspace server scope support exposes the canonical workspace helper surface", () => {
+  const support = createWorkspaceServerScopeSupport();
+
+  assert.equal(support.available, true);
+  assert.equal(typeof support.paramsValidator?.normalize, "function");
+  assert.deepEqual(support.buildInputFromRouteParams({ workspaceSlug: "  ACME  " }), {
+    workspaceSlug: "acme"
+  });
+  assert.deepEqual(
+    support.resolveWorkspace(
+      {
+        requestMeta: {
+          resolvedWorkspaceContext: {
+            workspace: {
+              id: 7,
+              slug: "acme"
+            }
+          }
+        }
+      },
+      {}
+    ),
+    {
+      id: 7,
+      slug: "acme"
+    }
+  );
+});
+
+test("registerWorkspaceCore registers the workspace server scope support token", () => {
+  const singletons = new Map();
+  const app = {
+    singleton(token, factory) {
+      singletons.set(token, factory);
+      return this;
+    },
+    tag() {
+      return this;
+    },
+    has() {
+      return false;
+    }
+  };
+
+  registerWorkspaceCore(app);
+
+  assert.equal(singletons.has("workspaces.server.scope-support"), true);
+  const support = singletons.get("workspaces.server.scope-support")();
+  assert.equal(support.available, true);
+  assert.equal(typeof support.buildInputFromRouteParams, "function");
+  assert.equal(typeof support.resolveWorkspace, "function");
+});

--- a/packages/workspaces-web/package.descriptor.mjs
+++ b/packages/workspaces-web/package.descriptor.mjs
@@ -56,6 +56,7 @@ export default Object.freeze({
           "workspaces.web.workspace-members.menu-item",
           "workspaces.web.members-admin.element",
           "workspaces.web.bootstrap-placement.runtime",
+          "workspaces.web.scope-support",
           "workspaces.web.account-settings.section.invites"
         ]
       }

--- a/packages/workspaces-web/src/client/composables/useWorkspaceRouteContext.js
+++ b/packages/workspaces-web/src/client/composables/useWorkspaceRouteContext.js
@@ -1,26 +1,15 @@
 import { computed } from "vue";
-import {
-  extractWorkspaceSlugFromSurfacePathname
-} from "../lib/workspaceSurfacePaths.js";
 import { useSurfaceRouteContext } from "@jskit-ai/users-web/client/composables/useSurfaceRouteContext";
+import { readWorkspaceRouteScope } from "../support/workspaceScopeSupport.js";
 
 function useWorkspaceRouteContext() {
-  const { route, routePath, placementContext, mergePlacementContext, currentSurfaceId } = useSurfaceRouteContext();
+  const routeContext = useSurfaceRouteContext();
   const workspaceSlugFromRoute = computed(() => {
-    const workspaceSlug = extractWorkspaceSlugFromSurfacePathname(
-      placementContext.value,
-      currentSurfaceId.value,
-      routePath.value
-    );
-    return String(workspaceSlug || "").trim();
+    return readWorkspaceRouteScope(routeContext).workspaceSlug;
   });
 
   return Object.freeze({
-    route,
-    routePath,
-    placementContext,
-    mergePlacementContext,
-    currentSurfaceId,
+    ...routeContext,
     workspaceSlugFromRoute
   });
 }

--- a/packages/workspaces-web/src/client/providers/WorkspacesWebClientProvider.js
+++ b/packages/workspaces-web/src/client/providers/WorkspacesWebClientProvider.js
@@ -7,6 +7,10 @@ import UsersWorkspaceSettingsMenuItem from "../components/UsersWorkspaceSettings
 import UsersWorkspaceMembersMenuItem from "../components/UsersWorkspaceMembersMenuItem.vue";
 import MembersAdminClientElement from "../components/MembersAdminClientElement.vue";
 import { createBootstrapPlacementRuntime } from "../runtime/bootstrapPlacementRuntime.js";
+import {
+  WORKSPACES_WEB_SCOPE_SUPPORT_INJECTION_KEY,
+  createWorkspaceScopeSupport
+} from "../support/workspaceScopeSupport.js";
 
 class WorkspacesWebClientProvider {
   static id = "workspaces.web.client";
@@ -24,6 +28,7 @@ class WorkspacesWebClientProvider {
     app.singleton("workspaces.web.workspace-members.menu-item", () => UsersWorkspaceMembersMenuItem);
     app.singleton("workspaces.web.members-admin.element", () => MembersAdminClientElement);
     app.singleton("workspaces.web.bootstrap-placement.runtime", (scope) => createBootstrapPlacementRuntime({ app: scope }));
+    app.singleton("workspaces.web.scope-support", () => createWorkspaceScopeSupport());
     app.singleton("workspaces.web.account-settings.section.invites", () =>
       Object.freeze({
         title: "Invites",
@@ -45,6 +50,20 @@ class WorkspacesWebClientProvider {
     if (runtime && typeof runtime.initialize === "function") {
       await runtime.initialize();
     }
+
+    if (!app.has("jskit.client.vue.app")) {
+      return;
+    }
+
+    const vueApp = app.make("jskit.client.vue.app");
+    if (!vueApp || typeof vueApp.provide !== "function") {
+      return;
+    }
+
+    vueApp.provide(
+      WORKSPACES_WEB_SCOPE_SUPPORT_INJECTION_KEY,
+      app.make("workspaces.web.scope-support")
+    );
   }
 
   shutdown(app) {

--- a/packages/workspaces-web/src/client/support/workspaceScopeSupport.js
+++ b/packages/workspaces-web/src/client/support/workspaceScopeSupport.js
@@ -1,0 +1,48 @@
+import { getClientAppConfig } from "@jskit-ai/kernel/client";
+import { normalizeText } from "@jskit-ai/kernel/shared/support/normalize";
+import {
+  extractWorkspaceSlugFromSurfacePathname
+} from "../lib/workspaceSurfacePaths.js";
+
+const WORKSPACES_WEB_SCOPE_SUPPORT_INJECTION_KEY = "jskit.workspaces.web.scope-support";
+
+function unwrapRefValue(value) {
+  if (value && typeof value === "object" && Object.hasOwn(value, "value")) {
+    return value.value;
+  }
+
+  return value;
+}
+
+function readWorkspaceRouteScope(routeContext = {}) {
+  const placementContext = unwrapRefValue(routeContext?.placementContext);
+  const currentSurfaceId = normalizeText(unwrapRefValue(routeContext?.currentSurfaceId)).toLowerCase();
+  const routePath = normalizeText(unwrapRefValue(routeContext?.routePath));
+  const workspaceSlug = extractWorkspaceSlugFromSurfacePathname(
+    placementContext,
+    currentSurfaceId,
+    routePath
+  );
+
+  return Object.freeze({
+    workspaceSlug: String(workspaceSlug || "").trim()
+  });
+}
+
+function createWorkspaceScopeSupport() {
+  const appConfig = getClientAppConfig();
+  const tenancyMode = normalizeText(appConfig?.tenancyMode).toLowerCase();
+
+  return Object.freeze({
+    available: tenancyMode === "personal" || tenancyMode === "workspaces",
+    readRouteScope(routeContext = {}) {
+      return readWorkspaceRouteScope(routeContext);
+    }
+  });
+}
+
+export {
+  WORKSPACES_WEB_SCOPE_SUPPORT_INJECTION_KEY,
+  createWorkspaceScopeSupport,
+  readWorkspaceRouteScope
+};

--- a/packages/workspaces-web/test/workspaceScopeSupport.test.js
+++ b/packages/workspaces-web/test/workspaceScopeSupport.test.js
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  createWorkspaceScopeSupport,
+  readWorkspaceRouteScope
+} from "../src/client/support/workspaceScopeSupport.js";
+
+test("readWorkspaceRouteScope extracts workspace slug from the current dynamic surface path", () => {
+  const scope = readWorkspaceRouteScope({
+    placementContext: {
+      value: {
+        surfaceConfig: {
+          defaultSurfaceId: "app",
+          surfacesById: {
+            app: {
+              id: "app",
+              routeBase: "w/[workspaceSlug]",
+              requiresWorkspace: true
+            },
+            admin: {
+              id: "admin",
+              routeBase: "w/[workspaceSlug]/admin",
+              requiresWorkspace: true
+            }
+          }
+        }
+      }
+    },
+    currentSurfaceId: {
+      value: "admin"
+    },
+    routePath: {
+      value: "/w/acme/admin/settings"
+    }
+  });
+
+  assert.deepEqual(scope, {
+    workspaceSlug: "acme"
+  });
+});
+
+test("workspace scope support exposes the shared route-scope reader", () => {
+  const support = createWorkspaceScopeSupport();
+
+  assert.equal(typeof support.available, "boolean");
+  assert.equal(typeof support.readRouteScope, "function");
+  assert.deepEqual(
+    support.readRouteScope({
+      placementContext: {
+        value: {
+          surfaceConfig: {
+            defaultSurfaceId: "app",
+            surfacesById: {
+              app: {
+                id: "app",
+                routeBase: "w/[workspaceSlug]",
+                requiresWorkspace: true
+              }
+            }
+          }
+        }
+      },
+      currentSurfaceId: {
+        value: "app"
+      },
+      routePath: {
+        value: "/w/dogandgroom"
+      }
+    }),
+    {
+      workspaceSlug: "dogandgroom"
+    }
+  );
+});

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -442,9 +442,7 @@
           "@jskit-ai/http-runtime",
           "@jskit-ai/shell-web",
           "@jskit-ai/users-core",
-          "@jskit-ai/users-web",
-          "@jskit-ai/workspaces-core",
-          "@jskit-ai/workspaces-web"
+          "@jskit-ai/users-web"
         ],
         "capabilities": {
           "provides": [
@@ -456,9 +454,7 @@
             "auth.policy",
             "runtime.http-client",
             "users.core",
-            "users.web",
-            "workspaces.core",
-            "workspaces.web"
+            "users.web"
           ]
         },
         "runtime": {
@@ -519,8 +515,6 @@
               "@jskit-ai/shell-web": "0.1.42",
               "@jskit-ai/users-core": "0.1.53",
               "@jskit-ai/users-web": "0.1.58",
-              "@jskit-ai/workspaces-core": "0.1.19",
-              "@jskit-ai/workspaces-web": "0.1.19",
               "@tanstack/vue-query": "^5.90.5",
               "vuetify": "^4.0.0"
             },
@@ -4226,7 +4220,9 @@
               }
             ],
             "containerTokens": {
-              "server": [],
+              "server": [
+                "workspaces.server.scope-support"
+              ],
               "client": []
             }
           },
@@ -4547,6 +4543,7 @@
                 "workspaces.web.workspace-members.menu-item",
                 "workspaces.web.members-admin.element",
                 "workspaces.web.bootstrap-placement.runtime",
+                "workspaces.web.scope-support",
                 "workspaces.web.account-settings.section.invites"
               ]
             }


### PR DESCRIPTION
## Summary
- decouple assistant-runtime from hard workspaces package dependencies by introducing workspace scope support shims
- preserve nullable booleans end-to-end in generic CRUD form helpers
- generate tri-state select controls for nullable boolean CRUD fields by default

## Notes
- not waiting for GitHub checks
- not running repo-wide verify in this flow