### PR TITLE
Add request query params to add/edit runtime

### DIFF
--- a/packages/agent-docs/guide/agent/generators/advanced-cruds.md
+++ b/packages/agent-docs/guide/agent/generators/advanced-cruds.md
@@ -656,6 +656,44 @@ const paths = usePaths();
 const reportsApiPath = computed(() => paths.api("/reports"));
 ```
 
+Use `requestQueryParams` when a runtime needs endpoint query parameters. Do not put query strings into `apiUrlTemplate`; URL templates are for path shape only.
+
+For routed CRUD edit forms, pass request query params through `addEditOptions`:
+
+```js
+const formRuntime = useCrudAddEdit({
+  resource: uiResource,
+  operationName: "patch",
+  formFields: UI_EDIT_FORM_FIELDS,
+  addEditOptions: {
+    apiUrlTemplate: "/products/:productId",
+    requestQueryParams: {
+      include: "serviceId,bookingSteps,bookingSteps.requiredRoleId"
+    }
+  }
+});
+```
+
+`requestQueryParams` may also be a callback. The add/edit callback receives the same scoped request context used by view/list, plus the current record id and model:
+
+```js
+const formRuntime = useCrudAddEdit({
+  resource: uiResource,
+  operationName: "patch",
+  formFields: UI_EDIT_FORM_FIELDS,
+  addEditOptions: {
+    apiUrlTemplate: "/products/:productId",
+    requestQueryParams({ recordId, model }) {
+      return {
+        include: "serviceId,bookingSteps,bookingSteps.requiredRoleId"
+      };
+    }
+  }
+});
+```
+
+For add/edit runtimes, these request query params apply to both the initial load and the save request path. That keeps the saved response shape aligned with the loaded form shape when an endpoint supports response includes.
+
 The safe mental model is:
 
 - do not raw `fetch(...)` for normal app work
@@ -663,6 +701,7 @@ The safe mental model is:
 - use the operation/runtime composable that matches the UI interaction
 - drop to `usersWebHttpClient.request(...)` only for exceptional low-level cases
 - use `usePaths().api(...)` when you need a custom scoped API path and the higher-level runtime does not already resolve it for you
+- keep `apiUrlTemplate` path-only and put endpoint query strings in `requestQueryParams`
 
 ### `_components/CrudAddEditForm.vue`
 

--- a/packages/agent-docs/patterns/client-requests.md
+++ b/packages/agent-docs/patterns/client-requests.md
@@ -47,6 +47,8 @@ Why this is the standard JSKIT shape:
 - The higher-level list, view, add/edit, and command runtimes send requests through the shared HTTP runtime.
 - `usersWebHttpClient` already handles credentials and CSRF behavior.
 - `useEndpointResource()` is the shared endpoint primitive for loading, saving, and standard load/save error handling. Higher-level runtimes add UI feedback and field-error handling on top.
+- Use `requestQueryParams` for endpoint query strings on list, view, and add/edit runtimes.
+- Keep `apiUrlTemplate` path-only. Do not put `?include=...` or other query strings in URL templates.
 
 Avoid:
 
@@ -54,3 +56,4 @@ Avoid:
 - page-local HTTP helpers that duplicate JSKIT runtime seams
 - manually concatenating scoped route params into API URLs
 - using a lower-level seam when a higher-level routed CRUD or command runtime already fits
+- smuggling query params into `apiUrlTemplate`

--- a/packages/agent-docs/reference/autogen/packages/crud-server-generator.md
+++ b/packages/agent-docs/reference/autogen/packages/crud-server-generator.md
@@ -215,39 +215,6 @@ Exports
 Exports
 - None
 
-### .tmp-crud-server-template-fixture-FNbPfi
-
-### `.tmp-crud-server-template-fixture-FNbPfi/src/server/actionIds.js`
-Exports
-- `actionIds`
-
-### `.tmp-crud-server-template-fixture-FNbPfi/src/server/actions.js`
-Exports
-- `createActions({ surface = "" } = {})`
-Local functions
-- `requireActionSurface(surface = "")`
-
-### `.tmp-crud-server-template-fixture-FNbPfi/src/server/listConfig.js`
-Exports
-- `LIST_CONFIG`
-
-### `.tmp-crud-server-template-fixture-FNbPfi/src/server/registerRoutes.js`
-Exports
-- `registerRoutes(app, { routeOwnershipFilter = "public", routeSurface = "", routeRelativePath = "" } = {})`
-
-### `.tmp-crud-server-template-fixture-FNbPfi/src/server/repository.js`
-Exports
-- `createRepository(knex, options = {})`
-
-### `.tmp-crud-server-template-fixture-FNbPfi/src/server/service.js`
-Exports
-- `createService({ customersRepository, fieldAccess = DEFAULT_FIELD_ACCESS } = {})`
-- `serviceEvents`
-
-### `.tmp-crud-server-template-fixture-FNbPfi/src/shared/customerResource.js`
-Exports
-- `resource`
-
 ### test-support
 
 ### `test-support/templateServerFixture.js`

--- a/packages/agent-docs/reference/autogen/packages/kernel.md
+++ b/packages/agent-docs/reference/autogen/packages/kernel.md
@@ -1288,7 +1288,7 @@ Local functions
 - `normalizePlacementTargetId(target = {})`
 - `resolveRelativeLinkToFromParent(pageTarget = {}, parentHost = null)`
 - `resolveRelativeLinkToFromNearestIndexOwner(pageTarget = {})`
-- `resolveInferredPageLinkTo({ explicitLinkTo = "", pageTarget = {}, parentHost = null, placementTarget = null } = {})`
+- `resolveInferredPageLinkTo({ explicitLinkTo = "", pageTarget = {}, parentHost = null, placementTarget = null, suppressImplicitRelativeLinks = false } = {})`
 - `resolveInferredPageLinkComponentToken({ explicitComponentToken = "", parentHost = null, placementTarget = null, defaultComponentToken = DEFAULT_PAGE_LINK_COMPONENT_TOKEN, subpageComponentToken = DEFAULT_SUBPAGE_LINK_COMPONENT_TOKEN } = {})`
 - `renderPageLinkWhenLine(pageTarget = {})`
 

--- a/packages/agent-docs/reference/autogen/packages/users-web.md
+++ b/packages/agent-docs/reference/autogen/packages/users-web.md
@@ -144,7 +144,7 @@ Local functions
 
 ### `src/client/composables/records/useAddEdit.js`
 Exports
-- `useAddEdit({ ownershipFilter = ROUTE_VISIBILITY_WORKSPACE, surfaceId = "", access = "auto", resource = null, apiSuffix = "", queryKeyFactory = null, viewPermissions = [], savePermissions = [], readMethod = "GET", readEnabled = true, writeMethod = "PATCH", placementSource = "users-web.add-edit", fallbackLoadError = "Unable to load resource.", fallbackSaveError = "Unable to save resource.", fieldErrorKeys = [], clearOnRouteChange = true, model, parseInput, mapLoadedToModel, buildRawPayload, buildSavePayload, onSaveSuccess, recordIdParam = "recordId", routeParams = null, routeRecordId = null, apiUrlTemplate = "", viewUrlTemplate = "", listUrlTemplate = "", saveRecordIdSelector = null, messages = {}, realtime = null, adapter = null } = {})`
+- `useAddEdit({ ownershipFilter = ROUTE_VISIBILITY_WORKSPACE, surfaceId = "", access = "auto", resource = null, apiSuffix = "", queryKeyFactory = null, viewPermissions = [], savePermissions = [], readMethod = "GET", readEnabled = true, writeMethod = "PATCH", placementSource = "users-web.add-edit", fallbackLoadError = "Unable to load resource.", fallbackSaveError = "Unable to save resource.", fieldErrorKeys = [], clearOnRouteChange = true, model, parseInput, mapLoadedToModel, buildRawPayload, buildSavePayload, onSaveSuccess, requestQueryParams = null, recordIdParam = "recordId", routeParams = null, routeRecordId = null, apiUrlTemplate = "", viewUrlTemplate = "", listUrlTemplate = "", saveRecordIdSelector = null, messages = {}, realtime = null, adapter = null } = {})`
 
 ### `src/client/composables/records/useCrudAddEdit.js`
 Exports
@@ -300,6 +300,12 @@ Exports
 ### `src/client/composables/support/requestQueryPathSupport.js`
 Exports
 - `appendRequestQueryEntriesToPath(path = "", entries = [])`
+
+### `src/client/composables/support/requestQueryRuntimeSupport.js`
+Exports
+- `createRequestQueryRuntime({ requestQueryParams = null, context = null, sourceQueryKey = null, sourcePath = "" } = {})`
+- `resolveRequestQueryBaseKey(sourceQueryKey = null)`
+- `resolveRequestQueryContext(context = null)`
 
 ### `src/client/composables/support/resourceLoadStateHelpers.js`
 Exports

--- a/packages/agent-docs/site/guide/generators/advanced-cruds.md
+++ b/packages/agent-docs/site/guide/generators/advanced-cruds.md
@@ -654,6 +654,44 @@ const paths = usePaths();
 const reportsApiPath = computed(() => paths.api("/reports"));
 ```
 
