### PR TITLE
Document client request patterns and exports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6176,26 +6176,26 @@
     },
     "packages/agent-docs": {
       "name": "@jskit-ai/agent-docs",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "engines": {
         "node": "20.x"
       }
     },
     "packages/assistant": {
       "name": "@jskit-ai/assistant",
-      "version": "0.1.54",
+      "version": "0.1.55",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.45"
+        "@jskit-ai/kernel": "0.1.46"
       }
     },
     "packages/assistant-core": {
       "name": "@jskit-ai/assistant-core",
-      "version": "0.1.21",
+      "version": "0.1.22",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.45",
-        "@jskit-ai/http-runtime": "0.1.44",
-        "@jskit-ai/kernel": "0.1.45",
-        "@jskit-ai/users-core": "0.1.55",
+        "@jskit-ai/database-runtime": "0.1.46",
+        "@jskit-ai/http-runtime": "0.1.45",
+        "@jskit-ai/kernel": "0.1.46",
+        "@jskit-ai/users-core": "0.1.56",
         "@tanstack/vue-query": "^5.90.5",
         "dompurify": "^3.3.3",
         "marked": "^17.0.4",
@@ -6273,15 +6273,15 @@
     },
     "packages/assistant-runtime": {
       "name": "@jskit-ai/assistant-runtime",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "dependencies": {
-        "@jskit-ai/assistant-core": "0.1.21",
-        "@jskit-ai/database-runtime": "0.1.45",
-        "@jskit-ai/http-runtime": "0.1.44",
-        "@jskit-ai/kernel": "0.1.45",
-        "@jskit-ai/shell-web": "0.1.44",
-        "@jskit-ai/users-core": "0.1.55",
-        "@jskit-ai/users-web": "0.1.60",
+        "@jskit-ai/assistant-core": "0.1.22",
+        "@jskit-ai/database-runtime": "0.1.46",
+        "@jskit-ai/http-runtime": "0.1.45",
+        "@jskit-ai/kernel": "0.1.46",
+        "@jskit-ai/shell-web": "0.1.45",
+        "@jskit-ai/users-core": "0.1.56",
+        "@jskit-ai/users-web": "0.1.61",
         "@tanstack/vue-query": "^5.90.5",
         "vuetify": "^4.0.0"
       }
@@ -6355,34 +6355,34 @@
     },
     "packages/auth-core": {
       "name": "@jskit-ai/auth-core",
-      "version": "0.1.44",
+      "version": "0.1.45",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0",
-        "@jskit-ai/kernel": "0.1.45",
+        "@jskit-ai/kernel": "0.1.46",
         "typebox": "^1.0.81"
       }
     },
     "packages/auth-provider-supabase-core": {
       "name": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.44",
+      "version": "0.1.45",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.44",
-        "@jskit-ai/kernel": "0.1.45",
+        "@jskit-ai/auth-core": "0.1.45",
+        "@jskit-ai/kernel": "0.1.46",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0"
       }
     },
     "packages/auth-web": {
       "name": "@jskit-ai/auth-web",
-      "version": "0.1.46",
+      "version": "0.1.47",
       "dependencies": {
         "@fastify/type-provider-typebox": "^6.1.0",
-        "@jskit-ai/auth-core": "0.1.44",
-        "@jskit-ai/http-runtime": "0.1.44",
-        "@jskit-ai/kernel": "0.1.45",
-        "@jskit-ai/shell-web": "0.1.44",
+        "@jskit-ai/auth-core": "0.1.45",
+        "@jskit-ai/http-runtime": "0.1.45",
+        "@jskit-ai/kernel": "0.1.46",
+        "@jskit-ai/shell-web": "0.1.45",
         "@mdi/js": "^7.4.47",
         "@tanstack/vue-query": "^5.90.5",
         "pinia": "^3.0.4",
@@ -6469,34 +6469,34 @@
     },
     "packages/console-core": {
       "name": "@jskit-ai/console-core",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.45",
-        "@jskit-ai/http-runtime": "0.1.44",
-        "@jskit-ai/kernel": "0.1.45",
-        "@jskit-ai/users-core": "0.1.55",
+        "@jskit-ai/database-runtime": "0.1.46",
+        "@jskit-ai/http-runtime": "0.1.45",
+        "@jskit-ai/kernel": "0.1.46",
+        "@jskit-ai/users-core": "0.1.56",
         "typebox": "^1.0.81"
       }
     },
     "packages/console-web": {
       "name": "@jskit-ai/console-web",
-      "version": "0.1.13",
+      "version": "0.1.14",
       "dependencies": {
-        "@jskit-ai/auth-web": "0.1.46",
-        "@jskit-ai/console-core": "0.1.8",
-        "@jskit-ai/shell-web": "0.1.44"
+        "@jskit-ai/auth-web": "0.1.47",
+        "@jskit-ai/console-core": "0.1.9",
+        "@jskit-ai/shell-web": "0.1.45"
       }
     },
     "packages/crud-core": {
       "name": "@jskit-ai/crud-core",
-      "version": "0.1.53",
+      "version": "0.1.54",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.45",
-        "@jskit-ai/kernel": "0.1.45",
-        "@jskit-ai/realtime": "0.1.44",
-        "@jskit-ai/shell-web": "0.1.44",
-        "@jskit-ai/users-core": "0.1.55",
-        "@jskit-ai/users-web": "0.1.60",
+        "@jskit-ai/database-runtime": "0.1.46",
+        "@jskit-ai/kernel": "0.1.46",
+        "@jskit-ai/realtime": "0.1.45",
+        "@jskit-ai/shell-web": "0.1.45",
+        "@jskit-ai/users-core": "0.1.56",
+        "@jskit-ai/users-web": "0.1.61",
         "@tanstack/vue-query": "^5.90.5",
         "typebox": "^1.0.81"
       }
