### PR TITLE
Add auth policy resolver and decorator registries

### DIFF
--- a/packages/auth-core/package.json
+++ b/packages/auth-core/package.json
@@ -8,6 +8,8 @@
   "exports": {
     "./server/providers/AccessCoreServiceProvider": "./src/server/providers/AccessCoreServiceProvider.js",
     "./server/providers/FastifyAuthPolicyServiceProvider": "./src/server/providers/FastifyAuthPolicyServiceProvider.js",
+    "./server/authPolicyContextResolverRegistry": "./src/server/authPolicyContextResolverRegistry.js",
+    "./server/authServiceDecoratorRegistry": "./src/server/authServiceDecoratorRegistry.js",
     "./server/utils": "./src/server/utils.js",
     "./server/validators": "./src/server/validators.js",
     "./server/inviteTokens": "./src/server/inviteTokens.js",

--- a/packages/auth-core/src/server/authPolicyContextResolverRegistry.js
+++ b/packages/auth-core/src/server/authPolicyContextResolverRegistry.js
@@ -1,0 +1,125 @@
+import { normalizePermissionList } from "@jskit-ai/kernel/shared/support/permissions";
+import { registerTaggedSingleton, resolveTaggedEntries } from "@jskit-ai/kernel/server/registries";
+
+const AUTH_POLICY_CONTEXT_RESOLVER_TAG = "jskit.auth.policy.context.resolvers";
+
+function normalizeAuthPolicyContextResolver(entry) {
+  if (typeof entry === "function") {
+    return Object.freeze({
+      resolverId: String(entry.name || "anonymous"),
+      order: 0,
+      resolveAuthPolicyContext: entry
+    });
+  }
+
+  if (!entry || typeof entry !== "object" || typeof entry.resolveAuthPolicyContext !== "function") {
+    return null;
+  }
+
+  const resolverId = String(entry.resolverId || "anonymous");
+  const order = Number.isFinite(entry.order) ? Number(entry.order) : 0;
+
+  return Object.freeze({
+    ...entry,
+    resolverId,
+    order,
+    resolveAuthPolicyContext: entry.resolveAuthPolicyContext
+  });
+}
+
+function registerAuthPolicyContextResolver(app, token, factory) {
+  registerTaggedSingleton(app, token, factory, AUTH_POLICY_CONTEXT_RESOLVER_TAG, {
+    context: "registerAuthPolicyContextResolver"
+  });
+}
+
+function resolveAuthPolicyContextResolvers(scope) {
+  return resolveTaggedEntries(scope, AUTH_POLICY_CONTEXT_RESOLVER_TAG)
+    .map((entry, index) => ({
+      resolver: normalizeAuthPolicyContextResolver(entry),
+      index
+    }))
+    .filter((entry) => Boolean(entry.resolver))
+    .sort((left, right) => {
+      if (left.resolver.order !== right.resolver.order) {
+        return left.resolver.order - right.resolver.order;
+      }
+
+      return left.index - right.index;
+    })
+    .map((entry) => entry.resolver);
+}
+
+function mergeAuthPolicyContexts(contexts = []) {
+  const merged = {};
+  let hasValues = false;
+  const permissions = new Set();
+
+  for (const context of Array.isArray(contexts) ? contexts : [contexts]) {
+    if (!context || typeof context !== "object") {
+      continue;
+    }
+
+    for (const [key, value] of Object.entries(context)) {
+      if (key === "permissions") {
+        for (const permission of normalizePermissionList(value)) {
+          permissions.add(permission);
+        }
+        continue;
+      }
+
+      if (value === undefined) {
+        continue;
+      }
+
+      merged[key] = value;
+      hasValues = true;
+    }
+  }
+
+  if (permissions.size > 0) {
+    merged.permissions = Object.freeze([...permissions]);
+    hasValues = true;
+  }
+
+  return hasValues ? Object.freeze(merged) : null;
+}
+
+function composeAuthPolicyContextResolvers(resolvers = []) {
+  const normalizedResolvers = (Array.isArray(resolvers) ? resolvers : [resolvers])
+    .map((entry, index) => ({
+      resolver: normalizeAuthPolicyContextResolver(entry),
+      index
+    }))
+    .filter((entry) => Boolean(entry.resolver))
+    .sort((left, right) => {
+      if (left.resolver.order !== right.resolver.order) {
+        return left.resolver.order - right.resolver.order;
+      }
+
+      return left.index - right.index;
+    })
+    .map((entry) => entry.resolver);
+
+  if (normalizedResolvers.length < 1) {
+    return null;
+  }
+
+  return async function resolveComposedAuthPolicyContext(input = {}) {
+    const contexts = [];
+
+    for (const resolver of normalizedResolvers) {
+      contexts.push(await resolver.resolveAuthPolicyContext(input));
+    }
+
+    return mergeAuthPolicyContexts(contexts);
+  };
+}
+
+export {
+  AUTH_POLICY_CONTEXT_RESOLVER_TAG,
+  registerAuthPolicyContextResolver,
+  resolveAuthPolicyContextResolvers,
+  mergeAuthPolicyContexts,
+  composeAuthPolicyContextResolvers
+};

--- a/packages/auth-core/src/server/authServiceDecoratorRegistry.js
+++ b/packages/auth-core/src/server/authServiceDecoratorRegistry.js
@@ -1,0 +1,56 @@
+import { registerTaggedSingleton, resolveTaggedEntries } from "@jskit-ai/kernel/server/registries";
+
+const AUTH_SERVICE_DECORATOR_TAG = "jskit.auth.service.decorators";
+
+function normalizeAuthServiceDecorator(entry) {
+  if (typeof entry === "function") {
+    return Object.freeze({
+      decoratorId: String(entry.name || "anonymous"),
+      order: 0,
+      decorateAuthService: entry
+    });
+  }
+
+  if (!entry || typeof entry !== "object" || typeof entry.decorateAuthService !== "function") {
+    return null;
+  }
+
+  const decoratorId = String(entry.decoratorId || "anonymous");
+  const order = Number.isFinite(entry.order) ? Number(entry.order) : 0;
+
+  return Object.freeze({
+    ...entry,
+    decoratorId,
+    order,
+    decorateAuthService: entry.decorateAuthService
+  });
+}
+
+function registerAuthServiceDecorator(app, token, factory) {
+  registerTaggedSingleton(app, token, factory, AUTH_SERVICE_DECORATOR_TAG, {
+    context: "registerAuthServiceDecorator"
+  });
+}
+
+function resolveAuthServiceDecorators(scope) {
+  return resolveTaggedEntries(scope, AUTH_SERVICE_DECORATOR_TAG)
+    .map((entry, index) => ({
+      decorator: normalizeAuthServiceDecorator(entry),
+      index
+    }))
+    .filter((entry) => Boolean(entry.decorator))
+    .sort((left, right) => {
+      if (left.decorator.order !== right.decorator.order) {
+        return left.decorator.order - right.decorator.order;
+      }
+
+      return left.index - right.index;
+    })
+    .map((entry) => entry.decorator);
+}
+
+export {
+  AUTH_SERVICE_DECORATOR_TAG,
+  registerAuthServiceDecorator,
+  resolveAuthServiceDecorators
+};

--- a/packages/auth-core/src/server/providers/FastifyAuthPolicyServiceProvider.js
+++ b/packages/auth-core/src/server/providers/FastifyAuthPolicyServiceProvider.js
@@ -1,5 +1,9 @@
 import { registerActionContextContributor } from "@jskit-ai/kernel/server/actions";
 import { registerRouteVisibilityResolver } from "@jskit-ai/kernel/server/http";
+import {
+  composeAuthPolicyContextResolvers,
+  resolveAuthPolicyContextResolvers
+} from "../authPolicyContextResolverRegistry.js";
 import { authPolicyPlugin } from "../lib/plugin.js";
 import { createAuthActionContextContributor } from "../lib/actionContextContributor.js";
 import { createAuthRouteVisibilityResolver } from "../lib/routeVisibilityResolver.js";
@@ -74,16 +78,29 @@ class FastifyAuthPolicyServiceProvider {
     const env = app.has("jskit.env") ? app.make("jskit.env") : {};
     const fastify = app.make("jskit.fastify");
     const authService = app.make("authService");
-    const resolveContext =
+    const legacyResolveContext =
       typeof app.has === "function" && app.has("auth.policy.contextResolver")
         ? app.make("auth.policy.contextResolver")
         : null;
 
-    if (resolveContext != null && typeof resolveContext !== "function") {
+    if (legacyResolveContext != null && typeof legacyResolveContext !== "function") {
       throw new Error(
         "FastifyAuthPolicyServiceProvider requires auth.policy.contextResolver to be a function when provided."
       );
     }
+
+    const resolveContext = composeAuthPolicyContextResolvers([
+      ...resolveAuthPolicyContextResolvers(app),
+      ...(legacyResolveContext
+        ? [
+            {
+              resolverId: "legacy.auth.policy.contextResolver",
+              order: 1000,
+              resolveAuthPolicyContext: legacyResolveContext
+            }
+          ]
+        : [])
+    ]);
 
     const pluginDeps = {
       resolveActor: async (request) => {

--- a/packages/auth-core/src/shared/commands/authCommandValidators.js
+++ b/packages/auth-core/src/shared/commands/authCommandValidators.js
@@ -204,6 +204,8 @@ const sessionResponseValidator = Object.freeze({
     {
       authenticated: Type.Boolean(),
       username: Type.Optional(Type.String({ minLength: 1, maxLength: 120 })),
+      email: Type.Optional(authEmailValidator.schema),
+      permissions: Type.Optional(Type.Array(Type.String({ minLength: 1, maxLength: 200 }))),
       csrfToken: Type.String({ minLength: 1 }),
       oauthProviders: Type.Array(oauthProviderCatalogEntryValidator.schema),
       oauthDefaultProvider: Type.Union([oauthProviderValidator.schema, Type.Null()])

--- a/packages/auth-core/test/authPolicyContextResolverRegistry.test.js
+++ b/packages/auth-core/test/authPolicyContextResolverRegistry.test.js
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createApplication } from "@jskit-ai/kernel/_testable";
+import {
+  AUTH_POLICY_CONTEXT_RESOLVER_TAG,
+  composeAuthPolicyContextResolvers,
+  registerAuthPolicyContextResolver,
+  resolveAuthPolicyContextResolvers
+} from "../src/server/authPolicyContextResolverRegistry.js";
+
+test("auth policy context resolver registry resolves resolvers in order", async () => {
+  const app = createApplication();
+
+  registerAuthPolicyContextResolver(app, "test.auth.policy.context.permissions", () => ({
+    resolverId: "permissions",
+    order: 20,
+    async resolveAuthPolicyContext() {
+      return {
+        permissions: ["alpha.read"]
+      };
+    }
+  }));
+
+  registerAuthPolicyContextResolver(app, "test.auth.policy.context.workspace", () => ({
+    resolverId: "workspace",
+    order: 10,
+    async resolveAuthPolicyContext() {
+      return {
+        workspace: { id: "11" },
+        membership: { roleSid: "member" },
+        permissions: ["workspace.read"]
+      };
+    }
+  }));
+
+  const resolvers = resolveAuthPolicyContextResolvers(app);
+  assert.deepEqual(
+    resolvers.map((entry) => entry.resolverId),
+    ["workspace", "permissions"]
+  );
+
+  const resolveContext = composeAuthPolicyContextResolvers(resolvers);
+  const context = await resolveContext({
+    actor: { id: "7" }
+  });
+
+  assert.deepEqual(context, {
+    workspace: { id: "11" },
+    membership: { roleSid: "member" },
+    permissions: ["workspace.read", "alpha.read"]
+  });
+});
+
+test("auth policy context resolver registry exports canonical tag", () => {
+  assert.equal(AUTH_POLICY_CONTEXT_RESOLVER_TAG, "jskit.auth.policy.context.resolvers");
+});

--- a/packages/auth-core/test/authServiceDecoratorRegistry.test.js
+++ b/packages/auth-core/test/authServiceDecoratorRegistry.test.js
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createApplication } from "@jskit-ai/kernel/_testable";
+import {
+  AUTH_SERVICE_DECORATOR_TAG,
+  registerAuthServiceDecorator,
+  resolveAuthServiceDecorators
+} from "../src/server/authServiceDecoratorRegistry.js";
+
+test("auth service decorator registry resolves decorators in order", () => {
+  const app = createApplication();
+
+  registerAuthServiceDecorator(app, "test.auth.decorator.zeta", () => ({
+    decoratorId: "zeta",
+    order: 50,
+    decorateAuthService(service) {
+      return {
+        ...service,
+        trace: [...service.trace, "zeta"]
+      };
+    }
+  }));
+
+  registerAuthServiceDecorator(app, "test.auth.decorator.alpha", () => ({
+    decoratorId: "alpha",
+    order: 10,
+    decorateAuthService(service) {
+      return {
+        ...service,
+        trace: [...service.trace, "alpha"]
+      };
+    }
+  }));
+
+  const decorators = resolveAuthServiceDecorators(app);
+  assert.equal(decorators.length, 2);
+  assert.deepEqual(
+    decorators.map((entry) => entry.decoratorId),
+    ["alpha", "zeta"]
+  );
+
+  const decorated = decorators.reduce(
+    (service, decorator) => decorator.decorateAuthService(service),
+    { trace: [] }
+  );
+  assert.deepEqual(decorated.trace, ["alpha", "zeta"]);
+});
+
+test("auth service decorator registry exports canonical tag", () => {
+  assert.equal(AUTH_SERVICE_DECORATOR_TAG, "jskit.auth.service.decorators");
+});

--- a/packages/auth-core/test/providerRuntime.test.js
+++ b/packages/auth-core/test/providerRuntime.test.js
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { FastifyAuthPolicyServiceProvider } from "../src/server/providers/FastifyAuthPolicyServiceProvider.js";
+import { AUTH_POLICY_CONTEXT_RESOLVER_TAG } from "../src/server/authPolicyContextResolverRegistry.js";
 import { createFakeFastifyPolicyRuntime } from "../../../tooling/testUtils/fakeFastify.mjs";
 
 test("FastifyAuthPolicyServiceProvider registers auth policy plugin through provider boot", async () => {
@@ -84,6 +85,17 @@ test("FastifyAuthPolicyServiceProvider wires optional auth policy context resolv
         throw new Error(`Missing token ${String(token)}`);
       }
       return bag.get(token);
+    },
+    resolveTag(tag) {
+      if (tag !== AUTH_POLICY_CONTEXT_RESOLVER_TAG) {
+        return [];
+      }
+
+      return [
+        async () => ({
+          permissions: ["settings.manage"]
+        })
+      ];
     }
   };
 
@@ -108,5 +120,5 @@ test("FastifyAuthPolicyServiceProvider wires optional auth policy context resolv
   assert.equal(request.workspace?.id, 11);
   assert.equal(request.workspace?.slug, "acme");
   assert.equal(request.membership?.roleSid, "member");
-  assert.deepEqual(request.permissions, ["projects.read"]);
+  assert.deepEqual(request.permissions, ["settings.manage", "projects.read"]);
 });

--- a/packages/auth-provider-supabase-core/src/server/providers/AuthSupabaseServiceProvider.js
+++ b/packages/auth-provider-supabase-core/src/server/providers/AuthSupabaseServiceProvider.js
@@ -1,6 +1,7 @@
 import { resolveAllowedOriginsFromSurfaceDefinitions } from "@jskit-ai/kernel/shared/support/returnToPath";
 import { withActionDefaults } from "@jskit-ai/kernel/shared/actions";
 import { normalizeRecordId } from "@jskit-ai/kernel/shared/support/normalize";
+import { resolveAuthServiceDecorators } from "@jskit-ai/auth-core/server/authServiceDecoratorRegistry";
 import { createService } from "../lib/service.js";
 import { createStandaloneProfileSyncService } from "../lib/standaloneProfileSyncService.js";
 import { createAuthSessionEventsService } from "../lib/authSessionEventsService.js";
@@ -185,6 +186,19 @@ function resolveOptionalRepositories(scope) {
   return repositories;
 }
 
+function applyAuthServiceDecorators(scope, authService) {
+  let decoratedAuthService = authService;
+
+  for (const decorator of resolveAuthServiceDecorators(scope)) {
+    decoratedAuthService = decorator.decorateAuthService(decoratedAuthService);
+    if (!decoratedAuthService || typeof decoratedAuthService !== "object") {
+      throw new Error(`Auth service decorator "${decorator.decoratorId}" must return an auth service object.`);
+    }
+  }
+
+  return decoratedAuthService;
+}
+
 class AuthSupabaseServiceProvider {
   static id = "auth.provider.supabase";
 
@@ -225,7 +239,7 @@ class AuthSupabaseServiceProvider {
           userProfileSyncService = scope.make("users.profile.sync.service");
         }
 
-        return createService({
+        const authService = createService({
           authProvider,
           appPublicUrl: String(env.APP_PUBLIC_URL || "").trim(),
           authAllowedReturnToOrigins: resolveAllowedReturnToOrigins({
@@ -241,6 +255,8 @@ class AuthSupabaseServiceProvider {
           devAuthAccessTtlSeconds: env.AUTH_DEV_ACCESS_TTL_SECONDS,
           devAuthRefreshTtlSeconds: env.AUTH_DEV_REFRESH_TTL_SECONDS
         });
+
+        return applyAuthServiceDecorators(scope, authService);
       });
     }
 

--- a/packages/auth-provider-supabase-core/test/providerRuntime.test.js
+++ b/packages/auth-provider-supabase-core/test/providerRuntime.test.js
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { createApplication } from "@jskit-ai/kernel/_testable";
+import { registerAuthServiceDecorator } from "@jskit-ai/auth-core/server/authServiceDecoratorRegistry";
 import { ActionRuntimeServiceProvider } from "@jskit-ai/kernel/server/actions";
 import { AuthSupabaseServiceProvider } from "../src/server/providers/AuthSupabaseServiceProvider.js";
 
@@ -218,6 +219,46 @@ test("auth supabase provider can boot dev auth without Supabase credentials", as
   const actionExecutor = app.make("actionExecutor");
   const definitions = actionExecutor.listDefinitions();
   assert.equal(definitions.some((definition) => definition.id === "auth.dev.loginAs"), true);
+});
+
+test("auth supabase provider applies registered auth service decorators", async () => {
+  const app = createApplication();
+  app.instance("appConfig", createAppConfigFixture());
+  app.instance("jskit.env", {
+    AUTH_SUPABASE_URL: "https://example.supabase.co",
+    AUTH_SUPABASE_PUBLISHABLE_KEY: "sb_publishable_test_key",
+    AUTH_PROFILE_MODE: "standalone",
+    APP_PUBLIC_URL: "http://localhost:5173",
+    NODE_ENV: "test"
+  });
+  app.instance("jskit.logger", {
+    info() {},
+    warn() {},
+    error() {},
+    debug() {}
+  });
+  app.instance("domainEvents", {
+    async publish() {}
+  });
+
+  registerAuthServiceDecorator(app, "test.auth.decorator.marker", () => ({
+    decoratorId: "marker",
+    order: 10,
+    decorateAuthService(authService) {
+      return {
+        ...authService,
+        marker: "decorated"
+      };
+    }
+  }));
+
+  await app.start({
+    providers: [ActionRuntimeServiceProvider, AuthSupabaseServiceProvider]
+  });
+
+  const authService = app.make("authService");
+  assert.equal(authService.marker, "decorated");
+  assert.equal(typeof authService.login, "function");
 });
 
 test("auth supabase provider rejects dev auth bypass in production", async () => {

--- a/packages/auth-web/src/client/runtime/authGuardRuntime.js
+++ b/packages/auth-web/src/client/runtime/authGuardRuntime.js
@@ -3,6 +3,7 @@ import { AUTH_PATHS } from "@jskit-ai/auth-core/shared/authPaths";
 import { isExternalLinkTarget } from "@jskit-ai/kernel/shared/support/linkPath";
 import { normalizePathname as normalizeSurfacePathname } from "@jskit-ai/kernel/shared/surface/paths";
 import { createListenerSubscription } from "@jskit-ai/kernel/shared/support/listenerSet";
+import { normalizePermissionList } from "@jskit-ai/kernel/shared/support/permissions";
 
 const GLOBAL_GUARD_EVALUATOR_KEY = "__JSKIT_WEB_SHELL_GUARD_EVALUATOR__";
 const AUTH_POLICY_AUTHENTICATED = "authenticated";
@@ -34,6 +35,8 @@ const KEEP_PREVIOUS_AUTH_STATE = Symbol("keepPreviousAuthState");
 const DEFAULT_AUTH_STATE = Object.freeze({
   authenticated: false,
   username: "",
+  email: "",
+  permissions: Object.freeze([]),
   oauthDefaultProvider: "",
   oauthProviders: Object.freeze([])
 });
@@ -102,10 +105,14 @@ function normalizeAuthState(payload = {}) {
     .toLowerCase();
   const authenticated = Boolean(payload.authenticated);
   const username = authenticated ? String(payload.username || "").trim() : "";
+  const email = authenticated ? String(payload.email || "").trim().toLowerCase() : "";
+  const permissions = authenticated ? Object.freeze(normalizePermissionList(payload.permissions)) : Object.freeze([]);
 
   return Object.freeze({
     authenticated,
     username,
+    email,
+    permissions,
     oauthDefaultProvider,
     oauthProviders
   });
@@ -129,6 +136,8 @@ function applyAuthContext(nextState, placementRuntime) {
     {
       auth: {
         authenticated: nextState.authenticated,
+        email: nextState.email,
+        permissions: nextState.permissions,
         oauthDefaultProvider: nextState.oauthDefaultProvider,
         oauthProviders: nextState.oauthProviders
       }

--- a/packages/auth-web/src/server/controllers/AuthController.js
+++ b/packages/auth-web/src/server/controllers/AuthController.js
@@ -157,6 +157,8 @@ class AuthController {
     reply.code(200).send({
       authenticated: true,
       username: authResult.profile.displayName,
+      email: authResult.profile.email,
+      permissions: Array.isArray(authResult.permissions) ? authResult.permissions : [],
       csrfToken,
       ...oauthCatalogPayload
     });

--- a/packages/auth-web/test/authGuardRuntime.test.js
+++ b/packages/auth-web/test/authGuardRuntime.test.js
@@ -170,6 +170,8 @@ test("auth guard runtime only updates placement auth context", async () => {
           return {
             authenticated: true,
             username: "ada",
+            email: "ada@example.com",
+            permissions: ["settings.allowed"],
             oauthProviders: [{ id: "github", label: "GitHub" }],
             oauthDefaultProvider: "github"
           };
@@ -191,6 +193,8 @@ test("auth guard runtime only updates placement auth context", async () => {
   });
   assert.deepEqual(context.auth, {
     authenticated: true,
+    email: "ada@example.com",
+    permissions: ["settings.allowed"],
     oauthDefaultProvider: "github",
     oauthProviders: [{ id: "github", label: "GitHub" }]
   });


### PR DESCRIPTION
## Summary
- add shared auth policy context resolver and auth service decorator registries
- wire auth-core, auth-provider-supabase-core, and auth-web through the new auth context and decoration hooks
- extend session/auth responses with email and permissions support

## Verification
- npm test --workspace @jskit-ai/auth-provider-supabase-core
- npm test --workspace @jskit-ai/auth-web

## Notes
- `npm test --workspace @jskit-ai/auth-core` still has one unrelated failing expectation in `packages/auth-core/test/authApi.test.js` around the existing `devLoginAs` method; that file is unchanged in this branch.