### PR TITLE
Improve doctor filter validation and filter guidance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6176,26 +6176,26 @@
     },
     "packages/agent-docs": {
       "name": "@jskit-ai/agent-docs",
-      "version": "0.1.4",
+      "version": "0.1.6",
       "engines": {
         "node": "20.x"
       }
     },
     "packages/assistant": {
       "name": "@jskit-ai/assistant",
-      "version": "0.1.52",
+      "version": "0.1.54",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.43"
+        "@jskit-ai/kernel": "0.1.45"
       }
     },
     "packages/assistant-core": {
       "name": "@jskit-ai/assistant-core",
-      "version": "0.1.19",
+      "version": "0.1.21",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.43",
-        "@jskit-ai/http-runtime": "0.1.42",
-        "@jskit-ai/kernel": "0.1.43",
-        "@jskit-ai/users-core": "0.1.53",
+        "@jskit-ai/database-runtime": "0.1.45",
+        "@jskit-ai/http-runtime": "0.1.44",
+        "@jskit-ai/kernel": "0.1.45",
+        "@jskit-ai/users-core": "0.1.55",
         "@tanstack/vue-query": "^5.90.5",
         "dompurify": "^3.3.3",
         "marked": "^17.0.4",
@@ -6273,17 +6273,15 @@
     },
     "packages/assistant-runtime": {
       "name": "@jskit-ai/assistant-runtime",
-      "version": "0.1.14",
+      "version": "0.1.16",
       "dependencies": {
-        "@jskit-ai/assistant-core": "0.1.19",
-        "@jskit-ai/database-runtime": "0.1.43",
-        "@jskit-ai/http-runtime": "0.1.42",
-        "@jskit-ai/kernel": "0.1.43",
-        "@jskit-ai/shell-web": "0.1.42",
-        "@jskit-ai/users-core": "0.1.53",
-        "@jskit-ai/users-web": "0.1.58",
-        "@jskit-ai/workspaces-core": "0.1.19",
-        "@jskit-ai/workspaces-web": "0.1.19",
+        "@jskit-ai/assistant-core": "0.1.21",
+        "@jskit-ai/database-runtime": "0.1.45",
+        "@jskit-ai/http-runtime": "0.1.44",
+        "@jskit-ai/kernel": "0.1.45",
+        "@jskit-ai/shell-web": "0.1.44",
+        "@jskit-ai/users-core": "0.1.55",
+        "@jskit-ai/users-web": "0.1.60",
         "@tanstack/vue-query": "^5.90.5",
         "vuetify": "^4.0.0"
       }
@@ -6357,34 +6355,34 @@
     },
     "packages/auth-core": {
       "name": "@jskit-ai/auth-core",
-      "version": "0.1.42",
+      "version": "0.1.44",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0",
-        "@jskit-ai/kernel": "0.1.43",
+        "@jskit-ai/kernel": "0.1.45",
         "typebox": "^1.0.81"
       }
     },
     "packages/auth-provider-supabase-core": {
       "name": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.42",
+      "version": "0.1.44",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.42",
-        "@jskit-ai/kernel": "0.1.43",
+        "@jskit-ai/auth-core": "0.1.44",
+        "@jskit-ai/kernel": "0.1.45",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0"
       }
     },
     "packages/auth-web": {
       "name": "@jskit-ai/auth-web",
-      "version": "0.1.44",
+      "version": "0.1.46",
       "dependencies": {
         "@fastify/type-provider-typebox": "^6.1.0",
-        "@jskit-ai/auth-core": "0.1.42",
-        "@jskit-ai/http-runtime": "0.1.42",
-        "@jskit-ai/kernel": "0.1.43",
-        "@jskit-ai/shell-web": "0.1.42",
+        "@jskit-ai/auth-core": "0.1.44",
+        "@jskit-ai/http-runtime": "0.1.44",
+        "@jskit-ai/kernel": "0.1.45",
+        "@jskit-ai/shell-web": "0.1.44",
         "@mdi/js": "^7.4.47",
         "@tanstack/vue-query": "^5.90.5",
         "pinia": "^3.0.4",
@@ -6471,34 +6469,34 @@
     },
     "packages/console-core": {
       "name": "@jskit-ai/console-core",
-      "version": "0.1.6",
+      "version": "0.1.8",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.43",
-        "@jskit-ai/http-runtime": "0.1.42",
-        "@jskit-ai/kernel": "0.1.43",
-        "@jskit-ai/users-core": "0.1.53",
+        "@jskit-ai/database-runtime": "0.1.45",
+        "@jskit-ai/http-runtime": "0.1.44",
+        "@jskit-ai/kernel": "0.1.45",
+        "@jskit-ai/users-core": "0.1.55",
         "typebox": "^1.0.81"
       }
     },
     "packages/console-web": {
       "name": "@jskit-ai/console-web",
-      "version": "0.1.11",
+      "version": "0.1.13",
       "dependencies": {
-        "@jskit-ai/auth-web": "0.1.44",
-        "@jskit-ai/console-core": "0.1.6",
-        "@jskit-ai/shell-web": "0.1.42"
+        "@jskit-ai/auth-web": "0.1.46",
+        "@jskit-ai/console-core": "0.1.8",
+        "@jskit-ai/shell-web": "0.1.44"
       }
     },
     "packages/crud-core": {
       "name": "@jskit-ai/crud-core",
-      "version": "0.1.51",
+      "version": "0.1.53",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.43",
-        "@jskit-ai/kernel": "0.1.43",
-        "@jskit-ai/realtime": "0.1.42",
-        "@jskit-ai/shell-web": "0.1.42",
-        "@jskit-ai/users-core": "0.1.53",
-        "@jskit-ai/users-web": "0.1.58",
+        "@jskit-ai/database-runtime": "0.1.45",
+        "@jskit-ai/kernel": "0.1.45",
+        "@jskit-ai/realtime": "0.1.44",
+        "@jskit-ai/shell-web": "0.1.44",
+        "@jskit-ai/users-core": "0.1.55",
+        "@jskit-ai/users-web": "0.1.60",
         "@tanstack/vue-query": "^5.90.5",
         "typebox": "^1.0.81"
       }