@@ -6570,68 +6570,68 @@
     },
     "packages/crud-server-generator": {
       "name": "@jskit-ai/crud-server-generator",
-      "version": "0.1.53",
+      "version": "0.1.54",
       "dependencies": {
         "@babel/parser": "^7.29.2",
-        "@jskit-ai/crud-core": "0.1.53",
-        "@jskit-ai/database-runtime": "0.1.45",
-        "@jskit-ai/http-runtime": "0.1.44",
-        "@jskit-ai/kernel": "0.1.45",
-        "@jskit-ai/users-core": "0.1.55",
+        "@jskit-ai/crud-core": "0.1.54",
+        "@jskit-ai/database-runtime": "0.1.46",
+        "@jskit-ai/http-runtime": "0.1.45",
+        "@jskit-ai/kernel": "0.1.46",
+        "@jskit-ai/users-core": "0.1.56",
         "recast": "^0.23.11",
         "typebox": "^1.0.81"
       }
     },
     "packages/crud-ui-generator": {
       "name": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.28",
+      "version": "0.1.29",
       "dependencies": {
-        "@jskit-ai/crud-core": "0.1.53",
-        "@jskit-ai/kernel": "0.1.45"
+        "@jskit-ai/crud-core": "0.1.54",
+        "@jskit-ai/kernel": "0.1.46"
       }
     },
     "packages/database-runtime": {
       "name": "@jskit-ai/database-runtime",
-      "version": "0.1.45",
+      "version": "0.1.46",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.45"
+        "@jskit-ai/kernel": "0.1.46"
       }
     },
     "packages/database-runtime-mysql": {
       "name": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.44",
+      "version": "0.1.45",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.45"
+        "@jskit-ai/database-runtime": "0.1.46"
       }
     },
     "packages/database-runtime-postgres": {
       "name": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.44",
+      "version": "0.1.45",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.45"
+        "@jskit-ai/database-runtime": "0.1.46"
       }
     },
     "packages/http-runtime": {
       "name": "@jskit-ai/http-runtime",
-      "version": "0.1.44",
+      "version": "0.1.45",
       "dependencies": {
         "@fastify/type-provider-typebox": "^6.1.0",
-        "@jskit-ai/kernel": "0.1.45",
+        "@jskit-ai/kernel": "0.1.46",
         "typebox": "^1.0.81"
       }
     },
     "packages/kernel": {
       "name": "@jskit-ai/kernel",
-      "version": "0.1.45",
+      "version": "0.1.46",
       "dependencies": {
         "typebox": "^1.0.81"
       }
     },
     "packages/realtime": {
       "name": "@jskit-ai/realtime",
-      "version": "0.1.44",
+      "version": "0.1.45",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.45",
+        "@jskit-ai/kernel": "0.1.46",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",
@@ -6640,9 +6640,9 @@
     },
     "packages/shell-web": {
       "name": "@jskit-ai/shell-web",
-      "version": "0.1.44",
+      "version": "0.1.45",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.45",
+        "@jskit-ai/kernel": "0.1.46",
         "@mdi/js": "^7.4.47",
         "@tanstack/vue-query": "^5.90.5",
         "pinia": "^3.0.4",
@@ -6708,25 +6708,25 @@
     },
     "packages/storage-runtime": {
       "name": "@jskit-ai/storage-runtime",
-      "version": "0.1.44",
+      "version": "0.1.45",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.45",
+        "@jskit-ai/kernel": "0.1.46",
         "unstorage": "^1.17.3"
       }
     },
     "packages/ui-generator": {
       "name": "@jskit-ai/ui-generator",
-      "version": "0.1.28",
+      "version": "0.1.29",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.45",
-        "@jskit-ai/shell-web": "0.1.44"
+        "@jskit-ai/kernel": "0.1.46",
+        "@jskit-ai/shell-web": "0.1.45"
       }
     },
     "packages/uploads-image-web": {
       "name": "@jskit-ai/uploads-image-web",
-      "version": "0.1.23",
+      "version": "0.1.24",
       "dependencies": {
-        "@jskit-ai/uploads-runtime": "0.1.23",
+        "@jskit-ai/uploads-runtime": "0.1.24",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",
@@ -6736,35 +6736,35 @@
     },
     "packages/uploads-runtime": {
       "name": "@jskit-ai/uploads-runtime",
-      "version": "0.1.23",
+      "version": "0.1.24",
       "dependencies": {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.45"
+        "@jskit-ai/kernel": "0.1.46"
       }
     },
     "packages/users-core": {
       "name": "@jskit-ai/users-core",
-      "version": "0.1.55",
+      "version": "0.1.56",
       "dependencies": {
         "@fastify/type-provider-typebox": "^6.1.0",
-        "@jskit-ai/auth-core": "0.1.44",
-        "@jskit-ai/database-runtime": "0.1.45",
-        "@jskit-ai/http-runtime": "0.1.44",
-        "@jskit-ai/kernel": "0.1.45",
-        "@jskit-ai/uploads-runtime": "0.1.23",
+        "@jskit-ai/auth-core": "0.1.45",
+        "@jskit-ai/database-runtime": "0.1.46",
+        "@jskit-ai/http-runtime": "0.1.45",
+        "@jskit-ai/kernel": "0.1.46",
+        "@jskit-ai/uploads-runtime": "0.1.24",
         "typebox": "^1.0.81"
       }
     },
     "packages/users-web": {
       "name": "@jskit-ai/users-web",
-      "version": "0.1.60",
+      "version": "0.1.61",
       "dependencies": {
-        "@jskit-ai/http-runtime": "0.1.44",
-        "@jskit-ai/kernel": "0.1.45",
-        "@jskit-ai/realtime": "0.1.44",
-        "@jskit-ai/shell-web": "0.1.44",
-        "@jskit-ai/uploads-image-web": "0.1.23",
-        "@jskit-ai/users-core": "0.1.55",
+        "@jskit-ai/http-runtime": "0.1.45",
+        "@jskit-ai/kernel": "0.1.46",
+        "@jskit-ai/realtime": "0.1.45",
+        "@jskit-ai/shell-web": "0.1.45",
+        "@jskit-ai/uploads-image-web": "0.1.24",
+        "@jskit-ai/users-core": "0.1.56",
         "@mdi/js": "^7.4.47",
         "@tanstack/vue-query": "5.92.12",
         "vuetify": "^4.0.0"
@@ -6839,27 +6839,27 @@
     },
     "packages/workspaces-core": {
       "name": "@jskit-ai/workspaces-core",
-      "version": "0.1.21",
+      "version": "0.1.22",
       "dependencies": {
         "@fastify/type-provider-typebox": "^6.1.0",
-        "@jskit-ai/auth-core": "0.1.44",
-        "@jskit-ai/database-runtime": "0.1.45",
-        "@jskit-ai/http-runtime": "0.1.44",
-        "@jskit-ai/kernel": "0.1.45",
-        "@jskit-ai/users-core": "0.1.55",
+        "@jskit-ai/auth-core": "0.1.45",
+        "@jskit-ai/database-runtime": "0.1.46",
+        "@jskit-ai/http-runtime": "0.1.45",
+        "@jskit-ai/kernel": "0.1.46",
+        "@jskit-ai/users-core": "0.1.56",
         "typebox": "^1.0.81"
       }
     },
     "packages/workspaces-web": {
       "name": "@jskit-ai/workspaces-web",
-      "version": "0.1.21",
+      "version": "0.1.22",
       "dependencies": {
-        "@jskit-ai/http-runtime": "0.1.44",
-        "@jskit-ai/kernel": "0.1.45",
-        "@jskit-ai/shell-web": "0.1.44",
-        "@jskit-ai/users-core": "0.1.55",
-        "@jskit-ai/users-web": "0.1.60",
-        "@jskit-ai/workspaces-core": "0.1.21",
+        "@jskit-ai/http-runtime": "0.1.45",
+        "@jskit-ai/kernel": "0.1.46",
+        "@jskit-ai/shell-web": "0.1.45",
+        "@jskit-ai/users-core": "0.1.56",
+        "@jskit-ai/users-web": "0.1.61",
+        "@jskit-ai/workspaces-core": "0.1.22",
         "@mdi/js": "^7.4.47",
         "@tanstack/vue-query": "5.92.12",
         "vuetify": "^4.0.0"
@@ -6934,7 +6934,7 @@
     },
     "tooling/config-eslint": {
       "name": "@jskit-ai/config-eslint",
-      "version": "0.1.44",
+      "version": "0.1.45",
       "dependencies": {
         "@eslint/js": "^9.39.1",
         "eslint-plugin-vue": "^10.5.1",
@@ -6952,7 +6952,7 @@
     },
     "tooling/create-app": {
       "name": "@jskit-ai/create-app",
-      "version": "0.1.53",
+      "version": "0.1.54",
       "bin": {
         "jskit-create-app": "bin/jskit-create-app.js"
       },
@@ -6962,18 +6962,18 @@
     },
     "tooling/jskit-catalog": {
       "name": "@jskit-ai/jskit-catalog",
-      "version": "0.1.53",
+      "version": "0.1.54",
       "engines": {
         "node": "20.x"
       }
     },
     "tooling/jskit-cli": {
       "name": "@jskit-ai/jskit-cli",
-      "version": "0.2.54",
+      "version": "0.2.55",
       "dependencies": {
-        "@jskit-ai/jskit-catalog": "0.1.53",
-        "@jskit-ai/kernel": "0.1.45",
-        "@jskit-ai/shell-web": "0.1.44"
+        "@jskit-ai/jskit-catalog": "0.1.54",
+        "@jskit-ai/kernel": "0.1.46",
+        "@jskit-ai/shell-web": "0.1.45"
       },
       "bin": {
         "jskit": "bin/jskit.js"

--- a/packages/agent-docs/guide/agent/generators/advanced-cruds.md
+++ b/packages/agent-docs/guide/agent/generators/advanced-cruds.md
@@ -613,6 +613,57 @@ The safe mental model is:
 - use command runtimes for actions
 - keep the server as the source of truth for derived state
 
+### Choosing the right client request seam
+
+When you need client-side HTTP work in JSKIT, do not start with raw `fetch(...)`.
+
+Choose the highest-level runtime that matches the interaction:
+
+```js
+// 1. Button/toggle/small mutation
+const command = useCommand({ ... });
+
+// 2. List endpoint
+const list = useList({ ... });
+
+// 3. Single-record endpoint
+const view = useView({ ... });
+
+// 4. Form save flow
+const form = useAddEdit({ ... });
+
+// 5. Truly custom endpoint
+const resource = useEndpointResource({ ... });
+```
+
+Use the CRUD wrappers when they fit:
+
+- `useCrudList()` for routed CRUD lists
+- `useCrudView()` for routed CRUD record loading
+- `useCrudAddEdit()` for routed CRUD forms
+
+Why this is the standard JSKIT shape:
+
+- `useCommand()` resolves the correct scoped API path for the current route and surface.
+- The higher-level list, view, add/edit, and command runtimes send requests through the standard HTTP runtime instead of ad hoc request code.
+- The default client runtime uses `usersWebHttpClient`, which already handles credentials and CSRF token behavior.
+- `useEndpointResource()` gives the shared endpoint primitive for loading, saving, and standard load/save error handling. Higher-level runtimes like `useCommand()` and `useAddEdit()` layer UI feedback and field-error behavior on top of that primitive.
+
+If you need a custom scoped endpoint path outside the higher-level runtimes, prefer `usePaths().api(...)` rather than hand-building scoped URLs:
+
+```js
+const paths = usePaths();
+const reportsApiPath = computed(() => paths.api("/reports"));
+```
+
+The safe mental model is:
+
+- do not raw `fetch(...)` for normal app work
+- do not invent ad hoc local AJAX helpers
+- use the operation/runtime composable that matches the UI interaction
+- drop to `usersWebHttpClient.request(...)` only for exceptional low-level cases
+- use `usePaths().api(...)` when you need a custom scoped API path and the higher-level runtime does not already resolve it for you
+
 ### `_components/CrudAddEditForm.vue`
 
 This is the shared rendering shell for the add/edit form.

--- a/packages/agent-docs/package.json
+++ b/packages/agent-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/agent-docs",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Distributed JSKIT agent workflows, guides, and generated reference maps.",
   "type": "module",
   "files": [

--- a/packages/agent-docs/patterns/INDEX.md
+++ b/packages/agent-docs/patterns/INDEX.md
@@ -20,6 +20,8 @@ How to use it:
   - `crud-links.md`
 - live actions, checkbox, toggle, patch button, inline action, `useCommand()`
   - `live-actions.md`
+- ajax, fetch, API call, request, endpoint, HTTP client, `useList()`, `useView()`, `useAddEdit()`, `useEndpointResource()`, `usersWebHttpClient`
+  - `client-requests.md`
 - filter, filters, search facets, chips, date range, enum filter, lookup filter, `useCrudListFilters`, `createCrudListFilters`
   - `filters.md`
 
@@ -30,4 +32,5 @@ How to use it:
 - [child-cruds.md](./child-cruds.md)
 - [crud-links.md](./crud-links.md)
 - [live-actions.md](./live-actions.md)
+- [client-requests.md](./client-requests.md)
 - [filters.md](./filters.md)

--- a/packages/agent-docs/patterns/client-requests.md
+++ b/packages/agent-docs/patterns/client-requests.md
@@ -1,0 +1,56 @@
+# Client Request Patterns
+
+Use when:
+
+- deciding which JSKIT client function to use for HTTP work
+- custom endpoint reads or writes
+- AJAX questions
+- replacing raw `fetch(...)` calls
+- choosing between `useCommand()`, `useList()`, `useView()`, `useAddEdit()`, and `useEndpointResource()`
+
+Rules:
+
+- Prefer the highest-level JSKIT runtime that matches the UI interaction.
+- Do not hand-roll local AJAX helpers when an existing JSKIT runtime already fits.
+- Do not use raw `fetch(...)` for normal app work.
+- Use `usePaths().api(...)` for custom scoped API paths instead of concatenating route params into URLs by hand.
+- Drop to `usersWebHttpClient.request(...)` only for exceptional low-level cases.
+
+Choose the function like this:
+
+```js
+// 1. Button/toggle/small mutation
+const command = useCommand({ ... });
+
+// 2. List endpoint
+const list = useList({ ... });
+
+// 3. Single-record endpoint
+const view = useView({ ... });
+
+// 4. Form save flow
+const form = useAddEdit({ ... });
+
+// 5. Truly custom endpoint
+const resource = useEndpointResource({ ... });
+```
+
+Use the CRUD wrappers when they fit:
+
+- `useCrudList()` for routed CRUD lists
+- `useCrudView()` for routed CRUD record loading
+- `useCrudAddEdit()` for routed CRUD forms
+
+Why this is the standard JSKIT shape:
+
+- `useCommand()` resolves the scoped API path for the current route and surface.
+- The higher-level list, view, add/edit, and command runtimes send requests through the shared HTTP runtime.
+- `usersWebHttpClient` already handles credentials and CSRF behavior.
+- `useEndpointResource()` is the shared endpoint primitive for loading, saving, and standard load/save error handling. Higher-level runtimes add UI feedback and field-error handling on top.
+
+Avoid:
+
+- raw `fetch(...)` for standard page or component work
+- page-local HTTP helpers that duplicate JSKIT runtime seams
+- manually concatenating scoped route params into API URLs
+- using a lower-level seam when a higher-level routed CRUD or command runtime already fits

--- a/packages/agent-docs/site/guide/generators/advanced-cruds.md
+++ b/packages/agent-docs/site/guide/generators/advanced-cruds.md
@@ -611,6 +611,57 @@ The safe mental model is:
 - use command runtimes for actions
 - keep the server as the source of truth for derived state
 
+### Choosing the right client request seam
+
+When you need client-side HTTP work in JSKIT, do not start with raw `fetch(...)`.
+
+Choose the highest-level runtime that matches the interaction:
+
+```js
+// 1. Button/toggle/small mutation
+const command = useCommand({ ... });
+
+// 2. List endpoint
+const list = useList({ ... });
+
+// 3. Single-record endpoint
+const view = useView({ ... });
+
+// 4. Form save flow
+const form = useAddEdit({ ... });
+
+// 5. Truly custom endpoint
+const resource = useEndpointResource({ ... });
+```
+
+Use the CRUD wrappers when they fit:
+
+- `useCrudList()` for routed CRUD lists
+- `useCrudView()` for routed CRUD record loading
+- `useCrudAddEdit()` for routed CRUD forms
+
+Why this is the standard JSKIT shape:
+
+- `useCommand()` resolves the correct scoped API path for the current route and surface.
+- The higher-level list, view, add/edit, and command runtimes send requests through the standard HTTP runtime instead of ad hoc request code.
+- The default client runtime uses `usersWebHttpClient`, which already handles credentials and CSRF token behavior.
+- `useEndpointResource()` gives the shared endpoint primitive for loading, saving, and standard load/save error handling. Higher-level runtimes like `useCommand()` and `useAddEdit()` layer UI feedback and field-error behavior on top of that primitive.
+
+If you need a custom scoped endpoint path outside the higher-level runtimes, prefer `usePaths().api(...)` rather than hand-building scoped URLs:
+
+```js
+const paths = usePaths();
+const reportsApiPath = computed(() => paths.api("/reports"));
+```
+
+The safe mental model is:
+
+- do not raw `fetch(...)` for normal app work
+- do not invent ad hoc local AJAX helpers
+- use the operation/runtime composable that matches the UI interaction
+- drop to `usersWebHttpClient.request(...)` only for exceptional low-level cases
+- use `usePaths().api(...)` when you need a custom scoped API path and the higher-level runtime does not already resolve it for you
+
 ### `_components/CrudAddEditForm.vue`
 
 This is the shared rendering shell for the add/edit form.

--- a/packages/assistant-core/package.descriptor.mjs
+++ b/packages/assistant-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-core",
-  version: "0.1.21",
+  version: "0.1.22",
   kind: "runtime",
   description: "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
   dependsOn: [
@@ -45,9 +45,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/http-runtime": "0.1.44",
-        "@jskit-ai/kernel": "0.1.45",
-        "@jskit-ai/users-core": "0.1.55",
+        "@jskit-ai/http-runtime": "0.1.45",
+        "@jskit-ai/kernel": "0.1.46",
+        "@jskit-ai/users-core": "0.1.56",
         "@tanstack/vue-query": "^5.90.5",
         "dompurify": "^3.3.3",
         "marked": "^17.0.4",

--- a/packages/assistant-core/package.json
+++ b/packages/assistant-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-core",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,10 +11,10 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.45",
-    "@jskit-ai/http-runtime": "0.1.44",
-    "@jskit-ai/kernel": "0.1.45",
-    "@jskit-ai/users-core": "0.1.55",
+    "@jskit-ai/database-runtime": "0.1.46",
+    "@jskit-ai/http-runtime": "0.1.45",
+    "@jskit-ai/kernel": "0.1.46",
+    "@jskit-ai/users-core": "0.1.56",
     "@tanstack/vue-query": "^5.90.5",
     "dompurify": "^3.3.3",
     "marked": "^17.0.4",

--- a/packages/assistant-runtime/package.descriptor.mjs
+++ b/packages/assistant-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-runtime",
-  version: "0.1.16",
+  version: "0.1.17",
   kind: "runtime",
   description: "Shared assistant runtime with per-surface assistant registration.",
   dependsOn: [
@@ -74,13 +74,13 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/assistant-core": "0.1.21",
-        "@jskit-ai/database-runtime": "0.1.45",
-        "@jskit-ai/http-runtime": "0.1.44",
-        "@jskit-ai/kernel": "0.1.45",
-        "@jskit-ai/shell-web": "0.1.44",
-        "@jskit-ai/users-core": "0.1.55",
-        "@jskit-ai/users-web": "0.1.60",
+        "@jskit-ai/assistant-core": "0.1.22",
+        "@jskit-ai/database-runtime": "0.1.46",
+        "@jskit-ai/http-runtime": "0.1.45",
+        "@jskit-ai/kernel": "0.1.46",
+        "@jskit-ai/shell-web": "0.1.45",
+        "@jskit-ai/users-core": "0.1.56",
+        "@jskit-ai/users-web": "0.1.61",
         "@tanstack/vue-query": "^5.90.5",
         "vuetify": "^4.0.0"
       },

--- a/packages/assistant-runtime/package.json
+++ b/packages/assistant-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-runtime",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "type": "module",
   "exports": {
     "./client": "./src/client/index.js",
@@ -8,13 +8,13 @@
     "./server/actionIds": "./src/server/actionIds.js"
   },
   "dependencies": {
-    "@jskit-ai/assistant-core": "0.1.21",
-    "@jskit-ai/database-runtime": "0.1.45",
-    "@jskit-ai/http-runtime": "0.1.44",
-    "@jskit-ai/kernel": "0.1.45",
-    "@jskit-ai/shell-web": "0.1.44",
-    "@jskit-ai/users-core": "0.1.55",
-    "@jskit-ai/users-web": "0.1.60",
+    "@jskit-ai/assistant-core": "0.1.22",
+    "@jskit-ai/database-runtime": "0.1.46",
+    "@jskit-ai/http-runtime": "0.1.45",
+    "@jskit-ai/kernel": "0.1.46",
+    "@jskit-ai/shell-web": "0.1.45",
+    "@jskit-ai/users-core": "0.1.56",
+    "@jskit-ai/users-web": "0.1.61",
     "@tanstack/vue-query": "^5.90.5",
     "vuetify": "^4.0.0"
   }

--- a/packages/assistant/package.descriptor.mjs
+++ b/packages/assistant/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant",
-  version: "0.1.54",
+  version: "0.1.55",
   kind: "generator",
   description: "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
   options: {

--- a/packages/assistant/package.json
+++ b/packages/assistant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant",
-  "version": "0.1.54",
+  "version": "0.1.55",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.45"
+    "@jskit-ai/kernel": "0.1.46"
   }
 }

--- a/packages/auth-core/package.descriptor.mjs
+++ b/packages/auth-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-core",
-  "version": "0.1.44",
+  "version": "0.1.45",
   "kind": "runtime",
   "dependsOn": [
     "@jskit-ai/value-app-config-shared"
@@ -69,7 +69,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.45",
+        "@jskit-ai/kernel": "0.1.46",
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0"

--- a/packages/auth-core/package.json
+++ b/packages/auth-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-core",
-  "version": "0.1.44",
+  "version": "0.1.45",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -43,7 +43,7 @@
     "./shared/commands/authSessionReadCommand": "./src/shared/commands/authSessionReadCommand.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.45",
+    "@jskit-ai/kernel": "0.1.46",
     "@fastify/cookie": "^11.0.2",
     "@fastify/csrf-protection": "^7.1.0",
     "@fastify/rate-limit": "^10.3.0",

--- a/packages/auth-provider-supabase-core/package.descriptor.mjs
+++ b/packages/auth-provider-supabase-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.44",
+  "version": "0.1.45",
   "kind": "runtime",
   "options": {
     "auth-supabase-url": {
@@ -83,8 +83,8 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/auth-core": "0.1.44",
-        "@jskit-ai/kernel": "0.1.45",
+        "@jskit-ai/auth-core": "0.1.45",
+        "@jskit-ai/kernel": "0.1.46",
         "dotenv": "^16.4.5",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0"

--- a/packages/auth-provider-supabase-core/package.json
+++ b/packages/auth-provider-supabase-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.44",
+  "version": "0.1.45",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,8 +12,8 @@
     "./client": "./src/client/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.44",
-    "@jskit-ai/kernel": "0.1.45",
+    "@jskit-ai/auth-core": "0.1.45",
+    "@jskit-ai/kernel": "0.1.46",
     "jose": "^6.1.0",
     "@supabase/supabase-js": "^2.57.4"
   }

--- a/packages/auth-web/package.descriptor.mjs
+++ b/packages/auth-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-web",
-  "version": "0.1.46",
+  "version": "0.1.47",
   "kind": "runtime",
   "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
   "dependsOn": [
@@ -220,10 +220,10 @@ export default Object.freeze({
         "@tanstack/vue-query": "5.92.12",
         "@mdi/js": "^7.4.47",
         "@fastify/type-provider-typebox": "^6.1.0",
-        "@jskit-ai/auth-core": "0.1.44",
-        "@jskit-ai/http-runtime": "0.1.44",
-        "@jskit-ai/kernel": "0.1.45",
-        "@jskit-ai/shell-web": "0.1.44",
+        "@jskit-ai/auth-core": "0.1.45",
+        "@jskit-ai/http-runtime": "0.1.45",
+        "@jskit-ai/kernel": "0.1.46",
+        "@jskit-ai/shell-web": "0.1.45",
         "vuetify": "^4.0.0"
       },
       "dev": {}

--- a/packages/auth-web/package.json
+++ b/packages/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-web",
-  "version": "0.1.46",
+  "version": "0.1.47",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -18,13 +18,13 @@
   },
   "dependencies": {
     "@tanstack/vue-query": "^5.90.5",
-    "@jskit-ai/auth-core": "0.1.44",
+    "@jskit-ai/auth-core": "0.1.45",
     "@mdi/js": "^7.4.47",
     "@fastify/type-provider-typebox": "^6.1.0",
-    "@jskit-ai/kernel": "0.1.45",
-    "@jskit-ai/shell-web": "0.1.44",
+    "@jskit-ai/kernel": "0.1.46",
+    "@jskit-ai/shell-web": "0.1.45",
     "pinia": "^3.0.4",
     "vuetify": "^4.0.0",
-    "@jskit-ai/http-runtime": "0.1.44"
+    "@jskit-ai/http-runtime": "0.1.45"
   }
 }

--- a/packages/console-core/package.descriptor.mjs
+++ b/packages/console-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-core",
-  version: "0.1.8",
+  version: "0.1.9",
   kind: "runtime",
   description: "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
   dependsOn: [
@@ -72,10 +72,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.45",
-        "@jskit-ai/http-runtime": "0.1.44",
-        "@jskit-ai/kernel": "0.1.45",
-        "@jskit-ai/users-core": "0.1.55",
+        "@jskit-ai/database-runtime": "0.1.46",
+        "@jskit-ai/http-runtime": "0.1.45",
+        "@jskit-ai/kernel": "0.1.46",
+        "@jskit-ai/users-core": "0.1.56",
         "typebox": "^1.0.81"
       },
       dev: {}

--- a/packages/console-core/package.json
+++ b/packages/console-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/console-core",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,10 +9,10 @@
     "./shared/resources/consoleSettingsFields": "./src/shared/resources/consoleSettingsFields.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.45",
-    "@jskit-ai/http-runtime": "0.1.44",
-    "@jskit-ai/kernel": "0.1.45",
-    "@jskit-ai/users-core": "0.1.55",
+    "@jskit-ai/database-runtime": "0.1.46",
+    "@jskit-ai/http-runtime": "0.1.45",
+    "@jskit-ai/kernel": "0.1.46",
+    "@jskit-ai/users-core": "0.1.56",
     "typebox": "^1.0.81"
   }
 }

--- a/packages/console-web/package.descriptor.mjs
+++ b/packages/console-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-web",
-  version: "0.1.13",
+  version: "0.1.14",
   kind: "runtime",
   description: "Authenticated console surface scaffold and surface policy wiring.",
   dependsOn: [
@@ -65,9 +65,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-web": "0.1.46",
-        "@jskit-ai/console-core": "0.1.8",
-        "@jskit-ai/shell-web": "0.1.44",
+        "@jskit-ai/auth-web": "0.1.47",
+        "@jskit-ai/console-core": "0.1.9",
+        "@jskit-ai/shell-web": "0.1.45",
       },
       dev: {}
     },

--- a/packages/console-web/package.json
+++ b/packages/console-web/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/console-web",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-web": "0.1.46",
-    "@jskit-ai/console-core": "0.1.8",
-    "@jskit-ai/shell-web": "0.1.44"
+    "@jskit-ai/auth-web": "0.1.47",
+    "@jskit-ai/console-core": "0.1.9",
+    "@jskit-ai/shell-web": "0.1.45"
   }
 }

--- a/packages/crud-core/package.descriptor.mjs
+++ b/packages/crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-core",
-  version: "0.1.53",
+  version: "0.1.54",
   kind: "runtime",
   description: "Shared CRUD helpers used by CRUD modules.",
   dependsOn: [
@@ -26,7 +26,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/crud-core": "0.1.53"
+        "@jskit-ai/crud-core": "0.1.54"
       },
       dev: {}
     },

--- a/packages/crud-core/package.json
+++ b/packages/crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-core",
-  "version": "0.1.53",
+  "version": "0.1.54",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -27,12 +27,12 @@
   },
   "dependencies": {
     "@tanstack/vue-query": "^5.90.5",
-    "@jskit-ai/database-runtime": "0.1.45",
-    "@jskit-ai/kernel": "0.1.45",
-    "@jskit-ai/realtime": "0.1.44",
-    "@jskit-ai/shell-web": "0.1.44",
-    "@jskit-ai/users-core": "0.1.55",
-    "@jskit-ai/users-web": "0.1.60",
+    "@jskit-ai/database-runtime": "0.1.46",
+    "@jskit-ai/kernel": "0.1.46",
+    "@jskit-ai/realtime": "0.1.45",
+    "@jskit-ai/shell-web": "0.1.45",
+    "@jskit-ai/users-core": "0.1.56",
+    "@jskit-ai/users-web": "0.1.61",
     "typebox": "^1.0.81"
   }
 }

--- a/packages/crud-server-generator/package.descriptor.mjs
+++ b/packages/crud-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-server-generator",
-  version: "0.1.53",
+  version: "0.1.54",
   kind: "generator",
   description: "CRUD server generator with routes, actions, and persistence scaffolding.",
   options: {
@@ -151,13 +151,13 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.44",
-        "@jskit-ai/crud-core": "0.1.53",
-        "@jskit-ai/database-runtime": "0.1.45",
-        "@jskit-ai/http-runtime": "0.1.44",
-        "@jskit-ai/kernel": "0.1.45",
-        "@jskit-ai/realtime": "0.1.44",
-        "@jskit-ai/users-core": "0.1.55",
+        "@jskit-ai/auth-core": "0.1.45",
+        "@jskit-ai/crud-core": "0.1.54",
+        "@jskit-ai/database-runtime": "0.1.46",
+        "@jskit-ai/http-runtime": "0.1.45",
+        "@jskit-ai/kernel": "0.1.46",
+        "@jskit-ai/realtime": "0.1.45",
+        "@jskit-ai/users-core": "0.1.56",
         "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}",
         "typebox": "^1.0.81"
       },

--- a/packages/crud-server-generator/package.json
+++ b/packages/crud-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-server-generator",
-  "version": "0.1.53",
+  "version": "0.1.54",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,11 +13,11 @@
   },
   "dependencies": {
     "@babel/parser": "^7.29.2",
-    "@jskit-ai/crud-core": "0.1.53",
-    "@jskit-ai/database-runtime": "0.1.45",
-    "@jskit-ai/http-runtime": "0.1.44",
-    "@jskit-ai/kernel": "0.1.45",
-    "@jskit-ai/users-core": "0.1.55",
+    "@jskit-ai/crud-core": "0.1.54",
+    "@jskit-ai/database-runtime": "0.1.46",
+    "@jskit-ai/http-runtime": "0.1.45",
+    "@jskit-ai/kernel": "0.1.46",
+    "@jskit-ai/users-core": "0.1.56",
     "recast": "^0.23.11",
     "typebox": "^1.0.81"
   }

