### PR TITLE
Refresh package metadata after generator updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6176,26 +6176,26 @@
     },
     "packages/agent-docs": {
       "name": "@jskit-ai/agent-docs",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "engines": {
         "node": "20.x"
       }
     },
     "packages/assistant": {
       "name": "@jskit-ai/assistant",
-      "version": "0.1.57",
+      "version": "0.1.58",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.48"
+        "@jskit-ai/kernel": "0.1.49"
       }
     },
     "packages/assistant-core": {
       "name": "@jskit-ai/assistant-core",
-      "version": "0.1.24",
+      "version": "0.1.25",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.48",
-        "@jskit-ai/http-runtime": "0.1.47",
-        "@jskit-ai/kernel": "0.1.48",
-        "@jskit-ai/users-core": "0.1.58",
+        "@jskit-ai/database-runtime": "0.1.49",
+        "@jskit-ai/http-runtime": "0.1.48",
+        "@jskit-ai/kernel": "0.1.49",
+        "@jskit-ai/users-core": "0.1.59",
         "@tanstack/vue-query": "^5.90.5",
         "dompurify": "^3.3.3",
         "marked": "^17.0.4",
@@ -6273,15 +6273,15 @@
     },
     "packages/assistant-runtime": {
       "name": "@jskit-ai/assistant-runtime",
-      "version": "0.1.19",
+      "version": "0.1.20",
       "dependencies": {
-        "@jskit-ai/assistant-core": "0.1.24",
-        "@jskit-ai/database-runtime": "0.1.48",
-        "@jskit-ai/http-runtime": "0.1.47",
-        "@jskit-ai/kernel": "0.1.48",
-        "@jskit-ai/shell-web": "0.1.47",
-        "@jskit-ai/users-core": "0.1.58",
-        "@jskit-ai/users-web": "0.1.63",
+        "@jskit-ai/assistant-core": "0.1.25",
+        "@jskit-ai/database-runtime": "0.1.49",
+        "@jskit-ai/http-runtime": "0.1.48",
+        "@jskit-ai/kernel": "0.1.49",
+        "@jskit-ai/shell-web": "0.1.48",
+        "@jskit-ai/users-core": "0.1.59",
+        "@jskit-ai/users-web": "0.1.64",
         "@tanstack/vue-query": "^5.90.5",
         "vuetify": "^4.0.0"
       }
@@ -6355,34 +6355,34 @@
     },
     "packages/auth-core": {
       "name": "@jskit-ai/auth-core",
-      "version": "0.1.47",
+      "version": "0.1.48",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0",
-        "@jskit-ai/kernel": "0.1.48",
+        "@jskit-ai/kernel": "0.1.49",
         "typebox": "^1.0.81"
       }
     },
     "packages/auth-provider-supabase-core": {
       "name": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.47",
+      "version": "0.1.48",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.47",
-        "@jskit-ai/kernel": "0.1.48",
+        "@jskit-ai/auth-core": "0.1.48",
+        "@jskit-ai/kernel": "0.1.49",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0"
       }
     },
     "packages/auth-web": {
       "name": "@jskit-ai/auth-web",
-      "version": "0.1.49",
+      "version": "0.1.50",
       "dependencies": {
         "@fastify/type-provider-typebox": "^6.1.0",
-        "@jskit-ai/auth-core": "0.1.47",
-        "@jskit-ai/http-runtime": "0.1.47",
-        "@jskit-ai/kernel": "0.1.48",
-        "@jskit-ai/shell-web": "0.1.47",
+        "@jskit-ai/auth-core": "0.1.48",
+        "@jskit-ai/http-runtime": "0.1.48",
+        "@jskit-ai/kernel": "0.1.49",
+        "@jskit-ai/shell-web": "0.1.48",
         "@mdi/js": "^7.4.47",
         "@tanstack/vue-query": "^5.90.5",
         "pinia": "^3.0.4",
@@ -6469,34 +6469,34 @@
     },
     "packages/console-core": {
       "name": "@jskit-ai/console-core",
-      "version": "0.1.11",
+      "version": "0.1.12",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.48",
-        "@jskit-ai/http-runtime": "0.1.47",
-        "@jskit-ai/kernel": "0.1.48",
-        "@jskit-ai/users-core": "0.1.58",
+        "@jskit-ai/database-runtime": "0.1.49",
+        "@jskit-ai/http-runtime": "0.1.48",
+        "@jskit-ai/kernel": "0.1.49",
+        "@jskit-ai/users-core": "0.1.59",
         "typebox": "^1.0.81"
       }
     },
     "packages/console-web": {
       "name": "@jskit-ai/console-web",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "dependencies": {
-        "@jskit-ai/auth-web": "0.1.49",
-        "@jskit-ai/console-core": "0.1.11",
-        "@jskit-ai/shell-web": "0.1.47"
+        "@jskit-ai/auth-web": "0.1.50",
+        "@jskit-ai/console-core": "0.1.12",
+        "@jskit-ai/shell-web": "0.1.48"
       }
     },
     "packages/crud-core": {
       "name": "@jskit-ai/crud-core",
-      "version": "0.1.56",
+      "version": "0.1.57",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.48",
-        "@jskit-ai/kernel": "0.1.48",
-        "@jskit-ai/realtime": "0.1.47",
-        "@jskit-ai/shell-web": "0.1.47",
-        "@jskit-ai/users-core": "0.1.58",
-        "@jskit-ai/users-web": "0.1.63",
+        "@jskit-ai/database-runtime": "0.1.49",
+        "@jskit-ai/kernel": "0.1.49",
+        "@jskit-ai/realtime": "0.1.48",
+        "@jskit-ai/shell-web": "0.1.48",
+        "@jskit-ai/users-core": "0.1.59",
+        "@jskit-ai/users-web": "0.1.64",
         "@tanstack/vue-query": "^5.90.5",
         "typebox": "^1.0.81"
       }
