### PR TITLE
Rebuild-driven JSKIT runtime and generator fixes

### DIFF
--- a/DOGANDGROOM_REBUILD_JSKIT_LOG.md
+++ b/DOGANDGROOM_REBUILD_JSKIT_LOG.md
@@ -119,3 +119,23 @@ The goal is to give the maintainer a clean review trail separate from app-local 
   - `packages/users-web/test/useViewRequestQueryParams.test.js`
 - Verification:
   - `npm test --workspace @jskit-ai/users-web`
+
+### CRUD UI wrappers emitted lint-warn blank lines when no lookup fields existed
+
+- Problem:
+  - the freshly generated `practice/roles` pages in `dogandgroom2` linted with `vue/html-closing-bracket-newline` warnings before any app-local changes
+  - both generated wrapper pages (`new.vue` and `edit.vue`) left a double blank line before the self-closing `CrudAddEditForm` tag when the resource had no lookup fields
+- Root cause:
+  - the shared CRUD UI wrapper templates always reserved a separate line for `__JSKIT_UI_*_LOOKUP_FORM_PROPS__`
+  - when the template context correctly returned an empty string for non-lookup resources, that placeholder line became an extra blank line in the rendered Vue file
+- Fix:
+  - change the wrapper templates so lookup form props append inline after `:cancel-to=...`
+  - make the lookup-form-props context string include its own leading newline only when lookup props are actually present
+  - extend the template-context test to assert that the non-empty lookup prop block now starts with that newline
+- Files:
+  - `packages/crud-ui-generator/templates/src/pages/admin/ui-generator/NewWrapperElement.vue`
+  - `packages/crud-ui-generator/templates/src/pages/admin/ui-generator/EditWrapperElement.vue`
+  - `packages/crud-ui-generator/src/server/buildTemplateContext.js`
+  - `packages/crud-ui-generator/test/buildTemplateContext.test.js`
+- Verification:
+  - `npm test --workspace @jskit-ai/crud-ui-generator`

--- a/DOGANDGROOM_REBUILD_JSKIT_LOG.md
+++ b/DOGANDGROOM_REBUILD_JSKIT_LOG.md
@@ -29,3 +29,18 @@ The goal is to give the maintainer a clean review trail separate from app-local 
   - `npm test --workspace @jskit-ai/workspaces-core`
   - `npm test --workspace @jskit-ai/users-core` ran, but it still contains an unrelated pre-existing scaffold-version contract failure outside this fix
 
+### Workspace CRUD providers omitted routeSurfaceRequiresWorkspace
+
+- Problem:
+  - the current CRUD server scaffold generated providers that only passed `routeSurface` and `routeRelativePath` into `registerRoutes()`
+  - workspace-aware CRUDs therefore booted with an incomplete route contract even though the generated `registerRoutes.js` already supports `routeSurfaceRequiresWorkspace`
+- Root cause:
+  - `packages/crud-server-generator/templates/src/local-package/server/CrudProvider.js` never forwarded `crudPolicy.surfaceDefinition.requiresWorkspace`
+- Fix:
+  - add `routeSurfaceRequiresWorkspace: crudPolicy.surfaceDefinition.requiresWorkspace === true` to the provider template
+  - lock the template contract with a focused test assertion
+- Files:
+  - `packages/crud-server-generator/templates/src/local-package/server/CrudProvider.js`
+  - `packages/crud-server-generator/test/buildTemplateContext.test.js`
+- Verification:
+  - `npm test --workspace @jskit-ai/crud-server-generator`

--- a/DOGANDGROOM_REBUILD_JSKIT_LOG.md
+++ b/DOGANDGROOM_REBUILD_JSKIT_LOG.md
@@ -1,0 +1,31 @@
+# Dogandgroom Rebuild JSKIT Log
+
+This file records every framework-side change made in `jskit-ai` while rebuilding `dogandgroom` onto the latest JSKIT baseline.
+
+The goal is to give the maintainer a clean review trail separate from app-local migration commits.
+
+## 2026-04-21
+
+### Missing-row normalization in internal workspace repositories
+
+- Problem:
+  - the fresh `dogandgroom2` recap baseline could not seed the first local dev user in `personal` tenancy
+  - `workspaces.core.profileSyncLifecycleContributor` called `internal.repository.workspaces.findPersonalByOwnerUserId()`
+  - that repository wrapper defaulted `undefined` query results to `{}` before normalization, so an empty result was treated as a real row and failed on `is_personal`
+- Root cause:
+  - several internal repository helper functions used `function normalizeXRecord(payload = {})`
+  - their null-guard checked `if (!payload)` after the default parameter had already converted `undefined` into `{}`.
+- Fix:
+  - remove the default object from the internal record-normalization wrappers so missing rows stay `null`
+  - add regression coverage for the workspace path that failed in the fresh baseline
+- Files:
+  - `packages/workspaces-core/src/server/common/repositories/workspacesRepository.js`
+  - `packages/workspaces-core/src/server/common/repositories/workspaceMembershipsRepository.js`
+  - `packages/workspaces-core/src/server/common/repositories/workspaceInvitesRepository.js`
+  - `packages/users-core/src/server/common/repositories/userProfilesRepository.js`
+  - `packages/workspaces-core/test/workspacesRepository.test.js`
+  - `packages/users-core/test/repositoryContracts.test.js`
+- Verification:
+  - `npm test --workspace @jskit-ai/workspaces-core`
+  - `npm test --workspace @jskit-ai/users-core` ran, but it still contains an unrelated pre-existing scaffold-version contract failure outside this fix
+

--- a/DOGANDGROOM_REBUILD_JSKIT_LOG.md
+++ b/DOGANDGROOM_REBUILD_JSKIT_LOG.md
@@ -61,3 +61,21 @@ The goal is to give the maintainer a clean review trail separate from app-local 
   - `packages/crud-ui-generator/test/buildTemplateContext.test.js`
 - Verification:
   - `npm test --workspace @jskit-ai/crud-ui-generator`
+
+### CRUD server generator imported unused non-nullable time schemas
+
+- Problem:
+  - a fresh `services` scaffold in `dogandgroom2` failed lint before any app-local patching
+  - the generated `serviceResource.js` imported both `HTML_TIME_STRING_SCHEMA` and `NULLABLE_HTML_TIME_STRING_SCHEMA` even though every time column in that table was nullable
+- Root cause:
+  - `packages/crud-server-generator/src/server/buildTemplateContext.js` used a coarse `needsHtmlTimeSchemas` boolean based on “any time column exists”
+  - the validator import builder therefore pulled in both time schema helpers instead of the exact subset the generated schemas referenced
+- Fix:
+  - derive the actual set of referenced time-schema imports from the generated columns
+  - import only the nullable and/or non-nullable time schema helpers that the resource will really use
+  - add regression coverage for both nullable-only and non-nullable-only time columns
+- Files:
+  - `packages/crud-server-generator/src/server/buildTemplateContext.js`
+  - `packages/crud-server-generator/test/buildTemplateContext.test.js`
+- Verification:
+  - `npm test --workspace @jskit-ai/crud-server-generator`

--- a/DOGANDGROOM_REBUILD_JSKIT_LOG.md
+++ b/DOGANDGROOM_REBUILD_JSKIT_LOG.md
@@ -79,3 +79,25 @@ The goal is to give the maintainer a clean review trail separate from app-local 
   - `packages/crud-server-generator/test/buildTemplateContext.test.js`
 - Verification:
   - `npm test --workspace @jskit-ai/crud-server-generator`
+
+## 2026-04-22
+
+### `useView()` dropped request query params for lookup-heavy view pages
+
+- Problem:
+  - while finishing the `pets` stage in `dogandgroom2`, the rebuilt `contacts` view needed `include=vetId,linkedUserId,pets,pets.breedId`
+  - the old source app expressed that include string by embedding `?include=...` in `apiUrlTemplate`
+  - on latest JSKIT, `useCrudView()` / `useView()` normalized the API path as a pathname, so embedded query strings were silently stripped and the view never hydrated pets
+- Root cause:
+  - `useList()` already supports `requestQueryParams`, but `useView()` had no equivalent
+  - `useScopeRuntime.resolveApiPath()` intentionally produces pathnames, so the old “put query in the URL template” trick is not a supported contract anymore
+- Fix:
+  - add `requestQueryParams` support to `useView()`
+  - reuse the existing query-param descriptor/token helpers so request params affect both the actual request path and the query key
+  - keep the request-path appending logic in a pure support helper with direct unit coverage
+- Files:
+  - `packages/users-web/src/client/composables/records/useView.js`
+  - `packages/users-web/src/client/composables/support/requestQueryPathSupport.js`
+  - `packages/users-web/test/useViewRequestQueryParams.test.js`
+- Verification:
+  - `npm test --workspace @jskit-ai/users-web`

--- a/DOGANDGROOM_REBUILD_JSKIT_LOG.md
+++ b/DOGANDGROOM_REBUILD_JSKIT_LOG.md
@@ -82,6 +82,24 @@ The goal is to give the maintainer a clean review trail separate from app-local 
 
 ## 2026-04-22
 
+### CRUD numeric-bound inference skipped `BETWEEN ... AND ...` checks
+
+- Problem:
+  - the fresh `pet-notes` scaffold in `dogandgroom2` still generated `severity` as `minimum: 0`
+  - but the real table contract is `CHECK (severity is null or severity between 1 and 10)`
+- Root cause:
+  - the numeric-bound inference added during the `beepollen2` rebuild only parsed simple `>`, `>=`, `<`, `<=` comparisons
+  - it ignored `BETWEEN ... AND ...`, so unsigned integers fell back to `minimum: 0`
+- Fix:
+  - extend the CRUD generator’s numeric-check inference to parse `BETWEEN ... AND ...`
+  - keep using the same lower/upper bound merge logic so `BETWEEN` and comparison constraints compose cleanly
+  - add regression coverage for a nullable unsigned integer constrained to `1..10`
+- Files:
+  - `packages/crud-server-generator/src/server/buildTemplateContext.js`
+  - `packages/crud-server-generator/test/buildTemplateContext.test.js`
+- Verification:
+  - `npm test --workspace @jskit-ai/crud-server-generator`
+
 ### `useView()` dropped request query params for lookup-heavy view pages
 
 - Problem:

--- a/DOGANDGROOM_REBUILD_JSKIT_LOG.md
+++ b/DOGANDGROOM_REBUILD_JSKIT_LOG.md
@@ -44,3 +44,20 @@ The goal is to give the maintainer a clean review trail separate from app-local 
   - `packages/crud-server-generator/test/buildTemplateContext.test.js`
 - Verification:
   - `npm test --workspace @jskit-ai/crud-server-generator`
+
+### CRUD add/edit forms kept dead lookup prop contracts
+
+- Problem:
+  - no-lookup CRUD pages now correctly skip the lookup runtime setup in the page script
+  - but the shared add/edit form template still declared `resolveLookupItems`/`resolveLookupLoading`/`resolveLookupSearch`/`setLookupSearch` as required props even when neither mode used lookup fields
+- Root cause:
+  - the page template context already knew when lookup form props were empty, but the shared form template had unconditional prop definitions
+- Fix:
+  - make the shared form’s lookup prop definitions conditional on whether the create or edit mode actually includes lookup fields
+  - add template-context assertions for both the no-lookup and lookup-enabled cases
+- Files:
+  - `packages/crud-ui-generator/templates/src/pages/admin/ui-generator/AddEditForm.vue`
+  - `packages/crud-ui-generator/src/server/buildTemplateContext.js`
+  - `packages/crud-ui-generator/test/buildTemplateContext.test.js`
+- Verification:
+  - `npm test --workspace @jskit-ai/crud-ui-generator`

