### PR TITLE
Stabilize surface-aware generated menu links

### DIFF
--- a/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/AddEditForm.vue
+++ b/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/AddEditForm.vue
@@ -9,9 +9,10 @@
           </div>
           <v-spacer />
           <div class="d-flex ga-2 flex-wrap">
-            <v-btn v-if="cancelTo" variant="tonal" :to="resolveCancelTo(cancelTo)">Cancel</v-btn>
+            <v-btn v-if="cancelTo" color="primary" variant="outlined" :to="resolveCancelTo(cancelTo)">Cancel</v-btn>
             <v-btn
               color="primary"
+              variant="flat"
               :loading="addEdit.isSaving"
               :disabled="addEdit.isSubmitDisabled"
               @click="addEdit.submit"

--- a/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/EditElement.vue
+++ b/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/EditElement.vue
@@ -10,13 +10,15 @@
           <v-spacer />
           <v-btn
             v-if="UI_CANCEL_URL"
-            variant="text"
+            color="primary"
+            variant="outlined"
             :to="{ path: formRuntime.addEdit.resolveParams(UI_CANCEL_URL), query: $route.query }"
           >
             Cancel
           </v-btn>
           <v-btn
             color="primary"
+            variant="flat"
             :loading="formRuntime.addEdit.isSaving"
             :disabled="formRuntime.addEdit.isSubmitDisabled"
             @click="formRuntime.addEdit.submit"

--- a/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/ListElement.vue
+++ b/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/ListElement.vue
@@ -8,8 +8,10 @@
             <v-card-subtitle class="px-0">Manage __JSKIT_UI_RESOURCE_PLURAL_TITLE__.</v-card-subtitle>
           </div>
           <v-spacer />
-          <v-btn variant="outlined" :loading="records.isFetching" @click="records.reload">Refresh</v-btn>
-          <v-btn v-if="UI_NEW_URL" color="primary" :to="records.resolveParams(UI_NEW_URL)">New __JSKIT_UI_RESOURCE_SINGULAR_TITLE__</v-btn>
+          <v-btn color="primary" variant="tonal" :loading="records.isFetching" @click="records.reload">Refresh</v-btn>
+          <v-btn v-if="UI_NEW_URL" color="primary" variant="flat" :to="records.resolveParams(UI_NEW_URL)">
+            New __JSKIT_UI_RESOURCE_SINGULAR_TITLE__
+          </v-btn>
         </div>
       </v-card-item>
       <v-divider />
@@ -51,7 +53,8 @@ __JSKIT_UI_LIST_ROW_COLUMNS__
                 <td v-if="UI_VIEW_URL" class="text-right">
                   <v-btn
                     size="small"
-                    variant="text"
+                    color="primary"
+                    variant="outlined"
                     :to="{ path: records.resolveViewUrl(record), query: $route.query }"
                     :disabled="!records.resolveViewUrl(record)"
                   >
@@ -61,7 +64,8 @@ __JSKIT_UI_LIST_ROW_COLUMNS__
                 <td v-if="UI_EDIT_URL" class="text-right">
                   <v-btn
                     size="small"
-                    variant="text"
+                    color="primary"
+                    variant="tonal"
                     :to="{ path: records.resolveEditUrl(record), query: $route.query }"
                     :disabled="!records.resolveEditUrl(record)"
                   >
@@ -73,7 +77,9 @@ __JSKIT_UI_LIST_ROW_COLUMNS__
           </v-table>
 
           <div v-if="records.hasMore" class="d-flex justify-center pt-4">
-            <v-btn variant="text" :loading="records.isLoadingMore" @click="records.loadMore">Load more</v-btn>
+            <v-btn color="primary" variant="outlined" :loading="records.isLoadingMore" @click="records.loadMore">
+              Load more
+            </v-btn>
           </div>
         </template>
       </v-card-text>

--- a/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/NewElement.vue
+++ b/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/NewElement.vue
@@ -8,9 +8,12 @@
             <v-card-subtitle class="px-0">Create a new __JSKIT_UI_RESOURCE_SINGULAR_TITLE__.</v-card-subtitle>
           </div>
           <v-spacer />
-          <v-btn v-if="UI_LIST_URL" variant="text" :to="formRuntime.addEdit.resolveParams(UI_LIST_URL)">Cancel</v-btn>
+          <v-btn v-if="UI_LIST_URL" color="primary" variant="outlined" :to="formRuntime.addEdit.resolveParams(UI_LIST_URL)">
+            Cancel
+          </v-btn>
           <v-btn
             color="primary"
