### PR TITLE
Add shared page redirect helper for settings shells

### DIFF
--- a/packages/agent-docs/guide/agent/app-setup/a-more-interesting-shell.md
+++ b/packages/agent-docs/guide/agent/app-setup/a-more-interesting-shell.md
@@ -181,6 +181,16 @@ In JSKIT's file-based routing, a page file can act as a layout if it renders a `
 - `src/pages/home/settings/general/index.vue` is the first real child page created by the starter shell.
 - `src/pages/home/settings/profile/index.vue` becomes `/home/settings/profile` and still renders inside the layout from `settings.vue`.
 
+JSKIT uses a small helper for that redirect instead of hand-building the child path:
+
+```js
+import { redirectToChild } from "@jskit-ai/kernel/client/pageRedirects";
+
+definePage({
+  redirect: redirectToChild("general")
+});
+```
+
 This is why the `home-settings:primary-menu` outlet from `list-placements` is such a useful clue: it tells you which page is acting as the host.
 
 Even an `index.vue` page can have children. If you want an index page to stay visible while child routes render underneath it, put those children under an `index/` directory such as `src/pages/home/settings/profile/index/details.vue`.
@@ -622,6 +632,16 @@ The starter shell now uses a real child-page structure right away:
 - `src/pages/home/settings/index.vue` is only a redirect into the first child page
 - `src/pages/home/settings/general/index.vue` is the first real settings page
 - `src/placement.js` already seeds a `General` link into `home-settings:primary-menu`
+
+When you need that landing redirect yourself, use the same helper pattern:
+
+```js
+import { redirectToChild } from "@jskit-ai/kernel/client/pageRedirects";
+
+definePage({
+  redirect: redirectToChild("general")
+});
+```
 
 That is what makes the page-generation examples in this chapter important. They are not inventing a new pattern. They are extending the exact same host-and-child-page structure that `shell-web` already uses for its own starter `General` page.
 

--- a/packages/agent-docs/patterns/INDEX.md
+++ b/packages/agent-docs/patterns/INDEX.md
@@ -18,6 +18,8 @@ How to use it:
   - `child-cruds.md`
 - CRUD links, record placeholders, `paths.page()`, `resolveViewUrl`, `resolveEditUrl`, `resolveParams`
   - `crud-links.md`
+- `definePage`, redirect, child redirect, settings landing, `redirectToChild`
+  - `page-redirects.md`
 - live actions, checkbox, toggle, patch button, inline action, `useCommand()`
   - `live-actions.md`
 - ajax, fetch, API call, request, endpoint, HTTP client, `useList()`, `useView()`, `useAddEdit()`, `useEndpointResource()`, `usersWebHttpClient`
@@ -35,6 +37,7 @@ How to use it:
 - [surfaces.md](./surfaces.md)
 - [child-cruds.md](./child-cruds.md)
 - [crud-links.md](./crud-links.md)
+- [page-redirects.md](./page-redirects.md)
 - [live-actions.md](./live-actions.md)
 - [client-requests.md](./client-requests.md)
 - [ui-testing.md](./ui-testing.md)

--- a/packages/agent-docs/patterns/page-redirects.md
+++ b/packages/agent-docs/patterns/page-redirects.md
@@ -1,0 +1,41 @@
+# Page Redirect Patterns
+
+Use when:
+
+- redirecting a page index route to a child page
+- writing `definePage({ redirect: ... })`
+- seeding settings landing pages such as `/home/settings`
+- wiring a section shell that should land on a real child page first
+
+Check first:
+
+- whether the page is only a landing route for child pages
+- whether the destination child route is explicit and stable
+- whether the redirect should preserve incoming query and hash
+
+Rules:
+
+- For “index page lands on child page” redirects, use `redirectToChild()` from `@jskit-ai/kernel/client/pageRedirects`.
+- Do not hand-build child redirects with string surgery such as `` `${String(to.path || "").replace(/\\/$/, "")}/general` ``.
+- Keep the destination explicit. Do not infer it from placements, menu order, or “first child page wins” behavior.
+- If the redirect is just “go to this child page”, prefer:
+
+```js
+import { redirectToChild } from "@jskit-ai/kernel/client/pageRedirects";
+
+definePage({
+  redirect: redirectToChild("general")
+});
+```
+
+Why:
+
+- the helper centralizes slash handling
+- it preserves incoming query and hash unless the child target overrides them
+- templates, guides, and apps all stay on one obvious pattern
+
+Avoid:
+
+- copying redirect lambdas between apps and templates
+- building implicit redirect behavior from placements
+- inventing page-local helper utilities for the same pattern

--- a/packages/agent-docs/reference/autogen/packages/auth-core.md
+++ b/packages/agent-docs/reference/autogen/packages/auth-core.md
@@ -35,6 +35,24 @@ Exports
 Exports
 - `runAuthSignOutFlow`
 
+### `src/server/authPolicyContextResolverRegistry.js`
+Exports
+- `AUTH_POLICY_CONTEXT_RESOLVER_TAG`
+- `registerAuthPolicyContextResolver(app, token, factory)`
+- `resolveAuthPolicyContextResolvers(scope)`
+- `mergeAuthPolicyContexts(contexts = [])`
+- `composeAuthPolicyContextResolvers(resolvers = [])`
+Local functions
+- `normalizeAuthPolicyContextResolver(entry)`
+
+### `src/server/authServiceDecoratorRegistry.js`
+Exports
+- `AUTH_SERVICE_DECORATOR_TAG`
+- `registerAuthServiceDecorator(app, token, factory)`
+- `resolveAuthServiceDecorators(scope)`
+Local functions
+- `normalizeAuthServiceDecorator(entry)`
+
 ### `src/server/inviteTokens.js`
 Exports
 - `OPAQUE_INVITE_TOKEN_HASH_PREFIX`

--- a/packages/agent-docs/reference/autogen/packages/auth-provider-supabase-core.md
+++ b/packages/agent-docs/reference/autogen/packages/auth-provider-supabase-core.md
@@ -110,13 +110,13 @@ Exports
 
 ### `src/server/lib/devAuthBootstrap.js`
 Exports
