### PR TITLE
Refine CRUD filter validation and presets

### DIFF
--- a/packages/agent-docs/guide/agent/generators/advanced-cruds.md
+++ b/packages/agent-docs/guide/agent/generators/advanced-cruds.md
@@ -797,7 +797,8 @@ Instead:
 
 1. define the filters once in a shared CRUD-package module
 2. build the server runtime from that definition with `createCrudListFilters(...)`
-3. build the client runtime from that same definition with `useCrudListFilters(...)`
+3. choose the route/action invalid-value contract explicitly with `createQueryValidator({ invalidValues: "reject" | "discard" })`
+4. build the client runtime from that same definition with `useCrudListFilters(...)`
 
 For example, a shared filter-definition module can look like this:
 
@@ -817,6 +818,22 @@ export const CONTACTS_LIST_FILTER_DEFINITIONS = Object.freeze({
   }
 });
 ```
+
+#### Exact file checklist
+
+For a generated CRUD, treat this as the concrete file plan:
+
+- create `packages/contacts/src/shared/contactListFilters.js`
+- update `packages/contacts/src/server/registerRoutes.js` so the list route query validator includes an explicit `createQueryValidator({ invalidValues: ... })` choice, unless you already extracted list-query composition into `packages/contacts/src/server/listQueryValidators.js`
+- update `packages/contacts/src/server/actions.js` so the list action input validator includes that same explicit contract choice
+- update `packages/contacts/src/server/repository.js` so the list query path builds the `createCrudListFilters(...)` runtime and calls `applyQuery(...)`
+- update the app-owned list page or list-runtime composable, usually under `src/pages/.../contacts/` or `src/composables/...`, so it builds `useCrudListFilters(...)`, passes `queryParams` into `useCrudList(...)`, and renders chips / reset behavior from that runtime
+
+The only file in that list that is normally **new** is the shared module:
+
+- `packages/contacts/src/shared/contactListFilters.js`
+
+The others are normally edits to the generated CRUD package and the app-owned page layer that already exist.
 
 #### Client side
 
@@ -846,11 +863,14 @@ That gives you, from one place:
 
 - `listFilters.values`
 - `listFilters.queryParams`
+- `listFilters.presets`
 - `listFilters.activeChips`
 - `listFilters.hasActiveFilters`
 - `listFilters.clearChip(...)`
 - `listFilters.clearFilters()`
 - `listFilters.toggle(...)` for flag filters
+- `listFilters.applyPreset(...)`
+- `listFilters.matchesPreset(...)`
 
 So the same runtime owns:
 
@@ -858,7 +878,61 @@ So the same runtime owns:
 - filter chips
 - reset logic
 - preset application
+- preset active-state matching
 - small flag toggles
+
+For relative-date quick filters, keep the date math in runtime presets instead of page-local helper state. `resolveValues(...)` runs at preset-apply time and receives `{ values, filters, presetKey, preset }`, so the preset can derive values from the current filter state and the normalized preset metadata:
+
+```js
+const listFilters = useCrudListFilters(
+  RECEIVAL_LIST_FILTER_DEFINITIONS,
+  {
+    presets: [
+      {
+        key: "today",
+        label: "Today",
+        resolveValues({ presetKey }) {
+          const today = formatDateInputValue(new Date());
+          return {
+            arrivalDate: {
+              from: today,
+              to: today
+            }
+          };
+        }
+      },
+      {
+        key: "last7",
+        label: "Last 7 Days",
+        resolveValues({ values }) {
+          const today = formatDateInputValue(new Date());
+          return {
+            arrivalDate: {
+              from: shiftDateInputValue(today, -6),
+              to: today
+            }
+          };
+        }
+      }
+    ]
+  }
+);
+```
+
+```vue
+<v-chip
+  v-for="preset in listFilters.presets"
+  :key="preset.key"
+  :variant="listFilters.matchesPreset(preset.key) ? 'flat' : 'outlined'"
+  @click="listFilters.applyPreset(preset.key, { mode: 'merge' })"
+>
+  {{ preset.label }}
+</v-chip>
+```
+
+Use `mode: "merge"` when a preset should only change one filter group, such as the arrival date range, and should not clear the rest of the page's active filters.
+
+`matchesPreset(...)` is strict by design. It compares the preset against the full current filter state after basic normalization, and it does **not** silently drop extra `enumMany` or `recordIdMany` values that were hydrated from the route and still appear as chips. If the URL contains `status=archived&status=bogus`, a preset for only `archived` should render as inactive until the extra `bogus` value is cleared.
 
 #### Server side
 
@@ -875,11 +949,47 @@ const contactsListFiltersRuntime = createCrudListFilters(
     }
   }
 );
+```
 
-const contactsListFiltersQueryValidator = contactsListFiltersRuntime.queryValidator;
+There is no default query-validator mode and no `runtime.queryValidator` alias. Create the validator that matches the contract you want at that route or action boundary.
+
+Strict contract example:
+
+```js
+const contactsListFiltersQueryValidator = contactsListFiltersRuntime.createQueryValidator({
+  invalidValues: "reject" // malformed filter values should fail validation and return 400
+});
+```
+
+Lenient contract example:
+
+```js
+const contactsListFiltersQueryValidator = contactsListFiltersRuntime.createQueryValidator({
+  invalidValues: "discard" // malformed filter values should be ignored and dropped by normalize()
+});
 ```
 
 Wire the runtime into the list validator and the repository:
+
+```js
+queryValidator: [
+  listCursorPaginationQueryValidator,
+  listSearchQueryValidator,
+  contactsListFiltersQueryValidator,
+  listParentFilterQueryValidator,
+  lookupIncludeQueryValidator
+]
+```
+
+Use that same `contactsListFiltersQueryValidator` anywhere else the list query is validated, such as the list action input validator if your CRUD package validates query shape at both the route and action boundaries.
+
+Choose the invalid-value contract deliberately:
+
+- there is no default mode and no fallback alias, so every route or action that validates structured filters must call `createQueryValidator({ invalidValues: ... })` explicitly
+- use `invalidValues: "reject"` when malformed filter values should fail validation and produce a 400-style contract error
+- use `invalidValues: "discard"` when malformed filter values should be ignored and normalization should drop them
+- route query validation runs before auth, so this choice changes whether malformed unauthenticated requests fail at validation or fall through to auth
+- for normal HTTP CRUD handlers, route-level `discard` means the handler receives already-normalized query input, so the action layer will not see those discarded bad values again later
 
 ```js
 async function list(query = {}, callOptions = {}) {
@@ -895,6 +1005,8 @@ async function list(query = {}, callOptions = {}) {
 
 - Put the filter definitions in the CRUD package, not the page. Both server and client need them.
 - Keep the filter keys identical all the way through: definition key, query param key, and repository meaning.
+- Do not expect a default `runtime.queryValidator` to exist. Every structured-filter validator must be created explicitly with `createQueryValidator({ invalidValues: ... })`.
+- Use `type: "presence"` for null/not-null filters such as assigned vs unassigned storage. Do not model those as custom enums plus `applyQuery(...)` overrides unless the SQL semantics are genuinely different from `whereNotNull(...)` / `whereNull(...)`.
 - Use `createCrudListFilters(...)` unless the list semantics are truly unusual.
 - Use `q` for free-text and explicit query params for structured filters.
 
@@ -933,6 +1045,17 @@ export const RECEIVAL_LIST_FILTER_DEFINITIONS = Object.freeze({
   }
 });
 ```
+
+#### Exact file checklist
+
+Lookup-backed filters do **not** change the ownership model from Pattern 3. The file plan is still:
+
+- keep the shared definition in `packages/receivals/src/shared/receivalListFilters.js`
+- update the same server validator and repository files from Pattern 3
+- update the app-owned list page or list-runtime composable so it creates both `useCrudListFilters(...)` and `useCrudListFilterLookups(...)`
+- bind the lookup UI, such as `v-autocomplete`, from `filterLookups.resolveLookup(...)`
+
+Do **not** create a second page-local filter schema just because the UI needs remote autocomplete. The shared definition file stays the source of truth.
 
 #### Client side
 
@@ -1167,10 +1290,12 @@ Use `scaffold-field` when it fits, then review the generated result.
 
 Touch:
 
-- a client filter composable or page state
-- `useCrudList({ queryParams: ... })`
-- a dedicated server query validator
-- `repository.js`
+- `packages/<crud>/src/shared/<crud>ListFilters.js` and make it the only authored filter-definition module
+- `packages/<crud>/src/server/registerRoutes.js` and `packages/<crud>/src/server/actions.js` so the list validator includes an explicit `createQueryValidator({ invalidValues: ... })` choice, or `packages/<crud>/src/server/listQueryValidators.js` if you extracted list-query composition there
+- `packages/<crud>/src/server/repository.js` so the list query applies the runtime
+- the app-owned list page or list-runtime composable that calls `useCrudList(...)`
+
+If the filter is lookup-backed, touch that same client file again to wire `useCrudListFilterLookups(...)`.
 
 ### "I want a new save rule."
 

--- a/packages/agent-docs/patterns/filters.md
+++ b/packages/agent-docs/patterns/filters.md
@@ -17,10 +17,24 @@ Default JSKIT pattern:
 1. Put shared filter definitions in the CRUD package.
    Example path: `packages/<crud>/src/shared/<crud>ListFilters.js`
 2. Build the server runtime from that module with `createCrudListFilters(...)`.
-3. Use the runtime's `queryValidator` in routes/actions and `applyQuery(...)` in the repository.
-4. Build the client runtime from the same shared definitions with `useCrudListFilters(...)`.
+3. Build route/action validators explicitly with `createQueryValidator({ invalidValues: "reject" | "discard" })`, and use `applyQuery(...)` in the repository. There is no default validator mode and no `runtime.queryValidator` alias.
+4. Build the client runtime from the same shared definitions with `useCrudListFilters(...)`. Presets can use static `values` or dynamic `resolveValues({ values, filters, presetKey, preset })`.
 5. Pass `listFilters.queryParams` into `useCrudList(...)`.
 6. For lookup-backed filters, use `useCrudListFilterLookups(...)` instead of hand-rolling `useList()` in each page.
+
+Exact file checklist:
+- create `packages/<crud>/src/shared/<crud>ListFilters.js`
+- update `packages/<crud>/src/server/registerRoutes.js` and `packages/<crud>/src/server/actions.js` so the list query validator includes an explicit `createQueryValidator({ invalidValues: ... })` choice, or update `packages/<crud>/src/server/listQueryValidators.js` if that package already extracts list-query composition there
+- update `packages/<crud>/src/server/repository.js` so list queries call the runtime's `applyQuery(...)`
+- update the app-owned list page or list-runtime composable under `src/pages/...` or `src/composables/...` so it builds `useCrudListFilters(...)`, passes `queryParams` into `useCrudList(...)`, and binds chips / reset behavior
+- for lookup-backed filters, update that same client file to build `useCrudListFilterLookups(...)` and bind the lookup control from `resolveLookup(...)`
+
+Validation mode is part of the contract:
+- there is no default mode and no fallback alias, so every route/action boundary that validates structured filters must call `createQueryValidator({ invalidValues: ... })` explicitly
+- use `invalidValues: "reject"` when malformed filter values should fail validation and return a 400-style contract error
+- use `invalidValues: "discard"` when malformed filter values should be ignored and normalization should drop them
+- route query validation runs before auth, so this choice affects whether malformed unauthenticated requests fail at validation or fall through to auth
+- for normal HTTP CRUD handlers, route-level `discard` means the action layer receives already-normalized query input; do not assume route `discard` plus action `reject` will still reject malformed HTTP query strings later
 
 Keep separate:
 - free-text search uses `records.searchQuery` and `q`
@@ -31,22 +45,42 @@ Use `useCrudListFilterLookups(...)` when:
 - the UI needs remote autocomplete search
 - chips should show readable labels instead of raw ids
 
+Use built-in `presence` when:
+- a filter means null vs not-null, such as assigned vs unassigned storage
+- the UI wants custom labels like "Assigned" / "Unassigned" but the transport contract can stay `present` / `missing`
+- you do **not** need custom SQL beyond `whereNotNull(...)` / `whereNull(...)`
+
+Use runtime presets when:
+- the page has quick filters such as "Today", "Last 7 Days", or "Only Archived"
+- the preset should reuse the same filter state/reset/query-param runtime as the rest of the page
+- relative-date presets need dynamic `resolveValues()` instead of hard-coded dates
+- the active-state UI should reflect the full current filter state through `matchesPreset(...)`, including extra route-hydrated values that still appear as chips
+
 Put unusual SQL semantics on the server:
-- examples: `pending` meaning `whereNull("ccp1_passed")`, or `assigned/unassigned` meaning `whereNotNull(...)` / `whereNull(...)`
+- examples: `pending` meaning `whereNull("ccp1_passed")`, or business-specific status buckets that combine multiple columns
 - implement those in `createCrudListFilters(..., { apply: { ... } })`
+- do not use custom `apply` just for null/not-null checks when `type: "presence"` fits
 
 Avoid:
 - local filter composables that duplicate the same keys the server already knows about
 - a custom validator shape that does not match the page state
+- assuming a default `runtime.queryValidator` exists; always create the validator explicitly with `createQueryValidator({ invalidValues: ... })`
+- hand-rolled preset apply/reset/active-state helpers when `useCrudListFilters(..., { presets })`, `applyPreset(...)`, and `matchesPreset(...)` fit
 - per-screen `useList()` wrappers for lookup-backed filters when `useCrudListFilterLookups(...)` fits
+- a second page-local filter-definition file when `packages/<crud>/src/shared/<crud>ListFilters.js` should be the source of truth
 - overloading `q` with structured filter meaning
 
 Good shape:
 - `packages/receivals/src/shared/receivalListFilters.js`
 - `createCrudListFilters(RECEIVAL_LIST_FILTER_DEFINITIONS, ...)`
-- `const listFilters = useCrudListFilters(RECEIVAL_LIST_FILTER_DEFINITIONS)`
+- `const listFilters = useCrudListFilters(RECEIVAL_LIST_FILTER_DEFINITIONS, { presets: [...] })`
 - `const filterLookups = useCrudListFilterLookups(RECEIVAL_LIST_FILTER_DEFINITIONS, { values: listFilters.values, ... })`
 - `queryParams: listFilters.queryParams`
+
+Preset contract notes:
+- `resolveValues({ values, filters, presetKey, preset })` receives the current filter state and the normalized preset metadata, so relative-date presets can derive values at apply time without page-local helper state
+- `matchesPreset(...)` compares against the full current filter state after basic normalization; it does **not** silently drop extra `enumMany` or `recordIdMany` values that were hydrated from the route and still show up as active chips
+- if the URL contains `status=archived&status=bogus`, a preset for only `archived` should not render as active while the `bogus` chip is still visible
 
 Review checks:
 - one shared filter definition source of truth

--- a/packages/agent-docs/reference/autogen/packages/crud-core.md
+++ b/packages/agent-docs/reference/autogen/packages/crud-core.md
@@ -134,8 +134,11 @@ Local functions
 
 ### `src/server/listFilters.js`
 Exports
+- `CRUD_LIST_FILTER_INVALID_VALUES_REJECT`
+- `CRUD_LIST_FILTER_INVALID_VALUES_DISCARD`
 - `createCrudListFilters(definitions = {}, { columns = {}, apply = {} } = {})`
 Local functions
+- `normalizeCrudListFilterInvalidValues(value = "")`
 - `createSingleOrMultiValueSchema(itemSchema)`
 - `firstValue(value)`
 - `normalizeDateFilterValue(value)`
@@ -146,7 +149,7 @@ Local functions
 - `normalizeAllowedTextValue(value, allowedValues = new Set())`
 - `normalizeAllowedTextValues(value, allowedValues = new Set())`
 - `addDaysToDateFilterValue(value = "", days = 0)`
-- `createFilterQuerySchema(filter = {})`
+- `createFilterQuerySchema(filter = {}, { invalidValues = CRUD_LIST_FILTER_INVALID_VALUES_REJECT } = {})`
 - `normalizeFilterValue(filter = {}, source = {})`
 - `normalizeColumnsMap(columns = {})`
 - `applyDefaultFilterQuery(queryBuilder, filter = {}, value, column = "")`

--- a/packages/agent-docs/reference/autogen/packages/users-web.md
+++ b/packages/agent-docs/reference/autogen/packages/users-web.md
@@ -363,7 +363,11 @@ Local functions
 - `normalizeFunctionMap(value = {})`
 - `createInitialFilterValue(filter = {})`
 - `normalizePresetEntries(presets = [])`
+- `resolvePresetValues(preset = {}, { values = {}, filters = {} } = {})`
 - `normalizePresetFilterValue(filter = {}, rawValue)`
+- `normalizeCurrentManyFilterValues(value)`
+- `matchArrayValues(currentValue = [], expectedValue = [])`
+- `matchesPresetFilterValue(filter = {}, currentValue, rawExpectedValue)`
 - `resetFilterValue(values, filter = {})`
 - `applyPresetFilterValue(values, filter = {}, rawValue)`
 - `createQueryParams(values, filterEntries = [])`

--- a/packages/agent-docs/site/guide/generators/advanced-cruds.md
+++ b/packages/agent-docs/site/guide/generators/advanced-cruds.md
@@ -795,7 +795,8 @@ Instead:
 
 1. define the filters once in a shared CRUD-package module
 2. build the server runtime from that definition with `createCrudListFilters(...)`
-3. build the client runtime from that same definition with `useCrudListFilters(...)`
+3. choose the route/action invalid-value contract explicitly with `createQueryValidator({ invalidValues: "reject" | "discard" })`
+4. build the client runtime from that same definition with `useCrudListFilters(...)`
 
 For example, a shared filter-definition module can look like this:
 