+            variant="flat"
             :loading="formRuntime.addEdit.isSaving"
             :disabled="formRuntime.addEdit.isSubmitDisabled"
             @click="formRuntime.addEdit.submit"

--- a/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/ViewElement.vue
+++ b/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/ViewElement.vue
@@ -17,7 +17,8 @@
           <v-spacer />
           <v-btn
             v-if="UI_LIST_URL"
-            variant="text"
+            color="primary"
+            variant="outlined"
             :to="{ path: view.resolveParams(UI_LIST_URL), query: $route.query }"
           >
             Back to __JSKIT_UI_RESOURCE_PLURAL_TITLE__
@@ -25,7 +26,7 @@
           <v-btn
             v-if="UI_EDIT_URL"
             color="primary"
-            variant="outlined"
+            variant="flat"
             :to="{ path: view.resolveParams(UI_EDIT_URL), query: $route.query }"
           >
             Edit

--- a/packages/crud-ui-generator/test/buildTemplateContext.test.js
+++ b/packages/crud-ui-generator/test/buildTemplateContext.test.js
@@ -679,7 +679,7 @@ test("buildUiTemplateContext infers tab placement and relative link-to from the 
   });
 });
 
-test("buildUiTemplateContext prefers an outlet-declared default link token over subpage heuristics", async () => {
+test("buildUiTemplateContext prefers an outlet-declared default link token and omits fragile relative to output", async () => {
   await withTempApp(async (appRoot) => {
     await writeResource(appRoot, RESOURCE_FILE, FULL_RESOURCE_SOURCE);
     await writeFileInApp(
@@ -706,7 +706,7 @@ test("buildUiTemplateContext prefers an outlet-declared default link token over 
 
     assert.equal(context.__JSKIT_UI_MENU_PLACEMENT_TARGET__, "admin-settings:primary-menu");
     assert.equal(context.__JSKIT_UI_MENU_COMPONENT_TOKEN__, "local.main.ui.surface-aware-menu-link-item");
-    assert.equal(context.__JSKIT_UI_MENU_TO_PROP_LINE__, "      to: \"./customers\",\n");
+    assert.equal(context.__JSKIT_UI_MENU_TO_PROP_LINE__, "");
   });
 });
 

--- a/packages/kernel/server/support/pageTargets.js
+++ b/packages/kernel/server/support/pageTargets.js
@@ -580,11 +580,15 @@ function resolveInferredPageLinkTo({
   explicitLinkTo = "",
   pageTarget = {},
   parentHost = null,
-  placementTarget = null
+  placementTarget = null,
+  suppressImplicitRelativeLinks = false
 } = {}) {
   const normalizedExplicitLinkTo = normalizeText(explicitLinkTo);
   if (normalizedExplicitLinkTo) {
     return normalizedExplicitLinkTo;
+  }
+  if (suppressImplicitRelativeLinks === true) {
+    return "";
   }
 
   const parentTargetId = normalizePlacementTargetId(parentHost);
@@ -670,24 +674,26 @@ async function resolvePageLinkTargetDetails({
     context,
     placement: normalizeText(placement) || parentHost?.id || ""
   });
+  const resolvedComponentToken = resolveInferredPageLinkComponentToken({
+    explicitComponentToken: componentToken,
+    parentHost,
+    placementTarget,
+    defaultComponentToken,
+    subpageComponentToken
+  });
 
   return Object.freeze({
     pageTarget: resolvedPageTarget,
     parentHost,
     placementTarget,
-    componentToken: resolveInferredPageLinkComponentToken({
-      explicitComponentToken: componentToken,
-      parentHost,
-      placementTarget,
-      defaultComponentToken,
-      subpageComponentToken
-    }),
+    componentToken: resolvedComponentToken,
     whenLine: renderPageLinkWhenLine(resolvedPageTarget),
     linkTo: resolveInferredPageLinkTo({
       explicitLinkTo: linkTo,
       pageTarget: resolvedPageTarget,
       parentHost,
-      placementTarget
+      placementTarget,
+      suppressImplicitRelativeLinks: resolvedComponentToken === (normalizeText(defaultComponentToken) || DEFAULT_PAGE_LINK_COMPONENT_TOKEN)
     })
   });
 }

--- a/packages/kernel/server/support/pageTargets.test.js
+++ b/packages/kernel/server/support/pageTargets.test.js
@@ -316,7 +316,7 @@ test("resolvePageLinkTargetDetails prefers an outlet-declared default link token
     assert.equal(details.parentHost?.id, "home-settings:primary-menu");
     assert.equal(details.placementTarget.id, "home-settings:primary-menu");
     assert.equal(details.componentToken, "local.main.ui.surface-aware-menu-link-item");
-    assert.equal(details.linkTo, "./pollen-types");
+    assert.equal(details.linkTo, "");
   });
 });
 

--- a/packages/shell-web/templates/src/placement.js
+++ b/packages/shell-web/templates/src/placement.js
@@ -50,7 +50,6 @@ addPlacement({
     label: "General",
     surface: "home",
     scopedSuffix: "/settings/general",
-    unscopedSuffix: "/settings/general",
-    to: "./general"
+    unscopedSuffix: "/settings/general"
   }
 });