-- `assertDevAuthBootstrapConfig(config, { usersRepository = null } = {})`
-- `authenticateDevAuthRequest({ request, accessToken = "", refreshToken = "" }, { config, usersRepository = null } = {})`
+- `assertDevAuthBootstrapConfig(config, { userProfilesRepository = null } = {})`
+- `authenticateDevAuthRequest({ request, accessToken = "", refreshToken = "" }, { config, userProfilesRepository = null } = {})`
 - `createDevAuthSession(profile, config)`
 - `ensureDevAuthBootstrapAvailable(config, request)`
 - `isDevAuthToken(token)`
 - `resolveDevAuthConfig({ enabled = false, secret = "", nodeEnv = "development", jwtAudience = "authenticated", accessTtlSeconds = DEFAULT_DEV_AUTH_ACCESS_TTL_SECONDS, refreshTtlSeconds = DEFAULT_DEV_AUTH_REFRESH_TTL_SECONDS } = {})`
-- `resolveDevAuthProfile(input = {}, { usersRepository = null, validationError } = {})`
+- `resolveDevAuthProfile(input = {}, { userProfilesRepository = null, validationError } = {})`
 Local functions
 - `parseBoolean(value, fallback = false)`
 - `normalizePositiveInteger(value, fallback)`
@@ -128,7 +128,7 @@ Local functions
 - `isLocalDevAuthRequest(request)`
 - `stripDevAuthTokenPrefix(token)`
 - `buildProfileFromTokenClaims(payload)`
-- `resolveProfileFromTokenClaims(payload, { usersRepository = null } = {})`
+- `resolveProfileFromTokenClaims(payload, { userProfilesRepository = null } = {})`
 - `signDevAuthToken(kind, profile, config)`
 - `verifyDevAuthToken(token, kind, config)`
 
@@ -247,6 +247,7 @@ Local functions
 - `resolveCommonDependencies(scope)`
 - `resolveRuntimeEnv(scope)`
 - `resolveOptionalRepositories(scope)`
+- `applyAuthServiceDecorators(scope, authService)`
 
 ### root
 

--- a/packages/agent-docs/reference/autogen/packages/crud-core.md
+++ b/packages/agent-docs/reference/autogen/packages/crud-core.md
@@ -68,10 +68,6 @@ Exports
 - `createCrudClientSupport`
 - `useCrudRealtimeInvalidation`
 
-### `src/server/createCrudRepositoryFromResource.js`
-Exports
-- `createCrudRepositoryFromResource(resource = {}, { context = "crudRepository", list = {}, virtualFields = {} } = {})`
-
 ### `src/server/createCrudServiceFromResource.js`
 Exports
 - `createCrudServiceFromResource(resource = {}, { context = "crudService" } = {})`
@@ -205,52 +201,6 @@ Exports
 Local functions
 - `normalizeLookupOwnershipFilter(value, { context = "crudLookup ownershipFilter" } = {})`
 
-### `src/server/repositoryMethods.js`
-Exports
-- `createCrudResourceRuntime(resource = {}, { context = "crudRepository", list = {}, virtualFields = {} } = {})`
-- `crudRepositoryList(runtime, knex, query = {}, repositoryOptions = {}, callOptions = {}, hooks = null)`
-- `crudRepositoryFindById(runtime, knex, recordId, repositoryOptions = {}, callOptions = {}, hooks = null)`
-- `crudRepositoryListByIds(runtime, knex, ids = [], repositoryOptions = {}, callOptions = {}, hooks = null)`
-- `crudRepositoryListByForeignIds(runtime, knex, ids = [], foreignKey = "", repositoryOptions = {}, callOptions = {}, hooks = null)`
-- `crudRepositoryCreate(runtime, knex, payload = {}, repositoryOptions = {}, callOptions = {}, hooks = null)`
-- `crudRepositoryUpdateById(runtime, knex, recordId, patch = {}, repositoryOptions = {}, callOptions = {}, hooks = null)`
-- `crudRepositoryDeleteById(runtime, knex, recordId, repositoryOptions = {}, callOptions = {}, hooks = null)`
-Local functions
-- `requireCrudRecordId(value, { context = "crudRepository" } = {})`
-- `resolveRepositoryDefaults(resource = {}, repositoryMapping = {})`
-- `normalizeCrudVirtualFieldHandlers(virtualFields = {}, repositoryMapping = {}, { context = "crudRepository" } = {})`
-- `applyCrudRepositoryVirtualProjections(dbQuery, runtime = {}, { knex, tableName } = {})`
-- `normalizeSearchColumns(searchColumns = [], fallbackColumns = [])`
-- `normalizeListOrderDirection(value = LIST_ORDER_DIRECTION_ASC)`
-- `normalizeListOrderNulls(value = LIST_ORDER_NULLS_LAST)`
-- `normalizeListOrderBy(orderBy = [], { idColumn = "id" } = {})`
-- `resolveListRuntimeConfig(list = {}, fallbackSearchColumns = [], { idColumn = "id" } = {})`
-- `encodeOrderedListCursorValue(value = null)`
-- `decodeOrderedListCursorValue(value = null)`
-- `encodeOrderedListCursor(row = null, orderBy = [])`
-- `decodeOrderedListCursor(cursor = "", orderBy = [])`
-- `applyOrderedListCursorEquality(query, descriptor = {}, value = null)`
-- `applyOrderedListCursorAfterBranch(query, descriptor = {}, value = null)`
-- `canApplyOrderedListCursorAfterBranch(descriptor = {}, value = null)`
-- `appendOrderedListCursorBranches(query, orderBy = [], cursorValues = [], index = 0, { useOr = false } = {})`
-- `applyOrderedListCursorFilter(query, { orderBy = [], cursor = "" } = {})`
-- `resolveRecordOutputValidator(resource = {}, { context = "crudRepository" } = {})`
-- `formatOutputValidationError(error = {})`
-- `normalizeRepositoryOutputRecord(runtime, record = {}, { operation = "read" } = {})`
-- `resolveCrudRepositoryCall(runtime, knex, repositoryOptions = {}, callOptions = {})`
-- `normalizeCrudRepositoryHooks(hooks = null, allowedHookKeys = [], { context = "crudRepository" } = {})`
-- `resolveOptionalCrudRepositoryHook(hooks = {}, hookKey = "", { context = "crudRepository" } = {})`
-- `applyCrudRepositoryQueryHook(dbQuery, hook = null, hookContext = {}, { context = "crudRepository", hookKey = "modifyQuery" } = {})`
-- `normalizeCrudRepositoryObjectInput(value = {})`
-- `applyCrudRepositoryPayloadHook(payload = {}, hook = null, hookContext = {}, { context = "crudRepository", hookKey = "modifyPayload" } = {})`
-- `applyCrudRepositoryRecordsHook(items = [], hook = null, hookContext = {}, { context = "crudRepository", hookKey = "afterQuery" } = {})`
-- `applyCrudRepositoryRecordHook(record = null, hook = null, hookContext = {}, { context = "crudRepository", hookKey = "transformReturnedRecord" } = {})`
-- `applyCrudRepositoryOutputHook(output, hook = null, hookContext = {}, { context = "crudRepository", hookKey = "finalizeOutput", validateOutput = null } = {})`
-- `applyCrudRepositoryAfterWriteHook(meta = {}, hook = null, hookContext = {}, { context = "crudRepository", hookKey = "afterWrite" } = {})`
-- `applyOrderedListControls(dbQuery, orderBy = [])`
-- `enforceCrudRepositoryListControls(dbQuery, { idColumn = "id", limit = DEFAULT_LIST_LIMIT + 1, orderBy = [] } = {})`
-- `createCrudRepositoryHookContextBase(runtime, repositoryOptions = {}, callOptions = {})`
-
 ### `src/server/repositorySupport.js`
 Exports
 - `DEFAULT_LIST_LIMIT`
