### PR TITLE
Add CRUD list filter support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ Before non-trivial edits, print a short visible checkpoint for the user in this 
 - `Why this sticks: ...`
 - `Not doing: ...`
 
-Keep it compact. Do not expand this into a long multi-paragraph preamble unless the user asks for detail.
+Keep it compact. Do not expand this into a long multi-paragraph preamble unless the user asks for detail. Have all of them in one line.
 
 When asked to create or refresh distributed agent docs:
 
@@ -38,5 +38,5 @@ When asked to create or refresh distributed agent docs:
 ## JSKIT Patterns
 
 - `packages/agent-docs/patterns/INDEX.md` is the keyword index for recurring JSKIT implementation heuristics and workflow traps.
-- When a request involves JSKIT UI, routing, surfaces, CRUDs, placements, live actions, or similar implementation details, scan the pattern index for matching keywords and read only the relevant pattern files.
+- When a request involves JSKIT UI, routing, surfaces, CRUDs, filters, placements, live actions, or similar implementation details, scan the pattern index for matching keywords and read only the relevant pattern files.
 - Keep `AGENTS.md` short. Add recurring JSKIT heuristics to `packages/agent-docs/patterns/`, not as one-off bullets here.

--- a/packages/agent-docs/DISTR_AGENT.md
+++ b/packages/agent-docs/DISTR_AGENT.md
@@ -29,7 +29,7 @@ Core rules:
   - `Why this sticks: ...`
   - `Not doing: ...`
 - Keep that checkpoint compact. Do not expand it into a long preamble unless the developer asks for detail.
-- When a request involves JSKIT UI, routing, surfaces, CRUDs, placements, live actions, or similar implementation details, scan `patterns/INDEX.md` for matching keywords and read only the relevant pattern files.
+- When a request involves JSKIT UI, routing, surfaces, CRUDs, filters, placements, live actions, or similar implementation details, scan `patterns/INDEX.md` for matching keywords and read only the relevant pattern files.
 - Reuse existing JSKIT helpers and runtime seams before adding new local helpers.
 - A freshly scaffolded JSKIT app can still be in Stage 1. If platform decisions are not settled yet, continue with the initialize workflow before adding runtime packages.
 - Do not treat a missing `config.tenancyMode` line or an untouched minimal scaffold as a final tenancy decision.

--- a/packages/agent-docs/guide/agent/generators/advanced-cruds.md
+++ b/packages/agent-docs/guide/agent/generators/advanced-cruds.md
@@ -678,7 +678,7 @@ The baseline generator output is only the start. As the tutorial's `contacts`, `
 
 - `src/server/listQueryValidators.js` when a list needs extra query filters beyond `q`
 - `src/server/service.test.js` once save/delete rules stop being trivial
-- `src/composables/contacts/useContactsListFilters.js` when the contacts page gains route-backed filter state
+- `packages/contacts/src/shared/contactListFilters.js` when the contacts CRUD gains structured list filters that both server and client should share
 - `src/composables/addresses/useAddressDisplay.js` when addresses need app-specific display formatting
 - `src/composables/comments/useCommentsListRuntime.js` when an embedded comments list needs local UI state
 
@@ -686,6 +686,7 @@ That is the right direction of growth:
 
 - server customizations stay in the CRUD package
 - presentation and page-specific UI state stay in app-owned client files
+- shared structured list filters live best in a CRUD-package shared module that both server and client can import
 
 ## Search and filters: the deep dive
 
@@ -782,18 +783,47 @@ Usually nothing changes. The client can keep sending `q`.
 - Do not dump every text column into search just because you can.
 - In this tutorial CRUD, `notes` is a good example of a field you might leave out if you want fast, predictable list search.
 
-### Pattern 3: structured `contacts` filters such as `hasEmail`, `hasPhone`, and `hasNotes`
+### Pattern 3: structured list filters from one shared definition
 
-This is the first extension that still fits the `contacts` table from the previous chapter with no schema changes.
+This is the default pattern once a CRUD list needs real filters.
+
+Do not hand-build:
+
+- one filter shape in the page
+- a second filter shape in `listQueryValidators.js`
+- and a third filter shape in `repository.js`
+
+Instead:
+
+1. define the filters once in a shared CRUD-package module
+2. build the server runtime from that definition with `createCrudListFilters(...)`
+3. build the client runtime from that same definition with `useCrudListFilters(...)`
+
+For example, a shared filter-definition module can look like this:
+
+```js
+export const CONTACTS_LIST_FILTER_DEFINITIONS = Object.freeze({
+  onlyStaff: {
+    type: "flag",
+    label: "Staff"
+  },
+  onlyVip: {
+    type: "flag",
+    label: "VIP"
+  },
+  onlyArchived: {
+    type: "flag",
+    label: "Archived"
+  }
+});
+```
 
 #### Client side
 
-Keep filter state in a small app-owned composable, then pass it into `useCrudList()` as `queryParams`.
-
-Example shape:
+Build the filter runtime directly from the shared definitions:
 
 ```js
-const listFilters = useContactsListFilters();
+const listFilters = useCrudListFilters(CONTACTS_LIST_FILTER_DEFINITIONS);
 
 const records = useCrudList({
   resource: uiResource,
@@ -802,9 +832,7 @@ const records = useCrudList({
     enabled: true,
     mode: "query"
   },
-  queryParams: computed(() => ({
-    ...listFilters.filters
-  })),
+  queryParams: listFilters.queryParams,
   syncToRoute: {
     enabled: true,
     search: true,
@@ -814,53 +842,50 @@ const records = useCrudList({
 });
 ```
 
-This keeps the filters:
+That gives you, from one place:
 
-- visible in the URL
-- restorable on refresh
-- preserved when opening a record and coming back
+- `listFilters.values`
+- `listFilters.queryParams`
+- `listFilters.activeChips`
+- `listFilters.hasActiveFilters`
+- `listFilters.clearChip(...)`
+- `listFilters.clearFilters()`
+- `listFilters.toggle(...)` for flag filters
+
+So the same runtime owns:
+
+- URL-synced query params
+- filter chips
+- reset logic
+- preset application
+- small flag toggles
 
 #### Server side
 
-Add a dedicated query validator:
+Build the server runtime from the same shared definitions:
 
 ```js
-const contactsListFiltersQueryValidator = Object.freeze({
-  schema: Type.Object(
-    {
-      hasEmail: Type.Optional(...),
-      hasPhone: Type.Optional(...),
-      hasNotes: Type.Optional(...)
-    },
-    { additionalProperties: false }
-  ),
-  normalize(payload = {}) {
-    const normalized = {};
-    if (Object.hasOwn(payload, "hasEmail")) normalized.hasEmail = 1;
-    if (Object.hasOwn(payload, "hasPhone")) normalized.hasPhone = 1;
-    if (Object.hasOwn(payload, "hasNotes")) normalized.hasNotes = 1;
-    return normalized;
+const contactsListFiltersRuntime = createCrudListFilters(
+  CONTACTS_LIST_FILTER_DEFINITIONS,
+  {
+    columns: {
+      onlyStaff: "is_staff",
+      onlyVip: "vip",
+      onlyArchived: "archived"
+    }
   }
-});
+);
+
+const contactsListFiltersQueryValidator = contactsListFiltersRuntime.queryValidator;
 ```
 