--- a/packages/crud-ui-generator/package.descriptor.mjs
+++ b/packages/crud-ui-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-ui-generator",
-  version: "0.1.28",
+  version: "0.1.29",
   kind: "generator",
   description: "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
   options: {
@@ -168,7 +168,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.60"
+        "@jskit-ai/users-web": "0.1.61"
       },
       dev: {}
     },

--- a/packages/crud-ui-generator/package.json
+++ b/packages/crud-ui-generator/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/crud-ui-generator",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/crud-core": "0.1.53",
-    "@jskit-ai/kernel": "0.1.45"
+    "@jskit-ai/crud-core": "0.1.54",
+    "@jskit-ai/kernel": "0.1.46"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/database-runtime-mysql/package.descriptor.mjs
+++ b/packages/database-runtime-mysql/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-mysql",
-  version: "0.1.44",
+  version: "0.1.45",
   kind: "runtime",
   options: {
     "db-host": {
@@ -91,7 +91,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.45",
+        "@jskit-ai/database-runtime": "0.1.46",
         "mysql2": "^3.11.2"
       },
       dev: {}

--- a/packages/database-runtime-mysql/package.json
+++ b/packages/database-runtime-mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-mysql",
-  "version": "0.1.44",
+  "version": "0.1.45",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,6 +12,6 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.45"
+    "@jskit-ai/database-runtime": "0.1.46"
   }
 }

