### PR TITLE
Add UI verification receipts to jskit app flow

### DIFF
--- a/packages/agent-docs/guide/agent/app-setup/authentication.md
+++ b/packages/agent-docs/guide/agent/app-setup/authentication.md
@@ -924,6 +924,7 @@ This is the standard path the agent should use for authenticated browser tests:
 - create a session for an existing user through the local app
 - let the browser keep the resulting HTTP-only cookies
 - navigate to the protected page and verify the feature
+- record the Playwright run through `jskit app verify-ui` so `jskit doctor` can verify the receipt later
 
 The feature is intentionally narrow.
 
@@ -1020,9 +1021,19 @@ await page.evaluate(async ({ email }) => {
 await page.goto("/w/acme/admin/contacts");
 ```
 
+In practice, the preferred wrapper is:
+
+```bash
+npx jskit app verify-ui \
+  --command "npx playwright test tests/e2e/contacts.spec.ts -g filters" \
+  --feature "contacts filters" \
+  --auth-mode dev-auth-login-as
+```
+
 That flow is preferable to driving the real sign-in form in feature tests because it keeps the test focused on the UI feature being added, not on an external auth dependency. If a chunk changes user-facing UI and the flow requires login, the expected JSKIT review standard is:
 
 - use Playwright
+- record the run with `jskit app verify-ui`
 - use the local dev auth bypass or another local session bootstrap path
 - exercise the actual changed behavior, not only page load
 

--- a/packages/agent-docs/guide/agent/app-setup/working-with-the-jskit-cli.md
+++ b/packages/agent-docs/guide/agent/app-setup/working-with-the-jskit-cli.md
@@ -666,6 +666,7 @@ In the current CLI, that includes checks such as:
 - whether managed files recorded in the lock still exist
 - whether installed packages are still visible in the package registry
 - certain JSKIT-specific app checks, such as invalid raw `mdi-*` icon literals in Vue templates when the app uses Vuetify's `mdi-svg` iconset
+- UI verification receipts for current dirty UI files in git, via `.jskit/verification/ui.json`
 
 That last check is narrower than it sounds. `doctor` is looking for the broken case in direct Vue templates, such as:
 
@@ -725,6 +726,24 @@ Good times to run it manually include:
 - when you want a fast JSKIT-specific health check without waiting for a full test suite
 
 One important nuance: `doctor` is checking for broken JSKIT ownership and visibility, not trying to stop you from editing app-owned files. For example, a managed file that still exists but whose contents changed is normally fine. The problem is when JSKIT expects a managed file to exist and it is gone, or when the installed package state no longer resolves cleanly.
+
+There is one intentional exception now for user-facing UI work.
+
+If the current git working tree has changed UI files under the app's normal UI paths, `doctor` expects a matching `.jskit/verification/ui.json` receipt. The intended way to create that receipt is:
+
+```bash
+npx jskit app verify-ui \
+  --command "npx playwright test tests/e2e/contacts.spec.ts -g filters" \
+  --feature "contacts filters" \
+  --auth-mode dev-auth-login-as
+```
+
+That command does two things:
+
+- runs the targeted Playwright command you give it
+- writes a receipt describing the verified feature, auth mode, and current dirty UI file set
+
+`doctor` then compares the current changed UI files to that receipt. If you edit the UI again afterwards, the receipt is stale and `doctor` tells you to rerun `jskit app verify-ui`.
 
 ### Why `--json` exists
 

--- a/packages/agent-docs/patterns/ui-testing.md
+++ b/packages/agent-docs/patterns/ui-testing.md
@@ -10,6 +10,8 @@ Use when:
 Rules:
 
 - Any chunk that adds or changes user-facing UI must include a Playwright flow that exercises the changed behavior before the chunk is done.
+- Record that Playwright run with `jskit app verify-ui --command "<playwright command>" --feature "<label>" --auth-mode <mode>`.
+- `jskit doctor` expects `.jskit/verification/ui.json` to match the current dirty UI file set when UI files are changed.
 - Do not rely on a live external auth provider for Playwright verification of normal app features.
 - For authenticated UI in the standard JSKIT auth stack, use the development-only dev auth bypass route instead.
 - The standard route is `POST /api/dev-auth/login-as`.
@@ -20,7 +22,16 @@ Rules:
 - Make the bootstrap request from the same browser context that will run the assertions so the auth cookies land in the page session.
 - Use stable seeded users or fixtures for Playwright. Do not depend on whatever account happens to exist in a developer's browser or external auth provider.
 
-Playwright setup shape:
+Recommended flow:
+
+```bash
+npx jskit app verify-ui \
+  --command "npx playwright test tests/e2e/contacts.spec.ts -g filters" \
+  --feature "contacts filters" \
+  --auth-mode dev-auth-login-as
+```
+
+The Playwright command itself should follow this setup shape when login is needed:
 
 ```ts
 await page.goto("/");

--- a/packages/agent-docs/reference/autogen/tooling/jskit-cli.md
+++ b/packages/agent-docs/reference/autogen/tooling/jskit-cli.md
@@ -379,6 +379,7 @@ Exports
 - `normalizeText(value = "")`
 - `isTruthyFlag(rawValue = "")`
 - `runExternalCommand(command, args = [], { cwd = "", env = {}, stdout, stderr, quiet = false, createCliError } = {})`
+- `runExternalShellCommand(commandText, { cwd = "", env = {}, stdout, stderr, quiet = false, createCliError } = {})`
 - `formatUtcReleaseTimestamp(date = new Date())`
 - `resolveLocalJskitBin(appRoot = "")`
 - `runLocalJskit(appRoot, args = [], { stdout, stderr, createCliError, quiet = false } = {})`
@@ -401,6 +402,10 @@ Local functions
 ### `src/server/commandHandlers/appCommands/verify.js`
 Exports
 - `runAppVerifyCommand(ctx = {}, { appRoot = "", options = {}, stdout, stderr })`
+
+### `src/server/commandHandlers/appCommands/verifyUi.js`
+Exports
+- `runAppVerifyUiCommand(ctx = {}, { appRoot = "", options = {}, stdout, stderr })`
 
 ### `src/server/commandHandlers/completion.js`
 Exports
@@ -671,6 +676,22 @@ Exports
 - `CATALOG_PACKAGES_PATH`
 Local functions
 - `resolveCatalogPackagesPath()`
+
+### `src/server/shared/uiVerification.js`
+Exports
+- `UI_VERIFICATION_AUTH_MODES`
+- `UI_VERIFICATION_RECEIPT_RELATIVE_PATH`
+- `UI_VERIFICATION_RECEIPT_VERSION`
+- `UI_VERIFICATION_RUNNER`
+- `isUiVerificationAuthMode(value = "")`
+- `isUiVerificationPath(relativePath = "")`
+- `isValidUiVerificationReceipt(receipt)`
+- `normalizeUiVerificationReceipt(rawReceipt = {})`
+- `resolveChangedUiFilesFromGit(appRoot = "")`
+- `sortUniqueStrings(values = [])`
+Local functions
+- `normalizeText(value = "")`
+- `readGitPathList(appRoot = "", args = [])`
 
 ### bin
 

--- a/packages/agent-docs/site/guide/app-setup/authentication.md
+++ b/packages/agent-docs/site/guide/app-setup/authentication.md
@@ -937,6 +937,7 @@ This is the standard path the agent should use for authenticated browser tests:
 - create a session for an existing user through the local app
 - let the browser keep the resulting HTTP-only cookies
 - navigate to the protected page and verify the feature
+- record the Playwright run through `jskit app verify-ui` so `jskit doctor` can verify the receipt later
 
 The feature is intentionally narrow.
 
@@ -1033,9 +1034,19 @@ await page.evaluate(async ({ email }) => {
 await page.goto("/w/acme/admin/contacts");
 ```
 
+In practice, the preferred wrapper is:
+
+```bash
+npx jskit app verify-ui \
+  --command "npx playwright test tests/e2e/contacts.spec.ts -g filters" \
+  --feature "contacts filters" \
+  --auth-mode dev-auth-login-as
+```
+
 That flow is preferable to driving the real sign-in form in feature tests because it keeps the test focused on the UI feature being added, not on an external auth dependency. If a chunk changes user-facing UI and the flow requires login, the expected JSKIT review standard is:
 
 - use Playwright
+- record the run with `jskit app verify-ui`
 - use the local dev auth bypass or another local session bootstrap path
 - exercise the actual changed behavior, not only page load
 

--- a/packages/agent-docs/site/guide/app-setup/working-with-the-jskit-cli.md
+++ b/packages/agent-docs/site/guide/app-setup/working-with-the-jskit-cli.md
@@ -678,6 +678,7 @@ In the current CLI, that includes checks such as:
 - whether managed files recorded in the lock still exist
 - whether installed packages are still visible in the package registry
 - certain JSKIT-specific app checks, such as invalid raw `mdi-*` icon literals in Vue templates when the app uses Vuetify's `mdi-svg` iconset
+- UI verification receipts for current dirty UI files in git, via `.jskit/verification/ui.json`
 
 That last check is narrower than it sounds. `doctor` is looking for the broken case in direct Vue templates, such as:
 
@@ -737,6 +738,24 @@ Good times to run it manually include:
 - when you want a fast JSKIT-specific health check without waiting for a full test suite
 
 One important nuance: `doctor` is checking for broken JSKIT ownership and visibility, not trying to stop you from editing app-owned files. For example, a managed file that still exists but whose contents changed is normally fine. The problem is when JSKIT expects a managed file to exist and it is gone, or when the installed package state no longer resolves cleanly.
+
+There is one intentional exception now for user-facing UI work.
+
+If the current git working tree has changed UI files under the app's normal UI paths, `doctor` expects a matching `.jskit/verification/ui.json` receipt. The intended way to create that receipt is:
+
+```bash
+npx jskit app verify-ui \
+  --command "npx playwright test tests/e2e/contacts.spec.ts -g filters" \
+  --feature "contacts filters" \
+  --auth-mode dev-auth-login-as
+```
+
+That command does two things:
+
+- runs the targeted Playwright command you give it
+- writes a receipt describing the verified feature, auth mode, and current dirty UI file set
+
+`doctor` then compares the current changed UI files to that receipt. If you edit the UI again afterwards, the receipt is stale and `doctor` tells you to rerun `jskit app verify-ui`.
 
 ### Why `--json` exists
 

--- a/packages/agent-docs/templates/app/AGENTS.md
+++ b/packages/agent-docs/templates/app/AGENTS.md
@@ -73,6 +73,7 @@ Core rules:
 - For CRUD chunks, ask the developer which operations are allowed, which fields belong in the list view if one exists, and the intended look of the view and edit/new forms before generating code.
 - Every user-facing screen must pass a Material Design and Vuetify quality review before the chunk is considered done.
 - Any chunk that adds or changes user-facing UI must include a Playwright check that exercises the changed behavior before the chunk is considered done.
+- Record that Playwright run with `jskit app verify-ui --command "<playwright command>" --feature "<label>" --auth-mode <mode>` so `jskit doctor` can verify the receipt.
 - If the UI flow requires login, use the app's development-only auth bypass or session bootstrap path instead of a live external auth login flow.
 - In JSKIT apps using the standard auth stack, that means enabling the dev auth bypass in development and using `POST /api/dev-auth/login-as` during Playwright setup.
 - If authenticated UI work has no usable local auth bootstrap path yet, treat that as a testability gap and call it out before the chunk can be considered complete.

--- a/packages/agent-docs/test/appAgentTemplate.test.js
+++ b/packages/agent-docs/test/appAgentTemplate.test.js
@@ -28,6 +28,7 @@ test("app agent template includes mandatory JSKIT start and done gates", async (
   assert.match(body, /Commands run:/);
   assert.match(body, /Remaining unverified:/);
   assert.match(body, /Any chunk that adds or changes user-facing UI must include a Playwright check/);
+  assert.match(body, /jskit app verify-ui/);
   assert.match(body, /use the app's development-only auth bypass or session bootstrap path/);
   assert.match(body, /POST \/api\/dev-auth\/login-as/);
 });

--- a/packages/agent-docs/test/uiTestingGuidance.test.js
+++ b/packages/agent-docs/test/uiTestingGuidance.test.js
@@ -13,6 +13,7 @@ test("workflow and guide docs require Playwright plus dev auth bypass for authen
   const authGuide = await readFile(path.join(packageRoot, "site/guide/app-setup/authentication.md"), "utf8");
 
   assert.match(featureDelivery, /adds or changes user-facing UI must include a Playwright flow/);
+  assert.match(featureDelivery, /jskit app verify-ui/);
   assert.match(featureDelivery, /\/api\/dev-auth\/login-as/);
   assert.match(featureDelivery, /must not be enabled in production/);
 
@@ -20,11 +21,13 @@ test("workflow and guide docs require Playwright plus dev auth bypass for authen
   assert.match(review, /development-only .*\/api\/dev-auth\/login-as/);
 
   assert.match(pattern, /^# UI Testing Pattern$/m);
+  assert.match(pattern, /jskit app verify-ui/);
   assert.match(pattern, /\/api\/dev-auth\/login-as/);
   assert.match(pattern, /AUTH_DEV_BYPASS_ENABLED=true/);
   assert.match(pattern, /csrf-token/);
 
   assert.match(authGuide, /^### Authenticated Playwright testing with the dev auth bypass$/m);
+  assert.match(authGuide, /jskit app verify-ui/);
   assert.match(authGuide, /AUTH_DEV_BYPASS_ENABLED=true/);
   assert.match(authGuide, /POST \/api\/dev-auth\/login-as/);
   assert.match(authGuide, /This is the standard path the agent should use for authenticated browser tests/);

--- a/packages/agent-docs/workflow/feature-delivery.md
+++ b/packages/agent-docs/workflow/feature-delivery.md
@@ -22,7 +22,7 @@ For each chunk, follow this order:
 5. Deslop the chunk.
 6. Review the chunk against JSKIT reuse and best practices.
 7. Review user-facing screens against Material Design and Vuetify best practices, and improve any screens that do not meet that bar.
-8. Verify the chunk with the relevant commands. Any chunk that adds or changes user-facing UI must include a Playwright flow that exercises the changed behavior.
+8. Verify the chunk with the relevant commands. Any chunk that adds or changes user-facing UI must include a Playwright flow that exercises the changed behavior, and that run must be recorded with `jskit app verify-ui`.
 9. Update `.jskit/WORKBOARD.md` with status, commands run, and anything still unverified.
 10. Only then move to the next chunk.
 
@@ -60,6 +60,7 @@ After the last chunk:
 Playwright note:
 
 - When login is required, use a test-only auth bypass or session bootstrap path instead of dependence on a live external auth provider.
+- Record the run through `jskit app verify-ui --command "<playwright command>" --feature "<label>" --auth-mode <mode>` so `jskit doctor` can verify the receipt against the current changed UI files.
 - In the standard JSKIT auth stack, the default development path is `POST /api/dev-auth/login-as`, guarded by `AUTH_DEV_BYPASS_ENABLED=true` and `AUTH_DEV_BYPASS_SECRET=...`.
 - That route is development-only and must not be enabled in production.
 - Because it is still an unsafe POST, fetch `csrfToken` from `/api/session`, send it as the `csrf-token` header, and make the request in the same browser context that will run the Playwright assertions so the session cookies land in the page session.

--- a/packages/agent-docs/workflow/review.md
+++ b/packages/agent-docs/workflow/review.md
@@ -32,6 +32,7 @@ Before calling a chunk or a whole changeset done, review it in four passes:
    - run the smallest relevant verification commands for a chunk
    - run the widest relevant verification commands for a whole changeset
    - any added or changed user-facing UI must be exercised with Playwright
+   - that Playwright run should normally be recorded through `jskit app verify-ui`
    - if login is required, use the chosen local test-auth path instead of live external auth
    - in the standard JSKIT auth stack, prefer the development-only `POST /api/dev-auth/login-as` path
    - if there is no usable local auth bootstrap path, explicitly record that as a blocking testability gap

--- a/tooling/create-app/templates/base-shell/gitignore
+++ b/tooling/create-app/templates/base-shell/gitignore
@@ -3,6 +3,7 @@ dist/
 coverage/
 test-results/
 .jskit/WORKBOARD.md
+.jskit/verification/
 .env
 .env.*
 !.env.example

--- a/tooling/create-app/test/createApp.test.js
+++ b/tooling/create-app/test/createApp.test.js
@@ -89,6 +89,7 @@ test("create-app scaffolds the base shell with placeholder replacements", async 
 
     const gitignore = await readFile(path.join(appRoot, ".gitignore"), "utf8");
     assert.match(gitignore, /node_modules\//);
+    assert.match(gitignore, /\.jskit\/verification\//);
 
     const indexHtml = await readFile(path.join(appRoot, "index.html"), "utf8");
     assert.match(indexHtml, /<title>Sample App<\/title>/);

--- a/tooling/jskit-cli/src/server/cliRuntime/appState.js
+++ b/tooling/jskit-cli/src/server/cliRuntime/appState.js
@@ -232,6 +232,7 @@ function removeEnvValue(content, key, expectedValue, previous) {
 }
 
 export {
+  directoryLooksLikeJskitAppRoot,
   resolveAppRootFromCwd,
   loadAppPackageJson,
   createDefaultLock,

--- a/tooling/jskit-cli/src/server/commandHandlers/app.js
+++ b/tooling/jskit-cli/src/server/commandHandlers/app.js
@@ -13,6 +13,7 @@ import { runAppLinkLocalPackagesCommand } from "./appCommands/linkLocalPackages.
 import { runAppReleaseCommand } from "./appCommands/release.js";
 import { runAppUpdatePackagesCommand } from "./appCommands/updatePackages.js";
 import { runAppVerifyCommand } from "./appCommands/verify.js";
+import { runAppVerifyUiCommand } from "./appCommands/verifyUi.js";
 
 function renderAppHelp(stream, definition = null) {
   const color = createColorFormatter(stream);
@@ -134,6 +135,9 @@ function createAppCommands(ctx = {}) {
 
     if (definition.name === "verify") {
       return runAppVerifyCommand(ctx, { appRoot, options, stdout, stderr });
+    }
+    if (definition.name === "verify-ui") {
+      return runAppVerifyUiCommand(ctx, { appRoot, options, stdout, stderr });
     }
     if (definition.name === "update-packages") {
       return runAppUpdatePackagesCommand(ctx, { appRoot, options, stdout, stderr });

--- a/tooling/jskit-cli/src/server/commandHandlers/appCommandCatalog.js
+++ b/tooling/jskit-cli/src/server/commandHandlers/appCommandCatalog.js
@@ -38,6 +38,30 @@ const APP_COMMAND_DEFINITIONS = Object.freeze({
       "The scaffolded npm run verify wrapper can append npm run --if-present verify:app afterwards."
     ])
   }),
+  "verify-ui": Object.freeze({
+    name: "verify-ui",
+    summary: "Run a targeted Playwright command and write a UI verification receipt for jskit doctor.",
+    usage: "jskit app verify-ui --command <shell-command> --feature <label> --auth-mode <mode>",
+    options: Object.freeze([
+      Object.freeze({
+        label: "--command <shell-command>",
+        description: "Targeted Playwright command to run, for example: npx playwright test tests/e2e/contacts.spec.ts -g filters."
+      }),
+      Object.freeze({
+        label: "--feature <label>",
+        description: "Short human label for the UI feature or flow that was verified."
+      }),
+      Object.freeze({
+        label: "--auth-mode <mode>",
+        description: "Auth path used by the Playwright flow: none | dev-auth-login-as | session-bootstrap | custom-local."
+      })
+    ]),
+    defaults: Object.freeze([
+      "Requires a git working tree so the receipt can record the currently changed UI files.",
+      "Writes .jskit/verification/ui.json after the command succeeds.",
+      "Doctor expects the receipt to match the current dirty UI file set."
+    ])
+  }),
   "update-packages": Object.freeze({
     name: "update-packages",
     summary: "Update installed @jskit-ai dependencies and refresh managed migrations.",
@@ -151,6 +175,11 @@ function buildAppCommandOptionMeta(subcommandName = "") {
   }
   if (definition.name === "update-packages" || definition.name === "release") {
     optionMeta.registry = { inputType: "text" };
+  }
+  if (definition.name === "verify-ui") {
+    optionMeta.command = { inputType: "text" };
+    optionMeta.feature = { inputType: "text" };
+    optionMeta["auth-mode"] = { inputType: "text" };
   }
   if (definition.name === "link-local-packages") {
     optionMeta["repo-root"] = { inputType: "text" };

--- a/tooling/jskit-cli/src/server/commandHandlers/appCommands/shared.js
+++ b/tooling/jskit-cli/src/server/commandHandlers/appCommands/shared.js
@@ -80,6 +80,36 @@ function runExternalCommand(
   });
 }
 
+function runExternalShellCommand(
+  commandText,
+  {
+    cwd = "",
+    env = {},
+    stdout,
+    stderr,
+    quiet = false,
+    createCliError
+  } = {}
+) {
+  const result = spawnSync(String(commandText || ""), {
+    cwd: cwd || process.cwd(),
+    encoding: "utf8",
+    shell: true,
+    env: {
+      ...process.env,
+      ...env
+    }
+  });
+
+  return ensureCommandSucceeded(result, String(commandText || "").trim() || "shell command", {
+    createCliError,
+    cwd,
+    stdout,
+    stderr,
+    quiet
+  });
+}
+
 function formatUtcReleaseTimestamp(date = new Date()) {
   const year = date.getUTCFullYear();
   const month = String(date.getUTCMonth() + 1).padStart(2, "0");
@@ -265,6 +295,7 @@ export {
   normalizeText,
   isTruthyFlag,
   runExternalCommand,
+  runExternalShellCommand,
   formatUtcReleaseTimestamp,
   resolveLocalJskitBin,
   runLocalJskit,

--- a/tooling/jskit-cli/src/server/commandHandlers/appCommands/verifyUi.js
+++ b/tooling/jskit-cli/src/server/commandHandlers/appCommands/verifyUi.js
@@ -1,0 +1,102 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { runExternalShellCommand } from "./shared.js";
+import {
+  directoryLooksLikeJskitAppRoot
+} from "../../cliRuntime/appState.js";
+import {
+  UI_VERIFICATION_RECEIPT_RELATIVE_PATH,
+  UI_VERIFICATION_RECEIPT_VERSION,
+  UI_VERIFICATION_RUNNER,
+  isUiVerificationAuthMode,
+  resolveChangedUiFilesFromGit
+} from "../../shared/uiVerification.js";
+
+async function runAppVerifyUiCommand(ctx = {}, { appRoot = "", options = {}, stdout, stderr }) {
+  const { createCliError } = ctx;
+
+  if (options?.dryRun) {
+    throw createCliError("jskit app verify-ui does not support --dry-run.", { exitCode: 1 });
+  }
+
+  const inlineOptions =
+    options?.inlineOptions && typeof options.inlineOptions === "object" ? options.inlineOptions : {};
+  const command = String(inlineOptions.command || "").trim();
+  const feature = String(inlineOptions.feature || "").trim();
+  const authMode = String(inlineOptions["auth-mode"] || "").trim();
+
+  if (!command) {
+    throw createCliError("jskit app verify-ui requires --command <shell-command>.", {
+      exitCode: 1
+    });
+  }
+  if (!feature) {
+    throw createCliError("jskit app verify-ui requires --feature <label>.", {
+      exitCode: 1
+    });
+  }
+  if (!isUiVerificationAuthMode(authMode)) {
+    throw createCliError(
+      "jskit app verify-ui requires --auth-mode <none|dev-auth-login-as|session-bootstrap|custom-local>.",
+      {
+        exitCode: 1
+      }
+    );
+  }
+  if (!(await directoryLooksLikeJskitAppRoot(appRoot))) {
+    throw createCliError(
+      "jskit app verify-ui only works in a JSKIT app root (expected app.json or .jskit/lock.json).",
+      {
+        exitCode: 1
+      }
+    );
+  }
+
+  const changedUiState = resolveChangedUiFilesFromGit(appRoot);
+  if (!changedUiState.available) {
+    throw createCliError("jskit app verify-ui requires a git working tree so it can record changed UI files.", {
+      exitCode: 1
+    });
+  }
+  if (changedUiState.paths.length < 1) {
+    throw createCliError("jskit app verify-ui found no changed UI files in src/ or packages/.", {
+      exitCode: 1
+    });
+  }
+
+  runExternalShellCommand(command, {
+    cwd: appRoot,
+    stdout,
+    stderr,
+    createCliError
+  });
+
+  const recordedAt = new Date().toISOString();
+  const receiptPath = path.join(appRoot, UI_VERIFICATION_RECEIPT_RELATIVE_PATH);
+  await mkdir(path.dirname(receiptPath), { recursive: true });
+  await writeFile(
+    receiptPath,
+    `${JSON.stringify(
+      {
+        version: UI_VERIFICATION_RECEIPT_VERSION,
+        runner: UI_VERIFICATION_RUNNER,
+        recordedAt,
+        feature,
+        command,
+        authMode,
+        changedUiFiles: changedUiState.paths
+      },
+      null,
+      2
+    )}\n`,
+    "utf8"
+  );
+
+  stdout.write(
+    `[verify-ui] wrote ${UI_VERIFICATION_RECEIPT_RELATIVE_PATH} for ${changedUiState.paths.length} changed UI file(s).\n`
+  );
+
+  return 0;
+}
+
+export { runAppVerifyUiCommand };

--- a/tooling/jskit-cli/src/server/commandHandlers/health.js
+++ b/tooling/jskit-cli/src/server/commandHandlers/health.js
@@ -7,9 +7,16 @@ import {
   ensureObject,
   sortStrings
 } from "../shared/collectionUtils.js";
+import {
+  UI_VERIFICATION_RECEIPT_RELATIVE_PATH,
+  isValidUiVerificationReceipt,
+  normalizeUiVerificationReceipt,
+  resolveChangedUiFilesFromGit
+} from "../shared/uiVerification.js";
 
 function createHealthCommands(ctx = {}) {
   const {
+    directoryLooksLikeJskitAppRoot,
     resolveAppRootFromCwd,
     loadLockFile,
     loadPackageRegistry,
@@ -621,6 +628,49 @@ function createHealthCommands(ctx = {}) {
     }
   }
 
+  async function collectUiVerificationDoctorIssues({ appRoot, issues }) {
+    if (!(await directoryLooksLikeJskitAppRoot(appRoot))) {
+      return;
+    }
+
+    const changedUiState = resolveChangedUiFilesFromGit(appRoot);
+    if (!changedUiState.available || changedUiState.paths.length < 1) {
+      return;
+    }
+
+    const receiptPath = path.join(appRoot, UI_VERIFICATION_RECEIPT_RELATIVE_PATH);
+    if (!(await fileExists(receiptPath))) {
+      issues.push(
+        `[ui:verification] changed UI files require a matching ${UI_VERIFICATION_RECEIPT_RELATIVE_PATH} receipt. Run jskit app verify-ui --command "<playwright command>" --feature "<label>" --auth-mode <mode>. Current files: ${changedUiState.paths.join(", ")}`
+      );
+      return;
+    }
+
+    let parsedReceipt = null;
+    try {
+      parsedReceipt = JSON.parse(await readFile(receiptPath, "utf8"));
+    } catch (error) {
+      issues.push(
+        `[ui:verification] ${UI_VERIFICATION_RECEIPT_RELATIVE_PATH} is not valid JSON: ${error instanceof Error ? error.message : String(error)}`
+      );
+      return;
+    }
+
+    const receipt = normalizeUiVerificationReceipt(parsedReceipt);
+    if (!isValidUiVerificationReceipt(receipt)) {
+      issues.push(
+        `[ui:verification] ${UI_VERIFICATION_RECEIPT_RELATIVE_PATH} is incomplete. It must include version, runner, recordedAt, feature, command, authMode, and changedUiFiles from jskit app verify-ui.`
+      );
+      return;
+    }
+
+    if (JSON.stringify(receipt.changedUiFiles) !== JSON.stringify(changedUiState.paths)) {
+      issues.push(
+        `[ui:verification] ${UI_VERIFICATION_RECEIPT_RELATIVE_PATH} does not match the current changed UI file set. Re-run jskit app verify-ui after the latest UI edits. Current files: ${changedUiState.paths.join(", ")}`
+      );
+    }
+  }
+
   function collectDiLabelParityIssuesForPackage({ packageEntry, packageInsights }) {
     const packageId = String(packageEntry?.packageId || "").trim();
     const descriptor = ensureObject(packageEntry?.descriptor);
@@ -710,6 +760,10 @@ function createHealthCommands(ctx = {}) {
       issues
     });
     await collectCrudFilterDoctorIssues({
+      appRoot,
+      issues
+    });
+    await collectUiVerificationDoctorIssues({
       appRoot,
       issues
     });

--- a/tooling/jskit-cli/src/server/core/buildCommandDeps.js
+++ b/tooling/jskit-cli/src/server/core/buildCommandDeps.js
@@ -6,6 +6,7 @@ function createCommandHandlerDeps(deps = {}) {
     writeWrappedItems: deps.writeWrappedItems,
     normalizeRelativePath: deps.normalizeRelativePath,
     normalizeRelativePosixPath: deps.normalizeRelativePosixPath,
+    directoryLooksLikeJskitAppRoot: deps.directoryLooksLikeJskitAppRoot,
     resolveAppRootFromCwd: deps.resolveAppRootFromCwd,
     loadLockFile: deps.loadLockFile,
     loadPackageRegistry: deps.loadPackageRegistry,

--- a/tooling/jskit-cli/src/server/core/createCliRunner.js
+++ b/tooling/jskit-cli/src/server/core/createCliRunner.js
@@ -33,6 +33,7 @@ import {
   readFileBufferIfExists
 } from "../cliRuntime/ioAndMigrations.js";
 import {
+  directoryLooksLikeJskitAppRoot,
   resolveAppRootFromCwd,
   loadAppPackageJson,
   loadLockFile,
@@ -97,6 +98,7 @@ const commandHandlers = createCommandHandlers(
     writeWrappedItems,
     normalizeRelativePath,
     normalizeRelativePosixPath,
+    directoryLooksLikeJskitAppRoot,
     resolveAppRootFromCwd,
     loadLockFile,
     loadPackageRegistry,

--- a/tooling/jskit-cli/src/server/shared/uiVerification.js
+++ b/tooling/jskit-cli/src/server/shared/uiVerification.js
@@ -1,0 +1,148 @@
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+
+const UI_VERIFICATION_RECEIPT_VERSION = 1;
+const UI_VERIFICATION_RECEIPT_RELATIVE_PATH = ".jskit/verification/ui.json";
+const UI_VERIFICATION_RUNNER = "playwright";
+const UI_VERIFICATION_AUTH_MODES = new Set([
+  "none",
+  "dev-auth-login-as",
+  "session-bootstrap",
+  "custom-local"
+]);
+
+const UI_EXTENSION_SET = new Set([
+  ".vue"
+]);
+
+const UI_SCRIPT_PATH_PATTERNS = Object.freeze([
+  /^src\/components\//u,
+  /^src\/composables\//u,
+  /^src\/layouts\//u,
+  /^src\/pages\//u,
+  /^src\/stores\//u,
+  /^src\/placement\.[A-Za-z0-9]+$/u,
+  /^packages\/[^/]+(?:-web)?\/src\/client\//u
+]);
+
+function normalizeText(value = "") {
+  return String(value || "").trim();
+}
+
+function sortUniqueStrings(values = []) {
+  return [...new Set(values.map((value) => normalizeText(value)).filter(Boolean))].sort((left, right) =>
+    left.localeCompare(right)
+  );
+}
+
+function isUiVerificationAuthMode(value = "") {
+  return UI_VERIFICATION_AUTH_MODES.has(normalizeText(value));
+}
+
+function isUiVerificationPath(relativePath = "") {
+  const normalizedPath = normalizeText(relativePath).replace(/\\/g, "/");
+  if (!normalizedPath) {
+    return false;
+  }
+
+  if (UI_EXTENSION_SET.has(path.extname(normalizedPath).toLowerCase())) {
+    return normalizedPath.startsWith("src/") || normalizedPath.startsWith("packages/");
+  }
+
+  return UI_SCRIPT_PATH_PATTERNS.some((pattern) => pattern.test(normalizedPath));
+}
+
+function readGitPathList(appRoot = "", args = []) {
+  const result = spawnSync("git", Array.isArray(args) ? args : [], {
+    cwd: appRoot || process.cwd(),
+    encoding: "utf8"
+  });
+
+  if (result?.error || result?.status !== 0) {
+    return {
+      ok: false,
+      paths: []
+    };
+  }
+
+  return {
+    ok: true,
+    paths: sortUniqueStrings(String(result.stdout || "").split(/\r?\n/u))
+  };
+}
+
+function resolveChangedUiFilesFromGit(appRoot = "") {
+  const gitRepoCheck = spawnSync("git", ["rev-parse", "--is-inside-work-tree"], {
+    cwd: appRoot || process.cwd(),
+    encoding: "utf8"
+  });
+
+  if (
+    gitRepoCheck?.error ||
+    gitRepoCheck?.status !== 0 ||
+    normalizeText(gitRepoCheck.stdout).toLowerCase() !== "true"
+  ) {
+    return {
+      available: false,
+      paths: []
+    };
+  }
+
+  const changedPathSets = [
+    readGitPathList(appRoot, ["diff", "--name-only", "--relative", "--cached", "--", "src", "packages"]),
+    readGitPathList(appRoot, ["diff", "--name-only", "--relative", "--", "src", "packages"]),
+    readGitPathList(appRoot, ["ls-files", "--others", "--exclude-standard", "--", "src", "packages"])
+  ];
+
+  const changedPaths = sortUniqueStrings(
+    changedPathSets
+      .filter((entry) => entry.ok)
+      .flatMap((entry) => entry.paths)
+      .filter((relativePath) => isUiVerificationPath(relativePath))
+  );
+
+  return {
+    available: true,
+    paths: changedPaths
+  };
+}
+
+function normalizeUiVerificationReceipt(rawReceipt = {}) {
+  const receipt = rawReceipt && typeof rawReceipt === "object" && !Array.isArray(rawReceipt) ? rawReceipt : {};
+
+  return Object.freeze({
+    version: Number.isInteger(receipt.version) ? receipt.version : null,
+    runner: normalizeText(receipt.runner),
+    recordedAt: normalizeText(receipt.recordedAt),
+    feature: normalizeText(receipt.feature),
+    command: normalizeText(receipt.command),
+    authMode: normalizeText(receipt.authMode),
+    changedUiFiles: sortUniqueStrings(receipt.changedUiFiles)
+  });
+}
+
+function isValidUiVerificationReceipt(receipt) {
+  const normalizedReceipt = normalizeUiVerificationReceipt(receipt);
+
+  return (
+    normalizedReceipt.version === UI_VERIFICATION_RECEIPT_VERSION &&
+    normalizedReceipt.runner === UI_VERIFICATION_RUNNER &&
+    Boolean(normalizedReceipt.recordedAt) &&
+    Boolean(normalizedReceipt.feature) &&
+    Boolean(normalizedReceipt.command) &&
+    isUiVerificationAuthMode(normalizedReceipt.authMode)
+  );
+}
+
+export {
+  UI_VERIFICATION_AUTH_MODES,
+  UI_VERIFICATION_RECEIPT_RELATIVE_PATH,
+  UI_VERIFICATION_RECEIPT_VERSION,
+  UI_VERIFICATION_RUNNER,
+  isUiVerificationAuthMode,
+  isUiVerificationPath,
+  isValidUiVerificationReceipt,
+  normalizeUiVerificationReceipt,
+  resolveChangedUiFilesFromGit,
+  sortUniqueStrings
+};

--- a/tooling/jskit-cli/test/appCommand.test.js
+++ b/tooling/jskit-cli/test/appCommand.test.js
@@ -1,12 +1,13 @@
 import assert from "node:assert/strict";
 import {
   chmod,
-  lstat,
   mkdir,
+  lstat,
   readFile,
   readlink,
   writeFile
 } from "node:fs/promises";
+import { spawnSync } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
@@ -25,7 +26,8 @@ async function writeExecutable(filePath, source) {
 async function createMinimalApp(appRoot, {
   dependencies = {},
   devDependencies = {},
-  scripts = {}
+  scripts = {},
+  jskitApp = false
 } = {}) {
   await mkdir(appRoot, { recursive: true });
   await writeFile(
@@ -45,6 +47,13 @@ async function createMinimalApp(appRoot, {
     )}\n`,
     "utf8"
   );
+  if (jskitApp) {
+    await writeFile(
+      path.join(appRoot, "app.json"),
+      `${JSON.stringify({ name: "tmp-app" }, null, 2)}\n`,
+      "utf8"
+    );
+  }
   await mkdir(path.join(appRoot, "node_modules", ".bin"), { recursive: true });
 }
 
@@ -80,6 +89,22 @@ async function readLogLines(logPath) {
   return content.split(/\r?\n/u).filter(Boolean);
 }
 
+function runGit(appRoot, args = []) {
+  const result = spawnSync("git", Array.isArray(args) ? args : [], {
+    cwd: appRoot,
+    encoding: "utf8"
+  });
+  assert.equal(result.status, 0, String(result.stderr || ""));
+}
+
+async function initializeGitApp(appRoot) {
+  runGit(appRoot, ["init"]);
+  runGit(appRoot, ["config", "user.name", "JSKIT Test"]);
+  runGit(appRoot, ["config", "user.email", "test@example.com"]);
+  runGit(appRoot, ["add", "package.json"]);
+  runGit(appRoot, ["commit", "-m", "Initial scaffold"]);
+}
+
 test("jskit app verify runs the baseline npm scripts and doctor in order", async () => {
   await withTempDir(async (cwd) => {
     const appRoot = path.join(cwd, "app");
@@ -111,6 +136,89 @@ fs.appendFileSync(process.env.TEST_LOG_PATH, ["npm", ...process.argv.slice(2)].j
       "npm run --if-present build",
       "local-jskit doctor"
     ]);
+  });
+});
+
+test("jskit app verify-ui runs the provided command and writes a matching UI verification receipt", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "app");
+    const binDir = path.join(cwd, "bin");
+    const logPath = path.join(cwd, "commands.log");
+
+    await createMinimalApp(appRoot, { jskitApp: true });
+    await initializeGitApp(appRoot);
+
+    await mkdir(path.join(appRoot, "src", "pages", "home", "contacts"), { recursive: true });
+    await writeFile(
+      path.join(appRoot, "src", "pages", "home", "contacts", "index.vue"),
+      "<template><div>Contacts</div></template>\n",
+      "utf8"
+    );
+
+    await installFakeCommand(
+      binDir,
+      "npm",
+      `#!/usr/bin/env node
+const fs = require("node:fs");
+fs.appendFileSync(process.env.TEST_LOG_PATH, ["npm", ...process.argv.slice(2)].join(" ") + "\\n");
+`
+    );
+
+    const result = runCli({
+      cwd: appRoot,
+      args: [
+        "app",
+        "verify-ui",
+        "--command",
+        "npm run e2e -- tests/e2e/contacts.spec.ts -g filters",
+        "--feature",
+        "contacts filters",
+        "--auth-mode",
+        "dev-auth-login-as"
+      ],
+      env: buildTestEnv(binDir, logPath)
+    });
+
+    assert.equal(result.status, 0, String(result.stderr || ""));
+    assert.deepEqual(await readLogLines(logPath), [
+      "npm run e2e -- tests/e2e/contacts.spec.ts -g filters"
+    ]);
+
+    const receipt = JSON.parse(await readFile(path.join(appRoot, ".jskit", "verification", "ui.json"), "utf8"));
+    assert.equal(receipt.version, 1);
+    assert.equal(receipt.runner, "playwright");
+    assert.equal(receipt.feature, "contacts filters");
+    assert.equal(receipt.command, "npm run e2e -- tests/e2e/contacts.spec.ts -g filters");
+    assert.equal(receipt.authMode, "dev-auth-login-as");
+    assert.deepEqual(receipt.changedUiFiles, ["src/pages/home/contacts/index.vue"]);
+  });
+});
+
+test("jskit app verify-ui rejects generic package roots that are not JSKIT apps", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "package-only-root");
+
+    await createMinimalApp(appRoot);
+    await initializeGitApp(appRoot);
+    await mkdir(path.join(appRoot, "src", "pages"), { recursive: true });
+    await writeFile(path.join(appRoot, "src", "pages", "index.vue"), "<template />\n", "utf8");
+
+    const result = runCli({
+      cwd: appRoot,
+      args: [
+        "app",
+        "verify-ui",
+        "--command",
+        "npm run e2e -- tests/e2e/example.spec.ts",
+        "--feature",
+        "example",
+        "--auth-mode",
+        "none"
+      ]
+    });
+
+    assert.equal(result.status, 1, String(result.stdout || ""));
+    assert.match(String(result.stderr || ""), /jskit app verify-ui only works in a JSKIT app root/);
   });
 });
 