@@ -6570,68 +6570,68 @@
     },
     "packages/crud-server-generator": {
       "name": "@jskit-ai/crud-server-generator",
-      "version": "0.1.56",
+      "version": "0.1.57",
       "dependencies": {
         "@babel/parser": "^7.29.2",
-        "@jskit-ai/crud-core": "0.1.56",
-        "@jskit-ai/database-runtime": "0.1.48",
-        "@jskit-ai/http-runtime": "0.1.47",
-        "@jskit-ai/kernel": "0.1.48",
-        "@jskit-ai/users-core": "0.1.58",
+        "@jskit-ai/crud-core": "0.1.57",
+        "@jskit-ai/database-runtime": "0.1.49",
+        "@jskit-ai/http-runtime": "0.1.48",
+        "@jskit-ai/kernel": "0.1.49",
+        "@jskit-ai/users-core": "0.1.59",
         "recast": "^0.23.11",
         "typebox": "^1.0.81"
       }
     },
     "packages/crud-ui-generator": {
       "name": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.31",
+      "version": "0.1.32",
       "dependencies": {
-        "@jskit-ai/crud-core": "0.1.56",
-        "@jskit-ai/kernel": "0.1.48"
+        "@jskit-ai/crud-core": "0.1.57",
+        "@jskit-ai/kernel": "0.1.49"
       }
     },
     "packages/database-runtime": {
       "name": "@jskit-ai/database-runtime",
-      "version": "0.1.48",
+      "version": "0.1.49",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.48"
+        "@jskit-ai/kernel": "0.1.49"
       }
     },
     "packages/database-runtime-mysql": {
       "name": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.47",
+      "version": "0.1.48",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.48"
+        "@jskit-ai/database-runtime": "0.1.49"
       }
     },
     "packages/database-runtime-postgres": {
       "name": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.47",
+      "version": "0.1.48",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.48"
+        "@jskit-ai/database-runtime": "0.1.49"
       }
     },
     "packages/http-runtime": {
       "name": "@jskit-ai/http-runtime",
-      "version": "0.1.47",
+      "version": "0.1.48",
       "dependencies": {
         "@fastify/type-provider-typebox": "^6.1.0",
-        "@jskit-ai/kernel": "0.1.48",
+        "@jskit-ai/kernel": "0.1.49",
         "typebox": "^1.0.81"
       }
     },
     "packages/kernel": {
       "name": "@jskit-ai/kernel",
-      "version": "0.1.48",
+      "version": "0.1.49",
       "dependencies": {
         "typebox": "^1.0.81"
       }
     },
     "packages/realtime": {
       "name": "@jskit-ai/realtime",
-      "version": "0.1.47",
+      "version": "0.1.48",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.48",
+        "@jskit-ai/kernel": "0.1.49",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",
@@ -6640,9 +6640,9 @@
     },
     "packages/shell-web": {
       "name": "@jskit-ai/shell-web",
-      "version": "0.1.47",
+      "version": "0.1.48",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.48",
+        "@jskit-ai/kernel": "0.1.49",
         "@mdi/js": "^7.4.47",
         "@tanstack/vue-query": "^5.90.5",
         "pinia": "^3.0.4",
@@ -6708,25 +6708,25 @@
     },
     "packages/storage-runtime": {
       "name": "@jskit-ai/storage-runtime",
-      "version": "0.1.47",
+      "version": "0.1.48",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.48",
+        "@jskit-ai/kernel": "0.1.49",
         "unstorage": "^1.17.3"
       }
     },
     "packages/ui-generator": {
       "name": "@jskit-ai/ui-generator",
-      "version": "0.1.31",
+      "version": "0.1.32",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.48",
-        "@jskit-ai/shell-web": "0.1.47"
+        "@jskit-ai/kernel": "0.1.49",
+        "@jskit-ai/shell-web": "0.1.48"
       }
     },
     "packages/uploads-image-web": {
       "name": "@jskit-ai/uploads-image-web",
-      "version": "0.1.26",
+      "version": "0.1.27",
       "dependencies": {
-        "@jskit-ai/uploads-runtime": "0.1.26",
+        "@jskit-ai/uploads-runtime": "0.1.27",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",
@@ -6736,35 +6736,35 @@
     },
     "packages/uploads-runtime": {
       "name": "@jskit-ai/uploads-runtime",
-      "version": "0.1.26",
+      "version": "0.1.27",
       "dependencies": {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.48"
+        "@jskit-ai/kernel": "0.1.49"
       }
     },
     "packages/users-core": {
       "name": "@jskit-ai/users-core",
-      "version": "0.1.58",
+      "version": "0.1.59",
       "dependencies": {
         "@fastify/type-provider-typebox": "^6.1.0",
-        "@jskit-ai/auth-core": "0.1.47",
-        "@jskit-ai/database-runtime": "0.1.48",
-        "@jskit-ai/http-runtime": "0.1.47",
-        "@jskit-ai/kernel": "0.1.48",
-        "@jskit-ai/uploads-runtime": "0.1.26",
+        "@jskit-ai/auth-core": "0.1.48",
+        "@jskit-ai/database-runtime": "0.1.49",
+        "@jskit-ai/http-runtime": "0.1.48",
+        "@jskit-ai/kernel": "0.1.49",
+        "@jskit-ai/uploads-runtime": "0.1.27",
         "typebox": "^1.0.81"
       }
     },
     "packages/users-web": {
       "name": "@jskit-ai/users-web",
-      "version": "0.1.63",
+      "version": "0.1.64",
       "dependencies": {
-        "@jskit-ai/http-runtime": "0.1.47",
-        "@jskit-ai/kernel": "0.1.48",
-        "@jskit-ai/realtime": "0.1.47",
-        "@jskit-ai/shell-web": "0.1.47",
-        "@jskit-ai/uploads-image-web": "0.1.26",
-        "@jskit-ai/users-core": "0.1.58",
+        "@jskit-ai/http-runtime": "0.1.48",
+        "@jskit-ai/kernel": "0.1.49",
+        "@jskit-ai/realtime": "0.1.48",
+        "@jskit-ai/shell-web": "0.1.48",
+        "@jskit-ai/uploads-image-web": "0.1.27",
+        "@jskit-ai/users-core": "0.1.59",
         "@mdi/js": "^7.4.47",
         "@tanstack/vue-query": "5.92.12",
         "vuetify": "^4.0.0"
@@ -6839,27 +6839,27 @@
     },
     "packages/workspaces-core": {
       "name": "@jskit-ai/workspaces-core",
-      "version": "0.1.24",
+      "version": "0.1.25",
       "dependencies": {
         "@fastify/type-provider-typebox": "^6.1.0",
-        "@jskit-ai/auth-core": "0.1.47",
-        "@jskit-ai/database-runtime": "0.1.48",
-        "@jskit-ai/http-runtime": "0.1.47",
-        "@jskit-ai/kernel": "0.1.48",
-        "@jskit-ai/users-core": "0.1.58",
+        "@jskit-ai/auth-core": "0.1.48",
+        "@jskit-ai/database-runtime": "0.1.49",
+        "@jskit-ai/http-runtime": "0.1.48",
+        "@jskit-ai/kernel": "0.1.49",
+        "@jskit-ai/users-core": "0.1.59",
         "typebox": "^1.0.81"
       }
     },
     "packages/workspaces-web": {
       "name": "@jskit-ai/workspaces-web",
-      "version": "0.1.24",
+      "version": "0.1.25",
       "dependencies": {
-        "@jskit-ai/http-runtime": "0.1.47",
-        "@jskit-ai/kernel": "0.1.48",
-        "@jskit-ai/shell-web": "0.1.47",
-        "@jskit-ai/users-core": "0.1.58",
-        "@jskit-ai/users-web": "0.1.63",
-        "@jskit-ai/workspaces-core": "0.1.24",
+        "@jskit-ai/http-runtime": "0.1.48",
+        "@jskit-ai/kernel": "0.1.49",
+        "@jskit-ai/shell-web": "0.1.48",
+        "@jskit-ai/users-core": "0.1.59",
+        "@jskit-ai/users-web": "0.1.64",
+        "@jskit-ai/workspaces-core": "0.1.25",
         "@mdi/js": "^7.4.47",
         "@tanstack/vue-query": "5.92.12",
         "vuetify": "^4.0.0"
@@ -6934,7 +6934,7 @@
     },
     "tooling/config-eslint": {
       "name": "@jskit-ai/config-eslint",
-      "version": "0.1.47",
+      "version": "0.1.48",
       "dependencies": {
         "@eslint/js": "^9.39.1",
         "eslint-plugin-vue": "^10.5.1",
@@ -6952,7 +6952,7 @@
     },
     "tooling/create-app": {
       "name": "@jskit-ai/create-app",
-      "version": "0.1.56",
+      "version": "0.1.57",
       "bin": {
         "jskit-create-app": "bin/jskit-create-app.js"
       },
@@ -6962,18 +6962,18 @@
     },
     "tooling/jskit-catalog": {
       "name": "@jskit-ai/jskit-catalog",
-      "version": "0.1.56",
+      "version": "0.1.57",
       "engines": {
         "node": "20.x"
       }
     },
     "tooling/jskit-cli": {
       "name": "@jskit-ai/jskit-cli",
-      "version": "0.2.57",
+      "version": "0.2.58",
       "dependencies": {
-        "@jskit-ai/jskit-catalog": "0.1.56",
-        "@jskit-ai/kernel": "0.1.48",
-        "@jskit-ai/shell-web": "0.1.47"
+        "@jskit-ai/jskit-catalog": "0.1.57",
+        "@jskit-ai/kernel": "0.1.49",
+        "@jskit-ai/shell-web": "0.1.48"
       },
       "bin": {
         "jskit": "bin/jskit.js"

--- a/packages/agent-docs/package.json
+++ b/packages/agent-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/agent-docs",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Distributed JSKIT agent workflows, guides, and generated reference maps.",
   "type": "module",
   "files": [

--- a/packages/assistant-core/package.descriptor.mjs
+++ b/packages/assistant-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-core",
-  version: "0.1.24",
+  version: "0.1.25",
   kind: "runtime",
   description: "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
   dependsOn: [
@@ -45,9 +45,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/http-runtime": "0.1.47",
-        "@jskit-ai/kernel": "0.1.48",
-        "@jskit-ai/users-core": "0.1.58",
+        "@jskit-ai/http-runtime": "0.1.48",
+        "@jskit-ai/kernel": "0.1.49",
+        "@jskit-ai/users-core": "0.1.59",
         "@tanstack/vue-query": "^5.90.5",
         "dompurify": "^3.3.3",
         "marked": "^17.0.4",

--- a/packages/assistant-core/package.json
+++ b/packages/assistant-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-core",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,10 +11,10 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.48",
-    "@jskit-ai/http-runtime": "0.1.47",
-    "@jskit-ai/kernel": "0.1.48",
-    "@jskit-ai/users-core": "0.1.58",
+    "@jskit-ai/database-runtime": "0.1.49",
+    "@jskit-ai/http-runtime": "0.1.48",
+    "@jskit-ai/kernel": "0.1.49",
+    "@jskit-ai/users-core": "0.1.59",
     "@tanstack/vue-query": "^5.90.5",
     "dompurify": "^3.3.3",
     "marked": "^17.0.4",

--- a/packages/assistant-runtime/package.descriptor.mjs
+++ b/packages/assistant-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-runtime",
-  version: "0.1.19",
+  version: "0.1.20",
   kind: "runtime",
   description: "Shared assistant runtime with per-surface assistant registration.",
   dependsOn: [
@@ -74,13 +74,13 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/assistant-core": "0.1.24",
-        "@jskit-ai/database-runtime": "0.1.48",
-        "@jskit-ai/http-runtime": "0.1.47",
-        "@jskit-ai/kernel": "0.1.48",
-        "@jskit-ai/shell-web": "0.1.47",
-        "@jskit-ai/users-core": "0.1.58",
-        "@jskit-ai/users-web": "0.1.63",
+        "@jskit-ai/assistant-core": "0.1.25",
+        "@jskit-ai/database-runtime": "0.1.49",
+        "@jskit-ai/http-runtime": "0.1.48",
+        "@jskit-ai/kernel": "0.1.49",
+        "@jskit-ai/shell-web": "0.1.48",
+        "@jskit-ai/users-core": "0.1.59",
+        "@jskit-ai/users-web": "0.1.64",
         "@tanstack/vue-query": "^5.90.5",
         "vuetify": "^4.0.0"
       },

--- a/packages/assistant-runtime/package.json
+++ b/packages/assistant-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-runtime",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "type": "module",
   "exports": {
     "./client": "./src/client/index.js",
@@ -8,13 +8,13 @@
     "./server/actionIds": "./src/server/actionIds.js"
   },
   "dependencies": {
-    "@jskit-ai/assistant-core": "0.1.24",
-    "@jskit-ai/database-runtime": "0.1.48",
-    "@jskit-ai/http-runtime": "0.1.47",
-    "@jskit-ai/kernel": "0.1.48",
-    "@jskit-ai/shell-web": "0.1.47",
-    "@jskit-ai/users-core": "0.1.58",
-    "@jskit-ai/users-web": "0.1.63",
+    "@jskit-ai/assistant-core": "0.1.25",
+    "@jskit-ai/database-runtime": "0.1.49",
+    "@jskit-ai/http-runtime": "0.1.48",
+    "@jskit-ai/kernel": "0.1.49",
+    "@jskit-ai/shell-web": "0.1.48",
+    "@jskit-ai/users-core": "0.1.59",
+    "@jskit-ai/users-web": "0.1.64",
     "@tanstack/vue-query": "^5.90.5",
     "vuetify": "^4.0.0"
   }

--- a/packages/assistant/package.descriptor.mjs
+++ b/packages/assistant/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant",
-  version: "0.1.57",
+  version: "0.1.58",
   kind: "generator",
   description: "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
   options: {

--- a/packages/assistant/package.json
+++ b/packages/assistant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant",
-  "version": "0.1.57",
+  "version": "0.1.58",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.48"
+    "@jskit-ai/kernel": "0.1.49"
   }
 }

--- a/packages/auth-core/package.descriptor.mjs
+++ b/packages/auth-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-core",
-  "version": "0.1.47",
+  "version": "0.1.48",
   "kind": "runtime",
   "dependsOn": [
     "@jskit-ai/value-app-config-shared"
@@ -69,7 +69,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.48",
+        "@jskit-ai/kernel": "0.1.49",
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0"

--- a/packages/auth-core/package.json
+++ b/packages/auth-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-core",
-  "version": "0.1.47",
+  "version": "0.1.48",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -44,7 +44,7 @@
     "./shared/commands/authSessionReadCommand": "./src/shared/commands/authSessionReadCommand.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.48",
+    "@jskit-ai/kernel": "0.1.49",
     "@fastify/cookie": "^11.0.2",
     "@fastify/csrf-protection": "^7.1.0",
     "@fastify/rate-limit": "^10.3.0",

--- a/packages/auth-provider-supabase-core/package.descriptor.mjs
+++ b/packages/auth-provider-supabase-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.47",
+  "version": "0.1.48",
   "kind": "runtime",
   "options": {
     "auth-supabase-url": {
@@ -83,8 +83,8 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/auth-core": "0.1.47",
-        "@jskit-ai/kernel": "0.1.48",
+        "@jskit-ai/auth-core": "0.1.48",
+        "@jskit-ai/kernel": "0.1.49",
         "dotenv": "^16.4.5",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0"

--- a/packages/auth-provider-supabase-core/package.json
+++ b/packages/auth-provider-supabase-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.47",
+  "version": "0.1.48",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,8 +12,8 @@
     "./client": "./src/client/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.47",
-    "@jskit-ai/kernel": "0.1.48",
+    "@jskit-ai/auth-core": "0.1.48",
+    "@jskit-ai/kernel": "0.1.49",
     "jose": "^6.1.0",
     "@supabase/supabase-js": "^2.57.4"
   }

--- a/packages/auth-web/package.descriptor.mjs
+++ b/packages/auth-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-web",
-  "version": "0.1.49",
+  "version": "0.1.50",
   "kind": "runtime",
   "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
   "dependsOn": [
@@ -220,10 +220,10 @@ export default Object.freeze({
         "@tanstack/vue-query": "5.92.12",
         "@mdi/js": "^7.4.47",
         "@fastify/type-provider-typebox": "^6.1.0",
-        "@jskit-ai/auth-core": "0.1.47",
-        "@jskit-ai/http-runtime": "0.1.47",
-        "@jskit-ai/kernel": "0.1.48",
-        "@jskit-ai/shell-web": "0.1.47",
+        "@jskit-ai/auth-core": "0.1.48",
+        "@jskit-ai/http-runtime": "0.1.48",
+        "@jskit-ai/kernel": "0.1.49",
+        "@jskit-ai/shell-web": "0.1.48",
         "vuetify": "^4.0.0"
       },
       "dev": {}

--- a/packages/auth-web/package.json
+++ b/packages/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-web",
-  "version": "0.1.49",
+  "version": "0.1.50",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -18,13 +18,13 @@
   },
   "dependencies": {
     "@tanstack/vue-query": "^5.90.5",
-    "@jskit-ai/auth-core": "0.1.47",
+    "@jskit-ai/auth-core": "0.1.48",
     "@mdi/js": "^7.4.47",
     "@fastify/type-provider-typebox": "^6.1.0",
-    "@jskit-ai/kernel": "0.1.48",
-    "@jskit-ai/shell-web": "0.1.47",
+    "@jskit-ai/kernel": "0.1.49",
+    "@jskit-ai/shell-web": "0.1.48",
     "pinia": "^3.0.4",
     "vuetify": "^4.0.0",
-    "@jskit-ai/http-runtime": "0.1.47"
+    "@jskit-ai/http-runtime": "0.1.48"
   }
 }

--- a/packages/console-core/package.descriptor.mjs
+++ b/packages/console-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-core",
-  version: "0.1.11",
+  version: "0.1.12",
   kind: "runtime",
   description: "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
   dependsOn: [
@@ -72,10 +72,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.48",
-        "@jskit-ai/http-runtime": "0.1.47",
-        "@jskit-ai/kernel": "0.1.48",
-        "@jskit-ai/users-core": "0.1.58",
+        "@jskit-ai/database-runtime": "0.1.49",
+        "@jskit-ai/http-runtime": "0.1.48",
+        "@jskit-ai/kernel": "0.1.49",
+        "@jskit-ai/users-core": "0.1.59",
         "typebox": "^1.0.81"
       },
       dev: {}

--- a/packages/console-core/package.json
+++ b/packages/console-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/console-core",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,10 +9,10 @@
     "./shared/resources/consoleSettingsFields": "./src/shared/resources/consoleSettingsFields.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.48",
-    "@jskit-ai/http-runtime": "0.1.47",
-    "@jskit-ai/kernel": "0.1.48",
-    "@jskit-ai/users-core": "0.1.58",
+    "@jskit-ai/database-runtime": "0.1.49",
+    "@jskit-ai/http-runtime": "0.1.48",
+    "@jskit-ai/kernel": "0.1.49",
+    "@jskit-ai/users-core": "0.1.59",
     "typebox": "^1.0.81"
   }
 }

--- a/packages/console-web/package.descriptor.mjs
+++ b/packages/console-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-web",
-  version: "0.1.16",
+  version: "0.1.17",
   kind: "runtime",
   description: "Authenticated console surface scaffold and surface policy wiring.",
   dependsOn: [
@@ -65,9 +65,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-web": "0.1.49",
-        "@jskit-ai/console-core": "0.1.11",
-        "@jskit-ai/shell-web": "0.1.47",
+        "@jskit-ai/auth-web": "0.1.50",
+        "@jskit-ai/console-core": "0.1.12",
+        "@jskit-ai/shell-web": "0.1.48",
       },
       dev: {}
     },

--- a/packages/console-web/package.json
+++ b/packages/console-web/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/console-web",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-web": "0.1.49",
-    "@jskit-ai/console-core": "0.1.11",
-    "@jskit-ai/shell-web": "0.1.47"
+    "@jskit-ai/auth-web": "0.1.50",
+    "@jskit-ai/console-core": "0.1.12",
+    "@jskit-ai/shell-web": "0.1.48"
   }
 }

--- a/packages/crud-core/package.descriptor.mjs
+++ b/packages/crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-core",
-  version: "0.1.56",
+  version: "0.1.57",
   kind: "runtime",
   description: "Shared CRUD helpers used by CRUD modules.",
   dependsOn: [
@@ -26,7 +26,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/crud-core": "0.1.56"
+        "@jskit-ai/crud-core": "0.1.57"
       },
       dev: {}
     },

--- a/packages/crud-core/package.json
+++ b/packages/crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-core",
-  "version": "0.1.56",
+  "version": "0.1.57",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -26,12 +26,12 @@
   },
   "dependencies": {
     "@tanstack/vue-query": "^5.90.5",
-    "@jskit-ai/database-runtime": "0.1.48",
-    "@jskit-ai/kernel": "0.1.48",
-    "@jskit-ai/realtime": "0.1.47",
-    "@jskit-ai/shell-web": "0.1.47",
-    "@jskit-ai/users-core": "0.1.58",
-    "@jskit-ai/users-web": "0.1.63",
+    "@jskit-ai/database-runtime": "0.1.49",
+    "@jskit-ai/kernel": "0.1.49",
+    "@jskit-ai/realtime": "0.1.48",
+    "@jskit-ai/shell-web": "0.1.48",
+    "@jskit-ai/users-core": "0.1.59",
+    "@jskit-ai/users-web": "0.1.64",
     "typebox": "^1.0.81"
   }
 }

--- a/packages/crud-server-generator/package.descriptor.mjs
+++ b/packages/crud-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-server-generator",
-  version: "0.1.56",
+  version: "0.1.57",
   kind: "generator",
   description: "CRUD server generator with routes, actions, and persistence scaffolding.",
   options: {
@@ -151,13 +151,13 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.47",
-        "@jskit-ai/crud-core": "0.1.56",
-        "@jskit-ai/database-runtime": "0.1.48",
-        "@jskit-ai/http-runtime": "0.1.47",
-        "@jskit-ai/kernel": "0.1.48",
-        "@jskit-ai/realtime": "0.1.47",
-        "@jskit-ai/users-core": "0.1.58",
+        "@jskit-ai/auth-core": "0.1.48",
+        "@jskit-ai/crud-core": "0.1.57",
+        "@jskit-ai/database-runtime": "0.1.49",
+        "@jskit-ai/http-runtime": "0.1.48",
+        "@jskit-ai/kernel": "0.1.49",
+        "@jskit-ai/realtime": "0.1.48",
+        "@jskit-ai/users-core": "0.1.59",
         "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}",
         "typebox": "^1.0.81"
       },

--- a/packages/crud-server-generator/package.json
+++ b/packages/crud-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-server-generator",
-  "version": "0.1.56",
+  "version": "0.1.57",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,11 +13,11 @@
   },
   "dependencies": {
     "@babel/parser": "^7.29.2",
-    "@jskit-ai/crud-core": "0.1.56",
-    "@jskit-ai/database-runtime": "0.1.48",
-    "@jskit-ai/http-runtime": "0.1.47",
-    "@jskit-ai/kernel": "0.1.48",
-    "@jskit-ai/users-core": "0.1.58",
+    "@jskit-ai/crud-core": "0.1.57",
+    "@jskit-ai/database-runtime": "0.1.49",
+    "@jskit-ai/http-runtime": "0.1.48",
+    "@jskit-ai/kernel": "0.1.49",
+    "@jskit-ai/users-core": "0.1.59",
     "recast": "^0.23.11",
     "typebox": "^1.0.81"
   }

