### PR TITLE
Tighten direct CRUD generation and infer numeric bounds

### DIFF
--- a/packages/crud-server-generator/src/server/buildTemplateContext.js
+++ b/packages/crud-server-generator/src/server/buildTemplateContext.js
@@ -391,9 +391,194 @@ function resolveColumnKey(column, idColumn) {
   return String(column.key || "");
 }
 
+const NUMERIC_CHECK_CONSTRAINT_PATTERN = /(?:`([^`]+)`|([A-Za-z_][A-Za-z0-9_]*))\s*(>=|>|<=|<)\s*(-?\d+(?:\.\d+)?)/g;
+
+function normalizeNumericBoundValue(value, scale = null) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    return null;
+  }
+  if (!Number.isInteger(scale) || scale < 0) {
+    return parsed;
+  }
+  return Number(parsed.toFixed(scale));
+}
+
+function resolveNumericExclusiveStep(column) {
+  if (column?.typeKind === "integer") {
+    return 1;
+  }
+  if (column?.typeKind === "number" && Number.isInteger(column?.numericScale) && column.numericScale > 0) {
+    return 1 / (10 ** column.numericScale);
+  }
+  return null;
+}
+
+function applyLowerBound(current = null, candidate = null) {
+  if (!candidate) {
+    return current;
+  }
+  if (!current) {
+    return candidate;
+  }
+  if (candidate.value > current.value) {
+    return candidate;
+  }
+  if (candidate.value < current.value) {
+    return current;
+  }
+  if (candidate.exclusive === true && current.exclusive !== true) {
+    return candidate;
+  }
+  return current;
+}
+
+function applyUpperBound(current = null, candidate = null) {
+  if (!candidate) {
+    return current;
+  }
+  if (!current) {
+    return candidate;
+  }
+  if (candidate.value < current.value) {
+    return candidate;
+  }
+  if (candidate.value > current.value) {
+    return current;
+  }
+  if (candidate.exclusive === true && current.exclusive !== true) {
+    return candidate;
+  }
+  return current;
+}
+
+function resolveColumnNumericBounds(snapshot = {}) {
+  const byColumnName = new Map();
+  const columns = Array.isArray(snapshot.columns) ? snapshot.columns : [];
+  const checkConstraints = Array.isArray(snapshot.checkConstraints) ? snapshot.checkConstraints : [];
+  const numericColumnsByName = new Map(
+    columns
+      .filter((column) => column?.typeKind === "integer" || column?.typeKind === "number")
+      .map((column) => [String(column.name || ""), column])
+  );
+
+  function getColumnBounds(columnName) {
+    if (!byColumnName.has(columnName)) {
+      byColumnName.set(columnName, {
+        minimum: null,
+        exclusiveMinimum: null,
+        maximum: null,
+        exclusiveMaximum: null
+      });
+    }
+    return byColumnName.get(columnName);
+  }
+
+  for (const column of numericColumnsByName.values()) {
+    if (column.unsigned === true) {
+      const target = getColumnBounds(column.name);
+      target.minimum = 0;
+    }
+  }
+
+  for (const constraint of checkConstraints) {
+    const clause = String(constraint?.clause || "");
+    if (!clause) {
+      continue;
+    }
+
+    let match = null;
+    while ((match = NUMERIC_CHECK_CONSTRAINT_PATTERN.exec(clause)) != null) {
+      const columnName = String(match[1] || match[2] || "");
+      const operator = String(match[3] || "");
+      const rawValue = Number(match[4]);
+      const column = numericColumnsByName.get(columnName) || null;
+      if (!column || !Number.isFinite(rawValue)) {
+        continue;
+      }
+
+      const target = getColumnBounds(columnName);
+      if (operator === ">=" || operator === ">") {
+        let candidate = null;
+        if (operator === ">=") {
+          candidate = {
+            value: normalizeNumericBoundValue(rawValue, column.numericScale),
+            exclusive: false
+          };
+        } else {
+          const exclusiveStep = resolveNumericExclusiveStep(column);
+          if (exclusiveStep != null) {
+            candidate = {
+              value: normalizeNumericBoundValue(rawValue + exclusiveStep, column.numericScale),
+              exclusive: false
+            };
+          } else {
+            candidate = {
+              value: normalizeNumericBoundValue(rawValue, column.numericScale),
+              exclusive: true
+            };
+          }
+        }
+
+        const nextBound = applyLowerBound(
+          target.minimum != null || target.exclusiveMinimum != null
+            ? {
+                value: target.minimum ?? target.exclusiveMinimum,
+                exclusive: target.exclusiveMinimum != null
+              }
+            : null,
+          candidate
+        );
+        target.minimum = nextBound?.exclusive === true ? null : nextBound?.value ?? null;
+        target.exclusiveMinimum = nextBound?.exclusive === true ? nextBound?.value ?? null : null;
+        continue;
+      }
+
+      if (operator === "<=" || operator === "<") {
+        let candidate = null;
+        if (operator === "<=") {
+          candidate = {
+            value: normalizeNumericBoundValue(rawValue, column.numericScale),
+            exclusive: false
+          };
+        } else {
+          const exclusiveStep = resolveNumericExclusiveStep(column);
+          if (exclusiveStep != null) {
+            candidate = {
+              value: normalizeNumericBoundValue(rawValue - exclusiveStep, column.numericScale),
+              exclusive: false
+            };
+          } else {
+            candidate = {
+              value: normalizeNumericBoundValue(rawValue, column.numericScale),
+              exclusive: true
+            };
+          }
+        }
+
+        const nextBound = applyUpperBound(
+          target.maximum != null || target.exclusiveMaximum != null
+            ? {
+                value: target.maximum ?? target.exclusiveMaximum,
+                exclusive: target.exclusiveMaximum != null
+              }
+            : null,
+          candidate
+        );
+        target.maximum = nextBound?.exclusive === true ? null : nextBound?.value ?? null;
+        target.exclusiveMaximum = nextBound?.exclusive === true ? nextBound?.value ?? null : null;
+      }
+    }
+    NUMERIC_CHECK_CONSTRAINT_PATTERN.lastIndex = 0;
+  }
+
+  return byColumnName;
+}
+
 function resolveScaffoldColumns(snapshot) {
   const idColumn = String(snapshot.idColumn || DEFAULT_ID_COLUMN);
   const sourceColumns = Array.isArray(snapshot.columns) ? snapshot.columns : [];
+  const numericBoundsByColumnName = resolveColumnNumericBounds(snapshot);
   const foreignKeyColumnNames = new Set(
     (Array.isArray(snapshot.foreignKeys) ? snapshot.foreignKeys : [])
       .flatMap((foreignKey) => Array.isArray(foreignKey?.columns) ? foreignKey.columns : [])
@@ -427,6 +612,7 @@ function resolveScaffoldColumns(snapshot) {
 
     return Object.freeze({
       ...column,
+      ...(numericBoundsByColumnName.get(column.name) || {}),
       key,
       isOwnerColumn,
       isIdColumn,
@@ -462,8 +648,18 @@ function renderPropertyAccess(sourceName, key) {
 
 function renderIntegerSchema(column) {
   const options = [];
-  if (column.unsigned === true) {
+  if (Number.isFinite(column?.minimum)) {
+    options.push(`minimum: ${column.minimum}`);
+  } else if (Number.isFinite(column?.exclusiveMinimum)) {
+    options.push(`exclusiveMinimum: ${column.exclusiveMinimum}`);
+  } else if (column.unsigned === true) {
     options.push("minimum: 0");
+  }
+  if (Number.isFinite(column?.maximum)) {
+    options.push(`maximum: ${column.maximum}`);
+  }
+  if (Number.isFinite(column?.exclusiveMaximum)) {
+    options.push(`exclusiveMaximum: ${column.exclusiveMaximum}`);
   }
   if (options.length > 0) {
     return `Type.Integer({ ${options.join(", ")} })`;
@@ -499,7 +695,22 @@ function renderResourceFieldSchema(column, { forOutput = false } = {}) {
     }
     schemaExpression = renderIntegerSchema(column);
   } else if (typeKind === "number") {
-    schemaExpression = "Type.Number()";
+    const options = [];
+    if (Number.isFinite(column?.minimum)) {
+      options.push(`minimum: ${column.minimum}`);
+    }
+    if (Number.isFinite(column?.exclusiveMinimum)) {
+      options.push(`exclusiveMinimum: ${column.exclusiveMinimum}`);
+    }
+    if (Number.isFinite(column?.maximum)) {
+      options.push(`maximum: ${column.maximum}`);
+    }
+    if (Number.isFinite(column?.exclusiveMaximum)) {
+      options.push(`exclusiveMaximum: ${column.exclusiveMaximum}`);
+    }
+    schemaExpression = options.length > 0
+      ? `Type.Number({ ${options.join(", ")} })`
+      : "Type.Number()";
   } else if (typeKind === "boolean") {
     schemaExpression = "Type.Boolean()";
   } else if (typeKind === "datetime") {

--- a/packages/crud-server-generator/test/buildTemplateContext.test.js
+++ b/packages/crud-server-generator/test/buildTemplateContext.test.js
@@ -738,6 +738,118 @@ test("buildReplacementsFromSnapshot preserves custom collations, hash unique ind
   );
 });
 
+test("resolveScaffoldColumns derives resource numeric bounds from check constraints", () => {
+  const snapshot = createSnapshot({
+    tableName: "batch_receivals",
+    hasWorkspaceIdColumn: false,
+    hasUserIdColumn: false
+  });
+
+  const inputWeightColumn = Object.freeze({
+    name: "input_weight",
+    key: "inputWeight",
+    dataType: "decimal",
+    columnType: "decimal(10,3)",
+    typeKind: "number",
+    nullable: false,
+    hasDefault: false,
+    defaultValue: null,
+    autoIncrement: false,
+    unsigned: false,
+    extra: "",
+    maxLength: null,
+    numericPrecision: 10,
+    numericScale: 3,
+    datetimePrecision: null,
+    characterSetName: "",
+    collationName: "",
+    enumValues: Object.freeze([])
+  });
+
+  const batchedDailySequenceColumn = Object.freeze({
+    name: "batched_daily_sequence",
+    key: "batchedDailySequence",
+    dataType: "int",
+    columnType: "int unsigned",
+    typeKind: "integer",
+    nullable: false,
+    hasDefault: false,
+    defaultValue: null,
+    autoIncrement: false,
+    unsigned: true,
+    extra: "",
+    maxLength: null,
+    numericPrecision: 10,
+    numericScale: 0,
+    datetimePrecision: null,
+    characterSetName: "",
+    collationName: "",
+    enumValues: Object.freeze([])
+  });
+
+  const moistureLevelColumn = Object.freeze({
+    name: "moisture_level",
+    key: "moistureLevel",
+    dataType: "decimal",
+    columnType: "decimal(5,2)",
+    typeKind: "number",
+    nullable: true,
+    hasDefault: false,
+    defaultValue: null,
+    autoIncrement: false,
+    unsigned: false,
+    extra: "",
+    maxLength: null,
+    numericPrecision: 5,
+    numericScale: 2,
+    datetimePrecision: null,
+    characterSetName: "",
+    collationName: "",
+    enumValues: Object.freeze([])
+  });
+
+  const scaffoldColumns = __testables.resolveScaffoldColumns({
+    ...snapshot,
+    columns: Object.freeze([
+      snapshot.columns[0],
+      inputWeightColumn,
+      batchedDailySequenceColumn,
+      moistureLevelColumn
+    ]),
+    checkConstraints: Object.freeze([
+      Object.freeze({
+        name: "chk_batch_receivals_input_weight",
+        clause: "`input_weight` > 0"
+      }),
+      Object.freeze({
+        name: "chk_batches_batched_daily_sequence",
+        clause: "`batched_daily_sequence` >= 1"
+      }),
+      Object.freeze({
+        name: "chk_batches_moisture_level",
+        clause: "`moisture_level` is null or `moisture_level` >= 0 and `moisture_level` <= 100"
+      })
+    ])
+  });
+
+  const inputWeight = scaffoldColumns.find((column) => column.name === "input_weight");
+  const batchedDailySequence = scaffoldColumns.find((column) => column.name === "batched_daily_sequence");
+  const moistureLevel = scaffoldColumns.find((column) => column.name === "moisture_level");
+
+  assert.equal(
+    __testables.renderResourceFieldSchema(inputWeight),
+    "Type.Number({ minimum: 0.001 })"
+  );
+  assert.equal(
+    __testables.renderResourceFieldSchema(batchedDailySequence),
+    "Type.Integer({ minimum: 1 })"
+  );
+  assert.equal(
+    __testables.renderResourceFieldSchema(moistureLevel),
+    "Type.Union([Type.Number({ minimum: 0, maximum: 100 }), Type.Null()])"
+  );
+});
+
 test("buildReplacementsFromSnapshot normalizes nullable temporal inputs without invalid date errors", () => {
   const snapshot = createSnapshot({
     hasWorkspaceIdColumn: false,

--- a/packages/crud-ui-generator/src/server/buildTemplateContext.js
+++ b/packages/crud-ui-generator/src/server/buildTemplateContext.js
@@ -258,6 +258,57 @@ function filterDisplayFields(selectedFieldKeys, fields) {
   });
 }
 
+function hasLookupFormFields(fields = []) {
+  return (Array.isArray(fields) ? fields : []).some((field) => normalizeText(field?.component).toLowerCase() === "lookup");
+}
+
+function buildLookupImportLine(fields = []) {
+  return hasLookupFormFields(fields)
+    ? 'import { createCrudLookupFieldRuntime } from "@jskit-ai/users-web/client/composables/crudLookupFieldRuntime";'
+    : "";
+}
+
+function buildLookupRuntimeSetup(fields = [], {
+  formFieldsVariable = "",
+  resourceNamespace = "",
+  mode = ""
+} = {}) {
+  if (!hasLookupFormFields(fields)) {
+    return "";
+  }
+
+  const normalizedFormFieldsVariable = normalizeText(formFieldsVariable) || "UI_FORM_FIELDS";
+  const normalizedResourceNamespace = normalizeText(resourceNamespace) || "resource";
+  const normalizedMode = normalizeText(mode) || "new";
+
+  return `const lookupFieldRuntime = createCrudLookupFieldRuntime({
+  formFields: ${normalizedFormFieldsVariable},
+  adapter: UI_OPERATION_ADAPTER || undefined,
+  recordIdParam: UI_RECORD_ID_PARAM,
+  lookupContainerKey: uiResource?.contract?.lookup?.containerKey,
+  queryKeyPrefix: ["ui-generator", "${normalizedResourceNamespace}", "lookup", "${normalizedMode}"],
+  placementSourcePrefix: "ui-generator.${normalizedResourceNamespace}.${normalizedMode}.lookup"
+});
+const {
+  resolveLookupItems,
+  resolveLookupLoading,
+  resolveLookupSearch,
+  setLookupSearch
+} = lookupFieldRuntime;
+`;
+}
+
+function buildLookupFormProps(fields = []) {
+  if (!hasLookupFormFields(fields)) {
+    return "";
+  }
+
+  return `    :resolve-lookup-items="resolveLookupItems"
+    :resolve-lookup-loading="resolveLookupLoading"
+    :resolve-lookup-search="resolveLookupSearch"
+    :set-lookup-search="setLookupSearch"`;
+}
+
 function filterDefaultHiddenListFields(selectedFieldKeys, fields, { recordIdFieldKey = "" } = {}) {
   const selectedFields = Array.isArray(selectedFieldKeys) ? selectedFieldKeys : [];
   const availableFields = Array.isArray(fields) ? fields : [];
@@ -523,6 +574,20 @@ async function buildUiTemplateContext({ appRoot, options } = {}) {
     __JSKIT_UI_EDIT_FORM_FIELDS__: JSON.stringify(editFields),
     __JSKIT_UI_CREATE_FORM_FIELD_PUSH_LINES__: renderObjectPushLines("UI_CREATE_FORM_FIELDS", createFields),
     __JSKIT_UI_EDIT_FORM_FIELD_PUSH_LINES__: renderObjectPushLines("UI_EDIT_FORM_FIELDS", editFields),
+    __JSKIT_UI_CREATE_LOOKUP_IMPORT_LINE__: buildLookupImportLine(createFields),
+    __JSKIT_UI_EDIT_LOOKUP_IMPORT_LINE__: buildLookupImportLine(editFields),
+    __JSKIT_UI_CREATE_LOOKUP_RUNTIME_SETUP__: buildLookupRuntimeSetup(createFields, {
+      formFieldsVariable: "UI_CREATE_FORM_FIELDS",
+      resourceNamespace,
+      mode: "new"
+    }),
+    __JSKIT_UI_EDIT_LOOKUP_RUNTIME_SETUP__: buildLookupRuntimeSetup(editFields, {
+      formFieldsVariable: "UI_EDIT_FORM_FIELDS",
+      resourceNamespace,
+      mode: "edit"
+    }),
+    __JSKIT_UI_CREATE_LOOKUP_FORM_PROPS__: buildLookupFormProps(createFields),
+    __JSKIT_UI_EDIT_LOOKUP_FORM_PROPS__: buildLookupFormProps(editFields),
     __JSKIT_UI_MENU_MARKER__: menuMarker,
     __JSKIT_UI_MENU_PLACEMENT_ID__: String(pageLinkTarget?.pageTarget?.placementId || ""),
     __JSKIT_UI_MENU_PLACEMENT_TARGET__: String(pageLinkTarget?.placementTarget?.id || ""),

--- a/packages/crud-ui-generator/src/server/buildTemplateContext.js
+++ b/packages/crud-ui-generator/src/server/buildTemplateContext.js
@@ -258,16 +258,23 @@ function filterDisplayFields(selectedFieldKeys, fields) {
   });
 }
 
-function indentGeneratedBlock(source = "", prefix = "") {
+function rewriteGeneratedBlockIndent(source = "", { trimPrefix = "", addPrefix = "" } = {}) {
   const text = String(source || "");
-  const indent = String(prefix || "");
+  const trimmedPrefix = String(trimPrefix || "");
+  const extraPrefix = String(addPrefix || "");
   if (!text) {
     return "";
   }
 
   return text
     .split("\n")
-    .map((line) => `${indent}${line}`)
+    .map((line) => {
+      let nextLine = line;
+      if (trimmedPrefix && nextLine.startsWith(trimmedPrefix)) {
+        nextLine = nextLine.slice(trimmedPrefix.length);
+      }
+      return `${extraPrefix}${nextLine}`;
+    })
     .join("\n");
 }
 
@@ -585,8 +592,8 @@ async function buildUiTemplateContext({ appRoot, options } = {}) {
     __JSKIT_UI_VIEW_PAGE_EDIT_URL__: JSON.stringify(hasEditOperation ? "./edit" : ""),
     __JSKIT_UI_CREATE_FORM_COLUMNS__: createFormColumns,
     __JSKIT_UI_EDIT_FORM_COLUMNS__: editFormColumns,
-    __JSKIT_UI_CREATE_FORM_COLUMNS_DIRECT__: indentGeneratedBlock(createFormColumns, "  "),
-    __JSKIT_UI_EDIT_FORM_COLUMNS_DIRECT__: indentGeneratedBlock(editFormColumns, "  "),
+    __JSKIT_UI_CREATE_FORM_COLUMNS_DIRECT__: rewriteGeneratedBlockIndent(createFormColumns, { trimPrefix: "  " }),
+    __JSKIT_UI_EDIT_FORM_COLUMNS_DIRECT__: rewriteGeneratedBlockIndent(editFormColumns, { trimPrefix: "  " }),
     __JSKIT_UI_CREATE_FORM_FIELDS__: JSON.stringify(createFields),
     __JSKIT_UI_EDIT_FORM_FIELDS__: JSON.stringify(editFields),
     __JSKIT_UI_CREATE_FORM_FIELD_PUSH_LINES__: renderObjectPushLines("UI_CREATE_FORM_FIELDS", createFields),

--- a/packages/crud-ui-generator/src/server/buildTemplateContext.js
+++ b/packages/crud-ui-generator/src/server/buildTemplateContext.js
@@ -258,6 +258,19 @@ function filterDisplayFields(selectedFieldKeys, fields) {
   });
 }
 
+function indentGeneratedBlock(source = "", prefix = "") {
+  const text = String(source || "");
+  const indent = String(prefix || "");
+  if (!text) {
+    return "";
+  }
+
+  return text
+    .split("\n")
+    .map((line) => `${indent}${line}`)
+    .join("\n");
+}
+
 function hasLookupFormFields(fields = []) {
   return (Array.isArray(fields) ? fields : []).some((field) => normalizeText(field?.component).toLowerCase() === "lookup");
 }
@@ -536,6 +549,8 @@ async function buildUiTemplateContext({ appRoot, options } = {}) {
   const menuMarker = hasListOperation
     ? `jskit:crud-ui-generator.page.link:${pageTarget.surfaceId}:${pageTarget.routeUrlSuffix}`
     : "";
+  const createFormColumns = buildFormColumns(createFields);
+  const editFormColumns = buildFormColumns(editFields);
 
   return {
     __JSKIT_UI_RESOURCE_IMPORT_PATH__: `/${normalizeRelativeAppPath(options?.["resource-file"])}`,
@@ -568,8 +583,10 @@ async function buildUiTemplateContext({ appRoot, options } = {}) {
     __JSKIT_UI_EDIT_PAGE_VIEW_URL__: JSON.stringify(hasViewOperation ? ".." : ""),
     __JSKIT_UI_VIEW_PAGE_LIST_URL__: JSON.stringify(hasListOperation ? ".." : ""),
     __JSKIT_UI_VIEW_PAGE_EDIT_URL__: JSON.stringify(hasEditOperation ? "./edit" : ""),
-    __JSKIT_UI_CREATE_FORM_COLUMNS__: buildFormColumns(createFields),
-    __JSKIT_UI_EDIT_FORM_COLUMNS__: buildFormColumns(editFields),
+    __JSKIT_UI_CREATE_FORM_COLUMNS__: createFormColumns,
+    __JSKIT_UI_EDIT_FORM_COLUMNS__: editFormColumns,
+    __JSKIT_UI_CREATE_FORM_COLUMNS_DIRECT__: indentGeneratedBlock(createFormColumns, "  "),
+    __JSKIT_UI_EDIT_FORM_COLUMNS_DIRECT__: indentGeneratedBlock(editFormColumns, "  "),
     __JSKIT_UI_CREATE_FORM_FIELDS__: JSON.stringify(createFields),
     __JSKIT_UI_EDIT_FORM_FIELDS__: JSON.stringify(editFields),
     __JSKIT_UI_CREATE_FORM_FIELD_PUSH_LINES__: renderObjectPushLines("UI_CREATE_FORM_FIELDS", createFields),

--- a/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/EditElement.vue
+++ b/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/EditElement.vue
@@ -36,8 +36,10 @@
         <v-form v-else @submit.prevent="formRuntime.addEdit.submit" novalidate>
           <v-progress-linear v-if="formRuntime.addEdit.isRefetching" indeterminate class="mb-4" />
           <v-row>
-            <!-- jskit:crud-ui-fields:edit -->
+            <template>
+              <!-- jskit:crud-ui-fields:edit -->
 __JSKIT_UI_EDIT_FORM_COLUMNS__
+            </template>
           </v-row>
         </v-form>
       </v-card-text>

--- a/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/EditElement.vue
+++ b/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/EditElement.vue
@@ -49,7 +49,7 @@ __JSKIT_UI_EDIT_FORM_COLUMNS__
 import { computed } from "vue";
 import { useRoute } from "vue-router";
 import { useCrudAddEdit } from "@jskit-ai/users-web/client/composables/useCrudAddEdit";
-import { createCrudLookupFieldRuntime } from "@jskit-ai/users-web/client/composables/crudLookupFieldRuntime";
+__JSKIT_UI_EDIT_LOOKUP_IMPORT_LINE__
 import { resource as uiResource } from "__JSKIT_UI_RESOURCE_IMPORT_PATH__";
 
 const UI_OPERATION_ADAPTER = null;
@@ -79,20 +79,7 @@ const routeRecordId = computed(() => {
   return String(source ?? "").trim();
 });
 
-const lookupFieldRuntime = createCrudLookupFieldRuntime({
-  formFields: UI_EDIT_FORM_FIELDS,
-  adapter: UI_OPERATION_ADAPTER || undefined,
-  recordIdParam: UI_RECORD_ID_PARAM,
-  lookupContainerKey: uiResource?.contract?.lookup?.containerKey,
-  queryKeyPrefix: ["ui-generator", "__JSKIT_UI_RESOURCE_NAMESPACE__", "lookup", "edit"],
-  placementSourcePrefix: "ui-generator.__JSKIT_UI_RESOURCE_NAMESPACE__.edit.lookup"
-});
-const {
-  resolveLookupItems,
-  resolveLookupLoading,
-  resolveLookupSearch,
-  setLookupSearch
-} = lookupFieldRuntime;
+__JSKIT_UI_EDIT_LOOKUP_RUNTIME_SETUP__
 
 const formRuntime = useCrudAddEdit({
   resource: uiResource,

--- a/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/EditElement.vue
+++ b/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/EditElement.vue
@@ -36,10 +36,8 @@
         <v-form v-else @submit.prevent="formRuntime.addEdit.submit" novalidate>
           <v-progress-linear v-if="formRuntime.addEdit.isRefetching" indeterminate class="mb-4" />
           <v-row>
-            <template>
-              <!-- jskit:crud-ui-fields:edit -->
-__JSKIT_UI_EDIT_FORM_COLUMNS__
-            </template>
+            <!-- jskit:crud-ui-fields:edit -->
+__JSKIT_UI_EDIT_FORM_COLUMNS_DIRECT__
           </v-row>
         </v-form>
       </v-card-text>

--- a/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/EditWrapperElement.vue
+++ b/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/EditWrapperElement.vue
@@ -6,10 +6,7 @@
     subtitle="Update the selected __JSKIT_UI_RESOURCE_SINGULAR_TITLE__."
     save-label="Save changes"
     :cancel-to="cancelTo"
-    :resolve-lookup-items="resolveLookupItems"
-    :resolve-lookup-loading="resolveLookupLoading"
-    :resolve-lookup-search="resolveLookupSearch"
-    :set-lookup-search="setLookupSearch"
+__JSKIT_UI_EDIT_LOOKUP_FORM_PROPS__
   />
 </template>
 
@@ -17,7 +14,7 @@
 import { computed } from "vue";
 import { useRoute } from "vue-router";
 import { useCrudAddEdit } from "@jskit-ai/users-web/client/composables/useCrudAddEdit";
-import { createCrudLookupFieldRuntime } from "@jskit-ai/users-web/client/composables/crudLookupFieldRuntime";
+__JSKIT_UI_EDIT_LOOKUP_IMPORT_LINE__
 import { resource as uiResource } from "__JSKIT_UI_RESOURCE_IMPORT_PATH__";
 import CrudAddEditForm from "../_components/__JSKIT_UI_FORM_COMPONENT_FILE__";
 import { UI_EDIT_FORM_FIELDS } from "../_components/__JSKIT_UI_FORM_FIELDS_FILE__";
@@ -44,20 +41,7 @@ const routeRecordId = computed(() => {
   return String(source ?? "").trim();
 });
 
-const lookupFieldRuntime = createCrudLookupFieldRuntime({
-  formFields: UI_EDIT_FORM_FIELDS,
-  adapter: UI_OPERATION_ADAPTER || undefined,
-  recordIdParam: UI_RECORD_ID_PARAM,
-  lookupContainerKey: uiResource?.contract?.lookup?.containerKey,
-  queryKeyPrefix: ["ui-generator", "__JSKIT_UI_RESOURCE_NAMESPACE__", "lookup", "edit"],
-  placementSourcePrefix: "ui-generator.__JSKIT_UI_RESOURCE_NAMESPACE__.edit.lookup"
-});
-const {
-  resolveLookupItems,
-  resolveLookupLoading,
-  resolveLookupSearch,
-  setLookupSearch
-} = lookupFieldRuntime;
+__JSKIT_UI_EDIT_LOOKUP_RUNTIME_SETUP__
 
 const formRuntime = useCrudAddEdit({
   resource: uiResource,

--- a/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/NewElement.vue
+++ b/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/NewElement.vue
@@ -26,10 +26,8 @@
         </p>
         <v-form v-else @submit.prevent="formRuntime.addEdit.submit" novalidate>
           <v-row>
-            <template>
-              <!-- jskit:crud-ui-fields:new -->
-__JSKIT_UI_CREATE_FORM_COLUMNS__
-            </template>
+            <!-- jskit:crud-ui-fields:new -->
+__JSKIT_UI_CREATE_FORM_COLUMNS_DIRECT__
           </v-row>
         </v-form>
       </v-card-text>

--- a/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/NewElement.vue
+++ b/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/NewElement.vue
@@ -37,7 +37,7 @@ __JSKIT_UI_CREATE_FORM_COLUMNS__
 
 <script setup>
 import { useCrudAddEdit } from "@jskit-ai/users-web/client/composables/useCrudAddEdit";
-import { createCrudLookupFieldRuntime } from "@jskit-ai/users-web/client/composables/crudLookupFieldRuntime";
+__JSKIT_UI_CREATE_LOOKUP_IMPORT_LINE__
 import { resource as uiResource } from "__JSKIT_UI_RESOURCE_IMPORT_PATH__";
 
 const UI_OPERATION_ADAPTER = null;
@@ -54,20 +54,7 @@ void UI_CREATE_FORM_FIELDS;
 __JSKIT_UI_CREATE_FORM_FIELD_PUSH_LINES__
 Object.freeze(UI_CREATE_FORM_FIELDS);
 
-const lookupFieldRuntime = createCrudLookupFieldRuntime({
-  formFields: UI_CREATE_FORM_FIELDS,
-  adapter: UI_OPERATION_ADAPTER || undefined,
-  recordIdParam: UI_RECORD_ID_PARAM,
-  lookupContainerKey: uiResource?.contract?.lookup?.containerKey,
-  queryKeyPrefix: ["ui-generator", "__JSKIT_UI_RESOURCE_NAMESPACE__", "lookup", "new"],
-  placementSourcePrefix: "ui-generator.__JSKIT_UI_RESOURCE_NAMESPACE__.new.lookup"
-});
-const {
-  resolveLookupItems,
-  resolveLookupLoading,
-  resolveLookupSearch,
-  setLookupSearch
-} = lookupFieldRuntime;
+__JSKIT_UI_CREATE_LOOKUP_RUNTIME_SETUP__
 
 const formRuntime = useCrudAddEdit({
   resource: uiResource,

--- a/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/NewElement.vue
+++ b/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/NewElement.vue
@@ -26,8 +26,10 @@
         </p>
         <v-form v-else @submit.prevent="formRuntime.addEdit.submit" novalidate>
           <v-row>
-            <!-- jskit:crud-ui-fields:new -->
+            <template>
+              <!-- jskit:crud-ui-fields:new -->
 __JSKIT_UI_CREATE_FORM_COLUMNS__
+            </template>
           </v-row>
         </v-form>
       </v-card-text>

--- a/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/NewWrapperElement.vue
+++ b/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/NewWrapperElement.vue
@@ -6,16 +6,13 @@
     subtitle="Create a new __JSKIT_UI_RESOURCE_SINGULAR_TITLE__."
     save-label="Save __JSKIT_UI_RESOURCE_SINGULAR_TITLE__"
     :cancel-to="UI_CANCEL_URL"
-    :resolve-lookup-items="resolveLookupItems"
-    :resolve-lookup-loading="resolveLookupLoading"
-    :resolve-lookup-search="resolveLookupSearch"
-    :set-lookup-search="setLookupSearch"
+__JSKIT_UI_CREATE_LOOKUP_FORM_PROPS__
   />
 </template>
 
 <script setup>
 import { useCrudAddEdit } from "@jskit-ai/users-web/client/composables/useCrudAddEdit";
-import { createCrudLookupFieldRuntime } from "@jskit-ai/users-web/client/composables/crudLookupFieldRuntime";
+__JSKIT_UI_CREATE_LOOKUP_IMPORT_LINE__
 import { resource as uiResource } from "__JSKIT_UI_RESOURCE_IMPORT_PATH__";
 import CrudAddEditForm from "./_components/__JSKIT_UI_FORM_COMPONENT_FILE__";
 import { UI_CREATE_FORM_FIELDS } from "./_components/__JSKIT_UI_FORM_FIELDS_FILE__";
@@ -31,20 +28,7 @@ const UI_RECORD_CHANGED_EVENT = __JSKIT_UI_RECORD_CHANGED_EVENT__;
 // jskit:crud-ui-fields-target ./_components/__JSKIT_UI_FORM_COMPONENT_FILE__
 // jskit:crud-ui-form-fields-target ./_components/__JSKIT_UI_FORM_FIELDS_FILE__
 
-const lookupFieldRuntime = createCrudLookupFieldRuntime({
-  formFields: UI_CREATE_FORM_FIELDS,
-  adapter: UI_OPERATION_ADAPTER || undefined,
-  recordIdParam: UI_RECORD_ID_PARAM,
-  lookupContainerKey: uiResource?.contract?.lookup?.containerKey,
-  queryKeyPrefix: ["ui-generator", "__JSKIT_UI_RESOURCE_NAMESPACE__", "lookup", "new"],
-  placementSourcePrefix: "ui-generator.__JSKIT_UI_RESOURCE_NAMESPACE__.new.lookup"
-});
-const {
-  resolveLookupItems,
-  resolveLookupLoading,
-  resolveLookupSearch,
-  setLookupSearch
-} = lookupFieldRuntime;
+__JSKIT_UI_CREATE_LOOKUP_RUNTIME_SETUP__
 
 const formRuntime = useCrudAddEdit({
   resource: uiResource,

--- a/packages/crud-ui-generator/test/buildTemplateContext.test.js
+++ b/packages/crud-ui-generator/test/buildTemplateContext.test.js
@@ -479,8 +479,8 @@ test("buildUiTemplateContext indents direct-page form columns without changing s
 
     assert.match(context.__JSKIT_UI_CREATE_FORM_COLUMNS__, /^ {14}<v-col/m);
     assert.match(context.__JSKIT_UI_EDIT_FORM_COLUMNS__, /^ {14}<v-col/m);
-    assert.match(context.__JSKIT_UI_CREATE_FORM_COLUMNS_DIRECT__, /^ {16}<v-col/m);
-    assert.match(context.__JSKIT_UI_EDIT_FORM_COLUMNS_DIRECT__, /^ {16}<v-col/m);
+    assert.match(context.__JSKIT_UI_CREATE_FORM_COLUMNS_DIRECT__, /^ {12}<v-col/m);
+    assert.match(context.__JSKIT_UI_EDIT_FORM_COLUMNS_DIRECT__, /^ {12}<v-col/m);
   });
 });
 

--- a/packages/crud-ui-generator/test/buildTemplateContext.test.js
+++ b/packages/crud-ui-generator/test/buildTemplateContext.test.js
@@ -450,6 +450,44 @@ test("buildUiTemplateContext renders nullable booleans as tri-state selects by d
   });
 });
 
+test("buildUiTemplateContext omits lookup runtime placeholders when form fields do not include lookups", async () => {
+  await withTempApp(async (appRoot) => {
+    await writeResource(appRoot, RESOURCE_FILE, FULL_RESOURCE_SOURCE);
+
+    const context = await buildUiTemplateContext({
+      appRoot,
+      options: createOptions()
+    });
+
+    assert.equal(context.__JSKIT_UI_CREATE_LOOKUP_IMPORT_LINE__, "");
+    assert.equal(context.__JSKIT_UI_EDIT_LOOKUP_IMPORT_LINE__, "");
+    assert.equal(context.__JSKIT_UI_CREATE_LOOKUP_RUNTIME_SETUP__, "");
+    assert.equal(context.__JSKIT_UI_EDIT_LOOKUP_RUNTIME_SETUP__, "");
+    assert.equal(context.__JSKIT_UI_CREATE_LOOKUP_FORM_PROPS__, "");
+    assert.equal(context.__JSKIT_UI_EDIT_LOOKUP_FORM_PROPS__, "");
+  });
+});
+
+test("buildUiTemplateContext includes lookup runtime placeholders when form fields include lookups", async () => {
+  await withTempApp(async (appRoot) => {
+    await writeResource(appRoot, RESOURCE_FILE, LOOKUP_RESOURCE_SOURCE);
+
+    const context = await buildUiTemplateContext({
+      appRoot,
+      options: createOptions({
+        "display-fields": "serviceId"
+      })
+    });
+
+    assert.match(context.__JSKIT_UI_CREATE_LOOKUP_IMPORT_LINE__, /createCrudLookupFieldRuntime/);
+    assert.match(context.__JSKIT_UI_EDIT_LOOKUP_IMPORT_LINE__, /createCrudLookupFieldRuntime/);
+    assert.match(context.__JSKIT_UI_CREATE_LOOKUP_RUNTIME_SETUP__, /resolveLookupItems/);
+    assert.match(context.__JSKIT_UI_EDIT_LOOKUP_RUNTIME_SETUP__, /resolveLookupItems/);
+    assert.match(context.__JSKIT_UI_CREATE_LOOKUP_FORM_PROPS__, /resolve-lookup-items/);
+    assert.match(context.__JSKIT_UI_EDIT_LOOKUP_FORM_PROPS__, /resolve-lookup-items/);
+  });
+});
+
 test("buildUiTemplateContext escapes select option bindings safely for Vue attributes", async () => {
   await withTempApp(async (appRoot) => {
     await writeResource(appRoot, RESOURCE_FILE, SELECT_RESOURCE_SOURCE);

--- a/packages/crud-ui-generator/test/buildTemplateContext.test.js
+++ b/packages/crud-ui-generator/test/buildTemplateContext.test.js
@@ -468,6 +468,22 @@ test("buildUiTemplateContext omits lookup runtime placeholders when form fields 
   });
 });
 
+test("buildUiTemplateContext indents direct-page form columns without changing shared form columns", async () => {
+  await withTempApp(async (appRoot) => {
+    await writeResource(appRoot, RESOURCE_FILE, FULL_RESOURCE_SOURCE);
+
+    const context = await buildUiTemplateContext({
+      appRoot,
+      options: createOptions()
+    });
+
+    assert.match(context.__JSKIT_UI_CREATE_FORM_COLUMNS__, /^ {14}<v-col/m);
+    assert.match(context.__JSKIT_UI_EDIT_FORM_COLUMNS__, /^ {14}<v-col/m);
+    assert.match(context.__JSKIT_UI_CREATE_FORM_COLUMNS_DIRECT__, /^ {16}<v-col/m);
+    assert.match(context.__JSKIT_UI_EDIT_FORM_COLUMNS_DIRECT__, /^ {16}<v-col/m);
+  });
+});
+
 test("buildUiTemplateContext includes lookup runtime placeholders when form fields include lookups", async () => {
   await withTempApp(async (appRoot) => {
     await writeResource(appRoot, RESOURCE_FILE, LOOKUP_RESOURCE_SOURCE);


### PR DESCRIPTION
## Summary
- skip lookup runtime scaffolding on direct CRUD pages that have no lookup fields
- normalize direct CRUD form indentation so generated Vue stays stable and readable
- infer numeric minima and maxima from supported CRUD check constraints during scaffold generation

## Testing
- npm test --workspace @jskit-ai/crud-ui-generator
- npm test --workspace @jskit-ai/crud-server-generator