### PR TITLE
Formalize CRUD repository mapping

### DIFF
--- a/packages/agent-docs/guide/agent/generators/advanced-cruds.md
+++ b/packages/agent-docs/guide/agent/generators/advanced-cruds.md
@@ -834,6 +834,75 @@ Usually nothing changes. The client can keep sending `q`.
 - Do not dump every text column into search just because you can.
 - In this tutorial CRUD, `notes` is a good example of a field you might leave out if you want fast, predictable list search.
 
+### Pattern 2B: repository mapping and computed output fields
+
+Do not treat the output schema as if it also defined database storage.
+
+In JSKIT CRUD:
+
+- the schema defines the API contract
+- `resource.fieldMeta` defines storage mapping
+- the repository runtime owns computed SQL projections
+
+Use these rules:
+
+- for explicit DB column overrides, use `repository.column`
+- for computed output fields, use `repository.storage: "virtual"`
+- do not put computed fields in create/patch write schemas
+
+Example field metadata:
+
+```js
+RESOURCE_FIELD_META.push({
+  key: "createdAt",
+  repository: {
+    column: "created_at"
+  }
+});
+
+RESOURCE_FIELD_META.push({
+  key: "remainingBatchWeight",
+  repository: {
+    storage: "virtual"
+  }
+});
+```
+
+Register the computed projection once in the repository runtime:
+
+```js
+const repositoryRuntime = createCrudRepositoryRuntime(resource, {
+  context: "receivals repository",
+  list: LIST_CONFIG,
+  virtualFields: {
+    remainingBatchWeight: {
+      applyProjection(dbQuery, { knex, tableName, alias }) {
+        const { sql, bindings } = getRemainingBatchWeightSqlParts({ tableName });
+        dbQuery.select(knex.raw(`${sql} as ??`, [...bindings, alias]));
+      }
+    }
+  }
+});
+```
+
+Once registered there:
+
+- generic CRUD `list`
+- generic CRUD `findById`
+- generic CRUD `listByIds`
+- generic CRUD `listByForeignIds`
+
+all pick up the projection automatically, so you should not hand-patch `clearSelect()` / re-select logic into each method.
+
+Important limits:
+
+- `virtual` fields are output-only in v1
+- fallback search derivation only uses column-backed fields
+- parent-filter fallback derivation only uses column-backed fields
+- `listByIds(..., { valueKey })` requires a column-backed `valueKey`
+
+For the agent-facing quick rule, see `patterns/crud-repository-mapping.md`.
+
 ### Pattern 3: structured list filters from one shared definition
 
 This is the default pattern once a CRUD list needs real filters.

--- a/packages/agent-docs/patterns/INDEX.md
+++ b/packages/agent-docs/patterns/INDEX.md
@@ -26,6 +26,8 @@ How to use it:
   - `ui-testing.md`
 - filter, filters, search facets, chips, date range, enum filter, lookup filter, `useCrudListFilters`, `createCrudListFilters`
   - `filters.md`
+- fieldMeta, `repository.column`, computed field, virtual field, projection, `createCrudRepositoryRuntime`, `remainingBatchWeight`
+  - `crud-repository-mapping.md`
 
 ## Current Patterns
 
@@ -37,3 +39,4 @@ How to use it:
 - [client-requests.md](./client-requests.md)
 - [ui-testing.md](./ui-testing.md)
 - [filters.md](./filters.md)
+- [crud-repository-mapping.md](./crud-repository-mapping.md)

--- a/packages/agent-docs/patterns/crud-repository-mapping.md
+++ b/packages/agent-docs/patterns/crud-repository-mapping.md
@@ -1,0 +1,81 @@
+# CRUD Repository Mapping
+
+Use when:
+- a CRUD resource needs explicit DB column mapping
+- a field should exist in API output but is not a real DB column
+- the user mentions computed fields, projections, or `remainingBatchWeight`
+
+Default JSKIT pattern:
+1. Treat the schema as the API contract only.
+2. Put persistence mapping in `resource.fieldMeta`.
+3. Use `repository.column` for explicit DB column overrides.
+4. Use `repository.storage: "virtual"` for computed output fields.
+5. Register computed SQL projections once in the repository runtime with `virtualFields`.
+6. Let generic CRUD read paths apply those projections automatically.
+
+Field meta rules:
+- for a normal override, write:
+
+```js
+RESOURCE_FIELD_META.push({
+  key: "createdAt",
+  repository: {
+    column: "created_at"
+  }
+});
+```
+
+- for a computed output field, write:
+
+```js
+RESOURCE_FIELD_META.push({
+  key: "remainingBatchWeight",
+  repository: {
+    storage: "virtual"
+  }
+});
+```
+
+- omit `repository` entirely when the field is column-backed and the default snake_case mapping is correct
+- `repository.storage: "virtual"` cannot also define `repository.column`
+- `repository.storage: "virtual"` fields must not appear in create/patch write schemas
+
+Repository pattern:
+- build the runtime with `createCrudRepositoryRuntime(resource, { ... })`
+- register computed projections in `virtualFields`
+- keep SQL in the repository, not in shared metadata
+
+Example:
+
+```js
+const repositoryRuntime = createCrudRepositoryRuntime(resource, {
+  context: "receivals repository",
+  list: LIST_CONFIG,
+  virtualFields: {
+    remainingBatchWeight: {
+      applyProjection(dbQuery, { knex, tableName, alias }) {
+        const { sql, bindings } = getRemainingBatchWeightSqlParts({ tableName });
+        dbQuery.select(knex.raw(`${sql} as ??`, [...bindings, alias]));
+      }
+    }
+  }
+});
+```
+
+What CRUD core now does for you:
+- default select columns include only column-backed output fields
+- `list`, `findById`, `listByIds`, and `listByForeignIds` apply registered virtual projections automatically
+- search and parent-filter fallback derivation only use column-backed fields
+- `listByIds(..., { valueKey })` requires that `valueKey` be column-backed
+
+Avoid:
+- manual `clearSelect()` / re-select hacks in individual repository methods just to add computed fields
+- putting SQL fragments or joins into shared `fieldMeta`
+- inventing `repository.storage` modes beyond the documented `virtual` contract
+
+Review checks:
+- schema defines contract, not storage
+- `fieldMeta.repository` owns mapping
+- computed fields use `repository.storage: "virtual"`
+- repository runtime registers matching `virtualFields`
+- no per-method projection duplication when generic CRUD reads already cover the field

--- a/packages/agent-docs/reference/autogen/packages/crud-core.md
+++ b/packages/agent-docs/reference/autogen/packages/crud-core.md
@@ -70,7 +70,7 @@ Exports
 
 ### `src/server/createCrudRepositoryFromResource.js`
 Exports
-- `createCrudRepositoryFromResource(resource = {}, { context = "crudRepository", list = {} } = {})`
+- `createCrudRepositoryFromResource(resource = {}, { context = "crudRepository", list = {}, virtualFields = {} } = {})`
 
 ### `src/server/createCrudServiceFromResource.js`
 Exports
@@ -207,7 +207,7 @@ Local functions
 
 ### `src/server/repositoryMethods.js`
 Exports
-- `createCrudRepositoryRuntime(resource = {}, { context = "crudRepository", list = {} } = {})`
+- `createCrudRepositoryRuntime(resource = {}, { context = "crudRepository", list = {}, virtualFields = {} } = {})`
 - `crudRepositoryList(runtime, knex, query = {}, repositoryOptions = {}, callOptions = {}, hooks = null)`
 - `crudRepositoryFindById(runtime, knex, recordId, repositoryOptions = {}, callOptions = {}, hooks = null)`
 - `crudRepositoryListByIds(runtime, knex, ids = [], repositoryOptions = {}, callOptions = {}, hooks = null)`
@@ -218,6 +218,8 @@ Exports
 Local functions
 - `requireCrudRecordId(value, { context = "crudRepository" } = {})`
 - `resolveRepositoryDefaults(resource = {}, repositoryMapping = {})`
+- `normalizeCrudVirtualFieldHandlers(virtualFields = {}, repositoryMapping = {}, { context = "crudRepository" } = {})`
+- `applyCrudRepositoryVirtualProjections(dbQuery, runtime = {}, { knex, tableName } = {})`
 - `normalizeSearchColumns(searchColumns = [], fallbackColumns = [])`
 - `normalizeListOrderDirection(value = LIST_ORDER_DIRECTION_ASC)`
 - `normalizeListOrderNulls(value = LIST_ORDER_NULLS_LAST)`