--- a/packages/crud-ui-generator/package.descriptor.mjs
+++ b/packages/crud-ui-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-ui-generator",
-  version: "0.1.31",
+  version: "0.1.32",
   kind: "generator",
   description: "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
   options: {
@@ -168,7 +168,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.63"
+        "@jskit-ai/users-web": "0.1.64"
       },
       dev: {}
     },

--- a/packages/crud-ui-generator/package.json
+++ b/packages/crud-ui-generator/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/crud-ui-generator",
-  "version": "0.1.31",
+  "version": "0.1.32",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/crud-core": "0.1.56",
-    "@jskit-ai/kernel": "0.1.48"
+    "@jskit-ai/crud-core": "0.1.57",
+    "@jskit-ai/kernel": "0.1.49"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/database-runtime-mysql/package.descriptor.mjs
+++ b/packages/database-runtime-mysql/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-mysql",
-  version: "0.1.47",
+  version: "0.1.48",
   kind: "runtime",
   options: {
     "db-host": {
@@ -91,7 +91,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.48",
+        "@jskit-ai/database-runtime": "0.1.49",
         "mysql2": "^3.11.2"
       },
       dev: {}

--- a/packages/database-runtime-mysql/package.json
+++ b/packages/database-runtime-mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-mysql",
-  "version": "0.1.47",
+  "version": "0.1.48",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,6 +12,6 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.48"
+    "@jskit-ai/database-runtime": "0.1.49"
   }
 }