@@ -272,6 +222,81 @@ Local functions
 - `schemaIncludesStringType(schema = {})`
 - `schemaIncludesRecordIdType(schema = {})`
 
+### `src/server/resourceRuntime/index.js`
+Exports
+- `createCrudResourceRuntime(resource = {}, knex, repositoryOptions = {})`
+Local functions
+- `requireCrudRecordId(value, { context = "crudRepository" } = {})`
+- `requireCrudRepositoryOptions(value = {}, { context = "crudRepository" } = {})`
+- `resolveRepositoryDefaults(resource = {}, repositoryMapping = {}, { context = "crudRepository" } = {})`
+- `normalizeCrudVirtualFieldHandlers(virtualFields = {}, repositoryMapping = {}, { context = "crudRepository" } = {})`
+- `applyCrudRepositoryVirtualProjections(dbQuery, runtime = {}, { knex, tableName } = {})`
+- `normalizeSearchColumns(searchColumns = [], fallbackColumns = [])`
+- `normalizeListOrderDirection(value = LIST_ORDER_DIRECTION_ASC)`
+- `normalizeListOrderNulls(value = LIST_ORDER_NULLS_LAST)`
+- `normalizeListOrderBy(orderBy = [], { idColumn = "id" } = {})`
+- `resolveListRuntimeConfig(list = {}, fallbackSearchColumns = [], { idColumn = "id" } = {})`
+- `formatOutputValidationError(issue = {})`
+- `resolveRecordOutputValidator(resource = {}, { context = "crudRepository" } = {})`
+- `resolveOperationBodyValidator(resource = {}, operationKey = "", { context = "crudRepository" } = {})`
+- `extractExplicitFieldErrors(error)`
+- `normalizeRepositoryInputPayload(runtime = {}, payload = {}, { operationKey = "create", phase = "crudCreate", action = "create", recordId = null, existingRecord = null, actionContextBase = {} } = {})`
+- `normalizeRepositoryOutputRecord(runtime = {}, record = {}, { operation = "list" } = {})`
+- `encodeOrderedListCursorValue(value = null)`
+- `decodeOrderedListCursorValue(value = null)`
+- `encodeOrderedListCursor(row = null, orderBy = [])`
+- `decodeOrderedListCursor(cursor = "", orderBy = [])`
+- `applyOrderedListCursorEquality(query, descriptor = {}, value = null)`
+- `applyOrderedListCursorAfterBranch(query, descriptor = {}, value = null)`
+- `canApplyOrderedListCursorAfterBranch(descriptor = {}, value = null)`
+- `appendOrderedListCursorBranches(query, orderBy = [], cursorValues = [], index = 0, { useOr = false } = {})`
+- `applyOrderedListCursorFilter(query, { orderBy = [], cursor = "" } = {})`
+- `normalizeCrudRepositoryOperationStage(stage = null, stageLabel = "", { context = "crudRepository" } = {})`
+- `normalizeCrudRepositoryOperationConfig(config = {}, operationKey = "", { context = "crudRepository" } = {})`
+- `normalizeCrudRepositoryOperations(sourceOperations = {}, { context = "crudRepository" } = {})`
+- `applyConfiguredQueryStage(dbQuery, stage = null, stageContext = {}, { context = "crudRepository", stageKey = "applyQuery" } = {})`
+- `isCrudRepositoryQueryBuilder(value)`
+- `normalizeCrudRepositoryObjectInput(value = {})`
+- `applyConfiguredObjectStage(payload = {}, stage = null, stageContext = {}, { context = "crudRepository", stageKey = "preparePayload" } = {})`
+- `applyOrderedListControls(dbQuery, orderBy = [])`
+- `enforceCrudRepositoryListControls(dbQuery, { idColumn = "id", limit = DEFAULT_LIST_LIMIT + 1, orderBy = [] } = {})`
+- `createCrudRepositoryActionContextBase(runtime, callOptions = {})`
+- `createCompiledCrudRepositoryRuntime(resource = {}, repositoryOptions = {})`
+- `resolveCrudRepositoryCall(runtime, knex, callOptions = {})`
+- `applyCrudRepositoryReadLock(dbQuery, callOptions = {})`
+- `listRecords(runtime, knex, query = {}, callOptions = {})`
+- `findRecordById(runtime, knex, recordId, callOptions = {})`
+- `listRecordsByIds(runtime, knex, ids = [], callOptions = {})`
+- `createRecord(runtime, knex, payload = {}, callOptions = {})`
+- `updateRecordById(runtime, knex, recordId, patch = {}, callOptions = {})`
+- `deleteRecordById(runtime, knex, recordId, callOptions = {})`
+
+### `src/server/resourceRuntime/lookupHydration.js`
+Exports
+- `createCrudLookupRuntime(resource = {}, { outputKeys = [] } = {})`
+- `hydrateCrudLookupRecords(records = [], runtime = {}, { include, mode = "list", repositoryOptions = {}, callOptions = {} } = {})`
+Local functions
+- `normalizeLookupRelationEntry(entry = {}, outputKeys = new Set())`
+- `normalizeLookupDefaultInclude(value)`
+- `normalizeLookupMaxDepth(value)`
+- `resolveLookupRuntimeDefaults(resource = {})`
+- `normalizeLookupIdentifier(value)`
+- `normalizeIncludePaths(include, { defaultInclude = DEFAULT_LOOKUP_INCLUDE } = {})`
+- `resolveChildIncludeFromPaths(paths = [])`
+- `shouldHydrateByMode(entry = {}, mode = "list")`
+- `buildLookupHydrationPlan(runtime = {}, include, { mode = "list", context = "crudRepository", includeWasExplicit = false, skippedNamespaces = new Set() } = {})`
+- `resolveLookupResolver(repositoryOptions = {}, callOptions = {}, { context = "crudRepository" } = {})`
+- `resolveLookupDepthRuntime(runtime = {}, repositoryOptions = {}, callOptions = {})`
+- `buildLookupGroupKey(relation = {})`
+- `normalizeLookupRelationValues(records = [], entries = [], childIncludeByKey = {})`
+- `resolveGroupChildInclude(group = {})`
+- `normalizeLookup(provider, relation = {}, { context = "crudRepository" } = {})`
+- `resolveLookupOwnershipFilter(provider = {}, { context = "crudRepository" } = {})`
+- `resolveLookupVisibilityContext(provider = {}, relation = {}, callOptions = {}, { context = "crudRepository" } = {})`
+- `buildLookupRecordMap(records = [], valueKey = "")`
+- `buildLookupCollectionMap(records = [], foreignKey = "")`
+- `resolveLookupVisitedNamespaces(runtime = {}, callOptions = {})`
+
 ### `src/server/serviceEvents.js`
 Exports
 - `createCrudServiceEvents(resource = {}, { context = "crudService" } = {})`