@@ -6572,68 +6570,68 @@
     },
     "packages/crud-server-generator": {
       "name": "@jskit-ai/crud-server-generator",
-      "version": "0.1.51",
+      "version": "0.1.53",
       "dependencies": {
         "@babel/parser": "^7.29.2",
-        "@jskit-ai/crud-core": "0.1.51",
-        "@jskit-ai/database-runtime": "0.1.43",
-        "@jskit-ai/http-runtime": "0.1.42",
-        "@jskit-ai/kernel": "0.1.43",
-        "@jskit-ai/users-core": "0.1.53",
+        "@jskit-ai/crud-core": "0.1.53",
+        "@jskit-ai/database-runtime": "0.1.45",
+        "@jskit-ai/http-runtime": "0.1.44",
+        "@jskit-ai/kernel": "0.1.45",
+        "@jskit-ai/users-core": "0.1.55",
         "recast": "^0.23.11",
         "typebox": "^1.0.81"
       }
     },
     "packages/crud-ui-generator": {
       "name": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.26",
+      "version": "0.1.28",
       "dependencies": {
-        "@jskit-ai/crud-core": "0.1.51",
-        "@jskit-ai/kernel": "0.1.43"
+        "@jskit-ai/crud-core": "0.1.53",
+        "@jskit-ai/kernel": "0.1.45"
       }
     },
     "packages/database-runtime": {
       "name": "@jskit-ai/database-runtime",
-      "version": "0.1.43",
+      "version": "0.1.45",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.43"
+        "@jskit-ai/kernel": "0.1.45"
       }
     },
     "packages/database-runtime-mysql": {
       "name": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.42",
+      "version": "0.1.44",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.43"
+        "@jskit-ai/database-runtime": "0.1.45"
       }
     },
     "packages/database-runtime-postgres": {
       "name": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.42",
+      "version": "0.1.44",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.43"
+        "@jskit-ai/database-runtime": "0.1.45"
       }
     },
     "packages/http-runtime": {
       "name": "@jskit-ai/http-runtime",
-      "version": "0.1.42",
+      "version": "0.1.44",
       "dependencies": {
         "@fastify/type-provider-typebox": "^6.1.0",
-        "@jskit-ai/kernel": "0.1.43",
+        "@jskit-ai/kernel": "0.1.45",
         "typebox": "^1.0.81"
       }
     },
     "packages/kernel": {
       "name": "@jskit-ai/kernel",
-      "version": "0.1.43",
+      "version": "0.1.45",
       "dependencies": {
         "typebox": "^1.0.81"
       }
     },
     "packages/realtime": {
       "name": "@jskit-ai/realtime",
-      "version": "0.1.42",
+      "version": "0.1.44",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.43",
+        "@jskit-ai/kernel": "0.1.45",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",
@@ -6642,9 +6640,9 @@
     },
     "packages/shell-web": {
       "name": "@jskit-ai/shell-web",
-      "version": "0.1.42",
+      "version": "0.1.44",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.43",
+        "@jskit-ai/kernel": "0.1.45",
         "@mdi/js": "^7.4.47",
         "@tanstack/vue-query": "^5.90.5",
         "pinia": "^3.0.4",
@@ -6710,25 +6708,25 @@
     },
     "packages/storage-runtime": {
       "name": "@jskit-ai/storage-runtime",
-      "version": "0.1.42",
+      "version": "0.1.44",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.43",
+        "@jskit-ai/kernel": "0.1.45",
         "unstorage": "^1.17.3"
       }
     },
     "packages/ui-generator": {
       "name": "@jskit-ai/ui-generator",
-      "version": "0.1.26",
+      "version": "0.1.28",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.43",
-        "@jskit-ai/shell-web": "0.1.42"
+        "@jskit-ai/kernel": "0.1.45",
+        "@jskit-ai/shell-web": "0.1.44"
       }
     },
     "packages/uploads-image-web": {
       "name": "@jskit-ai/uploads-image-web",
-      "version": "0.1.21",
+      "version": "0.1.23",
       "dependencies": {
-        "@jskit-ai/uploads-runtime": "0.1.21",
+        "@jskit-ai/uploads-runtime": "0.1.23",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",
@@ -6738,35 +6736,35 @@
     },
     "packages/uploads-runtime": {
       "name": "@jskit-ai/uploads-runtime",
-      "version": "0.1.21",
+      "version": "0.1.23",
       "dependencies": {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.43"
+        "@jskit-ai/kernel": "0.1.45"
       }
     },
     "packages/users-core": {
       "name": "@jskit-ai/users-core",
-      "version": "0.1.53",
+      "version": "0.1.55",
       "dependencies": {
         "@fastify/type-provider-typebox": "^6.1.0",
-        "@jskit-ai/auth-core": "0.1.42",
-        "@jskit-ai/database-runtime": "0.1.43",
-        "@jskit-ai/http-runtime": "0.1.42",
-        "@jskit-ai/kernel": "0.1.43",
-        "@jskit-ai/uploads-runtime": "0.1.21",
+        "@jskit-ai/auth-core": "0.1.44",
+        "@jskit-ai/database-runtime": "0.1.45",
+        "@jskit-ai/http-runtime": "0.1.44",
+        "@jskit-ai/kernel": "0.1.45",
+        "@jskit-ai/uploads-runtime": "0.1.23",
         "typebox": "^1.0.81"
       }
     },
     "packages/users-web": {
       "name": "@jskit-ai/users-web",
-      "version": "0.1.58",
+      "version": "0.1.60",
       "dependencies": {
-        "@jskit-ai/http-runtime": "0.1.42",
-        "@jskit-ai/kernel": "0.1.43",
-        "@jskit-ai/realtime": "0.1.42",
-        "@jskit-ai/shell-web": "0.1.42",
-        "@jskit-ai/uploads-image-web": "0.1.21",
-        "@jskit-ai/users-core": "0.1.53",
+        "@jskit-ai/http-runtime": "0.1.44",
+        "@jskit-ai/kernel": "0.1.45",
+        "@jskit-ai/realtime": "0.1.44",
+        "@jskit-ai/shell-web": "0.1.44",
+        "@jskit-ai/uploads-image-web": "0.1.23",
+        "@jskit-ai/users-core": "0.1.55",
         "@mdi/js": "^7.4.47",
         "@tanstack/vue-query": "5.92.12",
         "vuetify": "^4.0.0"
@@ -6841,27 +6839,27 @@
     },
     "packages/workspaces-core": {
       "name": "@jskit-ai/workspaces-core",
-      "version": "0.1.19",
+      "version": "0.1.21",
       "dependencies": {
         "@fastify/type-provider-typebox": "^6.1.0",
-        "@jskit-ai/auth-core": "0.1.42",
-        "@jskit-ai/database-runtime": "0.1.43",
-        "@jskit-ai/http-runtime": "0.1.42",
-        "@jskit-ai/kernel": "0.1.43",
-        "@jskit-ai/users-core": "0.1.53",
+        "@jskit-ai/auth-core": "0.1.44",
+        "@jskit-ai/database-runtime": "0.1.45",
+        "@jskit-ai/http-runtime": "0.1.44",
+        "@jskit-ai/kernel": "0.1.45",
+        "@jskit-ai/users-core": "0.1.55",
         "typebox": "^1.0.81"
       }
     },
     "packages/workspaces-web": {
       "name": "@jskit-ai/workspaces-web",
-      "version": "0.1.19",
+      "version": "0.1.21",
       "dependencies": {
-        "@jskit-ai/http-runtime": "0.1.42",
-        "@jskit-ai/kernel": "0.1.43",
-        "@jskit-ai/shell-web": "0.1.42",
-        "@jskit-ai/users-core": "0.1.53",
-        "@jskit-ai/users-web": "0.1.58",
-        "@jskit-ai/workspaces-core": "0.1.19",
+        "@jskit-ai/http-runtime": "0.1.44",
+        "@jskit-ai/kernel": "0.1.45",
+        "@jskit-ai/shell-web": "0.1.44",
+        "@jskit-ai/users-core": "0.1.55",
+        "@jskit-ai/users-web": "0.1.60",
+        "@jskit-ai/workspaces-core": "0.1.21",
         "@mdi/js": "^7.4.47",
         "@tanstack/vue-query": "5.92.12",
         "vuetify": "^4.0.0"
@@ -6936,7 +6934,7 @@
     },
     "tooling/config-eslint": {
       "name": "@jskit-ai/config-eslint",
-      "version": "0.1.42",
+      "version": "0.1.44",
       "dependencies": {
         "@eslint/js": "^9.39.1",
         "eslint-plugin-vue": "^10.5.1",
@@ -6954,7 +6952,7 @@
     },
     "tooling/create-app": {
       "name": "@jskit-ai/create-app",
-      "version": "0.1.51",
+      "version": "0.1.53",
       "bin": {
         "jskit-create-app": "bin/jskit-create-app.js"
       },
@@ -6964,18 +6962,18 @@
     },
     "tooling/jskit-catalog": {
       "name": "@jskit-ai/jskit-catalog",
-      "version": "0.1.51",
+      "version": "0.1.53",
       "engines": {
         "node": "20.x"
       }
     },
     "tooling/jskit-cli": {
       "name": "@jskit-ai/jskit-cli",
-      "version": "0.2.52",
+      "version": "0.2.54",
       "dependencies": {
-        "@jskit-ai/jskit-catalog": "0.1.51",
-        "@jskit-ai/kernel": "0.1.43",
-        "@jskit-ai/shell-web": "0.1.42"
+        "@jskit-ai/jskit-catalog": "0.1.53",
+        "@jskit-ai/kernel": "0.1.45",
+        "@jskit-ai/shell-web": "0.1.44"
       },
       "bin": {
         "jskit": "bin/jskit.js"

--- a/packages/agent-docs/guide/agent/generators/advanced-cruds.md
+++ b/packages/agent-docs/guide/agent/generators/advanced-cruds.md
@@ -990,6 +990,7 @@ Choose the invalid-value contract deliberately:
 - use `invalidValues: "discard"` when malformed filter values should be ignored and normalization should drop them
 - route query validation runs before auth, so this choice changes whether malformed unauthenticated requests fail at validation or fall through to auth
 - for normal HTTP CRUD handlers, route-level `discard` means the handler receives already-normalized query input, so the action layer will not see those discarded bad values again later
+- `jskit doctor` flags `createQueryValidator(...)` calls that do not spell out `invalidValues` directly at the call site
 
 ```js
 async function list(query = {}, callOptions = {}) {
@@ -1009,6 +1010,7 @@ async function list(query = {}, callOptions = {}) {
 - Use `type: "presence"` for null/not-null filters such as assigned vs unassigned storage. Do not model those as custom enums plus `applyQuery(...)` overrides unless the SQL semantics are genuinely different from `whereNotNull(...)` / `whereNull(...)`.
 - Use `createCrudListFilters(...)` unless the list semantics are truly unusual.
 - Use `q` for free-text and explicit query params for structured filters.
+- Run `jskit doctor` after wiring filters. It flags inline/local filter-definition objects passed into `useCrudListFilters(...)` or `createCrudListFilters(...)`, and it flags `createQueryValidator(...)` calls that hide the invalid-value policy.
 
 ### Pattern 4: lookup-backed structured filters
 

--- a/packages/agent-docs/package.json
+++ b/packages/agent-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/agent-docs",
-  "version": "0.1.4",
+  "version": "0.1.6",
   "description": "Distributed JSKIT agent workflows, guides, and generated reference maps.",
   "type": "module",
   "files": [

--- a/packages/agent-docs/patterns/filters.md
+++ b/packages/agent-docs/patterns/filters.md
@@ -35,6 +35,7 @@ Validation mode is part of the contract:
 - use `invalidValues: "discard"` when malformed filter values should be ignored and normalization should drop them
 - route query validation runs before auth, so this choice affects whether malformed unauthenticated requests fail at validation or fall through to auth
 - for normal HTTP CRUD handlers, route-level `discard` means the action layer receives already-normalized query input; do not assume route `discard` plus action `reject` will still reject malformed HTTP query strings later
+- `jskit doctor` flags `createQueryValidator(...)` calls that do not spell out `invalidValues` directly at the call site
 
 Keep separate:
 - free-text search uses `records.searchQuery` and `q`
@@ -69,6 +70,7 @@ Avoid:
 - per-screen `useList()` wrappers for lookup-backed filters when `useCrudListFilterLookups(...)` fits
 - a second page-local filter-definition file when `packages/<crud>/src/shared/<crud>ListFilters.js` should be the source of truth
 - overloading `q` with structured filter meaning
+- local or inline filter-definition objects passed into `useCrudListFilters(...)` or `createCrudListFilters(...)`; `jskit doctor` expects those runtimes to import from a CRUD shared `*ListFilters` module
 
 Good shape:
 - `packages/receivals/src/shared/receivalListFilters.js`
@@ -87,3 +89,4 @@ Review checks:
 - server validator/repository logic derived from that source
 - client query params/chips/reset logic derived from that source
 - lookup-backed filters use the shared lookup helper, not a page-local mini-framework
+- `jskit doctor` stays clean for filter ownership and explicit validator policy

--- a/packages/agent-docs/site/guide/generators/advanced-cruds.md
+++ b/packages/agent-docs/site/guide/generators/advanced-cruds.md
@@ -988,6 +988,7 @@ Choose the invalid-value contract deliberately:
 - use `invalidValues: "discard"` when malformed filter values should be ignored and normalization should drop them
 - route query validation runs before auth, so this choice changes whether malformed unauthenticated requests fail at validation or fall through to auth
 - for normal HTTP CRUD handlers, route-level `discard` means the handler receives already-normalized query input, so the action layer will not see those discarded bad values again later
+- `jskit doctor` flags `createQueryValidator(...)` calls that do not spell out `invalidValues` directly at the call site
 
 ```js
 async function list(query = {}, callOptions = {}) {
@@ -1007,6 +1008,7 @@ async function list(query = {}, callOptions = {}) {
 - Use `type: "presence"` for null/not-null filters such as assigned vs unassigned storage. Do not model those as custom enums plus `applyQuery(...)` overrides unless the SQL semantics are genuinely different from `whereNotNull(...)` / `whereNull(...)`.
 - Use `createCrudListFilters(...)` unless the list semantics are truly unusual.
 - Use `q` for free-text and explicit query params for structured filters.
+- Run `jskit doctor` after wiring filters. It flags inline/local filter-definition objects passed into `useCrudListFilters(...)` or `createCrudListFilters(...)`, and it flags `createQueryValidator(...)` calls that hide the invalid-value policy.
 
 ### Pattern 4: lookup-backed structured filters
 

--- a/packages/assistant-core/package.descriptor.mjs
+++ b/packages/assistant-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-core",
-  version: "0.1.19",
+  version: "0.1.21",
   kind: "runtime",
   description: "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
   dependsOn: [
@@ -45,9 +45,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/http-runtime": "0.1.42",
-        "@jskit-ai/kernel": "0.1.43",
-        "@jskit-ai/users-core": "0.1.53",
+        "@jskit-ai/http-runtime": "0.1.44",
+        "@jskit-ai/kernel": "0.1.45",
+        "@jskit-ai/users-core": "0.1.55",
         "@tanstack/vue-query": "^5.90.5",
         "dompurify": "^3.3.3",
         "marked": "^17.0.4",

--- a/packages/assistant-core/package.json
+++ b/packages/assistant-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-core",
-  "version": "0.1.19",
+  "version": "0.1.21",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,10 +11,10 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.43",
-    "@jskit-ai/http-runtime": "0.1.42",
-    "@jskit-ai/kernel": "0.1.43",
-    "@jskit-ai/users-core": "0.1.53",
+    "@jskit-ai/database-runtime": "0.1.45",
+    "@jskit-ai/http-runtime": "0.1.44",
+    "@jskit-ai/kernel": "0.1.45",
+    "@jskit-ai/users-core": "0.1.55",
     "@tanstack/vue-query": "^5.90.5",
     "dompurify": "^3.3.3",
     "marked": "^17.0.4",

--- a/packages/assistant-runtime/package.descriptor.mjs
+++ b/packages/assistant-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-runtime",
-  version: "0.1.14",
+  version: "0.1.16",
   kind: "runtime",
   description: "Shared assistant runtime with per-surface assistant registration.",
   dependsOn: [
@@ -74,13 +74,13 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/assistant-core": "0.1.19",
-        "@jskit-ai/database-runtime": "0.1.43",
-        "@jskit-ai/http-runtime": "0.1.42",
-        "@jskit-ai/kernel": "0.1.43",
-        "@jskit-ai/shell-web": "0.1.42",
-        "@jskit-ai/users-core": "0.1.53",
-        "@jskit-ai/users-web": "0.1.58",
+        "@jskit-ai/assistant-core": "0.1.21",
+        "@jskit-ai/database-runtime": "0.1.45",
+        "@jskit-ai/http-runtime": "0.1.44",
+        "@jskit-ai/kernel": "0.1.45",
+        "@jskit-ai/shell-web": "0.1.44",
+        "@jskit-ai/users-core": "0.1.55",
+        "@jskit-ai/users-web": "0.1.60",
         "@tanstack/vue-query": "^5.90.5",
         "vuetify": "^4.0.0"
       },

--- a/packages/assistant-runtime/package.json
+++ b/packages/assistant-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-runtime",
-  "version": "0.1.14",
+  "version": "0.1.16",
   "type": "module",
   "exports": {
     "./client": "./src/client/index.js",
@@ -8,13 +8,13 @@
     "./server/actionIds": "./src/server/actionIds.js"
   },
   "dependencies": {
-    "@jskit-ai/assistant-core": "0.1.19",
-    "@jskit-ai/database-runtime": "0.1.43",
-    "@jskit-ai/http-runtime": "0.1.42",
-    "@jskit-ai/kernel": "0.1.43",
-    "@jskit-ai/shell-web": "0.1.42",
-    "@jskit-ai/users-core": "0.1.53",
-    "@jskit-ai/users-web": "0.1.58",
+    "@jskit-ai/assistant-core": "0.1.21",
+    "@jskit-ai/database-runtime": "0.1.45",
+    "@jskit-ai/http-runtime": "0.1.44",
+    "@jskit-ai/kernel": "0.1.45",
+    "@jskit-ai/shell-web": "0.1.44",
+    "@jskit-ai/users-core": "0.1.55",
+    "@jskit-ai/users-web": "0.1.60",
     "@tanstack/vue-query": "^5.90.5",
     "vuetify": "^4.0.0"
   }

--- a/packages/assistant/package.descriptor.mjs
+++ b/packages/assistant/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant",
-  version: "0.1.52",
+  version: "0.1.54",
   kind: "generator",
   description: "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
   options: {

--- a/packages/assistant/package.json
+++ b/packages/assistant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant",
-  "version": "0.1.52",
+  "version": "0.1.54",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.43"
+    "@jskit-ai/kernel": "0.1.45"
   }
 }

--- a/packages/auth-core/package.descriptor.mjs
+++ b/packages/auth-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-core",
-  "version": "0.1.42",
+  "version": "0.1.44",
   "kind": "runtime",
   "dependsOn": [
     "@jskit-ai/value-app-config-shared"
@@ -69,7 +69,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.43",
+        "@jskit-ai/kernel": "0.1.45",
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0"

--- a/packages/auth-core/package.json
+++ b/packages/auth-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-core",
-  "version": "0.1.42",
+  "version": "0.1.44",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -43,7 +43,7 @@
     "./shared/commands/authSessionReadCommand": "./src/shared/commands/authSessionReadCommand.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.43",
+    "@jskit-ai/kernel": "0.1.45",
     "@fastify/cookie": "^11.0.2",
     "@fastify/csrf-protection": "^7.1.0",
     "@fastify/rate-limit": "^10.3.0",

--- a/packages/auth-provider-supabase-core/package.descriptor.mjs
+++ b/packages/auth-provider-supabase-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.42",
+  "version": "0.1.44",
   "kind": "runtime",
   "options": {
     "auth-supabase-url": {
@@ -83,8 +83,8 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/auth-core": "0.1.42",
-        "@jskit-ai/kernel": "0.1.43",
+        "@jskit-ai/auth-core": "0.1.44",
+        "@jskit-ai/kernel": "0.1.45",
         "dotenv": "^16.4.5",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0"

--- a/packages/auth-provider-supabase-core/package.json
+++ b/packages/auth-provider-supabase-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.42",
+  "version": "0.1.44",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,8 +12,8 @@
     "./client": "./src/client/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.42",
-    "@jskit-ai/kernel": "0.1.43",
+    "@jskit-ai/auth-core": "0.1.44",
+    "@jskit-ai/kernel": "0.1.45",
     "jose": "^6.1.0",
     "@supabase/supabase-js": "^2.57.4"
   }

--- a/packages/auth-web/package.descriptor.mjs
+++ b/packages/auth-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-web",
-  "version": "0.1.44",
+  "version": "0.1.46",
   "kind": "runtime",
   "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
   "dependsOn": [
@@ -220,10 +220,10 @@ export default Object.freeze({
         "@tanstack/vue-query": "5.92.12",
         "@mdi/js": "^7.4.47",
         "@fastify/type-provider-typebox": "^6.1.0",
-        "@jskit-ai/auth-core": "0.1.42",
-        "@jskit-ai/http-runtime": "0.1.42",
-        "@jskit-ai/kernel": "0.1.43",
-        "@jskit-ai/shell-web": "0.1.42",
+        "@jskit-ai/auth-core": "0.1.44",
+        "@jskit-ai/http-runtime": "0.1.44",
+        "@jskit-ai/kernel": "0.1.45",
+        "@jskit-ai/shell-web": "0.1.44",
         "vuetify": "^4.0.0"
       },
       "dev": {}

--- a/packages/auth-web/package.json
+++ b/packages/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-web",
-  "version": "0.1.44",
+  "version": "0.1.46",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -18,13 +18,13 @@
   },
   "dependencies": {
     "@tanstack/vue-query": "^5.90.5",
-    "@jskit-ai/auth-core": "0.1.42",
+    "@jskit-ai/auth-core": "0.1.44",
     "@mdi/js": "^7.4.47",
     "@fastify/type-provider-typebox": "^6.1.0",
-    "@jskit-ai/kernel": "0.1.43",
-    "@jskit-ai/shell-web": "0.1.42",
+    "@jskit-ai/kernel": "0.1.45",
+    "@jskit-ai/shell-web": "0.1.44",
     "pinia": "^3.0.4",
     "vuetify": "^4.0.0",
-    "@jskit-ai/http-runtime": "0.1.42"
+    "@jskit-ai/http-runtime": "0.1.44"
   }
 }

--- a/packages/console-core/package.descriptor.mjs
+++ b/packages/console-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-core",
-  version: "0.1.6",
+  version: "0.1.8",
   kind: "runtime",
   description: "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
   dependsOn: [
@@ -72,10 +72,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.43",
-        "@jskit-ai/http-runtime": "0.1.42",
-        "@jskit-ai/kernel": "0.1.43",
-        "@jskit-ai/users-core": "0.1.53",
+        "@jskit-ai/database-runtime": "0.1.45",
+        "@jskit-ai/http-runtime": "0.1.44",
+        "@jskit-ai/kernel": "0.1.45",
+        "@jskit-ai/users-core": "0.1.55",
         "typebox": "^1.0.81"
       },
       dev: {}

--- a/packages/console-core/package.json
+++ b/packages/console-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/console-core",
-  "version": "0.1.6",
+  "version": "0.1.8",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,10 +9,10 @@
     "./shared/resources/consoleSettingsFields": "./src/shared/resources/consoleSettingsFields.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.43",
-    "@jskit-ai/http-runtime": "0.1.42",
-    "@jskit-ai/kernel": "0.1.43",
-    "@jskit-ai/users-core": "0.1.53",
+    "@jskit-ai/database-runtime": "0.1.45",
+    "@jskit-ai/http-runtime": "0.1.44",
+    "@jskit-ai/kernel": "0.1.45",
+    "@jskit-ai/users-core": "0.1.55",
     "typebox": "^1.0.81"
   }
 }

--- a/packages/console-web/package.descriptor.mjs
+++ b/packages/console-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-web",
-  version: "0.1.11",
+  version: "0.1.13",
   kind: "runtime",
   description: "Authenticated console surface scaffold and surface policy wiring.",
   dependsOn: [
@@ -65,9 +65,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-web": "0.1.44",
-        "@jskit-ai/console-core": "0.1.6",
-        "@jskit-ai/shell-web": "0.1.42",
+        "@jskit-ai/auth-web": "0.1.46",
+        "@jskit-ai/console-core": "0.1.8",
+        "@jskit-ai/shell-web": "0.1.44",
       },
       dev: {}
     },

--- a/packages/console-web/package.json
+++ b/packages/console-web/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/console-web",
-  "version": "0.1.11",
+  "version": "0.1.13",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-web": "0.1.44",
-    "@jskit-ai/console-core": "0.1.6",
-    "@jskit-ai/shell-web": "0.1.42"
+    "@jskit-ai/auth-web": "0.1.46",
+    "@jskit-ai/console-core": "0.1.8",
+    "@jskit-ai/shell-web": "0.1.44"
   }
 }

--- a/packages/crud-core/package.descriptor.mjs
+++ b/packages/crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-core",
-  version: "0.1.51",
+  version: "0.1.53",
   kind: "runtime",
   description: "Shared CRUD helpers used by CRUD modules.",
   dependsOn: [
@@ -26,7 +26,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/crud-core": "0.1.51"
+        "@jskit-ai/crud-core": "0.1.53"
       },
       dev: {}
     },

--- a/packages/crud-core/package.json
+++ b/packages/crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-core",
-  "version": "0.1.51",
+  "version": "0.1.53",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -27,12 +27,12 @@
   },
   "dependencies": {
     "@tanstack/vue-query": "^5.90.5",
-    "@jskit-ai/database-runtime": "0.1.43",
-    "@jskit-ai/kernel": "0.1.43",
-    "@jskit-ai/realtime": "0.1.42",
-    "@jskit-ai/shell-web": "0.1.42",
-    "@jskit-ai/users-core": "0.1.53",
-    "@jskit-ai/users-web": "0.1.58",
+    "@jskit-ai/database-runtime": "0.1.45",
+    "@jskit-ai/kernel": "0.1.45",
+    "@jskit-ai/realtime": "0.1.44",
+    "@jskit-ai/shell-web": "0.1.44",
+    "@jskit-ai/users-core": "0.1.55",
+    "@jskit-ai/users-web": "0.1.60",
     "typebox": "^1.0.81"
   }
 }

--- a/packages/crud-server-generator/package.descriptor.mjs
+++ b/packages/crud-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-server-generator",
-  version: "0.1.51",
+  version: "0.1.53",
   kind: "generator",
   description: "CRUD server generator with routes, actions, and persistence scaffolding.",
   options: {
@@ -151,13 +151,13 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.42",
-        "@jskit-ai/crud-core": "0.1.51",
-        "@jskit-ai/database-runtime": "0.1.43",
-        "@jskit-ai/http-runtime": "0.1.42",
-        "@jskit-ai/kernel": "0.1.43",
-        "@jskit-ai/realtime": "0.1.42",
-        "@jskit-ai/users-core": "0.1.53",
+        "@jskit-ai/auth-core": "0.1.44",
+        "@jskit-ai/crud-core": "0.1.53",
+        "@jskit-ai/database-runtime": "0.1.45",
+        "@jskit-ai/http-runtime": "0.1.44",
+        "@jskit-ai/kernel": "0.1.45",
+        "@jskit-ai/realtime": "0.1.44",
+        "@jskit-ai/users-core": "0.1.55",
         "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}",
         "typebox": "^1.0.81"
       },

--- a/packages/crud-server-generator/package.json
+++ b/packages/crud-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-server-generator",
-  "version": "0.1.51",
+  "version": "0.1.53",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,11 +13,11 @@
   },
   "dependencies": {
     "@babel/parser": "^7.29.2",
-    "@jskit-ai/crud-core": "0.1.51",
-    "@jskit-ai/database-runtime": "0.1.43",
-    "@jskit-ai/http-runtime": "0.1.42",
-    "@jskit-ai/kernel": "0.1.43",
-    "@jskit-ai/users-core": "0.1.53",
+    "@jskit-ai/crud-core": "0.1.53",
+    "@jskit-ai/database-runtime": "0.1.45",
+    "@jskit-ai/http-runtime": "0.1.44",
+    "@jskit-ai/kernel": "0.1.45",
+    "@jskit-ai/users-core": "0.1.55",
     "recast": "^0.23.11",
     "typebox": "^1.0.81"
   }

--- a/packages/crud-ui-generator/package.descriptor.mjs
+++ b/packages/crud-ui-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-ui-generator",
-  version: "0.1.26",
+  version: "0.1.28",
   kind: "generator",
   description: "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
   options: {
@@ -168,7 +168,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.58"
+        "@jskit-ai/users-web": "0.1.60"
       },
       dev: {}
     },