@@ -262,8 +264,9 @@ Exports
 - `buildWritePayload(sourcePayload = {}, fieldKeys = [], overrides = {})`
 - `resolveColumnName(fieldKey, overrides = {})`
 - `resolveCrudIdColumn(idColumn, { fallback = "id" } = {})`
-- `buildRepositoryColumnMetadata({ outputKeys = [], writeKeys = [], columnOverrides = {} } = {})`
+- `buildRepositoryColumnMetadata({ outputKeys = [], writeKeys = [], columnOverrides = {}, fieldStorageByKey = {} } = {})`
 Local functions
+- `resolveOptionalObjectSchemaProperties(schema, options = {})`
 - `requireObjectSchemaProperties(schema, { context = "crudRepository", schemaLabel = "schema" } = {})`
 - `normalizeResourceFieldMetaEntries(fieldMeta = [])`
 - `schemaIncludesStringType(schema = {})`
@@ -286,11 +289,14 @@ Local functions
 
 ### `src/shared/crudFieldMetaSupport.js`
 Exports
+- `CRUD_FIELD_REPOSITORY_STORAGE_COLUMN`
+- `CRUD_FIELD_REPOSITORY_STORAGE_VIRTUAL`
 - `CRUD_LOOKUP_FORM_CONTROL_AUTOCOMPLETE`
 - `CRUD_LOOKUP_FORM_CONTROL_SELECT`
 - `CRUD_RUNTIME_LOOKUPS_FIELD_KEY`
 - `checkCrudLookupFormControl(value, { context = "crud fieldMeta ui.formControl", defaultValue = CRUD_LOOKUP_FORM_CONTROL_AUTOCOMPLETE } = {})`
 - `isCrudRuntimeOutputOnlyFieldKey(value = "", { lookupContainerKey = CRUD_RUNTIME_LOOKUPS_FIELD_KEY } = {})`
+- `normalizeCrudFieldRepositoryConfig(fieldMetaEntry = {}, { context = "crud fieldMeta repository", fieldKey = "" } = {})`
 
 ### `src/shared/crudNamespaceSupport.js`
 Exports

--- a/packages/agent-docs/reference/autogen/tooling/jskit-cli.md
+++ b/packages/agent-docs/reference/autogen/tooling/jskit-cli.md
@@ -28,6 +28,7 @@ Exports
 
 ### `src/server/cliRuntime/appState.js`
 Exports
+- `directoryLooksLikeJskitAppRoot(directoryPath)`
 - `resolveAppRootFromCwd(cwd)`
 - `loadAppPackageJson(appRoot)`
 - `createDefaultLock()`
@@ -41,8 +42,6 @@ Exports
 - `upsertEnvValue(content, key, value)`
 - `removeEnvValue(content, key, expectedValue, previous)`
 - `writeJsonFile`
-Local functions
-- `directoryLooksLikeJskitAppRoot(directoryPath)`
 
 ### `src/server/cliRuntime/capabilitySupport.js`
 Exports

--- a/packages/agent-docs/site/guide/generators/advanced-cruds.md
+++ b/packages/agent-docs/site/guide/generators/advanced-cruds.md
@@ -832,6 +832,75 @@ Usually nothing changes. The client can keep sending `q`.
 - Do not dump every text column into search just because you can.
 - In this tutorial CRUD, `notes` is a good example of a field you might leave out if you want fast, predictable list search.
 
+### Pattern 2B: repository mapping and computed output fields
+
+Do not treat the output schema as if it also defined database storage.
+
+In JSKIT CRUD:
+
+- the schema defines the API contract
+- `resource.fieldMeta` defines storage mapping
+- the repository runtime owns computed SQL projections
+
+Use these rules:
+
+- for explicit DB column overrides, use `repository.column`
+- for computed output fields, use `repository.storage: "virtual"`
+- do not put computed fields in create/patch write schemas
+
+Example field metadata:
+
+```js
+RESOURCE_FIELD_META.push({
+  key: "createdAt",
+  repository: {
+    column: "created_at"
+  }
+});
+
+RESOURCE_FIELD_META.push({
+  key: "remainingBatchWeight",
+  repository: {
+    storage: "virtual"
+  }
+});
+```
+
+Register the computed projection once in the repository runtime:
+
+```js
+const repositoryRuntime = createCrudRepositoryRuntime(resource, {
+  context: "receivals repository",
+  list: LIST_CONFIG,
+  virtualFields: {
+    remainingBatchWeight: {
+      applyProjection(dbQuery, { knex, tableName, alias }) {
+        const { sql, bindings } = getRemainingBatchWeightSqlParts({ tableName });
+        dbQuery.select(knex.raw(`${sql} as ??`, [...bindings, alias]));
+      }
+    }
+  }
+});
+```
+
+Once registered there:
+
+- generic CRUD `list`
+- generic CRUD `findById`
+- generic CRUD `listByIds`
+- generic CRUD `listByForeignIds`
+
+all pick up the projection automatically, so you should not hand-patch `clearSelect()` / re-select logic into each method.
+
+Important limits:
+
+- `virtual` fields are output-only in v1
+- fallback search derivation only uses column-backed fields
+- parent-filter fallback derivation only uses column-backed fields
+- `listByIds(..., { valueKey })` requires a column-backed `valueKey`
+
+For the agent-facing quick rule, see `patterns/crud-repository-mapping.md`.
+
 ### Pattern 3: structured list filters from one shared definition
 
 This is the default pattern once a CRUD list needs real filters.