@@ -286,6 +311,7 @@ Exports
 - `crudServiceDeleteRecord(runtime, repository, fieldAccess = {}, recordId, options = {})`
 Local functions
 - `requireCrudServiceRepository(runtime = {}, repository = null)`
+- `splitCrudListRepositoryCall(query = {}, options = {})`
 
 ### `src/shared/crudFieldMetaSupport.js`
 Exports

--- a/packages/agent-docs/reference/autogen/packages/crud-server-generator.md
+++ b/packages/agent-docs/reference/autogen/packages/crud-server-generator.md
@@ -45,11 +45,19 @@ Local functions
 - `resolveKnexFactory(moduleNamespace)`
 - `resolveMysqlSnapshotFromDatabase({ appRoot, tableName, idColumn } = {})`
 - `resolveColumnKey(column, idColumn)`
+- `normalizeNumericBoundValue(value, scale = null)`
+- `resolveNumericExclusiveStep(column)`
+- `applyLowerBound(current = null, candidate = null)`
+- `applyUpperBound(current = null, candidate = null)`
+- `applyNumericConstraintBound(target = {}, column = null, operator = "", rawValue = null)`
+- `resolveColumnNumericBounds(snapshot = {})`
 - `isIdentifier(value)`
 - `renderObjectPropertyKey(value)`
 - `renderIntegerSchema(column)`
 - `renderStringSchema(column, { forOutput = false } = {})`
-- `renderResourceValidatorsImport({ needsHtmlTimeSchemas = false, needsRecordIdSchemas = false } = {})`
+- `renderResourceValidatorsImport({ htmlTimeSchemaImports = [], recordIdValidatorImports = [] } = {})`
+- `resolveHtmlTimeSchemaImports(columns = [])`
+- `resolveRecordIdValidatorImports(...sources)`
 - `renderResourceSchemaPropertyLines(columns, { forOutput = false } = {})`
 - `renderResourceInputNormalizationLines(columns)`
 - `renderResourceOutputNormalizationLines(columns)`

--- a/packages/agent-docs/reference/autogen/packages/crud-ui-generator.md
+++ b/packages/agent-docs/reference/autogen/packages/crud-ui-generator.md
@@ -32,6 +32,12 @@ Local functions
 - `parseDisplayFieldsOption(options)`
 - `validateDisplayFieldsForOperation(selectedFieldKeys, fields, operationName)`
 - `filterDisplayFields(selectedFieldKeys, fields)`
+- `rewriteGeneratedBlockIndent(source = "", { trimPrefix = "", addPrefix = "" } = {})`
+- `hasLookupFormFields(fields = [])`
+- `buildLookupImportLine(fields = [])`
+- `buildLookupRuntimeSetup(fields = [], { formFieldsVariable = "", resourceNamespace = "", mode = "" } = {})`
+- `buildLookupFormProps(fields = [])`
+- `buildLookupFormPropDefinitions({ createFields = [], editFields = [] } = {})`
 - `filterDefaultHiddenListFields(selectedFieldKeys, fields, { recordIdFieldKey = "" } = {})`
 - `ensureFields(fields, fallbackFields = createFieldDefinitions({}))`
 - `resolveViewTitleFallbackFieldKey(fields = [])`
@@ -88,6 +94,7 @@ Local functions
 - `toOptionalAccessorExpression(baseName, fieldKey)`
 - `escapeHtml(value)`
 - `serializeTemplateBindingValue(value)`
+- `renderTemplateJsStringLiteral(value)`
 - `isLookupField(field = {})`
 - `toLookupDisplayFieldDescriptor(field = {})`
 - `toLookupDisplayFieldExpression(field = {})`
@@ -117,6 +124,7 @@ Local functions
 Exports
 - None
 Local functions
+- `resolveFieldErrors(fieldKey)`
 - `resolveCancelTo(target)`
 
 ### `templates/src/pages/admin/ui-generator/AddEditFormFields.js`
@@ -127,6 +135,8 @@ Exports
 ### `templates/src/pages/admin/ui-generator/EditElement.vue`
 Exports
 - None
+Local functions
+- `resolveFieldErrors(fieldKey)`
 
 ### `templates/src/pages/admin/ui-generator/EditWrapperElement.vue`
 Exports
@@ -139,6 +149,8 @@ Exports
 ### `templates/src/pages/admin/ui-generator/NewElement.vue`
 Exports
 - None