--- a/package-lock.json
+++ b/package-lock.json
@@ -6176,26 +6176,26 @@
     },
     "packages/agent-docs": {
       "name": "@jskit-ai/agent-docs",
-      "version": "0.1.10",
+      "version": "0.1.12",
       "engines": {
         "node": "20.x"
       }
     },
     "packages/assistant": {
       "name": "@jskit-ai/assistant",
-      "version": "0.1.58",
+      "version": "0.1.60",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.49"
+        "@jskit-ai/kernel": "0.1.51"
       }
     },
     "packages/assistant-core": {
       "name": "@jskit-ai/assistant-core",
-      "version": "0.1.25",
+      "version": "0.1.27",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.49",
-        "@jskit-ai/http-runtime": "0.1.48",
-        "@jskit-ai/kernel": "0.1.49",
-        "@jskit-ai/users-core": "0.1.59",
+        "@jskit-ai/database-runtime": "0.1.51",
+        "@jskit-ai/http-runtime": "0.1.50",
+        "@jskit-ai/kernel": "0.1.51",
+        "@jskit-ai/users-core": "0.1.61",
         "@tanstack/vue-query": "^5.90.5",
         "dompurify": "^3.3.3",
         "marked": "^17.0.4",
@@ -6273,15 +6273,15 @@
     },
     "packages/assistant-runtime": {
       "name": "@jskit-ai/assistant-runtime",
-      "version": "0.1.20",
+      "version": "0.1.22",
       "dependencies": {
-        "@jskit-ai/assistant-core": "0.1.25",
-        "@jskit-ai/database-runtime": "0.1.49",
-        "@jskit-ai/http-runtime": "0.1.48",
-        "@jskit-ai/kernel": "0.1.49",
-        "@jskit-ai/shell-web": "0.1.48",
-        "@jskit-ai/users-core": "0.1.59",
-        "@jskit-ai/users-web": "0.1.64",
+        "@jskit-ai/assistant-core": "0.1.27",
+        "@jskit-ai/database-runtime": "0.1.51",
+        "@jskit-ai/http-runtime": "0.1.50",
+        "@jskit-ai/kernel": "0.1.51",
+        "@jskit-ai/shell-web": "0.1.50",
+        "@jskit-ai/users-core": "0.1.61",
+        "@jskit-ai/users-web": "0.1.66",
         "@tanstack/vue-query": "^5.90.5",
         "vuetify": "^4.0.0"
       }
@@ -6355,34 +6355,34 @@
     },
     "packages/auth-core": {
       "name": "@jskit-ai/auth-core",
-      "version": "0.1.48",
+      "version": "0.1.50",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0",
-        "@jskit-ai/kernel": "0.1.49",
+        "@jskit-ai/kernel": "0.1.51",
         "typebox": "^1.0.81"
       }
     },
     "packages/auth-provider-supabase-core": {
       "name": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.48",
+      "version": "0.1.50",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.48",
-        "@jskit-ai/kernel": "0.1.49",
+        "@jskit-ai/auth-core": "0.1.50",
+        "@jskit-ai/kernel": "0.1.51",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0"
       }
     },
     "packages/auth-web": {
       "name": "@jskit-ai/auth-web",
-      "version": "0.1.50",
+      "version": "0.1.52",
       "dependencies": {
         "@fastify/type-provider-typebox": "^6.1.0",
-        "@jskit-ai/auth-core": "0.1.48",
-        "@jskit-ai/http-runtime": "0.1.48",
-        "@jskit-ai/kernel": "0.1.49",
-        "@jskit-ai/shell-web": "0.1.48",
+        "@jskit-ai/auth-core": "0.1.50",
+        "@jskit-ai/http-runtime": "0.1.50",
+        "@jskit-ai/kernel": "0.1.51",
+        "@jskit-ai/shell-web": "0.1.50",
         "@mdi/js": "^7.4.47",
         "@tanstack/vue-query": "^5.90.5",
         "pinia": "^3.0.4",
@@ -6469,34 +6469,34 @@
     },
     "packages/console-core": {
       "name": "@jskit-ai/console-core",
-      "version": "0.1.12",
+      "version": "0.1.14",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.49",
-        "@jskit-ai/http-runtime": "0.1.48",
-        "@jskit-ai/kernel": "0.1.49",
-        "@jskit-ai/users-core": "0.1.59",
+        "@jskit-ai/database-runtime": "0.1.51",
+        "@jskit-ai/http-runtime": "0.1.50",
+        "@jskit-ai/kernel": "0.1.51",
+        "@jskit-ai/users-core": "0.1.61",
         "typebox": "^1.0.81"
       }
     },
     "packages/console-web": {
       "name": "@jskit-ai/console-web",
-      "version": "0.1.17",
+      "version": "0.1.19",
       "dependencies": {
-        "@jskit-ai/auth-web": "0.1.50",
-        "@jskit-ai/console-core": "0.1.12",
-        "@jskit-ai/shell-web": "0.1.48"
+        "@jskit-ai/auth-web": "0.1.52",
+        "@jskit-ai/console-core": "0.1.14",
+        "@jskit-ai/shell-web": "0.1.50"
       }
     },
     "packages/crud-core": {
       "name": "@jskit-ai/crud-core",
-      "version": "0.1.57",
+      "version": "0.1.59",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.49",
-        "@jskit-ai/kernel": "0.1.49",
-        "@jskit-ai/realtime": "0.1.48",
-        "@jskit-ai/shell-web": "0.1.48",
-        "@jskit-ai/users-core": "0.1.59",
-        "@jskit-ai/users-web": "0.1.64",
+        "@jskit-ai/database-runtime": "0.1.51",
+        "@jskit-ai/kernel": "0.1.51",
+        "@jskit-ai/realtime": "0.1.50",
+        "@jskit-ai/shell-web": "0.1.50",
+        "@jskit-ai/users-core": "0.1.61",
+        "@jskit-ai/users-web": "0.1.66",
         "@tanstack/vue-query": "^5.90.5",
         "typebox": "^1.0.81"
       }