--- a/packages/database-runtime-postgres/package.descriptor.mjs
+++ b/packages/database-runtime-postgres/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-postgres",
-  version: "0.1.47",
+  version: "0.1.48",
   kind: "runtime",
   options: {
     "db-host": {
@@ -91,7 +91,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.48",
+        "@jskit-ai/database-runtime": "0.1.49",
         "pg": "^8.13.1"
       },
       dev: {}

--- a/packages/database-runtime-postgres/package.json
+++ b/packages/database-runtime-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-postgres",
-  "version": "0.1.47",
+  "version": "0.1.48",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,6 +12,6 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.48"
+    "@jskit-ai/database-runtime": "0.1.49"
   }
 }

--- a/packages/database-runtime/package.descriptor.mjs
+++ b/packages/database-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime",
-  version: "0.1.48",
+  version: "0.1.49",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -58,7 +58,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.48",
+        "@jskit-ai/kernel": "0.1.49",
         "dotenv": "^16.4.5",
         "knex": "^3.1.0"
       },

--- a/packages/database-runtime/package.json
+++ b/packages/database-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime",
-  "version": "0.1.48",
+  "version": "0.1.49",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -25,6 +25,6 @@
     "./shared/transactions": "./src/shared/transactions.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.48"
+    "@jskit-ai/kernel": "0.1.49"
   }
 }