--- a/tooling/jskit-cli/test/completionCommand.test.js
+++ b/tooling/jskit-cli/test/completionCommand.test.js
@@ -88,7 +88,7 @@ test("completion bash __complete__ lists app subcommands and app-specific option
   assert.equal(subcommandResult.status, 0, String(subcommandResult.stderr || ""));
   assert.deepEqual(
     String(subcommandResult.stdout || "").trim().split(/\r?\n/u).filter(Boolean),
-    ["adopt-managed-scripts", "link-local-packages", "release", "update-packages", "verify"]
+    ["adopt-managed-scripts", "link-local-packages", "release", "update-packages", "verify", "verify-ui"]
   );
 
   const optionResult = runCli({
@@ -109,6 +109,16 @@ test("completion bash __complete__ lists app subcommands and app-specific option
   assert.deepEqual(
     String(releaseOptionResult.stdout || "").trim().split(/\r?\n/u).filter(Boolean),
     ["--dry-run", "--help", "--registry"]
+  );
+
+  const verifyUiOptionResult = runCli({
+    args: ["completion", "bash", "__complete__", "4", "--", "npx", "jskit", "app", "verify-ui", "--"]
+  });
+
+  assert.equal(verifyUiOptionResult.status, 0, String(verifyUiOptionResult.stderr || ""));
+  assert.deepEqual(
+    String(verifyUiOptionResult.stdout || "").trim().split(/\r?\n/u).filter(Boolean),
+    ["--auth-mode", "--command", "--feature", "--help"]
   );
 });
 

--- a/tooling/jskit-cli/test/doctorUiVerificationReceipt.test.js
+++ b/tooling/jskit-cli/test/doctorUiVerificationReceipt.test.js
@@ -1,0 +1,205 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import test from "node:test";
+import { withTempDir } from "../../testUtils/tempDir.mjs";
+import { createCliRunner } from "../../testUtils/runCli.js";
+
+const CLI_PATH = fileURLToPath(new URL("../bin/jskit.js", import.meta.url));
+const runCli = createCliRunner(CLI_PATH);
+
+async function createMinimalApp(appRoot, { name = "tmp-app" } = {}) {
+  await mkdir(appRoot, { recursive: true });
+  await writeFile(
+    path.join(appRoot, "package.json"),
+    `${JSON.stringify(
+      {
+        name,
+        version: "0.1.0",
+        private: true,
+        type: "module"
+      },
+      null,
+      2
+    )}\n`,
+    "utf8"
+  );
+  await writeFile(
+    path.join(appRoot, "app.json"),
+    `${JSON.stringify({ name }, null, 2)}\n`,
+    "utf8"
+  );
+}
+
+function runGit(appRoot, args = []) {
+  const result = spawnSync("git", Array.isArray(args) ? args : [], {
+    cwd: appRoot,
+    encoding: "utf8"
+  });
+  assert.equal(result.status, 0, String(result.stderr || ""));
+}
+
+async function initializeGitApp(appRoot) {
+  runGit(appRoot, ["init"]);
+  runGit(appRoot, ["config", "user.name", "JSKIT Test"]);
+  runGit(appRoot, ["config", "user.email", "test@example.com"]);
+  runGit(appRoot, ["add", "package.json"]);
+  runGit(appRoot, ["commit", "-m", "Initial scaffold"]);
+}
+
+async function writeUiReceipt(appRoot, {
+  feature = "contacts list",
+  command = "npx playwright test tests/e2e/contacts.spec.ts -g list",
+  authMode = "none",
+  changedUiFiles = []
+} = {}) {
+  await mkdir(path.join(appRoot, ".jskit", "verification"), { recursive: true });
+  await writeFile(
+    path.join(appRoot, ".jskit", "verification", "ui.json"),
+    `${JSON.stringify(
+      {
+        version: 1,
+        runner: "playwright",
+        recordedAt: "2026-04-20T12:00:00.000Z",
+        feature,
+        command,
+        authMode,
+        changedUiFiles
+      },
+      null,
+      2
+    )}\n`,
+    "utf8"
+  );
+}
+
+test("doctor flags changed UI files when no verification receipt exists", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "doctor-ui-receipt-missing-app");
+    await createMinimalApp(appRoot, { name: "doctor-ui-receipt-missing-app" });
+    await initializeGitApp(appRoot);
+
+    await mkdir(path.join(appRoot, "src", "pages", "home", "contacts"), { recursive: true });
+    await writeFile(
+      path.join(appRoot, "src", "pages", "home", "contacts", "index.vue"),
+      "<template><div>Contacts</div></template>\n",
+      "utf8"
+    );
+
+    const doctorResult = runCli({
+      cwd: appRoot,
+      args: ["doctor", "--json"]
+    });
+
+    assert.equal(doctorResult.status, 1, String(doctorResult.stderr || ""));
+    const payload = JSON.parse(String(doctorResult.stdout || "{}"));
+    assert.equal(payload.issues.length, 1);
+    assert.match(
+      String(payload.issues[0] || ""),
+      /\[ui:verification\] changed UI files require a matching \.jskit\/verification\/ui\.json receipt/
+    );
+  });
+});
+
+test("doctor flags stale UI verification receipts when changed UI files no longer match", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "doctor-ui-receipt-stale-app");
+    await createMinimalApp(appRoot, { name: "doctor-ui-receipt-stale-app" });
+    await initializeGitApp(appRoot);
+
+    await mkdir(path.join(appRoot, "src", "pages", "home", "contacts"), { recursive: true });
+    await writeFile(
+      path.join(appRoot, "src", "pages", "home", "contacts", "index.vue"),
+      "<template><div>Contacts</div></template>\n",
+      "utf8"
+    );
+
+    await writeUiReceipt(appRoot, {
+      changedUiFiles: ["src/pages/home/contacts/index.vue"]
+    });
+
+    await writeFile(
+      path.join(appRoot, "src", "pages", "home", "contacts", "details.vue"),
+      "<template><div>Details</div></template>\n",
+      "utf8"
+    );
+
+    const doctorResult = runCli({
+      cwd: appRoot,
+      args: ["doctor", "--json"]
+    });
+
+    assert.equal(doctorResult.status, 1, String(doctorResult.stderr || ""));
+    const payload = JSON.parse(String(doctorResult.stdout || "{}"));
+    assert.equal(payload.issues.length, 1);
+    assert.match(
+      String(payload.issues[0] || ""),
+      /\[ui:verification\] \.jskit\/verification\/ui\.json does not match the current changed UI file set/
+    );
+  });
+});
+
+test("doctor accepts matching UI verification receipts for the current dirty UI file set", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "doctor-ui-receipt-valid-app");
+    await createMinimalApp(appRoot, { name: "doctor-ui-receipt-valid-app" });
+    await initializeGitApp(appRoot);
+
+    await mkdir(path.join(appRoot, "src", "pages", "home", "contacts"), { recursive: true });
+    await writeFile(
+      path.join(appRoot, "src", "pages", "home", "contacts", "index.vue"),
+      "<template><div>Contacts</div></template>\n",
+      "utf8"
+    );
+
+    await writeUiReceipt(appRoot, {
+      authMode: "dev-auth-login-as",
+      changedUiFiles: ["src/pages/home/contacts/index.vue"]
+    });
+
+    const doctorResult = runCli({
+      cwd: appRoot,
+      args: ["doctor", "--json"]
+    });
+
+    assert.equal(doctorResult.status, 0, String(doctorResult.stderr || ""));
+    const payload = JSON.parse(String(doctorResult.stdout || "{}"));
+    assert.deepEqual(payload.issues, []);
+  });
+});
+
+test("doctor skips UI verification receipt enforcement outside JSKIT app roots", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "package-only-root");
+    await mkdir(appRoot, { recursive: true });
+    await writeFile(
+      path.join(appRoot, "package.json"),
+      `${JSON.stringify(
+        {
+          name: "package-only-root",
+          version: "0.1.0",
+          private: true,
+          type: "module"
+        },
+        null,
+        2
+      )}\n`,
+      "utf8"
+    );
+    await initializeGitApp(appRoot);
+
+    await mkdir(path.join(appRoot, "src", "pages", "home"), { recursive: true });
+    await writeFile(path.join(appRoot, "src", "pages", "home", "index.vue"), "<template />\n", "utf8");
+
+    const doctorResult = runCli({
+      cwd: appRoot,
+      args: ["doctor", "--json"]
+    });
+
+    assert.equal(doctorResult.status, 0, String(doctorResult.stderr || ""));
+    const payload = JSON.parse(String(doctorResult.stdout || "{}"));
+    assert.deepEqual(payload.issues, []);
+  });
+});


### PR DESCRIPTION
## Summary
- add `jskit app verify-ui` to run a targeted Playwright command and write a UI verification receipt
- make `doctor` enforce matching receipts only inside JSKIT app roots
- ignore receipt files in fresh app scaffolds and document the workflow for agents and app authors

## Notes
- this PR contains the staged changes only
- per request, merge immediately without waiting on verify