@@ -6570,68 +6570,68 @@
     },
     "packages/crud-server-generator": {
       "name": "@jskit-ai/crud-server-generator",
-      "version": "0.1.57",
+      "version": "0.1.59",
       "dependencies": {
         "@babel/parser": "^7.29.2",
-        "@jskit-ai/crud-core": "0.1.57",
-        "@jskit-ai/database-runtime": "0.1.49",
-        "@jskit-ai/http-runtime": "0.1.48",
-        "@jskit-ai/kernel": "0.1.49",
-        "@jskit-ai/users-core": "0.1.59",
+        "@jskit-ai/crud-core": "0.1.59",
+        "@jskit-ai/database-runtime": "0.1.51",
+        "@jskit-ai/http-runtime": "0.1.50",
+        "@jskit-ai/kernel": "0.1.51",
+        "@jskit-ai/users-core": "0.1.61",
         "recast": "^0.23.11",
         "typebox": "^1.0.81"
       }
     },
     "packages/crud-ui-generator": {
       "name": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.32",
+      "version": "0.1.34",
       "dependencies": {
-        "@jskit-ai/crud-core": "0.1.57",
-        "@jskit-ai/kernel": "0.1.49"
+        "@jskit-ai/crud-core": "0.1.59",
+        "@jskit-ai/kernel": "0.1.51"
       }
     },
     "packages/database-runtime": {
       "name": "@jskit-ai/database-runtime",
-      "version": "0.1.49",
+      "version": "0.1.51",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.49"
+        "@jskit-ai/kernel": "0.1.51"
       }
     },
     "packages/database-runtime-mysql": {
       "name": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.48",
+      "version": "0.1.50",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.49"
+        "@jskit-ai/database-runtime": "0.1.51"
       }
     },
     "packages/database-runtime-postgres": {
       "name": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.48",
+      "version": "0.1.50",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.49"
+        "@jskit-ai/database-runtime": "0.1.51"
       }
     },
     "packages/http-runtime": {
       "name": "@jskit-ai/http-runtime",
-      "version": "0.1.48",
+      "version": "0.1.50",
       "dependencies": {
         "@fastify/type-provider-typebox": "^6.1.0",
-        "@jskit-ai/kernel": "0.1.49",
+        "@jskit-ai/kernel": "0.1.51",
         "typebox": "^1.0.81"
       }
     },
     "packages/kernel": {
       "name": "@jskit-ai/kernel",
-      "version": "0.1.49",
+      "version": "0.1.51",
       "dependencies": {
         "typebox": "^1.0.81"
       }
     },
     "packages/realtime": {
       "name": "@jskit-ai/realtime",
-      "version": "0.1.48",
+      "version": "0.1.50",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.49",
+        "@jskit-ai/kernel": "0.1.51",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",
@@ -6640,9 +6640,9 @@
     },
     "packages/shell-web": {
       "name": "@jskit-ai/shell-web",
-      "version": "0.1.48",
+      "version": "0.1.50",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.49",
+        "@jskit-ai/kernel": "0.1.51",
         "@mdi/js": "^7.4.47",
         "@tanstack/vue-query": "^5.90.5",
         "pinia": "^3.0.4",
@@ -6708,25 +6708,25 @@
     },
     "packages/storage-runtime": {
       "name": "@jskit-ai/storage-runtime",
-      "version": "0.1.48",
+      "version": "0.1.50",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.49",
+        "@jskit-ai/kernel": "0.1.51",
         "unstorage": "^1.17.3"
       }
     },
     "packages/ui-generator": {
       "name": "@jskit-ai/ui-generator",
-      "version": "0.1.32",
+      "version": "0.1.34",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.49",
-        "@jskit-ai/shell-web": "0.1.48"
+        "@jskit-ai/kernel": "0.1.51",
+        "@jskit-ai/shell-web": "0.1.50"
       }
     },
     "packages/uploads-image-web": {
       "name": "@jskit-ai/uploads-image-web",
-      "version": "0.1.27",
+      "version": "0.1.29",
       "dependencies": {
-        "@jskit-ai/uploads-runtime": "0.1.27",
+        "@jskit-ai/uploads-runtime": "0.1.29",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",
@@ -6736,35 +6736,35 @@
     },
     "packages/uploads-runtime": {
       "name": "@jskit-ai/uploads-runtime",
-      "version": "0.1.27",
+      "version": "0.1.29",
       "dependencies": {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.49"
+        "@jskit-ai/kernel": "0.1.51"
       }
     },
     "packages/users-core": {
       "name": "@jskit-ai/users-core",
-      "version": "0.1.59",
+      "version": "0.1.61",
       "dependencies": {
         "@fastify/type-provider-typebox": "^6.1.0",
-        "@jskit-ai/auth-core": "0.1.48",
-        "@jskit-ai/database-runtime": "0.1.49",
-        "@jskit-ai/http-runtime": "0.1.48",
-        "@jskit-ai/kernel": "0.1.49",
-        "@jskit-ai/uploads-runtime": "0.1.27",
+        "@jskit-ai/auth-core": "0.1.50",
+        "@jskit-ai/database-runtime": "0.1.51",
+        "@jskit-ai/http-runtime": "0.1.50",
+        "@jskit-ai/kernel": "0.1.51",
+        "@jskit-ai/uploads-runtime": "0.1.29",
         "typebox": "^1.0.81"
       }
     },
     "packages/users-web": {
       "name": "@jskit-ai/users-web",
-      "version": "0.1.64",
+      "version": "0.1.66",
       "dependencies": {
-        "@jskit-ai/http-runtime": "0.1.48",
-        "@jskit-ai/kernel": "0.1.49",
-        "@jskit-ai/realtime": "0.1.48",
-        "@jskit-ai/shell-web": "0.1.48",
-        "@jskit-ai/uploads-image-web": "0.1.27",
-        "@jskit-ai/users-core": "0.1.59",
+        "@jskit-ai/http-runtime": "0.1.50",
+        "@jskit-ai/kernel": "0.1.51",
+        "@jskit-ai/realtime": "0.1.50",
+        "@jskit-ai/shell-web": "0.1.50",
+        "@jskit-ai/uploads-image-web": "0.1.29",
+        "@jskit-ai/users-core": "0.1.61",
         "@mdi/js": "^7.4.47",
         "@tanstack/vue-query": "5.92.12",
         "vuetify": "^4.0.0"
@@ -6839,27 +6839,27 @@
     },
     "packages/workspaces-core": {
       "name": "@jskit-ai/workspaces-core",
-      "version": "0.1.25",
+      "version": "0.1.27",
       "dependencies": {
         "@fastify/type-provider-typebox": "^6.1.0",
-        "@jskit-ai/auth-core": "0.1.48",
-        "@jskit-ai/database-runtime": "0.1.49",
-        "@jskit-ai/http-runtime": "0.1.48",
-        "@jskit-ai/kernel": "0.1.49",
-        "@jskit-ai/users-core": "0.1.59",
+        "@jskit-ai/auth-core": "0.1.50",
+        "@jskit-ai/database-runtime": "0.1.51",
+        "@jskit-ai/http-runtime": "0.1.50",
+        "@jskit-ai/kernel": "0.1.51",
+        "@jskit-ai/users-core": "0.1.61",
         "typebox": "^1.0.81"
       }
     },
     "packages/workspaces-web": {
       "name": "@jskit-ai/workspaces-web",
-      "version": "0.1.25",
+      "version": "0.1.27",
       "dependencies": {
-        "@jskit-ai/http-runtime": "0.1.48",
-        "@jskit-ai/kernel": "0.1.49",
-        "@jskit-ai/shell-web": "0.1.48",
-        "@jskit-ai/users-core": "0.1.59",
-        "@jskit-ai/users-web": "0.1.64",
-        "@jskit-ai/workspaces-core": "0.1.25",
+        "@jskit-ai/http-runtime": "0.1.50",
+        "@jskit-ai/kernel": "0.1.51",
+        "@jskit-ai/shell-web": "0.1.50",
+        "@jskit-ai/users-core": "0.1.61",
+        "@jskit-ai/users-web": "0.1.66",
+        "@jskit-ai/workspaces-core": "0.1.27",
         "@mdi/js": "^7.4.47",
         "@tanstack/vue-query": "5.92.12",
         "vuetify": "^4.0.0"
@@ -6934,7 +6934,7 @@
     },
     "tooling/config-eslint": {
       "name": "@jskit-ai/config-eslint",
-      "version": "0.1.48",
+      "version": "0.1.50",
       "dependencies": {
         "@eslint/js": "^9.39.1",
         "eslint-plugin-vue": "^10.5.1",
@@ -6952,7 +6952,7 @@
     },
     "tooling/create-app": {
       "name": "@jskit-ai/create-app",
-      "version": "0.1.57",
+      "version": "0.1.59",
       "bin": {
         "jskit-create-app": "bin/jskit-create-app.js"
       },
@@ -6962,18 +6962,18 @@
     },
     "tooling/jskit-catalog": {
       "name": "@jskit-ai/jskit-catalog",
-      "version": "0.1.57",
+      "version": "0.1.59",
       "engines": {
         "node": "20.x"
       }
     },
     "tooling/jskit-cli": {
       "name": "@jskit-ai/jskit-cli",
-      "version": "0.2.58",
+      "version": "0.2.60",
       "dependencies": {
-        "@jskit-ai/jskit-catalog": "0.1.57",
-        "@jskit-ai/kernel": "0.1.49",
-        "@jskit-ai/shell-web": "0.1.48"
+        "@jskit-ai/jskit-catalog": "0.1.59",
+        "@jskit-ai/kernel": "0.1.51",
+        "@jskit-ai/shell-web": "0.1.50"
       },
       "bin": {
         "jskit": "bin/jskit.js"

--- a/packages/agent-docs/package.json
+++ b/packages/agent-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/agent-docs",
-  "version": "0.1.10",
+  "version": "0.1.12",
   "description": "Distributed JSKIT agent workflows, guides, and generated reference maps.",
   "type": "module",
   "files": [

--- a/packages/assistant-core/package.descriptor.mjs
+++ b/packages/assistant-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-core",
-  version: "0.1.25",
+  version: "0.1.27",
   kind: "runtime",
   description: "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
   dependsOn: [
@@ -45,9 +45,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/http-runtime": "0.1.48",
-        "@jskit-ai/kernel": "0.1.49",
-        "@jskit-ai/users-core": "0.1.59",
+        "@jskit-ai/http-runtime": "0.1.50",
+        "@jskit-ai/kernel": "0.1.51",
+        "@jskit-ai/users-core": "0.1.61",
         "@tanstack/vue-query": "^5.90.5",
         "dompurify": "^3.3.3",
         "marked": "^17.0.4",

--- a/packages/assistant-core/package.json
+++ b/packages/assistant-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-core",
-  "version": "0.1.25",
+  "version": "0.1.27",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,10 +11,10 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.49",
-    "@jskit-ai/http-runtime": "0.1.48",
-    "@jskit-ai/kernel": "0.1.49",
-    "@jskit-ai/users-core": "0.1.59",
+    "@jskit-ai/database-runtime": "0.1.51",
+    "@jskit-ai/http-runtime": "0.1.50",
+    "@jskit-ai/kernel": "0.1.51",
+    "@jskit-ai/users-core": "0.1.61",
     "@tanstack/vue-query": "^5.90.5",
     "dompurify": "^3.3.3",
     "marked": "^17.0.4",

--- a/packages/assistant-runtime/package.descriptor.mjs
+++ b/packages/assistant-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-runtime",
-  version: "0.1.20",
+  version: "0.1.22",
   kind: "runtime",
   description: "Shared assistant runtime with per-surface assistant registration.",
   dependsOn: [
@@ -74,13 +74,13 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/assistant-core": "0.1.25",
-        "@jskit-ai/database-runtime": "0.1.49",
-        "@jskit-ai/http-runtime": "0.1.48",
-        "@jskit-ai/kernel": "0.1.49",
-        "@jskit-ai/shell-web": "0.1.48",
-        "@jskit-ai/users-core": "0.1.59",
-        "@jskit-ai/users-web": "0.1.64",
+        "@jskit-ai/assistant-core": "0.1.27",
+        "@jskit-ai/database-runtime": "0.1.51",
+        "@jskit-ai/http-runtime": "0.1.50",
+        "@jskit-ai/kernel": "0.1.51",
+        "@jskit-ai/shell-web": "0.1.50",
+        "@jskit-ai/users-core": "0.1.61",
+        "@jskit-ai/users-web": "0.1.66",
         "@tanstack/vue-query": "^5.90.5",
         "vuetify": "^4.0.0"
       },

--- a/packages/assistant-runtime/package.json
+++ b/packages/assistant-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-runtime",
-  "version": "0.1.20",
+  "version": "0.1.22",
   "type": "module",
   "exports": {
     "./client": "./src/client/index.js",
@@ -8,13 +8,13 @@
     "./server/actionIds": "./src/server/actionIds.js"
   },
   "dependencies": {
-    "@jskit-ai/assistant-core": "0.1.25",
-    "@jskit-ai/database-runtime": "0.1.49",
-    "@jskit-ai/http-runtime": "0.1.48",
-    "@jskit-ai/kernel": "0.1.49",
-    "@jskit-ai/shell-web": "0.1.48",
-    "@jskit-ai/users-core": "0.1.59",
-    "@jskit-ai/users-web": "0.1.64",
+    "@jskit-ai/assistant-core": "0.1.27",
+    "@jskit-ai/database-runtime": "0.1.51",
+    "@jskit-ai/http-runtime": "0.1.50",
+    "@jskit-ai/kernel": "0.1.51",
+    "@jskit-ai/shell-web": "0.1.50",
+    "@jskit-ai/users-core": "0.1.61",
+    "@jskit-ai/users-web": "0.1.66",
     "@tanstack/vue-query": "^5.90.5",
     "vuetify": "^4.0.0"
   }

--- a/packages/assistant/package.descriptor.mjs
+++ b/packages/assistant/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant",
-  version: "0.1.58",
+  version: "0.1.60",
   kind: "generator",
   description: "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
   options: {

--- a/packages/assistant/package.json
+++ b/packages/assistant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant",
-  "version": "0.1.58",
+  "version": "0.1.60",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.49"
+    "@jskit-ai/kernel": "0.1.51"
   }
 }

--- a/packages/auth-core/package.descriptor.mjs
+++ b/packages/auth-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-core",
-  "version": "0.1.48",
+  "version": "0.1.50",
   "kind": "runtime",
   "dependsOn": [
     "@jskit-ai/value-app-config-shared"
@@ -69,7 +69,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.49",
+        "@jskit-ai/kernel": "0.1.51",
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0"

--- a/packages/auth-core/package.json
+++ b/packages/auth-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-core",
-  "version": "0.1.48",
+  "version": "0.1.50",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -44,7 +44,7 @@
     "./shared/commands/authSessionReadCommand": "./src/shared/commands/authSessionReadCommand.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.49",
+    "@jskit-ai/kernel": "0.1.51",
     "@fastify/cookie": "^11.0.2",
     "@fastify/csrf-protection": "^7.1.0",
     "@fastify/rate-limit": "^10.3.0",

--- a/packages/auth-provider-supabase-core/package.descriptor.mjs
+++ b/packages/auth-provider-supabase-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.48",
+  "version": "0.1.50",
   "kind": "runtime",
   "options": {
     "auth-supabase-url": {
@@ -83,8 +83,8 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/auth-core": "0.1.48",
-        "@jskit-ai/kernel": "0.1.49",
+        "@jskit-ai/auth-core": "0.1.50",
+        "@jskit-ai/kernel": "0.1.51",
         "dotenv": "^16.4.5",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0"

--- a/packages/auth-provider-supabase-core/package.json
+++ b/packages/auth-provider-supabase-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.48",
+  "version": "0.1.50",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,8 +12,8 @@
     "./client": "./src/client/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.48",
-    "@jskit-ai/kernel": "0.1.49",
+    "@jskit-ai/auth-core": "0.1.50",
+    "@jskit-ai/kernel": "0.1.51",
     "jose": "^6.1.0",
     "@supabase/supabase-js": "^2.57.4"
   }

--- a/packages/auth-web/package.descriptor.mjs
+++ b/packages/auth-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-web",
-  "version": "0.1.50",
+  "version": "0.1.52",
   "kind": "runtime",
   "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
   "dependsOn": [
@@ -220,10 +220,10 @@ export default Object.freeze({
         "@tanstack/vue-query": "5.92.12",
         "@mdi/js": "^7.4.47",
         "@fastify/type-provider-typebox": "^6.1.0",
-        "@jskit-ai/auth-core": "0.1.48",
-        "@jskit-ai/http-runtime": "0.1.48",
-        "@jskit-ai/kernel": "0.1.49",
-        "@jskit-ai/shell-web": "0.1.48",
+        "@jskit-ai/auth-core": "0.1.50",
+        "@jskit-ai/http-runtime": "0.1.50",
+        "@jskit-ai/kernel": "0.1.51",
+        "@jskit-ai/shell-web": "0.1.50",
         "vuetify": "^4.0.0"
       },
       "dev": {}

--- a/packages/auth-web/package.json
+++ b/packages/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-web",
-  "version": "0.1.50",
+  "version": "0.1.52",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -18,13 +18,13 @@
   },
   "dependencies": {
     "@tanstack/vue-query": "^5.90.5",
-    "@jskit-ai/auth-core": "0.1.48",
+    "@jskit-ai/auth-core": "0.1.50",
     "@mdi/js": "^7.4.47",
     "@fastify/type-provider-typebox": "^6.1.0",
-    "@jskit-ai/kernel": "0.1.49",
-    "@jskit-ai/shell-web": "0.1.48",
+    "@jskit-ai/kernel": "0.1.51",
+    "@jskit-ai/shell-web": "0.1.50",
     "pinia": "^3.0.4",
     "vuetify": "^4.0.0",
-    "@jskit-ai/http-runtime": "0.1.48"
+    "@jskit-ai/http-runtime": "0.1.50"
   }
 }

--- a/packages/console-core/package.descriptor.mjs
+++ b/packages/console-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-core",
-  version: "0.1.12",
+  version: "0.1.14",
   kind: "runtime",
   description: "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
   dependsOn: [
@@ -72,10 +72,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.49",
-        "@jskit-ai/http-runtime": "0.1.48",
-        "@jskit-ai/kernel": "0.1.49",
-        "@jskit-ai/users-core": "0.1.59",
+        "@jskit-ai/database-runtime": "0.1.51",
+        "@jskit-ai/http-runtime": "0.1.50",
+        "@jskit-ai/kernel": "0.1.51",
+        "@jskit-ai/users-core": "0.1.61",
         "typebox": "^1.0.81"
       },
       dev: {}

--- a/packages/console-core/package.json
+++ b/packages/console-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/console-core",
-  "version": "0.1.12",
+  "version": "0.1.14",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,10 +9,10 @@
     "./shared/resources/consoleSettingsFields": "./src/shared/resources/consoleSettingsFields.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.49",
-    "@jskit-ai/http-runtime": "0.1.48",
-    "@jskit-ai/kernel": "0.1.49",
-    "@jskit-ai/users-core": "0.1.59",
+    "@jskit-ai/database-runtime": "0.1.51",
+    "@jskit-ai/http-runtime": "0.1.50",
+    "@jskit-ai/kernel": "0.1.51",
+    "@jskit-ai/users-core": "0.1.61",
     "typebox": "^1.0.81"
   }
 }

--- a/packages/console-web/package.descriptor.mjs
+++ b/packages/console-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-web",
-  version: "0.1.17",
+  version: "0.1.19",
   kind: "runtime",
   description: "Authenticated console surface scaffold and surface policy wiring.",
   dependsOn: [
@@ -65,9 +65,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-web": "0.1.50",
-        "@jskit-ai/console-core": "0.1.12",
-        "@jskit-ai/shell-web": "0.1.48",
+        "@jskit-ai/auth-web": "0.1.52",
+        "@jskit-ai/console-core": "0.1.14",
+        "@jskit-ai/shell-web": "0.1.50",
       },
       dev: {}
     },

--- a/packages/console-web/package.json
+++ b/packages/console-web/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/console-web",
-  "version": "0.1.17",
+  "version": "0.1.19",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-web": "0.1.50",
-    "@jskit-ai/console-core": "0.1.12",
-    "@jskit-ai/shell-web": "0.1.48"
+    "@jskit-ai/auth-web": "0.1.52",
+    "@jskit-ai/console-core": "0.1.14",
+    "@jskit-ai/shell-web": "0.1.50"
   }
 }

--- a/packages/crud-core/package.descriptor.mjs
+++ b/packages/crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-core",
-  version: "0.1.57",
+  version: "0.1.59",
   kind: "runtime",
   description: "Shared CRUD helpers used by CRUD modules.",
   dependsOn: [
@@ -26,7 +26,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/crud-core": "0.1.57"
+        "@jskit-ai/crud-core": "0.1.59"
       },
       dev: {}
     },

--- a/packages/crud-core/package.json
+++ b/packages/crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-core",
-  "version": "0.1.57",
+  "version": "0.1.59",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -26,12 +26,12 @@
   },
   "dependencies": {
     "@tanstack/vue-query": "^5.90.5",
-    "@jskit-ai/database-runtime": "0.1.49",
-    "@jskit-ai/kernel": "0.1.49",
-    "@jskit-ai/realtime": "0.1.48",
-    "@jskit-ai/shell-web": "0.1.48",
-    "@jskit-ai/users-core": "0.1.59",
-    "@jskit-ai/users-web": "0.1.64",
+    "@jskit-ai/database-runtime": "0.1.51",
+    "@jskit-ai/kernel": "0.1.51",
+    "@jskit-ai/realtime": "0.1.50",
+    "@jskit-ai/shell-web": "0.1.50",
+    "@jskit-ai/users-core": "0.1.61",
+    "@jskit-ai/users-web": "0.1.66",
     "typebox": "^1.0.81"
   }
 }

--- a/packages/crud-server-generator/package.descriptor.mjs
+++ b/packages/crud-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-server-generator",
-  version: "0.1.57",
+  version: "0.1.59",
   kind: "generator",
   description: "CRUD server generator with routes, actions, and persistence scaffolding.",
   options: {
@@ -151,13 +151,13 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.48",
-        "@jskit-ai/crud-core": "0.1.57",
-        "@jskit-ai/database-runtime": "0.1.49",
-        "@jskit-ai/http-runtime": "0.1.48",
-        "@jskit-ai/kernel": "0.1.49",
-        "@jskit-ai/realtime": "0.1.48",
-        "@jskit-ai/users-core": "0.1.59",
+        "@jskit-ai/auth-core": "0.1.50",
+        "@jskit-ai/crud-core": "0.1.59",
+        "@jskit-ai/database-runtime": "0.1.51",
+        "@jskit-ai/http-runtime": "0.1.50",
+        "@jskit-ai/kernel": "0.1.51",
+        "@jskit-ai/realtime": "0.1.50",
+        "@jskit-ai/users-core": "0.1.61",
         "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}",
         "typebox": "^1.0.81"
       },

--- a/packages/crud-server-generator/package.json
+++ b/packages/crud-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-server-generator",
-  "version": "0.1.57",
+  "version": "0.1.59",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,11 +13,11 @@
   },
   "dependencies": {
     "@babel/parser": "^7.29.2",
-    "@jskit-ai/crud-core": "0.1.57",
-    "@jskit-ai/database-runtime": "0.1.49",
-    "@jskit-ai/http-runtime": "0.1.48",
-    "@jskit-ai/kernel": "0.1.49",
-    "@jskit-ai/users-core": "0.1.59",
+    "@jskit-ai/crud-core": "0.1.59",
+    "@jskit-ai/database-runtime": "0.1.51",
+    "@jskit-ai/http-runtime": "0.1.50",
+    "@jskit-ai/kernel": "0.1.51",
+    "@jskit-ai/users-core": "0.1.61",
     "recast": "^0.23.11",
     "typebox": "^1.0.81"
   }