--- a/packages/http-runtime/package.descriptor.mjs
+++ b/packages/http-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/http-runtime",
-  "version": "0.1.47",
+  "version": "0.1.48",
   "kind": "runtime",
   "dependsOn": [],
   "capabilities": {
@@ -67,7 +67,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.48",
+        "@jskit-ai/kernel": "0.1.49",
         "@fastify/type-provider-typebox": "^6.1.0",
         "typebox": "^1.0.81"
       },

--- a/packages/http-runtime/package.json
+++ b/packages/http-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/http-runtime",
-  "version": "0.1.47",
+  "version": "0.1.48",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -17,7 +17,7 @@
     "./shared/validators/operationValidation": "./src/shared/validators/operationValidation.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.48",
+    "@jskit-ai/kernel": "0.1.49",
     "@fastify/type-provider-typebox": "^6.1.0",
     "typebox": "^1.0.81"
   }

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/kernel",
-  "version": "0.1.48",
+  "version": "0.1.49",
   "type": "module",
   "dependencies": {
     "typebox": "^1.0.81"

--- a/packages/realtime/package.descriptor.mjs
+++ b/packages/realtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/realtime",
-  version: "0.1.47",
+  version: "0.1.48",
   kind: "runtime",
   description: "Thin, generic realtime runtime wrappers for socket.io server and client.",
   options: {
@@ -94,7 +94,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.48",
+        "@jskit-ai/kernel": "0.1.49",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/realtime",
-  "version": "0.1.47",
+  "version": "0.1.48",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@socket.io/redis-adapter": "^8.3.0",
-    "@jskit-ai/kernel": "0.1.48",
+    "@jskit-ai/kernel": "0.1.49",
     "redis": "^5.8.2",
     "socket.io": "^4.8.3",
     "socket.io-client": "^4.8.3"

--- a/packages/shell-web/package.descriptor.mjs
+++ b/packages/shell-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/shell-web",
-  version: "0.1.47",
+  version: "0.1.48",
   kind: "runtime",
   description: "Web shell layout runtime with outlet-based placement contributions.",
   dependsOn: [],
@@ -117,7 +117,7 @@ export default Object.freeze({
       runtime: {
         "@mdi/js": "^7.4.47",
         "@tanstack/vue-query": "^5.90.5",
-        "@jskit-ai/kernel": "0.1.48",
+        "@jskit-ai/kernel": "0.1.49",
         "vuetify": "^4.0.0"
       },
       dev: {}

--- a/packages/shell-web/package.json
+++ b/packages/shell-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/shell-web",
-  "version": "0.1.47",
+  "version": "0.1.48",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -24,7 +24,7 @@
   "dependencies": {
     "@mdi/js": "^7.4.47",
     "@tanstack/vue-query": "^5.90.5",
-    "@jskit-ai/kernel": "0.1.48",
+    "@jskit-ai/kernel": "0.1.49",
     "pinia": "^3.0.4",
     "vuetify": "^4.0.0"
   }

--- a/packages/storage-runtime/package.descriptor.mjs
+++ b/packages/storage-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/storage-runtime",
-  version: "0.1.47",
+  version: "0.1.48",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -50,7 +50,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.48",
+        "@jskit-ai/kernel": "0.1.49",
         "unstorage": "^1.17.3"
       },
       dev: {}

--- a/packages/storage-runtime/package.json
+++ b/packages/storage-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/storage-runtime",
-  "version": "0.1.47",
+  "version": "0.1.48",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./server/providers/StorageRuntimeServiceProvider": "./src/server/providers/StorageRuntimeServiceProvider.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.48",
+    "@jskit-ai/kernel": "0.1.49",
     "unstorage": "^1.17.3"
   }
 }

--- a/packages/ui-generator/package.descriptor.mjs
+++ b/packages/ui-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/ui-generator",
-  version: "0.1.31",
+  version: "0.1.32",
   kind: "generator",
   description: "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
   options: {
@@ -278,7 +278,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.63"
+        "@jskit-ai/users-web": "0.1.64"
       },
       dev: {}
     },

--- a/packages/ui-generator/package.json
+++ b/packages/ui-generator/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/ui-generator",
-  "version": "0.1.31",
+  "version": "0.1.32",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.48",
-    "@jskit-ai/shell-web": "0.1.47"
+    "@jskit-ai/kernel": "0.1.49",
+    "@jskit-ai/shell-web": "0.1.48"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/uploads-image-web/package.descriptor.mjs
+++ b/packages/uploads-image-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-image-web",
-  version: "0.1.26",
+  version: "0.1.27",
   kind: "runtime",
   description: "Reusable client-side image upload runtime with pre-upload image editing.",
   dependsOn: [
@@ -65,7 +65,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/uploads-runtime": "0.1.26",
+        "@jskit-ai/uploads-runtime": "0.1.27",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-image-web/package.json
+++ b/packages/uploads-image-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-image-web",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,7 +13,7 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/uploads-runtime": "0.1.26",
+    "@jskit-ai/uploads-runtime": "0.1.27",
     "@uppy/compressor": "^3.1.0",
     "@uppy/core": "^5.2.0",
     "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-runtime/package.descriptor.mjs
+++ b/packages/uploads-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-runtime",
-  version: "0.1.26",
+  version: "0.1.27",
   kind: "runtime",
   description: "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
   dependsOn: [
@@ -71,7 +71,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.48"
+        "@jskit-ai/kernel": "0.1.49"
       },
       dev: {}
     },

--- a/packages/uploads-runtime/package.json
+++ b/packages/uploads-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-runtime",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,6 +16,6 @@
   },
   "dependencies": {
     "@fastify/multipart": "^9.4.0",
-    "@jskit-ai/kernel": "0.1.48"
+    "@jskit-ai/kernel": "0.1.49"
   }
 }

--- a/packages/users-core/package.descriptor.mjs
+++ b/packages/users-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-core",
-  version: "0.1.58",
+  version: "0.1.59",
   kind: "runtime",
   description: "Users/account runtime plus HTTP routes for account features.",
   dependsOn: [
@@ -128,13 +128,13 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.47",
-        "@jskit-ai/crud-core": "0.1.56",
-        "@jskit-ai/database-runtime": "0.1.48",
-        "@jskit-ai/http-runtime": "0.1.47",
-        "@jskit-ai/kernel": "0.1.48",
+        "@jskit-ai/auth-core": "0.1.48",
+        "@jskit-ai/crud-core": "0.1.57",
+        "@jskit-ai/database-runtime": "0.1.49",
+        "@jskit-ai/http-runtime": "0.1.48",
+        "@jskit-ai/kernel": "0.1.49",
         "@local/users": "file:packages/users",
-        "@jskit-ai/uploads-runtime": "0.1.26",
+        "@jskit-ai/uploads-runtime": "0.1.27",
         "@fastify/type-provider-typebox": "^6.1.0",
         typebox: "^1.0.81"
       },

--- a/packages/users-core/package.json
+++ b/packages/users-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-core",
-  "version": "0.1.58",
+  "version": "0.1.59",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,11 +13,11 @@
     "./shared/resources/userSettingsResource": "./src/shared/resources/userSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.47",
