### PR TITLE
Add dev auth bootstrap for UI testing

### DIFF
--- a/packages/agent-docs/guide/agent/app-setup/authentication.md
+++ b/packages/agent-docs/guide/agent/app-setup/authentication.md
@@ -914,6 +914,118 @@ That explains why the login screen and auth guard runtime both care about `/api/
 
 It is also why the shell widget can react cleanly to auth state without storing raw session tokens in client state. The browser just asks the app for the current session view, and the app derives that from its cookies plus Supabase.
 
+### Authenticated Playwright testing with the dev auth bypass
+
+JSKIT now ships a development-only auth bootstrap path specifically so authenticated UI can be verified in Playwright without depending on a real live login flow through Supabase.
+
+This is the standard path the agent should use for authenticated browser tests:
+
+- enable the dev auth bypass in development
+- create a session for an existing user through the local app
+- let the browser keep the resulting HTTP-only cookies
+- navigate to the protected page and verify the feature
+
+The feature is intentionally narrow.
+
+- It is development-only.
+- It must never be enabled in production.
+- JSKIT rejects boot if `AUTH_DEV_BYPASS_ENABLED=true` while `NODE_ENV=production`.
+- The route only looks up an existing user. It does not create one.
+
+The environment variables are:
+
+```bash
+AUTH_DEV_BYPASS_ENABLED=true
+AUTH_DEV_BYPASS_SECRET=replace-this-with-a-local-dev-secret
+```
+
+When enabled outside production, the app exposes:
+
+```text
+POST /api/dev-auth/login-as
+```
+
+The request body must contain either:
+
+```json
+{ "userId": "7" }
+```
+
+or:
+
+```json
+{ "email": "ada@example.com" }
+```
+
+The response is intentionally small:
+
+```json
+{
+  "ok": true,
+  "userId": "7",
+  "username": "Ada Example",
+  "email": "ada@example.com"
+}
+```
+
+Behind the scenes, JSKIT creates the same HTTP-only auth cookies that the normal login flow would create. That means Playwright should not try to read raw tokens. It should bootstrap the session in the browser context, then navigate normally.
+
+One subtle point matters here:
+
+- `/api/dev-auth/login-as` is still an unsafe `POST`
+- JSKIT still expects a CSRF token
+- the browser can get that token from `/api/session`
+
+So the normal Playwright shape is:
+
+1. open a same-origin page first
+2. call `/api/session` to read `csrfToken`
+3. call `/api/dev-auth/login-as` with `credentials: "include"` and the `csrf-token` header
+4. navigate to the protected route and run the assertions
+
+For example:
+
+```ts
+await page.goto("/");
+
+await page.evaluate(async ({ email }) => {
+  const sessionResponse = await fetch("/api/session", {
+    credentials: "include"
+  });
+  if (!sessionResponse.ok) {
+    throw new Error(`Session bootstrap failed: ${sessionResponse.status}`);
+  }
+
+  const sessionPayload = await sessionResponse.json();
+  const csrfToken = String(sessionPayload?.csrfToken || "");
+  if (!csrfToken) {
+    throw new Error("Missing csrfToken from /api/session.");
+  }
+
+  const loginResponse = await fetch("/api/dev-auth/login-as", {
+    method: "POST",
+    credentials: "include",
+    headers: {
+      "content-type": "application/json",
+      "csrf-token": csrfToken
+    },
+    body: JSON.stringify({ email })
+  });
+
+  if (!loginResponse.ok) {
+    throw new Error(`Dev login failed: ${loginResponse.status} ${await loginResponse.text()}`);
+  }
+}, { email: "ada@example.com" });
+
+await page.goto("/w/acme/admin/contacts");
+```
+
+That flow is preferable to driving the real sign-in form in feature tests because it keeps the test focused on the UI feature being added, not on an external auth dependency. If a chunk changes user-facing UI and the flow requires login, the expected JSKIT review standard is:
+
+- use Playwright
+- use the local dev auth bypass or another local session bootstrap path
+- exercise the actual changed behavior, not only page load
+
 ## What appears in Supabase
 
 It is important to separate **Supabase auth data** from **JSKIT app-owned data**.

--- a/packages/agent-docs/patterns/INDEX.md
+++ b/packages/agent-docs/patterns/INDEX.md
@@ -22,6 +22,8 @@ How to use it:
   - `live-actions.md`
 - ajax, fetch, API call, request, endpoint, HTTP client, `useList()`, `useView()`, `useAddEdit()`, `useEndpointResource()`, `usersWebHttpClient`
   - `client-requests.md`
+- playwright, browser test, e2e, ui verification, authenticated ui test, test auth, dev login as, dev auth bypass
+  - `ui-testing.md`
 - filter, filters, search facets, chips, date range, enum filter, lookup filter, `useCrudListFilters`, `createCrudListFilters`
   - `filters.md`
 
@@ -33,4 +35,5 @@ How to use it:
 - [crud-links.md](./crud-links.md)
 - [live-actions.md](./live-actions.md)
 - [client-requests.md](./client-requests.md)
+- [ui-testing.md](./ui-testing.md)
 - [filters.md](./filters.md)

--- a/packages/agent-docs/patterns/ui-testing.md
+++ b/packages/agent-docs/patterns/ui-testing.md
@@ -1,0 +1,68 @@
+# UI Testing Pattern
+
+Use when:
+
+- deciding how to verify a new or changed user-facing screen
+- Playwright or browser-driven verification
+- authenticated UI flows
+- test auth, session bootstrap, dev login-as, or dev auth bypass
+
+Rules:
+
+- Any chunk that adds or changes user-facing UI must include a Playwright flow that exercises the changed behavior before the chunk is done.
+- Do not rely on a live external auth provider for Playwright verification of normal app features.
+- For authenticated UI in the standard JSKIT auth stack, use the development-only dev auth bypass route instead.
+- The standard route is `POST /api/dev-auth/login-as`.
+- The request body must include either `{ userId }` or `{ email }`.
+- The route is available only when `AUTH_DEV_BYPASS_ENABLED=true` and `AUTH_DEV_BYPASS_SECRET` is set outside production.
+- This route must never be enabled in production.
+- Because the route is an unsafe POST, fetch `csrfToken` from `/api/session` first and send it back as the `csrf-token` header.
+- Make the bootstrap request from the same browser context that will run the assertions so the auth cookies land in the page session.
+- Use stable seeded users or fixtures for Playwright. Do not depend on whatever account happens to exist in a developer's browser or external auth provider.
+
+Playwright setup shape:
+
+```ts
+await page.goto("/");
+
+await page.evaluate(async ({ email }) => {
+  const sessionResponse = await fetch("/api/session", {
+    credentials: "include"
+  });
+  if (!sessionResponse.ok) {
+    throw new Error(`Session bootstrap failed: ${sessionResponse.status}`);
+  }
+
+  const sessionPayload = await sessionResponse.json();
+  const csrfToken = String(sessionPayload?.csrfToken || "");
+  if (!csrfToken) {
+    throw new Error("Missing csrfToken from /api/session.");
+  }
+
+  const loginResponse = await fetch("/api/dev-auth/login-as", {
+    method: "POST",
+    credentials: "include",
+    headers: {
+      "content-type": "application/json",
+      "csrf-token": csrfToken
+    },
+    body: JSON.stringify({ email })
+  });
+
+  if (!loginResponse.ok) {
+    throw new Error(`Dev login failed: ${loginResponse.status} ${await loginResponse.text()}`);
+  }
+}, { email: "ada@example.com" });
+```
+
+After that bootstrap:
+
+- navigate to the protected page
+- exercise the new UI behavior
+- assert the actual outcome the chunk introduced
+
+Do not mark the chunk done if:
+
+- the feature changed user-facing UI but no Playwright flow ran
+- the Playwright flow skipped the changed behavior itself
+- authenticated UI work was left untested because no local auth bootstrap path was available and that gap was not called out

--- a/packages/agent-docs/reference/autogen/packages/auth-core.md
+++ b/packages/agent-docs/reference/autogen/packages/auth-core.md
@@ -202,11 +202,18 @@ Exports
 - `loginResponseValidator`
 - `otpVerifyResponseValidator`
 - `oauthCompleteResponseValidator`
+- `devLoginAsResponseValidator`
 - `logoutResponseValidator`
 - `oauthProviderCatalogEntryValidator`
 - `sessionResponseValidator`
 - `sessionUnavailableResponseValidator`
 - `createCommandMessages({ fields = {}, defaultMessage = "Invalid value." } = {})`
+
+### `src/shared/commands/authDevLoginAsCommand.js`
+Exports
+- `AUTH_DEV_LOGIN_AS_MESSAGES`
+- `authDevLoginAsBodyValidator`
+- `authDevLoginAsCommand`
 
 ### `src/shared/commands/authLoginOAuthCompleteCommand.js`
 Exports
@@ -300,6 +307,7 @@ Exports
 - `authLoginOtpVerifyCommand`
 - `authLoginOAuthStartCommand`
 - `authLoginOAuthCompleteCommand`
+- `authDevLoginAsCommand`
 - `authPasswordResetRequestCommand`
 - `authPasswordRecoveryCompleteCommand`
 - `authPasswordResetCommand`

--- a/packages/agent-docs/reference/autogen/packages/auth-provider-supabase-core.md
+++ b/packages/agent-docs/reference/autogen/packages/auth-provider-supabase-core.md
@@ -26,7 +26,9 @@ Local functions
 
 ### `src/server/lib/actions/auth.contributor.js`
 Exports
-- `authActions`
+- `baseAuthActions`
+- `buildAuthActions({ includeDevLoginAs = false } = {})`
+- `devLoginAsAction`
 Local functions
 - `requireRequestContext(context, actionId)`
 
@@ -106,6 +108,30 @@ Exports
 Exports
 - `createAuthSessionEventsService()`
 
+### `src/server/lib/devAuthBootstrap.js`
+Exports
+- `assertDevAuthBootstrapConfig(config, { usersRepository = null } = {})`
+- `authenticateDevAuthRequest({ request, accessToken = "", refreshToken = "" }, { config, usersRepository = null } = {})`
+- `createDevAuthSession(profile, config)`
+- `ensureDevAuthBootstrapAvailable(config, request)`
+- `isDevAuthToken(token)`
+- `resolveDevAuthConfig({ enabled = false, secret = "", nodeEnv = "development", jwtAudience = "authenticated", accessTtlSeconds = DEFAULT_DEV_AUTH_ACCESS_TTL_SECONDS, refreshTtlSeconds = DEFAULT_DEV_AUTH_REFRESH_TTL_SECONDS } = {})`
+- `resolveDevAuthProfile(input = {}, { usersRepository = null, validationError } = {})`
+Local functions
+- `parseBoolean(value, fallback = false)`
+- `normalizePositiveInteger(value, fallback)`
+- `normalizeRequestHostname(request)`
+- `resolveDirectRemoteAddress(request)`
+- `normalizeLoopbackIp(value)`
+- `isLoopbackIp(value)`
+- `isLoopbackHostname(value)`
+- `isLocalDevAuthRequest(request)`
+- `stripDevAuthTokenPrefix(token)`
+- `buildProfileFromTokenClaims(payload)`
+- `resolveProfileFromTokenClaims(payload, { usersRepository = null } = {})`
+- `signDevAuthToken(kind, profile, config)`
+- `verifyDevAuthToken(token, kind, config)`
+
 ### `src/server/lib/flowGuards.js`
 Exports
 - `requireNoFieldErrors(parsed, validationError)`
@@ -117,7 +143,9 @@ Exports
 Exports
 - `createService`
 - `__testables`
-- `authActions`
+- `baseAuthActions`
+- `buildAuthActions`
+- `devLoginAsAction`
 
 ### `src/server/lib/oauthFlows.js`
 Exports
@@ -206,14 +234,18 @@ Exports
 - `AuthSupabaseServiceProvider`
 Local functions
 - `splitCsv(value)`
+- `parseBoolean(value, fallback = false)`
 - `normalizeRecord(value)`
 - `normalizeOAuthProviderConfigList(value)`
 - `resolveOAuthConfigFromAppConfig(appConfig)`
 - `resolveAllowedReturnToOrigins({ appConfig = {}, appPublicUrl = "" } = {})`
 - `resolveAuthProviderConfig(env, appConfig = {})`
 - `resolveAuthProfileMode(env)`
+- `isDevAuthBypassEnabledForRegistration(env)`
+- `isDevAuthBypassRequested(env)`
 - `createInMemoryUserSettingsRepository()`
 - `resolveCommonDependencies(scope)`
+- `resolveRuntimeEnv(scope)`
 - `resolveOptionalRepositories(scope)`
 
 ### root

--- a/packages/agent-docs/reference/autogen/packages/auth-web.md
+++ b/packages/agent-docs/reference/autogen/packages/auth-web.md
@@ -217,7 +217,7 @@ Exports
 
 ### `src/server/routes/authRoutes.js`
 Exports
-- `buildRoutes(controller)`
+- `buildRoutes(controller, { includeDevLoginAs = false } = {})`
 
 ### `src/server/services/AuthWebService.js`
 Exports

--- a/packages/agent-docs/site/guide/app-setup/authentication.md
+++ b/packages/agent-docs/site/guide/app-setup/authentication.md
@@ -927,6 +927,118 @@ That explains why the login screen and auth guard runtime both care about `/api/
 
 It is also why the shell widget can react cleanly to auth state without storing raw session tokens in client state. The browser just asks the app for the current session view, and the app derives that from its cookies plus Supabase.
 