+Use `requestQueryParams` when a runtime needs endpoint query parameters. Do not put query strings into `apiUrlTemplate`; URL templates are for path shape only.
+
+For routed CRUD edit forms, pass request query params through `addEditOptions`:
+
+```js
+const formRuntime = useCrudAddEdit({
+  resource: uiResource,
+  operationName: "patch",
+  formFields: UI_EDIT_FORM_FIELDS,
+  addEditOptions: {
+    apiUrlTemplate: "/products/:productId",
+    requestQueryParams: {
+      include: "serviceId,bookingSteps,bookingSteps.requiredRoleId"
+    }
+  }
+});
+```
+
+`requestQueryParams` may also be a callback. The add/edit callback receives the same scoped request context used by view/list, plus the current record id and model:
+
+```js
+const formRuntime = useCrudAddEdit({
+  resource: uiResource,
+  operationName: "patch",
+  formFields: UI_EDIT_FORM_FIELDS,
+  addEditOptions: {
+    apiUrlTemplate: "/products/:productId",
+    requestQueryParams({ recordId, model }) {
+      return {
+        include: "serviceId,bookingSteps,bookingSteps.requiredRoleId"
+      };
+    }
+  }
+});
+```
+
+For add/edit runtimes, these request query params apply to both the initial load and the save request path. That keeps the saved response shape aligned with the loaded form shape when an endpoint supports response includes.
+
 The safe mental model is:
 
 - do not raw `fetch(...)` for normal app work