-    "@jskit-ai/database-runtime": "0.1.48",
-    "@jskit-ai/http-runtime": "0.1.47",
-    "@jskit-ai/kernel": "0.1.48",
-    "@jskit-ai/uploads-runtime": "0.1.26",
+    "@jskit-ai/auth-core": "0.1.48",
+    "@jskit-ai/database-runtime": "0.1.49",
+    "@jskit-ai/http-runtime": "0.1.48",
+    "@jskit-ai/kernel": "0.1.49",
+    "@jskit-ai/uploads-runtime": "0.1.27",
     "@fastify/type-provider-typebox": "^6.1.0",
     "typebox": "^1.0.81"
   }

--- a/packages/users-web/package.descriptor.mjs
+++ b/packages/users-web/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { HOME_TOOLS_OUTLET } from "./src/shared/toolsOutletContracts.js";
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-web",
-  version: "0.1.63",
+  version: "0.1.64",
   kind: "runtime",
   description: "Users web module: account/profile UI plus shared users web widgets.",
   dependsOn: [
@@ -154,12 +154,12 @@ export default Object.freeze({
       runtime: {
         "@tanstack/vue-query": "5.92.12",
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/http-runtime": "0.1.47",
-        "@jskit-ai/realtime": "0.1.47",
-        "@jskit-ai/kernel": "0.1.48",
-        "@jskit-ai/shell-web": "0.1.47",
-        "@jskit-ai/uploads-image-web": "0.1.26",
-        "@jskit-ai/users-core": "0.1.58",
+        "@jskit-ai/http-runtime": "0.1.48",
+        "@jskit-ai/realtime": "0.1.48",
+        "@jskit-ai/kernel": "0.1.49",
+        "@jskit-ai/shell-web": "0.1.48",
+        "@jskit-ai/uploads-image-web": "0.1.27",
+        "@jskit-ai/users-core": "0.1.59",
         vuetify: "^4.0.0"
       },
       dev: {}

--- a/packages/users-web/package.json
+++ b/packages/users-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-web",
-  "version": "0.1.63",
+  "version": "0.1.64",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -35,12 +35,12 @@
   "dependencies": {
     "@tanstack/vue-query": "5.92.12",
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/http-runtime": "0.1.47",
-    "@jskit-ai/kernel": "0.1.48",
-    "@jskit-ai/realtime": "0.1.47",
-    "@jskit-ai/shell-web": "0.1.47",
-    "@jskit-ai/uploads-image-web": "0.1.26",
-    "@jskit-ai/users-core": "0.1.58",
+    "@jskit-ai/http-runtime": "0.1.48",
+    "@jskit-ai/kernel": "0.1.49",
+    "@jskit-ai/realtime": "0.1.48",
+    "@jskit-ai/shell-web": "0.1.48",
+    "@jskit-ai/uploads-image-web": "0.1.27",
+    "@jskit-ai/users-core": "0.1.59",
     "vuetify": "^4.0.0"
   }
 }

--- a/packages/workspaces-core/package.descriptor.mjs
+++ b/packages/workspaces-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-core",
-  version: "0.1.24",
+  version: "0.1.25",
   kind: "runtime",
   description: "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
   dependsOn: [
@@ -112,7 +112,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-core": "0.1.58"
+        "@jskit-ai/users-core": "0.1.59"
       },
       dev: {}
     },

--- a/packages/workspaces-core/package.json
+++ b/packages/workspaces-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-core",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -18,11 +18,11 @@
   },
   "dependencies": {
     "@fastify/type-provider-typebox": "^6.1.0",
-    "@jskit-ai/auth-core": "0.1.47",
-    "@jskit-ai/database-runtime": "0.1.48",
-    "@jskit-ai/http-runtime": "0.1.47",
-    "@jskit-ai/kernel": "0.1.48",
-    "@jskit-ai/users-core": "0.1.58",
+    "@jskit-ai/auth-core": "0.1.48",
+    "@jskit-ai/database-runtime": "0.1.49",
+    "@jskit-ai/http-runtime": "0.1.48",
+    "@jskit-ai/kernel": "0.1.49",
+    "@jskit-ai/users-core": "0.1.59",
     "typebox": "^1.0.81"
   }
 }

--- a/packages/workspaces-web/package.descriptor.mjs
+++ b/packages/workspaces-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-web",
-  version: "0.1.24",
+  version: "0.1.25",
   kind: "runtime",
   description: "Workspace web module: workspace selector, tools widget, workspace surfaces, and members/settings UI.",
   dependsOn: [
@@ -148,8 +148,8 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/workspaces-core": "0.1.24",
-        "@jskit-ai/users-web": "0.1.63",
+        "@jskit-ai/workspaces-core": "0.1.25",
+        "@jskit-ai/users-web": "0.1.64",
         "vuetify": "^4.0.0"
       },
       dev: {}

--- a/packages/workspaces-web/package.json
+++ b/packages/workspaces-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-web",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -14,12 +14,12 @@
   "dependencies": {
     "@tanstack/vue-query": "5.92.12",
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/http-runtime": "0.1.47",
-    "@jskit-ai/kernel": "0.1.48",
-    "@jskit-ai/shell-web": "0.1.47",
-    "@jskit-ai/users-core": "0.1.58",
-    "@jskit-ai/users-web": "0.1.63",
-    "@jskit-ai/workspaces-core": "0.1.24",
+    "@jskit-ai/http-runtime": "0.1.48",
+    "@jskit-ai/kernel": "0.1.49",
+    "@jskit-ai/shell-web": "0.1.48",
+    "@jskit-ai/users-core": "0.1.59",
+    "@jskit-ai/users-web": "0.1.64",
+    "@jskit-ai/workspaces-core": "0.1.25",
     "vuetify": "^4.0.0"
   }
 }