--- a/packages/database-runtime-postgres/package.descriptor.mjs
+++ b/packages/database-runtime-postgres/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-postgres",
-  version: "0.1.44",
+  version: "0.1.45",
   kind: "runtime",
   options: {
     "db-host": {
@@ -91,7 +91,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.45",
+        "@jskit-ai/database-runtime": "0.1.46",
         "pg": "^8.13.1"
       },
       dev: {}

--- a/packages/database-runtime-postgres/package.json
+++ b/packages/database-runtime-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-postgres",
-  "version": "0.1.44",
+  "version": "0.1.45",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,6 +12,6 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.45"
+    "@jskit-ai/database-runtime": "0.1.46"
   }
 }

--- a/packages/database-runtime/package.descriptor.mjs
+++ b/packages/database-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime",
-  version: "0.1.45",
+  version: "0.1.46",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -58,7 +58,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.45",
+        "@jskit-ai/kernel": "0.1.46",
         "dotenv": "^16.4.5",
         "knex": "^3.1.0"
       },

--- a/packages/database-runtime/package.json
+++ b/packages/database-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime",
-  "version": "0.1.45",
+  "version": "0.1.46",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -25,6 +25,6 @@
     "./shared/transactions": "./src/shared/transactions.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.45"
+    "@jskit-ai/kernel": "0.1.46"
   }
 }