@@ -815,6 +816,22 @@ export const CONTACTS_LIST_FILTER_DEFINITIONS = Object.freeze({
   }
 });
 ```
+
+#### Exact file checklist
+
+For a generated CRUD, treat this as the concrete file plan:
+
+- create `packages/contacts/src/shared/contactListFilters.js`
+- update `packages/contacts/src/server/registerRoutes.js` so the list route query validator includes an explicit `createQueryValidator({ invalidValues: ... })` choice, unless you already extracted list-query composition into `packages/contacts/src/server/listQueryValidators.js`
+- update `packages/contacts/src/server/actions.js` so the list action input validator includes that same explicit contract choice
+- update `packages/contacts/src/server/repository.js` so the list query path builds the `createCrudListFilters(...)` runtime and calls `applyQuery(...)`
+- update the app-owned list page or list-runtime composable, usually under `src/pages/.../contacts/` or `src/composables/...`, so it builds `useCrudListFilters(...)`, passes `queryParams` into `useCrudList(...)`, and renders chips / reset behavior from that runtime
+
+The only file in that list that is normally **new** is the shared module:
+
+- `packages/contacts/src/shared/contactListFilters.js`
+
+The others are normally edits to the generated CRUD package and the app-owned page layer that already exist.
 
 #### Client side
 
@@ -844,11 +861,14 @@ That gives you, from one place:
 
 - `listFilters.values`
 - `listFilters.queryParams`
+- `listFilters.presets`
 - `listFilters.activeChips`
 - `listFilters.hasActiveFilters`
 - `listFilters.clearChip(...)`
 - `listFilters.clearFilters()`
 - `listFilters.toggle(...)` for flag filters
+- `listFilters.applyPreset(...)`
+- `listFilters.matchesPreset(...)`
 
 So the same runtime owns:
 
@@ -856,7 +876,61 @@ So the same runtime owns:
 - filter chips
 - reset logic
 - preset application
+- preset active-state matching
 - small flag toggles
+
+For relative-date quick filters, keep the date math in runtime presets instead of page-local helper state. `resolveValues(...)` runs at preset-apply time and receives `{ values, filters, presetKey, preset }`, so the preset can derive values from the current filter state and the normalized preset metadata:
+
+```js
+const listFilters = useCrudListFilters(
+  RECEIVAL_LIST_FILTER_DEFINITIONS,
+  {
+    presets: [
+      {
+        key: "today",
+        label: "Today",
+        resolveValues({ presetKey }) {
+          const today = formatDateInputValue(new Date());
+          return {
+            arrivalDate: {
+              from: today,
+              to: today
+            }
+          };
+        }
+      },
+      {
+        key: "last7",
+        label: "Last 7 Days",
+        resolveValues({ values }) {
+          const today = formatDateInputValue(new Date());
+          return {
+            arrivalDate: {
+              from: shiftDateInputValue(today, -6),
+              to: today
+            }
+          };
+        }
+      }
+    ]
+  }
+);
+```
+
+```vue
+<v-chip
+  v-for="preset in listFilters.presets"
+  :key="preset.key"
+  :variant="listFilters.matchesPreset(preset.key) ? 'flat' : 'outlined'"
+  @click="listFilters.applyPreset(preset.key, { mode: 'merge' })"
+>
+  {{ preset.label }}
+</v-chip>
+```
+
+Use `mode: "merge"` when a preset should only change one filter group, such as the arrival date range, and should not clear the rest of the page's active filters.
+
+`matchesPreset(...)` is strict by design. It compares the preset against the full current filter state after basic normalization, and it does **not** silently drop extra `enumMany` or `recordIdMany` values that were hydrated from the route and still appear as chips. If the URL contains `status=archived&status=bogus`, a preset for only `archived` should render as inactive until the extra `bogus` value is cleared.
 
 #### Server side
 
@@ -873,11 +947,47 @@ const contactsListFiltersRuntime = createCrudListFilters(
     }
   }
 );
+```
 
-const contactsListFiltersQueryValidator = contactsListFiltersRuntime.queryValidator;
+There is no default query-validator mode and no `runtime.queryValidator` alias. Create the validator that matches the contract you want at that route or action boundary.
+
+Strict contract example:
+
+```js
+const contactsListFiltersQueryValidator = contactsListFiltersRuntime.createQueryValidator({
+  invalidValues: "reject" // malformed filter values should fail validation and return 400
+});
+```
+
+Lenient contract example:
+
+```js
+const contactsListFiltersQueryValidator = contactsListFiltersRuntime.createQueryValidator({
+  invalidValues: "discard" // malformed filter values should be ignored and dropped by normalize()
+});
 ```
 
 Wire the runtime into the list validator and the repository:
+
+```js
+queryValidator: [
+  listCursorPaginationQueryValidator,
+  listSearchQueryValidator,
+  contactsListFiltersQueryValidator,
+  listParentFilterQueryValidator,
+  lookupIncludeQueryValidator
+]
+```
+
+Use that same `contactsListFiltersQueryValidator` anywhere else the list query is validated, such as the list action input validator if your CRUD package validates query shape at both the route and action boundaries.
+
+Choose the invalid-value contract deliberately:
+
+- there is no default mode and no fallback alias, so every route or action that validates structured filters must call `createQueryValidator({ invalidValues: ... })` explicitly
+- use `invalidValues: "reject"` when malformed filter values should fail validation and produce a 400-style contract error
+- use `invalidValues: "discard"` when malformed filter values should be ignored and normalization should drop them
+- route query validation runs before auth, so this choice changes whether malformed unauthenticated requests fail at validation or fall through to auth
+- for normal HTTP CRUD handlers, route-level `discard` means the handler receives already-normalized query input, so the action layer will not see those discarded bad values again later
 
 ```js
 async function list(query = {}, callOptions = {}) {
@@ -893,6 +1003,8 @@ async function list(query = {}, callOptions = {}) {
 
 - Put the filter definitions in the CRUD package, not the page. Both server and client need them.
 - Keep the filter keys identical all the way through: definition key, query param key, and repository meaning.
+- Do not expect a default `runtime.queryValidator` to exist. Every structured-filter validator must be created explicitly with `createQueryValidator({ invalidValues: ... })`.
+- Use `type: "presence"` for null/not-null filters such as assigned vs unassigned storage. Do not model those as custom enums plus `applyQuery(...)` overrides unless the SQL semantics are genuinely different from `whereNotNull(...)` / `whereNull(...)`.
 - Use `createCrudListFilters(...)` unless the list semantics are truly unusual.
 - Use `q` for free-text and explicit query params for structured filters.
 
@@ -931,6 +1043,17 @@ export const RECEIVAL_LIST_FILTER_DEFINITIONS = Object.freeze({
   }
 });
 ```
+
+#### Exact file checklist
+
+Lookup-backed filters do **not** change the ownership model from Pattern 3. The file plan is still:
+
+- keep the shared definition in `packages/receivals/src/shared/receivalListFilters.js`
+- update the same server validator and repository files from Pattern 3
+- update the app-owned list page or list-runtime composable so it creates both `useCrudListFilters(...)` and `useCrudListFilterLookups(...)`
+- bind the lookup UI, such as `v-autocomplete`, from `filterLookups.resolveLookup(...)`
+
+Do **not** create a second page-local filter schema just because the UI needs remote autocomplete. The shared definition file stays the source of truth.
 
 #### Client side
 