--- a/packages/crud-ui-generator/package.json
+++ b/packages/crud-ui-generator/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/crud-ui-generator",
-  "version": "0.1.26",
+  "version": "0.1.28",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/crud-core": "0.1.51",
-    "@jskit-ai/kernel": "0.1.43"
+    "@jskit-ai/crud-core": "0.1.53",
+    "@jskit-ai/kernel": "0.1.45"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/database-runtime-mysql/package.descriptor.mjs
+++ b/packages/database-runtime-mysql/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-mysql",
-  version: "0.1.42",
+  version: "0.1.44",
   kind: "runtime",
   options: {
     "db-host": {
@@ -91,7 +91,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.43",
+        "@jskit-ai/database-runtime": "0.1.45",
         "mysql2": "^3.11.2"
       },
       dev: {}

--- a/packages/database-runtime-mysql/package.json
+++ b/packages/database-runtime-mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-mysql",
-  "version": "0.1.42",
+  "version": "0.1.44",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,6 +12,6 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.43"
+    "@jskit-ai/database-runtime": "0.1.45"
   }
 }

--- a/packages/database-runtime-postgres/package.descriptor.mjs
+++ b/packages/database-runtime-postgres/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-postgres",
-  version: "0.1.42",
+  version: "0.1.44",
   kind: "runtime",
   options: {
     "db-host": {
@@ -91,7 +91,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.43",
+        "@jskit-ai/database-runtime": "0.1.45",
         "pg": "^8.13.1"
       },
       dev: {}

--- a/packages/database-runtime-postgres/package.json
+++ b/packages/database-runtime-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-postgres",
-  "version": "0.1.42",
+  "version": "0.1.44",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,6 +12,6 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.43"
+    "@jskit-ai/database-runtime": "0.1.45"
   }
 }