+Local functions
+- `resolveFieldErrors(fieldKey)`
 
 ### `templates/src/pages/admin/ui-generator/NewWrapperElement.vue`
 Exports

--- a/packages/agent-docs/reference/autogen/packages/kernel.md
+++ b/packages/agent-docs/reference/autogen/packages/kernel.md
@@ -600,6 +600,12 @@ Local functions
 - `normalizeClientModuleEntries(clientModules)`
 - `createClientRuntimeApp({ profile = "client", app, pinia = null, router, env, logger, surfaceRuntime, surfaceMode } = {})`
 
+### `client/pageRedirects.js`
+Exports
+- `redirectToChild(childTarget = "")`
+Local functions
+- `queryStringToObject(queryString = "")`
+
 ### `client/shellBootstrap.js`
 Exports
 - `resolveClientBootstrapDebugEnabled({ env = {}, debugEnabled = undefined, debugEnvKey = "VITE_JSKIT_CLIENT_DEBUG" } = {})`

--- a/packages/agent-docs/reference/autogen/packages/users-core.md
+++ b/packages/agent-docs/reference/autogen/packages/users-core.md
@@ -20,7 +20,7 @@ Exports
 
 ### `src/server/accountNotifications/accountNotificationsService.js`
 Exports
-- `createService({ userSettingsRepository, usersRepository, authService } = {})`
+- `createService({ userSettingsRepository, userProfilesRepository, authService } = {})`
 
 ### `src/server/accountNotifications/bootAccountNotificationsRoutes.js`
 Exports
@@ -36,7 +36,7 @@ Exports
 
 ### `src/server/accountPreferences/accountPreferencesService.js`
 Exports
-- `createService({ userSettingsRepository, usersRepository, authService } = {})`
+- `createService({ userSettingsRepository, userProfilesRepository, authService } = {})`
 
 ### `src/server/accountPreferences/bootAccountPreferencesRoutes.js`
 Exports
@@ -52,11 +52,11 @@ Exports
 
 ### `src/server/accountProfile/accountProfileService.js`
 Exports
-- `createService({ userSettingsRepository, usersRepository, authService, avatarService } = {})`
+- `createService({ userSettingsRepository, userProfilesRepository, authService, avatarService } = {})`
 
 ### `src/server/accountProfile/avatarService.js`
 Exports
-- `createService({ usersRepository, avatarStorageService, avatarPolicy } = {})`
+- `createService({ userProfilesRepository, avatarStorageService, avatarPolicy } = {})`
 - `__testables`
 Local functions
 - `resolveAvatarPolicy(policy = {})`
@@ -83,7 +83,7 @@ Exports
 
 ### `src/server/accountSecurity/accountSecurityService.js`
 Exports
-- `createService({ userSettingsRepository, usersRepository, authService } = {})`
+- `createService({ userSettingsRepository, userProfilesRepository, authService } = {})`
 
 ### `src/server/accountSecurity/bootAccountSecurityRoutes.js`
 Exports
@@ -138,20 +138,12 @@ Exports
 - `toDbJson(value, fallback = {})`
 - `createWithTransaction`
 
-### `src/server/common/repositories/userSettingsRepository.js`
+### `src/server/common/repositories/userProfilesRepository.js`
 Exports
 - `createRepository(knex)`
-- `mapRow(row)`
 Local functions
-- `normalizeBoolean(value, fallback = false)`
-- `createInsertPayload(userId)`
-
-### `src/server/common/repositories/usersRepository.js`
-Exports
-- `createRepository(knex)`
-- `mapProfileRow(row)`
-- `normalizeIdentity(identityLike)`
-Local functions
+- `normalizeProfileRecord(payload)`
+- `normalizeCreatePayload(payload = {})`
 - `normalizeUsername(value)`
 - `usernameBaseFromEmail(email)`
 - `buildUsernameCandidate(baseUsername, suffix)`
@@ -160,14 +152,32 @@ Local functions
 - `createDuplicateEmailConflictError()`
 - `resolveUniqueUsername(client, baseUsername, { excludeUserId = null } = {})`
 
+### `src/server/common/repositories/userSettingsRepository.js`
+Exports
+- `createRepository(knex)`
+- `mapRow(row)`
+Local functions
+- `normalizeBoolean(value, fallback = false)`
+- `createInsertPayload(userId)`
+
+### `src/server/common/resources/userProfilesResource.js`
+Exports
+- `resource`
+Local functions
+- `normalizeUsername(value)`
+- `normalizeNullableString(value)`
+- `normalizeNullableVersion(value)`
+- `normalizeProfileRecord(payload = {})`
+- `normalizeCreatePayload(payload = {})`
+
 ### `src/server/common/services/accountContextService.js`
 Exports
-- `resolveUserProfile(usersRepository, user)`
+- `resolveUserProfile(userProfilesRepository, user)`
 - `resolveSecurityStatus(authService, request)`
 
 ### `src/server/common/services/authProfileSyncService.js`
 Exports
-- `createService({ usersRepository, lifecycleContributors = [], userSettingsRepository = null } = {})`
+- `createService({ userProfilesRepository, lifecycleContributors = [], userSettingsRepository = null } = {})`
 Local functions
 - `buildNormalizedIdentityKey(identityLike)`
 - `buildNormalizedIdentityProfile(profileLike)`
@@ -178,6 +188,10 @@ Local functions
 ### `src/server/common/support/deepFreeze.js`
 Exports
 - `deepFreeze`
+
+### `src/server/common/support/identity.js`
+Exports
+- `normalizeIdentity(identityLike)`
 
 ### `src/server/common/support/realtimeServiceEvents.js`
 Exports
@@ -213,7 +227,7 @@ Exports
 
 ### `src/server/usersBootstrapContributor.js`
 Exports
-- `createUsersBootstrapContributor({ usersRepository, userSettingsRepository, appConfig = {}, authService } = {})`
+- `createUsersBootstrapContributor({ userProfilesRepository, userSettingsRepository, appConfig = {}, authService } = {})`
 Local functions
 - `getOAuthProviderCatalogPayload(authService)`
 - `normalizeBoolean(value, fallback)`
@@ -293,6 +307,71 @@ Exports
 - None
 Local functions
 - `normalizePositiveInteger(value, fallback)`