@@ -1165,10 +1288,12 @@ Use `scaffold-field` when it fits, then review the generated result.
 
 Touch:
 
-- a client filter composable or page state
-- `useCrudList({ queryParams: ... })`
-- a dedicated server query validator
-- `repository.js`
+- `packages/<crud>/src/shared/<crud>ListFilters.js` and make it the only authored filter-definition module
+- `packages/<crud>/src/server/registerRoutes.js` and `packages/<crud>/src/server/actions.js` so the list validator includes an explicit `createQueryValidator({ invalidValues: ... })` choice, or `packages/<crud>/src/server/listQueryValidators.js` if you extracted list-query composition there
+- `packages/<crud>/src/server/repository.js` so the list query applies the runtime
+- the app-owned list page or list-runtime composable that calls `useCrudList(...)`
+
+If the filter is lookup-backed, touch that same client file again to wire `useCrudListFilterLookups(...)`.
 
 ### "I want a new save rule."
 

--- a/packages/crud-core/src/server/listFilters.js
+++ b/packages/crud-core/src/server/listFilters.js
@@ -24,9 +24,22 @@ import {
   CRUD_LIST_FILTER_TYPE_PRESENCE
 } from "@jskit-ai/kernel/shared/support/crudListFilters";
 
+const DATE_FILTER_PATTERN_SOURCE = "^\\d{4}-\\d{2}-\\d{2}$";
 const DATE_FILTER_PATTERN = /^\d{4}-\d{2}-\d{2}$/u;