--- a/packages/database-runtime/package.descriptor.mjs
+++ b/packages/database-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime",
-  version: "0.1.43",
+  version: "0.1.45",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -58,7 +58,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.43",
+        "@jskit-ai/kernel": "0.1.45",
         "dotenv": "^16.4.5",
         "knex": "^3.1.0"
       },

--- a/packages/database-runtime/package.json
+++ b/packages/database-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime",
-  "version": "0.1.43",
+  "version": "0.1.45",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -25,6 +25,6 @@
     "./shared/transactions": "./src/shared/transactions.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.43"
+    "@jskit-ai/kernel": "0.1.45"
   }
 }

--- a/packages/http-runtime/package.descriptor.mjs
+++ b/packages/http-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/http-runtime",
-  "version": "0.1.42",
+  "version": "0.1.44",
   "kind": "runtime",
   "dependsOn": [],
   "capabilities": {
@@ -67,7 +67,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.43",
+        "@jskit-ai/kernel": "0.1.45",
         "@fastify/type-provider-typebox": "^6.1.0",
         "typebox": "^1.0.81"
       },

--- a/packages/http-runtime/package.json
+++ b/packages/http-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/http-runtime",
-  "version": "0.1.42",
+  "version": "0.1.44",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -17,7 +17,7 @@
     "./shared/validators/operationValidation": "./src/shared/validators/operationValidation.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.43",
+    "@jskit-ai/kernel": "0.1.45",
     "@fastify/type-provider-typebox": "^6.1.0",
     "typebox": "^1.0.81"
   }

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/kernel",
-  "version": "0.1.43",
+  "version": "0.1.45",
   "type": "module",
   "dependencies": {
     "typebox": "^1.0.81"

--- a/packages/realtime/package.descriptor.mjs
+++ b/packages/realtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/realtime",
-  version: "0.1.42",
+  version: "0.1.44",
   kind: "runtime",
   description: "Thin, generic realtime runtime wrappers for socket.io server and client.",
   options: {
@@ -94,7 +94,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.43",
+        "@jskit-ai/kernel": "0.1.45",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/realtime",
-  "version": "0.1.42",
+  "version": "0.1.44",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@socket.io/redis-adapter": "^8.3.0",
-    "@jskit-ai/kernel": "0.1.43",
+    "@jskit-ai/kernel": "0.1.45",
     "redis": "^5.8.2",
     "socket.io": "^4.8.3",
     "socket.io-client": "^4.8.3"

--- a/packages/shell-web/package.descriptor.mjs
+++ b/packages/shell-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/shell-web",
-  version: "0.1.42",
+  version: "0.1.44",
   kind: "runtime",
   description: "Web shell layout runtime with outlet-based placement contributions.",
   dependsOn: [],
@@ -117,7 +117,7 @@ export default Object.freeze({
       runtime: {
         "@mdi/js": "^7.4.47",
         "@tanstack/vue-query": "^5.90.5",
-        "@jskit-ai/kernel": "0.1.43",
+        "@jskit-ai/kernel": "0.1.45",
         "vuetify": "^4.0.0"
       },
       dev: {}

--- a/packages/shell-web/package.json
+++ b/packages/shell-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/shell-web",
-  "version": "0.1.42",
+  "version": "0.1.44",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -24,7 +24,7 @@
   "dependencies": {
     "@mdi/js": "^7.4.47",
     "@tanstack/vue-query": "^5.90.5",
-    "@jskit-ai/kernel": "0.1.43",
+    "@jskit-ai/kernel": "0.1.45",
     "pinia": "^3.0.4",
     "vuetify": "^4.0.0"
   }

--- a/packages/storage-runtime/package.descriptor.mjs
+++ b/packages/storage-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/storage-runtime",
-  version: "0.1.42",
+  version: "0.1.44",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -50,7 +50,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.43",
+        "@jskit-ai/kernel": "0.1.45",
         "unstorage": "^1.17.3"
       },
       dev: {}

--- a/packages/storage-runtime/package.json
+++ b/packages/storage-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/storage-runtime",
-  "version": "0.1.42",
+  "version": "0.1.44",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./server/providers/StorageRuntimeServiceProvider": "./src/server/providers/StorageRuntimeServiceProvider.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.43",
+    "@jskit-ai/kernel": "0.1.45",
     "unstorage": "^1.17.3"
   }
 }

--- a/packages/ui-generator/package.descriptor.mjs
+++ b/packages/ui-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/ui-generator",
-  version: "0.1.26",
+  version: "0.1.28",
   kind: "generator",
   description: "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
   options: {
@@ -278,7 +278,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.58"
+        "@jskit-ai/users-web": "0.1.60"
       },
       dev: {}
     },

--- a/packages/ui-generator/package.json
+++ b/packages/ui-generator/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/ui-generator",
-  "version": "0.1.26",
+  "version": "0.1.28",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.43",
-    "@jskit-ai/shell-web": "0.1.42"
+    "@jskit-ai/kernel": "0.1.45",
+    "@jskit-ai/shell-web": "0.1.44"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/uploads-image-web/package.descriptor.mjs
+++ b/packages/uploads-image-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-image-web",
-  version: "0.1.21",
+  version: "0.1.23",
   kind: "runtime",
   description: "Reusable client-side image upload runtime with pre-upload image editing.",
   dependsOn: [
@@ -65,7 +65,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/uploads-runtime": "0.1.21",
+        "@jskit-ai/uploads-runtime": "0.1.23",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-image-web/package.json
+++ b/packages/uploads-image-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-image-web",
-  "version": "0.1.21",
+  "version": "0.1.23",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,7 +13,7 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/uploads-runtime": "0.1.21",
+    "@jskit-ai/uploads-runtime": "0.1.23",
     "@uppy/compressor": "^3.1.0",
     "@uppy/core": "^5.2.0",
     "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-runtime/package.descriptor.mjs
+++ b/packages/uploads-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-runtime",
-  version: "0.1.21",
+  version: "0.1.23",
   kind: "runtime",
   description: "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
   dependsOn: [
@@ -71,7 +71,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.43"
+        "@jskit-ai/kernel": "0.1.45"
       },
       dev: {}
     },

--- a/packages/uploads-runtime/package.json
+++ b/packages/uploads-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-runtime",
-  "version": "0.1.21",
+  "version": "0.1.23",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,6 +16,6 @@
   },
   "dependencies": {
     "@fastify/multipart": "^9.4.0",
-    "@jskit-ai/kernel": "0.1.43"
+    "@jskit-ai/kernel": "0.1.45"
   }
 }

--- a/packages/users-core/package.descriptor.mjs
+++ b/packages/users-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-core",
-  version: "0.1.53",
+  version: "0.1.55",
   kind: "runtime",
   description: "Users/account runtime plus HTTP routes for account features.",
   dependsOn: [
@@ -128,11 +128,11 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.42",
-        "@jskit-ai/database-runtime": "0.1.43",
-        "@jskit-ai/http-runtime": "0.1.42",
-        "@jskit-ai/kernel": "0.1.43",
-        "@jskit-ai/uploads-runtime": "0.1.21",
+        "@jskit-ai/auth-core": "0.1.44",
+        "@jskit-ai/database-runtime": "0.1.45",
+        "@jskit-ai/http-runtime": "0.1.44",
+        "@jskit-ai/kernel": "0.1.45",
+        "@jskit-ai/uploads-runtime": "0.1.23",
         "@fastify/type-provider-typebox": "^6.1.0",
         typebox: "^1.0.81"
       },

--- a/packages/users-core/package.json
+++ b/packages/users-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-core",
-  "version": "0.1.53",
+  "version": "0.1.55",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,11 +13,11 @@
     "./shared/resources/userSettingsResource": "./src/shared/resources/userSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.42",
-    "@jskit-ai/database-runtime": "0.1.43",
-    "@jskit-ai/http-runtime": "0.1.42",
-    "@jskit-ai/kernel": "0.1.43",
-    "@jskit-ai/uploads-runtime": "0.1.21",
+    "@jskit-ai/auth-core": "0.1.44",
+    "@jskit-ai/database-runtime": "0.1.45",
+    "@jskit-ai/http-runtime": "0.1.44",
+    "@jskit-ai/kernel": "0.1.45",
+    "@jskit-ai/uploads-runtime": "0.1.23",
     "@fastify/type-provider-typebox": "^6.1.0",
     "typebox": "^1.0.81"
   }