+
+### `templates/packages/users-workspace/package.descriptor.mjs`
+Exports
+- None
+
+### `templates/packages/users-workspace/src/server/actions.js`
+Exports
+- `createActions({ surface = "" } = {})`
+Local functions
+- `requireActionSurface(surface = "")`
+
+### `templates/packages/users-workspace/src/server/registerRoutes.js`
+Exports
+- `registerRoutes(app, { routeOwnershipFilter = "public", routeSurface = "", routeSurfaceRequiresWorkspace = false, routeRelativePath = "" } = {})`
+
+### `templates/packages/users-workspace/src/server/UsersProvider.js`
+Exports
+- `UsersProvider`
+Local functions
+- `resolveCrudPolicyFromApp(app)`
+
+### `templates/packages/users/package.descriptor.mjs`
+Exports
+- None
+
+### `templates/packages/users/src/server/actionIds.js`
+Exports
+- `actionIds`
+
+### `templates/packages/users/src/server/actions.js`
+Exports
+- `createActions({ surface = "" } = {})`
+Local functions
+- `requireActionSurface(surface = "")`
+
+### `templates/packages/users/src/server/listConfig.js`
+Exports
+- `LIST_CONFIG`
+
+### `templates/packages/users/src/server/registerRoutes.js`
+Exports
+- `registerRoutes(app, { routeOwnershipFilter = "public", routeSurface = "", routeRelativePath = "" } = {})`
+
+### `templates/packages/users/src/server/repository.js`
+Exports
+- `createRepository(knex, options = {})`
+
+### `templates/packages/users/src/server/service.js`
+Exports
+- `createService({ usersRepository } = {})`
+- `serviceEvents`
+
+### `templates/packages/users/src/server/UsersProvider.js`
+Exports
+- `UsersProvider`
+Local functions
+- `resolveCrudPolicyFromApp(app)`
+
+### `templates/packages/users/src/shared/index.js`
+Exports
+- `resource`
+
+### `templates/packages/users/src/shared/userResource.js`
+Exports
+- `resource`
 
 ### root
 

--- a/packages/agent-docs/reference/autogen/packages/users-web.md
+++ b/packages/agent-docs/reference/autogen/packages/users-web.md
@@ -16,8 +16,7 @@ Use this on demand; do not load the full index at startup.
 
 ### `src/client/account-settings/sections.js`
 Exports
-- `ACCOUNT_SETTINGS_SECTIONS_INJECTION_KEY`
-- `ACCOUNT_SETTINGS_SECTION_REGISTRY_TAG`
+- `ACCOUNT_SETTINGS_SECTION_TARGET`
 - `EMPTY_ACCOUNT_SETTINGS_SECTIONS`
 - `RESERVED_ACCOUNT_SETTINGS_SECTION_VALUES`
 - `normalizeAccountSettingsSectionEntry(entry = null)`
@@ -171,7 +170,7 @@ Exports
 
 ### `src/client/composables/records/useView.js`
 Exports
-- `useView({ ownershipFilter = ROUTE_VISIBILITY_WORKSPACE, surfaceId = "", access = "auto", apiSuffix = "", queryKeyFactory = null, viewPermissions = [], readMethod = "GET", readEnabled = true, placementSource = "users-web.view", fallbackLoadError = "Unable to load resource.", notFoundStatuses = [404], notFoundMessage = "Record not found.", model, mapLoadedToModel, recordIdParam = "recordId", routeParams = null, routeRecordId = null, apiUrlTemplate = "", listUrlTemplate = "", editUrlTemplate = "", includeRecordIdInQueryKey = false, realtime = null, adapter = null } = {})`
+- `useView({ ownershipFilter = ROUTE_VISIBILITY_WORKSPACE, surfaceId = "", access = "auto", apiSuffix = "", queryKeyFactory = null, viewPermissions = [], readMethod = "GET", readEnabled = true, placementSource = "users-web.view", fallbackLoadError = "Unable to load resource.", notFoundStatuses = [404], notFoundMessage = "Record not found.", model, mapLoadedToModel, requestQueryParams = null, recordIdParam = "recordId", routeParams = null, routeRecordId = null, apiUrlTemplate = "", listUrlTemplate = "", editUrlTemplate = "", includeRecordIdInQueryKey = false, realtime = null, adapter = null } = {})`
 
 ### `src/client/composables/runtime/addEditUiRuntime.js`
 Exports
@@ -297,6 +296,10 @@ Local functions
 Exports
 - `resolveEnabledRef(value)`
 - `resolveTextRef(value)`
+
+### `src/client/composables/support/requestQueryPathSupport.js`
+Exports
+- `appendRequestQueryEntriesToPath(path = "", entries = [])`
 
 ### `src/client/composables/support/resourceLoadStateHelpers.js`
 Exports
@@ -456,10 +459,6 @@ Exports
 Local functions
 - `resolveSystemThemeName({ prefersDark } = {})`
 - `resolveThemePreferenceStorage(options = {})`
-
-### `src/client/providers/bootUsersWebClientProvider.js`
-Exports
-- `bootUsersWebClientProvider(app)`
 
 ### `src/client/providers/UsersWebClientProvider.js`
 Exports

--- a/packages/agent-docs/reference/autogen/packages/workspaces-core.md
+++ b/packages/agent-docs/reference/autogen/packages/workspaces-core.md
@@ -55,19 +55,47 @@ Exports
 ### `src/server/common/repositories/workspaceInvitesRepository.js`
 Exports
 - `createRepository(knex)`
-- `mapRow(row)`
+- `normalizeInviteRecord(payload)`
+- `normalizeInviteWithWorkspace(payload = {})`
+Local functions
+- `normalizeInvitePatchPayload(payload = {})`
 
 ### `src/server/common/repositories/workspaceMembershipsRepository.js`
 Exports
 - `createRepository(knex)`
-- `mapRow(row)`
-- `mapMemberSummaryRow(row)`
+- `normalizeMembershipRecord(payload)`
+- `normalizeMemberSummaryRow(row)`
+Local functions
+- `normalizeMembershipPatchPayload(payload = {})`
 
 ### `src/server/common/repositories/workspacesRepository.js`
 Exports
 - `createRepository(knex)`