-Wire it into the route and action validators for the list operation, then apply the filter in `repository.js`:
+Wire the runtime into the list validator and the repository:
 
 ```js
 async function list(query = {}, callOptions = {}) {
   return crudRepositoryList(repositoryRuntime, knex, query, options, callOptions, {
     modifyQuery(dbQuery, context = {}) {
-      const sourceQuery = context.query || {};
-
-      if (sourceQuery.hasEmail !== undefined) {
-        dbQuery.whereNotNull("email").where("email", "<>", "");
-      }
-      if (sourceQuery.hasPhone !== undefined) {
-        dbQuery.whereNotNull("phone").where("phone", "<>", "");
-      }
-      if (sourceQuery.hasNotes !== undefined) {
-        dbQuery.whereNotNull("notes").where("notes", "<>", "");
-      }
+      return contactsListFiltersRuntime.applyQuery(dbQuery, context.query || {});
     }
   });
 }
@@ -868,11 +893,115 @@ async function list(query = {}, callOptions = {}) {
 
 #### Best practices
 
-- Keep the client keys, validator keys, and repository keys identical.
-- Use dedicated query params for booleans and facets. Do not overload `q`.
-- Put SQL in the repository, not in the page.
+- Put the filter definitions in the CRUD package, not the page. Both server and client need them.
+- Keep the filter keys identical all the way through: definition key, query param key, and repository meaning.
+- Use `createCrudListFilters(...)` unless the list semantics are truly unusual.
+- Use `q` for free-text and explicit query params for structured filters.
 
-### Pattern 4: free-text search plus structured `contacts` filters together
+### Pattern 4: lookup-backed structured filters
+
+This is the next real-world step: filters like `supplierContactId`, `locationId`, or `contactId` where the user needs:
+
+- remote autocomplete search
+- URL-synced selected ids
+- readable chip labels instead of raw ids
+
+The right pattern is:
+
+1. keep the lookup filter in the shared definitions
+2. use `useCrudListFilters(...)` for state, chips, and query params
+3. use `useCrudListFilterLookups(...)` for option loading and label resolution
+
+Example shared definition:
+
+```js
+export const RECEIVAL_LIST_FILTER_DEFINITIONS = Object.freeze({
+  supplierContactId: {
+    type: "recordIdMany",
+    label: "Supplier",
+    lookup: {
+      namespace: "contacts"
+    }
+  },
+  pollenTypeId: {
+    type: "recordIdMany",
+    label: "Pollen Type",
+    lookup: {
+      namespace: "pollen-types",
+      labelKey: "name"
+    }
+  }
+});
+```
+
+#### Client side
+
+```js
+let filterLookups = null;
+
+const listFilters = useCrudListFilters(
+  RECEIVAL_LIST_FILTER_DEFINITIONS,
+  {
+    labelResolvers: {
+      supplierContactId(value) {
+        return filterLookups?.resolveLookupLabel("supplierContactId", value, "Supplier") || "";
+      }
+    }
+  }
+);
+
+filterLookups = useCrudListFilterLookups(
+  RECEIVAL_LIST_FILTER_DEFINITIONS,
+  {
+    values: listFilters.values,
+    queryKeyPrefix: ["ui-generator", "receivals", "filters"],
+    placementSourcePrefix: "ui-generator.receivals.list.filters",
+    requestQueryParams: {
+      supplierContactId: { limit: 25 }
+    },
+    labelResolvers: {
+      supplierContactId(item = {}) {
+        return `${item.firstName} ${item.lastName}`.trim();
+      }
+    }
+  }
+);
+
+const supplierFilterLookup = filterLookups.resolveLookup("supplierContactId");
+```
+
+Then bind the autocomplete:
+
+```vue
+<v-autocomplete
+  v-model="listFilters.values.supplierContactId"
+  :items="supplierFilterLookup.options"
+  :search="supplierFilterLookup.searchQuery"
+  :loading="supplierFilterLookup.isLoading"
+  item-title="label"
+  item-value="value"
+  multiple
+  chips
+  no-filter
+  @update:search="supplierFilterLookup.setSearch"
+/>
+```
+
+#### Why this is better than a page-local `useList()` wrapper
+
+- the CRUD filter state still lives in `useCrudListFilters(...)`
+- the autocomplete loading logic lives in one reusable helper
+- the label resolution used by filter chips and the autocomplete stays consistent
+- a second screen can reuse the same pattern instead of rewriting it
+
+#### Best practices
+
+- Put lookup metadata in the shared filter definitions.
+- Use `useCrudListFilterLookups(...)` for remote filter autocompletes instead of building a custom `useList()` wrapper per screen.
+- Keep lookup label formatting on the client side. It is UI presentation, not repository logic.
+- Keep unusual SQL semantics, such as `pending = whereNull(...)`, in the server runtime `apply` override.
+
+### Pattern 5: free-text search plus structured filters together
 
 This is the most common real-world CRUD list.
 
@@ -895,7 +1024,7 @@ Let the generic list search handle `q`, and let your custom validator/repository
 - Preserve the current route query when linking to view/edit pages so users can return to the same filtered list state.
 - Let list changes reset pagination; `useCrudList()` already does this for search and query-param changes.
 
-### Pattern 5: parent-scoped child CRUD search for `addresses`
+### Pattern 6: parent-scoped child CRUD search for `addresses`
 
 For nested CRUDs such as the `addresses` resource from the previous chapter, parent scoping and search usually work together.
 
@@ -935,7 +1064,7 @@ That keeps child-list filtering grounded in the actual resource definition inste
 - Let the resource contract define parent filter shape.
 - Treat parent-scoped filtering as repository/query behavior, not as presentation logic.
 
-### Pattern 6: local-only search for embedded `comments`
+### Pattern 7: local-only search for embedded `comments`
 
 Sometimes server search is unnecessary.
 

--- a/packages/agent-docs/patterns/INDEX.md
+++ b/packages/agent-docs/patterns/INDEX.md
@@ -20,6 +20,8 @@ How to use it:
   - `crud-links.md`
 - live actions, checkbox, toggle, patch button, inline action, `useCommand()`
   - `live-actions.md`
+- filter, filters, search facets, chips, date range, enum filter, lookup filter, `useCrudListFilters`, `createCrudListFilters`
+  - `filters.md`
 
 ## Current Patterns
 
@@ -28,3 +30,4 @@ How to use it:
 - [child-cruds.md](./child-cruds.md)
 - [crud-links.md](./crud-links.md)
 - [live-actions.md](./live-actions.md)
+- [filters.md](./filters.md)

--- a/packages/agent-docs/patterns/filters.md
+++ b/packages/agent-docs/patterns/filters.md
@@ -1,0 +1,55 @@
+# Structured Filters
+
+Use when:
+- a CRUD list needs flags, enums, date ranges, record-id filters, or lookup-backed filters
+- the user asks to "add a filter", "make the list filterable", or "keep filters in the URL"
+- a screen mixes free-text search with structured facets
+
+Ask first:
+- which fields are filterable
+- whether each filter is a flag, enum, multi-enum, date/date-range, number-range, record id, or lookup-backed record id
+- whether filters must sync to the route query
+- whether the screen needs chips and clear/reset behavior
+- whether lookup filters need remote autocomplete search
+- whether there are presets such as "Today", "Last 7 Days", or "Only Archived"
+
+Default JSKIT pattern:
+1. Put shared filter definitions in the CRUD package.
+   Example path: `packages/<crud>/src/shared/<crud>ListFilters.js`
+2. Build the server runtime from that module with `createCrudListFilters(...)`.
+3. Use the runtime's `queryValidator` in routes/actions and `applyQuery(...)` in the repository.
+4. Build the client runtime from the same shared definitions with `useCrudListFilters(...)`.
+5. Pass `listFilters.queryParams` into `useCrudList(...)`.
+6. For lookup-backed filters, use `useCrudListFilterLookups(...)` instead of hand-rolling `useList()` in each page.
+
+Keep separate:
+- free-text search uses `records.searchQuery` and `q`
+- structured filters use explicit query params through `useCrudListFilters(...)`
+
+Use `useCrudListFilterLookups(...)` when:
+- a filter is `recordId` or `recordIdMany`
+- the UI needs remote autocomplete search
+- chips should show readable labels instead of raw ids
+
+Put unusual SQL semantics on the server:
+- examples: `pending` meaning `whereNull("ccp1_passed")`, or `assigned/unassigned` meaning `whereNotNull(...)` / `whereNull(...)`
+- implement those in `createCrudListFilters(..., { apply: { ... } })`
+
+Avoid:
+- local filter composables that duplicate the same keys the server already knows about
+- a custom validator shape that does not match the page state
+- per-screen `useList()` wrappers for lookup-backed filters when `useCrudListFilterLookups(...)` fits
+- overloading `q` with structured filter meaning
+
+Good shape:
+- `packages/receivals/src/shared/receivalListFilters.js`
+- `createCrudListFilters(RECEIVAL_LIST_FILTER_DEFINITIONS, ...)`
+- `const listFilters = useCrudListFilters(RECEIVAL_LIST_FILTER_DEFINITIONS)`
+- `const filterLookups = useCrudListFilterLookups(RECEIVAL_LIST_FILTER_DEFINITIONS, { values: listFilters.values, ... })`
+- `queryParams: listFilters.queryParams`
+
+Review checks:
+- one shared filter definition source of truth
+- server validator/repository logic derived from that source
+- client query params/chips/reset logic derived from that source
+- lookup-backed filters use the shared lookup helper, not a page-local mini-framework

--- a/packages/agent-docs/reference/autogen/KERNEL_MAP.md
+++ b/packages/agent-docs/reference/autogen/KERNEL_MAP.md
@@ -25,6 +25,33 @@ For the full repo inventory, read `reference/autogen/README.md` and the package 
 Exports
 - `isContainerToken(value)`
 
+### `support/crudListFilters.js`
+Exports
+- `CRUD_LIST_FILTER_TYPE_FLAG`
+- `CRUD_LIST_FILTER_TYPE_ENUM`
+- `CRUD_LIST_FILTER_TYPE_ENUM_MANY`
+- `CRUD_LIST_FILTER_TYPE_RECORD_ID`
+- `CRUD_LIST_FILTER_TYPE_RECORD_ID_MANY`
+- `CRUD_LIST_FILTER_TYPE_DATE`
+- `CRUD_LIST_FILTER_TYPE_DATE_RANGE`
+- `CRUD_LIST_FILTER_TYPE_NUMBER_RANGE`
+- `CRUD_LIST_FILTER_TYPE_PRESENCE`
+- `CRUD_LIST_FILTER_TYPES`
+- `CRUD_LIST_FILTER_PRESENCE_PRESENT`
+- `CRUD_LIST_FILTER_PRESENCE_MISSING`
+- `CRUD_LIST_FILTER_PRESENCE_OPTIONS`
+- `defineCrudListFilters(definitions = {})`
+- `resolveCrudListFilterQueryKeys(definition = {})`
+- `resolveCrudListFilterOptionLabel(definition = {}, value = "", { fallback = "" } = {})`
+Local functions
+- `normalizeCrudListFilterType(value = "")`
+- `normalizeCrudListFilterOption(rawOption = null, { context = "filter option" } = {})`
+- `normalizeCrudListFilterOptions(rawOptions = [], { context = "filter options" } = {})`
+- `normalizeCrudListFilterPresenceOptions(rawOptions = [])`
+- `normalizeCrudListFilterLookup(rawLookup = null)`
+- `resolveCrudListFilterOptionSet(rawDefinition = {}, type = "")`
+- `normalizeCrudListFilterDefinition(rawKey = "", rawDefinition = null)`
+
 ### `support/crudLookup.js`
 Exports
 - `DEFAULT_CRUD_LOOKUP_CONTAINER_KEY`

--- a/packages/agent-docs/reference/autogen/packages/crud-core.md
+++ b/packages/agent-docs/reference/autogen/packages/crud-core.md
@@ -132,6 +132,25 @@ Local functions
 - `resolveRoleMatrixPolicy(matrix = {}, operation = "readable", input = {})`
 - `applyReadableFieldPolicyToRecord(record, allowedFields, outputRules = null, { context = "crudFieldAccess" } = {})`
 
+### `src/server/listFilters.js`
+Exports
+- `createCrudListFilters(definitions = {}, { columns = {}, apply = {} } = {})`
+Local functions
+- `createSingleOrMultiValueSchema(itemSchema)`
+- `firstValue(value)`
+- `normalizeDateFilterValue(value)`
+- `normalizeNumberFilterValue(value)`
+- `normalizeRecordIdFilterValue(value)`
+- `normalizeRecordIdFilterValues(value)`
+- `resolveAllowedOptionValues(filter = {})`
+- `normalizeAllowedTextValue(value, allowedValues = new Set())`
+- `normalizeAllowedTextValues(value, allowedValues = new Set())`
+- `addDaysToDateFilterValue(value = "", days = 0)`
+- `createFilterQuerySchema(filter = {})`
+- `normalizeFilterValue(filter = {}, source = {})`
+- `normalizeColumnsMap(columns = {})`
+- `applyDefaultFilterQuery(queryBuilder, filter = {}, value, column = "")`
+
 ### `src/server/listQueryValidators.js`
 Exports
 - `createCrudCursorPaginationQueryValidator(list = {})`

--- a/packages/agent-docs/reference/autogen/packages/kernel.md
+++ b/packages/agent-docs/reference/autogen/packages/kernel.md
@@ -199,6 +199,33 @@ Exports
 Exports
 - `isContainerToken(value)`
 
+### `shared/support/crudListFilters.js`
+Exports
+- `CRUD_LIST_FILTER_TYPE_FLAG`
+- `CRUD_LIST_FILTER_TYPE_ENUM`
+- `CRUD_LIST_FILTER_TYPE_ENUM_MANY`
+- `CRUD_LIST_FILTER_TYPE_RECORD_ID`
+- `CRUD_LIST_FILTER_TYPE_RECORD_ID_MANY`
+- `CRUD_LIST_FILTER_TYPE_DATE`
+- `CRUD_LIST_FILTER_TYPE_DATE_RANGE`
+- `CRUD_LIST_FILTER_TYPE_NUMBER_RANGE`
+- `CRUD_LIST_FILTER_TYPE_PRESENCE`
+- `CRUD_LIST_FILTER_TYPES`
+- `CRUD_LIST_FILTER_PRESENCE_PRESENT`
+- `CRUD_LIST_FILTER_PRESENCE_MISSING`
+- `CRUD_LIST_FILTER_PRESENCE_OPTIONS`
+- `defineCrudListFilters(definitions = {})`
+- `resolveCrudListFilterQueryKeys(definition = {})`
+- `resolveCrudListFilterOptionLabel(definition = {}, value = "", { fallback = "" } = {})`
+Local functions
+- `normalizeCrudListFilterType(value = "")`
+- `normalizeCrudListFilterOption(rawOption = null, { context = "filter option" } = {})`
+- `normalizeCrudListFilterOptions(rawOptions = [], { context = "filter options" } = {})`
+- `normalizeCrudListFilterPresenceOptions(rawOptions = [])`
+- `normalizeCrudListFilterLookup(rawLookup = null)`
+- `resolveCrudListFilterOptionSet(rawDefinition = {}, type = "")`
+- `normalizeCrudListFilterDefinition(rawKey = "", rawDefinition = null)`
+
 ### `shared/support/crudLookup.js`
 Exports
 - `DEFAULT_CRUD_LOOKUP_CONTAINER_KEY`

--- a/packages/agent-docs/reference/autogen/packages/users-web.md
+++ b/packages/agent-docs/reference/autogen/packages/users-web.md
@@ -113,6 +113,18 @@ Local functions
 - `resolveFormFieldInitialValue(field = {})`
 - `shouldSerializeClearedFieldAsNull(field = {})`
 
+### `src/client/composables/internal/crudListFilterLookupSupport.js`
+Exports
+- `normalizeLookupQueryKeyPrefix(value = [])`
+- `normalizeLookupLabelResolverMap(value = {})`
+- `normalizeLookupRequestQueryParamsMap(value = {})`
+- `resolveLookupSelectedValues(filter = {}, rawValue = undefined)`
+- `createLookupOptionsFromItems(items = [], filter = {}, labelResolver = null)`
+- `mergeSelectedLookupOptions(options = [], selectedValues = [], cachedOptions = new Map())`
+- `resolveLookupOptionLabel(options = [], cachedOptions = new Map(), value = "", fallback = "Option")`
+Local functions
+- `createLookupOptionFromItem(item = {}, filter = {}, labelResolver = null)`
+
 ### `src/client/composables/internal/crudListParentTitleSupport.js`
 Exports
 - `resolveCrudListParentDescriptor({ resource = {}, route = null, recordIdParam = "recordId" } = {})`
@@ -339,6 +351,24 @@ Exports
 ### `src/client/composables/useCommand.js`
 Exports
 - `useCommand({ ownershipFilter = ROUTE_VISIBILITY_WORKSPACE, surfaceId = "", access = "auto", apiSuffix = "", runPermissions = [], writeMethod = "POST", placementSource = "users-web.command", fallbackRunError = "Unable to complete action.", fieldErrorKeys = [], clearOnRouteChange = true, model, parseInput, buildRawPayload, buildCommandPayload, buildCommandOptions, onRunSuccess, onRunError, suppressSuccessMessage = false, messages = {}, realtime = null } = {})`
+
+### `src/client/composables/useCrudListFilterLookups.js`
+Exports
+- `useCrudListFilterLookups(definitions = {}, { values = {}, adapter = null, recordIdParam = "recordId", queryKeyPrefix = [], placementSourcePrefix = "", requestQueryParams = {}, labelResolvers = {} } = {})`
+
+### `src/client/composables/useCrudListFilters.js`
+Exports
+- `useCrudListFilters(definitions = {}, { labelResolvers = {}, chipLabels = {}, presets = [] } = {})`
+Local functions
+- `normalizeFunctionMap(value = {})`
+- `createInitialFilterValue(filter = {})`
+- `normalizePresetEntries(presets = [])`
+- `normalizePresetFilterValue(filter = {}, rawValue)`
+- `resetFilterValue(values, filter = {})`
+- `applyPresetFilterValue(values, filter = {}, rawValue)`
+- `createQueryParams(values, filterEntries = [])`
+- `resolveAtomicValueLabel(filter = {}, value = "", labelResolvers = {})`
+- `defaultChipLabel(filter = {}, value, labelResolvers = {})`
 
 ### `src/client/composables/useCrudListParentTitle.js`
 Exports

--- a/packages/agent-docs/site/guide/generators/advanced-cruds.md
+++ b/packages/agent-docs/site/guide/generators/advanced-cruds.md
@@ -676,7 +676,7 @@ The baseline generator output is only the start. As the tutorial's `contacts`, `
 
 - `src/server/listQueryValidators.js` when a list needs extra query filters beyond `q`
 - `src/server/service.test.js` once save/delete rules stop being trivial
-- `src/composables/contacts/useContactsListFilters.js` when the contacts page gains route-backed filter state
+- `packages/contacts/src/shared/contactListFilters.js` when the contacts CRUD gains structured list filters that both server and client should share
 - `src/composables/addresses/useAddressDisplay.js` when addresses need app-specific display formatting
 - `src/composables/comments/useCommentsListRuntime.js` when an embedded comments list needs local UI state
 
@@ -684,6 +684,7 @@ That is the right direction of growth:
 
 - server customizations stay in the CRUD package
 - presentation and page-specific UI state stay in app-owned client files
+- shared structured list filters live best in a CRUD-package shared module that both server and client can import
 
 ## Search and filters: the deep dive
 
@@ -780,18 +781,47 @@ Usually nothing changes. The client can keep sending `q`.
 - Do not dump every text column into search just because you can.
 - In this tutorial CRUD, `notes` is a good example of a field you might leave out if you want fast, predictable list search.
 
-### Pattern 3: structured `contacts` filters such as `hasEmail`, `hasPhone`, and `hasNotes`
+### Pattern 3: structured list filters from one shared definition
 
-This is the first extension that still fits the `contacts` table from the previous chapter with no schema changes.
+This is the default pattern once a CRUD list needs real filters.
+
+Do not hand-build:
+
+- one filter shape in the page
+- a second filter shape in `listQueryValidators.js`
+- and a third filter shape in `repository.js`
+
+Instead:
+
+1. define the filters once in a shared CRUD-package module
+2. build the server runtime from that definition with `createCrudListFilters(...)`
+3. build the client runtime from that same definition with `useCrudListFilters(...)`
+
+For example, a shared filter-definition module can look like this:
+
+```js
+export const CONTACTS_LIST_FILTER_DEFINITIONS = Object.freeze({
+  onlyStaff: {
+    type: "flag",
+    label: "Staff"
+  },
+  onlyVip: {
+    type: "flag",
+    label: "VIP"
+  },
+  onlyArchived: {
+    type: "flag",
+    label: "Archived"
+  }
+});
+```
 
 #### Client side
 