--- a/packages/users-web/package.descriptor.mjs
+++ b/packages/users-web/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { HOME_TOOLS_OUTLET } from "./src/shared/toolsOutletContracts.js";
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-web",
-  version: "0.1.58",
+  version: "0.1.60",
   kind: "runtime",
   description: "Users web module: account/profile UI plus shared users web widgets.",
   dependsOn: [
@@ -146,12 +146,12 @@ export default Object.freeze({
       runtime: {
         "@tanstack/vue-query": "5.92.12",
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/http-runtime": "0.1.42",
-        "@jskit-ai/realtime": "0.1.42",
-        "@jskit-ai/kernel": "0.1.43",
-        "@jskit-ai/shell-web": "0.1.42",
-        "@jskit-ai/uploads-image-web": "0.1.21",
-        "@jskit-ai/users-core": "0.1.53",
+        "@jskit-ai/http-runtime": "0.1.44",
+        "@jskit-ai/realtime": "0.1.44",
+        "@jskit-ai/kernel": "0.1.45",
+        "@jskit-ai/shell-web": "0.1.44",
+        "@jskit-ai/uploads-image-web": "0.1.23",
+        "@jskit-ai/users-core": "0.1.55",
         vuetify: "^4.0.0"
       },
       dev: {}

--- a/packages/users-web/package.json
+++ b/packages/users-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-web",
-  "version": "0.1.58",
+  "version": "0.1.60",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -33,12 +33,12 @@
   "dependencies": {
     "@tanstack/vue-query": "5.92.12",
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/http-runtime": "0.1.42",
-    "@jskit-ai/kernel": "0.1.43",
-    "@jskit-ai/realtime": "0.1.42",
-    "@jskit-ai/shell-web": "0.1.42",
-    "@jskit-ai/uploads-image-web": "0.1.21",
-    "@jskit-ai/users-core": "0.1.53",
+    "@jskit-ai/http-runtime": "0.1.44",
+    "@jskit-ai/kernel": "0.1.45",
+    "@jskit-ai/realtime": "0.1.44",
+    "@jskit-ai/shell-web": "0.1.44",
+    "@jskit-ai/uploads-image-web": "0.1.23",
+    "@jskit-ai/users-core": "0.1.55",
     "vuetify": "^4.0.0"
   }
 }

--- a/packages/workspaces-core/package.descriptor.mjs
+++ b/packages/workspaces-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-core",
-  version: "0.1.19",
+  version: "0.1.21",
   kind: "runtime",
   description: "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
   dependsOn: [
@@ -112,7 +112,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-core": "0.1.53"
+        "@jskit-ai/users-core": "0.1.55"
       },
       dev: {}
     },

--- a/packages/workspaces-core/package.json
+++ b/packages/workspaces-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-core",
-  "version": "0.1.19",
+  "version": "0.1.21",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -18,11 +18,11 @@
   },
   "dependencies": {
     "@fastify/type-provider-typebox": "^6.1.0",
-    "@jskit-ai/auth-core": "0.1.42",
-    "@jskit-ai/database-runtime": "0.1.43",
-    "@jskit-ai/http-runtime": "0.1.42",
-    "@jskit-ai/kernel": "0.1.43",
-    "@jskit-ai/users-core": "0.1.53",
+    "@jskit-ai/auth-core": "0.1.44",
+    "@jskit-ai/database-runtime": "0.1.45",
+    "@jskit-ai/http-runtime": "0.1.44",
+    "@jskit-ai/kernel": "0.1.45",
+    "@jskit-ai/users-core": "0.1.55",
     "typebox": "^1.0.81"
   }
 }

--- a/packages/workspaces-web/package.descriptor.mjs
+++ b/packages/workspaces-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-web",
-  version: "0.1.19",
+  version: "0.1.21",
   kind: "runtime",
   description: "Workspace web module: workspace selector, tools widget, workspace surfaces, and members/settings UI.",
   dependsOn: [
@@ -148,8 +148,8 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/workspaces-core": "0.1.19",
-        "@jskit-ai/users-web": "0.1.58",
+        "@jskit-ai/workspaces-core": "0.1.21",
+        "@jskit-ai/users-web": "0.1.60",
         "vuetify": "^4.0.0"
       },
       dev: {}

--- a/packages/workspaces-web/package.json
+++ b/packages/workspaces-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-web",
-  "version": "0.1.19",
+  "version": "0.1.21",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -14,12 +14,12 @@
   "dependencies": {
     "@tanstack/vue-query": "5.92.12",
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/http-runtime": "0.1.42",
-    "@jskit-ai/kernel": "0.1.43",
-    "@jskit-ai/shell-web": "0.1.42",
-    "@jskit-ai/users-core": "0.1.53",
-    "@jskit-ai/users-web": "0.1.58",
-    "@jskit-ai/workspaces-core": "0.1.19",
+    "@jskit-ai/http-runtime": "0.1.44",
+    "@jskit-ai/kernel": "0.1.45",
+    "@jskit-ai/shell-web": "0.1.44",
+    "@jskit-ai/users-core": "0.1.55",
+    "@jskit-ai/users-web": "0.1.60",
+    "@jskit-ai/workspaces-core": "0.1.21",
     "vuetify": "^4.0.0"
   }
 }