+### Authenticated Playwright testing with the dev auth bypass
+
+JSKIT now ships a development-only auth bootstrap path specifically so authenticated UI can be verified in Playwright without depending on a real live login flow through Supabase.
+
+This is the standard path the agent should use for authenticated browser tests:
+
+- enable the dev auth bypass in development
+- create a session for an existing user through the local app
+- let the browser keep the resulting HTTP-only cookies
+- navigate to the protected page and verify the feature
+
+The feature is intentionally narrow.
+
+- It is development-only.
+- It must never be enabled in production.
+- JSKIT rejects boot if `AUTH_DEV_BYPASS_ENABLED=true` while `NODE_ENV=production`.
+- The route only looks up an existing user. It does not create one.
+
+The environment variables are:
+
+```bash
+AUTH_DEV_BYPASS_ENABLED=true
+AUTH_DEV_BYPASS_SECRET=replace-this-with-a-local-dev-secret
+```
+
+When enabled outside production, the app exposes:
+
+```text
+POST /api/dev-auth/login-as
+```
+
+The request body must contain either:
+
+```json
+{ "userId": "7" }
+```
+
+or:
+
+```json
+{ "email": "ada@example.com" }
+```
+
+The response is intentionally small:
+
+```json
+{
+  "ok": true,
+  "userId": "7",
+  "username": "Ada Example",
+  "email": "ada@example.com"
+}
+```
+
+Behind the scenes, JSKIT creates the same HTTP-only auth cookies that the normal login flow would create. That means Playwright should not try to read raw tokens. It should bootstrap the session in the browser context, then navigate normally.
+
+One subtle point matters here:
+
+- `/api/dev-auth/login-as` is still an unsafe `POST`
+- JSKIT still expects a CSRF token
+- the browser can get that token from `/api/session`
+
+So the normal Playwright shape is:
+
+1. open a same-origin page first
+2. call `/api/session` to read `csrfToken`
+3. call `/api/dev-auth/login-as` with `credentials: "include"` and the `csrf-token` header
+4. navigate to the protected route and run the assertions
+
+For example:
+
+```ts
+await page.goto("/");
+
+await page.evaluate(async ({ email }) => {
+  const sessionResponse = await fetch("/api/session", {
+    credentials: "include"
+  });
+  if (!sessionResponse.ok) {
+    throw new Error(`Session bootstrap failed: ${sessionResponse.status}`);
+  }
+
+  const sessionPayload = await sessionResponse.json();
+  const csrfToken = String(sessionPayload?.csrfToken || "");
+  if (!csrfToken) {
+    throw new Error("Missing csrfToken from /api/session.");
+  }
+
+  const loginResponse = await fetch("/api/dev-auth/login-as", {
+    method: "POST",
+    credentials: "include",
+    headers: {
+      "content-type": "application/json",
+      "csrf-token": csrfToken
+    },
+    body: JSON.stringify({ email })
+  });
+
+  if (!loginResponse.ok) {
+    throw new Error(`Dev login failed: ${loginResponse.status} ${await loginResponse.text()}`);
+  }
+}, { email: "ada@example.com" });
+
+await page.goto("/w/acme/admin/contacts");
+```
+
+That flow is preferable to driving the real sign-in form in feature tests because it keeps the test focused on the UI feature being added, not on an external auth dependency. If a chunk changes user-facing UI and the flow requires login, the expected JSKIT review standard is:
+
+- use Playwright
+- use the local dev auth bypass or another local session bootstrap path
+- exercise the actual changed behavior, not only page load
+
 ## What appears in Supabase
 
 It is important to separate **Supabase auth data** from **JSKIT app-owned data**.

--- a/packages/agent-docs/templates/app/AGENTS.md
+++ b/packages/agent-docs/templates/app/AGENTS.md
@@ -45,6 +45,7 @@ Before calling a chunk done, report:
 - `Deslop review: ...`
 - `JSKIT review: ...`
 - `Material/Vuetify review: ...`
+- `Playwright: ...` for any chunk that adds or changes user-facing UI
 - `Verification: ...`
 - `Files changed: ...`
 - `Commands run: ...`
@@ -71,6 +72,10 @@ Core rules:
 - Use the real env var names or option names instead of vague requests for "credentials". Values such as `DB_NAME`, `DB_USER`, `DB_PASSWORD`, `AUTH_SUPABASE_URL`, `AUTH_SUPABASE_PUBLISHABLE_KEY`, and `APP_PUBLIC_URL` are routine setup inputs when the relevant package stack needs them.
 - For CRUD chunks, ask the developer which operations are allowed, which fields belong in the list view if one exists, and the intended look of the view and edit/new forms before generating code.
 - Every user-facing screen must pass a Material Design and Vuetify quality review before the chunk is considered done.
+- Any chunk that adds or changes user-facing UI must include a Playwright check that exercises the changed behavior before the chunk is considered done.
+- If the UI flow requires login, use the app's development-only auth bypass or session bootstrap path instead of a live external auth login flow.
+- In JSKIT apps using the standard auth stack, that means enabling the dev auth bypass in development and using `POST /api/dev-auth/login-as` during Playwright setup.
+- If authenticated UI work has no usable local auth bootstrap path yet, treat that as a testability gap and call it out before the chunk can be considered complete.
 - Do not implement app features before the blueprint has the database, surfaces, ownership model, and route/screen plan written down.
 - Break planned work into reviewable chunks before implementing. One CRUD is usually one chunk, but auth/platform setup, shell work, and cross-cutting integrations can be their own chunks.
 - Do not move to the next chunk until the current chunk has passed implementation, deslop review, JSKIT best-practices review, Material Design/Vuetify review, and verification.