-- `mapRow(row)`
-- `mapMembershipWorkspaceRow(row)`
+- `normalizeWorkspaceRecord(payload)`
+- `normalizeMembershipWorkspaceRow(row)`
+Local functions
+- `normalizeCreatePayload(payload = {})`
+
+### `src/server/common/resources/workspaceInvitesResource.js`
+Exports
+- `workspaceInvitesResource`
+Local functions
+- `normalizeInviteRecord(payload = {})`
+- `normalizeInviteInput(payload = {})`
+
+### `src/server/common/resources/workspaceMembershipsResource.js`
+Exports
+- `workspaceMembershipsResource`
+Local functions
+- `normalizeMembershipRecord(payload = {})`
+- `normalizeMembershipInput(payload = {})`
+
+### `src/server/common/resources/workspacesResource.js`
+Exports
+- `workspacesResource`
+Local functions
+- `normalizeWorkspaceRecord(payload = {})`
+- `normalizeWorkspaceInput(payload = {})`
 
 ### `src/server/common/services/workspaceContextService.js`
 Exports
@@ -160,7 +188,7 @@ Exports
 
 ### `src/server/workspaceBootstrapContributor.js`
 Exports
-- `createWorkspaceBootstrapContributor({ workspaceService, workspacePendingInvitationsService, usersRepository, workspaceInvitationsEnabled = false, appConfig = {}, tenancyProfile = null } = {})`
+- `createWorkspaceBootstrapContributor({ workspaceService, workspacePendingInvitationsService, userProfilesRepository, workspaceInvitationsEnabled = false, appConfig = {}, tenancyProfile = null } = {})`
 Local functions
 - `normalizePendingInvites(invites)`
 - `normalizeQueryPayload(value = {})`

--- a/packages/agent-docs/reference/autogen/packages/workspaces-web.md
+++ b/packages/agent-docs/reference/autogen/packages/workspaces-web.md
@@ -337,6 +337,10 @@ Local functions
 - `resolveReturnToHref()`
 - `countPendingInvites(entries = [])`
 
+### `templates/packages/main/src/client/components/AccountSettingsInvitesSection.vue`
+Exports
+- None
+
 ### `templates/src/components/WorkspaceNotFoundCard.vue`
 Exports
 - None

--- a/packages/agent-docs/site/guide/app-setup/a-more-interesting-shell.md
+++ b/packages/agent-docs/site/guide/app-setup/a-more-interesting-shell.md
@@ -268,6 +268,16 @@ In JSKIT's file-based routing, a page file can act as a layout if it renders a `
 - `src/pages/home/settings/general/index.vue` is the first real child page created by the starter shell.
 - `src/pages/home/settings/profile/index.vue` becomes `/home/settings/profile` and still renders inside the layout from `settings.vue`.
 
+JSKIT uses a small helper for that redirect instead of hand-building the child path:
+
+```js
+import { redirectToChild } from "@jskit-ai/kernel/client/pageRedirects";
+
+definePage({
+  redirect: redirectToChild("general")
+});
+```
+
 This is why the `home-settings:primary-menu` outlet from `list-placements` is such a useful clue: it tells you which page is acting as the host.
 
 Even an `index.vue` page can have children. If you want an index page to stay visible while child routes render underneath it, put those children under an `index/` directory such as `src/pages/home/settings/profile/index/details.vue`.
@@ -711,6 +721,16 @@ The starter shell now uses a real child-page structure right away:
 - `src/pages/home/settings/index.vue` is only a redirect into the first child page
 - `src/pages/home/settings/general/index.vue` is the first real settings page
 - `src/placement.js` already seeds a `General` link into `home-settings:primary-menu`
+
+When you need that landing redirect yourself, use the same helper pattern:
+
+```js
+import { redirectToChild } from "@jskit-ai/kernel/client/pageRedirects";
+
+definePage({
+  redirect: redirectToChild("general")
+});
+```
 
 That is what makes the page-generation examples in this chapter important. They are not inventing a new pattern. They are extending the exact same host-and-child-page structure that `shell-web` already uses for its own starter `General` page.
 

--- a/packages/console-web/templates/src/pages/console/settings/index.vue
+++ b/packages/console-web/templates/src/pages/console/settings/index.vue
@@ -1,7 +1,8 @@
 <script setup>
 // To redirect this settings shell to a child page, uncomment and edit the example below.
+// import { redirectToChild } from "@jskit-ai/kernel/client/pageRedirects";
 // definePage({
-//   redirect: (to) => `${to.path}/your_child_segment`
+//   redirect: redirectToChild("your_child_segment")
 // });
 </script>
 

--- a/packages/kernel/client/pageRedirects.d.ts
+++ b/packages/kernel/client/pageRedirects.d.ts
@@ -1,0 +1,5 @@
+export function redirectToChild(childTarget?: string): (to?: any) => {
+  path: string;
+  query: any;
+  hash: string;
+};

--- a/packages/kernel/client/pageRedirects.js
+++ b/packages/kernel/client/pageRedirects.js
@@ -1,0 +1,45 @@
+import { resolveLinkPath } from "../shared/support/linkPath.js";
+import { splitPathQueryAndHash } from "../shared/support/queryPath.js";
+
+function queryStringToObject(queryString = "") {
+  const normalizedQueryString = String(queryString || "").trim().replace(/^\?+/, "");
+  if (!normalizedQueryString) {
+    return undefined;
+  }
+
+  const params = new URLSearchParams(normalizedQueryString);
+  const query = {};
+
+  for (const [key, value] of params.entries()) {
+    if (!Object.prototype.hasOwnProperty.call(query, key)) {
+      query[key] = value;
+      continue;
+    }
+
+    if (Array.isArray(query[key])) {
+      query[key].push(value);
+      continue;
+    }
+
+    query[key] = [query[key], value];
+  }
+
+  return query;
+}
+
+function redirectToChild(childTarget = "") {
+  const normalizedChildTarget = String(childTarget || "").trim();
+
+  return function redirectToChildRoute(to = {}) {
+    const resolvedTarget = resolveLinkPath(String(to?.path || "/"), normalizedChildTarget);
+    const { pathname, queryString, hash } = splitPathQueryAndHash(resolvedTarget);
+
+    return {
+      path: pathname || "/",
+      query: queryStringToObject(queryString) ?? to?.query,
+      hash: hash || String(to?.hash || "")
+    };
+  };
+}
+
+export { redirectToChild };