-Keep filter state in a small app-owned composable, then pass it into `useCrudList()` as `queryParams`.
-
-Example shape:
+Build the filter runtime directly from the shared definitions:
 
 ```js
-const listFilters = useContactsListFilters();
+const listFilters = useCrudListFilters(CONTACTS_LIST_FILTER_DEFINITIONS);
 
 const records = useCrudList({
   resource: uiResource,
@@ -800,9 +830,7 @@ const records = useCrudList({
     enabled: true,
     mode: "query"
   },
-  queryParams: computed(() => ({
-    ...listFilters.filters
-  })),
+  queryParams: listFilters.queryParams,
   syncToRoute: {
     enabled: true,
     search: true,
@@ -812,53 +840,50 @@ const records = useCrudList({
 });
 ```
 
-This keeps the filters:
+That gives you, from one place:
 
-- visible in the URL
-- restorable on refresh
-- preserved when opening a record and coming back
+- `listFilters.values`
+- `listFilters.queryParams`
+- `listFilters.activeChips`
+- `listFilters.hasActiveFilters`
+- `listFilters.clearChip(...)`
+- `listFilters.clearFilters()`
+- `listFilters.toggle(...)` for flag filters
+
+So the same runtime owns:
+
+- URL-synced query params
+- filter chips
+- reset logic
+- preset application
+- small flag toggles
 
 #### Server side
 
-Add a dedicated query validator:
+Build the server runtime from the same shared definitions:
 
 ```js
-const contactsListFiltersQueryValidator = Object.freeze({
-  schema: Type.Object(
-    {
-      hasEmail: Type.Optional(...),
-      hasPhone: Type.Optional(...),
-      hasNotes: Type.Optional(...)
-    },
-    { additionalProperties: false }
-  ),
-  normalize(payload = {}) {
-    const normalized = {};
-    if (Object.hasOwn(payload, "hasEmail")) normalized.hasEmail = 1;
-    if (Object.hasOwn(payload, "hasPhone")) normalized.hasPhone = 1;
-    if (Object.hasOwn(payload, "hasNotes")) normalized.hasNotes = 1;
-    return normalized;
+const contactsListFiltersRuntime = createCrudListFilters(
+  CONTACTS_LIST_FILTER_DEFINITIONS,
+  {
+    columns: {
+      onlyStaff: "is_staff",
+      onlyVip: "vip",
+      onlyArchived: "archived"
+    }
   }
-});
+);
+
+const contactsListFiltersQueryValidator = contactsListFiltersRuntime.queryValidator;
 ```
 