@@ -661,6 +699,7 @@ The safe mental model is:
 - use the operation/runtime composable that matches the UI interaction
 - drop to `usersWebHttpClient.request(...)` only for exceptional low-level cases
 - use `usePaths().api(...)` when you need a custom scoped API path and the higher-level runtime does not already resolve it for you
+- keep `apiUrlTemplate` path-only and put endpoint query strings in `requestQueryParams`
 
 ### `_components/CrudAddEditForm.vue`
 

--- a/packages/users-web/src/client/composables/records/useAddEdit.js
+++ b/packages/users-web/src/client/composables/records/useAddEdit.js
@@ -14,6 +14,7 @@ import {
 import {
   resolveResourceMessages
 } from "../support/scopeHelpers.js";
+import { createRequestQueryRuntime } from "../support/requestQueryRuntimeSupport.js";
 import { resolveRouteParamNamesInOrder } from "../support/routeTemplateHelpers.js";
 
 function useAddEdit({
@@ -39,6 +40,7 @@ function useAddEdit({
   buildRawPayload,
   buildSavePayload,
   onSaveSuccess,
+  requestQueryParams = null,
   recordIdParam = "recordId",
   routeParams = null,
   routeRecordId = null,
@@ -95,10 +97,25 @@ function useAddEdit({
   const canView = operationScope.permissionGate("view");
   const canSave = operationScope.permissionGate("save");
   const queryCanRun = operationScope.queryCanRun(canView);
+  const queryParamsContext = computed(() => {
+    return Object.freeze({
+      surfaceId: operationScope.routeContext.currentSurfaceId.value,
+      scopeParamValue: operationScope.scopeParamValue.value,
+      ownershipFilter: operationScope.normalizedOwnershipFilter,
+      recordId: addEditUiRuntime.recordId.value,
+      model
+    });
+  });
+  const requestQueryRuntime = createRequestQueryRuntime({
+    requestQueryParams,
+    context: queryParamsContext,
+    sourceQueryKey: operationScope.queryKey,
+    sourcePath: operationScope.apiPath
+  });
 
   const endpointResource = useEndpointResource({
-    queryKey: operationScope.queryKey,
-    path: operationScope.apiPath,
+    queryKey: requestQueryRuntime.queryKey,
+    path: requestQueryRuntime.requestPath,
     enabled: queryCanRun,
     readMethod,
     writeMethod,
@@ -114,7 +131,7 @@ function useAddEdit({
   const addEdit = useAddEditCore({
     model,
     resource: endpointResource,
-    queryKey: operationScope.queryKey,
+    queryKey: requestQueryRuntime.queryKey,
     canSave,
     fieldBag,
     feedback,

--- a/packages/users-web/src/client/composables/runtime/useAddEditCore.js
+++ b/packages/users-web/src/client/composables/runtime/useAddEditCore.js
@@ -73,6 +73,7 @@ function useAddEditCore({
       : parsedInput;
 
     try {
+      const queryKeySnapshot = queryKey?.value;
       const payload = await resource.save(savePayload);
 
       if (typeof mapLoadedToModel === "function") {
@@ -82,8 +83,8 @@ function useAddEditCore({
         });
       }
 
-      if (queryKey?.value !== undefined) {
-        queryClient.setQueryData(queryKey.value, payload);
+      if (queryKeySnapshot !== undefined) {
+        queryClient.setQueryData(queryKeySnapshot, payload);
       }
 
       if (typeof onSaveSuccess === "function") {

--- a/packages/users-web/src/client/composables/support/requestQueryRuntimeSupport.js
+++ b/packages/users-web/src/client/composables/support/requestQueryRuntimeSupport.js
@@ -1,0 +1,69 @@
+import { computed, unref } from "vue";
+import {
+  resolveQueryParamDescriptors,
+  resolveActiveQueryParamEntries,
+  buildQueryParamEntriesToken
+} from "./listQueryParamSupport.js";
+import { appendRequestQueryEntriesToPath } from "./requestQueryPathSupport.js";
+
+function resolveRequestQueryContext(context = null) {
+  const source = unref(context);
+  return source && typeof source === "object" && !Array.isArray(source) ? source : {};
+}
+
+function resolveRequestQueryBaseKey(sourceQueryKey = null) {
+  const source = unref(sourceQueryKey);
+  if (Array.isArray(source)) {
+    return [...source];
+  }
+  if (source == null) {
+    return [];
+  }
+  return [source];
+}
+
+function createRequestQueryRuntime({
+  requestQueryParams = null,
+  context = null,
+  sourceQueryKey = null,
+  sourcePath = ""
+} = {}) {
+  const requestQueryParamDescriptors = computed(() => {
+    return resolveQueryParamDescriptors(requestQueryParams, resolveRequestQueryContext(context));
+  });
+  const activeRequestQueryParamEntries = computed(() => {
+    return resolveActiveQueryParamEntries(requestQueryParamDescriptors.value);
+  });
+  const activeRequestQueryParamsToken = computed(() => {
+    return buildQueryParamEntriesToken(activeRequestQueryParamEntries.value);
+  });
+  const queryKey = computed(() => {
+    if (!activeRequestQueryParamsToken.value) {
+      return unref(sourceQueryKey);
+    }
+
+    const next = resolveRequestQueryBaseKey(sourceQueryKey);
+    next.push("__request_query__", activeRequestQueryParamsToken.value);
+    return next;
+  });
+  const requestPath = computed(() => {
+    return appendRequestQueryEntriesToPath(
+      unref(sourcePath),
+      activeRequestQueryParamEntries.value
+    );
+  });
+
+  return Object.freeze({
+    requestQueryParamDescriptors,
+    activeRequestQueryParamEntries,
+    activeRequestQueryParamsToken,
+    queryKey,
+    requestPath
+  });
+}
+
+export {
+  createRequestQueryRuntime,
+  resolveRequestQueryBaseKey,
+  resolveRequestQueryContext
+};

--- a/packages/users-web/test/useAddEditCore.test.js
+++ b/packages/users-web/test/useAddEditCore.test.js
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { QueryClient, VueQueryPlugin } from "@tanstack/vue-query";
+import { computed, createSSRApp, effectScope, h, reactive, ref } from "vue";
+import { useAddEditCore } from "../src/client/composables/runtime/useAddEditCore.js";
+
+test("useAddEditCore writes saved payloads to the submit-time query key", async () => {
+  const queryClient = new QueryClient();
+  const model = reactive({
+    status: "draft"
+  });
+  const payload = {
+    id: 42,
+    status: "published"
+  };
+  const resource = {
+    isSaving: ref(false),
+    async save() {
+      return payload;
+    }
+  };
+  let runtime = null;
+  const app = createSSRApp({
+    render() {
+      return h("div");
+    }
+  });
+  app.use(VueQueryPlugin, {
+    queryClient
+  });
+  const scope = effectScope();
+
+  app.runWithContext(() => {
+    scope.run(() => {
+      runtime = useAddEditCore({
+        model,
+        resource,
+        queryKey: computed(() => ["products", model.status]),
+        canSave: ref(true),
+        fieldBag: {
+          clear() {},
+          apply() {}
+        },
+        feedback: {
+          clear() {},
+          success() {},
+          error() {}
+        },
+        mapLoadedToModel(target = {}, loaded = {}) {
+          target.status = loaded.status;
+        }
+      });
+    });
+  });
+
+  await runtime.submit();
+  scope.stop();
+
+  assert.equal(model.status, "published");
+  assert.deepEqual(queryClient.getQueryData(["products", "draft"]), payload);
+  assert.equal(queryClient.getQueryData(["products", "published"]), undefined);
+});
+
+test("useAddEditCore snapshots the cache key after payload normalization", async () => {
+  const queryClient = new QueryClient();
+  const model = reactive({
+    status: "draft"
+  });
+  const payload = {
+    id: 42,
+    status: "published"
+  };
+  const resource = {
+    isSaving: ref(false),
+    async save() {
+      return payload;
+    }
+  };
+  let runtime = null;
+  const app = createSSRApp({
+    render() {
+      return h("div");
+    }
+  });
+  app.use(VueQueryPlugin, {
+    queryClient
+  });
+  const scope = effectScope();
+
+  app.runWithContext(() => {
+    scope.run(() => {
+      runtime = useAddEditCore({
+        model,
+        resource,
+        queryKey: computed(() => ["products", model.status]),
+        canSave: ref(true),
+        fieldBag: {
+          clear() {},
+          apply() {}
+        },
+        feedback: {
+          clear() {},
+          success() {},
+          error() {}
+        },
+        buildRawPayload() {
+          model.status = "normalized";
+          return {};
+        },
+        mapLoadedToModel(target = {}, loaded = {}) {
+          target.status = loaded.status;
+        }
+      });
+    });
+  });
+
+  await runtime.submit();
+  scope.stop();
+
+  assert.equal(model.status, "published");
+  assert.equal(queryClient.getQueryData(["products", "draft"]), undefined);
+  assert.deepEqual(queryClient.getQueryData(["products", "normalized"]), payload);
+  assert.equal(queryClient.getQueryData(["products", "published"]), undefined);
+});

--- a/packages/users-web/test/useAddEditRequestQueryParams.test.js
+++ b/packages/users-web/test/useAddEditRequestQueryParams.test.js
@@ -1,0 +1,166 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { computed, reactive, ref, shallowRef } from "vue";
+import { createRequestQueryRuntime } from "../src/client/composables/support/requestQueryRuntimeSupport.js";
+
+test("add/edit request query params resolve stable cache tokens and request paths", () => {
+  const sourceQueryKey = ref(["products", "dev-admin"]);
+  const sourcePath = ref("/api/w/dev-admin/products/product-42");
+  const context = ref(Object.freeze({
+    surfaceId: "admin",
+    scopeParamValue: "dev-admin",
+    ownershipFilter: "workspace",
+    recordId: "product-42",
+    model: {
+      status: "draft"
+    }
+  }));
+  const runtime = createRequestQueryRuntime({
+    requestQueryParams(callbackContext = {}) {
+      assert.deepEqual(callbackContext, context.value);
+
+      return {
+        include: "serviceId,bookingSteps,bookingSteps.requiredRoleId",
+        preview: callbackContext.model.status === "draft"
+      };
+    },
+    context,
+    sourceQueryKey,
+    sourcePath
+  });
+
+  assert.deepEqual(runtime.activeRequestQueryParamEntries.value, [
+    {
+      key: "include",
+      values: ["serviceId,bookingSteps,bookingSteps.requiredRoleId"]
+    },
+    {
+      key: "preview",
+      values: ["1"]
+    }
+  ]);
+  assert.equal(
+    runtime.activeRequestQueryParamsToken.value,
+    "include=serviceId,bookingSteps,bookingSteps.requiredRoleId&preview=1"
+  );
+  assert.deepEqual(
+    runtime.queryKey.value,
+    [
+      "products",
+      "dev-admin",
+      "__request_query__",
+      "include=serviceId,bookingSteps,bookingSteps.requiredRoleId&preview=1"
+    ]
+  );
+  assert.equal(
+    runtime.requestPath.value,
+    "/api/w/dev-admin/products/product-42?include=serviceId%2CbookingSteps%2CbookingSteps.requiredRoleId&preview=1"
+  );
+});
+
+test("add/edit request query params react to callback context changes", () => {
+  const recordId = ref("product-42");
+  const model = reactive({
+    status: "draft"
+  });
+  const context = computed(() => Object.freeze({
+    surfaceId: "admin",
+    scopeParamValue: "dev-admin",
+    ownershipFilter: "workspace",
+    recordId: recordId.value,
+    model
+  }));
+  const runtime = createRequestQueryRuntime({
+    requestQueryParams(callbackContext = {}) {
+      return {
+        include: "bookingSteps",
+        preview: callbackContext.model.status === "draft",
+        recordId: callbackContext.recordId
+      };
+    },
+    context,
+    sourceQueryKey: computed(() => ["products", context.value.scopeParamValue]),
+    sourcePath: computed(() => `/api/w/dev-admin/products/${recordId.value}`)
+  });
+
+  assert.deepEqual(
+    runtime.queryKey.value,
+    [
+      "products",
+      "dev-admin",
+      "__request_query__",
+      "include=bookingSteps&preview=1&recordId=product-42"
+    ]
+  );
+  assert.equal(
+    runtime.requestPath.value,
+    "/api/w/dev-admin/products/product-42?include=bookingSteps&preview=1&recordId=product-42"
+  );
+
+  model.status = "published";
+  recordId.value = "product-99";
+
+  assert.deepEqual(
+    runtime.queryKey.value,
+    [
+      "products",
+      "dev-admin",
+      "__request_query__",
+      "include=bookingSteps&recordId=product-99"
+    ]
+  );
+  assert.equal(
+    runtime.requestPath.value,
+    "/api/w/dev-admin/products/product-99?include=bookingSteps&recordId=product-99"
+  );
+});
+
+test("request query runtime preserves scalar base query keys", () => {
+  const runtime = createRequestQueryRuntime({
+    requestQueryParams: {
+      include: "bookingSteps"
+    },
+    sourceQueryKey: ref("products"),
+    sourcePath: "/api/products/42"
+  });
+
+  assert.deepEqual(
+    runtime.queryKey.value,
+    [
+      "products",
+      "__request_query__",
+      "include=bookingSteps"
+    ]
+  );
+});
+
+test("request query runtime leaves keys and paths unchanged without active request params", () => {
+  const sourceQueryKey = ["products"];
+  const runtime = createRequestQueryRuntime({
+    requestQueryParams: {
+      include: "",
+      archived: false
+    },
+    sourceQueryKey: shallowRef(sourceQueryKey),
+    sourcePath: "/api/products/42"
+  });
+
+  assert.deepEqual(runtime.activeRequestQueryParamEntries.value, []);
+  assert.equal(runtime.activeRequestQueryParamsToken.value, "");
+  assert.deepEqual(runtime.queryKey.value, ["products"]);
+  assert.equal(runtime.queryKey.value, sourceQueryKey);
+  assert.equal(runtime.requestPath.value, "/api/products/42");
+});
+
+test("request query runtime preserves inactive scalar query keys", () => {
+  const runtime = createRequestQueryRuntime({
+    requestQueryParams: {
+      include: ""
+    },
+    sourceQueryKey: ref("products"),
+    sourcePath: "/api/products/42"
+  });
+
+  assert.equal(runtime.queryKey.value, "products");
+  assert.equal(runtime.requestPath.value, "/api/products/42");
+});


### PR DESCRIPTION
## Summary
- add requestQueryParams support for add/edit endpoint paths and query keys
- snapshot add/edit save cache keys after payload normalization and before loaded-model mapping
- document the path-only apiUrlTemplate contract and regenerate agent docs/reference output

## Verification
- npm --workspace packages/users-web test -- test/useAddEditCore.test.js test/useAddEditRequestQueryParams.test.js
- npm run agent-docs:build
- npm --workspace packages/users-web test
- npm run generated:check