### PR TITLE
Rename tools outlets to cog contracts

### DIFF
--- a/packages/agent-docs/guide/agent/app-setup/multi-homing.md
+++ b/packages/agent-docs/guide/agent/app-setup/multi-homing.md
@@ -535,7 +535,7 @@ addPlacement({
 
 addPlacement({
   id: "workspaces.workspace.menu.workspace-settings",
-  target: "workspace-tools:primary-menu",
+  target: "admin-cog:primary-menu",
   surfaces: ["admin"],
   order: 100,
   componentToken: "workspaces.web.workspace-settings.menu-item"
@@ -543,7 +543,7 @@ addPlacement({
 
 addPlacement({
   id: "workspaces.workspace.menu.members",
-  target: "workspace-tools:primary-menu",
+  target: "admin-cog:primary-menu",
   surfaces: ["admin"],
   order: 200,
   componentToken: "workspaces.web.workspace-members.menu-item"

--- a/packages/agent-docs/reference/autogen/packages/users-web.md
+++ b/packages/agent-docs/reference/autogen/packages/users-web.md
@@ -472,8 +472,8 @@ Exports
 
 ### `src/shared/toolsOutletContracts.js`
 Exports
-- `DEFAULT_TOOLS_LINK_COMPONENT_TOKEN`
-- `HOME_TOOLS_OUTLET`
+- `DEFAULT_COG_LINK_COMPONENT_TOKEN`
+- `HOME_COG_OUTLET`
 
 ### templates
 

--- a/packages/agent-docs/reference/autogen/packages/workspaces-web.md
+++ b/packages/agent-docs/reference/autogen/packages/workspaces-web.md
@@ -323,8 +323,8 @@ Local functions
 
 ### `src/shared/toolsOutletContracts.js`
 Exports
-- `DEFAULT_TOOLS_LINK_COMPONENT_TOKEN`
-- `WORKSPACE_TOOLS_OUTLET`
+- `DEFAULT_COG_LINK_COMPONENT_TOKEN`
+- `ADMIN_COG_OUTLET`
 
 ### templates
 

--- a/packages/agent-docs/site/guide/app-setup/multi-homing.md
+++ b/packages/agent-docs/site/guide/app-setup/multi-homing.md
@@ -673,7 +673,7 @@ addPlacement({
 
 addPlacement({
   id: "workspaces.workspace.menu.workspace-settings",
-  target: "workspace-tools:primary-menu",
+  target: "admin-cog:primary-menu",
   surfaces: ["admin"],
   order: 100,
   componentToken: "workspaces.web.workspace-settings.menu-item"
@@ -681,7 +681,7 @@ addPlacement({
 
 addPlacement({
   id: "workspaces.workspace.menu.members",
-  target: "workspace-tools:primary-menu",
+  target: "admin-cog:primary-menu",
   surfaces: ["admin"],
   order: 200,
   componentToken: "workspaces.web.workspace-members.menu-item"

--- a/packages/kernel/server/support/shellOutlets.test.js
+++ b/packages/kernel/server/support/shellOutlets.test.js
@@ -98,7 +98,7 @@ test("discoverShellOutletTargetsFromApp includes installed package placement out
       placements: {
         outlets: [
           {
-            target: "workspace-tools:primary-menu",
+            target: "admin-cog:primary-menu",
             defaultLinkComponentToken: "local.main.ui.surface-aware-menu-link-item",
             source: "src/client/components/UsersWorkspaceToolsWidget.vue"
           }
@@ -113,10 +113,10 @@ test("discoverShellOutletTargetsFromApp includes installed package placement out
     const discovered = await discoverShellOutletTargetsFromApp({ appRoot });
     assert.deepEqual(
       discovered.targets.map((entry) => entry.id),
-      ["shell-layout:primary-menu", "workspace-tools:primary-menu"]
+      ["admin-cog:primary-menu", "shell-layout:primary-menu"]
     );
-    assert.deepEqual(discovered.targets[1], {
-      id: "workspace-tools:primary-menu",
+    assert.deepEqual(discovered.targets[0], {
+      id: "admin-cog:primary-menu",
       default: false,
       defaultLinkComponentToken: "local.main.ui.surface-aware-menu-link-item",
       sourcePath: "package:@example/users-web:src/client/components/UsersWorkspaceToolsWidget.vue",
@@ -125,10 +125,10 @@ test("discoverShellOutletTargetsFromApp includes installed package placement out
 
     const target = await resolveShellOutletPlacementTargetFromApp({
       appRoot,
-      placement: "workspace-tools:primary-menu",
+      placement: "admin-cog:primary-menu",
       context: "ui-generator"
     });
-    assert.equal(target.id, "workspace-tools:primary-menu");
+    assert.equal(target.id, "admin-cog:primary-menu");
   });
 });
 
@@ -140,7 +140,7 @@ test("discoverShellOutletTargetsFromApp applies app config default-link override
       `export const config = {
   ui: {
     outletDefaults: {
-      "workspace-tools:primary-menu": {
+      "admin-cog:primary-menu": {
         linkComponentToken: "local.main.ui.surface-aware-menu-link-item"
       }
     }
@@ -178,7 +178,7 @@ test("discoverShellOutletTargetsFromApp applies app config default-link override
       placements: {
         outlets: [
           {
-            target: "workspace-tools:primary-menu",
+            target: "admin-cog:primary-menu",
             defaultLinkComponentToken: "local.main.ui.surface-aware-menu-link-item"
           }
         ]

--- a/packages/ui-generator/test/buildTemplateContext.test.js
+++ b/packages/ui-generator/test/buildTemplateContext.test.js
@@ -166,7 +166,7 @@ test("buildUiPageTemplateContext supports explicit package outlet link placement
       placements: {
         outlets: [
           {
-            target: "workspace-tools:primary-menu",
+            target: "admin-cog:primary-menu",
             defaultLinkComponentToken: "local.main.ui.surface-aware-menu-link-item",
             source: "src/client/components/UsersWorkspaceToolsWidget.vue"
           }
@@ -182,10 +182,10 @@ test("buildUiPageTemplateContext supports explicit package outlet link placement
       appRoot,
       targetFile: "admin/reports/index.vue",
       options: {
-        "link-placement": "workspace-tools:primary-menu"
+        "link-placement": "admin-cog:primary-menu"
       }
     });
-    assert.equal(context.__JSKIT_UI_LINK_PLACEMENT_TARGET__, "workspace-tools:primary-menu");
+    assert.equal(context.__JSKIT_UI_LINK_PLACEMENT_TARGET__, "admin-cog:primary-menu");
   });
 });
 

--- a/packages/users-web/package.descriptor.mjs
+++ b/packages/users-web/package.descriptor.mjs
@@ -1,4 +1,4 @@
-import { HOME_TOOLS_OUTLET } from "./src/shared/toolsOutletContracts.js";
+import { HOME_COG_OUTLET } from "./src/shared/toolsOutletContracts.js";
 
 export default Object.freeze({
   packageVersion: 1,
@@ -111,8 +111,8 @@ export default Object.freeze({
       placements: {
         outlets: [
           {
-            target: HOME_TOOLS_OUTLET.target,
-            defaultLinkComponentToken: HOME_TOOLS_OUTLET.defaultLinkComponentToken,
+            target: HOME_COG_OUTLET.target,
+            defaultLinkComponentToken: HOME_COG_OUTLET.defaultLinkComponentToken,
             surfaces: ["home"],
             source: "src/client/components/UsersHomeToolsWidget.vue"
           },
@@ -143,7 +143,7 @@ export default Object.freeze({
           },
           {
             id: "users.home.menu.settings",
-            target: "home-tools:primary-menu",
+            target: "home-cog:primary-menu",
             surfaces: ["home"],
             order: 100,
             componentToken: "local.main.ui.surface-aware-menu-link-item",
@@ -243,7 +243,7 @@ export default Object.freeze({
         position: "bottom",
         skipIfContains: "id: \"users.home.tools.widget\"",
         value:
-          "\naddPlacement({\n  id: \"users.home.tools.widget\",\n  target: \"shell-layout:top-right\",\n  surfaces: [\"home\"],\n  order: 900,\n  componentToken: \"users.web.home.tools.widget\",\n  when: ({ auth }) => auth?.authenticated === true\n});\n\naddPlacement({\n  id: \"users.home.menu.settings\",\n  target: \"home-tools:primary-menu\",\n  surfaces: [\"home\"],\n  order: 100,\n  componentToken: \"local.main.ui.surface-aware-menu-link-item\",\n  props: {\n    label: \"Settings\",\n    surface: \"home\",\n    scopedSuffix: \"/settings\",\n    unscopedSuffix: \"/settings\"\n  },\n  when: ({ auth }) => auth?.authenticated === true\n});\n",
+          "\naddPlacement({\n  id: \"users.home.tools.widget\",\n  target: \"shell-layout:top-right\",\n  surfaces: [\"home\"],\n  order: 900,\n  componentToken: \"users.web.home.tools.widget\",\n  when: ({ auth }) => auth?.authenticated === true\n});\n\naddPlacement({\n  id: \"users.home.menu.settings\",\n  target: \"home-cog:primary-menu\",\n  surfaces: [\"home\"],\n  order: 100,\n  componentToken: \"local.main.ui.surface-aware-menu-link-item\",\n  props: {\n    label: \"Settings\",\n    surface: \"home\",\n    scopedSuffix: \"/settings\",\n    unscopedSuffix: \"/settings\"\n  },\n  when: ({ auth }) => auth?.authenticated === true\n});\n",
         reason: "Append users-web home tools widget and settings menu placements into app-owned placement registry.",
         category: "users-web",
         id: "users-web-home-tools-placement"

--- a/packages/users-web/src/client/components/UsersHomeToolsWidget.vue
+++ b/packages/users-web/src/client/components/UsersHomeToolsWidget.vue
@@ -1,12 +1,12 @@
 <script setup>
 import ShellOutletMenuWidget from "@jskit-ai/shell-web/client/components/ShellOutletMenuWidget";
-import { HOME_TOOLS_OUTLET } from "../../shared/toolsOutletContracts.js";
+import { HOME_COG_OUTLET } from "../../shared/toolsOutletContracts.js";
 </script>
 
 <template>
   <ShellOutletMenuWidget
-    :target="HOME_TOOLS_OUTLET.target"
-    :default-link-component-token="HOME_TOOLS_OUTLET.defaultLinkComponentToken"
-    :aria-label="HOME_TOOLS_OUTLET.ariaLabel"
+    :target="HOME_COG_OUTLET.target"
+    :default-link-component-token="HOME_COG_OUTLET.defaultLinkComponentToken"
+    :aria-label="HOME_COG_OUTLET.ariaLabel"
   />
 </template>

--- a/packages/users-web/src/shared/toolsOutletContracts.js
+++ b/packages/users-web/src/shared/toolsOutletContracts.js
@@ -1,12 +1,12 @@
-const DEFAULT_TOOLS_LINK_COMPONENT_TOKEN = "local.main.ui.surface-aware-menu-link-item";
+const DEFAULT_COG_LINK_COMPONENT_TOKEN = "local.main.ui.surface-aware-menu-link-item";
 
-const HOME_TOOLS_OUTLET = Object.freeze({
-  target: "home-tools:primary-menu",
-  defaultLinkComponentToken: DEFAULT_TOOLS_LINK_COMPONENT_TOKEN,
-  ariaLabel: "Home tools"
+const HOME_COG_OUTLET = Object.freeze({
+  target: "home-cog:primary-menu",
+  defaultLinkComponentToken: DEFAULT_COG_LINK_COMPONENT_TOKEN,
+  ariaLabel: "Home cog"
 });
 
 export {
-  DEFAULT_TOOLS_LINK_COMPONENT_TOKEN,
-  HOME_TOOLS_OUTLET
+  DEFAULT_COG_LINK_COMPONENT_TOKEN,
+  HOME_COG_OUTLET
 };

--- a/packages/users-web/test/settingsPlacementContract.test.js
+++ b/packages/users-web/test/settingsPlacementContract.test.js
@@ -71,21 +71,21 @@ function expectTextMutation(id, { reason = "", category = "", skipIfContains = "
   }
 }
 
-test("users-web home tools widget exposes home-tools outlet", async () => {
+test("users-web home tools widget exposes home-cog outlet", async () => {
   const source = await readFile(path.join(PACKAGE_DIR, "src", "client", "components", "UsersHomeToolsWidget.vue"), "utf8");
 
-  assert.match(source, /import \{ HOME_TOOLS_OUTLET \} from "\.\.\/\.\.\/shared\/toolsOutletContracts\.js";/);
+  assert.match(source, /import \{ HOME_COG_OUTLET \} from "\.\.\/\.\.\/shared\/toolsOutletContracts\.js";/);
   assert.match(source, /<ShellOutletMenuWidget/);
-  assert.match(source, /:target="HOME_TOOLS_OUTLET\.target"/);
-  assert.match(source, /:default-link-component-token="HOME_TOOLS_OUTLET\.defaultLinkComponentToken"/);
+  assert.match(source, /:target="HOME_COG_OUTLET\.target"/);
+  assert.match(source, /:default-link-component-token="HOME_COG_OUTLET\.defaultLinkComponentToken"/);
 });
 
-test("users-web descriptor metadata advertises home tools outlet and standard home settings placements", () => {
+test("users-web descriptor metadata advertises home cog outlet and standard home settings placements", () => {
   assert.deepEqual(
-    readOutlets("home-tools:primary-menu"),
+    readOutlets("home-cog:primary-menu"),
     [
       {
-        target: "home-tools:primary-menu",
+        target: "home-cog:primary-menu",
         defaultLinkComponentToken: "local.main.ui.surface-aware-menu-link-item",
         surfaces: ["home"],
         source: "src/client/components/UsersHomeToolsWidget.vue"
@@ -122,7 +122,7 @@ test("users-web descriptor metadata advertises home tools outlet and standard ho
   });
 
   expectContribution("users.home.menu.settings", {
-    target: "home-tools:primary-menu",
+    target: "home-cog:primary-menu",
     surfaces: ["home"],
     order: 100,
     componentToken: "local.main.ui.surface-aware-menu-link-item",
@@ -139,7 +139,7 @@ test("users-web descriptor metadata advertises home tools outlet and standard ho
       'id: "users.home.tools.widget"',
       'componentToken: "users.web.home.tools.widget"',
       'id: "users.home.menu.settings"',
-      'target: "home-tools:primary-menu"',
+      'target: "home-cog:primary-menu"',
       'componentToken: "local.main.ui.surface-aware-menu-link-item"',
       'scopedSuffix: "/settings"',
       'unscopedSuffix: "/settings"'

--- a/packages/workspaces-web/package.descriptor.mjs
+++ b/packages/workspaces-web/package.descriptor.mjs
@@ -74,7 +74,7 @@ export default Object.freeze({
             source: "templates/src/pages/admin/workspace/settings.vue"
           },
           {
-            target: "workspace-tools:primary-menu",
+            target: "admin-cog:primary-menu",
             defaultLinkComponentToken: "local.main.ui.surface-aware-menu-link-item",
             surfaces: ["admin"],
             source: "src/client/components/UsersWorkspaceToolsWidget.vue"
@@ -145,7 +145,7 @@ export default Object.freeze({
           },
           {
             id: "workspaces.workspace.menu.workspace-settings",
-            target: "workspace-tools:primary-menu",
+            target: "admin-cog:primary-menu",
             surfaces: ["admin"],
             order: 100,
             componentToken: "workspaces.web.workspace-settings.menu-item",
@@ -153,7 +153,7 @@ export default Object.freeze({
           },
           {
             id: "workspaces.workspace.menu.members",
-            target: "workspace-tools:primary-menu",
+            target: "admin-cog:primary-menu",
             surfaces: ["admin"],
             order: 200,
             componentToken: "workspaces.web.workspace-members.menu-item",
@@ -324,7 +324,7 @@ export default Object.freeze({
         file: "src/placement.js",
         position: "bottom",
         skipIfContains: "id: \"workspaces.workspace.selector\"",
-        value: "\naddPlacement({\n  id: \"workspaces.workspace.menu.app\",\n  target: \"shell-layout:primary-menu\",\n  surfaces: [\"app\"],\n  order: 50,\n  componentToken: \"local.main.ui.surface-aware-menu-link-item\",\n  props: {\n    label: \"Home\",\n    surface: \"app\",\n    scopedSuffix: \"/\",\n    unscopedSuffix: \"/\",\n    exact: true\n  },\n  when: ({ auth }) => auth?.authenticated === true\n});\n\naddPlacement({\n  id: \"workspaces.workspace.menu.admin\",\n  target: \"shell-layout:primary-menu\",\n  surfaces: [\"admin\"],\n  order: 60,\n  componentToken: \"local.main.ui.surface-aware-menu-link-item\",\n  props: {\n    label: \"Home\",\n    surface: \"admin\",\n    scopedSuffix: \"/\",\n    unscopedSuffix: \"/\",\n    exact: true\n  },\n  when: ({ auth }) => auth?.authenticated === true\n});\n\naddPlacement({\n  id: \"workspaces.workspace.selector\",\n  target: \"shell-layout:top-left\",\n  surfaces: [\"*\"],\n  order: 200,\n  componentToken: \"workspaces.web.workspace.selector\",\n  props: {\n    allowOnNonWorkspaceSurface: true,\n    targetSurfaceId: \"app\"\n  },\n  when: ({ auth }) => auth?.authenticated === true\n});\n\naddPlacement({\n  id: \"workspaces.account.invites.cue\",\n  target: \"shell-layout:top-right\",\n  surfaces: [\"*\"],\n  order: 850,\n  componentToken: \"local.main.account.pending-invites.cue\",\n  when: ({ auth }) => auth?.authenticated === true\n});\n\naddPlacement({\n  id: \"workspaces.workspace.tools.widget\",\n  target: \"shell-layout:top-right\",\n  surfaces: [\"admin\"],\n  order: 900,\n  componentToken: \"workspaces.web.workspace.tools.widget\"\n});\n\naddPlacement({\n  id: \"workspaces.workspace.menu.workspace-settings\",\n  target: \"workspace-tools:primary-menu\",\n  surfaces: [\"admin\"],\n  order: 100,\n  componentToken: \"workspaces.web.workspace-settings.menu-item\"\n});\n\naddPlacement({\n  id: \"workspaces.workspace.menu.members\",\n  target: \"workspace-tools:primary-menu\",\n  surfaces: [\"admin\"],\n  order: 200,\n  componentToken: \"workspaces.web.workspace-members.menu-item\"\n});\n",
+        value: "\naddPlacement({\n  id: \"workspaces.workspace.menu.app\",\n  target: \"shell-layout:primary-menu\",\n  surfaces: [\"app\"],\n  order: 50,\n  componentToken: \"local.main.ui.surface-aware-menu-link-item\",\n  props: {\n    label: \"Home\",\n    surface: \"app\",\n    scopedSuffix: \"/\",\n    unscopedSuffix: \"/\",\n    exact: true\n  },\n  when: ({ auth }) => auth?.authenticated === true\n});\n\naddPlacement({\n  id: \"workspaces.workspace.menu.admin\",\n  target: \"shell-layout:primary-menu\",\n  surfaces: [\"admin\"],\n  order: 60,\n  componentToken: \"local.main.ui.surface-aware-menu-link-item\",\n  props: {\n    label: \"Home\",\n    surface: \"admin\",\n    scopedSuffix: \"/\",\n    unscopedSuffix: \"/\",\n    exact: true\n  },\n  when: ({ auth }) => auth?.authenticated === true\n});\n\naddPlacement({\n  id: \"workspaces.workspace.selector\",\n  target: \"shell-layout:top-left\",\n  surfaces: [\"*\"],\n  order: 200,\n  componentToken: \"workspaces.web.workspace.selector\",\n  props: {\n    allowOnNonWorkspaceSurface: true,\n    targetSurfaceId: \"app\"\n  },\n  when: ({ auth }) => auth?.authenticated === true\n});\n\naddPlacement({\n  id: \"workspaces.account.invites.cue\",\n  target: \"shell-layout:top-right\",\n  surfaces: [\"*\"],\n  order: 850,\n  componentToken: \"local.main.account.pending-invites.cue\",\n  when: ({ auth }) => auth?.authenticated === true\n});\n\naddPlacement({\n  id: \"workspaces.workspace.tools.widget\",\n  target: \"shell-layout:top-right\",\n  surfaces: [\"admin\"],\n  order: 900,\n  componentToken: \"workspaces.web.workspace.tools.widget\"\n});\n\naddPlacement({\n  id: \"workspaces.workspace.menu.workspace-settings\",\n  target: \"admin-cog:primary-menu\",\n  surfaces: [\"admin\"],\n  order: 100,\n  componentToken: \"workspaces.web.workspace-settings.menu-item\"\n});\n\naddPlacement({\n  id: \"workspaces.workspace.menu.members\",\n  target: \"admin-cog:primary-menu\",\n  surfaces: [\"admin\"],\n  order: 200,\n  componentToken: \"workspaces.web.workspace-members.menu-item\"\n});\n",
         reason: "Append workspace placement entries into app-owned placement registry.",
         category: "workspaces-web",
         id: "workspaces-web-placement-block",

--- a/packages/workspaces-web/src/client/components/UsersWorkspaceToolsWidget.vue
+++ b/packages/workspaces-web/src/client/components/UsersWorkspaceToolsWidget.vue
@@ -1,12 +1,12 @@
 <script setup>
 import ShellOutletMenuWidget from "@jskit-ai/shell-web/client/components/ShellOutletMenuWidget";
-import { WORKSPACE_TOOLS_OUTLET } from "../../shared/toolsOutletContracts.js";
+import { ADMIN_COG_OUTLET } from "../../shared/toolsOutletContracts.js";
 </script>
 
 <template>
   <ShellOutletMenuWidget
-    :target="WORKSPACE_TOOLS_OUTLET.target"
-    :default-link-component-token="WORKSPACE_TOOLS_OUTLET.defaultLinkComponentToken"
-    :aria-label="WORKSPACE_TOOLS_OUTLET.ariaLabel"
+    :target="ADMIN_COG_OUTLET.target"
+    :default-link-component-token="ADMIN_COG_OUTLET.defaultLinkComponentToken"
+    :aria-label="ADMIN_COG_OUTLET.ariaLabel"
   />
 </template>

--- a/packages/workspaces-web/src/shared/toolsOutletContracts.js
+++ b/packages/workspaces-web/src/shared/toolsOutletContracts.js
@@ -1,9 +1,9 @@
-const DEFAULT_TOOLS_LINK_COMPONENT_TOKEN = "local.main.ui.surface-aware-menu-link-item";
+const DEFAULT_COG_LINK_COMPONENT_TOKEN = "local.main.ui.surface-aware-menu-link-item";
 
-const WORKSPACE_TOOLS_OUTLET = Object.freeze({
-  target: "workspace-tools:primary-menu",
-  defaultLinkComponentToken: DEFAULT_TOOLS_LINK_COMPONENT_TOKEN,
-  ariaLabel: "Workspace tools"
+const ADMIN_COG_OUTLET = Object.freeze({
+  target: "admin-cog:primary-menu",
+  defaultLinkComponentToken: DEFAULT_COG_LINK_COMPONENT_TOKEN,
+  ariaLabel: "Admin cog"
 });
 
-export { DEFAULT_TOOLS_LINK_COMPONENT_TOKEN, WORKSPACE_TOOLS_OUTLET };
+export { DEFAULT_COG_LINK_COMPONENT_TOKEN, ADMIN_COG_OUTLET };

--- a/packages/workspaces-web/test/settingsPlacementContract.test.js
+++ b/packages/workspaces-web/test/settingsPlacementContract.test.js
@@ -90,10 +90,10 @@ test("workspaces-web descriptor metadata advertises admin settings outlets", () 
     ]
   );
   assert.deepEqual(
-    readOutlets("workspace-tools:primary-menu"),
+    readOutlets("admin-cog:primary-menu"),
     [
       {
-        target: "workspace-tools:primary-menu",
+        target: "admin-cog:primary-menu",
         defaultLinkComponentToken: "local.main.ui.surface-aware-menu-link-item",
         surfaces: ["admin"],
         source: "src/client/components/UsersWorkspaceToolsWidget.vue"


### PR DESCRIPTION
## Summary
- rename the old tools outlet contracts to explicit `home-cog` and `admin-cog` targets
- update users/workspaces widgets, descriptors, tests, and docs to use the new outlet ids
- keep shell outlet discovery and UI generator tests aligned with the renamed targets

## Verification
- `node --test server/support/shellOutlets.test.js` in `packages/kernel`
- `node --test test/buildTemplateContext.test.js` in `packages/ui-generator`
- `node --test test/settingsPlacementContract.test.js` in `packages/users-web`
- `node --test test/settingsPlacementContract.test.js` in `packages/workspaces-web`
- `npm run agent-docs:build`