--- a/packages/agent-docs/test/appAgentTemplate.test.js
+++ b/packages/agent-docs/test/appAgentTemplate.test.js
@@ -22,8 +22,12 @@ test("app agent template includes mandatory JSKIT start and done gates", async (
   assert.match(body, /Deslop review:/);
   assert.match(body, /JSKIT review:/);
   assert.match(body, /Material\/Vuetify review:/);
+  assert.match(body, /Playwright:/);
   assert.match(body, /Verification:/);
   assert.match(body, /Files changed:/);
   assert.match(body, /Commands run:/);
   assert.match(body, /Remaining unverified:/);
+  assert.match(body, /Any chunk that adds or changes user-facing UI must include a Playwright check/);
+  assert.match(body, /use the app's development-only auth bypass or session bootstrap path/);
+  assert.match(body, /POST \/api\/dev-auth\/login-as/);
 });

--- a/packages/agent-docs/test/uiTestingGuidance.test.js
+++ b/packages/agent-docs/test/uiTestingGuidance.test.js
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+test("workflow and guide docs require Playwright plus dev auth bypass for authenticated UI", async () => {
+  const featureDelivery = await readFile(path.join(packageRoot, "workflow/feature-delivery.md"), "utf8");
+  const review = await readFile(path.join(packageRoot, "workflow/review.md"), "utf8");
+  const pattern = await readFile(path.join(packageRoot, "patterns/ui-testing.md"), "utf8");
+  const authGuide = await readFile(path.join(packageRoot, "site/guide/app-setup/authentication.md"), "utf8");
+
+  assert.match(featureDelivery, /adds or changes user-facing UI must include a Playwright flow/);
+  assert.match(featureDelivery, /\/api\/dev-auth\/login-as/);
+  assert.match(featureDelivery, /must not be enabled in production/);
+
+  assert.match(review, /any added or changed user-facing UI must be exercised with Playwright/);
+  assert.match(review, /development-only .*\/api\/dev-auth\/login-as/);
+
+  assert.match(pattern, /^# UI Testing Pattern$/m);
+  assert.match(pattern, /\/api\/dev-auth\/login-as/);
+  assert.match(pattern, /AUTH_DEV_BYPASS_ENABLED=true/);
+  assert.match(pattern, /csrf-token/);
+
+  assert.match(authGuide, /^### Authenticated Playwright testing with the dev auth bypass$/m);
+  assert.match(authGuide, /AUTH_DEV_BYPASS_ENABLED=true/);
+  assert.match(authGuide, /POST \/api\/dev-auth\/login-as/);
+  assert.match(authGuide, /This is the standard path the agent should use for authenticated browser tests/);
+});

--- a/packages/agent-docs/workflow/feature-delivery.md
+++ b/packages/agent-docs/workflow/feature-delivery.md
@@ -22,7 +22,7 @@ For each chunk, follow this order:
 5. Deslop the chunk.
 6. Review the chunk against JSKIT reuse and best practices.
 7. Review user-facing screens against Material Design and Vuetify best practices, and improve any screens that do not meet that bar.
-8. Verify the chunk with the relevant commands, including Playwright for meaningful UI flows.
+8. Verify the chunk with the relevant commands. Any chunk that adds or changes user-facing UI must include a Playwright flow that exercises the changed behavior.
 9. Update `.jskit/WORKBOARD.md` with status, commands run, and anything still unverified.
 10. Only then move to the next chunk.
 
@@ -59,5 +59,8 @@ After the last chunk:
 
 Playwright note:
 
-- When login is required, prefer a test-only impersonation or session bootstrap path over dependence on a live external auth provider.
+- When login is required, use a test-only auth bypass or session bootstrap path instead of dependence on a live external auth provider.
+- In the standard JSKIT auth stack, the default development path is `POST /api/dev-auth/login-as`, guarded by `AUTH_DEV_BYPASS_ENABLED=true` and `AUTH_DEV_BYPASS_SECRET=...`.
+- That route is development-only and must not be enabled in production.
+- Because it is still an unsafe POST, fetch `csrfToken` from `/api/session`, send it as the `csrf-token` header, and make the request in the same browser context that will run the Playwright assertions so the session cookies land in the page session.
 - If such a path does not exist yet, treat that as a testability gap and decide whether the chunk must add it before the feature is considered complete.

--- a/packages/agent-docs/workflow/review.md
+++ b/packages/agent-docs/workflow/review.md
@@ -31,8 +31,10 @@ Before calling a chunk or a whole changeset done, review it in four passes:
 4. Verification review
    - run the smallest relevant verification commands for a chunk
    - run the widest relevant verification commands for a whole changeset
-   - include Playwright for meaningful user-facing flows
-   - if login is required, verify the chosen test-auth path or explicitly record that the lack of one is an open gap
+   - any added or changed user-facing UI must be exercised with Playwright
+   - if login is required, use the chosen local test-auth path instead of live external auth
+   - in the standard JSKIT auth stack, prefer the development-only `POST /api/dev-auth/login-as` path
+   - if there is no usable local auth bootstrap path, explicitly record that as a blocking testability gap
    - note anything left unverified
 
 Minimum expectation:

--- a/packages/auth-core/package.json
+++ b/packages/auth-core/package.json
@@ -36,6 +36,7 @@
     "./shared/commands/authLoginOtpVerifyCommand": "./src/shared/commands/authLoginOtpVerifyCommand.js",
     "./shared/commands/authLoginOAuthStartCommand": "./src/shared/commands/authLoginOAuthStartCommand.js",
     "./shared/commands/authLoginOAuthCompleteCommand": "./src/shared/commands/authLoginOAuthCompleteCommand.js",
+    "./shared/commands/authDevLoginAsCommand": "./src/shared/commands/authDevLoginAsCommand.js",
     "./shared/commands/authPasswordResetRequestCommand": "./src/shared/commands/authPasswordResetRequestCommand.js",
     "./shared/commands/authPasswordRecoveryCompleteCommand": "./src/shared/commands/authPasswordRecoveryCompleteCommand.js",
     "./shared/commands/authPasswordResetCommand": "./src/shared/commands/authPasswordResetCommand.js",

--- a/packages/auth-core/src/shared/authApi.js
+++ b/packages/auth-core/src/shared/authApi.js
@@ -35,6 +35,9 @@ function createApi({ request }) {
     oauthComplete(payload) {
       return request(AUTH_PATHS.OAUTH_COMPLETE, { method: "POST", body: payload });
     },
+    devLoginAs(payload) {
+      return request(AUTH_PATHS.DEV_LOGIN_AS, { method: "POST", body: payload });
+    },
     requestPasswordReset(payload) {
       return request(AUTH_PATHS.PASSWORD_FORGOT, { method: "POST", body: payload });
     },

--- a/packages/auth-core/src/shared/authPaths.js
+++ b/packages/auth-core/src/shared/authPaths.js
@@ -9,6 +9,7 @@ const AUTH_PATHS = Object.freeze({
   PASSWORD_FORGOT: "/api/password/forgot",
   PASSWORD_RECOVERY: "/api/password/recovery",
   PASSWORD_RESET: "/api/password/reset",
+  DEV_LOGIN_AS: "/api/dev-auth/login-as",
   LOGOUT: "/api/logout",
   SESSION: "/api/session"
 });

--- a/packages/auth-core/src/shared/commands/authCommandValidators.js
+++ b/packages/auth-core/src/shared/commands/authCommandValidators.js
@@ -162,6 +162,20 @@ const oauthCompleteResponseValidator = Object.freeze({
   )
 });
 
+const devLoginAsResponseValidator = Object.freeze({
+  schema: Type.Object(
+    {
+      ok: Type.Boolean(),
+      userId: Type.String({ minLength: 1 }),
+      username: Type.String({ minLength: 1, maxLength: 120 }),
+      email: authEmailValidator.schema
+    },
+    {
+      additionalProperties: false
+    }
+  )
+});
+
 const logoutResponseValidator = Object.freeze({
   schema: Type.Object(
     {
@@ -247,6 +261,7 @@ export {
   loginResponseValidator,
   otpVerifyResponseValidator,
   oauthCompleteResponseValidator,
+  devLoginAsResponseValidator,
   logoutResponseValidator,
   oauthProviderCatalogEntryValidator,
   sessionResponseValidator,

--- a/packages/auth-core/src/shared/commands/authDevLoginAsCommand.js
+++ b/packages/auth-core/src/shared/commands/authDevLoginAsCommand.js
@@ -1,0 +1,57 @@
+import { Type } from "typebox";
+import { recordIdInputSchema } from "@jskit-ai/kernel/shared/validators";
+import { normalizeObjectInput } from "../inputNormalization.js";
+import {
+  authEmailValidator,
+  createCommandMessages,
+  devLoginAsResponseValidator
+} from "./authCommandValidators.js";
+
+const AUTH_DEV_LOGIN_AS_MESSAGES = createCommandMessages({
+  fields: {
+    userId: {
+      pattern: "Provide a valid user id.",
+      default: "Provide a valid user id."
+    },
+    email: {
+      pattern: "Enter a valid email address.",
+      default: "Enter a valid email address."
+    }
+  },
+  defaultMessage: "Provide a valid user id or email."
+});
+
+const authDevLoginAsBodyValidator = Object.freeze({
+  schema: Type.Object(
+    {
+      userId: Type.Optional(recordIdInputSchema),
+      email: Type.Optional(authEmailValidator.schema)
+    },
+    {
+      additionalProperties: false,
+      anyOf: [{ required: ["userId"] }, { required: ["email"] }]
+    }
+  ),
+  normalize: normalizeObjectInput,
+  messages: {
+    ...AUTH_DEV_LOGIN_AS_MESSAGES,
+    keywords: {
+      ...AUTH_DEV_LOGIN_AS_MESSAGES.keywords,
+      anyOf: "Provide a user id or email."
+    }
+  }
+});
+
+const authDevLoginAsCommand = Object.freeze({
+  command: "auth.dev.loginAs",
+  operation: Object.freeze({
+    method: "POST",
+    bodyValidator: authDevLoginAsBodyValidator,
+    responseValidator: devLoginAsResponseValidator,
+    messages: AUTH_DEV_LOGIN_AS_MESSAGES,
+    idempotent: false,
+    invalidates: Object.freeze(["auth.session.read"])
+  })
+});
+
+export { AUTH_DEV_LOGIN_AS_MESSAGES, authDevLoginAsBodyValidator, authDevLoginAsCommand };

--- a/packages/auth-core/src/shared/commands/index.js
+++ b/packages/auth-core/src/shared/commands/index.js
@@ -5,6 +5,7 @@ export { authLoginOtpRequestCommand } from "./authLoginOtpRequestCommand.js";
 export { authLoginOtpVerifyCommand } from "./authLoginOtpVerifyCommand.js";
 export { authLoginOAuthStartCommand } from "./authLoginOAuthStartCommand.js";
 export { authLoginOAuthCompleteCommand } from "./authLoginOAuthCompleteCommand.js";
+export { authDevLoginAsCommand } from "./authDevLoginAsCommand.js";
 export { authPasswordResetRequestCommand } from "./authPasswordResetRequestCommand.js";
 export { authPasswordRecoveryCompleteCommand } from "./authPasswordRecoveryCompleteCommand.js";
 export { authPasswordResetCommand } from "./authPasswordResetCommand.js";

--- a/packages/auth-provider-supabase-core/src/server/lib/actions/auth.contributor.js
+++ b/packages/auth-provider-supabase-core/src/server/lib/actions/auth.contributor.js
@@ -9,6 +9,7 @@ import {
   authLoginOtpVerifyCommand,
   authLoginOAuthStartCommand,
   authLoginOAuthCompleteCommand,
+  authDevLoginAsCommand,
   authPasswordResetRequestCommand,
   authPasswordRecoveryCompleteCommand,
   authPasswordResetCommand
@@ -23,7 +24,24 @@ function requireRequestContext(context, actionId) {
   throw new Error(`${actionId} requires request context.`);
 }
 
-const authActions = Object.freeze([
+const devLoginAsAction = Object.freeze({
+  id: "auth.dev.loginAs",
+  version: 1,
+  kind: "command",
+  channels: ["api", "internal"],
+  surfacesFrom: "enabled",
+  inputValidator: authDevLoginAsCommand.operation.bodyValidator,
+  idempotency: "none",
+  audit: {
+    actionName: "auth.dev.loginAs"
+  },
+  observability: {},
+  async execute(input, context, deps) {
+    return deps.authService.devLoginAs(requireRequestContext(context, "auth.dev.loginAs"), input);
+  }
+});
+
+const authActionsBeforeDevLogin = Object.freeze([
   {
     id: "auth.register",
     version: 1,
@@ -135,7 +153,10 @@ const authActions = Object.freeze([
     async execute(input, _context, deps) {
       return deps.authService.oauthComplete(input);
     }
-  },
+  }
+]);
+
+const authActionsAfterDevLogin = Object.freeze([
   {
     id: "auth.password.reset.request",
     version: 1,
@@ -241,4 +262,21 @@ const authActions = Object.freeze([
   }
 ]);
 
-export { authActions };
+const baseAuthActions = Object.freeze([
+  ...authActionsBeforeDevLogin,
+  ...authActionsAfterDevLogin
+]);
+
+function buildAuthActions({ includeDevLoginAs = false } = {}) {
+  if (!includeDevLoginAs) {
+    return baseAuthActions;
+  }
+
+  return Object.freeze([
+    ...authActionsBeforeDevLogin,
+    devLoginAsAction,
+    ...authActionsAfterDevLogin
+  ]);
+}
+
+export { baseAuthActions, buildAuthActions, devLoginAsAction };

--- a/packages/auth-provider-supabase-core/src/server/lib/devAuthBootstrap.js
+++ b/packages/auth-provider-supabase-core/src/server/lib/devAuthBootstrap.js
@@ -1,0 +1,394 @@
+import { AppError } from "@jskit-ai/kernel/server/runtime/errors";
+import { normalizeRecordId } from "@jskit-ai/kernel/shared/support/normalize";
+import { normalizeEmail } from "@jskit-ai/auth-core/server/utils";
+import { loadJose, isExpiredJwtError } from "./authJwt.js";
+
+const DEV_AUTH_TOKEN_PREFIX = "jskit-dev.";
+const DEV_AUTH_ISSUER = "jskit:dev-auth";
+const DEFAULT_DEV_AUTH_ACCESS_TTL_SECONDS = 60 * 60 * 12;
+const DEFAULT_DEV_AUTH_REFRESH_TTL_SECONDS = 60 * 60 * 24 * 30;
+const encoder = new TextEncoder();
+
+function parseBoolean(value, fallback = false) {
+  const raw = String(value || "").trim().toLowerCase();
+  if (!raw) {
+    return fallback;
+  }
+  if (["1", "true", "yes", "on"].includes(raw)) {
+    return true;
+  }
+  if (["0", "false", "no", "off"].includes(raw)) {
+    return false;
+  }
+  return fallback;
+}
+
+function normalizePositiveInteger(value, fallback) {
+  const parsed = Number.parseInt(String(value || "").trim(), 10);
+  if (Number.isInteger(parsed) && parsed > 0) {
+    return parsed;
+  }
+  return fallback;
+}
+
+function normalizeRequestHostname(request) {
+  const hostHeader = String(request?.headers?.host || "").trim();
+  if (!hostHeader) {
+    return "";
+  }
+
+  const firstHost = hostHeader.split(",")[0]?.trim();
+  if (!firstHost) {
+    return "";
+  }
+
+  try {
+    return new URL(`http://${firstHost}`).hostname.trim().toLowerCase();
+  } catch {
+    return firstHost
+      .replace(/^\[/, "")
+      .replace(/\]$/, "")
+      .split(":")[0]
+      .trim()
+      .toLowerCase();
+  }
+}
+
+function resolveDirectRemoteAddress(request) {
+  return String(request?.socket?.remoteAddress || request?.raw?.socket?.remoteAddress || "").trim();
+}
+
+function normalizeLoopbackIp(value) {
+  return String(value || "")
+    .trim()
+    .toLowerCase()
+    .replace(/^\[|\]$/g, "")
+    .replace(/^::ffff:/, "");
+}
+
+function isLoopbackIp(value) {
+  const normalized = normalizeLoopbackIp(value);
+  return normalized === "::1" || normalized === "127.0.0.1" || normalized.startsWith("127.");
+}
+
+function isLoopbackHostname(value) {
+  const normalized = String(value || "")
+    .trim()
+    .toLowerCase()
+    .replace(/^\[|\]$/g, "");
+  return (
+    normalized === "localhost" ||
+    normalized.endsWith(".localhost") ||
+    normalized === "::1" ||
+    normalized === "127.0.0.1"
+  );
+}
+
+function isLocalDevAuthRequest(request) {
+  return (
+    isLoopbackIp(resolveDirectRemoteAddress(request)) &&
+    isLoopbackHostname(normalizeRequestHostname(request))
+  );
+}
+
+function isDevAuthToken(token) {
+  return String(token || "").trim().startsWith(DEV_AUTH_TOKEN_PREFIX);
+}
+
+function stripDevAuthTokenPrefix(token) {
+  return String(token || "").trim().slice(DEV_AUTH_TOKEN_PREFIX.length);
+}
+
+function resolveDevAuthConfig({
+  enabled = false,
+  secret = "",
+  nodeEnv = "development",
+  jwtAudience = "authenticated",
+  accessTtlSeconds = DEFAULT_DEV_AUTH_ACCESS_TTL_SECONDS,
+  refreshTtlSeconds = DEFAULT_DEV_AUTH_REFRESH_TTL_SECONDS
+} = {}) {
+  return Object.freeze({
+    enabled: parseBoolean(enabled, false),
+    secret: String(secret || "").trim(),
+    isProduction: String(nodeEnv || "development").trim().toLowerCase() === "production",
+    jwtAudience: String(jwtAudience || "authenticated").trim() || "authenticated",
+    accessTtlSeconds: normalizePositiveInteger(accessTtlSeconds, DEFAULT_DEV_AUTH_ACCESS_TTL_SECONDS),
+    refreshTtlSeconds: normalizePositiveInteger(refreshTtlSeconds, DEFAULT_DEV_AUTH_REFRESH_TTL_SECONDS)
+  });
+}
+
+function assertDevAuthBootstrapConfig(config, { usersRepository = null } = {}) {
+  if (!config?.enabled) {
+    return;
+  }
+
+  if (config.isProduction) {
+    throw new Error("AUTH_DEV_BYPASS_ENABLED must not be enabled in production.");
+  }
+  if (!config.secret) {
+    throw new Error("AUTH_DEV_BYPASS_SECRET is required when AUTH_DEV_BYPASS_ENABLED=true.");
+  }
+  if (!usersRepository || typeof usersRepository.findById !== "function" || typeof usersRepository.findByEmail !== "function") {
+    throw new Error(
+      "Dev auth bootstrap requires usersRepository with findById() and findByEmail() when AUTH_DEV_BYPASS_ENABLED=true."
+    );
+  }
+}
+
+function ensureDevAuthBootstrapAvailable(config, request) {
+  if (!config?.enabled || config?.isProduction) {
+    throw new AppError(404, "Not found.");
+  }
+  if (!config.secret) {
+    throw new AppError(500, "AUTH_DEV_BYPASS_SECRET is required when AUTH_DEV_BYPASS_ENABLED=true.");
+  }
+  if (!isLocalDevAuthRequest(request)) {
+    throw new AppError(403, "Dev auth bootstrap is only available from localhost.");
+  }
+}
+
+function buildProfileFromTokenClaims(payload) {
+  const id = normalizeRecordId(payload?.sub, { fallback: null });
+  const email = normalizeEmail(payload?.email || "");
+  if (!id || !email) {
+    return null;
+  }
+
+  const displayName = String(payload?.displayName || "").trim();
+  const username = String(payload?.username || "")
+    .trim()
+    .toLowerCase();
+  const authProvider = String(payload?.authProvider || "dev")
+    .trim()
+    .toLowerCase();
+  const authProviderUserSid = String(payload?.authProviderUserSid || payload?.sub || "").trim();
+
+  return {
+    id,
+    email,
+    username,
+    displayName: displayName || email || `User ${id}`,
+    authProvider,
+    authProviderUserSid,
+    avatarStorageKey: null,
+    avatarVersion: null
+  };
+}
+
+async function resolveProfileFromTokenClaims(payload, { usersRepository = null } = {}) {
+  const userId = normalizeRecordId(payload?.sub, { fallback: null });
+  if (userId && usersRepository && typeof usersRepository.findById === "function") {
+    const latest = await usersRepository.findById(userId);
+    if (latest?.id) {
+      return latest;
+    }
+  }
+
+  const profile = buildProfileFromTokenClaims(payload);
+  if (profile) {
+    return profile;
+  }
+
+  throw new AppError(401, "Dev session is invalid.");
+}
+
+async function signDevAuthToken(kind, profile, config) {
+  const jose = await loadJose();
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const ttlSeconds = kind === "refresh" ? config.refreshTtlSeconds : config.accessTtlSeconds;
+  const token = await new jose.SignJWT({
+    kind,
+    email: String(profile?.email || "").trim().toLowerCase(),
+    displayName: String(profile?.displayName || "").trim(),
+    username: String(profile?.username || "")
+      .trim()
+      .toLowerCase(),
+    authProvider: String(profile?.authProvider || "dev")
+      .trim()
+      .toLowerCase(),
+    authProviderUserSid: String(profile?.authProviderUserSid || profile?.id || "").trim()
+  })
+    .setProtectedHeader({ alg: "HS256", typ: "JWT" })
+    .setIssuer(DEV_AUTH_ISSUER)
+    .setAudience(config.jwtAudience)
+    .setSubject(String(profile?.id || "").trim())
+    .setIssuedAt(nowSeconds)
+    .setExpirationTime(nowSeconds + ttlSeconds)
+    .sign(encoder.encode(config.secret));
+
+  return `${DEV_AUTH_TOKEN_PREFIX}${token}`;
+}
+
+async function verifyDevAuthToken(token, kind, config) {
+  if (!isDevAuthToken(token) || !config?.secret) {
+    return {
+      status: "invalid",
+      payload: null
+    };
+  }
+
+  const jose = await loadJose();
+  try {
+    const { payload } = await jose.jwtVerify(stripDevAuthTokenPrefix(token), encoder.encode(config.secret), {
+      issuer: DEV_AUTH_ISSUER,
+      audience: config.jwtAudience
+    });
+
+    if (String(payload?.kind || "").trim() !== kind) {
+      return {
+        status: "invalid",
+        payload: null
+      };
+    }
+
+    return {
+      status: "valid",
+      payload
+    };
+  } catch (error) {
+    if (isExpiredJwtError(error)) {
+      return {
+        status: "expired",
+        payload: null
+      };
+    }
+
+    return {
+      status: "invalid",
+      payload: null
+    };
+  }
+}
+
+async function createDevAuthSession(profile, config) {
+  return {
+    access_token: await signDevAuthToken("access", profile, config),
+    refresh_token: await signDevAuthToken("refresh", profile, config),
+    expires_in: config.accessTtlSeconds,
+    token_type: "bearer"
+  };
+}
+
+async function resolveDevAuthProfile(input = {}, { usersRepository = null, validationError } = {}) {
+  if (!usersRepository || typeof usersRepository.findById !== "function") {
+    throw new AppError(500, "Dev auth bootstrap requires usersRepository.findById().");
+  }
+
+  const normalizedUserId = normalizeRecordId(input?.userId, { fallback: null });
+  const normalizedEmail = normalizeEmail(input?.email || "");
+  if (!normalizedUserId && !normalizedEmail) {
+    throw validationError({
+      userId: "Provide a user id or email.",
+      email: "Provide a user id or email."
+    });
+  }
+
+  const fieldErrors = {};
+
+  if (normalizedUserId) {
+    const byId = await usersRepository.findById(normalizedUserId);
+    if (byId?.id) {
+      return byId;
+    }
+    fieldErrors.userId = "User not found.";
+  }
+
+  if (normalizedEmail) {
+    if (typeof usersRepository.findByEmail !== "function") {
+      throw new AppError(500, "Dev auth bootstrap requires usersRepository.findByEmail() for email lookup.");
+    }
+
+    const byEmail = await usersRepository.findByEmail(normalizedEmail);
+    if (byEmail?.id) {
+      return byEmail;
+    }
+    fieldErrors.email = "User not found.";
+  }
+
+  throw validationError(fieldErrors);
+}
+
+async function authenticateDevAuthRequest(
+  { request, accessToken = "", refreshToken = "" },
+  { config, usersRepository = null } = {}
+) {
+  const hasDevAccessToken = isDevAuthToken(accessToken);
+  const hasDevRefreshToken = isDevAuthToken(refreshToken);
+  if (!hasDevAccessToken && !hasDevRefreshToken) {
+    return null;
+  }
+
+  if (!config?.enabled || config?.isProduction || !config?.secret || !isLocalDevAuthRequest(request)) {
+    return {
+      authenticated: false,
+      clearSession: true,
+      session: null,
+      transientFailure: false
+    };
+  }
+
+  if (hasDevAccessToken) {
+    const accessVerification = await verifyDevAuthToken(accessToken, "access", config);
+    if (accessVerification.status === "valid") {
+      const profile = await resolveProfileFromTokenClaims(accessVerification.payload, {
+        usersRepository
+      });
+      return {
+        authenticated: true,
+        profile,
+        clearSession: false,
+        session: null,
+        transientFailure: false
+      };
+    }
+
+    if (accessVerification.status === "invalid" && !hasDevRefreshToken) {
+      return {
+        authenticated: false,
+        clearSession: true,
+        session: null,
+        transientFailure: false
+      };
+    }
+  }
+
+  if (!hasDevRefreshToken) {
+    return {
+      authenticated: false,
+      clearSession: true,
+      session: null,
+      transientFailure: false
+    };
+  }
+
+  const refreshVerification = await verifyDevAuthToken(refreshToken, "refresh", config);
+  if (refreshVerification.status !== "valid") {
+    return {
+      authenticated: false,
+      clearSession: true,
+      session: null,
+      transientFailure: false
+    };
+  }
+
+  const profile = await resolveProfileFromTokenClaims(refreshVerification.payload, {
+    usersRepository
+  });
+  return {
+    authenticated: true,
+    profile,
+    clearSession: false,
+    session: await createDevAuthSession(profile, config),
+    transientFailure: false
+  };
+}
+
+export {
+  assertDevAuthBootstrapConfig,
+  authenticateDevAuthRequest,
+  createDevAuthSession,
+  ensureDevAuthBootstrapAvailable,
+  isDevAuthToken,
+  resolveDevAuthConfig,
+  resolveDevAuthProfile
+};

--- a/packages/auth-provider-supabase-core/src/server/lib/index.js
+++ b/packages/auth-provider-supabase-core/src/server/lib/index.js
@@ -1,2 +1,2 @@
 export { createService, __testables } from "./service.js";
-export { authActions } from "./actions/auth.contributor.js";
+export { baseAuthActions, buildAuthActions, devLoginAsAction } from "./actions/auth.contributor.js";

--- a/packages/auth-provider-supabase-core/src/server/lib/service.js
+++ b/packages/auth-provider-supabase-core/src/server/lib/service.js
@@ -55,6 +55,14 @@ import { createOauthFlows } from "./oauthFlows.js";
 import { createPasswordSecurityFlows } from "./passwordSecurityFlows.js";
 import { USER_PROFILE_EMAIL_CONFLICT_CODE } from "./standaloneProfileSyncService.js";
 import {
+  assertDevAuthBootstrapConfig,
+  authenticateDevAuthRequest,
+  createDevAuthSession,
+  ensureDevAuthBootstrapAvailable,
+  resolveDevAuthConfig,
+  resolveDevAuthProfile
+} from "./devAuthBootstrap.js";
+import {
   buildOAuthProviderCatalogResponse,
   resolveOAuthProviderQueryParams,
   resolveSupabaseOAuthProviderCatalog
@@ -103,6 +111,7 @@ function createService(options) {
   const supabaseUrl = String(authProvider.supabaseUrl || "").trim();
   const supabasePublishableKey = String(authProvider.supabasePublishableKey || "").trim();
   const userSettingsRepository = options.userSettingsRepository || null;
+  const usersRepository = options.usersRepository || null;
   const userProfileSyncService = options.userProfileSyncService;
   if (
     !userProfileSyncService ||
@@ -113,6 +122,17 @@ function createService(options) {
   }
   const isProduction = options.nodeEnv === "production";
   const jwtAudience = String(authProvider.jwtAudience || DEFAULT_AUDIENCE).trim();
+  const devAuthConfig = resolveDevAuthConfig({
+    enabled: options.devAuthBypassEnabled,
+    secret: options.devAuthBypassSecret,
+    nodeEnv: options.nodeEnv,
+    jwtAudience,
+    accessTtlSeconds: options.devAuthAccessTtlSeconds,
+    refreshTtlSeconds: options.devAuthRefreshTtlSeconds
+  });
+  assertDevAuthBootstrapConfig(devAuthConfig, {
+    usersRepository
+  });
   const settingsProfileAuthInfo = Object.freeze({
     emailManagedBy: normalizeAuthProviderId(authProvider.emailManagedBy || authProviderId, { fallback: authProviderId }),
     emailChangeFlow: normalizeAuthProviderId(authProvider.emailChangeFlow || authProviderId, { fallback: authProviderId })
@@ -651,11 +671,24 @@ function createService(options) {
   });
 
   async function authenticateRequest(request) {
-    ensureConfigured();
-
     const cookies = safeRequestCookies(request);
     const accessToken = String(cookies[ACCESS_TOKEN_COOKIE] || "");
     const refreshToken = String(cookies[REFRESH_TOKEN_COOKIE] || "");
+
+    const devAuthResult = await authenticateDevAuthRequest(
+      {
+        request,
+        accessToken,
+        refreshToken
+      },
+      {
+        config: devAuthConfig,
+        usersRepository
+      }
+    );
+    if (devAuthResult) {
+      return devAuthResult;
+    }
 
     if (!accessToken && !refreshToken) {
       return {
@@ -665,6 +698,8 @@ function createService(options) {
         transientFailure: false
       };
     }
+
+    ensureConfigured();
 
     if (accessToken) {
       const verification = await verifyAccessToken(accessToken);
@@ -796,6 +831,22 @@ function createService(options) {
     return authOAuthCatalogResponse;
   }
 
+  function isDevAuthBootstrapEnabled() {
+    return devAuthConfig.enabled === true;
+  }
+
+  async function devLoginAs(request, input = {}) {
+    ensureDevAuthBootstrapAvailable(devAuthConfig, request);
+    const profile = await resolveDevAuthProfile(input, {
+      usersRepository,
+      validationError
+    });
+    return {
+      profile,
+      session: await createDevAuthSession(profile, devAuthConfig)
+    };
+  }
+
   return {
     register,
     resendRegisterConfirmation,
@@ -816,6 +867,8 @@ function createService(options) {
     getSecurityStatus,
     getSettingsProfileAuthInfo,
     getOAuthProviderCatalog,
+    isDevAuthBootstrapEnabled,
+    devLoginAs,
     authenticateRequest,
     hasAccessTokenCookie,
     hasSessionCookie,

--- a/packages/auth-provider-supabase-core/src/server/providers/AuthSupabaseServiceProvider.js
+++ b/packages/auth-provider-supabase-core/src/server/providers/AuthSupabaseServiceProvider.js
@@ -4,7 +4,7 @@ import { normalizeRecordId } from "@jskit-ai/kernel/shared/support/normalize";
 import { createService } from "../lib/service.js";
 import { createStandaloneProfileSyncService } from "../lib/standaloneProfileSyncService.js";
 import { createAuthSessionEventsService } from "../lib/authSessionEventsService.js";
-import { authActions } from "../lib/actions/auth.contributor.js";
+import { buildAuthActions } from "../lib/actions/auth.contributor.js";
 const AUTH_PROFILE_MODE_STANDALONE = "standalone";
 const AUTH_PROFILE_MODE_USERS = "users";
 const SUPPORTED_AUTH_PROFILE_MODES = Object.freeze([AUTH_PROFILE_MODE_STANDALONE, AUTH_PROFILE_MODE_USERS]);
@@ -14,6 +14,20 @@ function splitCsv(value) {
     .split(",")
     .map((entry) => entry.trim())
     .filter(Boolean);
+}
+
+function parseBoolean(value, fallback = false) {
+  const raw = String(value || "").trim().toLowerCase();
+  if (!raw) {
+    return fallback;
+  }
+  if (["1", "true", "yes", "on"].includes(raw)) {
+    return true;
+  }
+  if (["0", "false", "no", "off"].includes(raw)) {
+    return false;
+  }
+  return fallback;
 }
 
 function normalizeRecord(value) {
@@ -88,6 +102,18 @@ function resolveAuthProfileMode(env) {
   );
 }
 
+function isDevAuthBypassEnabledForRegistration(env) {
+  if (!isDevAuthBypassRequested(env)) {
+    return false;
+  }
+
+  return String(env?.NODE_ENV || "development").trim().toLowerCase() !== "production";
+}
+
+function isDevAuthBypassRequested(env) {
+  return parseBoolean(env?.AUTH_DEV_BYPASS_ENABLED, false);
+}
+
 function createInMemoryUserSettingsRepository() {
   const settingsByUserId = new Map();
 
@@ -137,10 +163,24 @@ function resolveCommonDependencies(scope) {
   return dependencies;
 }
 
+function resolveRuntimeEnv(scope) {
+  const dependencies = resolveCommonDependencies(scope);
+  const envFromDependencies =
+    dependencies?.env && typeof dependencies.env === "object" ? dependencies.env : {};
+
+  return {
+    ...process.env,
+    ...envFromDependencies
+  };
+}
+
 function resolveOptionalRepositories(scope) {
   const repositories = {};
   if (scope.has("userSettingsRepository")) {
     repositories.userSettingsRepository = scope.make("userSettingsRepository");
+  }
+  if (scope.has("usersRepository")) {
+    repositories.usersRepository = scope.make("usersRepository");
   }
   return repositories;
 }
@@ -163,19 +203,16 @@ class AuthSupabaseServiceProvider {
 
     if (!app.has("authService")) {
       app.singleton("authService", (scope) => {
-        const dependencies = resolveCommonDependencies(scope);
-        const envFromDependencies =
-          dependencies?.env && typeof dependencies.env === "object" ? dependencies.env : {};
-        const env = {
-          ...process.env,
-          ...envFromDependencies
-        };
+        const env = resolveRuntimeEnv(scope);
         const appConfig = scope.has("appConfig") ? scope.make("appConfig") : {};
         const authProvider = resolveAuthProviderConfig(env, appConfig);
         const repositories = resolveOptionalRepositories(scope);
         const userSettingsRepository = repositories.userSettingsRepository || fallbackUserSettingsRepository;
+        const devAuthBypassEnabled = parseBoolean(env.AUTH_DEV_BYPASS_ENABLED, false);
         if (!authProvider.supabaseUrl || !authProvider.supabasePublishableKey) {
-          return null;
+          if (!devAuthBypassEnabled) {
+            return null;
+          }
         }
         const authProfileMode = resolveAuthProfileMode(env);
         let userProfileSyncService = fallbackStandaloneProfileSyncService;
@@ -197,7 +234,12 @@ class AuthSupabaseServiceProvider {
           }),
           nodeEnv: String(env.NODE_ENV || "development").trim() || "development",
           userSettingsRepository,
-          userProfileSyncService
+          userProfileSyncService,
+          usersRepository: repositories.usersRepository || null,
+          devAuthBypassEnabled,
+          devAuthBypassSecret: String(env.AUTH_DEV_BYPASS_SECRET || "").trim(),
+          devAuthAccessTtlSeconds: env.AUTH_DEV_ACCESS_TTL_SECONDS,
+          devAuthRefreshTtlSeconds: env.AUTH_DEV_REFRESH_TTL_SECONDS
         });
       });
     }
@@ -236,7 +278,9 @@ class AuthSupabaseServiceProvider {
     );
 
     app.actions(
-      withActionDefaults(authActions, {
+      withActionDefaults(buildAuthActions({
+        includeDevLoginAs: isDevAuthBypassEnabledForRegistration(resolveRuntimeEnv(app))
+      }), {
         domain: "auth",
         dependencies: {
           authService: "authService",
@@ -244,6 +288,18 @@ class AuthSupabaseServiceProvider {
         }
       })
     );
+  }
+
+  boot(app) {
+    if (!app || typeof app.make !== "function") {
+      throw new Error("AuthSupabaseServiceProvider requires application make().");
+    }
+
+    if (!isDevAuthBypassRequested(resolveRuntimeEnv(app))) {
+      return;
+    }
+
+    app.make("authService");
   }
 }
 

--- a/packages/auth-provider-supabase-core/test/devAuthBootstrap.test.js
+++ b/packages/auth-provider-supabase-core/test/devAuthBootstrap.test.js
@@ -1,0 +1,182 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createService } from "../src/server/lib/index.js";
+
+function createProfile(overrides = {}) {
+  return {
+    id: "7",
+    email: "ada@example.com",
+    username: "ada",
+    displayName: "Ada Example",
+    authProvider: "supabase",
+    authProviderUserSid: "supabase-user-7",
+    avatarStorageKey: null,
+    avatarVersion: null,
+    ...overrides
+  };
+}
+
+function createUsersRepository(profile = createProfile()) {
+  return {
+    async findById(userId) {
+      return String(userId || "") === String(profile.id) ? profile : null;
+    },
+    async findByEmail(email) {
+      return String(email || "").trim().toLowerCase() === String(profile.email || "").toLowerCase() ? profile : null;
+    }
+  };
+}
+
+function createUserProfileSyncService() {
+  return {
+    async findByIdentity() {
+      return null;
+    },
+    async syncIdentityProfile(profile) {
+      return createProfile({
+        authProvider: String(profile?.authProvider || "supabase"),
+        authProviderUserSid: String(profile?.authProviderUserSid || "supabase-user-7"),
+        email: String(profile?.email || "ada@example.com").toLowerCase(),
+        displayName: String(profile?.displayName || "Ada Example")
+      });
+    }
+  };
+}
+
+function createLocalRequest(overrides = {}) {
+  const remoteAddress = String(overrides?.socket?.remoteAddress || overrides?.raw?.socket?.remoteAddress || "127.0.0.1");
+  return {
+    ip: "127.0.0.1",
+    hostname: "localhost",
+    headers: {
+      host: "localhost:3000"
+    },
+    cookies: {},
+    socket: {
+      remoteAddress
+    },
+    raw: {
+      socket: {
+        remoteAddress
+      }
+    },
+    ...overrides
+  };
+}
+
+function createServiceFixture(overrides = {}) {
+  return createService({
+    authProvider: {
+      id: "supabase",
+      supabaseUrl: "",
+      supabasePublishableKey: "",
+      jwtAudience: "authenticated"
+    },
+    appPublicUrl: "http://localhost:5173",
+    nodeEnv: "development",
+    devAuthBypassEnabled: true,
+    devAuthBypassSecret: "dev-bootstrap-secret",
+    usersRepository: createUsersRepository(),
+    userProfileSyncService: createUserProfileSyncService(),
+    ...overrides
+  });
+}
+
+test("dev auth bootstrap can issue and authenticate a local session without Supabase", async () => {
+  const authService = createServiceFixture();
+  const loginRequest = createLocalRequest();
+
+  const loginResult = await authService.devLoginAs(loginRequest, {
+    userId: "7"
+  });
+
+  assert.equal(loginResult.profile.id, "7");
+  assert.match(loginResult.session.access_token, /^jskit-dev\./);
+  assert.match(loginResult.session.refresh_token, /^jskit-dev\./);
+
+  const authResult = await authService.authenticateRequest(
+    createLocalRequest({
+      cookies: {
+        sb_access_token: loginResult.session.access_token,
+        sb_refresh_token: loginResult.session.refresh_token
+      }
+    })
+  );
+
+  assert.equal(authResult.authenticated, true);
+  assert.equal(authResult.profile.id, "7");
+  assert.equal(authResult.profile.email, "ada@example.com");
+  assert.equal(authResult.session, null);
+});
+
+test("dev auth bootstrap supports email lookup", async () => {
+  const authService = createServiceFixture();
+
+  const result = await authService.devLoginAs(createLocalRequest(), {
+    email: "ADA@EXAMPLE.COM"
+  });
+
+  assert.equal(result.profile.id, "7");
+  assert.equal(result.profile.email, "ada@example.com");
+});
+
+test("dev auth bootstrap rejects non-local requests and clears leaked dev sessions", async () => {
+  const authService = createServiceFixture();
+  const issued = await authService.devLoginAs(createLocalRequest(), {
+    userId: "7"
+  });
+
+  await assert.rejects(
+    () =>
+      authService.devLoginAs(
+        createLocalRequest({
+          ip: "203.0.113.10",
+          hostname: "example.com",
+          headers: { host: "example.com" }
+        }),
+        { userId: "7" }
+      ),
+    /localhost/
+  );
+
+  const authResult = await authService.authenticateRequest({
+    ip: "203.0.113.10",
+    hostname: "example.com",
+    headers: { host: "example.com" },
+    cookies: {
+      sb_access_token: issued.session.access_token,
+      sb_refresh_token: issued.session.refresh_token
+    }
+  });
+
+  assert.equal(authResult.authenticated, false);
+  assert.equal(authResult.clearSession, true);
+});
+
+test("dev auth bootstrap does not trust forwarded localhost headers", async () => {
+  const authService = createServiceFixture();
+
+  await assert.rejects(
+    () =>
+      authService.devLoginAs(
+        createLocalRequest({
+          ip: "203.0.113.10",
+          socket: {
+            remoteAddress: "203.0.113.10"
+          },
+          raw: {
+            socket: {
+              remoteAddress: "203.0.113.10"
+            }
+          },
+          headers: {
+            host: "localhost:3000",
+            "x-forwarded-for": "127.0.0.1",
+            "x-forwarded-host": "localhost"
+          }
+        }),
+        { userId: "7" }
+      ),
+    /localhost/
+  );
+});

--- a/packages/auth-provider-supabase-core/test/providerRuntime.test.js
+++ b/packages/auth-provider-supabase-core/test/providerRuntime.test.js
@@ -21,6 +21,14 @@ function createAppConfigFixture() {
   };
 }
 
+function isBootFailureWithCause(error, pattern) {
+  return (
+    error instanceof Error &&
+    /failed during boot\(\)/.test(String(error.message || "")) &&
+    pattern.test(String(error.details?.cause?.message || ""))
+  );
+}
+
 test("auth supabase provider registers authService and contributes auth actions in users mode", async () => {
   const app = createApplication();
   app.instance("appConfig", createAppConfigFixture());
@@ -69,6 +77,7 @@ test("auth supabase provider registers authService and contributes auth actions 
   assert.equal(Array.isArray(definitions), true);
   assert.equal(definitions.some((definition) => definition.id === "auth.login.password"), true);
   assert.equal(definitions.some((definition) => definition.id === "auth.register.confirmation.resend"), true);
+  assert.equal(definitions.some((definition) => definition.id === "auth.dev.loginAs"), false);
   const sessionRead = definitions.find((definition) => definition.id === "auth.session.read");
   assert.deepEqual(sessionRead?.surfaces, ["home", "console"]);
 });
@@ -153,6 +162,206 @@ test("auth supabase provider rejects unsupported AUTH_PROFILE_MODE values", asyn
   });
 
   assert.throws(() => app.make("authService"), /Unsupported AUTH_PROFILE_MODE/);
+});
+
+test("auth supabase provider can boot dev auth without Supabase credentials", async () => {
+  const app = createApplication();
+  app.instance("appConfig", createAppConfigFixture());
+  app.instance("jskit.env", {
+    AUTH_DEV_BYPASS_ENABLED: "true",
+    AUTH_DEV_BYPASS_SECRET: "dev-bootstrap-secret",
+    AUTH_PROFILE_MODE: "users",
+    APP_PUBLIC_URL: "http://localhost:5173",
+    NODE_ENV: "development"
+  });
+  app.instance("jskit.logger", {
+    info() {},
+    warn() {},
+    error() {},
+    debug() {}
+  });
+  app.instance("domainEvents", {
+    async publish() {}
+  });
+  app.instance("users.profile.sync.service", {
+    async findByIdentity() {
+      return null;
+    },
+    async syncIdentityProfile(profile) {
+      return {
+        id: 1,
+        authProvider: String(profile?.authProvider || "supabase"),
+        authProviderUserSid: String(profile?.authProviderUserSid || "user-1"),
+        email: String(profile?.email || "test@example.com"),
+        displayName: String(profile?.displayName || "Test User")
+      };
+    }
+  });
+  app.instance("usersRepository", {
+    async findById() {
+      return null;
+    },
+    async findByEmail() {
+      return null;
+    }
+  });
+
+  await app.start({
+    providers: [ActionRuntimeServiceProvider, AuthSupabaseServiceProvider]
+  });
+
+  const authService = app.make("authService");
+  assert.equal(typeof authService?.devLoginAs, "function");
+  assert.equal(typeof authService?.isDevAuthBootstrapEnabled, "function");
+  assert.equal(authService.isDevAuthBootstrapEnabled(), true);
+
+  const actionExecutor = app.make("actionExecutor");
+  const definitions = actionExecutor.listDefinitions();
+  assert.equal(definitions.some((definition) => definition.id === "auth.dev.loginAs"), true);
+});
+
+test("auth supabase provider rejects dev auth bypass in production", async () => {
+  const app = createApplication();
+  app.instance("appConfig", createAppConfigFixture());
+  app.instance("jskit.env", {
+    AUTH_DEV_BYPASS_ENABLED: "true",
+    AUTH_DEV_BYPASS_SECRET: "dev-bootstrap-secret",
+    AUTH_PROFILE_MODE: "users",
+    APP_PUBLIC_URL: "https://example.com",
+    NODE_ENV: "production"
+  });
+  app.instance("jskit.logger", {
+    info() {},
+    warn() {},
+    error() {},
+    debug() {}
+  });
+  app.instance("domainEvents", {
+    async publish() {}
+  });
+  app.instance("users.profile.sync.service", {
+    async findByIdentity() {
+      return null;
+    },
+    async syncIdentityProfile(profile) {
+      return {
+        id: 1,
+        authProvider: String(profile?.authProvider || "supabase"),
+        authProviderUserSid: String(profile?.authProviderUserSid || "user-1"),
+        email: String(profile?.email || "test@example.com"),
+        displayName: String(profile?.displayName || "Test User")
+      };
+    }
+  });
+  app.instance("usersRepository", {
+    async findById() {
+      return null;
+    },
+    async findByEmail() {
+      return null;
+    }
+  });
+
+  await assert.rejects(
+    () =>
+      app.start({
+        providers: [ActionRuntimeServiceProvider, AuthSupabaseServiceProvider]
+      }),
+    (error) => isBootFailureWithCause(error, /must not be enabled in production/)
+  );
+});
+
+test("auth supabase provider rejects dev auth bypass without a secret during boot", async () => {
+  const app = createApplication();
+  app.instance("appConfig", createAppConfigFixture());
+  app.instance("jskit.env", {
+    AUTH_DEV_BYPASS_ENABLED: "true",
+    AUTH_PROFILE_MODE: "users",
+    APP_PUBLIC_URL: "http://localhost:5173",
+    NODE_ENV: "development"
+  });
+  app.instance("jskit.logger", {
+    info() {},
+    warn() {},
+    error() {},
+    debug() {}
+  });
+  app.instance("domainEvents", {
+    async publish() {}
+  });
+  app.instance("users.profile.sync.service", {
+    async findByIdentity() {
+      return null;
+    },
+    async syncIdentityProfile(profile) {
+      return {
+        id: 1,
+        authProvider: String(profile?.authProvider || "supabase"),
+        authProviderUserSid: String(profile?.authProviderUserSid || "user-1"),
+        email: String(profile?.email || "test@example.com"),
+        displayName: String(profile?.displayName || "Test User")
+      };
+    }
+  });
+  app.instance("usersRepository", {
+    async findById() {
+      return null;
+    },
+    async findByEmail() {
+      return null;
+    }
+  });
+
+  await assert.rejects(
+    () =>
+      app.start({
+        providers: [ActionRuntimeServiceProvider, AuthSupabaseServiceProvider]
+      }),
+    (error) => isBootFailureWithCause(error, /AUTH_DEV_BYPASS_SECRET is required/)
+  );
+});
+
+test("auth supabase provider rejects dev auth bypass without usersRepository during boot", async () => {
+  const app = createApplication();
+  app.instance("appConfig", createAppConfigFixture());
+  app.instance("jskit.env", {
+    AUTH_DEV_BYPASS_ENABLED: "true",
+    AUTH_DEV_BYPASS_SECRET: "dev-bootstrap-secret",
+    AUTH_PROFILE_MODE: "users",
+    APP_PUBLIC_URL: "http://localhost:5173",
+    NODE_ENV: "development"
+  });
+  app.instance("jskit.logger", {
+    info() {},
+    warn() {},
+    error() {},
+    debug() {}
+  });
+  app.instance("domainEvents", {
+    async publish() {}
+  });
+  app.instance("users.profile.sync.service", {
+    async findByIdentity() {
+      return null;
+    },
+    async syncIdentityProfile(profile) {
+      return {
+        id: 1,
+        authProvider: String(profile?.authProvider || "supabase"),
+        authProviderUserSid: String(profile?.authProviderUserSid || "user-1"),
+        email: String(profile?.email || "test@example.com"),
+        displayName: String(profile?.displayName || "Test User")
+      };
+    }
+  });
+
+  await assert.rejects(
+    () =>
+      app.start({
+        providers: [ActionRuntimeServiceProvider, AuthSupabaseServiceProvider]
+      }),
+    (error) => isBootFailureWithCause(error, /requires usersRepository with findById\(\) and findByEmail\(\)/)
+  );
 });
 
 test("auth supabase provider reads oauth providers from appConfig.auth.oauth", async () => {

--- a/packages/auth-web/src/server/constants/authActionIds.js
+++ b/packages/auth-web/src/server/constants/authActionIds.js
@@ -6,6 +6,7 @@ const AUTH_ACTION_IDS = Object.freeze({
   LOGIN_OTP_VERIFY: "auth.login.otp.verify",
   LOGIN_OAUTH_START: "auth.login.oauth.start",
   LOGIN_OAUTH_COMPLETE: "auth.login.oauth.complete",
+  DEV_LOGIN_AS: "auth.dev.loginAs",
   LOGOUT: "auth.logout",
   SESSION_READ: "auth.session.read",
   PASSWORD_RESET_REQUEST: "auth.password.reset.request",

--- a/packages/auth-web/src/server/controllers/AuthController.js
+++ b/packages/auth-web/src/server/controllers/AuthController.js
@@ -91,6 +91,18 @@ class AuthController {
     });
   }
 
+  async devLoginAs(request, reply) {
+    const payload = request.body || {};
+    const result = await this.service.devLoginAs(request, payload);
+    this.service.writeSessionCookies(reply, result.session);
+    reply.code(200).send({
+      ok: true,
+      userId: result.profile.id,
+      username: result.profile.displayName,
+      email: result.profile.email
+    });
+  }
+
   async logout(request, reply) {
     let clearSession = true;
     try {

--- a/packages/auth-web/src/server/providers/AuthRouteServiceProvider.js
+++ b/packages/auth-web/src/server/providers/AuthRouteServiceProvider.js
@@ -20,7 +20,10 @@ class AuthRouteServiceProvider {
     const router = app.make("jskit.http.router");
     const authWebService = app.make("auth.web.service");
     const controller = new AuthController({ service: authWebService });
-    const routes = buildRoutes(controller);
+    const routes = buildRoutes(controller, {
+      includeDevLoginAs:
+        typeof authWebService?.isDevLoginAsAvailable === "function" ? authWebService.isDevLoginAsAvailable() : false
+    });
     for (const route of routes) {
       router.register(route.method, route.path, route, route.handler);
     }

--- a/packages/auth-web/src/server/routes/authRoutes.js
+++ b/packages/auth-web/src/server/routes/authRoutes.js
@@ -7,6 +7,7 @@ import {
   authLoginOtpVerifyCommand,
   authLoginOAuthStartCommand,
   authLoginOAuthCompleteCommand,
+  authDevLoginAsCommand,
   authPasswordResetRequestCommand,
   authPasswordRecoveryCompleteCommand,
   authPasswordResetCommand,
@@ -15,7 +16,7 @@ import {
 } from "@jskit-ai/auth-core/shared/commands";
 import { AUTH_PATHS } from "@jskit-ai/auth-core/shared/authPaths";
 
-function buildRoutes(controller) {
+function buildRoutes(controller, { includeDevLoginAs = false } = {}) {
   if (!controller) {
     throw new Error("Auth routes require a controller instance.");
   }
@@ -172,6 +173,27 @@ function buildRoutes(controller) {
       },
       handler: handler("oauthComplete")
     },
+    ...(includeDevLoginAs ? [{
+      path: AUTH_PATHS.DEV_LOGIN_AS,
+      method: "POST",
+      auth: "public",
+      meta: {
+        tags: ["auth"],
+        summary: "Dev-only: create a local session for an existing user"
+      },
+      bodyValidator: authDevLoginAsCommand.operation.bodyValidator,
+      responseValidators: withStandardErrorResponses(
+        {
+          200: authDevLoginAsCommand.operation.responseValidator
+        },
+        { includeValidation400: true }
+      ),
+      rateLimit: {
+        max: 30,
+        timeWindow: "1 minute"
+      },
+      handler: handler("devLoginAs")
+    }] : []),
     {
       path: AUTH_PATHS.PASSWORD_FORGOT,
       method: "POST",

--- a/packages/auth-web/src/server/services/AuthWebService.js
+++ b/packages/auth-web/src/server/services/AuthWebService.js
@@ -61,6 +61,19 @@ class AuthWebService {
     });
   }
 
+  async devLoginAs(request, payload) {
+    return request.executeAction({
+      actionId: AUTH_ACTION_IDS.DEV_LOGIN_AS,
+      input: payload
+    });
+  }
+
+  isDevLoginAsAvailable() {
+    return typeof this.authService?.isDevAuthBootstrapEnabled === "function"
+      ? this.authService.isDevAuthBootstrapEnabled()
+      : false;
+  }
+
   async logout(request) {
     return request.executeAction({
       actionId: AUTH_ACTION_IDS.LOGOUT

--- a/packages/auth-web/test/providerRuntime.test.js
+++ b/packages/auth-web/test/providerRuntime.test.js
@@ -68,6 +68,12 @@ test("auth route provider registers routes and executes login/logout handlers", 
           profile: { displayName: "Ada" }
         };
       }
+      if (actionId === "auth.dev.loginAs") {
+        return {
+          session: { access_token: "dev-a", refresh_token: "dev-r" },
+          profile: { id: "7", displayName: "Dev Ada", email: "ada@example.com" }
+        };
+      }
       if (actionId === "auth.logout") {
         return {
           ok: true,
@@ -103,6 +109,9 @@ test("auth route provider registers routes and executes login/logout handlers", 
   assert.equal(resendConfirmationReply.statusCode, 200);
   assert.equal(resendConfirmationReply.payload.ok, true);
 
+  const devLoginRoute = fastify.routes.find((route) => route.method === "POST" && route.url === "/api/dev-auth/login-as");
+  assert.equal(devLoginRoute, undefined);
+
   const logoutRoute = fastify.routes.find((route) => route.method === "POST" && route.url === "/api/logout");
   assert.ok(logoutRoute);
   const logoutReply = createReplyStub();
@@ -112,4 +121,51 @@ test("auth route provider registers routes and executes login/logout handlers", 
 
   assert.equal(events.some((entry) => entry.type === "writeSession"), true);
   assert.equal(events.some((entry) => entry.type === "clearSession"), true);
+});
+
+test("auth route provider registers dev login route only when auth service enables it", async () => {
+  const fastify = createFastifyStub();
+  const app = createApplication();
+  const httpRuntime = createHttpRuntime({ app, fastify });
+
+  const authService = {
+    isDevAuthBootstrapEnabled() {
+      return true;
+    },
+    writeSessionCookies() {},
+    clearSessionCookies() {},
+    getOAuthProviderCatalog() {
+      return { providers: [], defaultProvider: "" };
+    }
+  };
+
+  app.instance("authService", authService);
+  app.instance("actionExecutor", {
+    async execute({ actionId }) {
+      if (actionId === "auth.dev.loginAs") {
+        return {
+          session: { access_token: "dev-a", refresh_token: "dev-r" },
+          profile: { id: "7", displayName: "Dev Ada", email: "ada@example.com" }
+        };
+      }
+      return {};
+    }
+  });
+
+  class MockAuthProvider {
+    static id = "auth.provider";
+  }
+
+  await app.start({ providers: [MockAuthProvider, AuthWebServiceProvider, AuthRouteServiceProvider] });
+
+  const registration = httpRuntime.registerRoutes();
+  assert.equal(registration.routeCount > 0, true);
+
+  const devLoginRoute = fastify.routes.find((route) => route.method === "POST" && route.url === "/api/dev-auth/login-as");
+  assert.ok(devLoginRoute);
+  const devLoginReply = createReplyStub();
+  await devLoginRoute.handler({ body: { userId: "7" } }, devLoginReply);
+  assert.equal(devLoginReply.statusCode, 200);
+  assert.equal(devLoginReply.payload.userId, "7");
+  assert.equal(devLoginReply.payload.username, "Dev Ada");
 });

--- a/packages/users-core/src/server/common/repositories/usersRepository.js
+++ b/packages/users-core/src/server/common/repositories/usersRepository.js
@@ -124,6 +124,17 @@ function createRepository(knex) {
     return mapProfileRow(row);
   }
 
+  async function findByEmail(email, options = {}) {
+    const normalizedEmail = normalizeLowerText(email);
+    if (!normalizedEmail) {
+      return null;
+    }
+
+    const client = options?.trx || knex;
+    const row = await client("users").where({ email: normalizedEmail }).first();
+    return mapProfileRow(row);
+  }
+
   async function findByIdentity(identityLike, options = {}) {
     const client = options?.trx || knex;
     const identity = normalizeIdentity(identityLike);
@@ -257,6 +268,7 @@ function createRepository(knex) {
   return Object.freeze({
     withTransaction,
     findById,
+    findByEmail,
     findByIdentity,
     updateDisplayNameById,
     updateAvatarById,

--- a/packages/users-core/test/repositoryContracts.test.js
+++ b/packages/users-core/test/repositoryContracts.test.js
@@ -15,6 +15,29 @@ function createKnexStub() {
   return knex;
 }
 
+function createFindByEmailKnexStub(expectedRow) {
+  const calls = [];
+  const knex = Object.assign((tableName) => {
+    assert.equal(tableName, "users");
+    return {
+      where(criteria) {
+        calls.push(criteria);
+        return {
+          async first() {
+            return expectedRow;
+          }
+        };
+      }
+    };
+  }, {
+    async transaction(work) {
+      return work({ trxId: "trx-1" });
+    }
+  });
+
+  return { knex, calls };
+}
+
 test("users-core repositories expose withTransaction", async () => {
   const knex = createKnexStub();
   const repositories = [
@@ -27,4 +50,27 @@ test("users-core repositories expose withTransaction", async () => {
     const result = await repository.withTransaction(async (trx) => ({ id: trx.trxId }));
     assert.deepEqual(result, { id: "trx-1" });
   }
+});
+
+test("usersRepository.findByEmail normalizes email lookup", async () => {
+  const { knex, calls } = createFindByEmailKnexStub({
+    id: 7,
+    auth_provider: "supabase",
+    auth_provider_user_sid: "supabase-user-7",
+    email: "ada@example.com",
+    username: "ada",
+    display_name: "Ada Example",
+    avatar_storage_key: null,
+    avatar_version: null,
+    avatar_updated_at: null,
+    created_at: "2026-04-20T00:00:00.000Z"
+  });
+  const repository = createUsersRepository(knex);
+
+  const profile = await repository.findByEmail(" ADA@EXAMPLE.COM ");
+
+  assert.deepEqual(calls, [{ email: "ada@example.com" }]);
+  assert.equal(profile?.id, "7");
+  assert.equal(profile?.email, "ada@example.com");
+  assert.equal(profile?.displayName, "Ada Example");
 });


### PR DESCRIPTION
## Summary
- add a development-only auth bootstrap route for UI and Playwright flows
- document the standard UI testing pattern and wire it into agent guidance
- refresh package metadata, catalog, and lockfile outputs for the new auth surface

## Notes
- this PR contains the staged changes only
- per request, merge immediately without waiting on verify