--- a/packages/shell-web/test/settingsPlacementContract.test.js
+++ b/packages/shell-web/test/settingsPlacementContract.test.js
@@ -75,7 +75,7 @@ test("shell-web placement template seeds default Home and Settings drawer naviga
   assert.match(source, /target: "home-settings:primary-menu"/);
   assert.match(source, /label: "General"/);
   assert.match(source, /unscopedSuffix: "\/settings\/general"/);
-  assert.match(source, /to: "\.\/general"/);
+  assert.doesNotMatch(source, /to: "\.\/general"/);
 });
 
 test("shell-web descriptor metadata advertises home settings outlets, default drawer links, and installs the scaffold page", () => {

--- a/packages/ui-generator/test/buildTemplateContext.test.js
+++ b/packages/ui-generator/test/buildTemplateContext.test.js
@@ -189,6 +189,44 @@ test("buildUiPageTemplateContext supports explicit package outlet link placement
   });
 });
 
+test("buildUiPageTemplateContext suppresses inferred relative link-to for surface-aware settings menu links", async () => {
+  await withTempApp(async (appRoot) => {
+    await writeConfig(
+      appRoot,
+      `export const config = {
+  surfaceDefinitions: {
+    home: { id: "home", pagesRoot: "home", enabled: true }
+  }
+};
+`
+    );
+    await writeFileInApp(
+      appRoot,
+      "src/pages/home/settings.vue",
+      `<template>
+  <section>
+    <ShellOutlet
+      target="home-settings:primary-menu"
+      default-link-component-token="local.main.ui.surface-aware-menu-link-item"
+    />
+    <RouterView />
+  </section>
+</template>
+`
+    );
+
+    const context = await buildUiPageTemplateContext({
+      appRoot,
+      targetFile: "home/settings/pollen-types/index.vue",
+      options: {}
+    });
+
+    assert.equal(context.__JSKIT_UI_LINK_PLACEMENT_TARGET__, "home-settings:primary-menu");
+    assert.equal(context.__JSKIT_UI_LINK_COMPONENT_TOKEN__, "local.main.ui.surface-aware-menu-link-item");
+    assert.equal(context.__JSKIT_UI_LINK_TO_PROP_LINE__, "");
+  });
+});
+
 test("buildUiPageTemplateContext supports explicit link component token and link-to", async () => {
   await withTempApp(async (appRoot) => {
     await writeConfig(

--- a/tooling/create-app/test/createApp.test.js
+++ b/tooling/create-app/test/createApp.test.js
@@ -28,6 +28,80 @@ function createCaptureWritable() {
   };
 }
 
+async function writeCrudCustomerResource(appRoot) {
+  const resourcePath = path.join(appRoot, "packages", "customers", "src", "shared", "customerResource.js");
+  await mkdir(path.dirname(resourcePath), { recursive: true });
+  await writeFile(
+    resourcePath,
+    `const customerRecordSchema = {
+  type: "object",
+  properties: {
+    id: { type: "integer" },
+    firstName: { type: "string" },
+    email: { type: "string" },
+    vip: { type: "boolean" }
+  },
+  additionalProperties: false
+};
+
+const customerBodySchema = {
+  type: "object",
+  properties: {
+    firstName: { type: "string", maxLength: 120 },
+    email: { type: "string", maxLength: 160 },
+    vip: { type: "boolean" }
+  },
+  additionalProperties: false
+};
+
+const resource = {
+  namespace: "customers",
+  operations: {
+    list: {
+      outputValidator: {
+        schema: {
+          type: "object",
+          properties: {
+            items: {
+              type: "array",
+              items: customerRecordSchema
+            },
+            nextCursor: { type: ["string", "null"] }
+          },
+          additionalProperties: false
+        }
+      }
+    },
+    view: {
+      outputValidator: {
+        schema: customerRecordSchema
+      }
+    },
+    create: {
+      bodyValidator: {
+        schema: customerBodySchema
+      },
+      outputValidator: {
+        schema: customerRecordSchema
+      }
+    },
+    patch: {
+      bodyValidator: {
+        schema: customerBodySchema
+      },
+      outputValidator: {
+        schema: customerRecordSchema
+      }
+    }
+  }
+};
+
+export { resource };
+`,
+    "utf8"
+  );
+}
+
 test("create-app scaffolds the base shell with placeholder replacements", async () => {
   await withCreateAppTempDir(async (cwd) => {
     const result = runCli({ cwd, args: ["sample-app"] });
@@ -497,6 +571,72 @@ test("generated shell-only app passes jskit doctor and keeps minimal Procfile", 
     await access(path.join(appRoot, "src/components/menus/MenuLinkItem.vue"));
     await access(path.join(appRoot, "src/components/menus/SurfaceAwareMenuLinkItem.vue"));
     await access(path.join(appRoot, "src/components/menus/TabLinkItem.vue"));
+  });
+});
+
+test("fresh app CRUD scaffolds encode explicit M3 action hierarchy and stable settings links", async () => {
+  await withCreateAppTempDir(async (cwd) => {
+    const createResult = runCli({ cwd, args: ["crud-ui-hierarchy-app"] });
+    assert.equal(createResult.status, 0, createResult.stderr);
+
+    const appRoot = path.join(cwd, "crud-ui-hierarchy-app");
+
+    const addShellWebResult = runJskit({
+      cwd: appRoot,
+      args: ["add", "package", "shell-web"]
+    });
+    assert.equal(addShellWebResult.status, 0, addShellWebResult.stderr);
+
+    await writeCrudCustomerResource(appRoot);
+
+    const generateCrudResult = runJskit({
+      cwd: appRoot,
+      args: [
+        "generate",
+        "@jskit-ai/crud-ui-generator",
+        "crud",
+        "home/settings/customers",
+        "--resource-file",
+        "packages/customers/src/shared/customerResource.js",
+        "--id-param",
+        "customerId"
+      ]
+    });
+    assert.equal(generateCrudResult.status, 0, generateCrudResult.stderr);
+
+    const placementSource = await readFile(path.join(appRoot, "src", "placement.js"), "utf8");
+    const listPageSource = await readFile(path.join(appRoot, "src/pages/home/settings/customers/index.vue"), "utf8");
+    const viewPageSource = await readFile(path.join(appRoot, "src/pages/home/settings/customers/[customerId]/index.vue"), "utf8");
+    const newPageSource = await readFile(path.join(appRoot, "src/pages/home/settings/customers/new.vue"), "utf8");
+    const editPageSource = await readFile(path.join(appRoot, "src/pages/home/settings/customers/[customerId]/edit.vue"), "utf8");
+    const addEditFormSource = await readFile(
+      path.join(appRoot, "src/pages/home/settings/customers/_components/CrudAddEditForm.vue"),
+      "utf8"
+    );
+
+    assert.match(placementSource, /target: "home-settings:primary-menu"/);
+    assert.match(placementSource, /componentToken: "local\.main\.ui\.surface-aware-menu-link-item"/);
+    assert.match(placementSource, /scopedSuffix: "\/settings\/customers"/);
+    assert.doesNotMatch(placementSource, /to: "\.\/customers"/);
+    assert.doesNotMatch(placementSource, /to: "\.\/general"/);
+
+    assert.match(listPageSource, /<v-btn color="primary" variant="tonal" :loading="records\.isFetching"/);
+    assert.match(listPageSource, /<v-btn v-if="UI_NEW_URL" color="primary" variant="flat"/);
+    assert.match(listPageSource, /size="small"[\s\S]*color="primary"[\s\S]*variant="outlined"[\s\S]*>\s*Open/);
+    assert.match(listPageSource, /size="small"[\s\S]*color="primary"[\s\S]*variant="tonal"[\s\S]*>\s*Edit/);
+    assert.match(listPageSource, /<v-btn color="primary" variant="outlined" :loading="records\.isLoadingMore"/);
+
+    assert.match(viewPageSource, /v-if="UI_LIST_URL"[\s\S]*color="primary"[\s\S]*variant="outlined"/);
+    assert.match(viewPageSource, /v-if="UI_EDIT_URL"[\s\S]*color="primary"[\s\S]*variant="flat"/);
+
+    assert.match(newPageSource, /<CrudAddEditForm/);
+    assert.match(newPageSource, /:cancel-to="UI_CANCEL_URL"/);
+
+    assert.match(editPageSource, /<CrudAddEditForm/);
+    assert.match(editPageSource, /:cancel-to="cancelTo"/);
+
+    assert.match(addEditFormSource, /<v-btn v-if="cancelTo" color="primary" variant="outlined"/);
+    assert.match(addEditFormSource, /color="primary"[\s\S]*variant="flat"[\s\S]*:loading="addEdit\.isSaving"/);
   });
 });
 

--- a/tooling/jskit-cli/test/appCommand.test.js
+++ b/tooling/jskit-cli/test/appCommand.test.js
@@ -194,6 +194,75 @@ fs.appendFileSync(process.env.TEST_LOG_PATH, ["npm", ...process.argv.slice(2)].j
   });
 });
 
+test("jskit app verify-ui records representative generated CRUD list, detail, and settings UI files", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "app");
+    const binDir = path.join(cwd, "bin");
+    const logPath = path.join(cwd, "commands.log");
+
+    await createMinimalApp(appRoot, { jskitApp: true });
+    await initializeGitApp(appRoot);
+
+    await mkdir(path.join(appRoot, "src", "pages", "home", "settings", "customers", "[customerId]"), {
+      recursive: true
+    });
+    await writeFile(
+      path.join(appRoot, "src", "pages", "home", "settings", "customers", "index.vue"),
+      "<template><div>Generated customers list with filters</div></template>\n",
+      "utf8"
+    );
+    await writeFile(
+      path.join(appRoot, "src", "pages", "home", "settings", "customers", "[customerId]", "index.vue"),
+      "<template><div>Generated customer detail</div></template>\n",
+      "utf8"
+    );
+    await writeFile(
+      path.join(appRoot, "src", "pages", "home", "settings", "customers", "new.vue"),
+      "<template><div>Generated customer create</div></template>\n",
+      "utf8"
+    );
+
+    await installFakeCommand(
+      binDir,
+      "npx",
+      `#!/usr/bin/env node
+const fs = require("node:fs");
+fs.appendFileSync(process.env.TEST_LOG_PATH, ["npx", ...process.argv.slice(2)].join(" ") + "\\n");
+`
+    );
+
+    const result = runCli({
+      cwd: appRoot,
+      args: [
+        "app",
+        "verify-ui",
+        "--command",
+        "npx playwright test tests/e2e/generated-crud-ui.spec.ts -g hierarchy",
+        "--feature",
+        "generated crud hierarchy",
+        "--auth-mode",
+        "none"
+      ],
+      env: buildTestEnv(binDir, logPath)
+    });
+
+    assert.equal(result.status, 0, String(result.stderr || ""));
+    assert.deepEqual(await readLogLines(logPath), [
+      "npx playwright test tests/e2e/generated-crud-ui.spec.ts -g hierarchy"
+    ]);
+
+    const receipt = JSON.parse(await readFile(path.join(appRoot, ".jskit", "verification", "ui.json"), "utf8"));
+    assert.equal(receipt.runner, "playwright");
+    assert.equal(receipt.feature, "generated crud hierarchy");
+    assert.equal(receipt.command, "npx playwright test tests/e2e/generated-crud-ui.spec.ts -g hierarchy");
+    assert.deepEqual(receipt.changedUiFiles, [
+      "src/pages/home/settings/customers/[customerId]/index.vue",
+      "src/pages/home/settings/customers/index.vue",
+      "src/pages/home/settings/customers/new.vue"
+    ]);
+  });
+});
+
 test("jskit app verify-ui rejects generic package roots that are not JSKIT apps", async () => {
   await withTempDir(async (cwd) => {
     const appRoot = path.join(cwd, "package-only-root");


### PR DESCRIPTION
## Summary
- stop inferred page link targets from emitting fragile relative `to` props when a surface-aware link token already owns navigation
- update CRUD UI templates to use a cleaner M3 action hierarchy for list/view/new/edit flows
- align shell/create-app/CLI tests with the new stable link behavior

## Verification
- `npm test --workspace @jskit-ai/crud-ui-generator`
- `npm test --workspace @jskit-ai/kernel`
- `npm test --workspace @jskit-ai/shell-web`
- `npm test --workspace @jskit-ai/ui-generator`
- `npm test --workspace @jskit-ai/create-app`
- `npm test --workspace @jskit-ai/jskit-cli`