--- a/packages/http-runtime/package.descriptor.mjs
+++ b/packages/http-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/http-runtime",
-  "version": "0.1.44",
+  "version": "0.1.45",
   "kind": "runtime",
   "dependsOn": [],
   "capabilities": {
@@ -67,7 +67,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.45",
+        "@jskit-ai/kernel": "0.1.46",
         "@fastify/type-provider-typebox": "^6.1.0",
         "typebox": "^1.0.81"
       },

--- a/packages/http-runtime/package.json
+++ b/packages/http-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/http-runtime",
-  "version": "0.1.44",
+  "version": "0.1.45",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -17,7 +17,7 @@
     "./shared/validators/operationValidation": "./src/shared/validators/operationValidation.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.45",
+    "@jskit-ai/kernel": "0.1.46",
     "@fastify/type-provider-typebox": "^6.1.0",
     "typebox": "^1.0.81"
   }

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/kernel",
-  "version": "0.1.45",
+  "version": "0.1.46",
   "type": "module",
   "dependencies": {
     "typebox": "^1.0.81"

--- a/packages/realtime/package.descriptor.mjs
+++ b/packages/realtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/realtime",
-  version: "0.1.44",
+  version: "0.1.45",
   kind: "runtime",
   description: "Thin, generic realtime runtime wrappers for socket.io server and client.",
   options: {
@@ -94,7 +94,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.45",
+        "@jskit-ai/kernel": "0.1.46",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/realtime",
-  "version": "0.1.44",
+  "version": "0.1.45",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@socket.io/redis-adapter": "^8.3.0",
-    "@jskit-ai/kernel": "0.1.45",
+    "@jskit-ai/kernel": "0.1.46",
     "redis": "^5.8.2",
     "socket.io": "^4.8.3",
     "socket.io-client": "^4.8.3"

--- a/packages/shell-web/package.descriptor.mjs
+++ b/packages/shell-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/shell-web",
-  version: "0.1.44",
+  version: "0.1.45",
   kind: "runtime",
   description: "Web shell layout runtime with outlet-based placement contributions.",
   dependsOn: [],
@@ -117,7 +117,7 @@ export default Object.freeze({
       runtime: {
         "@mdi/js": "^7.4.47",
         "@tanstack/vue-query": "^5.90.5",
-        "@jskit-ai/kernel": "0.1.45",
+        "@jskit-ai/kernel": "0.1.46",
         "vuetify": "^4.0.0"
       },
       dev: {}

--- a/packages/shell-web/package.json
+++ b/packages/shell-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/shell-web",
-  "version": "0.1.44",
+  "version": "0.1.45",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -24,7 +24,7 @@
   "dependencies": {
     "@mdi/js": "^7.4.47",
     "@tanstack/vue-query": "^5.90.5",
-    "@jskit-ai/kernel": "0.1.45",
+    "@jskit-ai/kernel": "0.1.46",
     "pinia": "^3.0.4",
     "vuetify": "^4.0.0"
   }

--- a/packages/storage-runtime/package.descriptor.mjs
+++ b/packages/storage-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/storage-runtime",
-  version: "0.1.44",
+  version: "0.1.45",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -50,7 +50,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.45",
+        "@jskit-ai/kernel": "0.1.46",
         "unstorage": "^1.17.3"
       },
       dev: {}

--- a/packages/storage-runtime/package.json
+++ b/packages/storage-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/storage-runtime",
-  "version": "0.1.44",
+  "version": "0.1.45",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./server/providers/StorageRuntimeServiceProvider": "./src/server/providers/StorageRuntimeServiceProvider.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.45",
+    "@jskit-ai/kernel": "0.1.46",
     "unstorage": "^1.17.3"
   }
 }

--- a/packages/ui-generator/package.descriptor.mjs
+++ b/packages/ui-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/ui-generator",
-  version: "0.1.28",
+  version: "0.1.29",
   kind: "generator",
   description: "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
   options: {
@@ -278,7 +278,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.60"
+        "@jskit-ai/users-web": "0.1.61"
       },
       dev: {}
     },

--- a/packages/ui-generator/package.json
+++ b/packages/ui-generator/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/ui-generator",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.45",
-    "@jskit-ai/shell-web": "0.1.44"
+    "@jskit-ai/kernel": "0.1.46",
+    "@jskit-ai/shell-web": "0.1.45"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/uploads-image-web/package.descriptor.mjs
+++ b/packages/uploads-image-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-image-web",
-  version: "0.1.23",
+  version: "0.1.24",
   kind: "runtime",
   description: "Reusable client-side image upload runtime with pre-upload image editing.",
   dependsOn: [
@@ -65,7 +65,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/uploads-runtime": "0.1.23",
+        "@jskit-ai/uploads-runtime": "0.1.24",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-image-web/package.json
+++ b/packages/uploads-image-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-image-web",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,7 +13,7 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/uploads-runtime": "0.1.23",
+    "@jskit-ai/uploads-runtime": "0.1.24",
     "@uppy/compressor": "^3.1.0",
     "@uppy/core": "^5.2.0",
     "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-runtime/package.descriptor.mjs
+++ b/packages/uploads-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-runtime",
-  version: "0.1.23",
+  version: "0.1.24",
   kind: "runtime",
   description: "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
   dependsOn: [
@@ -71,7 +71,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.45"
+        "@jskit-ai/kernel": "0.1.46"
       },
       dev: {}
     },

--- a/packages/uploads-runtime/package.json
+++ b/packages/uploads-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-runtime",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,6 +16,6 @@
   },
   "dependencies": {
     "@fastify/multipart": "^9.4.0",
-    "@jskit-ai/kernel": "0.1.45"
+    "@jskit-ai/kernel": "0.1.46"
   }
 }

--- a/packages/users-core/package.descriptor.mjs
+++ b/packages/users-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-core",
-  version: "0.1.55",
+  version: "0.1.56",
   kind: "runtime",
   description: "Users/account runtime plus HTTP routes for account features.",
   dependsOn: [
@@ -128,11 +128,11 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.44",
-        "@jskit-ai/database-runtime": "0.1.45",
-        "@jskit-ai/http-runtime": "0.1.44",
-        "@jskit-ai/kernel": "0.1.45",
-        "@jskit-ai/uploads-runtime": "0.1.23",
+        "@jskit-ai/auth-core": "0.1.45",
+        "@jskit-ai/database-runtime": "0.1.46",
+        "@jskit-ai/http-runtime": "0.1.45",
+        "@jskit-ai/kernel": "0.1.46",
+        "@jskit-ai/uploads-runtime": "0.1.24",
         "@fastify/type-provider-typebox": "^6.1.0",
         typebox: "^1.0.81"
       },