--- a/packages/kernel/client/pageRedirects.test.js
+++ b/packages/kernel/client/pageRedirects.test.js
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { redirectToChild } from "./pageRedirects.js";
+
+test("redirectToChild resolves a child path and preserves incoming query and hash", () => {
+  const redirect = redirectToChild("general");
+
+  assert.deepEqual(redirect({
+    path: "/home/settings/",
+    query: {
+      tab: "profile"
+    },
+    hash: "#advanced"
+  }), {
+    path: "/home/settings/general",
+    query: {
+      tab: "profile"
+    },
+    hash: "#advanced"
+  });
+});
+
+test("redirectToChild uses child query and hash when the target declares them", () => {
+  const redirect = redirectToChild("general?tab=security&filter=a&filter=b#advanced");
+
+  assert.deepEqual(redirect({
+    path: "/home/settings",
+    query: {
+      stale: "value"
+    },
+    hash: "#old"
+  }), {
+    path: "/home/settings/general",
+    query: {
+      tab: "security",
+      filter: ["a", "b"]
+    },
+    hash: "#advanced"
+  });
+});

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -14,6 +14,10 @@
       "types": "./client/index.d.ts",
       "default": "./client/index.js"
     },
+    "./client/pageRedirects": {
+      "types": "./client/pageRedirects.d.ts",
+      "default": "./client/pageRedirects.js"
+    },
     "./client/moduleBootstrap": "./client/moduleBootstrap.js",
     "./client/vite": "./client/vite/index.js",
     "./server/actions": "./server/actions/index.js",

--- a/packages/shell-web/templates/src/pages/home/settings/index.vue
+++ b/packages/shell-web/templates/src/pages/home/settings/index.vue
@@ -1,5 +1,7 @@
 <script setup>
+import { redirectToChild } from "@jskit-ai/kernel/client/pageRedirects";
+
 definePage({
-  redirect: (to) => `${String(to.path || "").replace(/\/$/, "")}/general`
+  redirect: redirectToChild("general")
 });
 </script>

--- a/packages/shell-web/test/settingsPlacementContract.test.js
+++ b/packages/shell-web/test/settingsPlacementContract.test.js
@@ -42,9 +42,9 @@ test("shell-web home settings template exposes surface-derived settings outlets"
 test("shell-web settings landing page redirects to the starter child page", async () => {
   const source = await readFile(path.join(PACKAGE_DIR, "templates", "src", "pages", "home", "settings", "index.vue"), "utf8");
 
+  assert.match(source, /@jskit-ai\/kernel\/client\/pageRedirects/);
   assert.match(source, /definePage/);
-  assert.match(source, /redirect:/);
-  assert.match(source, /\/general/);
+  assert.match(source, /redirectToChild\("general"\)/);
 });
 
 test("shell-web settings general child page exposes a tiny browser-local drawer preference", async () => {

--- a/packages/workspaces-web/package.descriptor.mjs
+++ b/packages/workspaces-web/package.descriptor.mjs
@@ -72,6 +72,12 @@ export default Object.freeze({
             defaultLinkComponentToken: "local.main.ui.surface-aware-menu-link-item",
             surfaces: ["admin"],
             source: "templates/src/pages/admin/workspace/settings.vue"
+          },
+          {
+            target: "workspace-tools:primary-menu",
+            defaultLinkComponentToken: "local.main.ui.surface-aware-menu-link-item",
+            surfaces: ["admin"],
+            source: "src/client/components/UsersWorkspaceToolsWidget.vue"
           }
         ],
         contributions: [

--- a/packages/workspaces-web/templates/src/pages/admin/workspace/settings/index.vue
+++ b/packages/workspaces-web/templates/src/pages/admin/workspace/settings/index.vue
@@ -1,7 +1,8 @@
 <script setup>
 // To redirect this settings shell to a child page, uncomment and edit the example below.
+// import { redirectToChild } from "@jskit-ai/kernel/client/pageRedirects";
 // definePage({
-//   redirect: (to) => `${to.path}/your_child_segment`
+//   redirect: redirectToChild("your_child_segment")
 // });
 </script>
 

--- a/packages/workspaces-web/test/settingsPlacementContract.test.js
+++ b/packages/workspaces-web/test/settingsPlacementContract.test.js
@@ -8,10 +8,11 @@ import descriptor from "../package.descriptor.mjs";
 const TEST_DIRECTORY = path.dirname(fileURLToPath(import.meta.url));
 const PACKAGE_DIR = path.resolve(TEST_DIRECTORY, "..");
 
-function readSettingsOutlets() {
+function readOutlets(target = "") {
   const outlets = descriptor?.metadata?.ui?.placements?.outlets;
+  const normalizedTarget = String(target || "").trim();
   return Array.isArray(outlets)
-    ? outlets.filter((entry) => String(entry?.target || "").trim() === "admin-settings:primary-menu")
+    ? outlets.filter((entry) => String(entry?.target || "").trim() === normalizedTarget)
     : [];
 }
 
@@ -78,13 +79,24 @@ test("workspaces-web admin settings index template is a simple developer-owned s
 
 test("workspaces-web descriptor metadata advertises admin settings outlets", () => {
   assert.deepEqual(
-    readSettingsOutlets(),
+    readOutlets("admin-settings:primary-menu"),
     [
       {
         target: "admin-settings:primary-menu",
         defaultLinkComponentToken: "local.main.ui.surface-aware-menu-link-item",
         surfaces: ["admin"],
         source: "templates/src/pages/admin/workspace/settings.vue"
+      }
+    ]
+  );
+  assert.deepEqual(
+    readOutlets("workspace-tools:primary-menu"),
+    [
+      {
+        target: "workspace-tools:primary-menu",
+        defaultLinkComponentToken: "local.main.ui.surface-aware-menu-link-item",
+        surfaces: ["admin"],
+        source: "src/client/components/UsersWorkspaceToolsWidget.vue"
       }
     ]
   );


### PR DESCRIPTION
## Summary
- add a shared `redirectToChild()` helper in `@jskit-ai/kernel/client/pageRedirects`
- update shell/settings templates and workspaces settings docs to use the helper pattern
- add the workspace tools outlet metadata and refresh generated agent docs

## Verification
- `node --test client/pageRedirects.test.js`
- `node --test test/settingsPlacementContract.test.js` in `packages/shell-web`
- `node --test test/settingsPlacementContract.test.js` in `packages/workspaces-web`
- `npm run agent-docs:build`