--- a/packages/crud-server-generator/src/server/buildTemplateContext.js
+++ b/packages/crud-server-generator/src/server/buildTemplateContext.js
@@ -731,7 +731,7 @@ function renderResourceFieldSchema(column, { forOutput = false } = {}) {
   return schemaExpression;
 }
 
-function renderResourceValidatorsImport({ needsHtmlTimeSchemas = false, recordIdValidatorImports = [] } = {}) {
+function renderResourceValidatorsImport({ htmlTimeSchemaImports = [], recordIdValidatorImports = [] } = {}) {
   const imports = [
     "normalizeObjectInput",
     "createCursorListValidator"
@@ -741,10 +741,28 @@ function renderResourceValidatorsImport({ needsHtmlTimeSchemas = false, recordId
       imports.push(importName);
     }
   }
-  if (needsHtmlTimeSchemas) {
-    imports.push("HTML_TIME_STRING_SCHEMA", "NULLABLE_HTML_TIME_STRING_SCHEMA");
+  for (const importName of Array.isArray(htmlTimeSchemaImports) ? htmlTimeSchemaImports : []) {
+    if (!imports.includes(importName)) {
+      imports.push(importName);
+    }
   }
   return `import {\n  ${imports.join(",\n  ")}\n} from "@jskit-ai/kernel/shared/validators";`;
+}
+
+function resolveHtmlTimeSchemaImports(columns = []) {
+  const imports = [];
+  for (const column of Array.isArray(columns) ? columns : []) {
+    if (column?.typeKind !== "time") {
+      continue;
+    }
+    const importName = column.nullable === true
+      ? "NULLABLE_HTML_TIME_STRING_SCHEMA"
+      : "HTML_TIME_STRING_SCHEMA";
+    if (!imports.includes(importName)) {
+      imports.push(importName);
+    }
+  }
+  return imports;
 }
 
 function resolveRecordIdValidatorImports(...sources) {
@@ -1788,7 +1806,7 @@ function buildReplacementsFromSnapshot({
   const needsNullableDateInput = writableColumns.some(
     (column) => column.typeKind === "date" && column.nullable === true
   );
-  const needsHtmlTimeSchemas = resourceColumns.some((column) => column.typeKind === "time");
+  const htmlTimeSchemaImports = resolveHtmlTimeSchemaImports(resourceColumns);
   const needsDate = resourceColumns.some((column) => column.typeKind === "date");
   const needsJson = resourceColumns.some((column) => column.typeKind === "json");
   const needsNormalizeText = resourceColumns.some((column) =>
@@ -1882,7 +1900,7 @@ function buildReplacementsFromSnapshot({
       surfaceRequiresWorkspace
     }),
     __JSKIT_CRUD_RESOURCE_VALIDATORS_IMPORT__: renderResourceValidatorsImport({
-      needsHtmlTimeSchemas,
+      htmlTimeSchemaImports,
       recordIdValidatorImports: resolveRecordIdValidatorImports(
         renderResourceSchemaPropertyLines(outputColumns, {
           forOutput: true

--- a/packages/crud-server-generator/src/server/buildTemplateContext.js
+++ b/packages/crud-server-generator/src/server/buildTemplateContext.js
@@ -392,6 +392,7 @@ function resolveColumnKey(column, idColumn) {
 }
 
 const NUMERIC_CHECK_CONSTRAINT_PATTERN = /(?:`([^`]+)`|([A-Za-z_][A-Za-z0-9_]*))\s*(>=|>|<=|<)\s*(-?\d+(?:\.\d+)?)/g;
+const NUMERIC_CHECK_CONSTRAINT_BETWEEN_PATTERN = /(?:`([^`]+)`|([A-Za-z_][A-Za-z0-9_]*))\s+between\s+(-?\d+(?:\.\d+)?)\s+and\s+(-?\d+(?:\.\d+)?)/gi;
 
 function normalizeNumericBoundValue(value, scale = null) {
   const parsed = Number(value);
@@ -452,6 +453,83 @@ function applyUpperBound(current = null, candidate = null) {
   return current;
 }
 
+function applyNumericConstraintBound(target = {}, column = null, operator = "", rawValue = null) {
+  if (!column || !Number.isFinite(rawValue)) {
+    return;
+  }
+
+  if (operator === ">=" || operator === ">") {
+    let candidate = null;
+    if (operator === ">=") {
+      candidate = {
+        value: normalizeNumericBoundValue(rawValue, column.numericScale),
+        exclusive: false
+      };
+    } else {
+      const exclusiveStep = resolveNumericExclusiveStep(column);
+      if (exclusiveStep != null) {
+        candidate = {
+          value: normalizeNumericBoundValue(rawValue + exclusiveStep, column.numericScale),
+          exclusive: false
+        };
+      } else {
+        candidate = {
+          value: normalizeNumericBoundValue(rawValue, column.numericScale),
+          exclusive: true
+        };
+      }
+    }
+
+    const nextBound = applyLowerBound(
+      target.minimum != null || target.exclusiveMinimum != null
+        ? {
+            value: target.minimum ?? target.exclusiveMinimum,
+            exclusive: target.exclusiveMinimum != null
+          }
+        : null,
+      candidate
+    );
+    target.minimum = nextBound?.exclusive === true ? null : nextBound?.value ?? null;
+    target.exclusiveMinimum = nextBound?.exclusive === true ? nextBound?.value ?? null : null;
+    return;
+  }
+
+  if (operator === "<=" || operator === "<") {
+    let candidate = null;
+    if (operator === "<=") {
+      candidate = {
+        value: normalizeNumericBoundValue(rawValue, column.numericScale),
+        exclusive: false
+      };
+    } else {
+      const exclusiveStep = resolveNumericExclusiveStep(column);
+      if (exclusiveStep != null) {
+        candidate = {
+          value: normalizeNumericBoundValue(rawValue - exclusiveStep, column.numericScale),
+          exclusive: false
+        };
+      } else {
+        candidate = {
+          value: normalizeNumericBoundValue(rawValue, column.numericScale),
+          exclusive: true
+        };
+      }
+    }
+
+    const nextBound = applyUpperBound(
+      target.maximum != null || target.exclusiveMaximum != null
+        ? {
+            value: target.maximum ?? target.exclusiveMaximum,
+            exclusive: target.exclusiveMaximum != null
+          }
+        : null,
+      candidate
+    );
+    target.maximum = nextBound?.exclusive === true ? null : nextBound?.value ?? null;
+    target.exclusiveMaximum = nextBound?.exclusive === true ? nextBound?.value ?? null : null;
+  }
+}
+
 function resolveColumnNumericBounds(snapshot = {}) {
   const byColumnName = new Map();
   const columns = Array.isArray(snapshot.columns) ? snapshot.columns : [];
@@ -487,6 +565,22 @@ function resolveColumnNumericBounds(snapshot = {}) {
       continue;
     }
 
+    let betweenMatch = null;
+    while ((betweenMatch = NUMERIC_CHECK_CONSTRAINT_BETWEEN_PATTERN.exec(clause)) != null) {
+      const columnName = String(betweenMatch[1] || betweenMatch[2] || "");
+      const lowerValue = Number(betweenMatch[3]);
+      const upperValue = Number(betweenMatch[4]);
+      const column = numericColumnsByName.get(columnName) || null;
+      if (!column || !Number.isFinite(lowerValue) || !Number.isFinite(upperValue)) {
+        continue;
+      }
+
+      const target = getColumnBounds(columnName);
+      applyNumericConstraintBound(target, column, ">=", lowerValue);
+      applyNumericConstraintBound(target, column, "<=", upperValue);
+    }
+    NUMERIC_CHECK_CONSTRAINT_BETWEEN_PATTERN.lastIndex = 0;
+
     let match = null;
     while ((match = NUMERIC_CHECK_CONSTRAINT_PATTERN.exec(clause)) != null) {
       const columnName = String(match[1] || match[2] || "");
@@ -498,76 +592,7 @@ function resolveColumnNumericBounds(snapshot = {}) {
       }
 
       const target = getColumnBounds(columnName);
-      if (operator === ">=" || operator === ">") {
-        let candidate = null;
-        if (operator === ">=") {
-          candidate = {
-            value: normalizeNumericBoundValue(rawValue, column.numericScale),
-            exclusive: false
-          };
-        } else {
-          const exclusiveStep = resolveNumericExclusiveStep(column);
-          if (exclusiveStep != null) {
-            candidate = {
-              value: normalizeNumericBoundValue(rawValue + exclusiveStep, column.numericScale),
-              exclusive: false
-            };
-          } else {
-            candidate = {
-              value: normalizeNumericBoundValue(rawValue, column.numericScale),
-              exclusive: true
-            };
-          }
-        }
-
-        const nextBound = applyLowerBound(
-          target.minimum != null || target.exclusiveMinimum != null
-            ? {
-                value: target.minimum ?? target.exclusiveMinimum,
-                exclusive: target.exclusiveMinimum != null
-              }
-            : null,
-          candidate
-        );
-        target.minimum = nextBound?.exclusive === true ? null : nextBound?.value ?? null;
-        target.exclusiveMinimum = nextBound?.exclusive === true ? nextBound?.value ?? null : null;
-        continue;
-      }
-
-      if (operator === "<=" || operator === "<") {
-        let candidate = null;
-        if (operator === "<=") {
-          candidate = {
-            value: normalizeNumericBoundValue(rawValue, column.numericScale),
-            exclusive: false
-          };
-        } else {
-          const exclusiveStep = resolveNumericExclusiveStep(column);
-          if (exclusiveStep != null) {
-            candidate = {
-              value: normalizeNumericBoundValue(rawValue - exclusiveStep, column.numericScale),
-              exclusive: false
-            };
-          } else {
-            candidate = {
-              value: normalizeNumericBoundValue(rawValue, column.numericScale),
-              exclusive: true
-            };
-          }
-        }
-
-        const nextBound = applyUpperBound(
-          target.maximum != null || target.exclusiveMaximum != null
-            ? {
-                value: target.maximum ?? target.exclusiveMaximum,
-                exclusive: target.exclusiveMaximum != null
-              }
-            : null,
-          candidate
-        );
-        target.maximum = nextBound?.exclusive === true ? null : nextBound?.value ?? null;
-        target.exclusiveMaximum = nextBound?.exclusive === true ? nextBound?.value ?? null : null;
-      }
+      applyNumericConstraintBound(target, column, operator, rawValue);
     }
     NUMERIC_CHECK_CONSTRAINT_PATTERN.lastIndex = 0;
   }

--- a/packages/crud-server-generator/templates/src/local-package/server/CrudProvider.js
+++ b/packages/crud-server-generator/templates/src/local-package/server/CrudProvider.js
@@ -82,6 +82,7 @@ class ${option:namespace|pascal}Provider {
     registerRoutes(app, {
       routeOwnershipFilter: crudPolicy.ownershipFilter,
       routeSurface: crudPolicy.surfaceId,
+      routeSurfaceRequiresWorkspace: crudPolicy.surfaceDefinition.requiresWorkspace === true,
       routeRelativePath: crudPolicy.relativePath
     });
   }

--- a/packages/crud-server-generator/test/buildTemplateContext.test.js
+++ b/packages/crud-server-generator/test/buildTemplateContext.test.js
@@ -1056,7 +1056,11 @@ test("buildReplacementsFromSnapshot uses shared framework time schemas in genera
 
   assert.match(
     replacements.__JSKIT_CRUD_RESOURCE_VALIDATORS_IMPORT__,
-    /NULLABLE_HTML_TIME_STRING_SCHEMA/
+    /(^|\n)\s*NULLABLE_HTML_TIME_STRING_SCHEMA(,|\n)/m
+  );
+  assert.doesNotMatch(
+    replacements.__JSKIT_CRUD_RESOURCE_VALIDATORS_IMPORT__,
+    /(^|\n)\s*HTML_TIME_STRING_SCHEMA(,|\n)/m
   );
   assert.match(
     replacements.__JSKIT_CRUD_RESOURCE_OUTPUT_SCHEMA_PROPERTIES__,
@@ -1069,6 +1073,54 @@ test("buildReplacementsFromSnapshot uses shared framework time schemas in genera
   assert.doesNotMatch(
     replacements.__JSKIT_CRUD_RESOURCE_OUTPUT_SCHEMA_PROPERTIES__,
     /Type\.String\(\{ pattern:/
+  );
+});
+
+test("buildReplacementsFromSnapshot imports only the non-nullable time schema when nullable time fields are absent", () => {
+  const snapshot = createSnapshot({
+    tableName: "opening_hours"
+  });
+  const timeColumn = Object.freeze({
+    name: "from_time",
+    key: "fromTime",
+    dataType: "time",
+    columnType: "time",
+    typeKind: "time",
+    nullable: false,
+    hasDefault: false,
+    defaultValue: null,
+    autoIncrement: false,
+    unsigned: false,
+    extra: "",
+    maxLength: null,
+    numericPrecision: null,
+    numericScale: null,
+    enumValues: Object.freeze([])
+  });
+  const replacements = __testables.buildReplacementsFromSnapshot({
+    namespace: "opening-hours",
+    snapshot: {
+      ...snapshot,
+      columns: Object.freeze([...snapshot.columns, timeColumn])
+    },
+    resolvedOwnershipFilter: "workspace_user"
+  });
+
+  assert.match(
+    replacements.__JSKIT_CRUD_RESOURCE_VALIDATORS_IMPORT__,
+    /(^|\n)\s*HTML_TIME_STRING_SCHEMA(,|\n)/m
+  );
+  assert.doesNotMatch(
+    replacements.__JSKIT_CRUD_RESOURCE_VALIDATORS_IMPORT__,
+    /(^|\n)\s*NULLABLE_HTML_TIME_STRING_SCHEMA(,|\n)/m
+  );
+  assert.match(
+    replacements.__JSKIT_CRUD_RESOURCE_OUTPUT_SCHEMA_PROPERTIES__,
+    /fromTime: HTML_TIME_STRING_SCHEMA/
+  );
+  assert.match(
+    replacements.__JSKIT_CRUD_RESOURCE_CREATE_SCHEMA_PROPERTIES__,
+    /fromTime: HTML_TIME_STRING_SCHEMA/
   );
 });
 

--- a/packages/crud-server-generator/test/buildTemplateContext.test.js
+++ b/packages/crud-server-generator/test/buildTemplateContext.test.js
@@ -1120,5 +1120,9 @@ test("crud provider template uses shared lookup provider helpers instead of inli
     templateSource,
     /return createCrudLookup\(scope\.make\("repository\.\$\{option:namespace\|snake\}"\), \{\s*ownershipFilter: crudPolicy\.ownershipFilter\s*\}\);/
   );
+  assert.match(
+    templateSource,
+    /routeSurfaceRequiresWorkspace: crudPolicy\.surfaceDefinition\.requiresWorkspace === true,/
+  );
   assert.doesNotMatch(templateSource, /normalizePathname\(relation\.apiPath\)/);
 });

--- a/packages/crud-server-generator/test/buildTemplateContext.test.js
+++ b/packages/crud-server-generator/test/buildTemplateContext.test.js
@@ -808,13 +808,35 @@ test("resolveScaffoldColumns derives resource numeric bounds from check constrai
     enumValues: Object.freeze([])
   });
 
+  const severityColumn = Object.freeze({
+    name: "severity",
+    key: "severity",
+    dataType: "tinyint",
+    columnType: "tinyint unsigned",
+    typeKind: "integer",
+    nullable: true,
+    hasDefault: false,
+    defaultValue: null,
+    autoIncrement: false,
+    unsigned: true,
+    extra: "",
+    maxLength: null,
+    numericPrecision: 3,
+    numericScale: 0,
+    datetimePrecision: null,
+    characterSetName: "",
+    collationName: "",
+    enumValues: Object.freeze([])
+  });
+
   const scaffoldColumns = __testables.resolveScaffoldColumns({
     ...snapshot,
     columns: Object.freeze([
       snapshot.columns[0],
       inputWeightColumn,
       batchedDailySequenceColumn,
-      moistureLevelColumn
+      moistureLevelColumn,
+      severityColumn
     ]),
     checkConstraints: Object.freeze([
       Object.freeze({
@@ -828,6 +850,10 @@ test("resolveScaffoldColumns derives resource numeric bounds from check constrai
       Object.freeze({
         name: "chk_batches_moisture_level",
         clause: "`moisture_level` is null or `moisture_level` >= 0 and `moisture_level` <= 100"
+      }),
+      Object.freeze({
+        name: "chk_pet_notes_severity",
+        clause: "`severity` is null or `severity` between 1 and 10"
       })
     ])
   });
@@ -835,6 +861,7 @@ test("resolveScaffoldColumns derives resource numeric bounds from check constrai
   const inputWeight = scaffoldColumns.find((column) => column.name === "input_weight");
   const batchedDailySequence = scaffoldColumns.find((column) => column.name === "batched_daily_sequence");
   const moistureLevel = scaffoldColumns.find((column) => column.name === "moisture_level");
+  const severity = scaffoldColumns.find((column) => column.name === "severity");
 
   assert.equal(
     __testables.renderResourceFieldSchema(inputWeight),
@@ -847,6 +874,10 @@ test("resolveScaffoldColumns derives resource numeric bounds from check constrai
   assert.equal(
     __testables.renderResourceFieldSchema(moistureLevel),
     "Type.Union([Type.Number({ minimum: 0, maximum: 100 }), Type.Null()])"
+  );
+  assert.equal(
+    __testables.renderResourceFieldSchema(severity),
+    "Type.Union([Type.Integer({ minimum: 1, maximum: 10 }), Type.Null()])"
   );
 });
 

--- a/packages/crud-ui-generator/package.descriptor.mjs
+++ b/packages/crud-ui-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-ui-generator",
-  version: "0.1.32",
+  version: "0.1.34",
   kind: "generator",
   description: "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
   options: {
@@ -168,7 +168,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.64"
+        "@jskit-ai/users-web": "0.1.66"
       },
       dev: {}
     },

--- a/packages/crud-ui-generator/package.json
+++ b/packages/crud-ui-generator/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/crud-ui-generator",
-  "version": "0.1.32",
+  "version": "0.1.34",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/crud-core": "0.1.57",
-    "@jskit-ai/kernel": "0.1.49"
+    "@jskit-ai/crud-core": "0.1.59",
+    "@jskit-ai/kernel": "0.1.51"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/crud-ui-generator/src/server/buildTemplateContext.js
+++ b/packages/crud-ui-generator/src/server/buildTemplateContext.js
@@ -323,7 +323,8 @@ function buildLookupFormProps(fields = []) {
     return "";
   }
 
-  return `    :resolve-lookup-items="resolveLookupItems"
+  return `
+    :resolve-lookup-items="resolveLookupItems"
     :resolve-lookup-loading="resolveLookupLoading"
     :resolve-lookup-search="resolveLookupSearch"
     :set-lookup-search="setLookupSearch"`;

--- a/packages/crud-ui-generator/src/server/buildTemplateContext.js
+++ b/packages/crud-ui-generator/src/server/buildTemplateContext.js
@@ -329,6 +329,30 @@ function buildLookupFormProps(fields = []) {
     :set-lookup-search="setLookupSearch"`;
 }
 
+function buildLookupFormPropDefinitions({ createFields = [], editFields = [] } = {}) {
+  if (!hasLookupFormFields(createFields) && !hasLookupFormFields(editFields)) {
+    return "";
+  }
+
+  return `,
+  resolveLookupItems: {
+    type: Function,
+    required: true
+  },
+  resolveLookupLoading: {
+    type: Function,
+    required: true
+  },
+  resolveLookupSearch: {
+    type: Function,
+    required: true
+  },
+  setLookupSearch: {
+    type: Function,
+    required: true
+  }`;
+}
+
 function filterDefaultHiddenListFields(selectedFieldKeys, fields, { recordIdFieldKey = "" } = {}) {
   const selectedFields = Array.isArray(selectedFieldKeys) ? selectedFieldKeys : [];
   const availableFields = Array.isArray(fields) ? fields : [];
@@ -612,6 +636,10 @@ async function buildUiTemplateContext({ appRoot, options } = {}) {
     }),
     __JSKIT_UI_CREATE_LOOKUP_FORM_PROPS__: buildLookupFormProps(createFields),
     __JSKIT_UI_EDIT_LOOKUP_FORM_PROPS__: buildLookupFormProps(editFields),
+    __JSKIT_UI_FORM_LOOKUP_PROP_DEFS__: buildLookupFormPropDefinitions({
+      createFields,
+      editFields
+    }),
     __JSKIT_UI_MENU_MARKER__: menuMarker,
     __JSKIT_UI_MENU_PLACEMENT_ID__: String(pageLinkTarget?.pageTarget?.placementId || ""),
     __JSKIT_UI_MENU_PLACEMENT_TARGET__: String(pageLinkTarget?.placementTarget?.id || ""),

--- a/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/AddEditForm.vue
+++ b/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/AddEditForm.vue
@@ -72,23 +72,8 @@ const props = defineProps({
   cancelTo: {
     type: [String, Object],
     default: ""
-  },
-  resolveLookupItems: {
-    type: Function,
-    required: true
-  },
-  resolveLookupLoading: {
-    type: Function,
-    required: true
-  },
-  resolveLookupSearch: {
-    type: Function,
-    required: true
-  },
-  setLookupSearch: {
-    type: Function,
-    required: true
   }
+__JSKIT_UI_FORM_LOOKUP_PROP_DEFS__
 });
 
 const formRuntime = props.formRuntime;

--- a/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/EditWrapperElement.vue
+++ b/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/EditWrapperElement.vue
@@ -5,8 +5,7 @@
     title="Edit __JSKIT_UI_RESOURCE_SINGULAR_TITLE__"
     subtitle="Update the selected __JSKIT_UI_RESOURCE_SINGULAR_TITLE__."
     save-label="Save changes"
-    :cancel-to="cancelTo"
-__JSKIT_UI_EDIT_LOOKUP_FORM_PROPS__
+    :cancel-to="cancelTo"__JSKIT_UI_EDIT_LOOKUP_FORM_PROPS__
   />
 </template>
 

--- a/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/NewWrapperElement.vue
+++ b/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/NewWrapperElement.vue
@@ -5,8 +5,7 @@
     title="New __JSKIT_UI_RESOURCE_SINGULAR_TITLE__"
     subtitle="Create a new __JSKIT_UI_RESOURCE_SINGULAR_TITLE__."
     save-label="Save __JSKIT_UI_RESOURCE_SINGULAR_TITLE__"
-    :cancel-to="UI_CANCEL_URL"
-__JSKIT_UI_CREATE_LOOKUP_FORM_PROPS__
+    :cancel-to="UI_CANCEL_URL"__JSKIT_UI_CREATE_LOOKUP_FORM_PROPS__
   />
 </template>
 

--- a/packages/crud-ui-generator/test/buildTemplateContext.test.js
+++ b/packages/crud-ui-generator/test/buildTemplateContext.test.js
@@ -498,6 +498,8 @@ test("buildUiTemplateContext includes lookup runtime placeholders when form fiel
 
     assert.match(context.__JSKIT_UI_CREATE_LOOKUP_IMPORT_LINE__, /createCrudLookupFieldRuntime/);
     assert.match(context.__JSKIT_UI_EDIT_LOOKUP_IMPORT_LINE__, /createCrudLookupFieldRuntime/);
+    assert.match(context.__JSKIT_UI_CREATE_LOOKUP_FORM_PROPS__, /^\n    :resolve-lookup-items=/);
+    assert.match(context.__JSKIT_UI_EDIT_LOOKUP_FORM_PROPS__, /^\n    :resolve-lookup-items=/);
     assert.match(context.__JSKIT_UI_CREATE_LOOKUP_RUNTIME_SETUP__, /resolveLookupItems/);
     assert.match(context.__JSKIT_UI_EDIT_LOOKUP_RUNTIME_SETUP__, /resolveLookupItems/);
     assert.match(context.__JSKIT_UI_CREATE_LOOKUP_FORM_PROPS__, /resolve-lookup-items/);

--- a/packages/crud-ui-generator/test/buildTemplateContext.test.js
+++ b/packages/crud-ui-generator/test/buildTemplateContext.test.js
@@ -465,6 +465,7 @@ test("buildUiTemplateContext omits lookup runtime placeholders when form fields 
     assert.equal(context.__JSKIT_UI_EDIT_LOOKUP_RUNTIME_SETUP__, "");
     assert.equal(context.__JSKIT_UI_CREATE_LOOKUP_FORM_PROPS__, "");
     assert.equal(context.__JSKIT_UI_EDIT_LOOKUP_FORM_PROPS__, "");
+    assert.equal(context.__JSKIT_UI_FORM_LOOKUP_PROP_DEFS__, "");
   });
 });
 
@@ -501,6 +502,7 @@ test("buildUiTemplateContext includes lookup runtime placeholders when form fiel
     assert.match(context.__JSKIT_UI_EDIT_LOOKUP_RUNTIME_SETUP__, /resolveLookupItems/);
     assert.match(context.__JSKIT_UI_CREATE_LOOKUP_FORM_PROPS__, /resolve-lookup-items/);
     assert.match(context.__JSKIT_UI_EDIT_LOOKUP_FORM_PROPS__, /resolve-lookup-items/);
+    assert.match(context.__JSKIT_UI_FORM_LOOKUP_PROP_DEFS__, /resolveLookupItems/);
   });
 });
 

--- a/packages/database-runtime-mysql/package.descriptor.mjs
+++ b/packages/database-runtime-mysql/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-mysql",
-  version: "0.1.48",
+  version: "0.1.50",
   kind: "runtime",
   options: {
     "db-host": {
@@ -91,7 +91,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.49",
+        "@jskit-ai/database-runtime": "0.1.51",
         "mysql2": "^3.11.2"
       },
       dev: {}

--- a/packages/database-runtime-mysql/package.json
+++ b/packages/database-runtime-mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-mysql",
-  "version": "0.1.48",
+  "version": "0.1.50",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,6 +12,6 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.49"
+    "@jskit-ai/database-runtime": "0.1.51"
   }
 }

--- a/packages/database-runtime-postgres/package.descriptor.mjs
+++ b/packages/database-runtime-postgres/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-postgres",
-  version: "0.1.48",
+  version: "0.1.50",
   kind: "runtime",
   options: {
     "db-host": {
@@ -91,7 +91,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.49",
+        "@jskit-ai/database-runtime": "0.1.51",
         "pg": "^8.13.1"
       },
       dev: {}

--- a/packages/database-runtime-postgres/package.json
+++ b/packages/database-runtime-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-postgres",
-  "version": "0.1.48",
+  "version": "0.1.50",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,6 +12,6 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.49"
+    "@jskit-ai/database-runtime": "0.1.51"
   }
 }

--- a/packages/database-runtime/package.descriptor.mjs
+++ b/packages/database-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime",
-  version: "0.1.49",
+  version: "0.1.51",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -58,7 +58,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.49",
+        "@jskit-ai/kernel": "0.1.51",
         "dotenv": "^16.4.5",
         "knex": "^3.1.0"
       },

--- a/packages/database-runtime/package.json
+++ b/packages/database-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime",
-  "version": "0.1.49",
+  "version": "0.1.51",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -25,6 +25,6 @@
     "./shared/transactions": "./src/shared/transactions.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.49"
+    "@jskit-ai/kernel": "0.1.51"
   }
 }

--- a/packages/http-runtime/package.descriptor.mjs
+++ b/packages/http-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/http-runtime",
-  "version": "0.1.48",
+  "version": "0.1.50",
   "kind": "runtime",
   "dependsOn": [],
   "capabilities": {
@@ -67,7 +67,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.49",
+        "@jskit-ai/kernel": "0.1.51",
         "@fastify/type-provider-typebox": "^6.1.0",
         "typebox": "^1.0.81"
       },

--- a/packages/http-runtime/package.json
+++ b/packages/http-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/http-runtime",
-  "version": "0.1.48",
+  "version": "0.1.50",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -17,7 +17,7 @@
     "./shared/validators/operationValidation": "./src/shared/validators/operationValidation.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.49",
+    "@jskit-ai/kernel": "0.1.51",
     "@fastify/type-provider-typebox": "^6.1.0",
     "typebox": "^1.0.81"
   }

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/kernel",
-  "version": "0.1.49",
+  "version": "0.1.51",
   "type": "module",
   "dependencies": {
     "typebox": "^1.0.81"

--- a/packages/realtime/package.descriptor.mjs
+++ b/packages/realtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/realtime",
-  version: "0.1.48",
+  version: "0.1.50",
   kind: "runtime",
   description: "Thin, generic realtime runtime wrappers for socket.io server and client.",
   options: {
@@ -94,7 +94,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.49",
+        "@jskit-ai/kernel": "0.1.51",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/realtime",
-  "version": "0.1.48",
+  "version": "0.1.50",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@socket.io/redis-adapter": "^8.3.0",
-    "@jskit-ai/kernel": "0.1.49",
+    "@jskit-ai/kernel": "0.1.51",
     "redis": "^5.8.2",
     "socket.io": "^4.8.3",
     "socket.io-client": "^4.8.3"

--- a/packages/shell-web/package.descriptor.mjs
+++ b/packages/shell-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/shell-web",
-  version: "0.1.48",
+  version: "0.1.50",
   kind: "runtime",
   description: "Web shell layout runtime with outlet-based placement contributions.",
   dependsOn: [],
@@ -117,7 +117,7 @@ export default Object.freeze({
       runtime: {
         "@mdi/js": "^7.4.47",
         "@tanstack/vue-query": "^5.90.5",
-        "@jskit-ai/kernel": "0.1.49",
+        "@jskit-ai/kernel": "0.1.51",
         "vuetify": "^4.0.0"
       },
       dev: {}

--- a/packages/shell-web/package.json
+++ b/packages/shell-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/shell-web",
-  "version": "0.1.48",
+  "version": "0.1.50",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -24,7 +24,7 @@
   "dependencies": {
     "@mdi/js": "^7.4.47",
     "@tanstack/vue-query": "^5.90.5",
-    "@jskit-ai/kernel": "0.1.49",
+    "@jskit-ai/kernel": "0.1.51",
     "pinia": "^3.0.4",
     "vuetify": "^4.0.0"
   }

--- a/packages/storage-runtime/package.descriptor.mjs
+++ b/packages/storage-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/storage-runtime",
-  version: "0.1.48",
+  version: "0.1.50",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -50,7 +50,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.49",
+        "@jskit-ai/kernel": "0.1.51",
         "unstorage": "^1.17.3"
       },
       dev: {}

--- a/packages/storage-runtime/package.json
+++ b/packages/storage-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/storage-runtime",
-  "version": "0.1.48",
+  "version": "0.1.50",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./server/providers/StorageRuntimeServiceProvider": "./src/server/providers/StorageRuntimeServiceProvider.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.49",
+    "@jskit-ai/kernel": "0.1.51",
     "unstorage": "^1.17.3"
   }
 }

--- a/packages/ui-generator/package.descriptor.mjs
+++ b/packages/ui-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/ui-generator",
-  version: "0.1.32",
+  version: "0.1.34",
   kind: "generator",
   description: "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
   options: {
@@ -278,7 +278,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.64"
+        "@jskit-ai/users-web": "0.1.66"
       },
       dev: {}
     },

--- a/packages/ui-generator/package.json
+++ b/packages/ui-generator/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/ui-generator",
-  "version": "0.1.32",
+  "version": "0.1.34",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.49",
-    "@jskit-ai/shell-web": "0.1.48"
+    "@jskit-ai/kernel": "0.1.51",
+    "@jskit-ai/shell-web": "0.1.50"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/uploads-image-web/package.descriptor.mjs
+++ b/packages/uploads-image-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-image-web",
-  version: "0.1.27",
+  version: "0.1.29",
   kind: "runtime",
   description: "Reusable client-side image upload runtime with pre-upload image editing.",
   dependsOn: [
@@ -65,7 +65,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/uploads-runtime": "0.1.27",
+        "@jskit-ai/uploads-runtime": "0.1.29",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-image-web/package.json
+++ b/packages/uploads-image-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-image-web",
-  "version": "0.1.27",
+  "version": "0.1.29",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,7 +13,7 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/uploads-runtime": "0.1.27",
+    "@jskit-ai/uploads-runtime": "0.1.29",
     "@uppy/compressor": "^3.1.0",
     "@uppy/core": "^5.2.0",
     "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-runtime/package.descriptor.mjs
+++ b/packages/uploads-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-runtime",
-  version: "0.1.27",
+  version: "0.1.29",
   kind: "runtime",
   description: "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
   dependsOn: [
@@ -71,7 +71,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.49"
+        "@jskit-ai/kernel": "0.1.51"
       },
       dev: {}
     },

--- a/packages/uploads-runtime/package.json
+++ b/packages/uploads-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-runtime",
-  "version": "0.1.27",
+  "version": "0.1.29",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,6 +16,6 @@
   },
   "dependencies": {
     "@fastify/multipart": "^9.4.0",
-    "@jskit-ai/kernel": "0.1.49"
+    "@jskit-ai/kernel": "0.1.51"
   }
 }

--- a/packages/users-core/package.descriptor.mjs
+++ b/packages/users-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-core",
-  version: "0.1.59",
+  version: "0.1.61",
   kind: "runtime",
   description: "Users/account runtime plus HTTP routes for account features.",
   dependsOn: [
@@ -128,13 +128,13 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.48",
-        "@jskit-ai/crud-core": "0.1.57",
-        "@jskit-ai/database-runtime": "0.1.49",
-        "@jskit-ai/http-runtime": "0.1.48",
-        "@jskit-ai/kernel": "0.1.49",
+        "@jskit-ai/auth-core": "0.1.50",
+        "@jskit-ai/crud-core": "0.1.59",
+        "@jskit-ai/database-runtime": "0.1.51",
+        "@jskit-ai/http-runtime": "0.1.50",
+        "@jskit-ai/kernel": "0.1.51",
         "@local/users": "file:packages/users",
-        "@jskit-ai/uploads-runtime": "0.1.27",
+        "@jskit-ai/uploads-runtime": "0.1.29",
         "@fastify/type-provider-typebox": "^6.1.0",
         typebox: "^1.0.81"
       },

--- a/packages/users-core/package.json
+++ b/packages/users-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-core",
-  "version": "0.1.59",
+  "version": "0.1.61",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,11 +13,11 @@
     "./shared/resources/userSettingsResource": "./src/shared/resources/userSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.48",
-    "@jskit-ai/database-runtime": "0.1.49",
-    "@jskit-ai/http-runtime": "0.1.48",
-    "@jskit-ai/kernel": "0.1.49",
-    "@jskit-ai/uploads-runtime": "0.1.27",
+    "@jskit-ai/auth-core": "0.1.50",
+    "@jskit-ai/database-runtime": "0.1.51",
+    "@jskit-ai/http-runtime": "0.1.50",
+    "@jskit-ai/kernel": "0.1.51",
+    "@jskit-ai/uploads-runtime": "0.1.29",
     "@fastify/type-provider-typebox": "^6.1.0",
     "typebox": "^1.0.81"
   }

--- a/packages/users-core/src/server/common/repositories/userProfilesRepository.js
+++ b/packages/users-core/src/server/common/repositories/userProfilesRepository.js
@@ -14,8 +14,8 @@ const REPOSITORY_CONFIG = Object.freeze({
   context: "internal.repository.user-profiles"
 });
 
-function normalizeProfileRecord(payload = {}) {
-  return resource.operations.view.outputValidator.normalize(payload);
+function normalizeProfileRecord(payload) {
+  return payload ? resource.operations.view.outputValidator.normalize(payload) : null;
 }
 
 function normalizeCreatePayload(payload = {}) {

--- a/packages/users-core/test/repositoryContracts.test.js
+++ b/packages/users-core/test/repositoryContracts.test.js
@@ -71,3 +71,12 @@ test("userProfilesRepository.findByEmail normalizes email lookup", async () => {
   assert.equal(profile?.email, "ada@example.com");
   assert.equal(profile?.displayName, "Ada Example");
 });
+
+test("userProfilesRepository.findByEmail returns null when the row is missing", async () => {
+  const { knex } = createFindByEmailKnexStub(undefined);
+  const repository = createUserProfilesRepository(knex);
+
+  const profile = await repository.findByEmail("missing@example.com");
+
+  assert.equal(profile, null);
+});

--- a/packages/users-web/package.descriptor.mjs
+++ b/packages/users-web/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { HOME_TOOLS_OUTLET } from "./src/shared/toolsOutletContracts.js";
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-web",
-  version: "0.1.64",
+  version: "0.1.66",
   kind: "runtime",
   description: "Users web module: account/profile UI plus shared users web widgets.",
   dependsOn: [
@@ -154,12 +154,12 @@ export default Object.freeze({
       runtime: {
         "@tanstack/vue-query": "5.92.12",
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/http-runtime": "0.1.48",
-        "@jskit-ai/realtime": "0.1.48",
-        "@jskit-ai/kernel": "0.1.49",
-        "@jskit-ai/shell-web": "0.1.48",
-        "@jskit-ai/uploads-image-web": "0.1.27",
-        "@jskit-ai/users-core": "0.1.59",
+        "@jskit-ai/http-runtime": "0.1.50",
+        "@jskit-ai/realtime": "0.1.50",
+        "@jskit-ai/kernel": "0.1.51",
+        "@jskit-ai/shell-web": "0.1.50",
+        "@jskit-ai/uploads-image-web": "0.1.29",
+        "@jskit-ai/users-core": "0.1.61",
         vuetify: "^4.0.0"
       },
       dev: {}

--- a/packages/users-web/package.json
+++ b/packages/users-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-web",
-  "version": "0.1.64",
+  "version": "0.1.66",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -35,12 +35,12 @@
   "dependencies": {
     "@tanstack/vue-query": "5.92.12",
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/http-runtime": "0.1.48",
-    "@jskit-ai/kernel": "0.1.49",
-    "@jskit-ai/realtime": "0.1.48",
-    "@jskit-ai/shell-web": "0.1.48",
-    "@jskit-ai/uploads-image-web": "0.1.27",
-    "@jskit-ai/users-core": "0.1.59",
+    "@jskit-ai/http-runtime": "0.1.50",
+    "@jskit-ai/kernel": "0.1.51",
+    "@jskit-ai/realtime": "0.1.50",
+    "@jskit-ai/shell-web": "0.1.50",
+    "@jskit-ai/uploads-image-web": "0.1.29",
+    "@jskit-ai/users-core": "0.1.61",
     "vuetify": "^4.0.0"
   }
 }

--- a/packages/users-web/src/client/composables/records/useView.js
+++ b/packages/users-web/src/client/composables/records/useView.js
@@ -6,6 +6,12 @@ import { useEndpointResource } from "../runtime/useEndpointResource.js";
 import { resolveOperationAdapter } from "../runtime/operationAdapters.js";
 import { setupOperationErrorReporting } from "../runtime/operationUiHelpers.js";
 import { createViewUiRuntime } from "../runtime/viewUiRuntime.js";
+import {
+  resolveQueryParamDescriptors,
+  resolveActiveQueryParamEntries,
+  buildQueryParamEntriesToken
+} from "../support/listQueryParamSupport.js";
+import { appendRequestQueryEntriesToPath } from "../support/requestQueryPathSupport.js";
 import { resolveRouteParamNamesInOrder } from "../support/routeTemplateHelpers.js";
 
 function useView({
@@ -23,6 +29,7 @@ function useView({
   notFoundMessage = "Record not found.",
   model,
   mapLoadedToModel,
+  requestQueryParams = null,
   recordIdParam = "recordId",
   routeParams = null,
   routeRecordId = null,
@@ -62,20 +69,46 @@ function useView({
     },
     realtime
   });
+  const queryParamsContext = computed(() => {
+    return Object.freeze({
+      surfaceId: operationScope.routeContext.currentSurfaceId.value,
+      scopeParamValue: operationScope.scopeParamValue.value,
+      ownershipFilter: operationScope.normalizedOwnershipFilter
+    });
+  });
+  const requestQueryParamDescriptors = computed(() => {
+    return resolveQueryParamDescriptors(requestQueryParams, queryParamsContext.value);
+  });
+  const activeRequestQueryParamEntries = computed(() => {
+    return resolveActiveQueryParamEntries(requestQueryParamDescriptors.value);
+  });
+  const activeRequestQueryParamsToken = computed(() => {
+    return buildQueryParamEntriesToken(activeRequestQueryParamEntries.value);
+  });
   const queryKey = computed(() => {
     const source = Array.isArray(operationScope.queryKey.value) ? operationScope.queryKey.value : [];
+    const next = [...source];
+    if (activeRequestQueryParamsToken.value) {
+      next.push("__request_query__", activeRequestQueryParamsToken.value);
+    }
     if (!includeRecordIdInQueryKey) {
-      return source;
+      return next;
     }
 
     const recordIdToken = String(viewUiRuntime.recordId.value || "").trim();
-    return [...source, recordIdToken];
+    return [...next, recordIdToken];
+  });
+  const requestPath = computed(() => {
+    return appendRequestQueryEntriesToPath(
+      operationScope.apiPath.value,
+      activeRequestQueryParamEntries.value
+    );
   });
   const canView = operationScope.permissionGate("view");
 
   const resource = useEndpointResource({
     queryKey,
-    path: operationScope.apiPath,
+    path: requestPath,
     enabled: operationScope.queryCanRun(canView),
     readMethod,
     fallbackLoadError

--- a/packages/users-web/src/client/composables/support/requestQueryPathSupport.js
+++ b/packages/users-web/src/client/composables/support/requestQueryPathSupport.js
@@ -1,0 +1,31 @@
+import { appendQueryString } from "@jskit-ai/kernel/shared/support";
+
+function appendRequestQueryEntriesToPath(path = "", entries = []) {
+  const normalizedPath = String(path || "").trim();
+  if (!normalizedPath) {
+    return "";
+  }
+
+  const sourceEntries = Array.isArray(entries) ? entries : [];
+  const searchParams = new URLSearchParams();
+  for (const entry of sourceEntries) {
+    const key = String(entry?.key || "").trim();
+    const values = Array.isArray(entry?.values) ? entry.values : [];
+    if (!key || values.length < 1) {
+      continue;
+    }
+
+    for (const value of values) {
+      searchParams.append(key, value);
+    }
+  }
+
+  const serializedSearch = searchParams.toString();
+  if (!serializedSearch) {
+    return normalizedPath;
+  }
+
+  return appendQueryString(normalizedPath, serializedSearch);
+}
+
+export { appendRequestQueryEntriesToPath };

--- a/packages/users-web/test/useViewRequestQueryParams.test.js
+++ b/packages/users-web/test/useViewRequestQueryParams.test.js
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { appendRequestQueryEntriesToPath } from "../src/client/composables/support/requestQueryPathSupport.js";
+
+test("appendRequestQueryEntriesToPath appends request query params deterministically", () => {
+  assert.equal(
+    appendRequestQueryEntriesToPath("/api/w/dev-admin/contacts/1", [
+      { key: "include", values: ["vetId", "linkedUserId", "pets", "pets.breedId"] },
+      { key: "limit", values: ["10"] }
+    ]),
+    "/api/w/dev-admin/contacts/1?include=vetId&include=linkedUserId&include=pets&include=pets.breedId&limit=10"
+  );
+});
+
+test("appendRequestQueryEntriesToPath leaves the base path unchanged when no request params are active", () => {
+  assert.equal(
+    appendRequestQueryEntriesToPath("/api/w/dev-admin/contacts/1", []),
+    "/api/w/dev-admin/contacts/1"
+  );
+});

--- a/packages/workspaces-core/package.descriptor.mjs
+++ b/packages/workspaces-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-core",
-  version: "0.1.25",
+  version: "0.1.27",
   kind: "runtime",
   description: "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
   dependsOn: [
@@ -112,7 +112,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-core": "0.1.59"
+        "@jskit-ai/users-core": "0.1.61"
       },
       dev: {}
     },

--- a/packages/workspaces-core/package.json
+++ b/packages/workspaces-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-core",
-  "version": "0.1.25",
+  "version": "0.1.27",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -18,11 +18,11 @@
   },
   "dependencies": {
     "@fastify/type-provider-typebox": "^6.1.0",
-    "@jskit-ai/auth-core": "0.1.48",
-    "@jskit-ai/database-runtime": "0.1.49",
-    "@jskit-ai/http-runtime": "0.1.48",
-    "@jskit-ai/kernel": "0.1.49",
-    "@jskit-ai/users-core": "0.1.59",
+    "@jskit-ai/auth-core": "0.1.50",
+    "@jskit-ai/database-runtime": "0.1.51",
+    "@jskit-ai/http-runtime": "0.1.50",
+    "@jskit-ai/kernel": "0.1.51",
+    "@jskit-ai/users-core": "0.1.61",
     "typebox": "^1.0.81"
   }
 }

--- a/packages/workspaces-core/src/server/common/repositories/workspaceInvitesRepository.js
+++ b/packages/workspaces-core/src/server/common/repositories/workspaceInvitesRepository.js
@@ -12,7 +12,7 @@ const REPOSITORY_CONFIG = Object.freeze({
   context: "internal.repository.workspace-invites"
 });
 
-function normalizeInviteRecord(payload = {}) {
+function normalizeInviteRecord(payload) {
   if (!payload) {
     return null;
   }

--- a/packages/workspaces-core/src/server/common/repositories/workspaceMembershipsRepository.js
+++ b/packages/workspaces-core/src/server/common/repositories/workspaceMembershipsRepository.js
@@ -13,7 +13,7 @@ const REPOSITORY_CONFIG = Object.freeze({
   context: "internal.repository.workspace-memberships"
 });
 
-function normalizeMembershipRecord(payload = {}) {
+function normalizeMembershipRecord(payload) {
   if (!payload) {
     return null;
   }

--- a/packages/workspaces-core/src/server/common/repositories/workspacesRepository.js
+++ b/packages/workspaces-core/src/server/common/repositories/workspacesRepository.js
@@ -11,7 +11,7 @@ const REPOSITORY_CONFIG = Object.freeze({
   context: "internal.repository.workspaces"
 });
 
-function normalizeWorkspaceRecord(payload = {}) {
+function normalizeWorkspaceRecord(payload) {
   if (!payload) {
     return null;
   }

--- a/packages/workspaces-core/test/workspacesRepository.test.js
+++ b/packages/workspaces-core/test/workspacesRepository.test.js
@@ -142,6 +142,15 @@ test("workspacesRepository.findById normalizes internal workspace fields via the
   });
 });
 
+test("workspacesRepository.findPersonalByOwnerUserId returns null when no personal workspace exists", async () => {
+  const { knex } = createWorkspacesKnexStub();
+  const repository = createRepository(knex);
+
+  const workspace = await repository.findPersonalByOwnerUserId("999");
+
+  assert.equal(workspace, null);
+});
+
 test("workspacesRepository.insert uses runtime normalization and timestamp columns", async () => {
   const insertedRow = {
     id: 1,

--- a/packages/workspaces-web/package.descriptor.mjs
+++ b/packages/workspaces-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-web",
-  version: "0.1.25",
+  version: "0.1.27",
   kind: "runtime",
   description: "Workspace web module: workspace selector, tools widget, workspace surfaces, and members/settings UI.",
   dependsOn: [
@@ -148,8 +148,8 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/workspaces-core": "0.1.25",
-        "@jskit-ai/users-web": "0.1.64",
+        "@jskit-ai/workspaces-core": "0.1.27",
+        "@jskit-ai/users-web": "0.1.66",
         "vuetify": "^4.0.0"
       },
       dev: {}

--- a/packages/workspaces-web/package.json
+++ b/packages/workspaces-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-web",
-  "version": "0.1.25",
+  "version": "0.1.27",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -14,12 +14,12 @@
   "dependencies": {
     "@tanstack/vue-query": "5.92.12",
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/http-runtime": "0.1.48",
-    "@jskit-ai/kernel": "0.1.49",
-    "@jskit-ai/shell-web": "0.1.48",
-    "@jskit-ai/users-core": "0.1.59",
-    "@jskit-ai/users-web": "0.1.64",
-    "@jskit-ai/workspaces-core": "0.1.25",
+    "@jskit-ai/http-runtime": "0.1.50",
+    "@jskit-ai/kernel": "0.1.51",
+    "@jskit-ai/shell-web": "0.1.50",
+    "@jskit-ai/users-core": "0.1.61",
+    "@jskit-ai/users-web": "0.1.66",
+    "@jskit-ai/workspaces-core": "0.1.27",
     "vuetify": "^4.0.0"
   }
 }

--- a/tooling/config-eslint/package.json
+++ b/tooling/config-eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/config-eslint",
-  "version": "0.1.48",
+  "version": "0.1.50",
   "description": "Shared flat ESLint presets for JSKIT projects.",
   "type": "module",
   "files": [

--- a/tooling/create-app/package.descriptor.mjs
+++ b/tooling/create-app/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/create-app",
-  "version": "0.1.57",
+  "version": "0.1.59",
   "dependsOn": [],
   "capabilities": {
     "provides": [

--- a/tooling/create-app/package.json
+++ b/tooling/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/create-app",
-  "version": "0.1.57",
+  "version": "0.1.59",
   "description": "Scaffold minimal JSKIT app shells.",
   "type": "module",
   "files": [

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -6,11 +6,11 @@
   "packages": [
     {
       "packageId": "@jskit-ai/assistant",
-      "version": "0.1.58",
+      "version": "0.1.60",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant",
-        "version": "0.1.58",
+        "version": "0.1.60",
         "kind": "generator",
         "description": "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
         "options": {
@@ -356,11 +356,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-core",
-      "version": "0.1.25",
+      "version": "0.1.27",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-core",
-        "version": "0.1.25",
+        "version": "0.1.27",
         "kind": "runtime",
         "description": "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
         "dependsOn": [
@@ -406,9 +406,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/http-runtime": "0.1.48",
-              "@jskit-ai/kernel": "0.1.49",
-              "@jskit-ai/users-core": "0.1.59",
+              "@jskit-ai/http-runtime": "0.1.50",
+              "@jskit-ai/kernel": "0.1.51",
+              "@jskit-ai/users-core": "0.1.61",
               "@tanstack/vue-query": "^5.90.5",
               "dompurify": "^3.3.3",
               "marked": "^17.0.4",
@@ -429,11 +429,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-runtime",
-      "version": "0.1.20",
+      "version": "0.1.22",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-runtime",
-        "version": "0.1.20",
+        "version": "0.1.22",
         "kind": "runtime",
         "description": "Shared assistant runtime with per-surface assistant registration.",
         "dependsOn": [
@@ -508,13 +508,13 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/assistant-core": "0.1.25",
-              "@jskit-ai/database-runtime": "0.1.49",
-              "@jskit-ai/http-runtime": "0.1.48",
-              "@jskit-ai/kernel": "0.1.49",
-              "@jskit-ai/shell-web": "0.1.48",
-              "@jskit-ai/users-core": "0.1.59",
-              "@jskit-ai/users-web": "0.1.64",
+              "@jskit-ai/assistant-core": "0.1.27",
+              "@jskit-ai/database-runtime": "0.1.51",
+              "@jskit-ai/http-runtime": "0.1.50",
+              "@jskit-ai/kernel": "0.1.51",
+              "@jskit-ai/shell-web": "0.1.50",
+              "@jskit-ai/users-core": "0.1.61",
+              "@jskit-ai/users-web": "0.1.66",
               "@tanstack/vue-query": "^5.90.5",
               "vuetify": "^4.0.0"
             },
@@ -571,11 +571,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-core",
-      "version": "0.1.48",
+      "version": "0.1.50",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-core",
-        "version": "0.1.48",
+        "version": "0.1.50",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/value-app-config-shared"
@@ -643,7 +643,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.49",
+              "@jskit-ai/kernel": "0.1.51",
               "@fastify/cookie": "^11.0.2",
               "@fastify/csrf-protection": "^7.1.0",
               "@fastify/rate-limit": "^10.3.0"
@@ -661,11 +661,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.48",
+      "version": "0.1.50",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-supabase-core",
-        "version": "0.1.48",
+        "version": "0.1.50",
         "kind": "runtime",
         "options": {
           "auth-supabase-url": {
@@ -747,8 +747,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.48",
-              "@jskit-ai/kernel": "0.1.49",
+              "@jskit-ai/auth-core": "0.1.50",
+              "@jskit-ai/kernel": "0.1.51",
               "dotenv": "^16.4.5",
               "@supabase/supabase-js": "^2.57.4",
               "jose": "^6.1.0"
@@ -813,11 +813,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-web",
-      "version": "0.1.50",
+      "version": "0.1.52",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-web",
-        "version": "0.1.50",
+        "version": "0.1.52",
         "kind": "runtime",
         "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
         "dependsOn": [
@@ -1044,10 +1044,10 @@
               "@tanstack/vue-query": "5.92.12",
               "@mdi/js": "^7.4.47",
               "@fastify/type-provider-typebox": "^6.1.0",
-              "@jskit-ai/auth-core": "0.1.48",
-              "@jskit-ai/http-runtime": "0.1.48",
-              "@jskit-ai/kernel": "0.1.49",
-              "@jskit-ai/shell-web": "0.1.48",
+              "@jskit-ai/auth-core": "0.1.50",
+              "@jskit-ai/http-runtime": "0.1.50",
+              "@jskit-ai/kernel": "0.1.51",
+              "@jskit-ai/shell-web": "0.1.50",
               "vuetify": "^4.0.0"
             },
             "dev": {}
@@ -1117,11 +1117,11 @@
     },
     {
       "packageId": "@jskit-ai/console-core",
-      "version": "0.1.12",
+      "version": "0.1.14",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-core",
-        "version": "0.1.12",
+        "version": "0.1.14",
         "kind": "runtime",
         "description": "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
         "dependsOn": [
@@ -1192,10 +1192,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.49",
-              "@jskit-ai/http-runtime": "0.1.48",
-              "@jskit-ai/kernel": "0.1.49",
-              "@jskit-ai/users-core": "0.1.59",
+              "@jskit-ai/database-runtime": "0.1.51",
+              "@jskit-ai/http-runtime": "0.1.50",
+              "@jskit-ai/kernel": "0.1.51",
+              "@jskit-ai/users-core": "0.1.61",
               "typebox": "^1.0.81"
             },
             "dev": {}
@@ -1240,11 +1240,11 @@
     },
     {
       "packageId": "@jskit-ai/console-web",
-      "version": "0.1.17",
+      "version": "0.1.19",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-web",
-        "version": "0.1.17",
+        "version": "0.1.19",
         "kind": "runtime",
         "description": "Authenticated console surface scaffold and surface policy wiring.",
         "dependsOn": [
@@ -1312,9 +1312,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-web": "0.1.50",
-              "@jskit-ai/console-core": "0.1.12",
-              "@jskit-ai/shell-web": "0.1.48"
+              "@jskit-ai/auth-web": "0.1.52",
+              "@jskit-ai/console-core": "0.1.14",
+              "@jskit-ai/shell-web": "0.1.50"
             },
             "dev": {}
           },
@@ -1401,11 +1401,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-core",
-      "version": "0.1.57",
+      "version": "0.1.59",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-core",
-        "version": "0.1.57",
+        "version": "0.1.59",
         "kind": "runtime",
         "description": "Shared CRUD helpers used by CRUD modules.",
         "dependsOn": [
@@ -1432,7 +1432,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/crud-core": "0.1.57"
+              "@jskit-ai/crud-core": "0.1.59"
             },
             "dev": {}
           },
@@ -1446,11 +1446,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-server-generator",
-      "version": "0.1.57",
+      "version": "0.1.59",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-server-generator",
-        "version": "0.1.57",
+        "version": "0.1.59",
         "kind": "generator",
         "description": "CRUD server generator with routes, actions, and persistence scaffolding.",
         "options": {
@@ -1608,13 +1608,13 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.48",
-              "@jskit-ai/crud-core": "0.1.57",
-              "@jskit-ai/database-runtime": "0.1.49",
-              "@jskit-ai/http-runtime": "0.1.48",
-              "@jskit-ai/kernel": "0.1.49",
-              "@jskit-ai/realtime": "0.1.48",
-              "@jskit-ai/users-core": "0.1.59",
+              "@jskit-ai/auth-core": "0.1.50",
+              "@jskit-ai/crud-core": "0.1.59",
+              "@jskit-ai/database-runtime": "0.1.51",
+              "@jskit-ai/http-runtime": "0.1.50",
+              "@jskit-ai/kernel": "0.1.51",
+              "@jskit-ai/realtime": "0.1.50",
+              "@jskit-ai/users-core": "0.1.61",
               "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}",
               "typebox": "^1.0.81"
             },
@@ -1761,11 +1761,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.32",
+      "version": "0.1.34",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-ui-generator",
-        "version": "0.1.32",
+        "version": "0.1.34",
         "kind": "generator",
         "description": "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
         "options": {
@@ -1940,7 +1940,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.64"
+              "@jskit-ai/users-web": "0.1.66"
             },
             "dev": {}
           },
@@ -2173,11 +2173,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime",
-      "version": "0.1.49",
+      "version": "0.1.51",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime",
-        "version": "0.1.49",
+        "version": "0.1.51",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -2234,7 +2234,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.49",
+              "@jskit-ai/kernel": "0.1.51",
               "dotenv": "^16.4.5",
               "knex": "^3.1.0"
             },
@@ -2269,11 +2269,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.48",
+      "version": "0.1.50",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-mysql",
-        "version": "0.1.48",
+        "version": "0.1.50",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -2363,7 +2363,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.49",
+              "@jskit-ai/database-runtime": "0.1.51",
               "mysql2": "^3.11.2"
             },
             "dev": {}
@@ -2434,11 +2434,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.48",
+      "version": "0.1.50",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-postgres",
-        "version": "0.1.48",
+        "version": "0.1.50",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -2528,7 +2528,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.49",
+              "@jskit-ai/database-runtime": "0.1.51",
               "pg": "^8.13.1"
             },
             "dev": {}
@@ -2599,11 +2599,11 @@
     },
     {
       "packageId": "@jskit-ai/http-runtime",
-      "version": "0.1.48",
+      "version": "0.1.50",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/http-runtime",
-        "version": "0.1.48",
+        "version": "0.1.50",
         "kind": "runtime",
         "dependsOn": [],
         "capabilities": {
@@ -2669,7 +2669,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.49",
+              "@jskit-ai/kernel": "0.1.51",
               "@fastify/type-provider-typebox": "^6.1.0",
               "typebox": "^1.0.81"
             },
@@ -2685,11 +2685,11 @@
     },
     {
       "packageId": "@jskit-ai/realtime",
-      "version": "0.1.48",
+      "version": "0.1.50",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/realtime",
-        "version": "0.1.48",
+        "version": "0.1.50",
         "kind": "runtime",
         "description": "Thin, generic realtime runtime wrappers for socket.io server and client.",
         "options": {
@@ -2784,7 +2784,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.49",
+              "@jskit-ai/kernel": "0.1.51",
               "@socket.io/redis-adapter": "^8.3.0",
               "redis": "^5.8.2",
               "socket.io": "^4.8.3",
@@ -2833,11 +2833,11 @@
     },
     {
       "packageId": "@jskit-ai/shell-web",
-      "version": "0.1.48",
+      "version": "0.1.50",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/shell-web",
-        "version": "0.1.48",
+        "version": "0.1.50",
         "kind": "runtime",
         "description": "Web shell layout runtime with outlet-based placement contributions.",
         "dependsOn": [],
@@ -2969,7 +2969,7 @@
             "runtime": {
               "@mdi/js": "^7.4.47",
               "@tanstack/vue-query": "^5.90.5",
-              "@jskit-ai/kernel": "0.1.49",
+              "@jskit-ai/kernel": "0.1.51",
               "vuetify": "^4.0.0"
             },
             "dev": {}
@@ -3154,11 +3154,11 @@
     },
     {
       "packageId": "@jskit-ai/storage-runtime",
-      "version": "0.1.48",
+      "version": "0.1.50",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/storage-runtime",
-        "version": "0.1.48",
+        "version": "0.1.50",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -3207,7 +3207,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.49",
+              "@jskit-ai/kernel": "0.1.51",
               "unstorage": "^1.17.3"
             },
             "dev": {}
@@ -3223,11 +3223,11 @@
     },
     {
       "packageId": "@jskit-ai/ui-generator",
-      "version": "0.1.32",
+      "version": "0.1.34",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/ui-generator",
-        "version": "0.1.32",
+        "version": "0.1.34",
         "kind": "generator",
         "description": "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
         "options": {
@@ -3526,7 +3526,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.64"
+              "@jskit-ai/users-web": "0.1.66"
             },
             "dev": {}
           },
@@ -3541,11 +3541,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-image-web",
-      "version": "0.1.27",
+      "version": "0.1.29",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-image-web",
-        "version": "0.1.27",
+        "version": "0.1.29",
         "kind": "runtime",
         "description": "Reusable client-side image upload runtime with pre-upload image editing.",
         "dependsOn": [
@@ -3609,7 +3609,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/uploads-runtime": "0.1.27",
+              "@jskit-ai/uploads-runtime": "0.1.29",
               "@uppy/compressor": "^3.1.0",
               "@uppy/core": "^5.2.0",
               "@uppy/dashboard": "^5.1.1",
@@ -3629,11 +3629,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-runtime",
-      "version": "0.1.27",
+      "version": "0.1.29",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-runtime",
-        "version": "0.1.27",
+        "version": "0.1.29",
         "kind": "runtime",
         "description": "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
         "dependsOn": [
@@ -3703,7 +3703,7 @@
           "dependencies": {
             "runtime": {
               "@fastify/multipart": "^9.4.0",
-              "@jskit-ai/kernel": "0.1.49"
+              "@jskit-ai/kernel": "0.1.51"
             },
             "dev": {}
           },
@@ -3718,11 +3718,11 @@
     },
     {
       "packageId": "@jskit-ai/users-core",
-      "version": "0.1.59",
+      "version": "0.1.61",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-core",
-        "version": "0.1.59",
+        "version": "0.1.61",
         "kind": "runtime",
         "description": "Users/account runtime plus HTTP routes for account features.",
         "dependsOn": [
@@ -3848,13 +3848,13 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.48",
-              "@jskit-ai/crud-core": "0.1.57",
-              "@jskit-ai/database-runtime": "0.1.49",
-              "@jskit-ai/http-runtime": "0.1.48",
-              "@jskit-ai/kernel": "0.1.49",
+              "@jskit-ai/auth-core": "0.1.50",
+              "@jskit-ai/crud-core": "0.1.59",
+              "@jskit-ai/database-runtime": "0.1.51",
+              "@jskit-ai/http-runtime": "0.1.50",
+              "@jskit-ai/kernel": "0.1.51",
               "@local/users": "file:packages/users",
-              "@jskit-ai/uploads-runtime": "0.1.27",
+              "@jskit-ai/uploads-runtime": "0.1.29",
               "@fastify/type-provider-typebox": "^6.1.0",
               "typebox": "^1.0.81"
             },
@@ -4129,11 +4129,11 @@
     },
     {
       "packageId": "@jskit-ai/users-web",
-      "version": "0.1.64",
+      "version": "0.1.66",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-web",
-        "version": "0.1.64",
+        "version": "0.1.66",
         "kind": "runtime",
         "description": "Users web module: account/profile UI plus shared users web widgets.",
         "dependsOn": [
@@ -4292,12 +4292,12 @@
             "runtime": {
               "@tanstack/vue-query": "5.92.12",
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/http-runtime": "0.1.48",
-              "@jskit-ai/realtime": "0.1.48",
-              "@jskit-ai/kernel": "0.1.49",
-              "@jskit-ai/shell-web": "0.1.48",
-              "@jskit-ai/uploads-image-web": "0.1.27",
-              "@jskit-ai/users-core": "0.1.59",
+              "@jskit-ai/http-runtime": "0.1.50",
+              "@jskit-ai/realtime": "0.1.50",
+              "@jskit-ai/kernel": "0.1.51",
+              "@jskit-ai/shell-web": "0.1.50",
+              "@jskit-ai/uploads-image-web": "0.1.29",
+              "@jskit-ai/users-core": "0.1.61",
               "vuetify": "^4.0.0"
             },
             "dev": {}
@@ -4384,11 +4384,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-core",
-      "version": "0.1.25",
+      "version": "0.1.27",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-core",
-        "version": "0.1.25",
+        "version": "0.1.27",
         "kind": "runtime",
         "description": "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
         "dependsOn": [
@@ -4499,7 +4499,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-core": "0.1.59"
+              "@jskit-ai/users-core": "0.1.61"
             },
             "dev": {}
           },
@@ -4689,11 +4689,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-web",
-      "version": "0.1.25",
+      "version": "0.1.27",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-web",
-        "version": "0.1.25",
+        "version": "0.1.27",
         "kind": "runtime",
         "description": "Workspace web module: workspace selector, tools widget, workspace surfaces, and members/settings UI.",
         "dependsOn": [
@@ -4858,8 +4858,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/workspaces-core": "0.1.25",
-              "@jskit-ai/users-web": "0.1.64",
+              "@jskit-ai/workspaces-core": "0.1.27",
+              "@jskit-ai/users-web": "0.1.66",
               "vuetify": "^4.0.0"
             },
             "dev": {}

--- a/tooling/jskit-catalog/package.json
+++ b/tooling/jskit-catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-catalog",
-  "version": "0.1.57",
+  "version": "0.1.59",
   "description": "Published metadata catalog for JSKIT package descriptors.",
   "type": "module",
   "files": [

--- a/tooling/jskit-cli/package.json
+++ b/tooling/jskit-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-cli",
-  "version": "0.2.58",
+  "version": "0.2.60",
   "description": "Bundle and package orchestration CLI for JSKIT apps.",
   "type": "module",
   "files": [
@@ -20,9 +20,9 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/jskit-catalog": "0.1.57",
-    "@jskit-ai/kernel": "0.1.49",
-    "@jskit-ai/shell-web": "0.1.48"
+    "@jskit-ai/jskit-catalog": "0.1.59",
+    "@jskit-ai/kernel": "0.1.51",
+    "@jskit-ai/shell-web": "0.1.50"
   },
   "engines": {
     "node": "20.x"


### PR DESCRIPTION
## Summary
- land the foundational CRUD/runtime cleanup that made the rebuilt apps generator-friendly again
- include the Beepollen rebuild fixes across CRUD core, server generation, and CRUD UI generation
- include the Dogandgroom rebuild fixes across internal repos, CRUD providers, CRUD UI, and users-web request handling

## Included commits
- 3facdef2 Fix internal repo missing-row normalization
- b2e0f749 Pass workspace route requirements through CRUD providers
- 209001af Drop dead lookup props from CRUD forms
- 4e68a0d3 Import only referenced CRUD time schemas
- 73b854a2 Latest release
- d14f2c69 Support request query params in useView
- 73df6ddd Infer BETWEEN bounds in CRUD generator
- e63a3c7c Keep CRUD UI wrappers lint clean

## Notes
- this PR intentionally carries the full pending rebuild-driven framework stack as one review unit rather than splitting it into smaller PRs