--- a/packages/users-core/package.json
+++ b/packages/users-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-core",
-  "version": "0.1.55",
+  "version": "0.1.56",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,11 +13,11 @@
     "./shared/resources/userSettingsResource": "./src/shared/resources/userSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.44",
-    "@jskit-ai/database-runtime": "0.1.45",
-    "@jskit-ai/http-runtime": "0.1.44",
-    "@jskit-ai/kernel": "0.1.45",
-    "@jskit-ai/uploads-runtime": "0.1.23",
+    "@jskit-ai/auth-core": "0.1.45",
+    "@jskit-ai/database-runtime": "0.1.46",
+    "@jskit-ai/http-runtime": "0.1.45",
+    "@jskit-ai/kernel": "0.1.46",
+    "@jskit-ai/uploads-runtime": "0.1.24",
     "@fastify/type-provider-typebox": "^6.1.0",
     "typebox": "^1.0.81"
   }

--- a/packages/users-web/package.descriptor.mjs
+++ b/packages/users-web/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { HOME_TOOLS_OUTLET } from "./src/shared/toolsOutletContracts.js";
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-web",
-  version: "0.1.60",
+  version: "0.1.61",
   kind: "runtime",
   description: "Users web module: account/profile UI plus shared users web widgets.",
   dependsOn: [
@@ -67,6 +67,10 @@ export default Object.freeze({
           summary: "Exports command operation composable."
         },
         {
+          subpath: "./client/composables/useEndpointResource",
+          summary: "Exports low-level endpoint resource composable for custom client requests."
+        },
+        {
           subpath: "./client/composables/useCrudListFilterLookups",
           summary: "Exports lookup-backed CRUD list filter helper for remote autocomplete filters."
         },
@@ -81,6 +85,10 @@ export default Object.freeze({
         {
           subpath: "./client/composables/usePaths",
           summary: "Exports surface route path resolver composable."
+        },
+        {
+          subpath: "./client/lib/httpClient",
+          summary: "Exports the shared users-web HTTP client with credentials and CSRF behavior."
         },
         {
           subpath: "./client/composables/useAccountSettingsRuntime",
@@ -146,12 +154,12 @@ export default Object.freeze({
       runtime: {
         "@tanstack/vue-query": "5.92.12",
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/http-runtime": "0.1.44",
-        "@jskit-ai/realtime": "0.1.44",
-        "@jskit-ai/kernel": "0.1.45",
-        "@jskit-ai/shell-web": "0.1.44",
-        "@jskit-ai/uploads-image-web": "0.1.23",
-        "@jskit-ai/users-core": "0.1.55",
+        "@jskit-ai/http-runtime": "0.1.45",
+        "@jskit-ai/realtime": "0.1.45",
+        "@jskit-ai/kernel": "0.1.46",
+        "@jskit-ai/shell-web": "0.1.45",
+        "@jskit-ai/uploads-image-web": "0.1.24",
+        "@jskit-ai/users-core": "0.1.56",
         vuetify: "^4.0.0"
       },
       dev: {}

--- a/packages/users-web/package.json
+++ b/packages/users-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-web",
-  "version": "0.1.60",
+  "version": "0.1.61",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -15,6 +15,7 @@
     "./client/composables/crudLookupFieldRuntime": "./src/client/composables/crud/crudLookupFieldRuntime.js",
     "./client/composables/useCrudListFilterLookups": "./src/client/composables/useCrudListFilterLookups.js",
     "./client/composables/useCrudListFilters": "./src/client/composables/useCrudListFilters.js",
+    "./client/composables/useEndpointResource": "./src/client/composables/runtime/useEndpointResource.js",
     "./client/composables/useList": "./src/client/composables/records/useList.js",
     "./client/composables/useCrudList": "./src/client/composables/records/useCrudList.js",
     "./client/composables/useCrudListParentTitle": "./src/client/composables/useCrudListParentTitle.js",
@@ -26,6 +27,7 @@
     "./client/composables/useAccountSettingsRuntime": "./src/client/composables/useAccountSettingsRuntime.js",
     "./client/composables/usePaths": "./src/client/composables/usePaths.js",
     "./client/composables/runtime/useUiFeedback": "./src/client/composables/runtime/useUiFeedback.js",
+    "./client/lib/httpClient": "./src/client/lib/httpClient.js",
     "./client/lib/bootstrap": "./src/client/lib/bootstrap.js",
     "./client/lib/permissions": "./src/client/lib/permissions.js",
     "./client/support/contractGuards": "./src/client/support/contractGuards.js"
@@ -33,12 +35,12 @@
   "dependencies": {
     "@tanstack/vue-query": "5.92.12",
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/http-runtime": "0.1.44",
-    "@jskit-ai/kernel": "0.1.45",
-    "@jskit-ai/realtime": "0.1.44",
-    "@jskit-ai/shell-web": "0.1.44",
-    "@jskit-ai/uploads-image-web": "0.1.23",
-    "@jskit-ai/users-core": "0.1.55",
+    "@jskit-ai/http-runtime": "0.1.45",
+    "@jskit-ai/kernel": "0.1.46",
+    "@jskit-ai/realtime": "0.1.45",
+    "@jskit-ai/shell-web": "0.1.45",
+    "@jskit-ai/uploads-image-web": "0.1.24",
+    "@jskit-ai/users-core": "0.1.56",
     "vuetify": "^4.0.0"
   }
 }

--- a/packages/users-web/test/exportsContract.test.js
+++ b/packages/users-web/test/exportsContract.test.js
@@ -17,13 +17,17 @@ test("users-web exports are explicit and aligned with production/template usage"
       "./client",
       "./client/account-settings/sections",
       "./client/composables/useAddEdit",
+      "./client/composables/useCommand",
+      "./client/composables/useEndpointResource",
       "./client/composables/useList",
+      "./client/composables/usePaths",
       "./client/composables/useView",
       "./client/composables/useCrudAddEdit",
       "./client/composables/useCrudListFilterLookups",
       "./client/composables/useCrudListFilters",
       "./client/composables/useCrudList",
-      "./client/composables/useCrudView"
+      "./client/composables/useCrudView",
+      "./client/lib/httpClient"
     ]
   });
 

--- a/packages/workspaces-core/package.descriptor.mjs
+++ b/packages/workspaces-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-core",
-  version: "0.1.21",
+  version: "0.1.22",
   kind: "runtime",
   description: "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
   dependsOn: [
@@ -112,7 +112,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-core": "0.1.55"
+        "@jskit-ai/users-core": "0.1.56"
       },
       dev: {}
     },

--- a/packages/workspaces-core/package.json
+++ b/packages/workspaces-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-core",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -18,11 +18,11 @@
   },
   "dependencies": {
     "@fastify/type-provider-typebox": "^6.1.0",
-    "@jskit-ai/auth-core": "0.1.44",
-    "@jskit-ai/database-runtime": "0.1.45",
-    "@jskit-ai/http-runtime": "0.1.44",
-    "@jskit-ai/kernel": "0.1.45",
-    "@jskit-ai/users-core": "0.1.55",
+    "@jskit-ai/auth-core": "0.1.45",
+    "@jskit-ai/database-runtime": "0.1.46",
+    "@jskit-ai/http-runtime": "0.1.45",
+    "@jskit-ai/kernel": "0.1.46",
+    "@jskit-ai/users-core": "0.1.56",
     "typebox": "^1.0.81"
   }
 }

--- a/packages/workspaces-web/package.descriptor.mjs
+++ b/packages/workspaces-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-web",
-  version: "0.1.21",
+  version: "0.1.22",
   kind: "runtime",
   description: "Workspace web module: workspace selector, tools widget, workspace surfaces, and members/settings UI.",
   dependsOn: [
@@ -148,8 +148,8 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/workspaces-core": "0.1.21",
-        "@jskit-ai/users-web": "0.1.60",
+        "@jskit-ai/workspaces-core": "0.1.22",
+        "@jskit-ai/users-web": "0.1.61",
         "vuetify": "^4.0.0"
       },
       dev: {}

--- a/packages/workspaces-web/package.json
+++ b/packages/workspaces-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-web",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -14,12 +14,12 @@
   "dependencies": {
     "@tanstack/vue-query": "5.92.12",
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/http-runtime": "0.1.44",
-    "@jskit-ai/kernel": "0.1.45",
-    "@jskit-ai/shell-web": "0.1.44",
-    "@jskit-ai/users-core": "0.1.55",
-    "@jskit-ai/users-web": "0.1.60",
-    "@jskit-ai/workspaces-core": "0.1.21",
+    "@jskit-ai/http-runtime": "0.1.45",
+    "@jskit-ai/kernel": "0.1.46",
+    "@jskit-ai/shell-web": "0.1.45",
+    "@jskit-ai/users-core": "0.1.56",
+    "@jskit-ai/users-web": "0.1.61",
+    "@jskit-ai/workspaces-core": "0.1.22",
     "vuetify": "^4.0.0"
   }
 }