--- a/tooling/config-eslint/package.json
+++ b/tooling/config-eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/config-eslint",
-  "version": "0.1.42",
+  "version": "0.1.44",
   "description": "Shared flat ESLint presets for JSKIT projects.",
   "type": "module",
   "files": [

--- a/tooling/create-app/package.descriptor.mjs
+++ b/tooling/create-app/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/create-app",
-  "version": "0.1.51",
+  "version": "0.1.53",
   "dependsOn": [],
   "capabilities": {
     "provides": [

--- a/tooling/create-app/package.json
+++ b/tooling/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/create-app",
-  "version": "0.1.51",
+  "version": "0.1.53",
   "description": "Scaffold minimal JSKIT app shells.",
   "type": "module",
   "files": [

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -6,11 +6,11 @@
   "packages": [
     {
       "packageId": "@jskit-ai/assistant",
-      "version": "0.1.52",
+      "version": "0.1.54",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant",
-        "version": "0.1.52",
+        "version": "0.1.54",
         "kind": "generator",
         "description": "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
         "options": {
@@ -356,11 +356,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-core",
-      "version": "0.1.19",
+      "version": "0.1.21",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-core",
-        "version": "0.1.19",
+        "version": "0.1.21",
         "kind": "runtime",
         "description": "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
         "dependsOn": [
@@ -406,9 +406,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/http-runtime": "0.1.42",
-              "@jskit-ai/kernel": "0.1.43",
-              "@jskit-ai/users-core": "0.1.53",
+              "@jskit-ai/http-runtime": "0.1.44",
+              "@jskit-ai/kernel": "0.1.45",
+              "@jskit-ai/users-core": "0.1.55",
               "@tanstack/vue-query": "^5.90.5",
               "dompurify": "^3.3.3",
               "marked": "^17.0.4",
@@ -429,11 +429,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-runtime",
-      "version": "0.1.14",
+      "version": "0.1.16",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-runtime",
-        "version": "0.1.14",
+        "version": "0.1.16",
         "kind": "runtime",
         "description": "Shared assistant runtime with per-surface assistant registration.",
         "dependsOn": [
@@ -508,13 +508,13 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/assistant-core": "0.1.19",
-              "@jskit-ai/database-runtime": "0.1.43",
-              "@jskit-ai/http-runtime": "0.1.42",
-              "@jskit-ai/kernel": "0.1.43",
-              "@jskit-ai/shell-web": "0.1.42",
-              "@jskit-ai/users-core": "0.1.53",
-              "@jskit-ai/users-web": "0.1.58",
+              "@jskit-ai/assistant-core": "0.1.21",
+              "@jskit-ai/database-runtime": "0.1.45",
+              "@jskit-ai/http-runtime": "0.1.44",
+              "@jskit-ai/kernel": "0.1.45",
+              "@jskit-ai/shell-web": "0.1.44",
+              "@jskit-ai/users-core": "0.1.55",
+              "@jskit-ai/users-web": "0.1.60",
               "@tanstack/vue-query": "^5.90.5",
               "vuetify": "^4.0.0"
             },
@@ -571,11 +571,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-core",
-      "version": "0.1.42",
+      "version": "0.1.44",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-core",
-        "version": "0.1.42",
+        "version": "0.1.44",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/value-app-config-shared"
@@ -643,7 +643,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.43",
+              "@jskit-ai/kernel": "0.1.45",
               "@fastify/cookie": "^11.0.2",
               "@fastify/csrf-protection": "^7.1.0",
               "@fastify/rate-limit": "^10.3.0"
@@ -661,11 +661,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.42",
+      "version": "0.1.44",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-supabase-core",
-        "version": "0.1.42",
+        "version": "0.1.44",
         "kind": "runtime",
         "options": {
           "auth-supabase-url": {
@@ -747,8 +747,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.42",
-              "@jskit-ai/kernel": "0.1.43",
+              "@jskit-ai/auth-core": "0.1.44",
+              "@jskit-ai/kernel": "0.1.45",
               "dotenv": "^16.4.5",
               "@supabase/supabase-js": "^2.57.4",
               "jose": "^6.1.0"
@@ -813,11 +813,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-web",
-      "version": "0.1.44",
+      "version": "0.1.46",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-web",
-        "version": "0.1.44",
+        "version": "0.1.46",
         "kind": "runtime",
         "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
         "dependsOn": [
@@ -1044,10 +1044,10 @@
               "@tanstack/vue-query": "5.92.12",
               "@mdi/js": "^7.4.47",
               "@fastify/type-provider-typebox": "^6.1.0",
-              "@jskit-ai/auth-core": "0.1.42",
-              "@jskit-ai/http-runtime": "0.1.42",
-              "@jskit-ai/kernel": "0.1.43",
-              "@jskit-ai/shell-web": "0.1.42",
+              "@jskit-ai/auth-core": "0.1.44",
+              "@jskit-ai/http-runtime": "0.1.44",
+              "@jskit-ai/kernel": "0.1.45",
+              "@jskit-ai/shell-web": "0.1.44",
               "vuetify": "^4.0.0"
             },
             "dev": {}
@@ -1117,11 +1117,11 @@
     },
     {
       "packageId": "@jskit-ai/console-core",
-      "version": "0.1.6",
+      "version": "0.1.8",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-core",
-        "version": "0.1.6",
+        "version": "0.1.8",
         "kind": "runtime",
         "description": "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
         "dependsOn": [
@@ -1192,10 +1192,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.43",
-              "@jskit-ai/http-runtime": "0.1.42",
-              "@jskit-ai/kernel": "0.1.43",
-              "@jskit-ai/users-core": "0.1.53",
+              "@jskit-ai/database-runtime": "0.1.45",
+              "@jskit-ai/http-runtime": "0.1.44",
+              "@jskit-ai/kernel": "0.1.45",
+              "@jskit-ai/users-core": "0.1.55",
               "typebox": "^1.0.81"
             },
             "dev": {}
@@ -1240,11 +1240,11 @@
     },
     {
       "packageId": "@jskit-ai/console-web",
-      "version": "0.1.11",
+      "version": "0.1.13",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-web",
-        "version": "0.1.11",
+        "version": "0.1.13",
         "kind": "runtime",
         "description": "Authenticated console surface scaffold and surface policy wiring.",
         "dependsOn": [
@@ -1312,9 +1312,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-web": "0.1.44",
-              "@jskit-ai/console-core": "0.1.6",
-              "@jskit-ai/shell-web": "0.1.42"
+              "@jskit-ai/auth-web": "0.1.46",
+              "@jskit-ai/console-core": "0.1.8",
+              "@jskit-ai/shell-web": "0.1.44"
             },
             "dev": {}
           },
@@ -1401,11 +1401,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-core",
-      "version": "0.1.51",
+      "version": "0.1.53",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-core",
-        "version": "0.1.51",
+        "version": "0.1.53",
         "kind": "runtime",
         "description": "Shared CRUD helpers used by CRUD modules.",
         "dependsOn": [
@@ -1432,7 +1432,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/crud-core": "0.1.51"
+              "@jskit-ai/crud-core": "0.1.53"
             },
             "dev": {}
           },
@@ -1446,11 +1446,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-server-generator",
-      "version": "0.1.51",
+      "version": "0.1.53",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-server-generator",
-        "version": "0.1.51",
+        "version": "0.1.53",
         "kind": "generator",
         "description": "CRUD server generator with routes, actions, and persistence scaffolding.",
         "options": {
@@ -1608,13 +1608,13 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.42",
-              "@jskit-ai/crud-core": "0.1.51",
-              "@jskit-ai/database-runtime": "0.1.43",
-              "@jskit-ai/http-runtime": "0.1.42",
-              "@jskit-ai/kernel": "0.1.43",
-              "@jskit-ai/realtime": "0.1.42",
-              "@jskit-ai/users-core": "0.1.53",
+              "@jskit-ai/auth-core": "0.1.44",
+              "@jskit-ai/crud-core": "0.1.53",
+              "@jskit-ai/database-runtime": "0.1.45",
+              "@jskit-ai/http-runtime": "0.1.44",
+              "@jskit-ai/kernel": "0.1.45",
+              "@jskit-ai/realtime": "0.1.44",
+              "@jskit-ai/users-core": "0.1.55",
               "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}",
               "typebox": "^1.0.81"
             },
@@ -1761,11 +1761,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.26",
+      "version": "0.1.28",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-ui-generator",
-        "version": "0.1.26",
+        "version": "0.1.28",
         "kind": "generator",
         "description": "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
         "options": {
@@ -1940,7 +1940,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.58"
+              "@jskit-ai/users-web": "0.1.60"
             },
             "dev": {}
           },
@@ -2173,11 +2173,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime",
-      "version": "0.1.43",
+      "version": "0.1.45",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime",
-        "version": "0.1.43",
+        "version": "0.1.45",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -2234,7 +2234,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.43",
+              "@jskit-ai/kernel": "0.1.45",
               "dotenv": "^16.4.5",
               "knex": "^3.1.0"
             },
@@ -2269,11 +2269,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.42",
+      "version": "0.1.44",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-mysql",
-        "version": "0.1.42",
+        "version": "0.1.44",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -2363,7 +2363,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.43",
+              "@jskit-ai/database-runtime": "0.1.45",
               "mysql2": "^3.11.2"
             },
             "dev": {}
@@ -2434,11 +2434,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.42",
+      "version": "0.1.44",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-postgres",
-        "version": "0.1.42",
+        "version": "0.1.44",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -2528,7 +2528,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.43",
+              "@jskit-ai/database-runtime": "0.1.45",
               "pg": "^8.13.1"
             },
             "dev": {}
@@ -2599,11 +2599,11 @@
     },
     {
       "packageId": "@jskit-ai/http-runtime",
-      "version": "0.1.42",
+      "version": "0.1.44",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/http-runtime",
-        "version": "0.1.42",
+        "version": "0.1.44",
         "kind": "runtime",
         "dependsOn": [],
         "capabilities": {
@@ -2669,7 +2669,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.43",
+              "@jskit-ai/kernel": "0.1.45",
               "@fastify/type-provider-typebox": "^6.1.0",
               "typebox": "^1.0.81"
             },
@@ -2685,11 +2685,11 @@
     },
     {
       "packageId": "@jskit-ai/realtime",
-      "version": "0.1.42",
+      "version": "0.1.44",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/realtime",
-        "version": "0.1.42",
+        "version": "0.1.44",
         "kind": "runtime",
         "description": "Thin, generic realtime runtime wrappers for socket.io server and client.",
         "options": {
@@ -2784,7 +2784,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.43",
+              "@jskit-ai/kernel": "0.1.45",
               "@socket.io/redis-adapter": "^8.3.0",
               "redis": "^5.8.2",
               "socket.io": "^4.8.3",
@@ -2833,11 +2833,11 @@
     },
     {
       "packageId": "@jskit-ai/shell-web",
-      "version": "0.1.42",
+      "version": "0.1.44",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/shell-web",
-        "version": "0.1.42",
+        "version": "0.1.44",
         "kind": "runtime",
         "description": "Web shell layout runtime with outlet-based placement contributions.",
         "dependsOn": [],
@@ -2969,7 +2969,7 @@
             "runtime": {
               "@mdi/js": "^7.4.47",
               "@tanstack/vue-query": "^5.90.5",
-              "@jskit-ai/kernel": "0.1.43",
+              "@jskit-ai/kernel": "0.1.45",
               "vuetify": "^4.0.0"
             },
             "dev": {}
@@ -3154,11 +3154,11 @@
     },
     {
       "packageId": "@jskit-ai/storage-runtime",
-      "version": "0.1.42",
+      "version": "0.1.44",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/storage-runtime",
-        "version": "0.1.42",
+        "version": "0.1.44",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -3207,7 +3207,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.43",
+              "@jskit-ai/kernel": "0.1.45",
               "unstorage": "^1.17.3"
             },
             "dev": {}
@@ -3223,11 +3223,11 @@
     },
     {
       "packageId": "@jskit-ai/ui-generator",
-      "version": "0.1.26",
+      "version": "0.1.28",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/ui-generator",
-        "version": "0.1.26",
+        "version": "0.1.28",
         "kind": "generator",
         "description": "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
         "options": {
@@ -3526,7 +3526,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.58"
+              "@jskit-ai/users-web": "0.1.60"
             },
             "dev": {}
           },
@@ -3541,11 +3541,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-image-web",
-      "version": "0.1.21",
+      "version": "0.1.23",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-image-web",
-        "version": "0.1.21",
+        "version": "0.1.23",
         "kind": "runtime",
         "description": "Reusable client-side image upload runtime with pre-upload image editing.",
         "dependsOn": [
@@ -3609,7 +3609,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/uploads-runtime": "0.1.21",
+              "@jskit-ai/uploads-runtime": "0.1.23",
               "@uppy/compressor": "^3.1.0",
               "@uppy/core": "^5.2.0",
               "@uppy/dashboard": "^5.1.1",
@@ -3629,11 +3629,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-runtime",
-      "version": "0.1.21",
+      "version": "0.1.23",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-runtime",
-        "version": "0.1.21",
+        "version": "0.1.23",
         "kind": "runtime",
         "description": "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
         "dependsOn": [
@@ -3703,7 +3703,7 @@
           "dependencies": {
             "runtime": {
               "@fastify/multipart": "^9.4.0",
-              "@jskit-ai/kernel": "0.1.43"
+              "@jskit-ai/kernel": "0.1.45"
             },
             "dev": {}
           },
@@ -3718,11 +3718,11 @@
     },
     {
       "packageId": "@jskit-ai/users-core",
-      "version": "0.1.53",
+      "version": "0.1.55",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-core",
-        "version": "0.1.53",
+        "version": "0.1.55",
         "kind": "runtime",
         "description": "Users/account runtime plus HTTP routes for account features.",
         "dependsOn": [
@@ -3848,11 +3848,11 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.42",
-              "@jskit-ai/database-runtime": "0.1.43",
-              "@jskit-ai/http-runtime": "0.1.42",
-              "@jskit-ai/kernel": "0.1.43",
-              "@jskit-ai/uploads-runtime": "0.1.21",
+              "@jskit-ai/auth-core": "0.1.44",
+              "@jskit-ai/database-runtime": "0.1.45",
+              "@jskit-ai/http-runtime": "0.1.44",
+              "@jskit-ai/kernel": "0.1.45",
+              "@jskit-ai/uploads-runtime": "0.1.23",
               "@fastify/type-provider-typebox": "^6.1.0",
               "typebox": "^1.0.81"
             },
@@ -3936,11 +3936,11 @@
     },
     {
       "packageId": "@jskit-ai/users-web",
-      "version": "0.1.58",
+      "version": "0.1.60",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-web",
-        "version": "0.1.58",
+        "version": "0.1.60",
         "kind": "runtime",
         "description": "Users web module: account/profile UI plus shared users web widgets.",
         "dependsOn": [
@@ -4091,12 +4091,12 @@
             "runtime": {
               "@tanstack/vue-query": "5.92.12",
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/http-runtime": "0.1.42",
-              "@jskit-ai/realtime": "0.1.42",
-              "@jskit-ai/kernel": "0.1.43",
-              "@jskit-ai/shell-web": "0.1.42",
-              "@jskit-ai/uploads-image-web": "0.1.21",
-              "@jskit-ai/users-core": "0.1.53",
+              "@jskit-ai/http-runtime": "0.1.44",
+              "@jskit-ai/realtime": "0.1.44",
+              "@jskit-ai/kernel": "0.1.45",
+              "@jskit-ai/shell-web": "0.1.44",
+              "@jskit-ai/uploads-image-web": "0.1.23",
+              "@jskit-ai/users-core": "0.1.55",
               "vuetify": "^4.0.0"
             },
             "dev": {}
@@ -4183,11 +4183,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-core",
-      "version": "0.1.19",
+      "version": "0.1.21",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-core",
-        "version": "0.1.19",
+        "version": "0.1.21",
         "kind": "runtime",
         "description": "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
         "dependsOn": [
@@ -4298,7 +4298,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-core": "0.1.53"
+              "@jskit-ai/users-core": "0.1.55"
             },
             "dev": {}
           },
@@ -4488,11 +4488,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-web",
-      "version": "0.1.19",
+      "version": "0.1.21",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-web",
-        "version": "0.1.19",
+        "version": "0.1.21",
         "kind": "runtime",
         "description": "Workspace web module: workspace selector, tools widget, workspace surfaces, and members/settings UI.",
         "dependsOn": [
@@ -4657,8 +4657,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/workspaces-core": "0.1.19",
-              "@jskit-ai/users-web": "0.1.58",
+              "@jskit-ai/workspaces-core": "0.1.21",
+              "@jskit-ai/users-web": "0.1.60",
               "vuetify": "^4.0.0"
             },
             "dev": {}

--- a/tooling/jskit-catalog/package.json
+++ b/tooling/jskit-catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-catalog",
-  "version": "0.1.51",
+  "version": "0.1.53",
   "description": "Published metadata catalog for JSKIT package descriptors.",
   "type": "module",
   "files": [

--- a/tooling/jskit-cli/package.json
+++ b/tooling/jskit-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-cli",
-  "version": "0.2.52",
+  "version": "0.2.54",
   "description": "Bundle and package orchestration CLI for JSKIT apps.",
   "type": "module",
   "files": [
@@ -20,9 +20,9 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/jskit-catalog": "0.1.51",
-    "@jskit-ai/kernel": "0.1.43",
-    "@jskit-ai/shell-web": "0.1.42"
+    "@jskit-ai/jskit-catalog": "0.1.53",
+    "@jskit-ai/kernel": "0.1.45",
+    "@jskit-ai/shell-web": "0.1.44"
   },
   "engines": {
     "node": "20.x"

--- a/tooling/jskit-cli/src/server/commandHandlers/health.js
+++ b/tooling/jskit-cli/src/server/commandHandlers/health.js
@@ -23,16 +23,11 @@ function createHealthCommands(ctx = {}) {
     path
   } = ctx;
 
-  const MDI_SVG_MAIN_ENTRY_CANDIDATES = Object.freeze([
-    "src/main.js",
-    "src/main.mjs",
-    "src/main.ts"
-  ]);
-  const MDI_SVG_SCAN_ROOTS = Object.freeze([
+  const APP_SOURCE_SCAN_ROOTS = Object.freeze([
     "src",
     "packages"
   ]);
-  const MDI_SVG_IGNORED_DIRECTORY_NAMES = new Set([
+  const APP_SOURCE_IGNORED_DIRECTORY_NAMES = new Set([
     ".git",
     ".jskit",
     ".build",
@@ -45,15 +40,34 @@ function createHealthCommands(ctx = {}) {
     "tests",
     "__tests__"
   ]);
-  const MDI_SVG_IGNORED_FILE_PATTERNS = Object.freeze([
+  const APP_SOURCE_IGNORED_FILE_PATTERNS = Object.freeze([
     /\.spec\./i,
     /\.test\./i,
     /\.vitest\./i
+  ]);
+  const APP_SOURCE_CODE_EXTENSIONS = new Set([
+    ".cjs",
+    ".js",
+    ".jsx",
+    ".mjs",
+    ".ts",
+    ".tsx",
+    ".vue"
+  ]);
+  const VUE_SOURCE_EXTENSIONS = new Set([".vue"]);
+  const MDI_SVG_MAIN_ENTRY_CANDIDATES = Object.freeze([
+    "src/main.js",
+    "src/main.mjs",
+    "src/main.ts"
   ]);
   const DIRECT_MDI_LITERAL_ICON_PATTERN =
     /<(v-[a-z0-9-]+)[^>]*?\b(icon|prepend-icon|append-icon)\s*=\s*(['"])(mdi-[^'"]+)\3/gi;
   const DIRECT_MDI_BOUND_LITERAL_ICON_PATTERN =
     /<(v-[a-z0-9-]+)[^>]*?(?::|v-bind:)(icon|prepend-icon|append-icon)\s*=\s*(['"])(['"])(mdi-[^'"]+)\4\3/gi;
+  const FILTER_RUNTIME_CALLEES = Object.freeze([
+    "createCrudListFilters",
+    "useCrudListFilters"
+  ]);
 
   function collectDescriptorContainerTokens({ packageId, side, values, issues }) {
     const declaredTokens = new Set();
@@ -152,6 +166,70 @@ function createHealthCommands(ctx = {}) {
     }
   }
 
+  function shouldSkipAppSourceDirectory(directoryName = "") {
+    return APP_SOURCE_IGNORED_DIRECTORY_NAMES.has(String(directoryName || "").trim());
+  }
+
+  function shouldSkipAppSourceFile(
+    fileName = "",
+    {
+      extensions = APP_SOURCE_CODE_EXTENSIONS,
+      ignoredFilePatterns = APP_SOURCE_IGNORED_FILE_PATTERNS
+    } = {}
+  ) {
+    const normalizedFileName = String(fileName || "").trim();
+    const extension = path.extname(normalizedFileName).toLowerCase();
+    if (!extensions.has(extension)) {
+      return true;
+    }
+    return ignoredFilePatterns.some((pattern) => pattern.test(normalizedFileName));
+  }
+
+  async function collectAppSourceFiles(
+    rootDirectory,
+    {
+      extensions = APP_SOURCE_CODE_EXTENSIONS,
+      ignoredFilePatterns = APP_SOURCE_IGNORED_FILE_PATTERNS
+    } = {},
+    collected = []
+  ) {
+    if (!(await fileExists(rootDirectory))) {
+      return collected;
+    }
+
+    const entries = await readdir(rootDirectory, { withFileTypes: true });
+    entries.sort((left, right) => left.name.localeCompare(right.name));
+
+    for (const entry of entries) {
+      const entryPath = path.join(rootDirectory, entry.name);
+      if (entry.isDirectory()) {
+        if (shouldSkipAppSourceDirectory(entry.name)) {
+          continue;
+        }
+        await collectAppSourceFiles(
+          entryPath,
+          {
+            extensions,
+            ignoredFilePatterns
+          },
+          collected
+        );
+        continue;
+      }
+      if (
+        entry.isFile() &&
+        !shouldSkipAppSourceFile(entry.name, {
+          extensions,
+          ignoredFilePatterns
+        })
+      ) {
+        collected.push(entryPath);
+      }
+    }
+
+    return collected;
+  }
+
   async function appUsesVuetifyMdiSvg(appRoot) {
     for (const relativePath of MDI_SVG_MAIN_ENTRY_CANDIDATES) {
       const absolutePath = path.join(appRoot, relativePath);
@@ -165,43 +243,6 @@ function createHealthCommands(ctx = {}) {
     }
 
     return false;
-  }
-
-  function shouldSkipMdiSvgDoctorDirectory(directoryName = "") {
-    return MDI_SVG_IGNORED_DIRECTORY_NAMES.has(String(directoryName || "").trim());
-  }
-
-  function shouldSkipMdiSvgDoctorFile(fileName = "") {
-    const normalizedFileName = String(fileName || "").trim();
-    if (!normalizedFileName.endsWith(".vue")) {
-      return true;
-    }
-    return MDI_SVG_IGNORED_FILE_PATTERNS.some((pattern) => pattern.test(normalizedFileName));
-  }
-
-  async function collectVueSourceFiles(rootDirectory, collected = []) {
-    if (!(await fileExists(rootDirectory))) {
-      return collected;
-    }
-
-    const entries = await readdir(rootDirectory, { withFileTypes: true });
-    entries.sort((left, right) => left.name.localeCompare(right.name));
-
-    for (const entry of entries) {
-      const entryPath = path.join(rootDirectory, entry.name);
-      if (entry.isDirectory()) {
-        if (shouldSkipMdiSvgDoctorDirectory(entry.name)) {
-          continue;
-        }
-        await collectVueSourceFiles(entryPath, collected);
-        continue;
-      }
-      if (entry.isFile() && !shouldSkipMdiSvgDoctorFile(entry.name)) {
-        collected.push(entryPath);
-      }
-    }
-
-    return collected;
   }
 
   function resolveLineNumberFromIndex(sourceText = "", index = 0) {
@@ -228,14 +269,312 @@ function createHealthCommands(ctx = {}) {
     }
   }
 
+  function isEscapedCharacter(sourceText = "", index = 0) {
+    let backslashCount = 0;
+    for (let position = index - 1; position >= 0 && sourceText[position] === "\\"; position -= 1) {
+      backslashCount += 1;
+    }
+    return backslashCount % 2 === 1;
+  }
+
+  function findClosingParenIndex(sourceText = "", openParenIndex = -1) {
+    if (openParenIndex < 0 || sourceText[openParenIndex] !== "(") {
+      return -1;
+    }
+
+    let parenDepth = 0;
+    let quote = "";
+    let inLineComment = false;
+    let inBlockComment = false;
+
+    for (let index = openParenIndex; index < sourceText.length; index += 1) {
+      const character = sourceText[index];
+      const nextCharacter = sourceText[index + 1] || "";
+
+      if (inLineComment) {
+        if (character === "\n") {
+          inLineComment = false;
+        }
+        continue;
+      }
+
+      if (inBlockComment) {
+        if (character === "*" && nextCharacter === "/") {
+          inBlockComment = false;
+          index += 1;
+        }
+        continue;
+      }
+
+      if (quote) {
+        if (character === quote && !isEscapedCharacter(sourceText, index)) {
+          quote = "";
+        }
+        continue;
+      }
+
+      if (character === "/" && nextCharacter === "/") {
+        inLineComment = true;
+        index += 1;
+        continue;
+      }
+
+      if (character === "/" && nextCharacter === "*") {
+        inBlockComment = true;
+        index += 1;
+        continue;
+      }
+
+      if (character === "'" || character === "\"" || character === "`") {
+        quote = character;
+        continue;
+      }
+
+      if (character === "(") {
+        parenDepth += 1;
+        continue;
+      }
+
+      if (character === ")") {
+        parenDepth -= 1;
+        if (parenDepth === 0) {
+          return index;
+        }
+      }
+    }
+
+    return -1;
+  }
+
+  function extractFirstArgumentText(argsText = "") {
+    let parenDepth = 0;
+    let braceDepth = 0;
+    let bracketDepth = 0;
+    let quote = "";
+    let inLineComment = false;
+    let inBlockComment = false;
+
+    for (let index = 0; index < argsText.length; index += 1) {
+      const character = argsText[index];
+      const nextCharacter = argsText[index + 1] || "";
+
+      if (inLineComment) {
+        if (character === "\n") {
+          inLineComment = false;
+        }
+        continue;
+      }
+
+      if (inBlockComment) {
+        if (character === "*" && nextCharacter === "/") {
+          inBlockComment = false;
+          index += 1;
+        }
+        continue;
+      }
+
+      if (quote) {
+        if (character === quote && !isEscapedCharacter(argsText, index)) {
+          quote = "";
+        }
+        continue;
+      }
+
+      if (character === "/" && nextCharacter === "/") {
+        inLineComment = true;
+        index += 1;
+        continue;
+      }
+
+      if (character === "/" && nextCharacter === "*") {
+        inBlockComment = true;
+        index += 1;
+        continue;
+      }
+
+      if (character === "'" || character === "\"" || character === "`") {
+        quote = character;
+        continue;
+      }
+
+      if (character === "(") {
+        parenDepth += 1;
+        continue;
+      }
+      if (character === ")") {
+        parenDepth -= 1;
+        continue;
+      }
+      if (character === "{") {
+        braceDepth += 1;
+        continue;
+      }
+      if (character === "}") {
+        braceDepth -= 1;
+        continue;
+      }
+      if (character === "[") {
+        bracketDepth += 1;
+        continue;
+      }
+      if (character === "]") {
+        bracketDepth -= 1;
+        continue;
+      }
+
+      if (character === "," && parenDepth === 0 && braceDepth === 0 && bracketDepth === 0) {
+        return argsText.slice(0, index);
+      }
+    }
+
+    return argsText;
+  }
+
+  function collectStaticImportBindings(sourceText = "") {
+    const bindings = new Map();
+    const importPattern = /^\s*import\s+([\s\S]*?)\s+from\s+["']([^"']+)["'];?/gmu;
+
+    for (const match of sourceText.matchAll(importPattern)) {
+      const specifierText = String(match[1] || "").trim();
+      const sourcePath = String(match[2] || "").trim();
+      if (!specifierText || !sourcePath) {
+        continue;
+      }
+
+      const namedMatch = specifierText.match(/\{([\s\S]*)\}/u);
+      if (namedMatch) {
+        const namedContent = String(namedMatch[1] || "");
+        for (const rawSpecifier of namedContent.split(",")) {
+          const specifier = String(rawSpecifier || "").trim();
+          if (!specifier) {
+            continue;
+          }
+          const aliasMatch = specifier.match(/^([A-Za-z_$][\w$]*)\s+as\s+([A-Za-z_$][\w$]*)$/u);
+          const localName = aliasMatch ? aliasMatch[2] : specifier;
+          if (/^[A-Za-z_$][\w$]*$/u.test(localName)) {
+            bindings.set(localName, sourcePath);
+          }
+        }
+      }
+
+      const leadingSpecifier = namedMatch
+        ? specifierText.slice(0, namedMatch.index).replace(/,$/u, "").trim()
+        : specifierText;
+      if (!leadingSpecifier) {
+        continue;
+      }
+
+      const namespaceMatch = leadingSpecifier.match(/^\*\s+as\s+([A-Za-z_$][\w$]*)$/u);
+      if (namespaceMatch) {
+        bindings.set(namespaceMatch[1], sourcePath);
+        continue;
+      }
+
+      if (/^[A-Za-z_$][\w$]*$/u.test(leadingSpecifier)) {
+        bindings.set(leadingSpecifier, sourcePath);
+      }
+    }
+
+    return bindings;
+  }
+
+  function isSharedListFiltersImportSource(sourcePath = "") {
+    return /(^|\/)shared\/[^/'"]*ListFilters(?:\.[A-Za-z0-9]+)?$/u.test(String(sourcePath || "").trim());
+  }
+
+  function findCallSites(sourceText = "", calleeName = "") {
+    const normalizedCalleeName = String(calleeName || "").trim();
+    if (!normalizedCalleeName) {
+      return [];
+    }
+
+    const callPattern = new RegExp(`\\b${normalizedCalleeName}\\s*\\(`, "gu");
+    const calls = [];
+
+    for (const match of sourceText.matchAll(callPattern)) {
+      const matchedText = String(match[0] || "");
+      const openParenIndex = (match.index || 0) + matchedText.lastIndexOf("(");
+      const closeParenIndex = findClosingParenIndex(sourceText, openParenIndex);
+      if (closeParenIndex < 0) {
+        continue;
+      }
+
+      calls.push({
+        calleeName: normalizedCalleeName,
+        index: match.index || 0,
+        openParenIndex,
+        closeParenIndex,
+        argsText: sourceText.slice(openParenIndex + 1, closeParenIndex)
+      });
+    }
+
+    return calls;
+  }
+
+  function collectFilterDefinitionOwnershipIssues({
+    sourceText = "",
+    relativePath = "",
+    issues = []
+  }) {
+    const importBindings = collectStaticImportBindings(sourceText);
+
+    for (const calleeName of FILTER_RUNTIME_CALLEES) {
+      for (const callSite of findCallSites(sourceText, calleeName)) {
+        const lineNumber = resolveLineNumberFromIndex(sourceText, callSite.index);
+        const firstArgument = extractFirstArgumentText(callSite.argsText).trim();
+
+        if (!firstArgument || firstArgument.startsWith("{")) {
+          issues.push(
+            `${relativePath}:${lineNumber}: [filters:shared-definition] do not inline structured filter definitions in ${calleeName}(...). Put them in packages/<crud>/src/shared/<crud>ListFilters.js and import that shared module.`
+          );
+          continue;
+        }
+
+        if (!/^[A-Za-z_$][\w$]*$/u.test(firstArgument)) {
+          issues.push(
+            `${relativePath}:${lineNumber}: [filters:shared-definition] ${calleeName}(...) must receive a definitions symbol imported from a CRUD shared *ListFilters module, not an ad-hoc expression.`
+          );
+          continue;
+        }
+
+        const importSource = importBindings.get(firstArgument) || "";
+        if (!isSharedListFiltersImportSource(importSource)) {
+          issues.push(
+            `${relativePath}:${lineNumber}: [filters:shared-definition] ${calleeName}(${firstArgument}, ...) must use definitions imported from a CRUD shared *ListFilters module. Found ${importSource ? `import source "${importSource}"` : "a local symbol"} instead.`
+          );
+        }
+      }
+    }
+  }
+
+  function collectFilterValidatorModeIssues({
+    sourceText = "",
+    relativePath = "",
+    issues = []
+  }) {
+    for (const callSite of findCallSites(sourceText, "createQueryValidator")) {
+      const lineNumber = resolveLineNumberFromIndex(sourceText, callSite.index);
+      const argsText = String(callSite.argsText || "").trim();
+      if (!argsText.startsWith("{") || !/\binvalidValues\s*:/u.test(argsText)) {
+        issues.push(
+          `${relativePath}:${lineNumber}: [filters:validator-mode] createQueryValidator(...) must be written explicitly as createQueryValidator({ invalidValues: "reject" | "discard" }). Do not rely on hidden defaults, aliases, or indirect option objects.`
+        );
+      }
+    }
+  }
+
   async function collectMdiSvgDoctorIssues({ appRoot, issues }) {
     if (!(await appUsesVuetifyMdiSvg(appRoot))) {
       return;
     }
 
     const vueFilePaths = [];
-    for (const relativeRoot of MDI_SVG_SCAN_ROOTS) {
-      await collectVueSourceFiles(path.join(appRoot, relativeRoot), vueFilePaths);
+    for (const relativeRoot of APP_SOURCE_SCAN_ROOTS) {
+      await collectAppSourceFiles(
+        path.join(appRoot, relativeRoot),
+        { extensions: VUE_SOURCE_EXTENSIONS },
+        vueFilePaths
+      );
     }
 
     vueFilePaths.sort((left, right) => left.localeCompare(right));
@@ -245,6 +584,38 @@ function createHealthCommands(ctx = {}) {
       collectDirectMdiSvgTemplateIconIssues({
         sourceText,
         relativePath: normalizeRelativePath(appRoot, absolutePath),
+        issues
+      });
+    }
+  }
+
+  async function collectCrudFilterDoctorIssues({ appRoot, issues }) {
+    const sourceFilePaths = [];
+    for (const relativeRoot of APP_SOURCE_SCAN_ROOTS) {
+      await collectAppSourceFiles(path.join(appRoot, relativeRoot), undefined, sourceFilePaths);
+    }
+
+    sourceFilePaths.sort((left, right) => left.localeCompare(right));
+
+    for (const absolutePath of sourceFilePaths) {
+      const sourceText = await readFile(absolutePath, "utf8");
+      if (
+        !sourceText.includes("useCrudListFilters") &&
+        !sourceText.includes("createCrudListFilters") &&
+        !sourceText.includes("createQueryValidator")
+      ) {
+        continue;
+      }
+
+      const relativePath = normalizeRelativePath(appRoot, absolutePath);
+      collectFilterDefinitionOwnershipIssues({
+        sourceText,
+        relativePath,
+        issues
+      });
+      collectFilterValidatorModeIssues({
+        sourceText,
+        relativePath,
         issues
       });
     }
@@ -335,6 +706,10 @@ function createHealthCommands(ctx = {}) {
     }
 
     await collectMdiSvgDoctorIssues({
+      appRoot,
+      issues
+    });
+    await collectCrudFilterDoctorIssues({
       appRoot,
       issues
     });

--- a/tooling/jskit-cli/test/doctorFilterContractValidation.test.js
+++ b/tooling/jskit-cli/test/doctorFilterContractValidation.test.js
@@ -1,0 +1,174 @@
+import assert from "node:assert/strict";
+import {
+  mkdir,
+  writeFile
+} from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import test from "node:test";
+import { withTempDir } from "../../testUtils/tempDir.mjs";
+import { createCliRunner } from "../../testUtils/runCli.js";
+
+const CLI_PATH = fileURLToPath(new URL("../bin/jskit.js", import.meta.url));
+const runCli = createCliRunner(CLI_PATH);
+
+async function createMinimalApp(appRoot, { name = "tmp-app" } = {}) {
+  await mkdir(appRoot, { recursive: true });
+  await writeFile(
+    path.join(appRoot, "package.json"),
+    `${JSON.stringify(
+      {
+        name,
+        version: "0.1.0",
+        private: true,
+        type: "module"
+      },
+      null,
+      2
+    )}\n`,
+    "utf8"
+  );
+}
+
+test("doctor flags inline structured filter definitions in page files", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "doctor-inline-filter-definitions-app");
+    await createMinimalApp(appRoot, { name: "doctor-inline-filter-definitions-app" });
+
+    await mkdir(path.join(appRoot, "src", "pages", "home", "contacts"), { recursive: true });
+    await writeFile(
+      path.join(appRoot, "src", "pages", "home", "contacts", "index.vue"),
+      [
+        "<script setup>",
+        "const listFilters = useCrudListFilters({",
+        "  onlyArchived: {",
+        "    type: \"flag\",",
+        "    label: \"Archived\"",
+        "  }",
+        "});",
+        "</script>"
+      ].join("\n"),
+      "utf8"
+    );
+
+    const doctorResult = runCli({
+      cwd: appRoot,
+      args: ["doctor", "--json"]
+    });
+
+    assert.equal(doctorResult.status, 1, String(doctorResult.stderr || ""));
+    const payload = JSON.parse(String(doctorResult.stdout || "{}"));
+    assert.equal(payload.issues.length, 1);
+    assert.match(
+      String(payload.issues[0] || ""),
+      /src\/pages\/home\/contacts\/index\.vue:2: \[filters:shared-definition\] do not inline structured filter definitions in useCrudListFilters\(\.\.\.\)/
+    );
+  });
+});
+
+test("doctor flags createQueryValidator calls without explicit invalidValues policy", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "doctor-filter-validator-mode-app");
+    await createMinimalApp(appRoot, { name: "doctor-filter-validator-mode-app" });
+
+    await mkdir(path.join(appRoot, "packages", "contacts", "src", "server"), { recursive: true });
+    await writeFile(
+      path.join(appRoot, "packages", "contacts", "src", "server", "listQueryValidators.js"),
+      [
+        "const contactsListFiltersRuntime = {};",
+        "const contactsListFiltersQueryValidator = contactsListFiltersRuntime.createQueryValidator({});",
+        "",
+        "void contactsListFiltersQueryValidator;"
+      ].join("\n"),
+      "utf8"
+    );
+
+    const doctorResult = runCli({
+      cwd: appRoot,
+      args: ["doctor", "--json"]
+    });
+
+    assert.equal(doctorResult.status, 1, String(doctorResult.stderr || ""));
+    const payload = JSON.parse(String(doctorResult.stdout || "{}"));
+    assert.equal(payload.issues.length, 1);
+    assert.match(
+      String(payload.issues[0] || ""),
+      /packages\/contacts\/src\/server\/listQueryValidators\.js:2: \[filters:validator-mode\] createQueryValidator\(\.\.\.\) must be written explicitly as createQueryValidator\(\{ invalidValues: "reject" \| "discard" \}\)/
+    );
+  });
+});
+
+test("doctor accepts shared filter definitions imported into runtimes and explicit validator policy", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "doctor-valid-filter-contract-app");
+    await createMinimalApp(appRoot, { name: "doctor-valid-filter-contract-app" });
+
+    await mkdir(path.join(appRoot, "packages", "contacts", "src", "shared"), { recursive: true });
+    await mkdir(path.join(appRoot, "packages", "contacts", "src", "server"), { recursive: true });
+    await mkdir(path.join(appRoot, "src", "pages", "home", "contacts"), { recursive: true });
+
+    await writeFile(
+      path.join(appRoot, "packages", "contacts", "src", "shared", "contactListFilters.js"),
+      [
+        "export const CONTACTS_LIST_FILTER_DEFINITIONS = Object.freeze({",
+        "  onlyArchived: {",
+        "    type: \"flag\",",
+        "    label: \"Archived\"",
+        "  }",
+        "});"
+      ].join("\n"),
+      "utf8"
+    );
+    await writeFile(
+      path.join(appRoot, "packages", "contacts", "src", "server", "contactListFilterSupport.js"),
+      [
+        "import { CONTACTS_LIST_FILTER_DEFINITIONS } from \"../shared/contactListFilters.js\";",
+        "",
+        "const contactsListFiltersRuntime = createCrudListFilters(CONTACTS_LIST_FILTER_DEFINITIONS, {",
+        "  columns: {",
+        "    onlyArchived: \"archived\"",
+        "  }",
+        "});",
+        "",
+        "void contactsListFiltersRuntime;"
+      ].join("\n"),
+      "utf8"
+    );
+    await writeFile(
+      path.join(appRoot, "packages", "contacts", "src", "server", "listQueryValidators.js"),
+      [
+        "const contactsListFiltersRuntime = {};",
+        "const contactsListFiltersQueryValidator = contactsListFiltersRuntime.createQueryValidator({",
+        "  invalidValues: \"reject\"",
+        "});",
+        "",
+        "void contactsListFiltersQueryValidator;"
+      ].join("\n"),
+      "utf8"
+    );
+    await writeFile(
+      path.join(appRoot, "src", "pages", "home", "contacts", "index.vue"),
+      [
+        "<script setup>",
+        "import { CONTACTS_LIST_FILTER_DEFINITIONS } from \"../../../../../packages/contacts/src/shared/contactListFilters.js\";",
+        "",
+        "const listFilters = useCrudListFilters(CONTACTS_LIST_FILTER_DEFINITIONS, {",
+        "  presets: []",
+        "});",
+        "",
+        "void listFilters;",
+        "</script>"
+      ].join("\n"),
+      "utf8"
+    );
+
+    const doctorResult = runCli({
+      cwd: appRoot,
+      args: ["doctor", "--json"]
+    });
+
+    assert.equal(doctorResult.status, 0, String(doctorResult.stderr || ""));
+    const payload = JSON.parse(String(doctorResult.stdout || "{}"));
+    assert.deepEqual(payload.issues, []);
+  });
+});


### PR DESCRIPTION
## Summary
- tighten JSKIT doctor validation around shared CRUD filter contracts
- document the unified filter pattern in the advanced CRUD guide and agent patterns
- refresh package metadata, catalog, and lockfile outputs for the new filter/runtime surface

## Notes
- per request, this PR is intended to be merged immediately without waiting on GitHub verify