--- a/packages/console-core/src/server/consoleSettings/consoleSettingsRepository.js
+++ b/packages/console-core/src/server/consoleSettings/consoleSettingsRepository.js
@@ -15,8 +15,9 @@ function nowDb() {
 function mapSettings(row = {}) {
   const settings = {};
   for (const field of consoleSettingsFields) {
-    const rawValue = Object.hasOwn(row, field.dbColumn)
-      ? row[field.dbColumn]
+    const repositoryColumn = field?.repository?.column;
+    const rawValue = Object.hasOwn(row, repositoryColumn)
+      ? row[repositoryColumn]
       : field.resolveDefault({
           settings: row
         });
@@ -96,7 +97,7 @@ function createRepository(knex) {
       if (!Object.hasOwn(source, field.key)) {
         continue;
       }
-      dbPatch[field.dbColumn] = field.normalizeInput(source[field.key], {
+      dbPatch[field.repository.column] = field.normalizeInput(source[field.key], {
         payload: source
       });
     }

--- a/packages/console-core/src/shared/resources/consoleSettingsFields.js
+++ b/packages/console-core/src/shared/resources/consoleSettingsFields.js
@@ -17,9 +17,9 @@ function defineField(field = {}) {
   if (!field.outputSchema || typeof field.outputSchema !== "object") {
     throw new TypeError(`consoleSettingsFields.defineField("${key}") requires outputSchema.`);
   }
-  const dbColumn = normalizeText(field.dbColumn);
-  if (!dbColumn) {
-    throw new TypeError(`consoleSettingsFields.defineField("${key}") requires dbColumn.`);
+  const repositoryColumn = normalizeText(field?.repository?.column);
+  if (!repositoryColumn) {
+    throw new TypeError(`consoleSettingsFields.defineField("${key}") requires repository.column.`);
   }
   if (typeof field.normalizeInput !== "function") {
     throw new TypeError(`consoleSettingsFields.defineField("${key}") requires normalizeInput.`);
@@ -33,7 +33,9 @@ function defineField(field = {}) {
 
   consoleSettingsFields.push({
     key,
-    dbColumn,
+    repository: Object.freeze({
+      column: repositoryColumn
+    }),
     required: field.required !== false,
     inputSchema: field.inputSchema,
     outputSchema: field.outputSchema,

--- a/packages/crud-core/src/server/createCrudRepositoryFromResource.js
+++ b/packages/crud-core/src/server/createCrudRepositoryFromResource.js
@@ -10,10 +10,11 @@ import {
 } from "./repositoryMethods.js";
 import { createWithTransaction } from "@jskit-ai/database-runtime/shared";
 
-function createCrudRepositoryFromResource(resource = {}, { context = "crudRepository", list = {} } = {}) {
+function createCrudRepositoryFromResource(resource = {}, { context = "crudRepository", list = {}, virtualFields = {} } = {}) {
   const runtime = createCrudRepositoryRuntime(resource, {
     context,
-    list
+    list,
+    virtualFields
   });
 
   return function createRepository(knex, options = {}) {

--- a/packages/crud-core/src/server/repositoryMethods.js
+++ b/packages/crud-core/src/server/repositoryMethods.js
@@ -20,6 +20,7 @@ import {
   createCrudLookupRuntime,
   hydrateCrudLookupRecords
 } from "./lookupHydration.js";
+import { CRUD_FIELD_REPOSITORY_STORAGE_COLUMN } from "../shared/crudFieldMetaSupport.js";
 
 const LIST_ORDER_DIRECTION_ASC = "asc";
 const LIST_ORDER_DIRECTION_DESC = "desc";
@@ -45,10 +46,12 @@ function resolveRepositoryDefaults(resource = {}, repositoryMapping = {}) {
   }
 
   const idColumn = normalizeText(resource.idColumn) || resolveColumnName("id", repositoryMapping.columnOverrides) || "id";
-  const createdAtColumn = repositoryMapping.outputKeys.includes("createdAt")
+  const createdAtColumn = repositoryMapping.outputKeys.includes("createdAt") &&
+    repositoryMapping.fieldStorageByKey?.createdAt === CRUD_FIELD_REPOSITORY_STORAGE_COLUMN
     ? resolveColumnName("createdAt", repositoryMapping.columnOverrides)
     : "";
-  const updatedAtColumn = repositoryMapping.outputKeys.includes("updatedAt")
+  const updatedAtColumn = repositoryMapping.outputKeys.includes("updatedAt") &&
+    repositoryMapping.fieldStorageByKey?.updatedAt === CRUD_FIELD_REPOSITORY_STORAGE_COLUMN
     ? resolveColumnName("updatedAt", repositoryMapping.columnOverrides)
     : "";
 
@@ -58,6 +61,95 @@ function resolveRepositoryDefaults(resource = {}, repositoryMapping = {}) {
     createdAtColumn,
     updatedAtColumn
   });
+}
+
+function normalizeCrudVirtualFieldHandlers(
+  virtualFields = {},
+  repositoryMapping = {},
+  { context = "crudRepository" } = {}
+) {
+  const expectedKeys = new Set(
+    (Array.isArray(repositoryMapping?.virtualOutputKeys) ? repositoryMapping.virtualOutputKeys : [])
+      .map((key) => normalizeText(key))
+      .filter(Boolean)
+  );
+  if (expectedKeys.size < 1) {
+    if (virtualFields === null || virtualFields === undefined) {
+      return Object.freeze([]);
+    }
+    if (!virtualFields || typeof virtualFields !== "object" || Array.isArray(virtualFields)) {
+      throw new TypeError(`${context} virtualFields must be an object when provided.`);
+    }
+    if (Object.keys(virtualFields).length > 0) {
+      throw new Error(
+        `${context} virtualFields contains registrations, but the resource does not declare any repository.storage "virtual" fields.`
+      );
+    }
+    return Object.freeze([]);
+  }
+
+  if (!virtualFields || typeof virtualFields !== "object" || Array.isArray(virtualFields)) {
+    throw new TypeError(`${context} virtualFields must be an object.`);
+  }
+
+  const normalizedHandlers = [];
+  const seenKeys = new Set();
+  for (const [rawKey, handlerConfig] of Object.entries(virtualFields)) {
+    const key = normalizeText(rawKey);
+    if (!key || seenKeys.has(key)) {
+      continue;
+    }
+    if (!expectedKeys.has(key)) {
+      throw new Error(
+        `${context} virtualFields["${key}"] is unknown; declare the field in resource.fieldMeta with repository.storage "virtual".`
+      );
+    }
+    if (!handlerConfig || typeof handlerConfig !== "object" || Array.isArray(handlerConfig)) {
+      throw new TypeError(`${context} virtualFields["${key}"] must be an object.`);
+    }
+    if (typeof handlerConfig.applyProjection !== "function") {
+      throw new TypeError(`${context} virtualFields["${key}"].applyProjection must be a function.`);
+    }
+
+    seenKeys.add(key);
+    normalizedHandlers.push(Object.freeze({
+      key,
+      alias: resolveColumnName(key, repositoryMapping.columnOverrides),
+      applyProjection: handlerConfig.applyProjection
+    }));
+  }
+
+  for (const key of expectedKeys) {
+    if (!seenKeys.has(key)) {
+      throw new Error(
+        `${context} resource output field "${key}" is virtual but no repository runtime projection was registered.`
+      );
+    }
+  }
+
+  return Object.freeze(normalizedHandlers);
+}
+
+function applyCrudRepositoryVirtualProjections(
+  dbQuery,
+  runtime = {},
+  { knex, tableName } = {}
+) {
+  const virtualFields = Array.isArray(runtime?.virtualFields) ? runtime.virtualFields : [];
+  if (virtualFields.length < 1) {
+    return dbQuery;
+  }
+
+  for (const virtualField of virtualFields) {
+    virtualField.applyProjection(dbQuery, {
+      knex,
+      tableName,
+      alias: virtualField.alias,
+      fieldKey: virtualField.key
+    });
+  }
+
+  return dbQuery;
 }
 
 function normalizeSearchColumns(searchColumns = [], fallbackColumns = []) {
@@ -376,7 +468,7 @@ async function normalizeRepositoryOutputRecord(runtime, record = {}, { operation
   );
 }
 
-function createCrudRepositoryRuntime(resource = {}, { context = "crudRepository", list = {} } = {}) {
+function createCrudRepositoryRuntime(resource = {}, { context = "crudRepository", list = {}, virtualFields = {} } = {}) {
   const repositoryMapping = deriveRepositoryMappingFromResource(resource, { context });
   const defaults = resolveRepositoryDefaults(resource, repositoryMapping);
   const output = resolveRecordOutputValidator(resource, { context });
@@ -387,9 +479,10 @@ function createCrudRepositoryRuntime(resource = {}, { context = "crudRepository"
     idColumn: defaults.idColumn
   });
   const { selectColumns } = buildRepositoryColumnMetadata({
-    outputKeys: repositoryMapping.outputKeys,
+    outputKeys: repositoryMapping.columnBackedOutputKeys,
     writeKeys: repositoryMapping.writeKeys,
-    columnOverrides: repositoryMapping.columnOverrides
+    columnOverrides: repositoryMapping.columnOverrides,
+    fieldStorageByKey: repositoryMapping.fieldStorageByKey
   });
   const normalizedSelectColumns = Object.freeze(
     [...new Set([
@@ -405,7 +498,8 @@ function createCrudRepositoryRuntime(resource = {}, { context = "crudRepository"
     output,
     list: listRuntime,
     lookup: lookupRuntime,
-    mapping: repositoryMapping
+    mapping: repositoryMapping,
+    virtualFields: normalizeCrudVirtualFieldHandlers(virtualFields, repositoryMapping, { context })
   });
 }
 
@@ -722,6 +816,10 @@ async function crudRepositoryList(runtime, knex, query = {}, repositoryOptions =
   const usesOrderedListCursor = runtime.list.orderBy.length > 0;
   let dbQuery = client(tableName)
     .select(...runtime.selectColumns);
+  dbQuery = applyCrudRepositoryVirtualProjections(dbQuery, runtime, {
+    knex: client,
+    tableName
+  });
 
   dbQuery = applyCrudListQueryFilters(dbQuery, {
     idColumn,
@@ -891,6 +989,10 @@ async function crudRepositoryFindById(runtime, knex, recordId, repositoryOptions
   const hookContextBase = createCrudRepositoryHookContextBase(runtime, repositoryOptions, callOptions);
   let dbQuery = client(tableName)
     .select(...runtime.selectColumns);
+  dbQuery = applyCrudRepositoryVirtualProjections(dbQuery, runtime, {
+    knex: client,
+    tableName
+  });
 
   const findByIdHookResult = await applyCrudRepositoryQueryHook(
     dbQuery,
@@ -1014,6 +1116,11 @@ async function crudRepositoryListByIds(runtime, knex, ids = [], repositoryOption
       `${runtime.context || "crudRepository"} listByIds requires valueKey "${lookupValueKey}" to exist in output schema.`
     );
   }
+  if (runtime.mapping.fieldStorageByKey?.[lookupValueKey] !== CRUD_FIELD_REPOSITORY_STORAGE_COLUMN) {
+    throw new TypeError(
+      `${runtime.context || "crudRepository"} listByIds requires valueKey "${lookupValueKey}" to be column-backed.`
+    );
+  }
   const lookupColumn = resolveColumnName(lookupValueKey, runtime.mapping.columnOverrides);
   if (!lookupColumn) {
     throw new TypeError(`${runtime.context || "crudRepository"} listByIds requires a valid valueKey.`);
@@ -1026,6 +1133,10 @@ async function crudRepositoryListByIds(runtime, knex, ids = [], repositoryOption
 
   let dbQuery = client(tableName)
     .select(...runtime.selectColumns);
+  dbQuery = applyCrudRepositoryVirtualProjections(dbQuery, runtime, {
+    knex: client,
+    tableName
+  });
 
   const listByIdsHookResult = await applyCrudRepositoryQueryHook(
     dbQuery,

--- a/packages/crud-core/src/server/repositorySupport.js
+++ b/packages/crud-core/src/server/repositorySupport.js
@@ -8,7 +8,12 @@ import {
   resolveCrudLookupContainerKey,
   resolveCrudLookupFieldKeys
 } from "@jskit-ai/kernel/shared/support/crudLookup";
-import { isCrudRuntimeOutputOnlyFieldKey } from "../shared/crudFieldMetaSupport.js";
+import {
+  CRUD_FIELD_REPOSITORY_STORAGE_COLUMN,
+  CRUD_FIELD_REPOSITORY_STORAGE_VIRTUAL,
+  isCrudRuntimeOutputOnlyFieldKey,
+  normalizeCrudFieldRepositoryConfig
+} from "../shared/crudFieldMetaSupport.js";
 
 const DEFAULT_LIST_LIMIT = 20;
 const MAX_LIST_LIMIT = 100;
@@ -70,7 +75,8 @@ function resolveColumnName(fieldKey, overrides = {}) {
 function buildRepositoryColumnMetadata({
   outputKeys = [],
   writeKeys = [],
-  columnOverrides = {}
+  columnOverrides = {},
+  fieldStorageByKey = {}
 } = {}) {
   const normalizedOutputKeys = (Array.isArray(outputKeys) ? outputKeys : [])
     .map((key) => String(key || "").trim())
@@ -80,6 +86,9 @@ function buildRepositoryColumnMetadata({
     .filter(Boolean);
 
   const deriveMapping = (key) => {
+    if (fieldStorageByKey?.[key] !== CRUD_FIELD_REPOSITORY_STORAGE_COLUMN) {
+      return null;
+    }
     const column = resolveColumnName(key, columnOverrides);
     if (!column) {
       return null;
@@ -98,6 +107,13 @@ function buildRepositoryColumnMetadata({
     outputMappings: Object.freeze(outputMappings),
     writeMappings: Object.freeze(writeMappings)
   });
+}
+
+function resolveOptionalObjectSchemaProperties(schema, options = {}) {
+  if (!schema) {
+    return {};
+  }
+  return requireObjectSchemaProperties(schema, options);
 }
 
 function requireObjectSchemaProperties(schema, { context = "crudRepository", schemaLabel = "schema" } = {}) {
@@ -189,6 +205,7 @@ function deriveRepositoryMappingFromResource(resource = {}, { context = "crudRep
 
   const outputSchema = operations?.view?.outputValidator?.schema;
   const writeSchema = operations?.create?.bodyValidator?.schema;
+  const patchSchema = operations?.patch?.bodyValidator?.schema;
   const outputProperties = requireObjectSchemaProperties(outputSchema, {
     context,
     schemaLabel: "operations.view.outputValidator.schema"
@@ -196,6 +213,10 @@ function deriveRepositoryMappingFromResource(resource = {}, { context = "crudRep
   const writeProperties = requireObjectSchemaProperties(writeSchema, {
     context,
     schemaLabel: "operations.create.bodyValidator.schema"
+  });
+  const patchProperties = resolveOptionalObjectSchemaProperties(patchSchema, {
+    context,
+    schemaLabel: "operations.patch.bodyValidator.schema"
   });
   const lookupContainerKey = resolveCrudLookupContainerKey(resource, {
     context: `${context} resource.contract.lookup.containerKey`
@@ -207,18 +228,58 @@ function deriveRepositoryMappingFromResource(resource = {}, { context = "crudRep
   );
   const writeKeys = Object.freeze(Object.keys(writeProperties));
 
+  const fieldStorageByKey = {};
   const columnOverrides = {};
   for (const entry of normalizeResourceFieldMetaEntries(resource.fieldMeta)) {
     const key = normalizeText(entry.key);
-    const dbColumn = normalizeText(entry.dbColumn);
-    if (!key || !dbColumn) {
+    if (!key) {
       continue;
     }
-    columnOverrides[key] = dbColumn;
+    const repositoryConfig = normalizeCrudFieldRepositoryConfig(entry, {
+      context: `${context} resource.fieldMeta`,
+      fieldKey: key
+    });
+    fieldStorageByKey[key] = repositoryConfig.storage;
+    if (repositoryConfig.column) {
+      columnOverrides[key] = repositoryConfig.column;
+    }
+  }
+
+  for (const key of [...outputKeys, ...writeKeys]) {
+    if (!fieldStorageByKey[key]) {
+      fieldStorageByKey[key] = CRUD_FIELD_REPOSITORY_STORAGE_COLUMN;
+    }
+  }
+
+  const virtualOutputKeys = [];
+  const columnBackedOutputKeys = [];
+  for (const key of outputKeys) {
+    const storage = fieldStorageByKey[key] || CRUD_FIELD_REPOSITORY_STORAGE_COLUMN;
+    if (storage === CRUD_FIELD_REPOSITORY_STORAGE_VIRTUAL) {
+      virtualOutputKeys.push(key);
+      continue;
+    }
+    columnBackedOutputKeys.push(key);
+  }
+
+  for (const key of virtualOutputKeys) {
+    if (Object.hasOwn(writeProperties, key)) {
+      throw new Error(
+        `${context} resource create schema field "${key}" cannot use repository.storage "virtual".`
+      );
+    }
+    if (Object.hasOwn(patchProperties, key)) {
+      throw new Error(
+        `${context} resource patch schema field "${key}" cannot use repository.storage "virtual".`
+      );
+    }
   }
 
   const listSearchColumns = [];
   for (const [key, schema] of Object.entries(outputProperties)) {
+    if ((fieldStorageByKey[key] || CRUD_FIELD_REPOSITORY_STORAGE_COLUMN) !== CRUD_FIELD_REPOSITORY_STORAGE_COLUMN) {
+      continue;
+    }
     if (!schemaIncludesStringType(schema)) {
       continue;
     }
@@ -232,6 +293,9 @@ function deriveRepositoryMappingFromResource(resource = {}, { context = "crudRep
 
   const parentFilterColumns = {};
   for (const key of resolveCrudLookupFieldKeys(resource, { allowKeys: writeKeys })) {
+    if ((fieldStorageByKey[key] || CRUD_FIELD_REPOSITORY_STORAGE_COLUMN) !== CRUD_FIELD_REPOSITORY_STORAGE_COLUMN) {
+      continue;
+    }
     const columnName = resolveColumnName(key, columnOverrides);
     if (!columnName) {
       continue;
@@ -249,7 +313,10 @@ function deriveRepositoryMappingFromResource(resource = {}, { context = "crudRep
   return Object.freeze({
     outputKeys,
     writeKeys,
+    fieldStorageByKey: Object.freeze(fieldStorageByKey),
     columnOverrides: Object.freeze(columnOverrides),
+    columnBackedOutputKeys: Object.freeze(columnBackedOutputKeys),
+    virtualOutputKeys: Object.freeze(virtualOutputKeys),
     listSearchColumns: Object.freeze(listSearchColumns),
     parentFilterColumns: Object.freeze(parentFilterColumns),
     outputRecordIdKeys: Object.freeze(outputRecordIdKeys)

--- a/packages/crud-core/src/shared/crudFieldMetaSupport.js
+++ b/packages/crud-core/src/shared/crudFieldMetaSupport.js
@@ -7,6 +7,8 @@ import {
 const CRUD_RUNTIME_LOOKUPS_FIELD_KEY = DEFAULT_CRUD_LOOKUP_CONTAINER_KEY;
 const CRUD_LOOKUP_FORM_CONTROL_AUTOCOMPLETE = "autocomplete";
 const CRUD_LOOKUP_FORM_CONTROL_SELECT = "select";
+const CRUD_FIELD_REPOSITORY_STORAGE_COLUMN = "column";
+const CRUD_FIELD_REPOSITORY_STORAGE_VIRTUAL = "virtual";
 
 function checkCrudLookupFormControl(
   value,
@@ -45,10 +47,71 @@ function isCrudRuntimeOutputOnlyFieldKey(
   return normalizeText(value) === resolvedLookupContainerKey;
 }
 
+function normalizeCrudFieldRepositoryConfig(
+  fieldMetaEntry = {},
+  {
+    context = "crud fieldMeta repository",
+    fieldKey = ""
+  } = {}
+) {
+  const normalizedFieldKey = normalizeText(fieldKey || fieldMetaEntry?.key);
+  const repository = fieldMetaEntry?.repository;
+  if (repository === undefined || repository === null) {
+    return Object.freeze({
+      storage: CRUD_FIELD_REPOSITORY_STORAGE_COLUMN,
+      column: ""
+    });
+  }
+  if (!repository || typeof repository !== "object" || Array.isArray(repository)) {
+    throw new TypeError(
+      `${context}${normalizedFieldKey ? `["${normalizedFieldKey}"]` : ""} must be an object when provided.`
+    );
+  }
+
+  const repositoryKeys = Object.keys(repository);
+  for (const repositoryKey of repositoryKeys) {
+    if (repositoryKey !== "column" && repositoryKey !== "storage") {
+      throw new Error(
+        `${context}${normalizedFieldKey ? `["${normalizedFieldKey}"]` : ""} does not support repository.${repositoryKey}.`
+      );
+    }
+  }
+
+  const column = normalizeText(repository.column);
+  const storage = normalizeText(repository.storage).toLowerCase();
+
+  if (!column && !storage) {
+    throw new Error(
+      `${context}${normalizedFieldKey ? `["${normalizedFieldKey}"]` : ""} requires repository.column or repository.storage.`
+    );
+  }
+
+  if (storage && storage !== CRUD_FIELD_REPOSITORY_STORAGE_VIRTUAL) {
+    throw new Error(
+      `${context}${normalizedFieldKey ? `["${normalizedFieldKey}"]` : ""} repository.storage must be "virtual" when provided.`
+    );
+  }
+  if (storage === CRUD_FIELD_REPOSITORY_STORAGE_VIRTUAL && column) {
+    throw new Error(
+      `${context}${normalizedFieldKey ? `["${normalizedFieldKey}"]` : ""} repository.storage "virtual" cannot define repository.column.`
+    );
+  }
+
+  return Object.freeze({
+    storage: storage === CRUD_FIELD_REPOSITORY_STORAGE_VIRTUAL
+      ? CRUD_FIELD_REPOSITORY_STORAGE_VIRTUAL
+      : CRUD_FIELD_REPOSITORY_STORAGE_COLUMN,
+    column
+  });
+}
+
 export {
+  CRUD_FIELD_REPOSITORY_STORAGE_COLUMN,
+  CRUD_FIELD_REPOSITORY_STORAGE_VIRTUAL,
   CRUD_LOOKUP_FORM_CONTROL_AUTOCOMPLETE,
   CRUD_LOOKUP_FORM_CONTROL_SELECT,
   CRUD_RUNTIME_LOOKUPS_FIELD_KEY,
   checkCrudLookupFormControl,
-  isCrudRuntimeOutputOnlyFieldKey
+  isCrudRuntimeOutputOnlyFieldKey,
+  normalizeCrudFieldRepositoryConfig
 };

--- a/packages/crud-core/test/createCrudRepositoryFromResource.test.js
+++ b/packages/crud-core/test/createCrudRepositoryFromResource.test.js
@@ -218,7 +218,7 @@ function createResourceFixture() {
     fieldMeta: [
       {
         key: "id",
-        dbColumn: "contact_id"
+        repository: { column: "contact_id" }
       }
     ]
   };
@@ -262,11 +262,11 @@ function createLookupResourceFixture() {
     fieldMeta: [
       {
         key: "id",
-        dbColumn: "contact_id"
+        repository: { column: "contact_id" }
       },
       {
         key: "primaryVetId",
-        dbColumn: "primary_vet_id",
+        repository: { column: "primary_vet_id" },
         relation: {
           kind: "lookup",
           namespace: "vets",
@@ -275,7 +275,7 @@ function createLookupResourceFixture() {
       },
       {
         key: "secondaryVetId",
-        dbColumn: "secondary_vet_id",
+        repository: { column: "secondary_vet_id" },
         relation: {
           kind: "lookup",
           namespace: "vets",
@@ -329,11 +329,11 @@ function createLookupResourceWithCustomContainerKeyFixture() {
     fieldMeta: [
       {
         key: "id",
-        dbColumn: "contact_id"
+        repository: { column: "contact_id" }
       },
       {
         key: "primaryVetId",
-        dbColumn: "primary_vet_id",
+        repository: { column: "primary_vet_id" },
         relation: {
           kind: "lookup",
           namespace: "vets",
@@ -342,7 +342,7 @@ function createLookupResourceWithCustomContainerKeyFixture() {
       },
       {
         key: "secondaryVetId",
-        dbColumn: "secondary_vet_id",
+        repository: { column: "secondary_vet_id" },
         relation: {
           kind: "lookup",
           namespace: "vets",
@@ -387,7 +387,7 @@ function createCollectionLookupResourceFixture() {
     fieldMeta: [
       {
         key: "id",
-        dbColumn: "contact_id"
+        repository: { column: "contact_id" }
       },
       {
         key: "pets",
@@ -437,11 +437,11 @@ function createPetsLookupBackToContactsResourceFixture() {
     fieldMeta: [
       {
         key: "id",
-        dbColumn: "pet_id"
+        repository: { column: "pet_id" }
       },
       {
         key: "customerId",
-        dbColumn: "customer_id",
+        repository: { column: "customer_id" },
         relation: {
           kind: "lookup",
           namespace: "contacts",
@@ -490,7 +490,7 @@ function createNormalizedResourceFixture() {
     fieldMeta: [
       {
         key: "id",
-        dbColumn: "contact_id"
+        repository: { column: "contact_id" }
       }
     ]
   };
@@ -530,19 +530,63 @@ function createWritableHookResourceFixture() {
     fieldMeta: [
       {
         key: "id",
-        dbColumn: "contact_id"
+        repository: { column: "contact_id" }
       },
       {
         key: "firstName",
-        dbColumn: "first_name"
+        repository: { column: "first_name" }
       },
       {
         key: "createdAt",
-        dbColumn: "created_at"
+        repository: { column: "created_at" }
       },
       {
         key: "updatedAt",
-        dbColumn: "updated_at"
+        repository: { column: "updated_at" }
+      }
+    ]
+  };
+}
+
+function createVirtualProjectionResourceFixture() {
+  return {
+    resource: "receivals",
+    tableName: "receivals_table",
+    idColumn: "receival_id",
+    operations: {
+      view: {
+        outputValidator: {
+          schema: {
+            type: "object",
+            properties: {
+              id: recordIdSchema,
+              firstName: { type: "string" },
+              remainingBatchWeight: { type: "number" }
+            }
+          }
+        }
+      },
+      create: {
+        bodyValidator: {
+          schema: {
+            type: "object",
+            properties: {
+              firstName: { type: "string" }
+            }
+          }
+        }
+      }
+    },
+    fieldMeta: [
+      {
+        key: "id",
+        repository: { column: "receival_id" }
+      },
+      {
+        key: "remainingBatchWeight",
+        repository: {
+          storage: "virtual"
+        }
       }
     ]
   };
@@ -652,6 +696,82 @@ test("createCrudRepositoryFromResource allows list tuning through list config", 
 
   assert.ok(calls.some((call) => call[0] === "where" && call[1] === "first_name" && call[2] === "like" && call[3] === "%to%"));
   assert.ok(calls.some((call) => call[0] === "limit" && call[1] === 3));
+});
+
+test("createCrudRepositoryFromResource requires virtual projection handlers for virtual output fields", () => {
+  assert.throws(
+    () => createCrudRepositoryFromResource(createVirtualProjectionResourceFixture()),
+    /resource output field "remainingBatchWeight" is virtual but no repository runtime projection was registered/
+  );
+});
+
+test("createCrudRepositoryFromResource rejects unknown virtual projection registrations", () => {
+  assert.throws(
+    () => createCrudRepositoryFromResource(createVirtualProjectionResourceFixture(), {
+      virtualFields: {
+        bogusField: {
+          applyProjection() {}
+        }
+      }
+    }),
+    /virtualFields\["bogusField"\] is unknown/
+  );
+});
+
+test("createCrudRepositoryFromResource applies virtual projections across generic read paths", async () => {
+  const createRepository = createCrudRepositoryFromResource(createVirtualProjectionResourceFixture(), {
+    virtualFields: {
+      remainingBatchWeight: {
+        applyProjection(dbQuery, { alias }) {
+          dbQuery.select(alias);
+        }
+      }
+    }
+  });
+  const { knex, calls } = createListKnexDouble([
+    {
+      receival_id: 3,
+      first_name: "Tony",
+      remaining_batch_weight: 42.5
+    }
+  ]);
+  const repository = createRepository(knex);
+
+  const listResult = await repository.list({});
+  const findResult = await repository.findById("3");
+  const listByIdsResult = await repository.listByIds(["3"]);
+
+  assert.deepEqual(listResult.items, [
+    {
+      id: "3",
+      firstName: "Tony",
+      remainingBatchWeight: 42.5
+    }
+  ]);
+  assert.deepEqual(findResult, {
+    id: "3",
+    firstName: "Tony",
+    remainingBatchWeight: 42.5
+  });
+  assert.deepEqual(listByIdsResult, [
+    {
+      id: "3",
+      firstName: "Tony",
+      remainingBatchWeight: 42.5
+    }
+  ]);
+  const projectionSelectCalls = calls.filter((call) => (
+    call[0] === "select" &&
+    call.length === 2 &&
+    call[1] === "remaining_batch_weight"
+  ));
+  const baseSelectCalls = calls.filter((call) => (
+    call[0] === "select" &&
+    call.length > 2
+  ));
+  assert.equal(projectionSelectCalls.length, 3);
+  assert.ok(baseSelectCalls.length >= 3);
+  assert.ok(baseSelectCalls.every((call) => call.includes("remaining_batch_weight") === false));
 });
 
 test("createCrudRepositoryFromResource supports declarative ordered list pagination", async () => {
@@ -946,6 +1066,34 @@ test("createCrudRepositoryFromResource listByIds fails fast when valueKey is not
         valueKey: "externalCustomerId"
       }),
     /valueKey "externalCustomerId" to exist in output schema/
+  );
+});
+
+test("createCrudRepositoryFromResource listByIds fails fast when valueKey is virtual", async () => {
+  const createRepository = createCrudRepositoryFromResource(createVirtualProjectionResourceFixture(), {
+    virtualFields: {
+      remainingBatchWeight: {
+        applyProjection(dbQuery, { alias }) {
+          dbQuery.select(alias);
+        }
+      }
+    }
+  });
+  const { knex } = createListKnexDouble([
+    {
+      receival_id: 3,
+      first_name: "Tony",
+      remaining_batch_weight: 42.5
+    }
+  ]);
+  const repository = createRepository(knex);
+
+  await assert.rejects(
+    () =>
+      repository.listByIds(["42.5"], {
+        valueKey: "remainingBatchWeight"
+      }),
+    /valueKey "remainingBatchWeight" to be column-backed/
   );
 });
 

--- a/packages/crud-core/test/repositorySupport.test.js
+++ b/packages/crud-core/test/repositorySupport.test.js
@@ -217,7 +217,11 @@ test("buildRepositoryColumnMetadata normalizes columns and applies overrides", (
   const metadata = buildRepositoryColumnMetadata({
     outputKeys: ["firstName", "lastName"],
     writeKeys: ["firstName"],
-    columnOverrides: { lastName: "surname" }
+    columnOverrides: { lastName: "surname" },
+    fieldStorageByKey: {
+      firstName: "column",
+      lastName: "column"
+    }
   });
 
   assert.deepEqual(metadata.selectColumns, Object.freeze(["first_name", "surname"]));
@@ -226,7 +230,7 @@ test("buildRepositoryColumnMetadata normalizes columns and applies overrides", (
   assert.equal(metadata.outputMappings[1].column, "surname");
 });
 
-test("deriveRepositoryMappingFromResource reads schema keys and fieldMeta dbColumn overrides", () => {
+test("deriveRepositoryMappingFromResource reads schema keys and repository column overrides", () => {
   const resource = {
     operations: {
       view: {
@@ -256,11 +260,11 @@ test("deriveRepositoryMappingFromResource reads schema keys and fieldMeta dbColu
     fieldMeta: [
       {
         key: "createdAt",
-        dbColumn: "created_at"
+        repository: { column: "created_at" }
       },
       {
         key: "vetId",
-        dbColumn: "vet_id",
+        repository: { column: "vet_id" },
         relation: {
           kind: "lookup",
           namespace: "vets",
@@ -281,6 +285,140 @@ test("deriveRepositoryMappingFromResource reads schema keys and fieldMeta dbColu
   assert.deepEqual(mapping.parentFilterColumns, {
     vetId: "vet_id"
   });
+});
+
+test("deriveRepositoryMappingFromResource treats virtual output fields as non-column projections", () => {
+  const resource = {
+    operations: {
+      view: {
+        outputValidator: {
+          schema: {
+            type: "object",
+            properties: {
+              id: { type: "integer" },
+              firstName: { type: "string" },
+              remainingBatchWeight: { type: "number" }
+            }
+          }
+        }
+      },
+      create: {
+        bodyValidator: {
+          schema: {
+            type: "object",
+            properties: {
+              firstName: { type: "string" }
+            }
+          }
+        }
+      }
+    },
+    fieldMeta: [
+      {
+        key: "remainingBatchWeight",
+        repository: {
+          storage: "virtual"
+        }
+      }
+    ]
+  };
+
+  const mapping = deriveRepositoryMappingFromResource(resource);
+  assert.deepEqual(mapping.outputKeys, ["id", "firstName", "remainingBatchWeight"]);
+  assert.deepEqual(mapping.columnBackedOutputKeys, ["id", "firstName"]);
+  assert.deepEqual(mapping.virtualOutputKeys, ["remainingBatchWeight"]);
+  assert.equal(mapping.fieldStorageByKey.remainingBatchWeight, "virtual");
+  assert.deepEqual(mapping.listSearchColumns, ["first_name"]);
+});
+
+test("deriveRepositoryMappingFromResource rejects virtual fields in create schema", () => {
+  const resource = {
+    operations: {
+      view: {
+        outputValidator: {
+          schema: {
+            type: "object",
+            properties: {
+              id: { type: "integer" },
+              remainingBatchWeight: { type: "number" }
+            }
+          }
+        }
+      },
+      create: {
+        bodyValidator: {
+          schema: {
+            type: "object",
+            properties: {
+              remainingBatchWeight: { type: "number" }
+            }
+          }
+        }
+      }
+    },
+    fieldMeta: [
+      {
+        key: "remainingBatchWeight",
+        repository: {
+          storage: "virtual"
+        }
+      }
+    ]
+  };
+
+  assert.throws(
+    () => deriveRepositoryMappingFromResource(resource),
+    /resource create schema field "remainingBatchWeight" cannot use repository\.storage "virtual"/
+  );
+});
+
+test("deriveRepositoryMappingFromResource rejects virtual fields in patch schema", () => {
+  const resource = {
+    operations: {
+      view: {
+        outputValidator: {
+          schema: {
+            type: "object",
+            properties: {
+              id: { type: "integer" },
+              remainingBatchWeight: { type: "number" }
+            }
+          }
+        }
+      },
+      create: {
+        bodyValidator: {
+          schema: {
+            type: "object",
+            properties: {}
+          }
+        }
+      },
+      patch: {
+        bodyValidator: {
+          schema: {
+            type: "object",
+            properties: {
+              remainingBatchWeight: { type: "number" }
+            }
+          }
+        }
+      }
+    },
+    fieldMeta: [
+      {
+        key: "remainingBatchWeight",
+        repository: {
+          storage: "virtual"
+        }
+      }
+    ]
+  };
+
+  assert.throws(
+    () => deriveRepositoryMappingFromResource(resource),
+    /resource patch schema field "remainingBatchWeight" cannot use repository\.storage "virtual"/
+  );
 });
 
 test("deriveRepositoryMappingFromResource excludes runtime-only lookups output key from db mapping", () => {

--- a/packages/crud-server-generator/src/server/buildTemplateContext.js
+++ b/packages/crud-server-generator/src/server/buildTemplateContext.js
@@ -1157,7 +1157,7 @@ function buildFieldMetaEntries({ outputColumns = [], writableColumns = [], snaps
     }
   }
 
-  const dbColumnEntries = [];
+  const repositoryEntries = [];
   for (const column of fieldColumnsByKey.values()) {
     const key = normalizeText(column?.key);
     const name = normalizeText(column?.name);
@@ -1167,9 +1167,11 @@ function buildFieldMetaEntries({ outputColumns = [], writableColumns = [], snaps
     if (toSnakeCase(key) === name) {
       continue;
     }
-    dbColumnEntries.push({
+    repositoryEntries.push({
       key,
-      dbColumn: name
+      repository: {
+        column: name
+      }
     });
   }
 
@@ -1235,15 +1237,19 @@ function buildFieldMetaEntries({ outputColumns = [], writableColumns = [], snaps
     });
   }
 
-  return mergeFieldMetaEntries(dbColumnEntries, relationEntries, enumEntries);
+  return mergeFieldMetaEntries(repositoryEntries, relationEntries, enumEntries);
 }
 
 function renderFieldMetaEntryLines(entry = {}) {
   const lines = ["RESOURCE_FIELD_META.push({"];
   const topLevelProperties = [`key: ${JSON.stringify(entry.key)}`];
-  const dbColumn = normalizeText(entry.dbColumn);
-  if (dbColumn) {
-    topLevelProperties.push(`dbColumn: ${JSON.stringify(dbColumn)}`);
+  const repositoryColumn = normalizeText(entry?.repository?.column);
+  if (repositoryColumn) {
+    topLevelProperties.push([
+      "repository: {",
+      `  column: ${JSON.stringify(repositoryColumn)}`,
+      "}"
+    ].join("\n"));
   }
 
   const relation = entry.relation && typeof entry.relation === "object" ? entry.relation : null;

--- a/packages/crud-server-generator/src/server/subcommands/resourceAst.js
+++ b/packages/crud-server-generator/src/server/subcommands/resourceAst.js
@@ -484,9 +484,11 @@ function renderResourceFieldMetaPushStatement(entry = {}) {
   const lines = ["RESOURCE_FIELD_META.push({"];
   lines.push(`  key: ${JSON.stringify(key)},`);
 
-  const dbColumn = normalizeText(entry?.dbColumn);
-  if (dbColumn) {
-    lines.push(`  dbColumn: ${JSON.stringify(dbColumn)},`);
+  const repositoryColumn = normalizeText(entry?.repository?.column);
+  if (repositoryColumn) {
+    lines.push("  repository: {");
+    lines.push(`    column: ${JSON.stringify(repositoryColumn)}`);
+    lines.push("  },");
   }
 
   const relation = entry?.relation && typeof entry.relation === "object" ? entry.relation : null;

--- a/packages/crud-ui-generator/src/server/resourceSupport.js
+++ b/packages/crud-ui-generator/src/server/resourceSupport.js
@@ -480,9 +480,11 @@ function buildResourceFieldMetaMap(resource = {}) {
     const nextEntry = {
       key
     };
-    const dbColumn = normalizeText(rawEntry.dbColumn);
-    if (dbColumn) {
-      nextEntry.dbColumn = dbColumn;
+    const repositoryColumn = normalizeText(rawEntry?.repository?.column);
+    if (repositoryColumn) {
+      nextEntry.repository = {
+        column: repositoryColumn
+      };
     }
 
     const relation = normalizeLookupRelation(rawEntry.relation);

--- a/packages/users-core/src/server/common/repositories/userSettingsRepository.js
+++ b/packages/users-core/src/server/common/repositories/userSettingsRepository.js
@@ -25,8 +25,9 @@ function mapRow(row) {
   };
 
   for (const field of userSettingsFields) {
-    const value = Object.hasOwn(row, field.dbColumn)
-      ? row[field.dbColumn]
+    const column = field.repository.column;
+    const value = Object.hasOwn(row, column)
+      ? row[column]
       : field.resolveDefault({
           settings: mapped,
           row
@@ -66,7 +67,7 @@ function createInsertPayload(userId) {
     const defaultValue = field.resolveDefault({
       settings: resolvedDefaults
     });
-    payload[field.dbColumn] = field.normalizeInput(defaultValue, {
+    payload[field.repository.column] = field.normalizeInput(defaultValue, {
       payload: resolvedDefaults,
       settings: resolvedDefaults
     });
@@ -132,14 +133,14 @@ function createRepository(knex) {
       updated_at: nowDb()
     };
 
-    for (const field of userSettingsFields) {
-      if (!Object.hasOwn(source, field.key)) {
-        continue;
-      }
-      dbPatch[field.dbColumn] = field.normalizeInput(source[field.key], {
-        payload: source,
-        settings: ensured
-      });
+  for (const field of userSettingsFields) {
+    if (!Object.hasOwn(source, field.key)) {
+      continue;
+    }
+    dbPatch[field.repository.column] = field.normalizeInput(source[field.key], {
+      payload: source,
+      settings: ensured
+    });
     }
 
     if (Object.hasOwn(source, "passwordSignInEnabled")) {

--- a/packages/users-core/src/shared/resources/userSettingsFields.js
+++ b/packages/users-core/src/shared/resources/userSettingsFields.js
@@ -24,9 +24,13 @@ function defineField(field = {}) {
   if (!field.outputSchema || typeof field.outputSchema !== "object") {
     throw new TypeError(`userSettingsFields.defineField("${key}") requires outputSchema.`);
   }
-  const dbColumn = normalizeText(field.dbColumn);
-  if (!dbColumn) {
-    throw new TypeError(`userSettingsFields.defineField("${key}") requires dbColumn.`);
+  const repository = field?.repository;
+  if (!repository || typeof repository !== "object" || Array.isArray(repository)) {
+    throw new TypeError(`userSettingsFields.defineField("${key}") requires repository.column.`);
+  }
+  const repositoryColumn = normalizeText(repository.column);
+  if (!repositoryColumn) {
+    throw new TypeError(`userSettingsFields.defineField("${key}") requires repository.column.`);
   }
   const section = normalizeLowerText(field.section);
   if (!USER_SETTINGS_SECTION_VALUES.includes(section)) {
@@ -47,7 +51,9 @@ function defineField(field = {}) {
   userSettingsFields.push({
     key,
     section,
-    dbColumn,
+    repository: Object.freeze({
+      column: repositoryColumn
+    }),
     required: field.required !== false,
     includeInBootstrap: field.includeInBootstrap !== false,
     inputSchema: field.inputSchema,

--- a/packages/users-core/templates/packages/main/src/shared/resources/userSettingsFields.js
+++ b/packages/users-core/templates/packages/main/src/shared/resources/userSettingsFields.js
@@ -20,7 +20,7 @@ resetUserSettingsFields();
 defineField({
   key: "theme",
   section: USER_SETTINGS_SECTIONS.PREFERENCES,
-  dbColumn: "theme",
+  repository: { column: "theme" },
   required: true,
   inputSchema: Type.String({ minLength: 1, maxLength: 32 }),
   outputSchema: Type.String({ minLength: 1, maxLength: 32 }),
@@ -32,7 +32,7 @@ defineField({
 defineField({
   key: "locale",
   section: USER_SETTINGS_SECTIONS.PREFERENCES,
-  dbColumn: "locale",
+  repository: { column: "locale" },
   required: true,
   inputSchema: Type.String({ minLength: 1, maxLength: 24 }),
   outputSchema: Type.String({ minLength: 1, maxLength: 24 }),
@@ -44,7 +44,7 @@ defineField({
 defineField({
   key: "timeZone",
   section: USER_SETTINGS_SECTIONS.PREFERENCES,
-  dbColumn: "time_zone",
+  repository: { column: "time_zone" },
   required: true,
   inputSchema: Type.String({ minLength: 1, maxLength: 64 }),
   outputSchema: Type.String({ minLength: 1, maxLength: 64 }),
@@ -56,7 +56,7 @@ defineField({
 defineField({
   key: "dateFormat",
   section: USER_SETTINGS_SECTIONS.PREFERENCES,
-  dbColumn: "date_format",
+  repository: { column: "date_format" },
   required: true,
   inputSchema: Type.String({ minLength: 1, maxLength: 32 }),
   outputSchema: Type.String({ minLength: 1, maxLength: 32 }),
@@ -68,7 +68,7 @@ defineField({
 defineField({
   key: "numberFormat",
   section: USER_SETTINGS_SECTIONS.PREFERENCES,
-  dbColumn: "number_format",
+  repository: { column: "number_format" },
   required: true,
   inputSchema: Type.String({ minLength: 1, maxLength: 32 }),
   outputSchema: Type.String({ minLength: 1, maxLength: 32 }),
@@ -80,7 +80,7 @@ defineField({
 defineField({
   key: "currencyCode",
   section: USER_SETTINGS_SECTIONS.PREFERENCES,
-  dbColumn: "currency_code",
+  repository: { column: "currency_code" },
   required: true,
   inputSchema: Type.String({ minLength: 3, maxLength: 3, pattern: "^[A-Za-z]{3}$" }),
   outputSchema: Type.String({ minLength: 3, maxLength: 3, pattern: "^[A-Z]{3}$" }),
@@ -92,7 +92,7 @@ defineField({
 defineField({
   key: "avatarSize",
   section: USER_SETTINGS_SECTIONS.PREFERENCES,
-  dbColumn: "avatar_size",
+  repository: { column: "avatar_size" },
   required: true,
   inputSchema: Type.Integer({ minimum: 1 }),
   outputSchema: Type.Integer({ minimum: 1 }),
@@ -104,7 +104,7 @@ defineField({
 defineField({
   key: "productUpdates",
   section: USER_SETTINGS_SECTIONS.NOTIFICATIONS,
-  dbColumn: "notify_product_updates",
+  repository: { column: "notify_product_updates" },
   required: true,
   inputSchema: Type.Boolean(),
   outputSchema: Type.Boolean(),
@@ -116,7 +116,7 @@ defineField({
 defineField({
   key: "accountActivity",
   section: USER_SETTINGS_SECTIONS.NOTIFICATIONS,
-  dbColumn: "notify_account_activity",
+  repository: { column: "notify_account_activity" },
   required: true,
   inputSchema: Type.Boolean(),
   outputSchema: Type.Boolean(),
@@ -128,7 +128,7 @@ defineField({
 defineField({
   key: "securityAlerts",
   section: USER_SETTINGS_SECTIONS.NOTIFICATIONS,
-  dbColumn: "notify_security_alerts",
+  repository: { column: "notify_security_alerts" },
   required: true,
   inputSchema: Type.Boolean(),
   outputSchema: Type.Boolean(),

--- a/packages/workspaces-core/src/server/workspaceSettings/workspaceSettingsRepository.js
+++ b/packages/workspaces-core/src/server/workspaceSettings/workspaceSettingsRepository.js
@@ -46,8 +46,9 @@ function createRepository(knex, { defaultInvitesEnabled } = {}) {
       workspaceId: normalizeDbRecordId(row.workspace_id, { fallback: "" })
     };
     for (const field of workspaceSettingsFields) {
-      const rawValue = Object.hasOwn(row, field.dbColumn)
-        ? row[field.dbColumn]
+      const column = field.repository.column;
+      const rawValue = Object.hasOwn(row, column)
+        ? row[column]
         : field.resolveDefault({
             defaultInvitesEnabled
           });
@@ -94,7 +95,7 @@ function createRepository(knex, { defaultInvitesEnabled } = {}) {
         updated_at: nowDb()
       };
       for (const field of workspaceSettingsFields) {
-        insertPayload[field.dbColumn] = seed[field.key];
+        insertPayload[field.repository.column] = seed[field.key];
       }
       await client("workspace_settings").insert(insertPayload);
     } catch (error) {
@@ -132,7 +133,7 @@ function createRepository(knex, { defaultInvitesEnabled } = {}) {
       if (!Object.hasOwn(settingsPatch, field.key)) {
         continue;
       }
-      dbPatch[field.dbColumn] = field.normalizeInput(settingsPatch[field.key], {
+      dbPatch[field.repository.column] = field.normalizeInput(settingsPatch[field.key], {
         payload: source
       });
     }

--- a/packages/workspaces-core/src/shared/resources/workspaceSettingsFields.js
+++ b/packages/workspaces-core/src/shared/resources/workspaceSettingsFields.js
@@ -17,9 +17,13 @@ function defineField(field = {}) {
   if (!field.outputSchema || typeof field.outputSchema !== "object") {
     throw new TypeError(`workspaceSettingsFields.defineField("${key}") requires outputSchema.`);
   }
-  const dbColumn = normalizeText(field.dbColumn);
-  if (!dbColumn) {
-    throw new TypeError(`workspaceSettingsFields.defineField("${key}") requires dbColumn.`);
+  const repository = field?.repository;
+  if (!repository || typeof repository !== "object" || Array.isArray(repository)) {
+    throw new TypeError(`workspaceSettingsFields.defineField("${key}") requires repository.column.`);
+  }
+  const repositoryColumn = normalizeText(repository.column);
+  if (!repositoryColumn) {
+    throw new TypeError(`workspaceSettingsFields.defineField("${key}") requires repository.column.`);
   }
   if (typeof field.normalizeInput !== "function") {
     throw new TypeError(`workspaceSettingsFields.defineField("${key}") requires normalizeInput.`);
@@ -33,7 +37,9 @@ function defineField(field = {}) {
 
   workspaceSettingsFields.push({
     key,
-    dbColumn,
+    repository: Object.freeze({
+      column: repositoryColumn
+    }),
     required: field.required !== false,
     inputSchema: field.inputSchema,
     outputSchema: field.outputSchema,

--- a/packages/workspaces-core/templates/packages/main/src/shared/resources/workspaceSettingsFields.js
+++ b/packages/workspaces-core/templates/packages/main/src/shared/resources/workspaceSettingsFields.js
@@ -22,7 +22,7 @@ resetWorkspaceSettingsFields();
 
 defineField({
   key: "lightPrimaryColor",
-  dbColumn: "light_primary_color",
+  repository: { column: "light_primary_color" },
   required: true,
   inputSchema: Type.String({
     minLength: 7,
@@ -42,7 +42,7 @@ defineField({
 
 defineField({
   key: "lightSecondaryColor",
-  dbColumn: "light_secondary_color",
+  repository: { column: "light_secondary_color" },
   required: true,
   inputSchema: Type.String({
     minLength: 7,
@@ -62,7 +62,7 @@ defineField({
 
 defineField({
   key: "lightSurfaceColor",
-  dbColumn: "light_surface_color",
+  repository: { column: "light_surface_color" },
   required: true,
   inputSchema: Type.String({
     minLength: 7,
@@ -82,7 +82,7 @@ defineField({
 
 defineField({
   key: "lightSurfaceVariantColor",
-  dbColumn: "light_surface_variant_color",
+  repository: { column: "light_surface_variant_color" },
   required: true,
   inputSchema: Type.String({
     minLength: 7,
@@ -102,7 +102,7 @@ defineField({
 
 defineField({
   key: "darkPrimaryColor",
-  dbColumn: "dark_primary_color",
+  repository: { column: "dark_primary_color" },
   required: true,
   inputSchema: Type.String({
     minLength: 7,
@@ -122,7 +122,7 @@ defineField({
 
 defineField({
   key: "darkSecondaryColor",
-  dbColumn: "dark_secondary_color",
+  repository: { column: "dark_secondary_color" },
   required: true,
   inputSchema: Type.String({
     minLength: 7,
@@ -142,7 +142,7 @@ defineField({
 
 defineField({
   key: "darkSurfaceColor",
-  dbColumn: "dark_surface_color",
+  repository: { column: "dark_surface_color" },
   required: true,
   inputSchema: Type.String({
     minLength: 7,
@@ -162,7 +162,7 @@ defineField({
 
 defineField({
   key: "darkSurfaceVariantColor",
-  dbColumn: "dark_surface_variant_color",
+  repository: { column: "dark_surface_variant_color" },
   required: true,
   inputSchema: Type.String({
     minLength: 7,
@@ -182,7 +182,7 @@ defineField({
 
 defineField({
   key: "invitesEnabled",
-  dbColumn: "invites_enabled",
+  repository: { column: "invites_enabled" },
   required: true,
   inputSchema: Type.Boolean({
     messages: {


### PR DESCRIPTION
## Summary
- formalize CRUD repository mapping around `fieldMeta.repository` and runtime `virtualFields`
- remove explicit legacy-shape handling so the code only knows the new repository contract
- update generators, internal packages, and distributed docs to the same one-shape model