--- a/tooling/config-eslint/package.json
+++ b/tooling/config-eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/config-eslint",
-  "version": "0.1.44",
+  "version": "0.1.45",
   "description": "Shared flat ESLint presets for JSKIT projects.",
   "type": "module",
   "files": [

--- a/tooling/create-app/package.descriptor.mjs
+++ b/tooling/create-app/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/create-app",
-  "version": "0.1.53",
+  "version": "0.1.54",
   "dependsOn": [],
   "capabilities": {
     "provides": [

--- a/tooling/create-app/package.json
+++ b/tooling/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/create-app",
-  "version": "0.1.53",
+  "version": "0.1.54",
   "description": "Scaffold minimal JSKIT app shells.",
   "type": "module",
   "files": [

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -6,11 +6,11 @@
   "packages": [
     {
       "packageId": "@jskit-ai/assistant",
-      "version": "0.1.54",
+      "version": "0.1.55",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant",
-        "version": "0.1.54",
+        "version": "0.1.55",
         "kind": "generator",
         "description": "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
         "options": {
@@ -356,11 +356,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-core",
-      "version": "0.1.21",
+      "version": "0.1.22",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-core",
-        "version": "0.1.21",
+        "version": "0.1.22",
         "kind": "runtime",
         "description": "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
         "dependsOn": [
@@ -406,9 +406,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/http-runtime": "0.1.44",
-              "@jskit-ai/kernel": "0.1.45",
-              "@jskit-ai/users-core": "0.1.55",
+              "@jskit-ai/http-runtime": "0.1.45",
+              "@jskit-ai/kernel": "0.1.46",
+              "@jskit-ai/users-core": "0.1.56",
               "@tanstack/vue-query": "^5.90.5",
               "dompurify": "^3.3.3",
               "marked": "^17.0.4",
@@ -429,11 +429,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-runtime",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-runtime",
-        "version": "0.1.16",
+        "version": "0.1.17",
         "kind": "runtime",
         "description": "Shared assistant runtime with per-surface assistant registration.",
         "dependsOn": [
@@ -508,13 +508,13 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/assistant-core": "0.1.21",
-              "@jskit-ai/database-runtime": "0.1.45",
-              "@jskit-ai/http-runtime": "0.1.44",
-              "@jskit-ai/kernel": "0.1.45",
-              "@jskit-ai/shell-web": "0.1.44",
-              "@jskit-ai/users-core": "0.1.55",
-              "@jskit-ai/users-web": "0.1.60",
+              "@jskit-ai/assistant-core": "0.1.22",
+              "@jskit-ai/database-runtime": "0.1.46",
+              "@jskit-ai/http-runtime": "0.1.45",
+              "@jskit-ai/kernel": "0.1.46",
+              "@jskit-ai/shell-web": "0.1.45",
+              "@jskit-ai/users-core": "0.1.56",
+              "@jskit-ai/users-web": "0.1.61",
               "@tanstack/vue-query": "^5.90.5",
               "vuetify": "^4.0.0"
             },
@@ -571,11 +571,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-core",
-      "version": "0.1.44",
+      "version": "0.1.45",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-core",
-        "version": "0.1.44",
+        "version": "0.1.45",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/value-app-config-shared"
@@ -643,7 +643,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.45",
+              "@jskit-ai/kernel": "0.1.46",
               "@fastify/cookie": "^11.0.2",
               "@fastify/csrf-protection": "^7.1.0",
               "@fastify/rate-limit": "^10.3.0"
@@ -661,11 +661,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.44",
+      "version": "0.1.45",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-supabase-core",
-        "version": "0.1.44",
+        "version": "0.1.45",
         "kind": "runtime",
         "options": {
           "auth-supabase-url": {
@@ -747,8 +747,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.44",
-              "@jskit-ai/kernel": "0.1.45",
+              "@jskit-ai/auth-core": "0.1.45",
+              "@jskit-ai/kernel": "0.1.46",
               "dotenv": "^16.4.5",
               "@supabase/supabase-js": "^2.57.4",
               "jose": "^6.1.0"
@@ -813,11 +813,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-web",
-      "version": "0.1.46",
+      "version": "0.1.47",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-web",
-        "version": "0.1.46",
+        "version": "0.1.47",
         "kind": "runtime",
         "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
         "dependsOn": [
@@ -1044,10 +1044,10 @@
               "@tanstack/vue-query": "5.92.12",
               "@mdi/js": "^7.4.47",
               "@fastify/type-provider-typebox": "^6.1.0",
-              "@jskit-ai/auth-core": "0.1.44",
-              "@jskit-ai/http-runtime": "0.1.44",
-              "@jskit-ai/kernel": "0.1.45",
-              "@jskit-ai/shell-web": "0.1.44",
+              "@jskit-ai/auth-core": "0.1.45",
+              "@jskit-ai/http-runtime": "0.1.45",
+              "@jskit-ai/kernel": "0.1.46",
+              "@jskit-ai/shell-web": "0.1.45",
               "vuetify": "^4.0.0"
             },
             "dev": {}
@@ -1117,11 +1117,11 @@
     },
     {
       "packageId": "@jskit-ai/console-core",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-core",
-        "version": "0.1.8",
+        "version": "0.1.9",
         "kind": "runtime",
         "description": "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
         "dependsOn": [
@@ -1192,10 +1192,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.45",
-              "@jskit-ai/http-runtime": "0.1.44",
-              "@jskit-ai/kernel": "0.1.45",
-              "@jskit-ai/users-core": "0.1.55",
+              "@jskit-ai/database-runtime": "0.1.46",
+              "@jskit-ai/http-runtime": "0.1.45",
+              "@jskit-ai/kernel": "0.1.46",
+              "@jskit-ai/users-core": "0.1.56",
               "typebox": "^1.0.81"
             },
             "dev": {}
@@ -1240,11 +1240,11 @@
     },
     {
       "packageId": "@jskit-ai/console-web",
-      "version": "0.1.13",
+      "version": "0.1.14",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-web",
-        "version": "0.1.13",
+        "version": "0.1.14",
         "kind": "runtime",
         "description": "Authenticated console surface scaffold and surface policy wiring.",
         "dependsOn": [
@@ -1312,9 +1312,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-web": "0.1.46",
-              "@jskit-ai/console-core": "0.1.8",
-              "@jskit-ai/shell-web": "0.1.44"
+              "@jskit-ai/auth-web": "0.1.47",
+              "@jskit-ai/console-core": "0.1.9",
+              "@jskit-ai/shell-web": "0.1.45"
             },
             "dev": {}
           },
@@ -1401,11 +1401,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-core",
-      "version": "0.1.53",
+      "version": "0.1.54",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-core",
-        "version": "0.1.53",
+        "version": "0.1.54",
         "kind": "runtime",
         "description": "Shared CRUD helpers used by CRUD modules.",
         "dependsOn": [
@@ -1432,7 +1432,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/crud-core": "0.1.53"
+              "@jskit-ai/crud-core": "0.1.54"
             },
             "dev": {}
           },
@@ -1446,11 +1446,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-server-generator",
-      "version": "0.1.53",
+      "version": "0.1.54",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-server-generator",
-        "version": "0.1.53",
+        "version": "0.1.54",
         "kind": "generator",
         "description": "CRUD server generator with routes, actions, and persistence scaffolding.",
         "options": {
@@ -1608,13 +1608,13 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.44",
-              "@jskit-ai/crud-core": "0.1.53",
-              "@jskit-ai/database-runtime": "0.1.45",
-              "@jskit-ai/http-runtime": "0.1.44",
-              "@jskit-ai/kernel": "0.1.45",
-              "@jskit-ai/realtime": "0.1.44",
-              "@jskit-ai/users-core": "0.1.55",
+              "@jskit-ai/auth-core": "0.1.45",
+              "@jskit-ai/crud-core": "0.1.54",
+              "@jskit-ai/database-runtime": "0.1.46",
+              "@jskit-ai/http-runtime": "0.1.45",
+              "@jskit-ai/kernel": "0.1.46",
+              "@jskit-ai/realtime": "0.1.45",
+              "@jskit-ai/users-core": "0.1.56",
               "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}",
               "typebox": "^1.0.81"
             },
@@ -1761,11 +1761,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.28",
+      "version": "0.1.29",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-ui-generator",
-        "version": "0.1.28",
+        "version": "0.1.29",
         "kind": "generator",
         "description": "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
         "options": {
@@ -1940,7 +1940,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.60"
+              "@jskit-ai/users-web": "0.1.61"
             },
             "dev": {}
           },
@@ -2173,11 +2173,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime",
-      "version": "0.1.45",
+      "version": "0.1.46",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime",
-        "version": "0.1.45",
+        "version": "0.1.46",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -2234,7 +2234,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.45",
+              "@jskit-ai/kernel": "0.1.46",
               "dotenv": "^16.4.5",
               "knex": "^3.1.0"
             },
@@ -2269,11 +2269,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.44",
+      "version": "0.1.45",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-mysql",
-        "version": "0.1.44",
+        "version": "0.1.45",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -2363,7 +2363,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.45",
+              "@jskit-ai/database-runtime": "0.1.46",
               "mysql2": "^3.11.2"
             },
             "dev": {}
@@ -2434,11 +2434,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.44",
+      "version": "0.1.45",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-postgres",
-        "version": "0.1.44",
+        "version": "0.1.45",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -2528,7 +2528,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.45",
+              "@jskit-ai/database-runtime": "0.1.46",
               "pg": "^8.13.1"
             },
             "dev": {}
@@ -2599,11 +2599,11 @@
     },
     {
       "packageId": "@jskit-ai/http-runtime",
-      "version": "0.1.44",
+      "version": "0.1.45",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/http-runtime",
-        "version": "0.1.44",
+        "version": "0.1.45",
         "kind": "runtime",
         "dependsOn": [],
         "capabilities": {
@@ -2669,7 +2669,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.45",
+              "@jskit-ai/kernel": "0.1.46",
               "@fastify/type-provider-typebox": "^6.1.0",
               "typebox": "^1.0.81"
             },
@@ -2685,11 +2685,11 @@
     },
     {
       "packageId": "@jskit-ai/realtime",
-      "version": "0.1.44",
+      "version": "0.1.45",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/realtime",
-        "version": "0.1.44",
+        "version": "0.1.45",
         "kind": "runtime",
         "description": "Thin, generic realtime runtime wrappers for socket.io server and client.",
         "options": {
@@ -2784,7 +2784,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.45",
+              "@jskit-ai/kernel": "0.1.46",
               "@socket.io/redis-adapter": "^8.3.0",
               "redis": "^5.8.2",
               "socket.io": "^4.8.3",
@@ -2833,11 +2833,11 @@
     },
     {
       "packageId": "@jskit-ai/shell-web",
-      "version": "0.1.44",
+      "version": "0.1.45",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/shell-web",
-        "version": "0.1.44",
+        "version": "0.1.45",
         "kind": "runtime",
         "description": "Web shell layout runtime with outlet-based placement contributions.",
         "dependsOn": [],
@@ -2969,7 +2969,7 @@
             "runtime": {
               "@mdi/js": "^7.4.47",
               "@tanstack/vue-query": "^5.90.5",
-              "@jskit-ai/kernel": "0.1.45",
+              "@jskit-ai/kernel": "0.1.46",
               "vuetify": "^4.0.0"
             },
             "dev": {}
@@ -3154,11 +3154,11 @@
     },
     {
       "packageId": "@jskit-ai/storage-runtime",
-      "version": "0.1.44",
+      "version": "0.1.45",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/storage-runtime",
-        "version": "0.1.44",
+        "version": "0.1.45",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -3207,7 +3207,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.45",
+              "@jskit-ai/kernel": "0.1.46",
               "unstorage": "^1.17.3"
             },
             "dev": {}
@@ -3223,11 +3223,11 @@
     },
     {
       "packageId": "@jskit-ai/ui-generator",
-      "version": "0.1.28",
+      "version": "0.1.29",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/ui-generator",
-        "version": "0.1.28",
+        "version": "0.1.29",
         "kind": "generator",
         "description": "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
         "options": {
@@ -3526,7 +3526,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.60"
+              "@jskit-ai/users-web": "0.1.61"
             },
             "dev": {}
           },
@@ -3541,11 +3541,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-image-web",
-      "version": "0.1.23",
+      "version": "0.1.24",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-image-web",
-        "version": "0.1.23",
+        "version": "0.1.24",
         "kind": "runtime",
         "description": "Reusable client-side image upload runtime with pre-upload image editing.",
         "dependsOn": [
@@ -3609,7 +3609,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/uploads-runtime": "0.1.23",
+              "@jskit-ai/uploads-runtime": "0.1.24",
               "@uppy/compressor": "^3.1.0",
               "@uppy/core": "^5.2.0",
               "@uppy/dashboard": "^5.1.1",
@@ -3629,11 +3629,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-runtime",
-      "version": "0.1.23",
+      "version": "0.1.24",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-runtime",
-        "version": "0.1.23",
+        "version": "0.1.24",
         "kind": "runtime",
         "description": "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
         "dependsOn": [
@@ -3703,7 +3703,7 @@
           "dependencies": {
             "runtime": {
               "@fastify/multipart": "^9.4.0",
-              "@jskit-ai/kernel": "0.1.45"
+              "@jskit-ai/kernel": "0.1.46"
             },
             "dev": {}
           },
@@ -3718,11 +3718,11 @@
     },
     {
       "packageId": "@jskit-ai/users-core",
-      "version": "0.1.55",
+      "version": "0.1.56",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-core",
-        "version": "0.1.55",
+        "version": "0.1.56",
         "kind": "runtime",
         "description": "Users/account runtime plus HTTP routes for account features.",
         "dependsOn": [
@@ -3848,11 +3848,11 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.44",
-              "@jskit-ai/database-runtime": "0.1.45",
-              "@jskit-ai/http-runtime": "0.1.44",
-              "@jskit-ai/kernel": "0.1.45",
-              "@jskit-ai/uploads-runtime": "0.1.23",
+              "@jskit-ai/auth-core": "0.1.45",
+              "@jskit-ai/database-runtime": "0.1.46",
+              "@jskit-ai/http-runtime": "0.1.45",
+              "@jskit-ai/kernel": "0.1.46",
+              "@jskit-ai/uploads-runtime": "0.1.24",
               "@fastify/type-provider-typebox": "^6.1.0",
               "typebox": "^1.0.81"
             },
@@ -3936,11 +3936,11 @@
     },
     {
       "packageId": "@jskit-ai/users-web",
-      "version": "0.1.60",
+      "version": "0.1.61",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-web",
-        "version": "0.1.60",
+        "version": "0.1.61",
         "kind": "runtime",
         "description": "Users web module: account/profile UI plus shared users web widgets.",
         "dependsOn": [
@@ -4004,6 +4004,10 @@
                 "summary": "Exports command operation composable."
               },
               {
+                "subpath": "./client/composables/useEndpointResource",
+                "summary": "Exports low-level endpoint resource composable for custom client requests."
+              },
+              {
                 "subpath": "./client/composables/useCrudListFilterLookups",
                 "summary": "Exports lookup-backed CRUD list filter helper for remote autocomplete filters."
               },
@@ -4018,6 +4022,10 @@
               {
                 "subpath": "./client/composables/usePaths",
                 "summary": "Exports surface route path resolver composable."
+              },
+              {
+                "subpath": "./client/lib/httpClient",
+                "summary": "Exports the shared users-web HTTP client with credentials and CSRF behavior."
               },
               {
                 "subpath": "./client/composables/useAccountSettingsRuntime",
@@ -4091,12 +4099,12 @@
             "runtime": {
               "@tanstack/vue-query": "5.92.12",
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/http-runtime": "0.1.44",
-              "@jskit-ai/realtime": "0.1.44",
-              "@jskit-ai/kernel": "0.1.45",
-              "@jskit-ai/shell-web": "0.1.44",
-              "@jskit-ai/uploads-image-web": "0.1.23",
-              "@jskit-ai/users-core": "0.1.55",
+              "@jskit-ai/http-runtime": "0.1.45",
+              "@jskit-ai/realtime": "0.1.45",
+              "@jskit-ai/kernel": "0.1.46",
+              "@jskit-ai/shell-web": "0.1.45",
+              "@jskit-ai/uploads-image-web": "0.1.24",
+              "@jskit-ai/users-core": "0.1.56",
               "vuetify": "^4.0.0"
             },
             "dev": {}
@@ -4183,11 +4191,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-core",
-      "version": "0.1.21",
+      "version": "0.1.22",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-core",
-        "version": "0.1.21",
+        "version": "0.1.22",
         "kind": "runtime",
         "description": "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
         "dependsOn": [
@@ -4298,7 +4306,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-core": "0.1.55"
+              "@jskit-ai/users-core": "0.1.56"
             },
             "dev": {}
           },
@@ -4488,11 +4496,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-web",
-      "version": "0.1.21",
+      "version": "0.1.22",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-web",
-        "version": "0.1.21",
+        "version": "0.1.22",
         "kind": "runtime",
         "description": "Workspace web module: workspace selector, tools widget, workspace surfaces, and members/settings UI.",
         "dependsOn": [
@@ -4657,8 +4665,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/workspaces-core": "0.1.21",
-              "@jskit-ai/users-web": "0.1.60",
+              "@jskit-ai/workspaces-core": "0.1.22",
+              "@jskit-ai/users-web": "0.1.61",
               "vuetify": "^4.0.0"
             },
             "dev": {}

--- a/tooling/jskit-catalog/package.json
+++ b/tooling/jskit-catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-catalog",
-  "version": "0.1.53",
+  "version": "0.1.54",
   "description": "Published metadata catalog for JSKIT package descriptors.",
   "type": "module",
   "files": [

--- a/tooling/jskit-cli/package.json
+++ b/tooling/jskit-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-cli",
-  "version": "0.2.54",
+  "version": "0.2.55",
   "description": "Bundle and package orchestration CLI for JSKIT apps.",
   "type": "module",
   "files": [
@@ -20,9 +20,9 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/jskit-catalog": "0.1.53",
-    "@jskit-ai/kernel": "0.1.45",
-    "@jskit-ai/shell-web": "0.1.44"
+    "@jskit-ai/jskit-catalog": "0.1.54",
+    "@jskit-ai/kernel": "0.1.46",
+    "@jskit-ai/shell-web": "0.1.45"
   },
   "engines": {
     "node": "20.x"


### PR DESCRIPTION
## Summary
- add JSKIT client request guidance to the advanced CRUD docs and agent patterns
- expose the low-level `users-web` request seams needed by that guidance
- refresh package metadata, catalog, and lockfile outputs for the exported surface

## Notes
- this PR contains the staged changes only
- per request, merge immediately without waiting on verify