-Wire it into the route and action validators for the list operation, then apply the filter in `repository.js`:
+Wire the runtime into the list validator and the repository:
 
 ```js
 async function list(query = {}, callOptions = {}) {
   return crudRepositoryList(repositoryRuntime, knex, query, options, callOptions, {
     modifyQuery(dbQuery, context = {}) {
-      const sourceQuery = context.query || {};
-
-      if (sourceQuery.hasEmail !== undefined) {
-        dbQuery.whereNotNull("email").where("email", "<>", "");
-      }
-      if (sourceQuery.hasPhone !== undefined) {
-        dbQuery.whereNotNull("phone").where("phone", "<>", "");
-      }
-      if (sourceQuery.hasNotes !== undefined) {
-        dbQuery.whereNotNull("notes").where("notes", "<>", "");
-      }
+      return contactsListFiltersRuntime.applyQuery(dbQuery, context.query || {});
     }
   });
 }
@@ -866,11 +891,115 @@ async function list(query = {}, callOptions = {}) {
 
 #### Best practices
 
-- Keep the client keys, validator keys, and repository keys identical.
-- Use dedicated query params for booleans and facets. Do not overload `q`.
-- Put SQL in the repository, not in the page.
+- Put the filter definitions in the CRUD package, not the page. Both server and client need them.
+- Keep the filter keys identical all the way through: definition key, query param key, and repository meaning.
+- Use `createCrudListFilters(...)` unless the list semantics are truly unusual.
+- Use `q` for free-text and explicit query params for structured filters.
 
-### Pattern 4: free-text search plus structured `contacts` filters together
+### Pattern 4: lookup-backed structured filters
+
+This is the next real-world step: filters like `supplierContactId`, `locationId`, or `contactId` where the user needs:
+
+- remote autocomplete search
+- URL-synced selected ids
+- readable chip labels instead of raw ids
+
+The right pattern is:
+
+1. keep the lookup filter in the shared definitions
+2. use `useCrudListFilters(...)` for state, chips, and query params
+3. use `useCrudListFilterLookups(...)` for option loading and label resolution
+
+Example shared definition:
+
+```js
+export const RECEIVAL_LIST_FILTER_DEFINITIONS = Object.freeze({
+  supplierContactId: {
+    type: "recordIdMany",
+    label: "Supplier",
+    lookup: {
+      namespace: "contacts"
+    }
+  },
+  pollenTypeId: {
+    type: "recordIdMany",
+    label: "Pollen Type",
+    lookup: {
+      namespace: "pollen-types",
+      labelKey: "name"
+    }
+  }
+});
+```
+
+#### Client side
+
+```js
+let filterLookups = null;
+
+const listFilters = useCrudListFilters(
+  RECEIVAL_LIST_FILTER_DEFINITIONS,
+  {
+    labelResolvers: {
+      supplierContactId(value) {
+        return filterLookups?.resolveLookupLabel("supplierContactId", value, "Supplier") || "";
+      }
+    }
+  }
+);
+
+filterLookups = useCrudListFilterLookups(
+  RECEIVAL_LIST_FILTER_DEFINITIONS,
+  {
+    values: listFilters.values,
+    queryKeyPrefix: ["ui-generator", "receivals", "filters"],
+    placementSourcePrefix: "ui-generator.receivals.list.filters",
+    requestQueryParams: {
+      supplierContactId: { limit: 25 }
+    },
+    labelResolvers: {
+      supplierContactId(item = {}) {
+        return `${item.firstName} ${item.lastName}`.trim();
+      }
+    }
+  }
+);
+
+const supplierFilterLookup = filterLookups.resolveLookup("supplierContactId");
+```
+
+Then bind the autocomplete:
+
+```vue
+<v-autocomplete
+  v-model="listFilters.values.supplierContactId"
+  :items="supplierFilterLookup.options"
+  :search="supplierFilterLookup.searchQuery"
+  :loading="supplierFilterLookup.isLoading"
+  item-title="label"
+  item-value="value"
+  multiple
+  chips
+  no-filter
+  @update:search="supplierFilterLookup.setSearch"
+/>
+```
+
+#### Why this is better than a page-local `useList()` wrapper
+
+- the CRUD filter state still lives in `useCrudListFilters(...)`
+- the autocomplete loading logic lives in one reusable helper
+- the label resolution used by filter chips and the autocomplete stays consistent
+- a second screen can reuse the same pattern instead of rewriting it
+
+#### Best practices
+
+- Put lookup metadata in the shared filter definitions.
+- Use `useCrudListFilterLookups(...)` for remote filter autocompletes instead of building a custom `useList()` wrapper per screen.
+- Keep lookup label formatting on the client side. It is UI presentation, not repository logic.
+- Keep unusual SQL semantics, such as `pending = whereNull(...)`, in the server runtime `apply` override.
+
+### Pattern 5: free-text search plus structured filters together
 
 This is the most common real-world CRUD list.
 
@@ -893,7 +1022,7 @@ Let the generic list search handle `q`, and let your custom validator/repository
 - Preserve the current route query when linking to view/edit pages so users can return to the same filtered list state.
 - Let list changes reset pagination; `useCrudList()` already does this for search and query-param changes.
 
-### Pattern 5: parent-scoped child CRUD search for `addresses`
+### Pattern 6: parent-scoped child CRUD search for `addresses`
 
 For nested CRUDs such as the `addresses` resource from the previous chapter, parent scoping and search usually work together.
 
@@ -933,7 +1062,7 @@ That keeps child-list filtering grounded in the actual resource definition inste
 - Let the resource contract define parent filter shape.
 - Treat parent-scoped filtering as repository/query behavior, not as presentation logic.
 
-### Pattern 6: local-only search for embedded `comments`
+### Pattern 7: local-only search for embedded `comments`
 
 Sometimes server search is unnecessary.
 

--- a/packages/agent-docs/templates/app/AGENTS.md
+++ b/packages/agent-docs/templates/app/AGENTS.md
@@ -31,7 +31,7 @@ Core rules:
   - `Why this sticks: ...`
   - `Not doing: ...`
 - Keep that checkpoint compact. Do not expand it into a long preamble unless the developer asks for detail.
-- When a request involves JSKIT UI, routing, surfaces, CRUDs, placements, live actions, or similar implementation details, scan `node_modules/@jskit-ai/agent-docs/patterns/INDEX.md` for matching keywords and read only the relevant pattern files.
+- When a request involves JSKIT UI, routing, surfaces, CRUDs, filters, placements, live actions, or similar implementation details, scan `node_modules/@jskit-ai/agent-docs/patterns/INDEX.md` for matching keywords and read only the relevant pattern files.
 - Reuse existing JSKIT helpers and runtime seams before adding new local helpers.
 - A freshly scaffolded JSKIT app can still be in Stage 1. If the app was just created and platform decisions are not settled yet, continue with the initialize workflow before adding runtime packages.
 - Do not treat a missing `config.tenancyMode` line or an untouched minimal scaffold as a final tenancy decision.

--- a/packages/crud-core/package.json
+++ b/packages/crud-core/package.json
@@ -22,7 +22,8 @@
     "./server/fieldAccess": "./src/server/fieldAccess.js",
     "./server/createCrudServiceFromResource": "./src/server/createCrudServiceFromResource.js",
     "./server/crudModuleConfig": "./src/server/crudModuleConfig.js",
-    "./server/listQueryValidators": "./src/server/listQueryValidators.js"
+    "./server/listQueryValidators": "./src/server/listQueryValidators.js",
+    "./server/listFilters": "./src/server/listFilters.js"
   },
   "dependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/crud-core/src/server/listFilters.js
+++ b/packages/crud-core/src/server/listFilters.js
@@ -1,0 +1,463 @@
+import { Type } from "typebox";
+import {
+  normalizeObjectInput,
+  mergeObjectSchemas,
+  RECORD_ID_PATTERN
+} from "@jskit-ai/kernel/shared/validators";
+import {
+  normalizeBoolean,
+  normalizeCanonicalRecordIdText,
+  normalizeObject,
+  normalizeText,
+  normalizeUniqueTextList
+} from "@jskit-ai/kernel/shared/support/normalize";
+import {
+  defineCrudListFilters,
+  CRUD_LIST_FILTER_TYPE_FLAG,
+  CRUD_LIST_FILTER_TYPE_ENUM,
+  CRUD_LIST_FILTER_TYPE_ENUM_MANY,
+  CRUD_LIST_FILTER_TYPE_RECORD_ID,
+  CRUD_LIST_FILTER_TYPE_RECORD_ID_MANY,
+  CRUD_LIST_FILTER_TYPE_DATE,
+  CRUD_LIST_FILTER_TYPE_DATE_RANGE,
+  CRUD_LIST_FILTER_TYPE_NUMBER_RANGE,
+  CRUD_LIST_FILTER_TYPE_PRESENCE
+} from "@jskit-ai/kernel/shared/support/crudListFilters";
+
+const DATE_FILTER_PATTERN = /^\d{4}-\d{2}-\d{2}$/u;
+const stringOrNumberSchema = Type.Union([
+  Type.String({ minLength: 1 }),
+  Type.Number()
+]);
+const recordIdInputSchema = Type.Union([
+  Type.String({ pattern: RECORD_ID_PATTERN }),
+  Type.Number({ minimum: 1 })
+]);
+const flagInputSchema = Type.Union([
+  Type.String({ minLength: 0 }),
+  Type.Boolean(),
+  Type.Number()
+]);
+
+function createSingleOrMultiValueSchema(itemSchema) {
+  return Type.Optional(
+    Type.Union([
+      itemSchema,
+      Type.Array(itemSchema, {
+        minItems: 1
+      })
+    ])
+  );
+}
+
+function firstValue(value) {
+  if (Array.isArray(value)) {
+    return value[0];
+  }
+
+  return value;
+}
+
+function normalizeDateFilterValue(value) {
+  const normalized = normalizeText(firstValue(value));
+  if (!normalized || !DATE_FILTER_PATTERN.test(normalized)) {
+    return "";
+  }
+
+  return normalized;
+}
+
+function normalizeNumberFilterValue(value) {
+  if (value == null || value === "") {
+    return null;
+  }
+
+  const normalized = typeof value === "number"
+    ? value
+    : Number(normalizeText(firstValue(value)));
+  return Number.isFinite(normalized) ? normalized : null;
+}
+
+function normalizeRecordIdFilterValue(value) {
+  return normalizeCanonicalRecordIdText(firstValue(value), {
+    fallback: ""
+  }) || "";
+}
+
+function normalizeRecordIdFilterValues(value) {
+  return normalizeUniqueTextList(value, {
+    acceptSingle: true
+  })
+    .map((entry) => normalizeCanonicalRecordIdText(entry, { fallback: "" }))
+    .filter(Boolean);
+}
+
+function resolveAllowedOptionValues(filter = {}) {
+  return new Set(
+    (Array.isArray(filter.options) ? filter.options : [])
+      .map((entry) => normalizeText(entry?.value))
+      .filter(Boolean)
+  );
+}
+
+function normalizeAllowedTextValue(value, allowedValues = new Set()) {
+  const normalized = normalizeText(firstValue(value));
+  if (!normalized || !allowedValues.has(normalized)) {
+    return "";
+  }
+
+  return normalized;
+}
+
+function normalizeAllowedTextValues(value, allowedValues = new Set()) {
+  return normalizeUniqueTextList(value, {
+    acceptSingle: true
+  }).filter((entry) => allowedValues.has(entry));
+}
+
+function addDaysToDateFilterValue(value = "", days = 0) {
+  const normalizedValue = normalizeDateFilterValue(value);
+  if (!normalizedValue || !Number.isInteger(days)) {
+    return "";
+  }
+
+  const date = new Date(`${normalizedValue}T00:00:00.000Z`);
+  if (Number.isNaN(date.getTime())) {
+    return "";
+  }
+
+  date.setUTCDate(date.getUTCDate() + days);
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(date.getUTCDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function createFilterQuerySchema(filter = {}) {
+  const allowedValues = (Array.isArray(filter.options) ? filter.options : []).map((entry) => entry.value);
+
+  if (filter.type === CRUD_LIST_FILTER_TYPE_FLAG) {
+    return Type.Object(
+      {
+        [filter.queryKey]: Type.Optional(flagInputSchema)
+      },
+      { additionalProperties: false }
+    );
+  }
+
+  if (filter.type === CRUD_LIST_FILTER_TYPE_ENUM || filter.type === CRUD_LIST_FILTER_TYPE_PRESENCE) {
+    return Type.Object(
+      {
+        [filter.queryKey]: Type.Optional(Type.String({ enum: allowedValues }))
+      },
+      { additionalProperties: false }
+    );
+  }
+
+  if (filter.type === CRUD_LIST_FILTER_TYPE_ENUM_MANY) {
+    return Type.Object(
+      {
+        [filter.queryKey]: createSingleOrMultiValueSchema(
+          Type.String({ enum: allowedValues })
+        )
+      },
+      { additionalProperties: false }
+    );
+  }
+
+  if (filter.type === CRUD_LIST_FILTER_TYPE_RECORD_ID) {
+    return Type.Object(
+      {
+        [filter.queryKey]: Type.Optional(recordIdInputSchema)
+      },
+      { additionalProperties: false }
+    );
+  }
+
+  if (filter.type === CRUD_LIST_FILTER_TYPE_RECORD_ID_MANY) {
+    return Type.Object(
+      {
+        [filter.queryKey]: createSingleOrMultiValueSchema(recordIdInputSchema)
+      },
+      { additionalProperties: false }
+    );
+  }
+
+  if (filter.type === CRUD_LIST_FILTER_TYPE_DATE) {
+    return Type.Object(
+      {
+        [filter.queryKey]: Type.Optional(Type.String({ pattern: "^\\d{4}-\\d{2}-\\d{2}$" }))
+      },
+      { additionalProperties: false }
+    );
+  }
+
+  if (filter.type === CRUD_LIST_FILTER_TYPE_DATE_RANGE) {
+    return Type.Object(
+      {
+        [filter.fromKey]: Type.Optional(Type.String({ pattern: "^\\d{4}-\\d{2}-\\d{2}$" })),
+        [filter.toKey]: Type.Optional(Type.String({ pattern: "^\\d{4}-\\d{2}-\\d{2}$" }))
+      },
+      { additionalProperties: false }
+    );
+  }
+
+  if (filter.type === CRUD_LIST_FILTER_TYPE_NUMBER_RANGE) {
+    return Type.Object(
+      {
+        [filter.minKey]: Type.Optional(stringOrNumberSchema),
+        [filter.maxKey]: Type.Optional(stringOrNumberSchema)
+      },
+      { additionalProperties: false }
+    );
+  }
+
+  return Type.Object({}, { additionalProperties: false });
+}
+
+function normalizeFilterValue(filter = {}, source = {}) {
+  const allowedValues = resolveAllowedOptionValues(filter);
+
+  if (filter.type === CRUD_LIST_FILTER_TYPE_FLAG) {
+    if (!Object.hasOwn(source, filter.queryKey)) {
+      return undefined;
+    }
+
+    const sourceValue = source[filter.queryKey];
+    if (sourceValue === null || sourceValue === "") {
+      return true;
+    }
+
+    try {
+      return normalizeBoolean(firstValue(sourceValue));
+    } catch {
+      return undefined;
+    }
+  }
+
+  if (filter.type === CRUD_LIST_FILTER_TYPE_ENUM || filter.type === CRUD_LIST_FILTER_TYPE_PRESENCE) {
+    if (!Object.hasOwn(source, filter.queryKey)) {
+      return undefined;
+    }
+
+    const normalizedValue = normalizeAllowedTextValue(source[filter.queryKey], allowedValues);
+    return normalizedValue || undefined;
+  }
+
+  if (filter.type === CRUD_LIST_FILTER_TYPE_ENUM_MANY) {
+    if (!Object.hasOwn(source, filter.queryKey)) {
+      return undefined;
+    }
+
+    const normalizedValues = normalizeAllowedTextValues(source[filter.queryKey], allowedValues);
+    return normalizedValues.length > 0 ? normalizedValues : undefined;
+  }
+
+  if (filter.type === CRUD_LIST_FILTER_TYPE_RECORD_ID) {
+    if (!Object.hasOwn(source, filter.queryKey)) {
+      return undefined;
+    }
+
+    const normalizedValue = normalizeRecordIdFilterValue(source[filter.queryKey]);
+    return normalizedValue || undefined;
+  }
+
+  if (filter.type === CRUD_LIST_FILTER_TYPE_RECORD_ID_MANY) {
+    if (!Object.hasOwn(source, filter.queryKey)) {
+      return undefined;
+    }
+
+    const normalizedValues = normalizeRecordIdFilterValues(source[filter.queryKey]);
+    return normalizedValues.length > 0 ? normalizedValues : undefined;
+  }
+
+  if (filter.type === CRUD_LIST_FILTER_TYPE_DATE) {
+    if (!Object.hasOwn(source, filter.queryKey)) {
+      return undefined;
+    }
+
+    const normalizedValue = normalizeDateFilterValue(source[filter.queryKey]);
+    return normalizedValue || undefined;
+  }
+
+  if (filter.type === CRUD_LIST_FILTER_TYPE_DATE_RANGE) {
+    const from = normalizeDateFilterValue(source[filter.fromKey]);
+    const to = normalizeDateFilterValue(source[filter.toKey]);
+    if (!from && !to) {
+      return undefined;
+    }
+
+    return Object.freeze({
+      ...(from ? { from } : {}),
+      ...(to ? { to } : {})
+    });
+  }
+
+  if (filter.type === CRUD_LIST_FILTER_TYPE_NUMBER_RANGE) {
+    const min = normalizeNumberFilterValue(source[filter.minKey]);
+    const max = normalizeNumberFilterValue(source[filter.maxKey]);
+    if (min == null && max == null) {
+      return undefined;
+    }
+
+    return Object.freeze({
+      ...(min != null ? { min } : {}),
+      ...(max != null ? { max } : {})
+    });
+  }
+
+  return undefined;
+}
+
+function normalizeColumnsMap(columns = {}) {
+  const source = normalizeObject(columns);
+  const normalized = {};
+  for (const [key, value] of Object.entries(source)) {
+    const normalizedKey = normalizeText(key);
+    const normalizedValue = normalizeText(value);
+    if (!normalizedKey || !normalizedValue) {
+      continue;
+    }
+
+    normalized[normalizedKey] = normalizedValue;
+  }
+
+  return Object.freeze(normalized);
+}
+
+function applyDefaultFilterQuery(queryBuilder, filter = {}, value, column = "") {
+  if (!column) {
+    return queryBuilder;
+  }
+
+  if (filter.type === CRUD_LIST_FILTER_TYPE_FLAG) {
+    if (value === true) {
+      queryBuilder.where(column, true);
+    }
+    return queryBuilder;
+  }
+
+  if (filter.type === CRUD_LIST_FILTER_TYPE_ENUM || filter.type === CRUD_LIST_FILTER_TYPE_RECORD_ID) {
+    if (value !== undefined) {
+      queryBuilder.where(column, value);
+    }
+    return queryBuilder;
+  }
+
+  if (filter.type === CRUD_LIST_FILTER_TYPE_ENUM_MANY || filter.type === CRUD_LIST_FILTER_TYPE_RECORD_ID_MANY) {
+    if (Array.isArray(value) && value.length > 0) {
+      queryBuilder.whereIn(column, value);
+    }
+    return queryBuilder;
+  }
+
+  if (filter.type === CRUD_LIST_FILTER_TYPE_PRESENCE) {
+    if (value === "present") {
+      queryBuilder.whereNotNull(column);
+    }
+    if (value === "missing") {
+      queryBuilder.whereNull(column);
+    }
+    return queryBuilder;
+  }
+
+  if (filter.type === CRUD_LIST_FILTER_TYPE_DATE) {
+    if (value) {
+      const nextDate = addDaysToDateFilterValue(value, 1);
+      queryBuilder.where(column, ">=", `${value} 00:00:00`);
+      if (nextDate) {
+        queryBuilder.where(column, "<", `${nextDate} 00:00:00`);
+      }
+    }
+    return queryBuilder;
+  }
+
+  if (filter.type === CRUD_LIST_FILTER_TYPE_DATE_RANGE) {
+    if (value?.from) {
+      queryBuilder.where(column, ">=", `${value.from} 00:00:00`);
+    }
+    if (value?.to) {
+      const nextDate = addDaysToDateFilterValue(value.to, 1);
+      if (nextDate) {
+        queryBuilder.where(column, "<", `${nextDate} 00:00:00`);
+      }
+    }
+    return queryBuilder;
+  }
+
+  if (filter.type === CRUD_LIST_FILTER_TYPE_NUMBER_RANGE) {
+    if (value?.min != null) {
+      queryBuilder.where(column, ">=", value.min);
+    }
+    if (value?.max != null) {
+      queryBuilder.where(column, "<=", value.max);
+    }
+    return queryBuilder;
+  }
+
+  return queryBuilder;
+}
+
+function createCrudListFilters(definitions = {}, { columns = {}, apply = {} } = {}) {
+  const normalizedFilters = defineCrudListFilters(definitions);
+  const normalizedColumns = normalizeColumnsMap(columns);
+  const filterEntries = Object.values(normalizedFilters);
+  const schema = mergeObjectSchemas(filterEntries.map((filter) => createFilterQuerySchema(filter)));
+
+  function normalize(payload = {}) {
+    const source = normalizeObjectInput(payload);
+    const normalized = {};
+
+    for (const filter of filterEntries) {
+      const value = normalizeFilterValue(filter, source);
+      if (value === undefined) {
+        continue;
+      }
+
+      normalized[filter.key] = value;
+    }
+
+    return Object.freeze(normalized);
+  }
+
+  function applyQuery(queryBuilder, payload = {}) {
+    if (!queryBuilder || typeof queryBuilder.where !== "function") {
+      throw new TypeError("createCrudListFilters.applyQuery requires query builder.");
+    }
+
+    const normalized = normalize(payload);
+    for (const filter of filterEntries) {
+      if (!Object.hasOwn(normalized, filter.key)) {
+        continue;
+      }
+
+      const value = normalized[filter.key];
+      const customApply = typeof apply?.[filter.key] === "function"
+        ? apply[filter.key]
+        : null;
+      if (customApply) {
+        customApply(queryBuilder, value, {
+          filter,
+          filters: normalized
+        });
+        continue;
+      }
+
+      applyDefaultFilterQuery(queryBuilder, filter, value, normalizedColumns[filter.key] || "");
+    }
+
+    return queryBuilder;
+  }
+
+  return Object.freeze({
+    filters: normalizedFilters,
+    queryValidator: Object.freeze({
+      schema,
+      normalize
+    }),
+    normalize,
+    applyQuery
+  });
+}
+
+export { createCrudListFilters };

--- a/packages/crud-core/test/listFilters.test.js
+++ b/packages/crud-core/test/listFilters.test.js
@@ -1,0 +1,252 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { compileRouteValidator } from "@jskit-ai/kernel/_testable";
+import { cursorPaginationQueryValidator } from "@jskit-ai/kernel/shared/validators";
+import { listSearchQueryValidator } from "../src/server/listQueryValidators.js";
+import { createCrudListFilters } from "../src/server/listFilters.js";
+
+test("crud-core exposes createCrudListFilters through the public package export", async () => {
+  const module = await import("@jskit-ai/crud-core/server/listFilters");
+  assert.equal(typeof module.createCrudListFilters, "function");
+});
+
+function createQueryDouble() {
+  const calls = [];
+  const nestedQuery = {
+    where(...args) {
+      calls.push(["innerWhere", ...args]);
+      return nestedQuery;
+    },
+    orWhere(...args) {
+      calls.push(["innerOrWhere", ...args]);
+      return nestedQuery;
+    },
+    whereNull(...args) {
+      calls.push(["innerWhereNull", ...args]);
+      return nestedQuery;
+    },
+    whereNotNull(...args) {
+      calls.push(["innerWhereNotNull", ...args]);
+      return nestedQuery;
+    }
+  };
+
+  const query = {
+    where(...args) {
+      if (args.length === 1 && typeof args[0] === "function") {
+        calls.push(["whereGroup"]);
+        args[0](nestedQuery);
+        return query;
+      }
+
+      calls.push(["where", ...args]);
+      return query;
+    },
+    whereIn(...args) {
+      calls.push(["whereIn", ...args]);
+      return query;
+    },
+    whereNull(...args) {
+      calls.push(["whereNull", ...args]);
+      return query;
+    },
+    whereNotNull(...args) {
+      calls.push(["whereNotNull", ...args]);
+      return query;
+    }
+  };
+
+  return {
+    query,
+    calls
+  };
+}
+
+test("createCrudListFilters normalizes filters into semantic values", () => {
+  const runtime = createCrudListFilters({
+    onlyStaff: {
+      type: "flag",
+      label: "Staff"
+    },
+    status: {
+      type: "enumMany",
+      label: "Status",
+      options: [
+        { value: "active", label: "Active" },
+        { value: "archived", label: "Archived" }
+      ]
+    },
+    arrivalDate: {
+      type: "dateRange",
+      label: "Arrival Date"
+    },
+    supplierContactId: {
+      type: "recordIdMany",
+      label: "Supplier"
+    },
+    weight: {
+      type: "numberRange",
+      label: "Weight"
+    }
+  });
+
+  const normalized = runtime.normalize({
+    onlyStaff: "",
+    status: ["active", "ignored", "archived"],
+    arrivalDateFrom: "2026-04-01",
+    arrivalDateTo: "2026-04-30",
+    supplierContactId: ["7", "bad", "4"],
+    weightMin: "12.5",
+    weightMax: 18
+  });
+
+  assert.deepEqual(normalized, {
+    onlyStaff: true,
+    status: ["active", "archived"],
+    arrivalDate: {
+      from: "2026-04-01",
+      to: "2026-04-30"
+    },
+    supplierContactId: ["7", "4"],
+    weight: {
+      min: 12.5,
+      max: 18
+    }
+  });
+});
+
+test("createCrudListFilters applies default column filters by type", () => {
+  const runtime = createCrudListFilters(
+    {
+      onlyStaff: {
+        type: "flag",
+        label: "Staff"
+      },
+      status: {
+        type: "enumMany",
+        label: "Status",
+        options: [
+          { value: "active", label: "Active" },
+          { value: "archived", label: "Archived" }
+        ]
+      },
+      supplierContactId: {
+        type: "recordId",
+        label: "Supplier"
+      },
+      arrivalDate: {
+        type: "dateRange",
+        label: "Arrival Date"
+      },
+      weight: {
+        type: "numberRange",
+        label: "Weight"
+      },
+      locationAssignment: {
+        type: "presence",
+        label: "Storage"
+      }
+    },
+    {
+      columns: {
+        onlyStaff: "is_staff",
+        status: "status",
+        supplierContactId: "supplier_contact_id",
+        arrivalDate: "arrival_datetime",
+        weight: "weight_received",
+        locationAssignment: "location_id"
+      }
+    }
+  );
+  const { query, calls } = createQueryDouble();
+
+  runtime.applyQuery(query, {
+    onlyStaff: "",
+    status: ["active", "archived"],
+    supplierContactId: "7",
+    arrivalDateFrom: "2026-04-01",
+    arrivalDateTo: "2026-04-30",
+    weightMin: "12.5",
+    weightMax: "18",
+    locationAssignment: "missing"
+  });
+
+  assert.deepEqual(calls, [
+    ["where", "is_staff", true],
+    ["whereIn", "status", ["active", "archived"]],
+    ["where", "supplier_contact_id", "7"],
+    ["where", "arrival_datetime", ">=", "2026-04-01 00:00:00"],
+    ["where", "arrival_datetime", "<", "2026-05-01 00:00:00"],
+    ["where", "weight_received", ">=", 12.5],
+    ["where", "weight_received", "<=", 18],
+    ["whereNull", "location_id"]
+  ]);
+});
+
+test("createCrudListFilters supports custom apply overrides for complex filters", () => {
+  const runtime = createCrudListFilters(
+    {
+      ccp1Status: {
+        type: "enumMany",
+        label: "CCP1",
+        options: [
+          { value: "pending", label: "Pending" },
+          { value: "passed", label: "Passed" },
+          { value: "failed", label: "Failed" }
+        ]
+      }
+    },
+    {
+      apply: {
+        ccp1Status(queryBuilder, values) {
+          queryBuilder.where((statusQuery) => {
+            if (values.includes("pending")) {
+              statusQuery.whereNull("ccp1_passed");
+            }
+            if (values.includes("failed")) {
+              statusQuery.orWhere("ccp1_passed", false);
+            }
+          });
+        }
+      }
+    }
+  );
+  const { query, calls } = createQueryDouble();
+
+  runtime.applyQuery(query, {
+    ccp1Status: ["pending", "failed"]
+  });
+
+  assert.deepEqual(calls, [
+    ["whereGroup"],
+    ["innerWhereNull", "ccp1_passed"],
+    ["innerOrWhere", "ccp1_passed", false]
+  ]);
+});
+
+test("createCrudListFilters query validator stays mergeable with search and cursor validators", () => {
+  const runtime = createCrudListFilters({
+    status: {
+      type: "enum",
+      label: "Status",
+      options: [
+        { value: "active", label: "Active" },
+        { value: "archived", label: "Archived" }
+      ]
+    },
+    arrivalDate: {
+      type: "dateRange",
+      label: "Arrival Date"
+    }
+  });
+
+  const compiled = compileRouteValidator({
+    queryValidator: [
+      cursorPaginationQueryValidator,
+      listSearchQueryValidator,
+      runtime.queryValidator
+    ]
+  });
+
+  assert.deepEqual(compiled.schema.querystring.required || [], []);
+});

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -35,6 +35,7 @@
     "./shared/support/tokens": "./shared/support/tokens.js",
     "./shared/support/normalize": "./shared/support/normalize.js",
     "./shared/support/permissions": "./shared/support/permissions.js",
+    "./shared/support/crudListFilters": "./shared/support/crudListFilters.js",
     "./shared/support/crudLookup": "./shared/support/crudLookup.js",
     "./shared/support/deepFreeze": "./shared/support/deepFreeze.js",
     "./shared/support/listenerSet": "./shared/support/listenerSet.js",

--- a/packages/kernel/shared/support/crudListFilters.js
+++ b/packages/kernel/shared/support/crudListFilters.js
@@ -1,0 +1,294 @@
+import { deepFreeze } from "./deepFreeze.js";
+import {
+  normalizeText,
+  normalizeObject
+} from "./normalize.js";
+import {
+  normalizeCrudLookupApiPath,
+  normalizeCrudLookupNamespace,
+  resolveCrudLookupApiPathFromNamespace
+} from "./crudLookup.js";
+
+const CRUD_LIST_FILTER_TYPE_FLAG = "flag";
+const CRUD_LIST_FILTER_TYPE_ENUM = "enum";
+const CRUD_LIST_FILTER_TYPE_ENUM_MANY = "enumMany";
+const CRUD_LIST_FILTER_TYPE_RECORD_ID = "recordId";
+const CRUD_LIST_FILTER_TYPE_RECORD_ID_MANY = "recordIdMany";
+const CRUD_LIST_FILTER_TYPE_DATE = "date";
+const CRUD_LIST_FILTER_TYPE_DATE_RANGE = "dateRange";
+const CRUD_LIST_FILTER_TYPE_NUMBER_RANGE = "numberRange";
+const CRUD_LIST_FILTER_TYPE_PRESENCE = "presence";
+
+const CRUD_LIST_FILTER_TYPES = Object.freeze([
+  CRUD_LIST_FILTER_TYPE_FLAG,
+  CRUD_LIST_FILTER_TYPE_ENUM,
+  CRUD_LIST_FILTER_TYPE_ENUM_MANY,
+  CRUD_LIST_FILTER_TYPE_RECORD_ID,
+  CRUD_LIST_FILTER_TYPE_RECORD_ID_MANY,
+  CRUD_LIST_FILTER_TYPE_DATE,
+  CRUD_LIST_FILTER_TYPE_DATE_RANGE,
+  CRUD_LIST_FILTER_TYPE_NUMBER_RANGE,
+  CRUD_LIST_FILTER_TYPE_PRESENCE
+]);
+
+const CRUD_LIST_FILTER_PRESENCE_PRESENT = "present";
+const CRUD_LIST_FILTER_PRESENCE_MISSING = "missing";
+const CRUD_LIST_FILTER_PRESENCE_OPTIONS = Object.freeze([
+  Object.freeze({
+    value: CRUD_LIST_FILTER_PRESENCE_PRESENT,
+    label: "Present"
+  }),
+  Object.freeze({
+    value: CRUD_LIST_FILTER_PRESENCE_MISSING,
+    label: "Missing"
+  })
+]);
+
+function normalizeCrudListFilterType(value = "") {
+  const normalized = normalizeText(value);
+  if (CRUD_LIST_FILTER_TYPES.includes(normalized)) {
+    return normalized;
+  }
+
+  throw new TypeError(`Unsupported CRUD list filter type "${value}".`);
+}
+
+function normalizeCrudListFilterOption(rawOption = null, { context = "filter option" } = {}) {
+  const source = typeof rawOption === "string"
+    ? { value: rawOption }
+    : normalizeObject(rawOption);
+  const value = normalizeText(source.value);
+  if (!value) {
+    throw new TypeError(`${context} requires value.`);
+  }
+
+  return Object.freeze({
+    value,
+    label: normalizeText(source.label) || value
+  });
+}
+
+function normalizeCrudListFilterOptions(rawOptions = [], { context = "filter options" } = {}) {
+  const source = Array.isArray(rawOptions) ? rawOptions : [];
+  const options = [];
+  const seenValues = new Set();
+
+  for (const rawOption of source) {
+    const option = normalizeCrudListFilterOption(rawOption, { context });
+    if (seenValues.has(option.value)) {
+      continue;
+    }
+
+    seenValues.add(option.value);
+    options.push(option);
+  }
+
+  return Object.freeze(options);
+}
+
+function normalizeCrudListFilterPresenceOptions(rawOptions = []) {
+  const sourceOptions = normalizeCrudListFilterOptions(rawOptions, {
+    context: "presence filter options"
+  });
+  if (sourceOptions.length < 1) {
+    return CRUD_LIST_FILTER_PRESENCE_OPTIONS;
+  }
+
+  const optionMap = new Map(sourceOptions.map((entry) => [entry.value, entry]));
+  const presentOption = optionMap.get(CRUD_LIST_FILTER_PRESENCE_PRESENT);
+  const missingOption = optionMap.get(CRUD_LIST_FILTER_PRESENCE_MISSING);
+  if (!presentOption || !missingOption) {
+    throw new TypeError('Presence filter options must contain both "present" and "missing" values.');
+  }
+
+  return Object.freeze([
+    presentOption,
+    missingOption
+  ]);
+}
+
+function normalizeCrudListFilterLookup(rawLookup = null) {
+  if (rawLookup == null) {
+    return null;
+  }
+  if (!rawLookup || typeof rawLookup !== "object" || Array.isArray(rawLookup)) {
+    throw new TypeError("CRUD list filter lookup must be an object.");
+  }
+  const source = normalizeObject(rawLookup);
+
+  const namespace = normalizeCrudLookupNamespace(source.namespace);
+  const explicitApiPath = normalizeCrudLookupApiPath(source.apiSuffix || source.apiPath);
+  const apiSuffix = explicitApiPath || resolveCrudLookupApiPathFromNamespace(namespace);
+  const labelKey = normalizeText(source.labelKey);
+  const valueKey = normalizeText(source.valueKey) || "id";
+
+  return Object.freeze({
+    ...(namespace ? { namespace } : {}),
+    ...(apiSuffix ? { apiSuffix } : {}),
+    ...(labelKey ? { labelKey } : {}),
+    valueKey
+  });
+}
+
+function resolveCrudListFilterOptionSet(rawDefinition = {}, type = "") {
+  if (type === CRUD_LIST_FILTER_TYPE_ENUM || type === CRUD_LIST_FILTER_TYPE_ENUM_MANY) {
+    const options = normalizeCrudListFilterOptions(rawDefinition.options, {
+      context: `${type} filter options`
+    });
+    if (options.length < 1) {
+      throw new TypeError(`${type} filters require at least one option.`);
+    }
+    return options;
+  }
+
+  if (type === CRUD_LIST_FILTER_TYPE_PRESENCE) {
+    return normalizeCrudListFilterPresenceOptions(rawDefinition.options);
+  }
+
+  return Object.freeze([]);
+}
+
+function resolveCrudListFilterQueryKeys(definition = {}) {
+  const type = normalizeCrudListFilterType(definition.type);
+  if (type === CRUD_LIST_FILTER_TYPE_DATE_RANGE) {
+    return Object.freeze([
+      normalizeText(definition.fromKey),
+      normalizeText(definition.toKey)
+    ].filter(Boolean));
+  }
+  if (type === CRUD_LIST_FILTER_TYPE_NUMBER_RANGE) {
+    return Object.freeze([
+      normalizeText(definition.minKey),
+      normalizeText(definition.maxKey)
+    ].filter(Boolean));
+  }
+
+  return Object.freeze([normalizeText(definition.queryKey)].filter(Boolean));
+}
+
+function resolveCrudListFilterOptionLabel(definition = {}, value = "", { fallback = "" } = {}) {
+  const normalizedValue = normalizeText(value);
+  if (!normalizedValue) {
+    return normalizeText(fallback);
+  }
+
+  const options = Array.isArray(definition?.options) ? definition.options : [];
+  const optionLabel = options.find((entry) => entry?.value === normalizedValue)?.label;
+  return normalizeText(optionLabel) || normalizeText(fallback) || normalizedValue;
+}
+
+function normalizeCrudListFilterDefinition(rawKey = "", rawDefinition = null) {
+  const key = normalizeText(rawKey);
+  if (!key) {
+    throw new TypeError("CRUD list filter definitions require non-empty keys.");
+  }
+
+  if (!rawDefinition || typeof rawDefinition !== "object" || Array.isArray(rawDefinition)) {
+    throw new TypeError(`CRUD list filter "${key}" must be an object.`);
+  }
+  const source = normalizeObject(rawDefinition);
+
+  const type = normalizeCrudListFilterType(source.type);
+  const label = normalizeText(source.label) || key;
+  const options = resolveCrudListFilterOptionSet(source, type);
+  const lookup = normalizeCrudListFilterLookup(source.lookup);
+  const chipLabel = typeof source.chipLabel === "function" ? source.chipLabel : null;
+  const ui = source.ui && typeof source.ui === "object" && !Array.isArray(source.ui)
+    ? deepFreeze({ ...source.ui })
+    : null;
+  const meta = source.meta && typeof source.meta === "object" && !Array.isArray(source.meta)
+    ? deepFreeze({ ...source.meta })
+    : null;
+
+  if (type === CRUD_LIST_FILTER_TYPE_DATE_RANGE) {
+    return Object.freeze({
+      key,
+      type,
+      label,
+      fromKey: normalizeText(source.fromKey) || `${key}From`,
+      toKey: normalizeText(source.toKey) || `${key}To`,
+      options,
+      lookup,
+      chipLabel,
+      ui,
+      meta
+    });
+  }
+
+  if (type === CRUD_LIST_FILTER_TYPE_NUMBER_RANGE) {
+    return Object.freeze({
+      key,
+      type,
+      label,
+      minKey: normalizeText(source.minKey) || `${key}Min`,
+      maxKey: normalizeText(source.maxKey) || `${key}Max`,
+      options,
+      lookup,
+      chipLabel,
+      ui,
+      meta
+    });
+  }
+
+  return Object.freeze({
+    key,
+    type,
+    label,
+    queryKey: normalizeText(source.queryKey) || key,
+    options,
+    lookup,
+    chipLabel,
+    ui,
+    meta
+  });
+}
+
+function defineCrudListFilters(definitions = {}) {
+  if (!definitions || typeof definitions !== "object" || Array.isArray(definitions)) {
+    throw new TypeError("defineCrudListFilters requires an object.");
+  }
+  const source = normalizeObject(definitions);
+
+  const normalized = {};
+  const seenFilterKeys = new Set();
+  const seenQueryKeys = new Map();
+
+  for (const [rawKey, rawDefinition] of Object.entries(source)) {
+    const filter = normalizeCrudListFilterDefinition(rawKey, rawDefinition);
+    if (seenFilterKeys.has(filter.key)) {
+      throw new TypeError(`Duplicate CRUD list filter key "${filter.key}".`);
+    }
+    seenFilterKeys.add(filter.key);
+
+    for (const queryKey of resolveCrudListFilterQueryKeys(filter)) {
+      const seenBy = seenQueryKeys.get(queryKey);
+      if (seenBy) {
+        throw new TypeError(`CRUD list filters "${seenBy}" and "${filter.key}" both use query key "${queryKey}".`);
+      }
+      seenQueryKeys.set(queryKey, filter.key);
+    }
+
+    normalized[filter.key] = filter;
+  }
+
+  return deepFreeze(normalized);
+}
+
+export {
+  CRUD_LIST_FILTER_TYPE_FLAG,
+  CRUD_LIST_FILTER_TYPE_ENUM,
+  CRUD_LIST_FILTER_TYPE_ENUM_MANY,
+  CRUD_LIST_FILTER_TYPE_RECORD_ID,
+  CRUD_LIST_FILTER_TYPE_RECORD_ID_MANY,
+  CRUD_LIST_FILTER_TYPE_DATE,
+  CRUD_LIST_FILTER_TYPE_DATE_RANGE,
+  CRUD_LIST_FILTER_TYPE_NUMBER_RANGE,
+  CRUD_LIST_FILTER_TYPE_PRESENCE,
+  CRUD_LIST_FILTER_TYPES,
+  CRUD_LIST_FILTER_PRESENCE_PRESENT,
+  CRUD_LIST_FILTER_PRESENCE_MISSING,
+  CRUD_LIST_FILTER_PRESENCE_OPTIONS,
+  defineCrudListFilters,
+  resolveCrudListFilterQueryKeys,
+  resolveCrudListFilterOptionLabel
+};

--- a/packages/kernel/shared/support/crudListFilters.test.js
+++ b/packages/kernel/shared/support/crudListFilters.test.js
@@ -1,0 +1,135 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  defineCrudListFilters,
+  resolveCrudListFilterQueryKeys,
+  resolveCrudListFilterOptionLabel
+} from "./crudListFilters.js";
+
+test("defineCrudListFilters normalizes common filter shapes", () => {
+  const filters = defineCrudListFilters({
+    onlyStaff: {
+      type: "flag",
+      label: "Staff"
+    },
+    status: {
+      type: "enumMany",
+      label: "Status",
+      options: [
+        { value: "active", label: "Active" },
+        { value: "archived", label: "Archived" }
+      ]
+    },
+    arrivalDate: {
+      type: "dateRange",
+      label: "Arrival Date"
+    },
+    weight: {
+      type: "numberRange",
+      label: "Weight"
+    },
+    supplierContactId: {
+      type: "recordIdMany",
+      label: "Supplier",
+      lookup: {
+        namespace: "contacts"
+      }
+    }
+  });
+
+  assert.deepEqual(filters.onlyStaff, {
+    key: "onlyStaff",
+    type: "flag",
+    label: "Staff",
+    queryKey: "onlyStaff",
+    options: [],
+    lookup: null,
+    chipLabel: null,
+    ui: null,
+    meta: null
+  });
+  assert.deepEqual(filters.arrivalDate, {
+    key: "arrivalDate",
+    type: "dateRange",
+    label: "Arrival Date",
+    fromKey: "arrivalDateFrom",
+    toKey: "arrivalDateTo",
+    options: [],
+    lookup: null,
+    chipLabel: null,
+    ui: null,
+    meta: null
+  });
+  assert.deepEqual(filters.weight, {
+    key: "weight",
+    type: "numberRange",
+    label: "Weight",
+    minKey: "weightMin",
+    maxKey: "weightMax",
+    options: [],
+    lookup: null,
+    chipLabel: null,
+    ui: null,
+    meta: null
+  });
+  assert.deepEqual(filters.supplierContactId.lookup, {
+    namespace: "contacts",
+    apiSuffix: "/contacts",
+    valueKey: "id"
+  });
+});
+
+test("defineCrudListFilters uses fixed presence semantics with optional label overrides", () => {
+  const filters = defineCrudListFilters({
+    locationAssignment: {
+      type: "presence",
+      label: "Storage",
+      options: [
+        { value: "present", label: "Assigned" },
+        { value: "missing", label: "Unassigned" }
+      ]
+    }
+  });
+
+  assert.deepEqual(filters.locationAssignment.options, [
+    { value: "present", label: "Assigned" },
+    { value: "missing", label: "Unassigned" }
+  ]);
+});
+
+test("defineCrudListFilters rejects duplicate query keys", () => {
+  assert.throws(
+    () => defineCrudListFilters({
+      arrivalDate: {
+        type: "dateRange",
+        label: "Arrival Date"
+      },
+      arrivalDateFrom: {
+        type: "date",
+        label: "Arrival Date From"
+      }
+    }),
+    /both use query key "arrivalDateFrom"/
+  );
+});
+
+test("resolveCrudListFilter helpers expose query keys and option labels", () => {
+  const filters = defineCrudListFilters({
+    status: {
+      type: "enum",
+      label: "Status",
+      options: [
+        { value: "active", label: "Active" }
+      ]
+    },
+    arrivalDate: {
+      type: "dateRange",
+      label: "Arrival Date"
+    }
+  });
+
+  assert.deepEqual(resolveCrudListFilterQueryKeys(filters.status), ["status"]);
+  assert.deepEqual(resolveCrudListFilterQueryKeys(filters.arrivalDate), ["arrivalDateFrom", "arrivalDateTo"]);
+  assert.equal(resolveCrudListFilterOptionLabel(filters.status, "active"), "Active");
+  assert.equal(resolveCrudListFilterOptionLabel(filters.status, "missing", { fallback: "Unknown" }), "Unknown");
+});

--- a/packages/users-web/package.descriptor.mjs
+++ b/packages/users-web/package.descriptor.mjs
@@ -67,6 +67,10 @@ export default Object.freeze({
           summary: "Exports command operation composable."
         },
         {
+          subpath: "./client/composables/useCrudListFilterLookups",
+          summary: "Exports lookup-backed CRUD list filter helper for remote autocomplete filters."
+        },
+        {
           subpath: "./client/composables/useView",
           summary: "Exports read/view operation composable."
         },

--- a/packages/users-web/package.json
+++ b/packages/users-web/package.json
@@ -13,6 +13,8 @@
     "./client/composables/useCommand": "./src/client/composables/useCommand.js",
     "./client/composables/useCrudAddEdit": "./src/client/composables/records/useCrudAddEdit.js",
     "./client/composables/crudLookupFieldRuntime": "./src/client/composables/crud/crudLookupFieldRuntime.js",
+    "./client/composables/useCrudListFilterLookups": "./src/client/composables/useCrudListFilterLookups.js",
+    "./client/composables/useCrudListFilters": "./src/client/composables/useCrudListFilters.js",
     "./client/composables/useList": "./src/client/composables/records/useList.js",
     "./client/composables/useCrudList": "./src/client/composables/records/useCrudList.js",
     "./client/composables/useCrudListParentTitle": "./src/client/composables/useCrudListParentTitle.js",

--- a/packages/users-web/src/client/composables/internal/crudListFilterLookupSupport.js
+++ b/packages/users-web/src/client/composables/internal/crudListFilterLookupSupport.js
@@ -1,0 +1,161 @@
+import { normalizeText, normalizeUniqueTextList } from "@jskit-ai/kernel/shared/support/normalize";
+import { resolveLookupItemLabel } from "../crud/crudLookupFieldLabelSupport.js";
+import { asPlainObject } from "../support/scopeHelpers.js";
+
+function normalizeLookupQueryKeyPrefix(value = []) {
+  const source = Array.isArray(value) ? value : [];
+  return Object.freeze(
+    source
+      .map((entry) => normalizeText(entry))
+      .filter(Boolean)
+  );
+}
+
+function normalizeLookupLabelResolverMap(value = {}) {
+  const source = value && typeof value === "object" && !Array.isArray(value)
+    ? value
+    : {};
+  const normalized = {};
+
+  for (const [key, entry] of Object.entries(source)) {
+    const normalizedKey = normalizeText(key);
+    if (!normalizedKey || typeof entry !== "function") {
+      continue;
+    }
+
+    normalized[normalizedKey] = entry;
+  }
+
+  return Object.freeze(normalized);
+}
+
+function normalizeLookupRequestQueryParamsMap(value = {}) {
+  const source = value && typeof value === "object" && !Array.isArray(value)
+    ? value
+    : {};
+  const normalized = {};
+
+  for (const [key, entry] of Object.entries(source)) {
+    const normalizedKey = normalizeText(key);
+    if (!normalizedKey) {
+      continue;
+    }
+    if (entry == null) {
+      continue;
+    }
+    if (typeof entry === "function") {
+      normalized[normalizedKey] = entry;
+      continue;
+    }
+    if (typeof entry !== "object" || Array.isArray(entry)) {
+      continue;
+    }
+
+    normalized[normalizedKey] = asPlainObject(entry);
+  }
+
+  return Object.freeze(normalized);
+}
+
+function resolveLookupSelectedValues(filter = {}, rawValue = undefined) {
+  if (filter?.type === "recordIdMany") {
+    return normalizeUniqueTextList(rawValue, {
+      acceptSingle: true
+    });
+  }
+
+  const normalizedValue = normalizeText(rawValue);
+  return normalizedValue ? Object.freeze([normalizedValue]) : Object.freeze([]);
+}
+
+function createLookupOptionFromItem(item = {}, filter = {}, labelResolver = null) {
+  const sourceRecord = asPlainObject(item);
+  const valueKey = normalizeText(filter?.lookup?.valueKey) || "id";
+  const labelKey = normalizeText(filter?.lookup?.labelKey);
+  const value = normalizeText(sourceRecord[valueKey]);
+  if (!value) {
+    return null;
+  }
+
+  const customLabel = typeof labelResolver === "function"
+    ? normalizeText(labelResolver(sourceRecord, filter))
+    : "";
+  const fallbackLabel = resolveLookupItemLabel(sourceRecord, labelKey) || value;
+
+  return Object.freeze({
+    value,
+    label: customLabel || String(fallbackLabel || value),
+    record: sourceRecord
+  });
+}
+
+function createLookupOptionsFromItems(items = [], filter = {}, labelResolver = null) {
+  const optionMap = new Map();
+  for (const item of Array.isArray(items) ? items : []) {
+    const option = createLookupOptionFromItem(item, filter, labelResolver);
+    if (!option || optionMap.has(option.value)) {
+      continue;
+    }
+
+    optionMap.set(option.value, option);
+  }
+
+  return Object.freeze([...optionMap.values()]);
+}
+
+function mergeSelectedLookupOptions(options = [], selectedValues = [], cachedOptions = new Map()) {
+  const optionMap = new Map(
+    (Array.isArray(options) ? options : []).map((option) => [normalizeText(option?.value), option])
+  );
+  const normalizedCache = cachedOptions instanceof Map ? cachedOptions : new Map();
+
+  for (const value of Array.isArray(selectedValues) ? selectedValues : []) {
+    const normalizedValue = normalizeText(value);
+    if (!normalizedValue || optionMap.has(normalizedValue)) {
+      continue;
+    }
+
+    const cachedOption = normalizedCache.get(normalizedValue);
+    if (cachedOption) {
+      optionMap.set(normalizedValue, cachedOption);
+    }
+  }
+
+  return Object.freeze(
+    [...optionMap.values()].sort((left, right) => {
+      return String(left?.label || "").localeCompare(String(right?.label || ""));
+    })
+  );
+}
+
+function resolveLookupOptionLabel(options = [], cachedOptions = new Map(), value = "", fallback = "Option") {
+  const normalizedValue = normalizeText(value);
+  if (!normalizedValue) {
+    return normalizeText(fallback) || "Option";
+  }
+
+  const matchingOption = (Array.isArray(options) ? options : [])
+    .find((option) => normalizeText(option?.value) === normalizedValue);
+  if (matchingOption?.label) {
+    return String(matchingOption.label);
+  }
+
+  const normalizedCache = cachedOptions instanceof Map ? cachedOptions : new Map();
+  const cachedOption = normalizedCache.get(normalizedValue);
+  if (cachedOption?.label) {
+    return String(cachedOption.label);
+  }
+
+  const normalizedFallback = normalizeText(fallback) || "Option";
+  return `${normalizedFallback} ${normalizedValue}`;
+}
+
+export {
+  normalizeLookupQueryKeyPrefix,
+  normalizeLookupLabelResolverMap,
+  normalizeLookupRequestQueryParamsMap,
+  resolveLookupSelectedValues,
+  createLookupOptionsFromItems,
+  mergeSelectedLookupOptions,
+  resolveLookupOptionLabel
+};

--- a/packages/users-web/src/client/composables/useCrudListFilterLookups.js
+++ b/packages/users-web/src/client/composables/useCrudListFilterLookups.js
@@ -1,0 +1,141 @@
+import { computed, proxyRefs, ref, watch } from "vue";
+import { normalizeText } from "@jskit-ai/kernel/shared/support/normalize";
+import {
+  defineCrudListFilters,
+  CRUD_LIST_FILTER_TYPE_RECORD_ID,
+  CRUD_LIST_FILTER_TYPE_RECORD_ID_MANY
+} from "@jskit-ai/kernel/shared/support/crudListFilters";
+import { useList } from "./records/useList.js";
+import {
+  normalizeLookupQueryKeyPrefix,
+  normalizeLookupLabelResolverMap,
+  normalizeLookupRequestQueryParamsMap,
+  resolveLookupSelectedValues,
+  createLookupOptionsFromItems,
+  mergeSelectedLookupOptions,
+  resolveLookupOptionLabel
+} from "./internal/crudListFilterLookupSupport.js";
+
+function useCrudListFilterLookups(
+  definitions = {},
+  {
+    values = {},
+    adapter = null,
+    recordIdParam = "recordId",
+    queryKeyPrefix = [],
+    placementSourcePrefix = "",
+    requestQueryParams = {},
+    labelResolvers = {}
+  } = {}
+) {
+  const filters = defineCrudListFilters(definitions);
+  const filterEntries = Object.values(filters);
+  const normalizedQueryKeyPrefix = normalizeLookupQueryKeyPrefix(queryKeyPrefix);
+  const normalizedPlacementSourcePrefix = normalizeText(placementSourcePrefix);
+  const normalizedLabelResolvers = normalizeLookupLabelResolverMap(labelResolvers);
+  const normalizedRequestQueryParams = normalizeLookupRequestQueryParamsMap(requestQueryParams);
+  const lookups = {};
+
+  for (const filter of filterEntries) {
+    if (
+      filter.type !== CRUD_LIST_FILTER_TYPE_RECORD_ID &&
+      filter.type !== CRUD_LIST_FILTER_TYPE_RECORD_ID_MANY
+    ) {
+      continue;
+    }
+    if (!filter.lookup?.apiSuffix) {
+      continue;
+    }
+
+    const runtime = useList({
+      adapter: adapter || undefined,
+      apiSuffix: filter.lookup.apiSuffix,
+      queryKeyFactory: (surfaceId = "", scopeParamValue = "") => [
+        ...normalizedQueryKeyPrefix,
+        filter.key,
+        String(surfaceId || ""),
+        String(scopeParamValue || "")
+      ],
+      search: {
+        enabled: true,
+        mode: "query"
+      },
+      ...(Object.hasOwn(normalizedRequestQueryParams, filter.key)
+        ? { requestQueryParams: normalizedRequestQueryParams[filter.key] }
+        : {}),
+      placementSource: normalizedPlacementSourcePrefix
+        ? `${normalizedPlacementSourcePrefix}.${filter.key}`
+        : `crud.list-filter.lookup.${filter.key}`,
+      fallbackLoadError: `Unable to load filter options (${filter.lookup.apiSuffix}).`,
+      recordIdParam,
+      recordIdSelector: (item = {}) => item[filter.lookup.valueKey || "id"],
+      viewUrlTemplate: "",
+      editUrlTemplate: ""
+    });
+
+    const cachedOptions = ref(new Map());
+    const selectedValues = computed(() => resolveLookupSelectedValues(filter, values?.[filter.key]));
+    const currentOptions = computed(() => createLookupOptionsFromItems(
+      Array.isArray(runtime.items) ? runtime.items : [],
+      filter,
+      normalizedLabelResolvers[filter.key]
+    ));
+    const options = computed(() => {
+      return mergeSelectedLookupOptions(
+        currentOptions.value,
+        selectedValues.value,
+        cachedOptions.value
+      );
+    });
+
+    watch(currentOptions, (nextOptions) => {
+      const nextCache = new Map(cachedOptions.value);
+      for (const option of nextOptions) {
+        nextCache.set(option.value, option);
+      }
+      cachedOptions.value = nextCache;
+    }, { immediate: true });
+
+    lookups[filter.key] = proxyRefs({
+      filter,
+      options,
+      searchQuery: computed(() => String(runtime.searchQuery || "")),
+      isLoading: computed(() => {
+        return Boolean(runtime.isInitialLoading || runtime.isFetching || runtime.isRefetching || runtime.isSearchDebouncing);
+      }),
+      resolveLabel(value, fallback = filter.label || "Option") {
+        return resolveLookupOptionLabel(options.value, cachedOptions.value, value, fallback);
+      },
+      setSearch(value = "") {
+        runtime.searchQuery = normalizeText(value);
+      }
+    });
+  }
+
+  function resolveLookup(filterKey = "") {
+    return lookups[normalizeText(filterKey)] || null;
+  }
+
+  return Object.freeze({
+    lookups: Object.freeze(lookups),
+    resolveLookup,
+    resolveLookupItems(filterKey = "") {
+      return resolveLookup(filterKey)?.options || [];
+    },
+    resolveLookupLoading(filterKey = "") {
+      return Boolean(resolveLookup(filterKey)?.isLoading);
+    },
+    resolveLookupSearch(filterKey = "") {
+      return String(resolveLookup(filterKey)?.searchQuery || "");
+    },
+    setLookupSearch(filterKey = "", value = "") {
+      resolveLookup(filterKey)?.setSearch(value);
+    },
+    resolveLookupLabel(filterKey = "", value = "", fallback = "Option") {
+      return resolveLookup(filterKey)?.resolveLabel(value, fallback)
+        || resolveLookupOptionLabel([], new Map(), value, fallback);
+    }
+  });
+}
+
+export { useCrudListFilterLookups };

--- a/packages/users-web/src/client/composables/useCrudListFilters.js
+++ b/packages/users-web/src/client/composables/useCrudListFilters.js
@@ -1,0 +1,407 @@
+import { computed, reactive, toRef } from "vue";
+import { normalizeText, normalizeUniqueTextList } from "@jskit-ai/kernel/shared/support/normalize";
+import {
+  defineCrudListFilters,
+  resolveCrudListFilterOptionLabel,
+  CRUD_LIST_FILTER_TYPE_FLAG,
+  CRUD_LIST_FILTER_TYPE_ENUM,
+  CRUD_LIST_FILTER_TYPE_ENUM_MANY,
+  CRUD_LIST_FILTER_TYPE_RECORD_ID,
+  CRUD_LIST_FILTER_TYPE_RECORD_ID_MANY,
+  CRUD_LIST_FILTER_TYPE_DATE,
+  CRUD_LIST_FILTER_TYPE_DATE_RANGE,
+  CRUD_LIST_FILTER_TYPE_NUMBER_RANGE,
+  CRUD_LIST_FILTER_TYPE_PRESENCE
+} from "@jskit-ai/kernel/shared/support/crudListFilters";
+
+function normalizeFunctionMap(value = {}) {
+  const source = value && typeof value === "object" && !Array.isArray(value)
+    ? value
+    : {};
+  const normalized = {};
+
+  for (const [key, entry] of Object.entries(source)) {
+    const normalizedKey = normalizeText(key);
+    if (!normalizedKey || typeof entry !== "function") {
+      continue;
+    }
+
+    normalized[normalizedKey] = entry;
+  }
+
+  return Object.freeze(normalized);
+}
+
+function createInitialFilterValue(filter = {}) {
+  if (filter.type === CRUD_LIST_FILTER_TYPE_FLAG) {
+    return false;
+  }
+  if (filter.type === CRUD_LIST_FILTER_TYPE_ENUM_MANY || filter.type === CRUD_LIST_FILTER_TYPE_RECORD_ID_MANY) {
+    return [];
+  }
+  if (filter.type === CRUD_LIST_FILTER_TYPE_DATE_RANGE) {
+    return reactive({
+      from: "",
+      to: ""
+    });
+  }
+  if (filter.type === CRUD_LIST_FILTER_TYPE_NUMBER_RANGE) {
+    return reactive({
+      min: "",
+      max: ""
+    });
+  }
+
+  return "";
+}
+
+function normalizePresetEntries(presets = []) {
+  const source = Array.isArray(presets) ? presets : [];
+  const normalized = [];
+  const seenKeys = new Set();
+
+  for (const rawPreset of source) {
+    if (!rawPreset || typeof rawPreset !== "object" || Array.isArray(rawPreset)) {
+      continue;
+    }
+
+    const key = normalizeText(rawPreset.key);
+    const label = normalizeText(rawPreset.label);
+    if (!key || !label || seenKeys.has(key)) {
+      continue;
+    }
+    seenKeys.add(key);
+
+    normalized.push(Object.freeze({
+      key,
+      label,
+      values: rawPreset.values && typeof rawPreset.values === "object" && !Array.isArray(rawPreset.values)
+        ? rawPreset.values
+        : {}
+    }));
+  }
+
+  return Object.freeze(normalized);
+}
+
+function normalizePresetFilterValue(filter = {}, rawValue) {
+  if (filter.type === CRUD_LIST_FILTER_TYPE_FLAG) {
+    return rawValue === true;
+  }
+
+  if (filter.type === CRUD_LIST_FILTER_TYPE_ENUM_MANY || filter.type === CRUD_LIST_FILTER_TYPE_RECORD_ID_MANY) {
+    const allowedValues = filter.type === CRUD_LIST_FILTER_TYPE_ENUM_MANY || filter.type === CRUD_LIST_FILTER_TYPE_PRESENCE
+      ? new Set((filter.options || []).map((entry) => entry.value))
+      : null;
+    const normalizedList = normalizeUniqueTextList(rawValue, {
+      acceptSingle: true
+    });
+    if (!allowedValues) {
+      return normalizedList;
+    }
+
+    return normalizedList.filter((entry) => allowedValues.has(entry));
+  }
+
+  if (filter.type === CRUD_LIST_FILTER_TYPE_DATE_RANGE) {
+    const source = rawValue && typeof rawValue === "object" && !Array.isArray(rawValue)
+      ? rawValue
+      : {};
+    return {
+      from: normalizeText(source.from),
+      to: normalizeText(source.to)
+    };
+  }
+
+  if (filter.type === CRUD_LIST_FILTER_TYPE_NUMBER_RANGE) {
+    const source = rawValue && typeof rawValue === "object" && !Array.isArray(rawValue)
+      ? rawValue
+      : {};
+    return {
+      min: normalizeText(source.min),
+      max: normalizeText(source.max)
+    };
+  }
+
+  const normalized = normalizeText(rawValue);
+  if (filter.type === CRUD_LIST_FILTER_TYPE_ENUM || filter.type === CRUD_LIST_FILTER_TYPE_PRESENCE) {
+    const allowedValues = new Set((filter.options || []).map((entry) => entry.value));
+    return allowedValues.has(normalized) ? normalized : "";
+  }
+
+  return normalized;
+}
+
+function resetFilterValue(values, filter = {}) {
+  if (filter.type === CRUD_LIST_FILTER_TYPE_FLAG) {
+    values[filter.key] = false;
+    return;
+  }
+
+  if (filter.type === CRUD_LIST_FILTER_TYPE_ENUM_MANY || filter.type === CRUD_LIST_FILTER_TYPE_RECORD_ID_MANY) {
+    values[filter.key] = [];
+    return;
+  }
+
+  if (filter.type === CRUD_LIST_FILTER_TYPE_DATE_RANGE) {
+    values[filter.key].from = "";
+    values[filter.key].to = "";
+    return;
+  }
+
+  if (filter.type === CRUD_LIST_FILTER_TYPE_NUMBER_RANGE) {
+    values[filter.key].min = "";
+    values[filter.key].max = "";
+    return;
+  }
+
+  values[filter.key] = "";
+}
+
+function applyPresetFilterValue(values, filter = {}, rawValue) {
+  if (filter.type === CRUD_LIST_FILTER_TYPE_DATE_RANGE || filter.type === CRUD_LIST_FILTER_TYPE_NUMBER_RANGE) {
+    const nextValue = normalizePresetFilterValue(filter, rawValue);
+    Object.assign(values[filter.key], nextValue);
+    return;
+  }
+
+  values[filter.key] = normalizePresetFilterValue(filter, rawValue);
+}
+
+function createQueryParams(values, filterEntries = []) {
+  const queryParams = {};
+
+  for (const filter of filterEntries) {
+    if (filter.type === CRUD_LIST_FILTER_TYPE_DATE_RANGE) {
+      queryParams[filter.fromKey] = toRef(values[filter.key], "from");
+      queryParams[filter.toKey] = toRef(values[filter.key], "to");
+      continue;
+    }
+
+    if (filter.type === CRUD_LIST_FILTER_TYPE_NUMBER_RANGE) {
+      queryParams[filter.minKey] = toRef(values[filter.key], "min");
+      queryParams[filter.maxKey] = toRef(values[filter.key], "max");
+      continue;
+    }
+
+    queryParams[filter.queryKey] = toRef(values, filter.key);
+  }
+
+  return Object.freeze(queryParams);
+}
+
+function resolveAtomicValueLabel(filter = {}, value = "", labelResolvers = {}) {
+  const customResolver = labelResolvers[filter.key];
+  if (typeof customResolver === "function") {
+    const customLabel = normalizeText(customResolver(value, filter));
+    if (customLabel) {
+      return customLabel;
+    }
+  }
+
+  return resolveCrudListFilterOptionLabel(filter, value, {
+    fallback: String(value || "")
+  });
+}
+
+function defaultChipLabel(filter = {}, value, labelResolvers = {}) {
+  if (filter.type === CRUD_LIST_FILTER_TYPE_FLAG) {
+    return filter.label;
+  }
+
+  if (
+    filter.type === CRUD_LIST_FILTER_TYPE_ENUM ||
+    filter.type === CRUD_LIST_FILTER_TYPE_PRESENCE ||
+    filter.type === CRUD_LIST_FILTER_TYPE_RECORD_ID
+  ) {
+    return `${filter.label}: ${resolveAtomicValueLabel(filter, value, labelResolvers)}`;
+  }
+
+  if (filter.type === CRUD_LIST_FILTER_TYPE_DATE) {
+    return `${filter.label}: ${value}`;
+  }
+
+  if (filter.type === CRUD_LIST_FILTER_TYPE_DATE_RANGE) {
+    if (value?.from && value?.to) {
+      return `${filter.label}: ${value.from} to ${value.to}`;
+    }
+    if (value?.from) {
+      return `${filter.label}: from ${value.from}`;
+    }
+    return `${filter.label}: to ${value?.to || ""}`;
+  }
+
+  if (filter.type === CRUD_LIST_FILTER_TYPE_NUMBER_RANGE) {
+    if (value?.min && value?.max) {
+      return `${filter.label}: ${value.min} to ${value.max}`;
+    }
+    if (value?.min) {
+      return `${filter.label}: min ${value.min}`;
+    }
+    return `${filter.label}: max ${value?.max || ""}`;
+  }
+
+  return filter.label;
+}
+
+function useCrudListFilters(definitions = {}, { labelResolvers = {}, chipLabels = {}, presets = [] } = {}) {
+  const filters = defineCrudListFilters(definitions);
+  const filterEntries = Object.values(filters);
+  const normalizedLabelResolvers = normalizeFunctionMap(labelResolvers);
+  const normalizedChipLabels = normalizeFunctionMap(chipLabels);
+  const normalizedPresets = normalizePresetEntries(presets);
+  const values = reactive({});
+  const options = {};
+
+  for (const filter of filterEntries) {
+    values[filter.key] = createInitialFilterValue(filter);
+    if (Array.isArray(filter.options) && filter.options.length > 0) {
+      options[filter.key] = filter.options;
+    }
+  }
+
+  const queryParams = createQueryParams(values, filterEntries);
+
+  const activeChips = computed(() => {
+    const chips = [];
+
+    for (const filter of filterEntries) {
+      const customChipLabel = normalizedChipLabels[filter.key];
+      const rawValue = values[filter.key];
+
+      if (filter.type === CRUD_LIST_FILTER_TYPE_FLAG) {
+        if (rawValue === true) {
+          chips.push({
+            id: filter.key,
+            filterKey: filter.key,
+            label: normalizeText(customChipLabel?.(rawValue, filter, values))
+              || normalizeText(filter.chipLabel?.(rawValue, filter, values))
+              || defaultChipLabel(filter, rawValue, normalizedLabelResolvers)
+          });
+        }
+        continue;
+      }
+
+      if (filter.type === CRUD_LIST_FILTER_TYPE_ENUM_MANY || filter.type === CRUD_LIST_FILTER_TYPE_RECORD_ID_MANY) {
+        for (const value of Array.isArray(rawValue) ? rawValue : []) {
+          chips.push({
+            id: `${filter.key}:${value}`,
+            filterKey: filter.key,
+            value,
+            label: normalizeText(customChipLabel?.(value, filter, values))
+              || normalizeText(filter.chipLabel?.(value, filter, values))
+              || `${filter.label}: ${resolveAtomicValueLabel(filter, value, normalizedLabelResolvers)}`
+          });
+        }
+        continue;
+      }
+
+      if (filter.type === CRUD_LIST_FILTER_TYPE_DATE_RANGE || filter.type === CRUD_LIST_FILTER_TYPE_NUMBER_RANGE) {
+        const hasValue = Boolean(rawValue?.from || rawValue?.to || rawValue?.min || rawValue?.max);
+        if (!hasValue) {
+          continue;
+        }
+
+        chips.push({
+          id: filter.key,
+          filterKey: filter.key,
+          label: normalizeText(customChipLabel?.(rawValue, filter, values))
+            || normalizeText(filter.chipLabel?.(rawValue, filter, values))
+            || defaultChipLabel(filter, rawValue, normalizedLabelResolvers)
+        });
+        continue;
+      }
+
+      if (!normalizeText(rawValue)) {
+        continue;
+      }
+
+      chips.push({
+        id: filter.key,
+        filterKey: filter.key,
+        label: normalizeText(customChipLabel?.(rawValue, filter, values))
+          || normalizeText(filter.chipLabel?.(rawValue, filter, values))
+          || defaultChipLabel(filter, rawValue, normalizedLabelResolvers)
+      });
+    }
+
+    return chips;
+  });
+
+  const hasActiveFilters = computed(() => activeChips.value.length > 0);
+
+  function clearFilter(filterKey = "") {
+    const filter = filters[normalizeText(filterKey)];
+    if (!filter) {
+      return;
+    }
+
+    resetFilterValue(values, filter);
+  }
+
+  function clearFilters() {
+    for (const filter of filterEntries) {
+      resetFilterValue(values, filter);
+    }
+  }
+
+  function clearChip(chip = {}) {
+    const filter = filters[normalizeText(chip.filterKey)];
+    if (!filter) {
+      return;
+    }
+
+    if (filter.type === CRUD_LIST_FILTER_TYPE_ENUM_MANY || filter.type === CRUD_LIST_FILTER_TYPE_RECORD_ID_MANY) {
+      values[filter.key] = (Array.isArray(values[filter.key]) ? values[filter.key] : [])
+        .filter((entry) => entry !== chip.value);
+      return;
+    }
+
+    resetFilterValue(values, filter);
+  }
+
+  function toggle(filterKey = "") {
+    const filter = filters[normalizeText(filterKey)];
+    if (!filter || filter.type !== CRUD_LIST_FILTER_TYPE_FLAG) {
+      return;
+    }
+
+    values[filter.key] = !values[filter.key];
+  }
+
+  function applyPreset(presetKey = "", { mode = "replace" } = {}) {
+    const preset = normalizedPresets.find((entry) => entry.key === normalizeText(presetKey));
+    if (!preset) {
+      return;
+    }
+
+    if (mode !== "merge") {
+      clearFilters();
+    }
+
+    for (const filter of filterEntries) {
+      if (!Object.hasOwn(preset.values, filter.key)) {
+        continue;
+      }
+
+      applyPresetFilterValue(values, filter, preset.values[filter.key]);
+    }
+  }
+
+  return Object.freeze({
+    filters,
+    values,
+    queryParams,
+    options: Object.freeze(options),
+    presets: normalizedPresets,
+    activeChips,
+    hasActiveFilters,
+    clearFilter,
+    clearFilters,
+    clearChip,
+    toggle,
+    applyPreset
+  });
+}
+
+export { useCrudListFilters };

--- a/packages/users-web/test/exportsContract.test.js
+++ b/packages/users-web/test/exportsContract.test.js
@@ -20,6 +20,8 @@ test("users-web exports are explicit and aligned with production/template usage"
       "./client/composables/useList",
       "./client/composables/useView",
       "./client/composables/useCrudAddEdit",
+      "./client/composables/useCrudListFilterLookups",
+      "./client/composables/useCrudListFilters",
       "./client/composables/useCrudList",
       "./client/composables/useCrudView"
     ]

--- a/packages/users-web/test/useCrudListFilterLookups.test.js
+++ b/packages/users-web/test/useCrudListFilterLookups.test.js
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  resolveLookupSelectedValues,
+  createLookupOptionsFromItems,
+  mergeSelectedLookupOptions,
+  resolveLookupOptionLabel
+} from "../src/client/composables/internal/crudListFilterLookupSupport.js";
+
+const supplierFilter = Object.freeze({
+  key: "supplierContactId",
+  type: "recordIdMany",
+  label: "Supplier",
+  lookup: Object.freeze({
+    apiSuffix: "/contacts",
+    valueKey: "id",
+    labelKey: "name"
+  })
+});
+
+test("lookup filter support normalizes selected record ids for single and many filters", () => {
+  assert.deepEqual(
+    resolveLookupSelectedValues(supplierFilter, ["7", "4", "7", ""]),
+    ["7", "4"]
+  );
+
+  assert.deepEqual(
+    resolveLookupSelectedValues(
+      {
+        ...supplierFilter,
+        type: "recordId"
+      },
+      12
+    ),
+    ["12"]
+  );
+});
+
+test("lookup filter support builds option labels from custom resolvers and fallback lookup labels", () => {
+  const options = createLookupOptionsFromItems(
+    [
+      {
+        id: 7,
+        firstName: "Pollen",
+        lastName: "Partners"
+      },
+      {
+        id: 4,
+        name: "Harbor Storage"
+      }
+    ],
+    supplierFilter,
+    (item = {}) => {
+      if (item.id === 7) {
+        return `${item.firstName} ${item.lastName}`;
+      }
+
+      return "";
+    }
+  );
+
+  assert.deepEqual(options, [
+    {
+      value: "7",
+      label: "Pollen Partners",
+      record: {
+        id: 7,
+        firstName: "Pollen",
+        lastName: "Partners"
+      }
+    },
+    {
+      value: "4",
+      label: "Harbor Storage",
+      record: {
+        id: 4,
+        name: "Harbor Storage"
+      }
+    }
+  ]);
+});
+
+test("lookup filter support merges cached selected labels and resolves fallback labels", () => {
+  const currentOptions = [
+    {
+      value: "7",
+      label: "Pollen Partners",
+      record: {
+        id: 7,
+        name: "Pollen Partners"
+      }
+    }
+  ];
+  const cachedOptions = new Map([
+    ["12", {
+      value: "12",
+      label: "North Shed",
+      record: {
+        id: 12,
+        name: "North Shed"
+      }
+    }]
+  ]);
+
+  const mergedOptions = mergeSelectedLookupOptions(
+    currentOptions,
+    ["12", "7"],
+    cachedOptions
+  );
+
+  assert.deepEqual(mergedOptions.map((option) => option.value), ["12", "7"]);
+  assert.equal(resolveLookupOptionLabel(mergedOptions, cachedOptions, "12", "Storage"), "North Shed");
+  assert.equal(resolveLookupOptionLabel(mergedOptions, cachedOptions, "55", "Storage"), "Storage 55");
+});

--- a/packages/users-web/test/useCrudListFilters.test.js
+++ b/packages/users-web/test/useCrudListFilters.test.js
@@ -1,0 +1,80 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+test("useCrudListFilters manages values, query params, chips, and presets", async () => {
+  const { useCrudListFilters } = await import("@jskit-ai/users-web/client/composables/useCrudListFilters");
+
+  const filters = useCrudListFilters(
+    {
+      onlyStaff: {
+        type: "flag",
+        label: "Staff"
+      },
+      status: {
+        type: "enumMany",
+        label: "Status",
+        options: [
+          { value: "active", label: "Active" },
+          { value: "archived", label: "Archived" }
+        ]
+      },
+      supplierContactId: {
+        type: "recordIdMany",
+        label: "Supplier"
+      },
+      arrivalDate: {
+        type: "dateRange",
+        label: "Arrival Date"
+      }
+    },
+    {
+      labelResolvers: {
+        supplierContactId(value) {
+          return value === "7" ? "Pollen Partners" : "";
+        }
+      },
+      presets: [
+        {
+          key: "needs-staff-review",
+          label: "Needs Staff Review",
+          values: {
+            onlyStaff: true,
+            status: ["archived"]
+          }
+        }
+      ]
+    }
+  );
+
+  filters.values.onlyStaff = true;
+  filters.values.status = ["active"];
+  filters.values.supplierContactId = ["7"];
+  filters.values.arrivalDate.from = "2026-04-01";
+
+  assert.equal(filters.queryParams.onlyStaff.value, true);
+  assert.deepEqual(filters.queryParams.status.value, ["active"]);
+  assert.equal(filters.queryParams.arrivalDateFrom.value, "2026-04-01");
+  assert.equal(filters.hasActiveFilters.value, true);
+  assert.deepEqual(
+    filters.activeChips.value.map((chip) => chip.label),
+    [
+      "Staff",
+      "Status: Active",
+      "Supplier: Pollen Partners",
+      "Arrival Date: from 2026-04-01"
+    ]
+  );
+
+  filters.clearChip(filters.activeChips.value.find((chip) => chip.filterKey === "supplierContactId"));
+  assert.deepEqual(filters.values.supplierContactId, []);
+
+  filters.applyPreset("needs-staff-review");
+  assert.equal(filters.values.onlyStaff, true);
+  assert.deepEqual(filters.values.status, ["archived"]);
+  assert.equal(filters.values.arrivalDate.from, "");
+
+  filters.clearFilters();
+  assert.equal(filters.values.onlyStaff, false);
+  assert.deepEqual(filters.values.status, []);
+  assert.equal(filters.hasActiveFilters.value, false);
+});

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -4004,6 +4004,10 @@
                 "summary": "Exports command operation composable."
               },
               {
+                "subpath": "./client/composables/useCrudListFilterLookups",
+                "summary": "Exports lookup-backed CRUD list filter helper for remote autocomplete filters."
+              },
+              {
                 "subpath": "./client/composables/useView",
                 "summary": "Exports read/view operation composable."
               },


### PR DESCRIPTION
## Summary
- add shared CRUD list filter support in `crud-core`, `kernel`, and `users-web`
- expose new client composables and lookup helpers with tests
- refresh distributed agent docs and catalog metadata for the new filter workflow

## Notes
- merged without waiting on GitHub verification per request