-const stringOrNumberSchema = Type.Union([
-  Type.String({ minLength: 1 }),
+const NUMBER_FILTER_PATTERN_SOURCE = "^[+-]?(?:\\d+(?:\\.\\d*)?|\\.\\d+)(?:[eE][+-]?\\d+)?$";
+const CRUD_LIST_FILTER_INVALID_VALUES_REJECT = "reject";
+const CRUD_LIST_FILTER_INVALID_VALUES_DISCARD = "discard";
+const CRUD_LIST_FILTER_INVALID_VALUES_MODES = Object.freeze([
+  CRUD_LIST_FILTER_INVALID_VALUES_REJECT,
+  CRUD_LIST_FILTER_INVALID_VALUES_DISCARD
+]);
+const looseTextInputSchema = Type.String({ minLength: 0 });
+const strictNumberInputSchema = Type.Union([
+  Type.String({ pattern: NUMBER_FILTER_PATTERN_SOURCE }),
+  Type.Number()
+]);
+const looseStringOrNumberSchema = Type.Union([
+  looseTextInputSchema,
   Type.Number()
 ]);
 const recordIdInputSchema = Type.Union([
@@ -38,6 +51,17 @@ const flagInputSchema = Type.Union([
   Type.Boolean(),
   Type.Number()
 ]);
+
+function normalizeCrudListFilterInvalidValues(value = "") {
+  const normalized = normalizeText(value).toLowerCase();
+  if (CRUD_LIST_FILTER_INVALID_VALUES_MODES.includes(normalized)) {
+    return normalized;
+  }
+
+  throw new TypeError(
+    `Unsupported CRUD list filter invalidValues mode "${value}". Expected one of: ${CRUD_LIST_FILTER_INVALID_VALUES_MODES.join(", ")}.`
+  );
+}
 
 function createSingleOrMultiValueSchema(itemSchema) {
   return Type.Optional(
@@ -133,7 +157,9 @@ function addDaysToDateFilterValue(value = "", days = 0) {
   return `${year}-${month}-${day}`;
 }
 
-function createFilterQuerySchema(filter = {}) {
+function createFilterQuerySchema(filter = {}, { invalidValues = CRUD_LIST_FILTER_INVALID_VALUES_REJECT } = {}) {
+  const invalidValueMode = normalizeCrudListFilterInvalidValues(invalidValues);
+  const discardInvalidValues = invalidValueMode === CRUD_LIST_FILTER_INVALID_VALUES_DISCARD;
   const allowedValues = (Array.isArray(filter.options) ? filter.options : []).map((entry) => entry.value);
 
   if (filter.type === CRUD_LIST_FILTER_TYPE_FLAG) {
@@ -148,7 +174,11 @@ function createFilterQuerySchema(filter = {}) {
   if (filter.type === CRUD_LIST_FILTER_TYPE_ENUM || filter.type === CRUD_LIST_FILTER_TYPE_PRESENCE) {
     return Type.Object(
       {
-        [filter.queryKey]: Type.Optional(Type.String({ enum: allowedValues }))
+        [filter.queryKey]: Type.Optional(
+          discardInvalidValues
+            ? looseTextInputSchema
+            : Type.String({ enum: allowedValues })
+        )
       },
       { additionalProperties: false }
     );
@@ -158,7 +188,9 @@ function createFilterQuerySchema(filter = {}) {
     return Type.Object(
       {
         [filter.queryKey]: createSingleOrMultiValueSchema(
-          Type.String({ enum: allowedValues })
+          discardInvalidValues
+            ? looseTextInputSchema
+            : Type.String({ enum: allowedValues })
         )
       },
       { additionalProperties: false }
@@ -168,7 +200,11 @@ function createFilterQuerySchema(filter = {}) {
   if (filter.type === CRUD_LIST_FILTER_TYPE_RECORD_ID) {
     return Type.Object(
       {
-        [filter.queryKey]: Type.Optional(recordIdInputSchema)
+        [filter.queryKey]: Type.Optional(
+          discardInvalidValues
+            ? looseStringOrNumberSchema
+            : recordIdInputSchema
+        )
       },
       { additionalProperties: false }
     );
@@ -177,7 +213,11 @@ function createFilterQuerySchema(filter = {}) {
   if (filter.type === CRUD_LIST_FILTER_TYPE_RECORD_ID_MANY) {
     return Type.Object(
       {
-        [filter.queryKey]: createSingleOrMultiValueSchema(recordIdInputSchema)
+        [filter.queryKey]: createSingleOrMultiValueSchema(
+          discardInvalidValues
+            ? looseStringOrNumberSchema
+            : recordIdInputSchema
+        )
       },
       { additionalProperties: false }
     );
@@ -186,7 +226,11 @@ function createFilterQuerySchema(filter = {}) {
   if (filter.type === CRUD_LIST_FILTER_TYPE_DATE) {
     return Type.Object(
       {
-        [filter.queryKey]: Type.Optional(Type.String({ pattern: "^\\d{4}-\\d{2}-\\d{2}$" }))
+        [filter.queryKey]: Type.Optional(
+          discardInvalidValues
+            ? looseTextInputSchema
+            : Type.String({ pattern: DATE_FILTER_PATTERN_SOURCE })
+        )
       },
       { additionalProperties: false }
     );
@@ -195,8 +239,16 @@ function createFilterQuerySchema(filter = {}) {
   if (filter.type === CRUD_LIST_FILTER_TYPE_DATE_RANGE) {
     return Type.Object(
       {
-        [filter.fromKey]: Type.Optional(Type.String({ pattern: "^\\d{4}-\\d{2}-\\d{2}$" })),
-        [filter.toKey]: Type.Optional(Type.String({ pattern: "^\\d{4}-\\d{2}-\\d{2}$" }))
+        [filter.fromKey]: Type.Optional(
+          discardInvalidValues
+            ? looseTextInputSchema
+            : Type.String({ pattern: DATE_FILTER_PATTERN_SOURCE })
+        ),
+        [filter.toKey]: Type.Optional(
+          discardInvalidValues
+            ? looseTextInputSchema
+            : Type.String({ pattern: DATE_FILTER_PATTERN_SOURCE })
+        )
       },
       { additionalProperties: false }
     );
@@ -205,8 +257,16 @@ function createFilterQuerySchema(filter = {}) {
   if (filter.type === CRUD_LIST_FILTER_TYPE_NUMBER_RANGE) {
     return Type.Object(
       {
-        [filter.minKey]: Type.Optional(stringOrNumberSchema),
-        [filter.maxKey]: Type.Optional(stringOrNumberSchema)
+        [filter.minKey]: Type.Optional(
+          discardInvalidValues
+            ? looseStringOrNumberSchema
+            : strictNumberInputSchema
+        ),
+        [filter.maxKey]: Type.Optional(
+          discardInvalidValues
+            ? looseStringOrNumberSchema
+            : strictNumberInputSchema
+        )
       },
       { additionalProperties: false }
     );
@@ -402,7 +462,6 @@ function createCrudListFilters(definitions = {}, { columns = {}, apply = {} } = 
   const normalizedFilters = defineCrudListFilters(definitions);
   const normalizedColumns = normalizeColumnsMap(columns);
   const filterEntries = Object.values(normalizedFilters);
-  const schema = mergeObjectSchemas(filterEntries.map((filter) => createFilterQuerySchema(filter)));
 
   function normalize(payload = {}) {
     const source = normalizeObjectInput(payload);
@@ -419,6 +478,25 @@ function createCrudListFilters(definitions = {}, { columns = {}, apply = {} } = 
 
     return Object.freeze(normalized);
   }
+
+  const queryValidators = Object.freeze({
+    [CRUD_LIST_FILTER_INVALID_VALUES_REJECT]: Object.freeze({
+      schema: mergeObjectSchemas(
+        filterEntries.map((filter) => createFilterQuerySchema(filter, {
+          invalidValues: CRUD_LIST_FILTER_INVALID_VALUES_REJECT
+        }))
+      ),
+      normalize
+    }),
+    [CRUD_LIST_FILTER_INVALID_VALUES_DISCARD]: Object.freeze({
+      schema: mergeObjectSchemas(
+        filterEntries.map((filter) => createFilterQuerySchema(filter, {
+          invalidValues: CRUD_LIST_FILTER_INVALID_VALUES_DISCARD
+        }))
+      ),
+      normalize
+    })
+  });
 
   function applyQuery(queryBuilder, payload = {}) {
     if (!queryBuilder || typeof queryBuilder.where !== "function") {
@@ -449,15 +527,21 @@ function createCrudListFilters(definitions = {}, { columns = {}, apply = {} } = 
     return queryBuilder;
   }
 
+  function createQueryValidator({ invalidValues } = {}) {
+    const invalidValueMode = normalizeCrudListFilterInvalidValues(invalidValues);
+    return queryValidators[invalidValueMode];
+  }
+
   return Object.freeze({
     filters: normalizedFilters,
-    queryValidator: Object.freeze({
-      schema,
-      normalize
-    }),
+    createQueryValidator,
     normalize,
     applyQuery
   });
 }
 
-export { createCrudListFilters };
+export {
+  CRUD_LIST_FILTER_INVALID_VALUES_REJECT,
+  CRUD_LIST_FILTER_INVALID_VALUES_DISCARD,
+  createCrudListFilters
+};

--- a/packages/crud-core/test/listFilters.test.js
+++ b/packages/crud-core/test/listFilters.test.js
@@ -1,13 +1,20 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { Check } from "typebox/value";
 import { compileRouteValidator } from "@jskit-ai/kernel/_testable";
 import { cursorPaginationQueryValidator } from "@jskit-ai/kernel/shared/validators";
 import { listSearchQueryValidator } from "../src/server/listQueryValidators.js";
-import { createCrudListFilters } from "../src/server/listFilters.js";
+import {
+  CRUD_LIST_FILTER_INVALID_VALUES_REJECT,
+  CRUD_LIST_FILTER_INVALID_VALUES_DISCARD,
+  createCrudListFilters
+} from "../src/server/listFilters.js";
 
 test("crud-core exposes createCrudListFilters through the public package export", async () => {
   const module = await import("@jskit-ai/crud-core/server/listFilters");
   assert.equal(typeof module.createCrudListFilters, "function");
+  assert.equal(module.CRUD_LIST_FILTER_INVALID_VALUES_REJECT, CRUD_LIST_FILTER_INVALID_VALUES_REJECT);
+  assert.equal(module.CRUD_LIST_FILTER_INVALID_VALUES_DISCARD, CRUD_LIST_FILTER_INVALID_VALUES_DISCARD);
 });
 
 function createQueryDouble() {
@@ -244,9 +251,129 @@ test("createCrudListFilters query validator stays mergeable with search and curs
     queryValidator: [
       cursorPaginationQueryValidator,
       listSearchQueryValidator,
-      runtime.queryValidator
+      runtime.createQueryValidator({
+        invalidValues: CRUD_LIST_FILTER_INVALID_VALUES_REJECT
+      })
     ]
   });
 
   assert.deepEqual(compiled.schema.querystring.required || [], []);
+});
+
+test("createCrudListFilters requires explicit invalid-value mode for new query validators", () => {
+  const runtime = createCrudListFilters({});
+
+  assert.throws(
+    () => runtime.createQueryValidator(),
+    /invalidValues mode/
+  );
+});
+
+test("createCrudListFilters reject validator keeps strict filter schemas", () => {
+  const runtime = createCrudListFilters({
+    arrivalDate: {
+      type: "dateRange",
+      label: "Arrival Date"
+    },
+    status: {
+      type: "enumMany",
+      label: "Status",
+      options: [
+        { value: "active", label: "Active" },
+        { value: "archived", label: "Archived" }
+      ]
+    },
+    supplierContactId: {
+      type: "recordIdMany",
+      label: "Supplier"
+    },
+    weight: {
+      type: "numberRange",
+      label: "Weight"
+    }
+  });
+
+  const validator = runtime.createQueryValidator({
+    invalidValues: CRUD_LIST_FILTER_INVALID_VALUES_REJECT
+  });
+
+  assert.equal(Check(validator.schema, {
+    arrivalDateFrom: "2026-04-01",
+    status: ["active"],
+    supplierContactId: ["7"],
+    weightMin: "12.5"
+  }), true);
+  assert.equal(Check(validator.schema, {
+    arrivalDateFrom: "bad-date"
+  }), false);
+  assert.equal(Check(validator.schema, {
+    status: ["active", "unexpected"]
+  }), false);
+  assert.equal(Check(validator.schema, {
+    supplierContactId: ["7", "bad"]
+  }), false);
+  assert.equal(Check(validator.schema, {
+    weightMin: "bad"
+  }), false);
+});
+
+test("createCrudListFilters discard validator accepts malformed values and lets normalize drop them", () => {
+  const runtime = createCrudListFilters({
+    arrivalDate: {
+      type: "dateRange",
+      label: "Arrival Date"
+    },
+    status: {
+      type: "enumMany",
+      label: "Status",
+      options: [
+        { value: "active", label: "Active" },
+        { value: "archived", label: "Archived" }
+      ]
+    },
+    supplierContactId: {
+      type: "recordIdMany",
+      label: "Supplier"
+    },
+    weight: {
+      type: "numberRange",
+      label: "Weight"
+    }
+  });
+
+  const validator = runtime.createQueryValidator({
+    invalidValues: CRUD_LIST_FILTER_INVALID_VALUES_DISCARD
+  });
+
+  assert.equal(Check(validator.schema, {
+    arrivalDateFrom: "bad-date",
+    status: ["active", "unexpected"],
+    supplierContactId: ["7", "bad"],
+    weightMin: "bad"
+  }), true);
+  assert.deepEqual(validator.normalize({
+    arrivalDateFrom: "bad-date",
+    arrivalDateTo: "2026-04-30",
+    status: ["active", "unexpected"],
+    supplierContactId: ["7", "bad"],
+    weightMin: "bad"
+  }), {
+    arrivalDate: {
+      to: "2026-04-30"
+    },
+    status: ["active"],
+    supplierContactId: ["7"]
+  });
+});
+
+test("createCrudListFilters exposes no default query validator alias", () => {
+  const runtime = createCrudListFilters({
+    arrivalDate: {
+      type: "dateRange",
+      label: "Arrival Date"
+    }
+  });
+
+  assert.equal(Object.hasOwn(runtime, "queryValidator"), false);
+  assert.equal(runtime.queryValidator, undefined);
 });

--- a/packages/users-web/src/client/composables/useCrudListFilters.js
+++ b/packages/users-web/src/client/composables/useCrudListFilters.js
@@ -72,16 +72,37 @@ function normalizePresetEntries(presets = []) {
     }
     seenKeys.add(key);
 
+    const values = rawPreset.values && typeof rawPreset.values === "object" && !Array.isArray(rawPreset.values)
+      ? rawPreset.values
+      : {};
+    const resolveValues = typeof rawPreset.resolveValues === "function"
+      ? rawPreset.resolveValues
+      : null;
+
     normalized.push(Object.freeze({
       key,
       label,
-      values: rawPreset.values && typeof rawPreset.values === "object" && !Array.isArray(rawPreset.values)
-        ? rawPreset.values
-        : {}
+      values,
+      resolveValues
     }));
   }
 
   return Object.freeze(normalized);
+}
+
+function resolvePresetValues(preset = {}, { values = {}, filters = {} } = {}) {
+  const rawValues = typeof preset.resolveValues === "function"
+    ? preset.resolveValues({
+        values,
+        filters,
+        presetKey: preset.key,
+        preset
+      })
+    : preset.values;
+
+  return rawValues && typeof rawValues === "object" && !Array.isArray(rawValues)
+    ? rawValues
+    : {};
 }
 
 function normalizePresetFilterValue(filter = {}, rawValue) {
@@ -90,7 +111,7 @@ function normalizePresetFilterValue(filter = {}, rawValue) {
   }
 
   if (filter.type === CRUD_LIST_FILTER_TYPE_ENUM_MANY || filter.type === CRUD_LIST_FILTER_TYPE_RECORD_ID_MANY) {
-    const allowedValues = filter.type === CRUD_LIST_FILTER_TYPE_ENUM_MANY || filter.type === CRUD_LIST_FILTER_TYPE_PRESENCE
+    const allowedValues = filter.type === CRUD_LIST_FILTER_TYPE_ENUM_MANY
       ? new Set((filter.options || []).map((entry) => entry.value))
       : null;
     const normalizedList = normalizeUniqueTextList(rawValue, {
@@ -130,6 +151,49 @@ function normalizePresetFilterValue(filter = {}, rawValue) {
   }
 
   return normalized;
+}
+
+function normalizeCurrentManyFilterValues(value) {
+  const source = Array.isArray(value) ? value : [value];
+  return source
+    .map((entry) => normalizeText(entry))
+    .filter(Boolean);
+}
+
+function matchArrayValues(currentValue = [], expectedValue = []) {
+  const currentList = Array.isArray(currentValue) ? [...currentValue].sort() : [];
+  const expectedList = Array.isArray(expectedValue) ? [...expectedValue].sort() : [];
+  if (currentList.length !== expectedList.length) {
+    return false;
+  }
+
+  return currentList.every((entry, index) => entry === expectedList[index]);
+}
+
+function matchesPresetFilterValue(filter = {}, currentValue, rawExpectedValue) {
+  const expectedValue = normalizePresetFilterValue(filter, rawExpectedValue);
+
+  if (filter.type === CRUD_LIST_FILTER_TYPE_ENUM_MANY || filter.type === CRUD_LIST_FILTER_TYPE_RECORD_ID_MANY) {
+    return matchArrayValues(normalizeCurrentManyFilterValues(currentValue), expectedValue);
+  }
+
+  const normalizedCurrentValue = normalizePresetFilterValue(filter, currentValue);
+
+  if (filter.type === CRUD_LIST_FILTER_TYPE_DATE_RANGE) {
+    return (
+      normalizeText(normalizedCurrentValue?.from) === normalizeText(expectedValue?.from) &&
+      normalizeText(normalizedCurrentValue?.to) === normalizeText(expectedValue?.to)
+    );
+  }
+
+  if (filter.type === CRUD_LIST_FILTER_TYPE_NUMBER_RANGE) {
+    return (
+      normalizeText(normalizedCurrentValue?.min) === normalizeText(expectedValue?.min) &&
+      normalizeText(normalizedCurrentValue?.max) === normalizeText(expectedValue?.max)
+    );
+  }
+
+  return normalizedCurrentValue === expectedValue;
 }
 
 function resetFilterValue(values, filter = {}) {
@@ -375,17 +439,48 @@ function useCrudListFilters(definitions = {}, { labelResolvers = {}, chipLabels 
       return;
     }
 
+    const presetValues = resolvePresetValues(preset, {
+      values,
+      filters
+    });
+
     if (mode !== "merge") {
       clearFilters();
     }
 
     for (const filter of filterEntries) {
-      if (!Object.hasOwn(preset.values, filter.key)) {
+      if (!Object.hasOwn(presetValues, filter.key)) {
         continue;
       }
 
-      applyPresetFilterValue(values, filter, preset.values[filter.key]);
+      applyPresetFilterValue(values, filter, presetValues[filter.key]);
     }
+  }
+
+  function matchesPreset(presetKey = "") {
+    const preset = normalizedPresets.find((entry) => entry.key === normalizeText(presetKey));
+    if (!preset) {
+      return false;
+    }
+
+    const presetValues = resolvePresetValues(preset, {
+      values,
+      filters
+    });
+    let matchedFilter = false;
+
+    for (const filter of filterEntries) {
+      if (!Object.hasOwn(presetValues, filter.key)) {
+        continue;
+      }
+
+      matchedFilter = true;
+      if (!matchesPresetFilterValue(filter, values[filter.key], presetValues[filter.key])) {
+        return false;
+      }
+    }
+
+    return matchedFilter;
   }
 
   return Object.freeze({
@@ -400,7 +495,8 @@ function useCrudListFilters(definitions = {}, { labelResolvers = {}, chipLabels 
     clearFilters,
     clearChip,
     toggle,
-    applyPreset
+    applyPreset,
+    matchesPreset
   });
 }
 

--- a/packages/users-web/test/useCrudListFilters.test.js
+++ b/packages/users-web/test/useCrudListFilters.test.js
@@ -78,3 +78,105 @@ test("useCrudListFilters manages values, query params, chips, and presets", asyn
   assert.deepEqual(filters.values.status, []);
   assert.equal(filters.hasActiveFilters.value, false);
 });
+
+test("useCrudListFilters supports dynamic presets and preset matching", async () => {
+  const { useCrudListFilters } = await import("@jskit-ai/users-web/client/composables/useCrudListFilters");
+  let today = "2026-04-18";
+
+  const filters = useCrudListFilters(
+    {
+      status: {
+        type: "enumMany",
+        label: "Status",
+        options: [
+          { value: "active", label: "Active" },
+          { value: "archived", label: "Archived" }
+        ]
+      },
+      arrivalDate: {
+        type: "dateRange",
+        label: "Arrival Date"
+      }
+    },
+    {
+      presets: [
+        {
+          key: "today",
+          label: "Today",
+          resolveValues() {
+            return {
+              arrivalDate: {
+                from: today,
+                to: today
+              }
+            };
+          }
+        },
+        {
+          key: "all-dates",
+          label: "All Dates",
+          values: {
+            arrivalDate: {
+              from: "",
+              to: ""
+            }
+          }
+        }
+      ]
+    }
+  );
+
+  filters.values.status = ["archived"];
+  filters.applyPreset("today", { mode: "merge" });
+
+  assert.equal(filters.values.arrivalDate.from, "2026-04-18");
+  assert.equal(filters.values.arrivalDate.to, "2026-04-18");
+  assert.deepEqual(filters.values.status, ["archived"]);
+  assert.equal(filters.matchesPreset("today"), true);
+  assert.equal(filters.matchesPreset("all-dates"), false);
+
+  today = "2026-04-19";
+  assert.equal(filters.matchesPreset("today"), false);
+
+  filters.applyPreset("all-dates", { mode: "merge" });
+  assert.equal(filters.values.arrivalDate.from, "");
+  assert.equal(filters.values.arrivalDate.to, "");
+  assert.deepEqual(filters.values.status, ["archived"]);
+  assert.equal(filters.matchesPreset("all-dates"), true);
+});
+
+test("useCrudListFilters preset matching rejects extra enumMany values present in current state", async () => {
+  const { useCrudListFilters } = await import("@jskit-ai/users-web/client/composables/useCrudListFilters");
+
+  const filters = useCrudListFilters(
+    {
+      status: {
+        type: "enumMany",
+        label: "Status",
+        options: [
+          { value: "active", label: "Active" },
+          { value: "archived", label: "Archived" }
+        ]
+      }
+    },
+    {
+      presets: [
+        {
+          key: "archived-only",
+          label: "Archived Only",
+          values: {
+            status: ["archived"]
+          }
+        }
+      ]
+    }
+  );
+
+  filters.values.status = ["archived", "bogus"];
+
+  assert.equal(filters.matchesPreset("archived-only"), false);
+  assert.deepEqual(
+    filters.activeChips.value.map((chip) => chip.label),
+    ["Status: Archived", "Status: bogus"]
+  );
+});


### PR DESCRIPTION
## Summary
- require explicit CRUD list filter validator policy selection and remove the old query validator alias
- tighten preset matching so extra route-hydrated values prevent false active-preset states
- refresh authored and generated agent docs for filter validators, presence filters, and runtime presets

## Testing
- not run (per request)