--- a/tooling/config-eslint/package.json
+++ b/tooling/config-eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/config-eslint",
-  "version": "0.1.47",
+  "version": "0.1.48",
   "description": "Shared flat ESLint presets for JSKIT projects.",
   "type": "module",
   "files": [

--- a/tooling/create-app/package.descriptor.mjs
+++ b/tooling/create-app/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/create-app",
-  "version": "0.1.56",
+  "version": "0.1.57",
   "dependsOn": [],
   "capabilities": {
     "provides": [

--- a/tooling/create-app/package.json
+++ b/tooling/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/create-app",
-  "version": "0.1.56",
+  "version": "0.1.57",
   "description": "Scaffold minimal JSKIT app shells.",
   "type": "module",
   "files": [

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -6,11 +6,11 @@
   "packages": [
     {
       "packageId": "@jskit-ai/assistant",
-      "version": "0.1.57",
+      "version": "0.1.58",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant",
-        "version": "0.1.57",
+        "version": "0.1.58",
         "kind": "generator",
         "description": "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
         "options": {
@@ -356,11 +356,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-core",
-      "version": "0.1.24",
+      "version": "0.1.25",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-core",
-        "version": "0.1.24",
+        "version": "0.1.25",
         "kind": "runtime",
         "description": "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
         "dependsOn": [
@@ -406,9 +406,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/http-runtime": "0.1.47",
-              "@jskit-ai/kernel": "0.1.48",
-              "@jskit-ai/users-core": "0.1.58",
+              "@jskit-ai/http-runtime": "0.1.48",
+              "@jskit-ai/kernel": "0.1.49",
+              "@jskit-ai/users-core": "0.1.59",
               "@tanstack/vue-query": "^5.90.5",
               "dompurify": "^3.3.3",
               "marked": "^17.0.4",
@@ -429,11 +429,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-runtime",
-      "version": "0.1.19",
+      "version": "0.1.20",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-runtime",
-        "version": "0.1.19",
+        "version": "0.1.20",
         "kind": "runtime",
         "description": "Shared assistant runtime with per-surface assistant registration.",
         "dependsOn": [
@@ -508,13 +508,13 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/assistant-core": "0.1.24",
-              "@jskit-ai/database-runtime": "0.1.48",
-              "@jskit-ai/http-runtime": "0.1.47",
-              "@jskit-ai/kernel": "0.1.48",
-              "@jskit-ai/shell-web": "0.1.47",
-              "@jskit-ai/users-core": "0.1.58",
-              "@jskit-ai/users-web": "0.1.63",
+              "@jskit-ai/assistant-core": "0.1.25",
+              "@jskit-ai/database-runtime": "0.1.49",
+              "@jskit-ai/http-runtime": "0.1.48",
+              "@jskit-ai/kernel": "0.1.49",
+              "@jskit-ai/shell-web": "0.1.48",
+              "@jskit-ai/users-core": "0.1.59",
+              "@jskit-ai/users-web": "0.1.64",
               "@tanstack/vue-query": "^5.90.5",
               "vuetify": "^4.0.0"
             },
@@ -571,11 +571,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-core",
-      "version": "0.1.47",
+      "version": "0.1.48",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-core",
-        "version": "0.1.47",
+        "version": "0.1.48",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/value-app-config-shared"
@@ -643,7 +643,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.48",
+              "@jskit-ai/kernel": "0.1.49",
               "@fastify/cookie": "^11.0.2",
               "@fastify/csrf-protection": "^7.1.0",
               "@fastify/rate-limit": "^10.3.0"
@@ -661,11 +661,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.47",
+      "version": "0.1.48",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-supabase-core",
-        "version": "0.1.47",
+        "version": "0.1.48",
         "kind": "runtime",
         "options": {
           "auth-supabase-url": {
@@ -747,8 +747,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.47",
-              "@jskit-ai/kernel": "0.1.48",
+              "@jskit-ai/auth-core": "0.1.48",
+              "@jskit-ai/kernel": "0.1.49",
               "dotenv": "^16.4.5",
               "@supabase/supabase-js": "^2.57.4",
               "jose": "^6.1.0"
@@ -813,11 +813,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-web",
-      "version": "0.1.49",
+      "version": "0.1.50",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-web",
-        "version": "0.1.49",
+        "version": "0.1.50",
         "kind": "runtime",
         "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
         "dependsOn": [
@@ -1044,10 +1044,10 @@
               "@tanstack/vue-query": "5.92.12",
               "@mdi/js": "^7.4.47",
               "@fastify/type-provider-typebox": "^6.1.0",
-              "@jskit-ai/auth-core": "0.1.47",
-              "@jskit-ai/http-runtime": "0.1.47",
-              "@jskit-ai/kernel": "0.1.48",
-              "@jskit-ai/shell-web": "0.1.47",
+              "@jskit-ai/auth-core": "0.1.48",
+              "@jskit-ai/http-runtime": "0.1.48",
+              "@jskit-ai/kernel": "0.1.49",
+              "@jskit-ai/shell-web": "0.1.48",
               "vuetify": "^4.0.0"
             },
             "dev": {}
@@ -1117,11 +1117,11 @@
     },
     {
       "packageId": "@jskit-ai/console-core",
-      "version": "0.1.11",
+      "version": "0.1.12",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-core",
-        "version": "0.1.11",
+        "version": "0.1.12",
         "kind": "runtime",
         "description": "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
         "dependsOn": [
@@ -1192,10 +1192,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.48",
-              "@jskit-ai/http-runtime": "0.1.47",
-              "@jskit-ai/kernel": "0.1.48",
-              "@jskit-ai/users-core": "0.1.58",
+              "@jskit-ai/database-runtime": "0.1.49",
+              "@jskit-ai/http-runtime": "0.1.48",
+              "@jskit-ai/kernel": "0.1.49",
+              "@jskit-ai/users-core": "0.1.59",
               "typebox": "^1.0.81"
             },
             "dev": {}
@@ -1240,11 +1240,11 @@
     },
     {
       "packageId": "@jskit-ai/console-web",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-web",
-        "version": "0.1.16",
+        "version": "0.1.17",
         "kind": "runtime",
         "description": "Authenticated console surface scaffold and surface policy wiring.",
         "dependsOn": [
@@ -1312,9 +1312,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-web": "0.1.49",
-              "@jskit-ai/console-core": "0.1.11",
-              "@jskit-ai/shell-web": "0.1.47"
+              "@jskit-ai/auth-web": "0.1.50",
+              "@jskit-ai/console-core": "0.1.12",
+              "@jskit-ai/shell-web": "0.1.48"
             },
             "dev": {}
           },
@@ -1401,11 +1401,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-core",
-      "version": "0.1.56",
+      "version": "0.1.57",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-core",
-        "version": "0.1.56",
+        "version": "0.1.57",
         "kind": "runtime",
         "description": "Shared CRUD helpers used by CRUD modules.",
         "dependsOn": [
@@ -1432,7 +1432,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/crud-core": "0.1.56"
+              "@jskit-ai/crud-core": "0.1.57"
             },
             "dev": {}
           },
@@ -1446,11 +1446,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-server-generator",
-      "version": "0.1.56",
+      "version": "0.1.57",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-server-generator",
-        "version": "0.1.56",
+        "version": "0.1.57",
         "kind": "generator",
         "description": "CRUD server generator with routes, actions, and persistence scaffolding.",
         "options": {
@@ -1608,13 +1608,13 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.47",
-              "@jskit-ai/crud-core": "0.1.56",
-              "@jskit-ai/database-runtime": "0.1.48",
-              "@jskit-ai/http-runtime": "0.1.47",
-              "@jskit-ai/kernel": "0.1.48",
-              "@jskit-ai/realtime": "0.1.47",
-              "@jskit-ai/users-core": "0.1.58",
+              "@jskit-ai/auth-core": "0.1.48",
+              "@jskit-ai/crud-core": "0.1.57",
+              "@jskit-ai/database-runtime": "0.1.49",
+              "@jskit-ai/http-runtime": "0.1.48",
+              "@jskit-ai/kernel": "0.1.49",
+              "@jskit-ai/realtime": "0.1.48",
+              "@jskit-ai/users-core": "0.1.59",
               "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}",
               "typebox": "^1.0.81"
             },
@@ -1761,11 +1761,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.31",
+      "version": "0.1.32",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-ui-generator",
-        "version": "0.1.31",
+        "version": "0.1.32",
         "kind": "generator",
         "description": "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
         "options": {
@@ -1940,7 +1940,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.63"
+              "@jskit-ai/users-web": "0.1.64"
             },
             "dev": {}
           },
@@ -2173,11 +2173,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime",
-      "version": "0.1.48",
+      "version": "0.1.49",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime",
-        "version": "0.1.48",
+        "version": "0.1.49",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -2234,7 +2234,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.48",
+              "@jskit-ai/kernel": "0.1.49",
               "dotenv": "^16.4.5",
               "knex": "^3.1.0"
             },
@@ -2269,11 +2269,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.47",
+      "version": "0.1.48",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-mysql",
-        "version": "0.1.47",
+        "version": "0.1.48",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -2363,7 +2363,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.48",
+              "@jskit-ai/database-runtime": "0.1.49",
               "mysql2": "^3.11.2"
             },
             "dev": {}
@@ -2434,11 +2434,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.47",
+      "version": "0.1.48",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-postgres",
-        "version": "0.1.47",
+        "version": "0.1.48",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -2528,7 +2528,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.48",
+              "@jskit-ai/database-runtime": "0.1.49",
               "pg": "^8.13.1"
             },
             "dev": {}
@@ -2599,11 +2599,11 @@
     },
     {
       "packageId": "@jskit-ai/http-runtime",
-      "version": "0.1.47",
+      "version": "0.1.48",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/http-runtime",
-        "version": "0.1.47",
+        "version": "0.1.48",
         "kind": "runtime",
         "dependsOn": [],
         "capabilities": {
@@ -2669,7 +2669,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.48",
+              "@jskit-ai/kernel": "0.1.49",
               "@fastify/type-provider-typebox": "^6.1.0",
               "typebox": "^1.0.81"
             },
@@ -2685,11 +2685,11 @@
     },
     {
       "packageId": "@jskit-ai/realtime",
-      "version": "0.1.47",
+      "version": "0.1.48",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/realtime",
-        "version": "0.1.47",
+        "version": "0.1.48",
         "kind": "runtime",
         "description": "Thin, generic realtime runtime wrappers for socket.io server and client.",
         "options": {
@@ -2784,7 +2784,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.48",
+              "@jskit-ai/kernel": "0.1.49",
               "@socket.io/redis-adapter": "^8.3.0",
               "redis": "^5.8.2",
               "socket.io": "^4.8.3",
@@ -2833,11 +2833,11 @@
     },
     {
       "packageId": "@jskit-ai/shell-web",
-      "version": "0.1.47",
+      "version": "0.1.48",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/shell-web",
-        "version": "0.1.47",
+        "version": "0.1.48",
         "kind": "runtime",
         "description": "Web shell layout runtime with outlet-based placement contributions.",
         "dependsOn": [],
@@ -2969,7 +2969,7 @@
             "runtime": {
               "@mdi/js": "^7.4.47",
               "@tanstack/vue-query": "^5.90.5",
-              "@jskit-ai/kernel": "0.1.48",
+              "@jskit-ai/kernel": "0.1.49",
               "vuetify": "^4.0.0"
             },
             "dev": {}
@@ -3154,11 +3154,11 @@
     },
     {
       "packageId": "@jskit-ai/storage-runtime",
-      "version": "0.1.47",
+      "version": "0.1.48",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/storage-runtime",
-        "version": "0.1.47",
+        "version": "0.1.48",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -3207,7 +3207,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.48",
+              "@jskit-ai/kernel": "0.1.49",
               "unstorage": "^1.17.3"
             },
             "dev": {}
@@ -3223,11 +3223,11 @@
     },
     {
       "packageId": "@jskit-ai/ui-generator",
-      "version": "0.1.31",
+      "version": "0.1.32",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/ui-generator",
-        "version": "0.1.31",
+        "version": "0.1.32",
         "kind": "generator",
         "description": "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
         "options": {
@@ -3526,7 +3526,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.63"
+              "@jskit-ai/users-web": "0.1.64"
             },
             "dev": {}
           },
@@ -3541,11 +3541,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-image-web",
-      "version": "0.1.26",
+      "version": "0.1.27",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-image-web",
-        "version": "0.1.26",
+        "version": "0.1.27",
         "kind": "runtime",
         "description": "Reusable client-side image upload runtime with pre-upload image editing.",
         "dependsOn": [
@@ -3609,7 +3609,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/uploads-runtime": "0.1.26",
+              "@jskit-ai/uploads-runtime": "0.1.27",
               "@uppy/compressor": "^3.1.0",
               "@uppy/core": "^5.2.0",
               "@uppy/dashboard": "^5.1.1",
@@ -3629,11 +3629,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-runtime",
-      "version": "0.1.26",
+      "version": "0.1.27",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-runtime",
-        "version": "0.1.26",
+        "version": "0.1.27",
         "kind": "runtime",
         "description": "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
         "dependsOn": [
@@ -3703,7 +3703,7 @@
           "dependencies": {
             "runtime": {
               "@fastify/multipart": "^9.4.0",
-              "@jskit-ai/kernel": "0.1.48"
+              "@jskit-ai/kernel": "0.1.49"
             },
             "dev": {}
           },
@@ -3718,11 +3718,11 @@
     },
     {
       "packageId": "@jskit-ai/users-core",
-      "version": "0.1.58",
+      "version": "0.1.59",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-core",
-        "version": "0.1.58",
+        "version": "0.1.59",
         "kind": "runtime",
         "description": "Users/account runtime plus HTTP routes for account features.",
         "dependsOn": [
@@ -3848,13 +3848,13 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.47",
-              "@jskit-ai/crud-core": "0.1.56",
-              "@jskit-ai/database-runtime": "0.1.48",
-              "@jskit-ai/http-runtime": "0.1.47",
-              "@jskit-ai/kernel": "0.1.48",
+              "@jskit-ai/auth-core": "0.1.48",
+              "@jskit-ai/crud-core": "0.1.57",
+              "@jskit-ai/database-runtime": "0.1.49",
+              "@jskit-ai/http-runtime": "0.1.48",
+              "@jskit-ai/kernel": "0.1.49",
               "@local/users": "file:packages/users",
-              "@jskit-ai/uploads-runtime": "0.1.26",
+              "@jskit-ai/uploads-runtime": "0.1.27",
               "@fastify/type-provider-typebox": "^6.1.0",
               "typebox": "^1.0.81"
             },
@@ -4129,11 +4129,11 @@
     },
     {
       "packageId": "@jskit-ai/users-web",
-      "version": "0.1.63",
+      "version": "0.1.64",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-web",
-        "version": "0.1.63",
+        "version": "0.1.64",
         "kind": "runtime",
         "description": "Users web module: account/profile UI plus shared users web widgets.",
         "dependsOn": [
@@ -4292,12 +4292,12 @@
             "runtime": {
               "@tanstack/vue-query": "5.92.12",
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/http-runtime": "0.1.47",
-              "@jskit-ai/realtime": "0.1.47",
-              "@jskit-ai/kernel": "0.1.48",
-              "@jskit-ai/shell-web": "0.1.47",
-              "@jskit-ai/uploads-image-web": "0.1.26",
-              "@jskit-ai/users-core": "0.1.58",
+              "@jskit-ai/http-runtime": "0.1.48",
+              "@jskit-ai/realtime": "0.1.48",
+              "@jskit-ai/kernel": "0.1.49",
+              "@jskit-ai/shell-web": "0.1.48",
+              "@jskit-ai/uploads-image-web": "0.1.27",
+              "@jskit-ai/users-core": "0.1.59",
               "vuetify": "^4.0.0"
             },
             "dev": {}
@@ -4384,11 +4384,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-core",
-      "version": "0.1.24",
+      "version": "0.1.25",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-core",
-        "version": "0.1.24",
+        "version": "0.1.25",
         "kind": "runtime",
         "description": "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
         "dependsOn": [
@@ -4499,7 +4499,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-core": "0.1.58"
+              "@jskit-ai/users-core": "0.1.59"
             },
             "dev": {}
           },
@@ -4689,11 +4689,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-web",
-      "version": "0.1.24",
+      "version": "0.1.25",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-web",
-        "version": "0.1.24",
+        "version": "0.1.25",
         "kind": "runtime",
         "description": "Workspace web module: workspace selector, tools widget, workspace surfaces, and members/settings UI.",
         "dependsOn": [
@@ -4858,8 +4858,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/workspaces-core": "0.1.24",
-              "@jskit-ai/users-web": "0.1.63",
+              "@jskit-ai/workspaces-core": "0.1.25",
+              "@jskit-ai/users-web": "0.1.64",
               "vuetify": "^4.0.0"
             },
             "dev": {}

--- a/tooling/jskit-catalog/package.json
+++ b/tooling/jskit-catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-catalog",
-  "version": "0.1.56",
+  "version": "0.1.57",
   "description": "Published metadata catalog for JSKIT package descriptors.",
   "type": "module",
   "files": [

--- a/tooling/jskit-cli/package.json
+++ b/tooling/jskit-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-cli",
-  "version": "0.2.57",
+  "version": "0.2.58",
   "description": "Bundle and package orchestration CLI for JSKIT apps.",
   "type": "module",
   "files": [
@@ -20,9 +20,9 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/jskit-catalog": "0.1.56",
-    "@jskit-ai/kernel": "0.1.48",
-    "@jskit-ai/shell-web": "0.1.47"
+    "@jskit-ai/jskit-catalog": "0.1.57",
+    "@jskit-ai/kernel": "0.1.49",
+    "@jskit-ai/shell-web": "0.1.48"
   },
   "engines": {
     "node": "20.x"


### PR DESCRIPTION
## Summary
- refresh package versions and descriptor metadata after the recent generator/runtime changes
- update dependent package version references and catalog entries
- refresh the root lockfile to match the published package metadata state

## Notes
- this PR intentionally captures the current tracked local metadata/catalog diff as-is