### PR TITLE
Add CRUD write serializer mapping support

### DIFF
--- a/packages/agent-docs/guide/agent/generators/advanced-cruds.md
+++ b/packages/agent-docs/guide/agent/generators/advanced-cruds.md
@@ -847,6 +847,8 @@ In JSKIT CRUD:
 Use these rules:
 
 - for explicit DB column overrides, use `repository.column`
+- standard writable `date-time` fields are serialized automatically during CRUD writes
+- use `repository.writeSerializer` only for non-default DB write serialization
 - for computed output fields, use `repository.storage: "virtual"`
 - do not put computed fields in create/patch write schemas
 
@@ -891,6 +893,8 @@ Once registered there:
 - generic CRUD `findById`
 - generic CRUD `listByIds`
 - generic CRUD `listByForeignIds`
+
+and generic CRUD writes automatically serialize standard writable `date-time` fields during create/update payload mapping, so normal datetime DB formatting does not need per-field metadata or repository-specific `preparePayload` hooks. Keep `repository.writeSerializer` for non-default cases only.
 
 all pick up the projection automatically, so you should not hand-patch `clearSelect()` / re-select logic into each method.
 

--- a/packages/agent-docs/patterns/INDEX.md
+++ b/packages/agent-docs/patterns/INDEX.md
@@ -28,7 +28,7 @@ How to use it:
   - `ui-testing.md`
 - filter, filters, search facets, chips, date range, enum filter, lookup filter, `useCrudListFilters`, `createCrudListFilters`
   - `filters.md`
-- fieldMeta, `repository.column`, computed field, virtual field, projection, `createCrudResourceRuntime`, `remainingBatchWeight`
+- fieldMeta, `repository.column`, `repository.writeSerializer`, computed field, virtual field, projection, `createCrudResourceRuntime`, `remainingBatchWeight`, datetime write serialization
   - `crud-repository-mapping.md`
 
 ## Current Patterns

--- a/packages/agent-docs/patterns/crud-repository-mapping.md
+++ b/packages/agent-docs/patterns/crud-repository-mapping.md
@@ -9,9 +9,11 @@ Default JSKIT pattern:
 1. Treat the schema as the API contract only.
 2. Put persistence mapping in `resource.fieldMeta`.
 3. Use `repository.column` for explicit DB column overrides.
-4. Use `repository.storage: "virtual"` for computed output fields.
-5. Register computed SQL projections once in the repository runtime with `virtualFields`.
-6. Let generic CRUD read paths apply those projections automatically.
+4. Let generic CRUD runtime handle standard writable `date-time` fields automatically at the DB write seam.
+5. Use `repository.writeSerializer` only for non-default write serialization.
+6. Use `repository.storage: "virtual"` for computed output fields.
+7. Register computed SQL projections once in the repository runtime with `virtualFields`.
+8. Let generic CRUD read paths apply those projections automatically.
 
 Field meta rules:
 - for a normal override, write:
@@ -36,14 +38,29 @@ RESOURCE_FIELD_META.push({
 });
 ```
 
+- for a non-default write serializer override, write:
+
+```js
+RESOURCE_FIELD_META.push({
+  key: "arrivalDatetime",
+  repository: {
+    writeSerializer: "datetime-utc"
+  }
+});
+```
+
 - omit `repository` entirely when the field is column-backed and the default snake_case mapping is correct
+- standard writable `format: "date-time"` fields do not need explicit `repository.writeSerializer`
+- use `repository.writeSerializer` only for non-default DB write behavior; keep `bodyValidator.normalize(...)` in API shape
 - `repository.storage: "virtual"` cannot also define `repository.column`
+- `repository.storage: "virtual"` cannot also define `repository.writeSerializer`
 - `repository.storage: "virtual"` fields must not appear in create/patch write schemas
 
 Repository pattern:
 - build the runtime with `createCrudResourceRuntime(resource, { ... })`
 - register computed projections in `virtualFields`
 - keep SQL in the repository, not in shared metadata
+- let generic CRUD runtime apply `repository.writeSerializer` during create/update writes
 
 Example:
 
@@ -64,6 +81,8 @@ const repositoryRuntime = createCrudResourceRuntime(resource, {
 
 What CRUD core now does for you:
 - default select columns include only column-backed output fields
+- create/update write payloads serialize standard writable `date-time` fields centrally
+- create/update write payloads also apply any explicit field write serializers centrally
 - `list`, `findById`, `listByIds`, and `listByForeignIds` apply registered virtual projections automatically
 - search and parent-filter fallback derivation only use column-backed fields
 - `listByIds(..., { valueKey })` requires that `valueKey` be column-backed
@@ -76,6 +95,8 @@ Avoid:
 Review checks:
 - schema defines contract, not storage
 - `fieldMeta.repository` owns mapping
+- standard datetime DB write serialization stays automatic and runtime-owned
+- any non-default DB write serialization lives in `repository.writeSerializer`, not in per-repository hooks
 - computed fields use `repository.storage: "virtual"`
 - repository runtime registers matching `virtualFields`
 - no per-method projection duplication when generic CRUD reads already cover the field

--- a/packages/agent-docs/reference/autogen/packages/crud-core.md
+++ b/packages/agent-docs/reference/autogen/packages/crud-core.md
@@ -211,7 +211,7 @@ Exports
 - `deriveRepositoryMappingFromResource(resource = {}, { context = "crudRepository" } = {})`
 - `applyCrudListQueryFilters(query, { idColumn = "id", cursor = "", applyCursor = true, q = "", searchColumns = [], parentFilters = {}, parentFilterColumns = {} } = {})`
 - `mapRecordRow(row, fieldKeys = [], overrides = {}, { recordIdKeys = [] } = {})`
-- `buildWritePayload(sourcePayload = {}, fieldKeys = [], overrides = {})`
+- `buildWritePayload(sourcePayload = {}, fieldKeys = [], overrides = {}, { serializerByKey = {} } = {})`
 - `resolveColumnName(fieldKey, overrides = {})`
 - `resolveCrudIdColumn(idColumn, { fallback = "id" } = {})`
 - `buildRepositoryColumnMetadata({ outputKeys = [], writeKeys = [], columnOverrides = {}, fieldStorageByKey = {} } = {})`
@@ -220,6 +220,7 @@ Local functions
 - `requireObjectSchemaProperties(schema, { context = "crudRepository", schemaLabel = "schema" } = {})`
 - `normalizeResourceFieldMetaEntries(fieldMeta = [])`
 - `schemaIncludesStringType(schema = {})`
+- `schemaIncludesDateTimeFormat(schema = {})`
 - `schemaIncludesRecordIdType(schema = {})`
 
 ### `src/server/resourceRuntime/index.js`
@@ -317,12 +318,14 @@ Local functions
 Exports
 - `CRUD_FIELD_REPOSITORY_STORAGE_COLUMN`
 - `CRUD_FIELD_REPOSITORY_STORAGE_VIRTUAL`
+- `CRUD_FIELD_REPOSITORY_WRITE_SERIALIZER_DATETIME_UTC`
 - `CRUD_LOOKUP_FORM_CONTROL_AUTOCOMPLETE`
 - `CRUD_LOOKUP_FORM_CONTROL_SELECT`
 - `CRUD_RUNTIME_LOOKUPS_FIELD_KEY`
 - `checkCrudLookupFormControl(value, { context = "crud fieldMeta ui.formControl", defaultValue = CRUD_LOOKUP_FORM_CONTROL_AUTOCOMPLETE } = {})`
 - `isCrudRuntimeOutputOnlyFieldKey(value = "", { lookupContainerKey = CRUD_RUNTIME_LOOKUPS_FIELD_KEY } = {})`
 - `normalizeCrudFieldRepositoryConfig(fieldMetaEntry = {}, { context = "crud fieldMeta repository", fieldKey = "" } = {})`
+- `normalizeCrudFieldRepositoryWriteSerializer(value, { context = "crud fieldMeta repository", fieldKey = "" } = {})`
 
 ### `src/shared/crudNamespaceSupport.js`
 Exports

--- a/packages/agent-docs/reference/autogen/packages/crud-server-generator.md
+++ b/packages/agent-docs/reference/autogen/packages/crud-server-generator.md
@@ -215,6 +215,39 @@ Exports
 Exports
 - None
 
+### .tmp-crud-server-template-fixture-FNbPfi
+
+### `.tmp-crud-server-template-fixture-FNbPfi/src/server/actionIds.js`
+Exports
+- `actionIds`
+
+### `.tmp-crud-server-template-fixture-FNbPfi/src/server/actions.js`
+Exports
+- `createActions({ surface = "" } = {})`
+Local functions
+- `requireActionSurface(surface = "")`
+
+### `.tmp-crud-server-template-fixture-FNbPfi/src/server/listConfig.js`
+Exports
+- `LIST_CONFIG`
+
+### `.tmp-crud-server-template-fixture-FNbPfi/src/server/registerRoutes.js`
+Exports
+- `registerRoutes(app, { routeOwnershipFilter = "public", routeSurface = "", routeRelativePath = "" } = {})`
+
+### `.tmp-crud-server-template-fixture-FNbPfi/src/server/repository.js`
+Exports
+- `createRepository(knex, options = {})`
+
+### `.tmp-crud-server-template-fixture-FNbPfi/src/server/service.js`
+Exports
+- `createService({ customersRepository, fieldAccess = DEFAULT_FIELD_ACCESS } = {})`
+- `serviceEvents`
+
+### `.tmp-crud-server-template-fixture-FNbPfi/src/shared/customerResource.js`
+Exports
+- `resource`
+
 ### test-support
 
 ### `test-support/templateServerFixture.js`

--- a/packages/agent-docs/site/guide/generators/advanced-cruds.md
+++ b/packages/agent-docs/site/guide/generators/advanced-cruds.md
@@ -845,6 +845,8 @@ In JSKIT CRUD:
 Use these rules:
 
 - for explicit DB column overrides, use `repository.column`
+- standard writable `date-time` fields are serialized automatically during CRUD writes
+- use `repository.writeSerializer` only for non-default DB write serialization
 - for computed output fields, use `repository.storage: "virtual"`
 - do not put computed fields in create/patch write schemas
 
@@ -889,6 +891,8 @@ Once registered there:
 - generic CRUD `findById`
 - generic CRUD `listByIds`
 - generic CRUD `listByForeignIds`
+
+and generic CRUD writes automatically serialize standard writable `date-time` fields during create/update payload mapping, so normal datetime DB formatting does not need per-field metadata or repository-specific `preparePayload` hooks. Keep `repository.writeSerializer` for non-default cases only.
 
 all pick up the projection automatically, so you should not hand-patch `clearSelect()` / re-select logic into each method.
 

--- a/packages/crud-core/src/server/repositorySupport.js
+++ b/packages/crud-core/src/server/repositorySupport.js
@@ -1,4 +1,7 @@
-import { normalizeDbRecordId } from "@jskit-ai/database-runtime/shared";
+import {
+  normalizeDbRecordId,
+  toDatabaseDateTimeUtc
+} from "@jskit-ai/database-runtime/shared";
 import { AppError } from "@jskit-ai/kernel/server/runtime/errors";
 import { RECORD_ID_PATTERN } from "@jskit-ai/kernel/shared/validators";
 import { normalizeRecordId, normalizeText } from "@jskit-ai/kernel/shared/support/normalize";
@@ -10,6 +13,7 @@ import {
 } from "@jskit-ai/kernel/shared/support/crudLookup";
 import {
   CRUD_FIELD_REPOSITORY_STORAGE_COLUMN,
+  CRUD_FIELD_REPOSITORY_WRITE_SERIALIZER_DATETIME_UTC,
   CRUD_FIELD_REPOSITORY_STORAGE_VIRTUAL,
   isCrudRuntimeOutputOnlyFieldKey,
   normalizeCrudFieldRepositoryConfig
@@ -17,6 +21,9 @@ import {
 
 const DEFAULT_LIST_LIMIT = 20;
 const MAX_LIST_LIMIT = 100;
+const CRUD_WRITE_SERIALIZERS = Object.freeze({
+  [CRUD_FIELD_REPOSITORY_WRITE_SERIALIZER_DATETIME_UTC]: (value) => toDatabaseDateTimeUtc(value)
+});
 
 function normalizeCrudListCursor(cursor = null, { allowEmpty = true } = {}) {
   if (cursor === undefined || cursor === null) {
@@ -170,6 +177,23 @@ function schemaIncludesStringType(schema = {}) {
   return variants.some((entry) => schemaIncludesStringType(entry));
 }
 
+function schemaIncludesDateTimeFormat(schema = {}) {
+  if (!schema || typeof schema !== "object" || Array.isArray(schema)) {
+    return false;
+  }
+
+  if (normalizeText(schema.format).toLowerCase() === "date-time") {
+    return true;
+  }
+
+  const variants = Array.isArray(schema.anyOf)
+    ? schema.anyOf
+    : Array.isArray(schema.oneOf)
+      ? schema.oneOf
+      : [];
+  return variants.some((entry) => schemaIncludesDateTimeFormat(entry));
+}
+
 function schemaIncludesRecordIdType(schema = {}) {
   if (!schema || typeof schema !== "object" || Array.isArray(schema)) {
     return false;
@@ -233,6 +257,7 @@ function deriveRepositoryMappingFromResource(resource = {}, { context = "crudRep
 
   const fieldStorageByKey = {};
   const columnOverrides = {};
+  const writeSerializerByKey = {};
   for (const entry of normalizeResourceFieldMetaEntries(resource.fieldMeta)) {
     const key = normalizeText(entry.key);
     if (!key) {
@@ -245,6 +270,9 @@ function deriveRepositoryMappingFromResource(resource = {}, { context = "crudRep
     fieldStorageByKey[key] = repositoryConfig.storage;
     if (repositoryConfig.column) {
       columnOverrides[key] = repositoryConfig.column;
+    }
+    if (repositoryConfig.writeSerializer) {
+      writeSerializerByKey[key] = repositoryConfig.writeSerializer;
     }
   }
 
@@ -313,9 +341,27 @@ function deriveRepositoryMappingFromResource(resource = {}, { context = "crudRep
     }
   }
 
+  for (const key of writeKeys) {
+    if ((fieldStorageByKey[key] || CRUD_FIELD_REPOSITORY_STORAGE_COLUMN) !== CRUD_FIELD_REPOSITORY_STORAGE_COLUMN) {
+      continue;
+    }
+
+    if (writeSerializerByKey[key]) {
+      continue;
+    }
+
+    const schema = writeProperties[key] || patchProperties[key];
+    if (!schemaIncludesDateTimeFormat(schema)) {
+      continue;
+    }
+
+    writeSerializerByKey[key] = CRUD_FIELD_REPOSITORY_WRITE_SERIALIZER_DATETIME_UTC;
+  }
+
   return Object.freeze({
     outputKeys,
     writeKeys,
+    writeSerializerByKey: Object.freeze(writeSerializerByKey),
     fieldStorageByKey: Object.freeze(fieldStorageByKey),
     columnOverrides: Object.freeze(columnOverrides),
     columnBackedOutputKeys: Object.freeze(columnBackedOutputKeys),
@@ -431,8 +477,11 @@ function applyCrudListQueryFilters(
   return nextQuery;
 }
 
-function buildWritePayload(sourcePayload = {}, fieldKeys = [], overrides = {}) {
+function buildWritePayload(sourcePayload = {}, fieldKeys = [], overrides = {}, { serializerByKey = {} } = {}) {
   const source = normalizeObjectInput(sourcePayload);
+  const normalizedSerializerByKey = serializerByKey && typeof serializerByKey === "object" && !Array.isArray(serializerByKey)
+    ? serializerByKey
+    : {};
   const payload = {};
   for (const key of fieldKeys) {
     const normalizedKey = String(key || "").trim();
@@ -443,7 +492,19 @@ function buildWritePayload(sourcePayload = {}, fieldKeys = [], overrides = {}) {
     if (!Object.hasOwn(source, normalizedKey)) {
       continue;
     }
-    payload[columnName] = source[normalizedKey];
+    const value = source[normalizedKey];
+    const serializerId = normalizeText(normalizedSerializerByKey[normalizedKey]).toLowerCase();
+    if (value === null || value === undefined || !serializerId) {
+      payload[columnName] = value;
+      continue;
+    }
+
+    const serializer = CRUD_WRITE_SERIALIZERS[serializerId];
+    if (typeof serializer !== "function") {
+      throw new Error(`crudRepository write serializer "${serializerId}" is not supported.`);
+    }
+
+    payload[columnName] = serializer(value);
   }
   return payload;
 }

--- a/packages/crud-core/src/server/resourceRuntime/index.js
+++ b/packages/crud-core/src/server/resourceRuntime/index.js
@@ -1186,7 +1186,14 @@ async function createRecord(runtime, knex, payload = {}, callOptions = {}) {
     }
   );
 
-  let insertPayload = buildWritePayload(sourcePayload, runtime.mapping.writeKeys, runtime.mapping.columnOverrides);
+  let insertPayload = buildWritePayload(
+    sourcePayload,
+    runtime.mapping.writeKeys,
+    runtime.mapping.columnOverrides,
+    {
+      serializerByKey: runtime.mapping.writeSerializerByKey
+    }
+  );
   const timestamp = toInsertDateTime();
   if (runtime.defaults.createdAtColumn && !Object.hasOwn(insertPayload, runtime.defaults.createdAtColumn)) {
     insertPayload[runtime.defaults.createdAtColumn] = timestamp;
@@ -1276,7 +1283,14 @@ async function updateRecordById(runtime, knex, recordId, patch = {}, callOptions
       stageKey: "operations.updateById.preparePatch"
     }
   );
-  const dbPatch = buildWritePayload(sourcePatch, runtime.mapping.writeKeys, runtime.mapping.columnOverrides);
+  const dbPatch = buildWritePayload(
+    sourcePatch,
+    runtime.mapping.writeKeys,
+    runtime.mapping.columnOverrides,
+    {
+      serializerByKey: runtime.mapping.writeSerializerByKey
+    }
+  );
 
   if (runtime.defaults.updatedAtColumn) {
     dbPatch[runtime.defaults.updatedAtColumn] = toInsertDateTime();

--- a/packages/crud-core/src/shared/crudFieldMetaSupport.js
+++ b/packages/crud-core/src/shared/crudFieldMetaSupport.js
@@ -9,6 +9,30 @@ const CRUD_LOOKUP_FORM_CONTROL_AUTOCOMPLETE = "autocomplete";
 const CRUD_LOOKUP_FORM_CONTROL_SELECT = "select";
 const CRUD_FIELD_REPOSITORY_STORAGE_COLUMN = "column";
 const CRUD_FIELD_REPOSITORY_STORAGE_VIRTUAL = "virtual";
+const CRUD_FIELD_REPOSITORY_WRITE_SERIALIZER_DATETIME_UTC = "datetime-utc";
+
+function normalizeCrudFieldRepositoryWriteSerializer(
+  value,
+  {
+    context = "crud fieldMeta repository",
+    fieldKey = ""
+  } = {}
+) {
+  const normalizedFieldKey = normalizeText(fieldKey);
+  const normalizedValue = normalizeText(value).toLowerCase();
+  if (!normalizedValue) {
+    return "";
+  }
+
+  if (normalizedValue === CRUD_FIELD_REPOSITORY_WRITE_SERIALIZER_DATETIME_UTC) {
+    return normalizedValue;
+  }
+
+  throw new Error(
+    `${context}${normalizedFieldKey ? `["${normalizedFieldKey}"]` : ""} repository.writeSerializer must be ` +
+      `"${CRUD_FIELD_REPOSITORY_WRITE_SERIALIZER_DATETIME_UTC}" when provided.`
+  );
+}
 
 function checkCrudLookupFormControl(
   value,
@@ -70,7 +94,7 @@ function normalizeCrudFieldRepositoryConfig(
 
   const repositoryKeys = Object.keys(repository);
   for (const repositoryKey of repositoryKeys) {
-    if (repositoryKey !== "column" && repositoryKey !== "storage") {
+    if (repositoryKey !== "column" && repositoryKey !== "storage" && repositoryKey !== "writeSerializer") {
       throw new Error(
         `${context}${normalizedFieldKey ? `["${normalizedFieldKey}"]` : ""} does not support repository.${repositoryKey}.`
       );
@@ -79,10 +103,14 @@ function normalizeCrudFieldRepositoryConfig(
 
   const column = normalizeText(repository.column);
   const storage = normalizeText(repository.storage).toLowerCase();
+  const writeSerializer = normalizeCrudFieldRepositoryWriteSerializer(repository.writeSerializer, {
+    context,
+    fieldKey: normalizedFieldKey
+  });
 
-  if (!column && !storage) {
+  if (!column && !storage && !writeSerializer) {
     throw new Error(
-      `${context}${normalizedFieldKey ? `["${normalizedFieldKey}"]` : ""} requires repository.column or repository.storage.`
+      `${context}${normalizedFieldKey ? `["${normalizedFieldKey}"]` : ""} requires repository.column, repository.storage, or repository.writeSerializer.`
     );
   }
 
@@ -96,22 +124,30 @@ function normalizeCrudFieldRepositoryConfig(
       `${context}${normalizedFieldKey ? `["${normalizedFieldKey}"]` : ""} repository.storage "virtual" cannot define repository.column.`
     );
   }
+  if (storage === CRUD_FIELD_REPOSITORY_STORAGE_VIRTUAL && writeSerializer) {
+    throw new Error(
+      `${context}${normalizedFieldKey ? `["${normalizedFieldKey}"]` : ""} repository.storage "virtual" cannot define repository.writeSerializer.`
+    );
+  }
 
   return Object.freeze({
     storage: storage === CRUD_FIELD_REPOSITORY_STORAGE_VIRTUAL
       ? CRUD_FIELD_REPOSITORY_STORAGE_VIRTUAL
       : CRUD_FIELD_REPOSITORY_STORAGE_COLUMN,
-    column
+    column,
+    writeSerializer
   });
 }
 
 export {
   CRUD_FIELD_REPOSITORY_STORAGE_COLUMN,
   CRUD_FIELD_REPOSITORY_STORAGE_VIRTUAL,
+  CRUD_FIELD_REPOSITORY_WRITE_SERIALIZER_DATETIME_UTC,
   CRUD_LOOKUP_FORM_CONTROL_AUTOCOMPLETE,
   CRUD_LOOKUP_FORM_CONTROL_SELECT,
   CRUD_RUNTIME_LOOKUPS_FIELD_KEY,
   checkCrudLookupFormControl,
   isCrudRuntimeOutputOnlyFieldKey,
-  normalizeCrudFieldRepositoryConfig
+  normalizeCrudFieldRepositoryConfig,
+  normalizeCrudFieldRepositoryWriteSerializer
 };

--- a/packages/crud-core/test/repositorySupport.test.js
+++ b/packages/crud-core/test/repositorySupport.test.js
@@ -132,6 +132,34 @@ test("buildWritePayload respects defined keys", () => {
   });
 });
 
+test("buildWritePayload serializes configured date-time keys to database shape", () => {
+  const payload = buildWritePayload(
+    {
+      scheduledAt: "2026-04-23T10:11:12.000Z",
+      archivedAt: null,
+      title: "Example"
+    },
+    ["scheduledAt", "archivedAt", "title"],
+    {
+      scheduledAt: "scheduled_at",
+      archivedAt: "archived_at",
+      title: "title"
+    },
+    {
+      serializerByKey: {
+        scheduledAt: "datetime-utc",
+        archivedAt: "datetime-utc"
+      }
+    }
+  );
+
+  assert.deepEqual(payload, {
+    scheduled_at: "2026-04-23 10:11:12.000",
+    archived_at: null,
+    title: "Example"
+  });
+});
+
 test("applyCrudListQueryFilters applies search and cursor filters", () => {
   const { query, calls } = createQueryDouble();
   const result = applyCrudListQueryFilters(query, {
@@ -564,4 +592,104 @@ test("deriveRepositoryMappingFromResource throws when create schema properties a
     () => deriveRepositoryMappingFromResource(resource),
     /operations\.create\.bodyValidator\.schema\.properties/
   );
+});
+
+test("deriveRepositoryMappingFromResource tracks writable column-backed write serializers", () => {
+  const resource = {
+    operations: {
+      view: {
+        outputValidator: {
+          schema: {
+            type: "object",
+            properties: {
+              id: { type: "integer" },
+              scheduledAt: { type: "string", format: "date-time" },
+              archivedAt: { type: "string", format: "date-time" },
+              remainingBatchWeight: { type: "number" }
+            }
+          }
+        }
+      },
+      create: {
+        bodyValidator: {
+          schema: {
+            type: "object",
+            properties: {
+              scheduledAt: { type: "string", format: "date-time" }
+            }
+          }
+        }
+      },
+      patch: {
+        bodyValidator: {
+          schema: {
+            type: "object",
+            properties: {
+              archivedAt: {
+                anyOf: [
+                  { type: "string", format: "date-time" },
+                  { type: "null" }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    fieldMeta: [
+      {
+        key: "remainingBatchWeight",
+        repository: {
+          storage: "virtual"
+        }
+      }
+    ]
+  };
+
+  const mapping = deriveRepositoryMappingFromResource(resource);
+  assert.deepEqual(mapping.writeSerializerByKey, {
+    scheduledAt: "datetime-utc",
+    archivedAt: "datetime-utc"
+  });
+});
+
+test("deriveRepositoryMappingFromResource keeps explicit repository.writeSerializer metadata", () => {
+  const resource = {
+    operations: {
+      view: {
+        outputValidator: {
+          schema: {
+            type: "object",
+            properties: {
+              id: { type: "integer" },
+              arrivalDatetime: { type: "string", format: "date-time" }
+            }
+          }
+        }
+      },
+      create: {
+        bodyValidator: {
+          schema: {
+            type: "object",
+            properties: {
+              arrivalDatetime: { type: "string", format: "date-time" }
+            }
+          }
+        }
+      }
+    },
+    fieldMeta: [
+      {
+        key: "arrivalDatetime",
+        repository: {
+          writeSerializer: "datetime-utc"
+        }
+      }
+    ]
+  };
+
+  const mapping = deriveRepositoryMappingFromResource(resource);
+  assert.deepEqual(mapping.writeSerializerByKey, {
+    arrivalDatetime: "datetime-utc"
+  });
 });

--- a/packages/crud-server-generator/src/server/buildTemplateContext.js
+++ b/packages/crud-server-generator/src/server/buildTemplateContext.js
@@ -832,9 +832,9 @@ function renderInputNormalizer(column) {
   }
   if (typeKind === "datetime") {
     if (nullable) {
-      return "(value) => { const normalized = normalizeText(value); return normalized ? toDatabaseDateTimeUtc(normalized) : null; }";
+      return "(value) => { const normalized = normalizeText(value); return normalized ? toIsoString(normalized) : null; }";
     }
-    return "toDatabaseDateTimeUtc";
+    return "toIsoString";
   }
   if (typeKind === "date") {
     if (nullable) {
@@ -1513,12 +1513,23 @@ function renderFieldMetaEntryLines(entry = {}) {
   const lines = ["RESOURCE_FIELD_META.push({"];
   const topLevelProperties = [`key: ${JSON.stringify(entry.key)}`];
   const repositoryColumn = normalizeText(entry?.repository?.column);
-  if (repositoryColumn) {
-    topLevelProperties.push([
+  const repositoryWriteSerializer = normalizeText(entry?.repository?.writeSerializer);
+  if (repositoryColumn || repositoryWriteSerializer) {
+    const repositoryLines = [
       "repository: {",
-      `  column: ${JSON.stringify(repositoryColumn)}`,
-      "}"
-    ].join("\n"));
+      ...(repositoryColumn ? [`  column: ${JSON.stringify(repositoryColumn)}`] : []),
+      ...(repositoryWriteSerializer ? [`  writeSerializer: ${JSON.stringify(repositoryWriteSerializer)}`] : [])
+    ];
+    if (repositoryLines.length > 2) {
+      repositoryLines[repositoryLines.length - 1] = repositoryLines[repositoryLines.length - 1].replace(/,$/, "");
+    }
+    repositoryLines.push("}");
+    for (let index = 1; index < repositoryLines.length - 1; index += 1) {
+      if (index < repositoryLines.length - 2) {
+        repositoryLines[index] = `${repositoryLines[index]},`;
+      }
+    }
+    topLevelProperties.push(repositoryLines.join("\n"));
   }
 
   const relation = entry.relation && typeof entry.relation === "object" ? entry.relation : null;
@@ -1824,7 +1835,6 @@ function buildReplacementsFromSnapshot({
   const needsRecordIdSchemas = resourceColumns.some((column) => column.typeKind === "integer" && column.isRecordIdColumn === true);
   const needsFiniteNumber = resourceColumns.some((column) => column.typeKind === "number");
   const needsDateTimeOutput = outputColumns.some((column) => column.typeKind === "datetime");
-  const needsDateTimeInput = writableColumns.some((column) => column.typeKind === "datetime");
   const needsNullableDateTimeInput = writableColumns.some(
     (column) => column.typeKind === "datetime" && column.nullable === true
   );
@@ -1936,8 +1946,8 @@ function buildReplacementsFromSnapshot({
       )
     }),
     __JSKIT_CRUD_RESOURCE_DATABASE_RUNTIME_IMPORT__: renderResourceDatabaseRuntimeImport({
-      needsToIsoString: needsDateTimeOutput || needsDate,
-      needsToDatabaseDateTimeUtc: needsDateTimeInput
+      needsToIsoString: needsDateTimeOutput || needsDate || writableColumns.some((column) => column.typeKind === "datetime"),
+      needsToDatabaseDateTimeUtc: false
     }),
     __JSKIT_CRUD_RESOURCE_NORMALIZE_SUPPORT_IMPORT__: renderResourceNormalizeSupportImport({
       needsNormalizeText,

--- a/packages/crud-server-generator/src/shared/crud/crudResource.js
+++ b/packages/crud-server-generator/src/shared/crud/crudResource.js
@@ -1,7 +1,6 @@
 import { Type } from "typebox";
 import {
-  toIsoString,
-  toDatabaseDateTimeUtc
+  toIsoString
 } from "@jskit-ai/database-runtime/shared";
 import {
   normalizeObjectInput,
@@ -100,7 +99,7 @@ const createBodyValidator = Object.freeze({
       normalized.textField = normalizeText(source.textField);
     }
     if (Object.hasOwn(source, "dateField")) {
-      normalized.dateField = toDatabaseDateTimeUtc(source.dateField);
+      normalized.dateField = toIsoString(source.dateField);
     }
     if (Object.hasOwn(source, "numberField")) {
       normalized.numberField = normalizeFiniteNumber(source.numberField);

--- a/packages/crud-server-generator/templates/src/local-package/server/repository.js
+++ b/packages/crud-server-generator/templates/src/local-package/server/repository.js
@@ -2,8 +2,10 @@ import { createCrudResourceRuntime } from "@jskit-ai/crud-core/server/resourceRu
 import { resource } from "../shared/${option:namespace|singular|camel}Resource.js";
 import { LIST_CONFIG } from "./listConfig.js";
 
+const REPOSITORY_CONTEXT = "${option:namespace|snake} repository";
+
 const REPOSITORY_CONFIG = Object.freeze({
-  context: "${option:namespace|snake} repository",
+  context: REPOSITORY_CONTEXT,
   list: LIST_CONFIG
 });
 

--- a/packages/crud-server-generator/test/buildTemplateContext.test.js
+++ b/packages/crud-server-generator/test/buildTemplateContext.test.js
@@ -952,7 +952,7 @@ test("buildReplacementsFromSnapshot normalizes nullable temporal inputs without 
 
   assert.match(
     replacements.__JSKIT_CRUD_RESOURCE_INPUT_NORMALIZATION_LINES__,
-    /normalizeIfInSource\(source, normalized, "scheduledAt", \(value\) => \{ const normalized = normalizeText\(value\); return normalized \? toDatabaseDateTimeUtc\(normalized\) : null; \}\);/
+    /normalizeIfInSource\(source, normalized, "scheduledAt", \(value\) => \{ const normalized = normalizeText\(value\); return normalized \? toIsoString\(normalized\) : null; \}\);/
   );
   assert.match(
     replacements.__JSKIT_CRUD_RESOURCE_INPUT_NORMALIZATION_LINES__,
@@ -961,6 +961,10 @@ test("buildReplacementsFromSnapshot normalizes nullable temporal inputs without 
   assert.match(
     replacements.__JSKIT_CRUD_RESOURCE_INPUT_NORMALIZATION_LINES__,
     /normalizeIfInSource\(source, normalized, "preferredTime", \(value\) => \{ const normalized = normalizeText\(value\); return normalized \|\| null; \}\);/
+  );
+  assert.doesNotMatch(
+    replacements.__JSKIT_CRUD_RESOURCE_FIELD_META_PUSH_LINES__,
+    /writeSerializer: "datetime-utc"/
   );
 });
 

--- a/packages/crud-server-generator/test/crudResource.test.js
+++ b/packages/crud-server-generator/test/crudResource.test.js
@@ -11,7 +11,7 @@ test("crudResource normalizes create payload", () => {
 
   assert.deepEqual(normalized, {
     textField: "Example text",
-    dateField: "2026-03-11 00:00:00.000",
+    dateField: "2026-03-11T00:00:00.000Z",
     numberField: 42.5
   });
 });


### PR DESCRIPTION
## Summary
- add `repository.writeSerializer` support to CRUD field metadata and runtime write payload mapping
- default writable `date-time` fields to centralized UTC DB serialization during create/update mapping
- update CRUD generator templates, tests, and docs to reflect the new mapping contract

## Verification
- `npm test --workspace @jskit-ai/crud-core`
- `npm test --workspace @jskit-ai/crud-server-generator`
- `npm run agent-docs:build`