### PR TITLE
Tighten auth and assistant validation flows

### DIFF
--- a/FLOW.md
+++ b/FLOW.md
@@ -1,0 +1,957 @@
+# CRUD Schema Flow
+
+This file describes how a CRUD module in `jskit-ai` uses `json-rest-schema` today, from the shared resource contract all the way through routes, actions, services, and the repository runtime.
+
+The key rule is:
+
+- shared CRUD contracts are authored once as schema definition objects
+- the same contracts are reused at the HTTP boundary, action boundary, and repository boundary
+
+The standard authored shape is:
+
+```js
+{
+  schema: createSchema({ ... }),
+  mode: "create" | "patch" | "replace"
+}
+```
+
+## 1. Shared Resource Contract
+
+The root contract for a CRUD module is the shared resource file.
+
+Representative file:
+
+- `packages/crud-server-generator/templates/src/local-package/shared/crudResource.js`
+
+Important shape:
+
+```js
+const recordOutputSchema = createSchema({
+  // record fields...
+});
+
+const createBodySchema = createSchema({
+  // create fields...
+});
+
+const patchBodySchema = createSchema({
+  // patch fields...
+});
+
+const recordOutput = deepFreeze({
+  schema: recordOutputSchema,
+  mode: "replace"
+});
+
+const listOutput = createCursorListValidator(recordOutput);
+
+const createBody = deepFreeze({
+  schema: createBodySchema,
+  mode: "create"
+});
+
+const patchBody = deepFreeze({
+  schema: patchBodySchema,
+  mode: "patch"
+});
+
+const resource = deepFreeze({
+  namespace: "customers",
+  tableName: "customers",
+  idColumn: "id",
+  operations: {
+    list: {
+      method: "GET",
+      output: listOutput
+    },
+    view: {
+      method: "GET",
+      output: recordOutput
+    },
+    create: {
+      method: "POST",
+      body: createBody,
+      output: recordOutput
+    },
+    patch: {
+      method: "PATCH",
+      body: patchBody,
+      output: recordOutput
+    },
+    delete: {
+      method: "DELETE",
+      output: deleteOutput
+    }
+  }
+});
+```
+
+Important points:
+
+- `resource.operations.create.body` is the canonical create-input contract
+- `resource.operations.patch.body` is the canonical patch-input contract
+- `resource.operations.view.output` is the canonical record-output contract
+- `resource.operations.list.output` is derived from the record-output contract
+
+## 2. List Output Wrapper
+
+List output is built from the item schema, not hand-authored separately.
+
+Owner:
+
+- `packages/kernel/shared/validators/createCursorListValidator.js`
+
+Important code:
+
+```js
+function createCursorListValidator(itemValidator) {
+  const itemDefinition = normalizeSingleSchemaDefinition(itemValidator, {
+    context: "cursor list item",
+    defaultMode: "replace"
+  });
+
+  return deepFreeze({
+    schema: createSchema({
+      items: {
+        type: "array",
+        required: true,
+        items: itemDefinition.schema
+      },
+      nextCursor: {
+        type: "string",
+        required: false,
+        nullable: true,
+        minLength: 1
+      }
+    }),
+    mode: "replace"
+  });
+}
+```
+
+So list output is:
+
+- `items: <array of record output items>`
+- `nextCursor: string | null`
+
+## 3. Provider Wiring
+
+The provider wires repository, service, actions, and routes.
+
+Representative file:
+
+- `packages/crud-server-generator/templates/src/local-package/server/CrudProvider.js`
+
+Important code:
+
+```js
+app.singleton("repository.customers", (scope) => {
+  const knex = scope.make("jskit.database.knex");
+  return createRepository(knex, {
+    resolveLookup: createCrudLookupResolver(scope)
+  });
+});
+
+app.service(
+  "crud.customers",
+  (scope) => {
+    return createService({
+      customersRepository: scope.make("repository.customers")
+    });
+  },
+  {
+    events: serviceEvents
+  }
+);
+
+app.actions(
+  withActionDefaults(
+    createActions({
+      surface: crudPolicy.surfaceId
+    }),
+    {
+      domain: "crud",
+      dependencies: {
+        customersService: "crud.customers"
+      }
+    }
+  )
+);
+```
+
+The provider does not validate payloads itself. It only wires the runtime graph.
+
+## 4. Route Contracts
+
+Routes consume the shared resource contract directly.
+
+Representative file:
+
+- `packages/crud-server-generator/templates/src/local-package/server/registerRoutes.js`
+
+### Create route
+
+```js
+router.register(
+  "POST",
+  routeBase,
+  {
+    body: resource.operations.create.body,
+    responses: withStandardErrorResponses(
+      {
+        201: resource.operations.create.output
+      },
+      { includeValidation400: true }
+    )
+  },
+  async function (request, reply) {
+    const response = await request.executeAction({
+      actionId: actionIds.create,
+      input: {
+        ...(request.input.body || {})
+      }
+    });
+    reply.code(201).send(response);
+  }
+);
+```
+
+### Patch route
+
+```js
+router.register(
+  "PATCH",
+  `${routeBase}/:recordId`,
+  {
+    params: recordRouteParamsValidator,
+    body: resource.operations.patch.body,
+    responses: withStandardErrorResponses(
+      {
+        200: resource.operations.patch.output
+      },
+      { includeValidation400: true }
+    )
+  },
+  async function (request, reply) {
+    const response = await request.executeAction({
+      actionId: actionIds.update,
+      input: {
+        recordId: request.input.params.recordId,
+        ...(request.input.body || {})
+      }
+    });
+    reply.code(200).send(response);
+  }
+);
+```
+
+### List route
+
+List query is composed from multiple schema definitions:
+
+```js
+const listRouteQueryValidator = composeSchemaDefinitions([
+  listCursorPaginationQueryValidator,
+  listSearchQueryValidator,
+  listParentFilterQueryValidator,
+  lookupIncludeQueryValidator
+], {
+  mode: "patch",
+  context: "customers.registerRoutes.listRouteQueryValidator"
+});
+```
+
+So routes use:
+
+- body schemas from `resource.operations.*.body`
+- output schemas from `resource.operations.*.output`
+- query/params schemas from shared validators composed into one schema definition
+
+## 5. Route Compilation
+
+Route definitions are compiled into:
+
+- Fastify transport schema
+- runtime input transforms that validate and normalize `request.body/query/params`
+
+Owner:
+
+- `packages/kernel/server/http/lib/routeValidator.js`
+
+Important code:
+
+```js
+if (normalizedValidator.body) {
+  schema.body = resolveSchemaTransportSchemaDefinition(normalizedValidator.body, {
+    defaultMode: "patch",
+    context: "route validator.body"
+  });
+  input.body = createJsonRestSchemaInputTransform(normalizedValidator.body, {
+    defaultMode: "patch",
+    context: "route validator.body"
+  });
+}
+```
+
+The input transform is:
+
+```js
+function createJsonRestSchemaInputTransform(definition, { defaultMode = "patch", context = "route validator" } = {}) {
+  return (payload) => validateSchemaPayload(definition, payload, {
+    phase: defaultMode === "replace" ? "output" : "input",
+    context,
+    statusCode: 400
+  });
+}
+```
+
+So each route validator produces:
+
+- `schema.body/querystring/params` for Fastify
+- `input.body/query/params` for normalized request input
+
+## 6. Request Input Construction
+
+Once a route is registered, `request.input` is built from the compiled transforms.
+
+Owner:
+
+- `packages/kernel/server/http/lib/routeRegistration.js`
+
+Important code:
+
+```js
+if (routeInputTransforms) {
+  request.input = await buildRequestInput({
+    request,
+    inputTransforms: routeInputTransforms
+  });
+}
+```
+
+And:
+
+```js
+const body = typeof transforms.body === "function" ? await transforms.body(request?.body, request) : request?.body;
+const query = typeof transforms.query === "function" ? await transforms.query(request?.query, request) : request?.query;
+const params = typeof transforms.params === "function" ? await transforms.params(request?.params, request) : request?.params;
+```
+
+After this stage:
+
+- `request.input.body`
+- `request.input.query`
+- `request.input.params`
+
+are already validated and normalized.
+
+## 7. Route Handler To Action Executor
+
+Route handlers do not call services directly. They call `request.executeAction(...)`.
+
+Owner:
+
+- `packages/kernel/server/http/lib/requestActionExecutor.js`
+
+Representative route code:
+
+```js
+const response = await request.executeAction({
+  actionId: actionIds.create,
+  input: {
+    ...(request.input.body || {})
+  }
+});
+```
+
+The request executor is attached by the HTTP runtime and forwards into the action runtime:
+
+```js
+const actionExecutor = resolutionScope.make(normalizedActionExecutorToken);
+
+return actionExecutor.execute({
+  actionId: source.actionId,
+  version: source.version == null ? null : source.version,
+  input: normalizedInput,
+  context: executionContext,
+  deps: normalizedDeps
+});
+```
+
+So the route layer hands off:
+
+- normalized route input
+- execution context
+- optional dependency overrides
+
+to the action runtime.
+
+## 8. Shared Schema Execution
+
+The central runtime entrypoint is `validateSchemaPayload(...)`.
+
+Owner:
+
+- `packages/kernel/shared/validators/schemaPayloadValidation.js`
+
+Important code:
+
+```js
+const result = executeJsonRestSchemaDefinition(schemaDefinition, payload, {
+  defaultMode: phase === "output" ? "replace" : "patch",
+  context
+});
+
+const fieldErrors = normalizeJsonRestSchemaFieldErrors(result?.errors, schemaDefinition);
+if (Object.keys(fieldErrors).length > 0) {
+  throw buildSchemaValidationError({
+    fieldErrors,
+    statusCode
+  });
+}
+
+return result?.validatedObject ?? payload;
+```
+
+This is the core runtime rule:
+
+1. execute the schema definition
+2. map schema errors into field errors
+3. throw if invalid
+4. return normalized `validatedObject`
+
+## 9. Action Input Contracts
+
+CRUD actions build their input contract from the same shared schemas.
+
+Representative file:
+
+- `packages/crud-server-generator/templates/src/local-package/server/actions.js`
+
+Important code:
+
+```js
+const createActionInputValidator = composeSchemaDefinitions([
+  resource.operations.create.body,
+], {
+  mode: "create"
+});
+
+const updateActionInputValidator = composeSchemaDefinitions([
+  recordIdParamsValidator,
+  resource.operations.patch.body,
+], {
+  mode: "patch"
+});
+```
+
+And the action definition uses them directly:
+
+```js
+{
+  id: actionIds.create,
+  kind: "command",
+  input: createActionInputValidator,
+  output: resource.operations.create.output,
+  async execute(input, context, deps) {
+    return deps.customersService.createRecord(input, {
+      context,
+      visibilityContext: context?.visibilityContext
+    });
+  }
+}
+```
+
+So actions do not invent new schemas. They compose existing ones.
+
+## 10. Action Definition Normalization
+
+Action definitions are normalized up front when registered.
+
+Owner:
+
+- `packages/kernel/shared/actions/actionDefinitions.js`
+
+Important code:
+
+```js
+return Object.freeze({
+  id,
+  version,
+  domain,
+  kind,
+  channels,
+  surfaces,
+  input: normalizeActionInputDefinition(source.input, "input", {
+    required: true
+  }),
+  output: normalizeActionOutputDefinition(source.output, "output", {
+    required: false
+  }),
+  ...
+});
+```
+
+So an action’s `input` and `output` must already be valid schema definition objects before the runtime starts using them.
+
+## 11. Action Runtime Validation
+
+Action execution validates input before `execute()`, and validates output after `execute()`.
+
+Owner:
+
+- `packages/kernel/shared/actions/policies.js`
+- `packages/kernel/shared/actions/pipeline.js`
+
+Important input validation:
+
+```js
+return validateSchemaPayload(definition?.input, input, {
+  phase: "input",
+  definition,
+  context
+});
+```
+
+Important output validation:
+
+```js
+return validateSchemaPayload(definition.output, output, {
+  phase: "output",
+  definition,
+  context
+});
+```
+
+And in the action pipeline:
+
+```js
+const normalizedInput = await normalizeActionInput(definition, input, normalizedContext);
+const executionResult = await definition.execute(normalizedInput, normalizedContext, deps);
+const normalizedResult = await normalizeActionOutput(definition, executionResult, normalizedContext);
+```
+
+So action execution is:
+
+1. validate input
+2. run business logic
+3. validate output
+
+## 12. Service Layer
+
+The CRUD service layer does not own schema validation. It owns orchestration and field access.
+
+Owner:
+
+- `packages/crud-core/src/server/serviceMethods.js`
+
+Example create flow:
+
+```js
+const writablePayload = await runtime.fieldAccessRuntime.enforceWritablePayload(payload, fieldAccess, {
+  action: "create",
+  payload,
+  options,
+  context: options?.context
+});
+
+const record = await resolvedRepository.create(writablePayload, options);
+return runtime.fieldAccessRuntime.filterReadableRecord(record, fieldAccess, {
+  action: "create",
+  options,
+  context: options?.context
+});
+```
+
+So the service layer does:
+
+- field access enforcement
+- orchestration
+- repository calls
+- record-not-found handling
+
+It does **not** define the CRUD schema.
+
+## 13. Repository Runtime Compilation
+
+The generated repository delegates into `createCrudResourceRuntime(resource, knex, ...)`.
+
+Owner:
+
+- `packages/crud-server-generator/templates/src/local-package/server/repository.js`
+- `packages/crud-core/src/server/resourceRuntime/index.js`
+
+Generated repository:
+
+```js
+const resourceRuntime = createCrudResourceRuntime(resource, knex, {
+  ...options,
+  ...REPOSITORY_CONFIG
+});
+```
+
+The compiled runtime pulls the same shared schemas out of the resource:
+
+```js
+return Object.freeze({
+  input: Object.freeze({
+    create: resolveOperationBodyValidator(resource, "create", { context }),
+    patch: resolveOperationBodyValidator(resource, "patch", { context })
+  }),
+  output,
+  mapping: repositoryMapping,
+  ...
+});
+```
+
+## 14. Repository Mapping Derived From Shared Contract
+
+The repository runtime derives DB mapping from the same shared resource contract. That includes:
+
+- the output/create/patch schema definitions
+- field metadata embedded in those definitions, such as:
+  - `actualField`
+  - `storage`
+  - `relation`
+  - `ui`
+
+Owner:
+
+- `packages/crud-core/src/server/repositorySupport.js`
+- `packages/kernel/shared/support/crudFieldContract.js`
+
+Important code:
+
+```js
+const outputSchema = resolveStructuredSchemaTransportSchema(operations?.view?.output, {
+  context: `${context} operations.view.output`,
+  defaultMode: "replace"
+});
+const writeSchema = resolveStructuredSchemaTransportSchema(operations?.create?.body, {
+  context: `${context} operations.create.body`,
+  defaultMode: "create"
+});
+const patchSchema = resolveStructuredSchemaTransportSchema(operations?.patch?.body, {
+  context: `${context} operations.patch.body`,
+  defaultMode: "patch"
+});
+```
+
+And field contract metadata is extracted from the same shared definitions:
+
+```js
+const sections = [
+  resolveCrudFieldSchemaProperties(resource?.operations?.view?.output, ...),
+  resolveCrudFieldSchemaProperties(resource?.operations?.create?.body, ...),
+  resolveCrudFieldSchemaProperties(resource?.operations?.patch?.body, ...)
+];
+
+const storage = normalizeCrudFieldStorageConfig(definition, ...);
+
+entries[key] = mergeFieldContractEntry(entries[key], {
+  actualField: normalizeText(definition.actualField),
+  parentRouteParamKey,
+  storage,
+  relation,
+  ui
+}, ...);
+```
+
+From the shared contract it derives:
+
+- output keys
+- write keys
+- list search columns
+- parent filter columns
+- record-id fields
+- datetime serializer hints
+
+So the repository does not need a second field registry, but it is not driven by schema shape alone. It also reads contract metadata carried on the shared field definitions.
+
+## 15. Repository Input Validation
+
+Create and patch payloads are validated again at the repository boundary.
+
+Owner:
+
+- `packages/crud-core/src/server/resourceRuntime/index.js`
+
+Important code:
+
+```js
+const nextPayload = validateSchemaPayload(input, normalizedPayload, {
+  phase: "input",
+  context: `${runtime?.context || "crudRepository"} operations.${operationKey}.body`
+});
+```
+
+This happens inside:
+
+```js
+let sourcePayload = await normalizeRepositoryInputPayload(runtime, payload, {
+  operationKey: "create"
+});
+```
+
+Then the normalized API payload is converted into a DB payload:
+
+```js
+let insertPayload = buildWritePayload(
+  sourcePayload,
+  runtime.mapping.writeKeys,
+  runtime.mapping.columnOverrides,
+  {
+    serializerByKey: runtime.mapping.writeSerializerByKey
+  }
+);
+```
+
+The same pattern is used for patch:
+
+```js
+let sourcePatch = await normalizeRepositoryInputPayload(runtime, patch, {
+  operationKey: "patch"
+});
+
+const dbPatch = buildWritePayload(
+  sourcePatch,
+  runtime.mapping.writeKeys,
+  runtime.mapping.columnOverrides,
+  {
+    serializerByKey: runtime.mapping.writeSerializerByKey
+  }
+);
+```
+
+So repository writes are protected by the same schemas even if the repository is called outside the HTTP/action path.
+
+## 16. Repository Output Validation
+
+After reading DB rows, the repository maps columns back to API fields and validates the result against the shared output schema.
+
+Important code:
+
+```js
+const mappedRecord = mapRecordRow(
+  row,
+  runtime.mapping.outputKeys,
+  runtime.mapping.columnOverrides,
+  { recordIdKeys: runtime.mapping.outputRecordIdKeys }
+);
+```
+
+Then:
+
+```js
+return validateSchemaPayload(runtime.output, record, {
+  phase: "output",
+  context: `${runtime?.context || "crudRepository"} operations.view.output`
+});
+```
+
+This happens for:
+
+- list
+- findById
+- listByIds
+
+So the repository validates what it reads back out of storage before returning it upward.
+
+## 17. Full `POST /resource` Flow
+
+Create flow, end to end:
+
+1. Shared resource defines:
+   - `resource.operations.create.body`
+   - `resource.operations.create.output`
+
+2. Route registers:
+
+```js
+body: resource.operations.create.body
+responses: { 201: resource.operations.create.output }
+```
+
+3. Route validator compiles:
+   - Fastify transport schema from the same schema definition
+   - runtime `request.input.body` transform from the same schema definition
+
+4. Route handler calls:
+
+```js
+request.executeAction({
+  actionId: actionIds.create,
+  input: {
+    ...(request.input.body || {})
+  }
+})
+```
+
+5. Action pipeline validates input against the action input contract.
+
+6. Service enforces field access and calls repository.
+
+7. Repository validates the payload again against `resource.operations.create.body`.
+
+8. Repository maps API keys to DB columns and inserts the row.
+
+9. Repository reloads the row and validates it against `resource.operations.view.output`.
+
+10. Action pipeline validates the returned result against `resource.operations.create.output`.
+
+11. Route sends the response, and the response transport schema is also derived from that same output contract.
+
+## 18. Full `PATCH /resource/:recordId` Flow
+
+Patch flow is the same structure, with one extra piece: params are merged with body for the action input.
+
+1. Route validates:
+   - `params`
+   - `body`
+
+2. Route handler builds action input:
+
+```js
+input: {
+  recordId: request.input.params.recordId,
+  ...(request.input.body || {})
+}
+```
+
+3. Action input is validated against:
+
+```js
+composeSchemaDefinitions([
+  recordIdParamsValidator,
+  resource.operations.patch.body,
+], {
+  mode: "patch"
+})
+```
+
+4. Repository validates patch payload again against `resource.operations.patch.body`
+
+5. Repository updates row and reloads normalized output
+
+6. Action output is validated against `resource.operations.patch.output`
+
+## 19. Full `GET /resource` List Flow
+
+List flow is query-shaped rather than body-shaped.
+
+1. Route query schema is composed from:
+   - cursor pagination
+   - text search
+   - parent filters
+   - include lookup options
+
+2. Route validates and normalizes `request.input.query`
+
+3. Action validates list input again through the same composed schema definition
+
+4. Repository applies:
+   - generic list search/cursor filters
+   - parent filters
+   - optional configured query stages
+
+5. Repository maps each row to API fields
+
+6. Repository validates each mapped record against the record output schema
+
+7. Repository hydrates lookups
+
+8. Action validates final `{ items, nextCursor }` against `resource.operations.list.output`
+
+## 20. Important Boundary Summary
+
+### Shared resource owns
+
+- canonical CRUD input/output schemas
+- lookup contract metadata
+- transport-visible field contract
+
+### Route layer owns
+
+- Fastify transport schema generation
+- request section validation at the HTTP boundary
+- construction of `request.input`
+- dispatch into `request.executeAction(...)`
+
+### Action layer owns
+
+- validation of action input/output
+- permissions, channels, surfaces
+- execution orchestration
+
+### Service layer owns
+
+- business orchestration
+- field access rules
+- repository invocation
+
+### Repository layer owns
+
+- DB column mapping derived from shared contract
+- validation before writes
+- validation after reads
+- list filtering/query application
+
+## 21. Current Exception
+
+The one notable exception to the neat schema-first flow is CRUD list filters.
+
+Owner:
+
+- `packages/crud-core/src/server/listFilters.js`
+
+The custom schema type validates raw query shapes:
+
+```js
+createSchema.addType(CRUD_LIST_FILTER_QUERY_TYPE, Object.assign(
+  (context) => {
+    ...
+    return context.value;
+  },
+  {
+    toJsonSchema(...) {
+      ...
+    }
+  }
+));
+```
+
+But semantic normalization still happens later in a separate runtime:
+
+```js
+function normalize(payload = {}) {
+  ...
+}
+```
+
+So list filters are still the main place where:
+
+- schema validation
+- semantic normalization
+
+are split instead of being fully unified.
+
+## 22. Bottom Line
+
+For normal CRUD create/view/update/delete and cursor-list flows, the architecture is now:
+
+- one shared CRUD contract
+- reused by routes
+- reused by actions
+- reused by repository runtime
+
+The same schemas are used for:
+
+- HTTP input validation
+- action input validation
+- repository input validation
+- repository output validation
+- action output validation
+- Fastify transport schema generation
+
+That is the current schema flow the CRUD stack is built around.

--- a/FLOW.md
+++ b/FLOW.md
@@ -905,26 +905,42 @@ Owner:
 
 - `packages/crud-core/src/server/listFilters.js`
 
-The custom schema type validates raw query shapes:
+At route/action boundaries, structured filter params should now still be authored explicitly:
 
 ```js
-createSchema.addType(CRUD_LIST_FILTER_QUERY_TYPE, Object.assign(
-  (context) => {
-    ...
-    return context.value;
-  },
-  {
-    toJsonSchema(...) {
-      ...
-    }
-  }
-));
+const listRouteQueryValidator = {
+  schema: createCrudListFilterQuerySchema({
+    status: createCrudListFilterQueryField(CONTACTS_LIST_FILTER_DEFINITIONS.status, {
+      invalidValues: "reject"
+    }),
+    arrivalDate: createCrudListFilterQueryField(CONTACTS_LIST_FILTER_DEFINITIONS.arrivalDate, {
+      invalidValues: "reject"
+    })
+  }),
+  mode: "patch"
+};
 ```
 
-But semantic normalization still happens later in a separate runtime:
+The custom schema type does own parsing of each filter field:
 
 ```js
-function normalize(payload = {}) {
+const parsedValue = parseCrudListFilterQueryValue(filter, context.value, {
+  invalidValues
+});
+
+return parsedValue;
+```
+
+But the server runtime still reprojects those parsed query-field values through filter keys and repository semantics:
+
+```js
+function parseFilterPayload(payload = {}) {
+  const result = discardValidator.schema.patch(normalizeObjectInput(payload));
+  return projectNormalizedFilterValues(filterEntries, result.validatedObject, result.errors);
+}
+
+function applyQuery(queryBuilder, payload = {}) {
+  const normalized = parseFilterPayload(payload);
   ...
 }
 ```
@@ -932,9 +948,15 @@ function normalize(payload = {}) {
 So list filters are still the main place where:
 
 - schema validation
-- semantic normalization
+- repository-facing semantic normalization / query application
 
-are split instead of being fully unified.
+are split instead of being fully unified in one schema pass.
+
+That split is intentional for now:
+
+- route/action query params stay explicit in app code
+- shared filter definitions still own filter metadata and parsing rules
+- repository runtime still owns the last step that maps parsed filter values to filter keys and SQL semantics
 
 ## 22. Bottom Line
 

--- a/LAST_ITEMS.md
+++ b/LAST_ITEMS.md
@@ -4,7 +4,7 @@
   - Current problem: `packages/assistant-runtime/src/server/registerRoutes.js` still builds `params` as validator arrays like `[workspaceScopeSupport.params, assistantSurfaceRouteParams]`.
   - Why it matters: the route layer now expects a single schema definition object, and the real router path throws on this shape.
 
-- [ ] 2. Convert `assistant-runtime` action input composition to real schema definitions.
+- [x] 2. Convert `assistant-runtime` action input composition to real schema definitions.
   - Current problem: `packages/assistant-runtime/src/server/actions.js` still uses legacy input arrays for `query`, `params`, `body`, and `patch` composition.
   - Why it matters: this keeps one package on the old contract model after the rest of the repo moved to single schema definitions.
 
@@ -16,10 +16,10 @@
   - Current problem: shared auth commands now define `json-rest-schema` contracts, but server flows still use manual parsers like `validators.registerInput(...)`, `validators.loginInput(...)`, `validators.forgotPasswordInput(...)`, `validatePasswordRecoveryPayload(...)`, and other handwritten payload parsers.
   - Why it matters: the shared schema is no longer the one owner of auth input semantics, and some flows still validate one subset of fields while reading other values directly from raw `payload`.
 
-- [ ] 5. Decide whether CRUD list filters should remain a deliberate two-phase exception or be pulled fully under the schema contract.
-  - Current problem: `packages/crud-core/src/server/listFilters.js` still splits query validation from final normalized filter projection.
-  - Why it matters: it is one of the few remaining places where “schema validates and normalizes” is not fully true.
+- [x] 5. Decide whether CRUD list filters should remain a deliberate two-phase exception or be pulled fully under the schema contract.
+  - Decision: keep the two-phase server runtime, but make route/action query params explicit with `createCrudListFilterQueryField(...)` and `createCrudListFilterQuerySchema(...)`.
+  - Why it matters: accepted filter params now stay visible in app code instead of hiding behind whole-query validator generation.
 
-- [ ] 6. If CRUD list filters stay two-phase, document that exception explicitly in the architecture docs.
-  - Current problem: the codebase otherwise presents a single-contract validation model.
-  - Why it matters: if the two-phase list-filter model remains intentional after the decision above, it should be called out instead of looking like accidental drift.
+- [x] 6. If CRUD list filters stay two-phase, document that exception explicitly in the architecture docs.
+  - Decision: documented in `FLOW.md` and CRUD filter guidance so the remaining exception is explicit instead of accidental drift.
+  - Why it matters: the codebase otherwise presents a single-contract validation model.

--- a/LAST_ITEMS.md
+++ b/LAST_ITEMS.md
@@ -1,0 +1,25 @@
+# Last Items
+
+- [x] 1. Convert `assistant-runtime` route param composition to real schema definitions.
+  - Current problem: `packages/assistant-runtime/src/server/registerRoutes.js` still builds `params` as validator arrays like `[workspaceScopeSupport.params, assistantSurfaceRouteParams]`.
+  - Why it matters: the route layer now expects a single schema definition object, and the real router path throws on this shape.
+
+- [ ] 2. Convert `assistant-runtime` action input composition to real schema definitions.
+  - Current problem: `packages/assistant-runtime/src/server/actions.js` still uses legacy input arrays for `query`, `params`, `body`, and `patch` composition.
+  - Why it matters: this keeps one package on the old contract model after the rest of the repo moved to single schema definitions.
+
+- [x] 3. Add regression coverage that exercises `assistant-runtime` through the real route validator path.
+  - Current problem: the current tests mostly stub `router.register(...)` and do not force route-validator compilation for the workspace-scoped assistant routes.
+  - Why it matters: that is how the legacy array-shaped params path survived without failing tests.
+
+- [ ] 4. Collapse `auth-provider-supabase-core` onto the shared auth command schema contract.
+  - Current problem: shared auth commands now define `json-rest-schema` contracts, but server flows still use manual parsers like `validators.registerInput(...)`, `validators.loginInput(...)`, `validators.forgotPasswordInput(...)`, `validatePasswordRecoveryPayload(...)`, and other handwritten payload parsers.
+  - Why it matters: the shared schema is no longer the one owner of auth input semantics, and some flows still validate one subset of fields while reading other values directly from raw `payload`.
+
+- [ ] 5. Decide whether CRUD list filters should remain a deliberate two-phase exception or be pulled fully under the schema contract.
+  - Current problem: `packages/crud-core/src/server/listFilters.js` still splits query validation from final normalized filter projection.
+  - Why it matters: it is one of the few remaining places where “schema validates and normalizes” is not fully true.
+
+- [ ] 6. If CRUD list filters stay two-phase, document that exception explicitly in the architecture docs.
+  - Current problem: the codebase otherwise presents a single-contract validation model.
+  - Why it matters: if the two-phase list-filter model remains intentional after the decision above, it should be called out instead of looking like accidental drift.

--- a/VALIDATION_CLEANUP_TODO.txt
+++ b/VALIDATION_CLEANUP_TODO.txt
@@ -1,0 +1,5 @@
+[done] 1. Remove CRUD field-contract fallback paths and require schema definitions only
+[done] 3. Replace local bootstrap boolean parsing with shared normalization
+[done] 4. Simplify generator output around schema composition
+[done] 2. Centralize CRUD list-filter parsing/normalization in shared support and make server/client consume it
+[done] Verification sweep and final review

--- a/packages/agent-docs/guide/agent/generators/advanced-cruds.md
+++ b/packages/agent-docs/guide/agent/generators/advanced-cruds.md
@@ -974,7 +974,7 @@ Instead:
 
 1. define the filters once in a shared CRUD-package module
 2. build the server runtime from that definition with `createCrudListFilters(...)`
-3. choose the route/action invalid-value contract explicitly with `createQueryValidator({ invalidValues: "reject" | "discard" })`
+3. choose the route/action invalid-value contract explicitly on each structured filter field with `createCrudListFilterQueryField(...)`
 4. build the client runtime from that same definition with `useCrudListFilters(...)`
 
 For example, a shared filter-definition module can look like this:
@@ -1001,7 +1001,7 @@ export const CONTACTS_LIST_FILTER_DEFINITIONS = Object.freeze({
 For a generated CRUD, treat this as the concrete file plan:
 
 - create `packages/contacts/src/shared/contactListFilters.js`
-- update `packages/contacts/src/server/registerRoutes.js` so the list route query validator includes an explicit `createQueryValidator({ invalidValues: ... })` choice, unless you already extracted list-query composition into `packages/contacts/src/server/listQueryValidators.js`
+- update `packages/contacts/src/server/registerRoutes.js` so the list route query validator lists structured filter params explicitly with `createCrudListFilterQueryField(...)`, unless you already extracted list-query composition into `packages/contacts/src/server/listQueryValidators.js`
 - update `packages/contacts/src/server/actions.js` so the list action input validator includes that same explicit contract choice
 - update `packages/contacts/src/server/repository.js` so the list query path builds the `createCrudListFilters(...)` runtime and calls `applyQuery(...)`
 - update the app-owned list page or list-runtime composable, usually under `src/pages/.../contacts/` or `src/composables/...`, so it builds `useCrudListFilters(...)`, passes `queryParams` into `useCrudList(...)`, and renders chips / reset behavior from that runtime
@@ -1128,25 +1128,43 @@ const contactsListFiltersRuntime = createCrudListFilters(
 );
 ```
 
-There is no default query-validator mode or legacy route-runtime alias. Create the validator that matches the contract you want at that route or action boundary.
+There is no default query-validator mode or legacy route-runtime alias. Keep the filter runtime for repository semantics, but author route/action query params explicitly.
 
 Strict contract example:
 
 ```js
-const contactsListFiltersQueryValidator = contactsListFiltersRuntime.createQueryValidator({
-  invalidValues: "reject" // malformed filter values should fail validation and return 400
-});
+const contactsListFilters = CONTACTS_LIST_FILTER_DEFINITIONS;
+
+const contactsListFiltersQueryValidator = {
+  schema: createCrudListFilterQuerySchema({
+    status: createCrudListFilterQueryField(contactsListFilters.status, {
+      invalidValues: "reject"
+    }),
+    arrivalDate: createCrudListFilterQueryField(contactsListFilters.arrivalDate, {
+      invalidValues: "reject"
+    })
+  }),
+  mode: "patch"
+};
 ```
 
 Lenient contract example:
 
 ```js
-const contactsListFiltersQueryValidator = contactsListFiltersRuntime.createQueryValidator({
-  invalidValues: "discard" // malformed filter values should be ignored and dropped by normalize()
-});
+const contactsListFiltersQueryValidator = {
+  schema: createCrudListFilterQuerySchema({
+    status: createCrudListFilterQueryField(CONTACTS_LIST_FILTER_DEFINITIONS.status, {
+      invalidValues: "discard"
+    }),
+    arrivalDate: createCrudListFilterQueryField(CONTACTS_LIST_FILTER_DEFINITIONS.arrivalDate, {
+      invalidValues: "discard"
+    })
+  }),
+  mode: "patch"
+};
 ```
 
-Wire the runtime into the list validator and the repository:
+Wire the explicit query contract into the list validator and the repository:
 
 ```js
 const listRouteQueryValidator = composeSchemaDefinitions([
@@ -1160,16 +1178,16 @@ const listRouteQueryValidator = composeSchemaDefinitions([
 });
 ```
 
-Use that same `contactsListFiltersQueryValidator` anywhere else the list query is validated, such as the composed list action input validator if your CRUD package validates query shape at both the route and action boundaries.
+Use that same explicit `contactsListFiltersQueryValidator` anywhere else the list query is validated, such as the composed list action input validator if your CRUD package validates query shape at both the route and action boundaries.
 
 Choose the invalid-value contract deliberately:
 
-- there is no default mode and no fallback alias, so every route or action that validates structured filters must call `createQueryValidator({ invalidValues: ... })` explicitly
+- there is no default mode and no fallback alias, so every structured filter field must choose `invalidValues: "reject"` or `invalidValues: "discard"` explicitly
 - use `invalidValues: "reject"` when malformed filter values should fail validation and produce a 400-style contract error
 - use `invalidValues: "discard"` when malformed filter values should be ignored and normalization should drop them
 - route query validation runs before auth, so this choice changes whether malformed unauthenticated requests fail at validation or fall through to auth
-- for normal HTTP CRUD handlers, route-level `discard` means the handler receives already-normalized query input, so the action layer will not see those discarded bad values again later
-- `jskit doctor` flags `createQueryValidator(...)` calls that do not spell out `invalidValues` directly at the call site
+- for normal HTTP CRUD handlers, route-level `discard` means the handler receives already-parsed filter values for the explicit fields you listed, so the action layer will not see those discarded bad values again later
+- the filter runtime is still a deliberate two-phase exception: schema parsing owns query-field values, then `applyQuery(...)` maps those parsed values back through filter keys and SQL semantics
 
 ```js
 async function list(query = {}, callOptions = {}) {
@@ -1185,11 +1203,11 @@ async function list(query = {}, callOptions = {}) {
 
 - Put the filter definitions in the CRUD package, not the page. Both server and client need them.
 - Keep the filter keys identical all the way through: definition key, query param key, and repository meaning.
-- Do not expect a default route-runtime query-validator alias. Every structured-filter validator must be created explicitly with `createQueryValidator({ invalidValues: ... })`.
+- Prefer `createCrudListFilterQueryField(...)` plus `createCrudListFilterQuerySchema(...)` at route/action boundaries so accepted structured-filter params stay visible in app code.
 - Use `type: "presence"` for null/not-null filters such as assigned vs unassigned storage. Do not model those as custom enums plus `applyQuery(...)` overrides unless the SQL semantics are genuinely different from `whereNotNull(...)` / `whereNull(...)`.
 - Use `createCrudListFilters(...)` unless the list semantics are truly unusual.
 - Use `q` for free-text and explicit query params for structured filters.
-- Run `jskit doctor` after wiring filters. It flags inline/local filter-definition objects passed into `useCrudListFilters(...)` or `createCrudListFilters(...)`, and it flags `createQueryValidator(...)` calls that hide the invalid-value policy.
+- Run `jskit doctor` after wiring filters. It flags inline/local filter-definition objects passed into `useCrudListFilters(...)` or `createCrudListFilters(...)`.
 
 ### Pattern 4: lookup-backed structured filters
 
@@ -1472,7 +1490,7 @@ Use `scaffold-field` when it fits, then review the generated result.
 Touch:
 
 - `packages/<crud>/src/shared/<crud>ListFilters.js` and make it the only authored filter-definition module
-- `packages/<crud>/src/server/registerRoutes.js` and `packages/<crud>/src/server/actions.js` so the list validator includes an explicit `createQueryValidator({ invalidValues: ... })` choice, or `packages/<crud>/src/server/listQueryValidators.js` if you extracted list-query composition there
+- `packages/<crud>/src/server/registerRoutes.js` and `packages/<crud>/src/server/actions.js` so the list validator lists structured filter params explicitly with `createCrudListFilterQueryField(...)`, or `packages/<crud>/src/server/listQueryValidators.js` if you extracted list-query composition there
 - `packages/<crud>/src/server/repository.js` so the list query applies the runtime
 - the app-owned list page or list-runtime composable that calls `useCrudList(...)`
 

--- a/packages/agent-docs/patterns/filters.md
+++ b/packages/agent-docs/patterns/filters.md
@@ -17,25 +17,25 @@ Default JSKIT pattern:
 1. Put shared filter definitions in the CRUD package.
    Example path: `packages/<crud>/src/shared/<crud>ListFilters.js`
 2. Build the server runtime from that module with `createCrudListFilters(...)`.
-3. Build route/action validators explicitly with `createQueryValidator({ invalidValues: "reject" | "discard" })`, and use `applyQuery(...)` in the repository. There is no default validator mode or legacy route-runtime alias.
+3. Build route/action validators explicitly with `createCrudListFilterQueryField(...)` plus `createCrudListFilterQuerySchema(...)`, and use `applyQuery(...)` in the repository. There is no default validator mode or legacy route-runtime alias.
 4. Build the client runtime from the same shared definitions with `useCrudListFilters(...)`. Presets can use static `values` or dynamic `resolveValues({ values, filters, presetKey, preset })`.
 5. Pass `listFilters.queryParams` into `useCrudList(...)`.
 6. For lookup-backed filters, use `useCrudListFilterLookups(...)` instead of hand-rolling `useList()` in each page.
 
 Exact file checklist:
 - create `packages/<crud>/src/shared/<crud>ListFilters.js`
-- update `packages/<crud>/src/server/registerRoutes.js` and `packages/<crud>/src/server/actions.js` so the list query validator includes an explicit `createQueryValidator({ invalidValues: ... })` choice, or update `packages/<crud>/src/server/listQueryValidators.js` if that package already extracts list-query composition there
+- update `packages/<crud>/src/server/registerRoutes.js` and `packages/<crud>/src/server/actions.js` so the list query validator lists structured filter params explicitly with `createCrudListFilterQueryField(...)` inside `createCrudListFilterQuerySchema(...)`, or update `packages/<crud>/src/server/listQueryValidators.js` if that package already extracts list-query composition there
 - update `packages/<crud>/src/server/repository.js` so list queries call the runtime's `applyQuery(...)`
 - update the app-owned list page or list-runtime composable under `src/pages/...` or `src/composables/...` so it builds `useCrudListFilters(...)`, passes `queryParams` into `useCrudList(...)`, and binds chips / reset behavior
 - for lookup-backed filters, update that same client file to build `useCrudListFilterLookups(...)` and bind the lookup control from `resolveLookup(...)`
 
 Validation mode is part of the contract:
-- there is no default mode and no fallback alias, so every route/action boundary that validates structured filters must call `createQueryValidator({ invalidValues: ... })` explicitly
+- there is no default mode and no fallback alias, so every explicit structured filter field must choose `invalidValues: "reject"` or `invalidValues: "discard"` deliberately
 - use `invalidValues: "reject"` when malformed filter values should fail validation and return a 400-style contract error
 - use `invalidValues: "discard"` when malformed filter values should be ignored and normalization should drop them
 - route query validation runs before auth, so this choice affects whether malformed unauthenticated requests fail at validation or fall through to auth
-- for normal HTTP CRUD handlers, route-level `discard` means the action layer receives already-normalized query input; do not assume route `discard` plus action `reject` will still reject malformed HTTP query strings later
-- `jskit doctor` flags `createQueryValidator(...)` calls that do not spell out `invalidValues` directly at the call site
+- for normal HTTP CRUD handlers, route-level `discard` means the action layer receives already-parsed values for those explicit filter fields; do not assume route `discard` plus action `reject` will still reject malformed HTTP query strings later
+- CRUD list filters are still a deliberate two-phase exception: schema parsing owns query-field values, then the server runtime reprojects those parsed values through filter keys and `applyQuery(...)`
 
 Keep separate:
 - free-text search uses `records.searchQuery` and `q`
@@ -65,7 +65,7 @@ Put unusual SQL semantics on the server:
 Avoid:
 - local filter composables that duplicate the same keys the server already knows about
 - a custom validator shape that does not match the page state
-- assuming a default route-runtime query-validator alias exists; always create the validator explicitly with `createQueryValidator({ invalidValues: ... })`
+- hiding accepted structured filter params behind whole-query validator generation when the route/action contract can list them directly
 - hand-rolled preset apply/reset/active-state helpers when `useCrudListFilters(..., { presets })`, `applyPreset(...)`, and `matchesPreset(...)` fit
 - per-screen `useList()` wrappers for lookup-backed filters when `useCrudListFilterLookups(...)` fits
 - a second page-local filter-definition file when `packages/<crud>/src/shared/<crud>ListFilters.js` should be the source of truth
@@ -86,7 +86,7 @@ Preset contract notes:
 
 Review checks:
 - one shared filter definition source of truth
-- server validator/repository logic derived from that source
+- server validator/repository logic derived from that source, with route/action query params still listed explicitly
 - client query params/chips/reset logic derived from that source
 - lookup-backed filters use the shared lookup helper, not a page-local mini-framework
-- `jskit doctor` stays clean for filter ownership and explicit validator policy
+- the two-phase server exception is intentional and documented, not accidental drift

--- a/packages/agent-docs/reference/autogen/packages/assistant-runtime.md
+++ b/packages/agent-docs/reference/autogen/packages/assistant-runtime.md
@@ -86,8 +86,7 @@ Exports
 Exports
 - `registerRoutes(app)`
 Local functions
-- `buildRouteParamsValidator(requiresWorkspace, workspaceScopeSupport = null)`
-- `buildConversationMessagesRouteParamsValidator(requiresWorkspace, workspaceScopeSupport = null)`
+- `requireWorkspaceAssistantRouteParams(workspaceScopeSupport = null)`
 - `readWorkspaceInput(request, requiresWorkspace, workspaceScopeSupport = null)`
 - `requireAssistantSurface(appConfig = {}, targetSurfaceId = "")`
 - `requireHostSurfaceId(request)`
@@ -195,6 +194,8 @@ Exports
 - `WORKSPACES_SERVER_SCOPE_SUPPORT_TOKEN`
 - `isWorkspaceServerScopeSupport(value)`
 - `resolveWorkspaceServerScopeSupport(scope = null, { required = false, caller = "assistant-runtime" } = {})`
+Local functions
+- `hasWorkspaceRouteParamsDefinition(value)`
 
 ### `src/shared/assistantRuntimeConfig.js`
 Exports

--- a/packages/agent-docs/reference/autogen/packages/auth-provider-supabase-core.md
+++ b/packages/agent-docs/reference/autogen/packages/auth-provider-supabase-core.md
@@ -58,12 +58,8 @@ Exports
 ### `src/server/lib/authInputParsers.js`
 Exports
 - `normalizeOAuthProviderInput(value, options = {})`
-- `validatePasswordRecoveryPayload(payload)`
-- `parseOAuthCompletePayload(payload = {}, options = {})`
-- `parseOtpLoginVerifyPayload(payload = {})`
 - `mapOAuthCallbackError(errorCode)`
 Local functions
-- `applySessionPairValidation(accessToken, refreshToken, fieldErrors)`
 - `resolveConfiguredOAuthProviders(options = {})`
 
 ### `src/server/lib/authJwt.js`
@@ -216,10 +212,7 @@ Exports
 - `buildOAuthLoginRedirectUrl`
 - `buildOAuthLinkRedirectUrl`
 - `normalizeOAuthProviderInput`
-- `parseOAuthCompletePayload`
-- `parseOtpLoginVerifyPayload`
 - `mapOAuthCallbackError`
-- `validatePasswordRecoveryPayload`
 - `resolveSupabaseOAuthProviderCatalog`
 - `resolveOAuthProviderQueryParams`
 - `buildOAuthProviderCatalogResponse`

--- a/packages/agent-docs/reference/autogen/packages/crud-core.md
+++ b/packages/agent-docs/reference/autogen/packages/crud-core.md
@@ -131,12 +131,15 @@ Local functions
 Exports
 - `CRUD_LIST_FILTER_INVALID_VALUES_REJECT`
 - `CRUD_LIST_FILTER_INVALID_VALUES_DISCARD`
+- `createCrudListFilterQueryField(filterDefinition = {}, { invalidValues = CRUD_LIST_FILTER_INVALID_VALUES_REJECT } = {})`
+- `createCrudListFilterQuerySchema(structure = {})`
 - `createCrudListFilters(definitions = {}, { columns = {}, apply = {} } = {})`
 Local functions
 - `cloneTransportSchema(value)`
 - `buildSingleOrMultiTransportSchema(itemSchema)`
 - `addDaysToDateFilterValue(value = "", days = 0)`
-- `buildFilterQueryFieldDefinition(filter = {}, { invalidValues = CRUD_LIST_FILTER_INVALID_VALUES_REJECT } = {})`
+- `normalizeCrudListFilterQueryFieldInput(filterDefinition = null)`
+- `buildFilterQueryFieldDefinition(filterDefinition = {}, { invalidValues = CRUD_LIST_FILTER_INVALID_VALUES_REJECT } = {})`
 - `buildFilterQueryTransportSchema(filter = {}, { invalidValues = CRUD_LIST_FILTER_INVALID_VALUES_REJECT } = {})`
 - `buildFilterQuerySchemaDefinition(filterEntries = [], { invalidValues = CRUD_LIST_FILTER_INVALID_VALUES_REJECT } = {})`
 - `projectNormalizedFilterValues(filterEntries = [], source = {}, errors = {})`

--- a/packages/agent-docs/site/guide/generators/advanced-cruds.md
+++ b/packages/agent-docs/site/guide/generators/advanced-cruds.md
@@ -972,7 +972,7 @@ Instead:
 
 1. define the filters once in a shared CRUD-package module
 2. build the server runtime from that definition with `createCrudListFilters(...)`
-3. choose the route/action invalid-value contract explicitly with `createQueryValidator({ invalidValues: "reject" | "discard" })`
+3. choose the route/action invalid-value contract explicitly on each structured filter field with `createCrudListFilterQueryField(...)`
 4. build the client runtime from that same definition with `useCrudListFilters(...)`
 
 For example, a shared filter-definition module can look like this:
@@ -999,7 +999,7 @@ export const CONTACTS_LIST_FILTER_DEFINITIONS = Object.freeze({
 For a generated CRUD, treat this as the concrete file plan:
 
 - create `packages/contacts/src/shared/contactListFilters.js`
-- update `packages/contacts/src/server/registerRoutes.js` so the list route query validator includes an explicit `createQueryValidator({ invalidValues: ... })` choice, unless you already extracted list-query composition into `packages/contacts/src/server/listQueryValidators.js`
+- update `packages/contacts/src/server/registerRoutes.js` so the list route query validator lists structured filter params explicitly with `createCrudListFilterQueryField(...)`, unless you already extracted list-query composition into `packages/contacts/src/server/listQueryValidators.js`
 - update `packages/contacts/src/server/actions.js` so the list action input validator includes that same explicit contract choice
 - update `packages/contacts/src/server/repository.js` so the list query path builds the `createCrudListFilters(...)` runtime and calls `applyQuery(...)`
 - update the app-owned list page or list-runtime composable, usually under `src/pages/.../contacts/` or `src/composables/...`, so it builds `useCrudListFilters(...)`, passes `queryParams` into `useCrudList(...)`, and renders chips / reset behavior from that runtime
@@ -1126,25 +1126,43 @@ const contactsListFiltersRuntime = createCrudListFilters(
 );
 ```
 
-There is no default query-validator mode or legacy route-runtime alias. Create the validator that matches the contract you want at that route or action boundary.
+There is no default query-validator mode or legacy route-runtime alias. Keep the filter runtime for repository semantics, but author route/action query params explicitly.
 
 Strict contract example:
 
 ```js
-const contactsListFiltersQueryValidator = contactsListFiltersRuntime.createQueryValidator({
-  invalidValues: "reject" // malformed filter values should fail validation and return 400
-});
+const contactsListFilters = CONTACTS_LIST_FILTER_DEFINITIONS;
+
+const contactsListFiltersQueryValidator = {
+  schema: createCrudListFilterQuerySchema({
+    status: createCrudListFilterQueryField(contactsListFilters.status, {
+      invalidValues: "reject"
+    }),
+    arrivalDate: createCrudListFilterQueryField(contactsListFilters.arrivalDate, {
+      invalidValues: "reject"
+    })
+  }),
+  mode: "patch"
+};
 ```
 
 Lenient contract example:
 
 ```js
-const contactsListFiltersQueryValidator = contactsListFiltersRuntime.createQueryValidator({
-  invalidValues: "discard" // malformed filter values should be ignored and dropped by normalize()
-});
+const contactsListFiltersQueryValidator = {
+  schema: createCrudListFilterQuerySchema({
+    status: createCrudListFilterQueryField(CONTACTS_LIST_FILTER_DEFINITIONS.status, {
+      invalidValues: "discard"
+    }),
+    arrivalDate: createCrudListFilterQueryField(CONTACTS_LIST_FILTER_DEFINITIONS.arrivalDate, {
+      invalidValues: "discard"
+    })
+  }),
+  mode: "patch"
+};
 ```
 
-Wire the runtime into the list validator and the repository:
+Wire the explicit query contract into the list validator and the repository:
 
 ```js
 const listRouteQueryValidator = composeSchemaDefinitions([
@@ -1158,16 +1176,16 @@ const listRouteQueryValidator = composeSchemaDefinitions([
 });
 ```
 
-Use that same `contactsListFiltersQueryValidator` anywhere else the list query is validated, such as the composed list action input validator if your CRUD package validates query shape at both the route and action boundaries.
+Use that same explicit `contactsListFiltersQueryValidator` anywhere else the list query is validated, such as the composed list action input validator if your CRUD package validates query shape at both the route and action boundaries.
 
 Choose the invalid-value contract deliberately:
 
-- there is no default mode and no fallback alias, so every route or action that validates structured filters must call `createQueryValidator({ invalidValues: ... })` explicitly
+- there is no default mode and no fallback alias, so every structured filter field must choose `invalidValues: "reject"` or `invalidValues: "discard"` explicitly
 - use `invalidValues: "reject"` when malformed filter values should fail validation and produce a 400-style contract error
 - use `invalidValues: "discard"` when malformed filter values should be ignored and normalization should drop them
 - route query validation runs before auth, so this choice changes whether malformed unauthenticated requests fail at validation or fall through to auth
-- for normal HTTP CRUD handlers, route-level `discard` means the handler receives already-normalized query input, so the action layer will not see those discarded bad values again later
-- `jskit doctor` flags `createQueryValidator(...)` calls that do not spell out `invalidValues` directly at the call site
+- for normal HTTP CRUD handlers, route-level `discard` means the handler receives already-parsed filter values for the explicit fields you listed, so the action layer will not see those discarded bad values again later
+- the filter runtime is still a deliberate two-phase exception: schema parsing owns query-field values, then `applyQuery(...)` maps those parsed values back through filter keys and SQL semantics
 
 ```js
 async function list(query = {}, callOptions = {}) {
@@ -1183,11 +1201,11 @@ async function list(query = {}, callOptions = {}) {
 
 - Put the filter definitions in the CRUD package, not the page. Both server and client need them.
 - Keep the filter keys identical all the way through: definition key, query param key, and repository meaning.
-- Do not expect a default route-runtime query-validator alias. Every structured-filter validator must be created explicitly with `createQueryValidator({ invalidValues: ... })`.
+- Prefer `createCrudListFilterQueryField(...)` plus `createCrudListFilterQuerySchema(...)` at route/action boundaries so accepted structured-filter params stay visible in app code.
 - Use `type: "presence"` for null/not-null filters such as assigned vs unassigned storage. Do not model those as custom enums plus `applyQuery(...)` overrides unless the SQL semantics are genuinely different from `whereNotNull(...)` / `whereNull(...)`.
 - Use `createCrudListFilters(...)` unless the list semantics are truly unusual.
 - Use `q` for free-text and explicit query params for structured filters.
-- Run `jskit doctor` after wiring filters. It flags inline/local filter-definition objects passed into `useCrudListFilters(...)` or `createCrudListFilters(...)`, and it flags `createQueryValidator(...)` calls that hide the invalid-value policy.
+- Run `jskit doctor` after wiring filters. It flags inline/local filter-definition objects passed into `useCrudListFilters(...)` or `createCrudListFilters(...)`.
 
 ### Pattern 4: lookup-backed structured filters
 
@@ -1470,7 +1488,7 @@ Use `scaffold-field` when it fits, then review the generated result.
 Touch:
 
 - `packages/<crud>/src/shared/<crud>ListFilters.js` and make it the only authored filter-definition module
-- `packages/<crud>/src/server/registerRoutes.js` and `packages/<crud>/src/server/actions.js` so the list validator includes an explicit `createQueryValidator({ invalidValues: ... })` choice, or `packages/<crud>/src/server/listQueryValidators.js` if you extracted list-query composition there
+- `packages/<crud>/src/server/registerRoutes.js` and `packages/<crud>/src/server/actions.js` so the list validator lists structured filter params explicitly with `createCrudListFilterQueryField(...)`, or `packages/<crud>/src/server/listQueryValidators.js` if you extracted list-query composition there
 - `packages/<crud>/src/server/repository.js` so the list query applies the runtime
 - the app-owned list page or list-runtime composable that calls `useCrudList(...)`
 

--- a/packages/assistant-runtime/src/server/actions.js
+++ b/packages/assistant-runtime/src/server/actions.js
@@ -1,3 +1,10 @@
+import { createSchema } from "json-rest-schema";
+import {
+  composeSchemaDefinitions
+} from "@jskit-ai/kernel/shared/validators";
+import {
+  deepFreeze
+} from "@jskit-ai/kernel/shared/support/deepFreeze";
 import {
   assistantConfigResource,
   assistantResource
@@ -5,32 +12,79 @@ import {
 import { actionIds } from "./actionIds.js";
 import { assistantTargetSurfaceInput } from "./inputSchemas.js";
 
-const runtimeQueryInputValidator = [
-  assistantTargetSurfaceInput,
-  { query: assistantResource.operations.conversationsList.query }
-];
+const runtimeConversationsListQueryInput = deepFreeze({
+  schema: createSchema({
+    query: {
+      type: "object",
+      required: false,
+      schema: assistantResource.operations.conversationsList.query.schema
+    }
+  }),
+  mode: "patch"
+});
 
-const runtimeMessagesInputValidator = [
-  assistantTargetSurfaceInput,
-  assistantResource.operations.conversationMessagesList.params,
+const runtimeConversationsListInput = composeSchemaDefinitions(
+  [assistantTargetSurfaceInput, runtimeConversationsListQueryInput],
   {
-    query: assistantResource.operations.conversationMessagesList.query
+    mode: "patch",
+    context: "assistant-runtime conversations list action input"
   }
-];
+);
 
-const runtimeChatInputValidator = [
-  assistantTargetSurfaceInput,
-  assistantResource.operations.chatStream.body
-];
+const runtimeConversationMessagesListQueryInput = deepFreeze({
+  schema: createSchema({
+    query: {
+      type: "object",
+      required: false,
+      schema: assistantResource.operations.conversationMessagesList.query.schema
+    }
+  }),
+  mode: "patch"
+});
 
-const settingsReadInputValidator = assistantTargetSurfaceInput;
-
-const settingsUpdateInputValidator = [
-  assistantTargetSurfaceInput,
+const runtimeConversationMessagesListInput = composeSchemaDefinitions(
+  [
+    assistantTargetSurfaceInput,
+    assistantResource.operations.conversationMessagesList.params,
+    runtimeConversationMessagesListQueryInput
+  ],
   {
-    patch: assistantConfigResource.operations.patch.body
+    mode: "patch",
+    context: "assistant-runtime conversation messages action input"
   }
-];
+);
+
+const runtimeChatStreamInput = composeSchemaDefinitions(
+  [
+    assistantTargetSurfaceInput,
+    assistantResource.operations.chatStream.body
+  ],
+  {
+    mode: "patch",
+    context: "assistant-runtime chat stream action input"
+  }
+);
+
+const settingsReadInput = assistantTargetSurfaceInput;
+
+const settingsUpdatePatchInput = deepFreeze({
+  schema: createSchema({
+    patch: {
+      type: "object",
+      required: true,
+      schema: assistantConfigResource.operations.patch.body.schema
+    }
+  }),
+  mode: "patch"
+});
+
+const settingsUpdateInput = composeSchemaDefinitions(
+  [assistantTargetSurfaceInput, settingsUpdatePatchInput],
+  {
+    mode: "patch",
+    context: "assistant-runtime settings update action input"
+  }
+);
 
 const assistantActions = Object.freeze([
   {
@@ -42,7 +96,7 @@ const assistantActions = Object.freeze([
     permission: {
       require: "authenticated"
     },
-    input: runtimeChatInputValidator,
+    input: runtimeChatStreamInput,
     idempotency: "optional",
     audit: {
       actionName: actionIds.chatStream
@@ -65,7 +119,7 @@ const assistantActions = Object.freeze([
     permission: {
       require: "authenticated"
     },
-    input: runtimeQueryInputValidator,
+    input: runtimeConversationsListInput,
     output: assistantResource.operations.conversationsList.output,
     idempotency: "none",
     audit: {
@@ -88,7 +142,7 @@ const assistantActions = Object.freeze([
     permission: {
       require: "authenticated"
     },
-    input: runtimeMessagesInputValidator,
+    input: runtimeConversationMessagesListInput,
     output: assistantResource.operations.conversationMessagesList.output,
     idempotency: "none",
     audit: {
@@ -111,7 +165,7 @@ const assistantActions = Object.freeze([
     permission: {
       require: "authenticated"
     },
-    input: settingsReadInputValidator,
+    input: settingsReadInput,
     output: assistantConfigResource.operations.view.output,
     idempotency: "none",
     audit: {
@@ -133,7 +187,7 @@ const assistantActions = Object.freeze([
     permission: {
       require: "authenticated"
     },
-    input: settingsUpdateInputValidator,
+    input: settingsUpdateInput,
     output: assistantConfigResource.operations.patch.output,
     idempotency: "optional",
     audit: {

--- a/packages/assistant-runtime/src/server/registerRoutes.js
+++ b/packages/assistant-runtime/src/server/registerRoutes.js
@@ -1,5 +1,6 @@
 import { AppError } from "@jskit-ai/kernel/server/runtime";
 import { resolveAppConfig } from "@jskit-ai/kernel/server/support";
+import { composeSchemaDefinitions } from "@jskit-ai/kernel/shared/validators";
 import { normalizeSurfaceId } from "@jskit-ai/kernel/shared/surface/registry";
 import { withStandardErrorResponses } from "@jskit-ai/http-runtime/shared/validators/errorResponses";
 import {
@@ -18,25 +19,18 @@ import { actionIds } from "./actionIds.js";
 import { assistantSurfaceRouteParams } from "./inputSchemas.js";
 import { resolveWorkspaceServerScopeSupport } from "./support/workspaceScopeSupport.js";
 
-function buildRouteParamsValidator(requiresWorkspace, workspaceScopeSupport = null) {
-  if (requiresWorkspace === true) {
-    if (!workspaceScopeSupport) {
-      throw new Error("Assistant workspace routes require workspace server scope support.");
+function requireWorkspaceAssistantRouteParams(workspaceScopeSupport = null) {
+  if (!workspaceScopeSupport) {
+    throw new Error("Assistant workspace routes require workspace server scope support.");
+  }
+
+  return composeSchemaDefinitions(
+    [workspaceScopeSupport.params, assistantSurfaceRouteParams],
+    {
+      mode: "patch",
+      context: "assistant-runtime workspace surface route params"
     }
-
-    return [workspaceScopeSupport.params, assistantSurfaceRouteParams];
-  }
-
-  return assistantSurfaceRouteParams;
-}
-
-function buildConversationMessagesRouteParamsValidator(requiresWorkspace, workspaceScopeSupport = null) {
-  const validators = buildRouteParamsValidator(requiresWorkspace, workspaceScopeSupport);
-  if (Array.isArray(validators)) {
-    return validators.concat(assistantResource.operations.conversationMessagesList.params);
-  }
-
-  return [validators, assistantResource.operations.conversationMessagesList.params];
+  );
 }
 
 function readWorkspaceInput(request, requiresWorkspace, workspaceScopeSupport = null) {
@@ -156,7 +150,9 @@ function registerSettingsRoutes(
   });
   const visibility = requiresWorkspace ? "workspace" : "public";
   const routePath = `${routeBase}/:surfaceId/settings`;
-  const params = buildRouteParamsValidator(requiresWorkspace, workspaceScopeSupport);
+  const params = requiresWorkspace === true
+    ? requireWorkspaceAssistantRouteParams(workspaceScopeSupport)
+    : assistantSurfaceRouteParams;
 
   router.register(
     "GET",
@@ -248,7 +244,18 @@ function registerRuntimeRoutes(
   });
   const visibility = requiresWorkspace ? "workspace" : "public";
   const surfaceRouteBase = `${routeBase}/:surfaceId`;
-  const params = buildRouteParamsValidator(requiresWorkspace, workspaceScopeSupport);
+  const params = requiresWorkspace === true
+    ? requireWorkspaceAssistantRouteParams(workspaceScopeSupport)
+    : assistantSurfaceRouteParams;
+  const conversationMessagesParams = composeSchemaDefinitions(
+    [params, assistantResource.operations.conversationMessagesList.params],
+    {
+      mode: "patch",
+      context: requiresWorkspace === true
+        ? "assistant-runtime workspace conversation messages route params"
+        : "assistant-runtime conversation messages route params"
+    }
+  );
 
   router.register(
     "POST",
@@ -418,7 +425,7 @@ function registerRuntimeRoutes(
     {
       auth: "required",
       visibility,
-      params: buildConversationMessagesRouteParamsValidator(requiresWorkspace, workspaceScopeSupport),
+      params: conversationMessagesParams,
       meta: {
         tags: ["assistant"],
         summary: "List assistant conversation messages."

--- a/packages/assistant-runtime/src/server/support/workspaceScopeSupport.js
+++ b/packages/assistant-runtime/src/server/support/workspaceScopeSupport.js
@@ -1,11 +1,23 @@
+import { normalizeSchemaDefinition } from "@jskit-ai/kernel/shared/validators";
+
 const WORKSPACES_SERVER_SCOPE_SUPPORT_TOKEN = "workspaces.server.scope-support";
+
+function hasWorkspaceRouteParamsDefinition(value) {
+  try {
+    return Boolean(normalizeSchemaDefinition(value, {
+      context: "assistant-runtime workspace scope support.params",
+      defaultMode: "patch"
+    }));
+  } catch {
+    return false;
+  }
+}
 
 function isWorkspaceServerScopeSupport(value) {
   return Boolean(
     value &&
       value.available === true &&
-      value.params &&
-      typeof value.params.normalize === "function" &&
+      hasWorkspaceRouteParamsDefinition(value.params) &&
       typeof value.buildInputFromRouteParams === "function" &&
       typeof value.resolveWorkspace === "function"
   );

--- a/packages/assistant-runtime/test/actionDefinitions.test.js
+++ b/packages/assistant-runtime/test/actionDefinitions.test.js
@@ -1,0 +1,192 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  withActionDefaults
+} from "@jskit-ai/kernel/shared/actions";
+import { ActionRuntimeServiceProvider } from "@jskit-ai/kernel/server/actions";
+
+import { assistantActions } from "../src/server/actions.js";
+import { actionIds } from "../src/server/actionIds.js";
+
+function createSingletonApp() {
+  const singletons = new Map();
+  const instances = new Map();
+  const tags = new Map();
+
+  return {
+    has(token) {
+      return singletons.has(token) || instances.has(token);
+    },
+    singleton(token, factory) {
+      singletons.set(token, {
+        factory,
+        resolved: false,
+        value: undefined
+      });
+    },
+    tag(token, tagName) {
+      if (!this.has(token)) {
+        throw new Error(`Cannot tag unresolved token "${String(token)}".`);
+      }
+      if (!tags.has(tagName)) {
+        tags.set(tagName, new Set());
+      }
+      tags.get(tagName).add(token);
+    },
+    resolveTag(tagName) {
+      const tagged = tags.get(tagName);
+      if (!tagged) {
+        return [];
+      }
+      return [...tagged].map((token) => this.make(token));
+    },
+    make(token) {
+      if (instances.has(token)) {
+        return instances.get(token);
+      }
+      if (!singletons.has(token)) {
+        throw new Error(`Token "${String(token)}" is not registered.`);
+      }
+      const entry = singletons.get(token);
+      if (!entry.resolved) {
+        entry.value = entry.factory(this);
+        entry.resolved = true;
+        instances.set(token, entry.value);
+      }
+      return entry.value;
+    }
+  };
+}
+
+function createAssistantActionExecutor() {
+  const app = createSingletonApp();
+  const provider = new ActionRuntimeServiceProvider();
+  provider.register(app);
+
+  app.singleton("jskit.surface.runtime", () => ({
+    listEnabledSurfaceIds() {
+      return ["home", "console"];
+    }
+  }));
+
+  app.singleton("assistant.chat.service", () => ({
+    streamChat() {
+      return { ok: true };
+    },
+    listConversations(query, { input }) {
+      return { query, input };
+    },
+    getConversationMessages(conversationId, query, { input }) {
+      return { conversationId, query, input };
+    }
+  }));
+
+  app.singleton("assistant.config.service", () => ({
+    getSettings(input) {
+      return { input };
+    },
+    updateSettings(input, patch) {
+      return { input, patch };
+    }
+  }));
+
+  app.actions(
+    withActionDefaults(assistantActions, {
+      domain: "assistant",
+      dependencies: {
+        chatService: "assistant.chat.service",
+        assistantConfigService: "assistant.config.service"
+      }
+    })
+  );
+
+  return app.make("actionExecutor");
+}
+
+function findDefinition(definitions, id) {
+  return definitions.find((definition) => definition.id === id);
+}
+
+test("assistant-runtime actions materialize through the action runtime with single schema-definition inputs", () => {
+  const actionExecutor = createAssistantActionExecutor();
+  const definitions = actionExecutor.listDefinitions();
+
+  assert.equal(definitions.length, assistantActions.length);
+
+  for (const action of assistantActions) {
+    assert.equal(Array.isArray(action.input), false, `${action.id} input must not be an array`);
+  }
+
+  for (const definition of definitions) {
+    assert.equal(typeof definition.input?.schema?.patch, "function", `${definition.id} input schema must normalize`);
+    assert.equal(
+      typeof definition.input?.schema?.toJsonSchema,
+      "function",
+      `${definition.id} input schema must export`
+    );
+    assert.deepEqual(definition.surfaces, ["home", "console"]);
+  }
+});
+
+test("assistant-runtime conversations list action keeps query nested under a schema definition", () => {
+  const definition = findDefinition(createAssistantActionExecutor().listDefinitions(), actionIds.conversationsList);
+  const result = definition.input.schema.patch({
+    targetSurfaceId: "home",
+    workspaceSlug: "example-workspace",
+    query: {
+      limit: 10,
+      status: "active"
+    }
+  });
+
+  assert.deepEqual(result.errors, {});
+  assert.deepEqual(result.validatedObject, {
+    targetSurfaceId: "home",
+    workspaceSlug: "example-workspace",
+    query: {
+      limit: 10,
+      status: "active"
+    }
+  });
+});
+
+test("assistant-runtime conversation messages list action composes params and nested query", () => {
+  const definition = findDefinition(createAssistantActionExecutor().listDefinitions(), actionIds.conversationMessagesList);
+  const result = definition.input.schema.patch({
+    targetSurfaceId: "home",
+    conversationId: "123",
+    query: {
+      page: 2,
+      pageSize: 25
+    }
+  });
+
+  assert.deepEqual(result.errors, {});
+  assert.deepEqual(result.validatedObject, {
+    targetSurfaceId: "home",
+    conversationId: 123,
+    query: {
+      page: 2,
+      pageSize: 25
+    }
+  });
+});
+
+test("assistant-runtime settings update action keeps patch nested under a schema definition", () => {
+  const definition = findDefinition(createAssistantActionExecutor().listDefinitions(), actionIds.settingsUpdate);
+  const result = definition.input.schema.patch({
+    targetSurfaceId: "home",
+    patch: {
+      systemPrompt: "Be concise."
+    }
+  });
+
+  assert.deepEqual(result.errors, {});
+  assert.deepEqual(result.validatedObject, {
+    targetSurfaceId: "home",
+    patch: {
+      systemPrompt: "Be concise."
+    }
+  });
+});

--- a/packages/assistant-runtime/test/lazyAppConfig.test.js
+++ b/packages/assistant-runtime/test/lazyAppConfig.test.js
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { createSchema } from "json-rest-schema";
 import { AppError } from "@jskit-ai/kernel/server/runtime";
+import { createRouter } from "../../kernel/server/http/lib/router.js";
 import { registerRoutes } from "../src/server/registerRoutes.js";
 import { createChatService } from "../src/server/services/chatService.js";
 
@@ -27,11 +29,16 @@ function createWorkspaceServerScopeSupport() {
   return Object.freeze({
     available: true,
     params: Object.freeze({
-      normalize(value = {}) {
-        return {
-          workspaceSlug: String(value?.workspaceSlug || "").trim().toLowerCase()
-        };
-      }
+      schema: createSchema({
+        workspaceSlug: {
+          type: "string",
+          required: true,
+          lowercase: true,
+          minLength: 1,
+          maxLength: 160
+        }
+      }),
+      mode: "patch"
     }),
     buildInputFromRouteParams(params = {}) {
       const workspaceSlug = String(params?.workspaceSlug || "").trim().toLowerCase();
@@ -43,39 +50,52 @@ function createWorkspaceServerScopeSupport() {
   });
 }
 
+function createAssistantTestApp({
+  resolveCurrentAppConfig = () => null,
+  workspaceScopeSupport = null,
+  router = null
+} = {}) {
+  const resolvedRouter = router || createRouter();
+
+  return {
+    router: resolvedRouter,
+    app: {
+      make(token) {
+        if (token === "jskit.http.router") {
+          return resolvedRouter;
+        }
+        if (token === "appConfig") {
+          return resolveCurrentAppConfig();
+        }
+        if (token === "workspaces.server.scope-support" && workspaceScopeSupport) {
+          return workspaceScopeSupport;
+        }
+        throw new Error(`Unexpected token: ${token}`);
+      },
+      has(token) {
+        if (token === "jskit.http.router") {
+          return true;
+        }
+        if (token === "appConfig") {
+          return Boolean(resolveCurrentAppConfig());
+        }
+        return token === "workspaces.server.scope-support" && Boolean(workspaceScopeSupport);
+      }
+    }
+  };
+}
+
 test("registerRoutes resolves appConfig lazily when handlers run", async () => {
-  const routes = [];
   let currentAppConfig = null;
+  const workspaceScopeSupport = createWorkspaceServerScopeSupport();
+  const testApp = createAssistantTestApp({
+    workspaceScopeSupport,
+    resolveCurrentAppConfig: () => currentAppConfig
+  });
 
-  const router = {
-    register(method, path, options, handler) {
-      routes.push({ method, path, options, handler });
-    }
-  };
-
-  const app = {
-    make(token) {
-      if (token === "jskit.http.router") {
-        return router;
-      }
-      if (token === "appConfig") {
-        return currentAppConfig;
-      }
-      if (token === "workspaces.server.scope-support") {
-        return createWorkspaceServerScopeSupport();
-      }
-      throw new Error(`Unexpected token: ${token}`);
-    },
-    has(token) {
-      return (
-        (token === "appConfig" ? Boolean(currentAppConfig) : token === "jskit.http.router") ||
-        token === "workspaces.server.scope-support"
-      );
-    }
-  };
-
-  registerRoutes(app);
+  registerRoutes(testApp.app);
   currentAppConfig = createAssistantAppConfig();
+  const routes = testApp.router.list();
 
   const route = routes.find(
     (entry) =>
@@ -135,38 +155,16 @@ test("registerRoutes resolves appConfig lazily when handlers run", async () => {
 });
 
 test("registerRoutes returns clear AppError payload for pre-stream assistant failures", async () => {
-  const routes = [];
   let currentAppConfig = null;
+  const workspaceScopeSupport = createWorkspaceServerScopeSupport();
+  const testApp = createAssistantTestApp({
+    workspaceScopeSupport,
+    resolveCurrentAppConfig: () => currentAppConfig
+  });
 
-  const router = {
-    register(method, path, options, handler) {
-      routes.push({ method, path, options, handler });
-    }
-  };
-
-  const app = {
-    make(token) {
-      if (token === "jskit.http.router") {
-        return router;
-      }
-      if (token === "appConfig") {
-        return currentAppConfig;
-      }
-      if (token === "workspaces.server.scope-support") {
-        return createWorkspaceServerScopeSupport();
-      }
-      throw new Error(`Unexpected token: ${token}`);
-    },
-    has(token) {
-      return (
-        (token === "appConfig" ? Boolean(currentAppConfig) : token === "jskit.http.router") ||
-        token === "workspaces.server.scope-support"
-      );
-    }
-  };
-
-  registerRoutes(app);
+  registerRoutes(testApp.app);
   currentAppConfig = createAssistantAppConfig();
+  const routes = testApp.router.list();
 
   const route = routes.find(
     (entry) =>
@@ -321,27 +319,12 @@ test("chat service rejects workspace-scoped assistant surfaces when workspace su
 });
 
 test("registerRoutes omits workspace assistant routes when workspace scope support is unavailable", () => {
-  const routes = [];
-  const app = {
-    make(token) {
-      if (token === "jskit.http.router") {
-        return {
-          register(method, path, options, handler) {
-            routes.push({ method, path, options, handler });
-          }
-        };
-      }
-      if (token === "appConfig") {
-        return createAssistantAppConfig();
-      }
-      throw new Error(`Unexpected token: ${token}`);
-    },
-    has(token) {
-      return token === "jskit.http.router" || token === "appConfig";
-    }
-  };
+  const testApp = createAssistantTestApp({
+    resolveCurrentAppConfig: () => createAssistantAppConfig()
+  });
 
-  registerRoutes(app);
+  registerRoutes(testApp.app);
+  const routes = testApp.router.list();
 
   assert.equal(
     routes.some((entry) => entry.path.startsWith("/api/w/:workspaceSlug/assistant/")),

--- a/packages/auth-core/src/shared/commands/authCommandValidators.js
+++ b/packages/auth-core/src/shared/commands/authCommandValidators.js
@@ -44,6 +44,7 @@ const oauthReturnToFieldDefinition = deepFreeze({
 
 const authEmailFieldDefinition = deepFreeze({
   type: "string",
+  lowercase: true,
   minLength: AUTH_EMAIL_MIN_LENGTH,
   maxLength: AUTH_EMAIL_MAX_LENGTH,
   pattern: AUTH_EMAIL_PATTERN

--- a/packages/auth-core/test/commandValidators.test.js
+++ b/packages/auth-core/test/commandValidators.test.js
@@ -57,6 +57,26 @@ test("oauth complete command allows provider-less session-pair callbacks", () =>
   assert.equal(responseRequired.includes("provider"), false);
 });
 
+test("auth command body validators lowercase email inputs", () => {
+  const commands = [
+    authRegisterCommand,
+    authRegisterConfirmationResendCommand,
+    authLoginPasswordCommand,
+    authLoginOtpRequestCommand,
+    authLoginOtpVerifyCommand,
+    authPasswordResetRequestCommand
+  ];
+
+  for (const command of commands) {
+    const result = command.operation.body.schema.patch({
+      email: "  ADA@EXAMPLE.COM  "
+    });
+    if (Object.hasOwn(result.validatedObject, "email")) {
+      assert.equal(result.validatedObject.email, "ada@example.com");
+    }
+  }
+});
+
 test("auth session and oauth start commands expose explicit nested response schemas", () => {
   const sessionResponseSchema = resolveStructuredSchemaTransportSchema(
     authSessionReadCommand.operation.response,

--- a/packages/auth-provider-supabase-core/src/server/lib/accountFlows.js
+++ b/packages/auth-provider-supabase-core/src/server/lib/accountFlows.js
@@ -1,8 +1,12 @@
 import { AppError } from "@jskit-ai/kernel/server/runtime/errors";
+import { authRegisterBodyValidator } from "@jskit-ai/auth-core/shared/commands/authRegisterCommand";
+import { authRegisterConfirmationResendBodyValidator } from "@jskit-ai/auth-core/shared/commands/authRegisterConfirmationResendCommand";
+import { authLoginPasswordBodyValidator } from "@jskit-ai/auth-core/shared/commands/authLoginPasswordCommand";
+import { authLoginOtpRequestBodyValidator } from "@jskit-ai/auth-core/shared/commands/authLoginOtpRequestCommand";
+import { authLoginOtpVerifyBodyValidator } from "@jskit-ai/auth-core/shared/commands/authLoginOtpVerifyCommand";
 import {
   requireAuthUser,
-  requireAuthUserSession,
-  requireNoFieldErrors
+  requireAuthUserSession
 } from "./flowGuards.js";
 
 function normalizeLocalReturnToPath(value, { fallback = "" } = {}) {
@@ -21,7 +25,6 @@ function normalizeLocalReturnToPath(value, { fallback = "" } = {}) {
 function createAccountFlows(deps) {
   const {
     ensureConfigured,
-    validators,
     validationError,
     getSupabaseClient,
     displayNameFromEmail,
@@ -33,7 +36,6 @@ function createAccountFlows(deps) {
     appPublicUrl,
     isTransientSupabaseError,
     isUserNotFoundLikeAuthError,
-    parseOtpLoginVerifyPayload,
     mapOtpVerifyError,
     setSessionFromRequestCookies,
     mapProfileUpdateError,
@@ -82,8 +84,11 @@ function createAccountFlows(deps) {
   async function register(payload) {
     ensureConfigured();
 
-    const parsed = validators.registerInput(payload);
-    requireNoFieldErrors(parsed, validationError);
+    const result = authRegisterBodyValidator.schema.create(payload);
+    if (Object.keys(result.errors).length > 0) {
+      throw validationError(result.errors);
+    }
+    const parsed = result.validatedObject;
 
     const supabase = getSupabaseClient();
     const response = await supabase.auth.signUp({
@@ -126,8 +131,11 @@ function createAccountFlows(deps) {
   async function resendRegisterConfirmation(payload) {
     ensureConfigured();
 
-    const parsed = validators.forgotPasswordInput(payload);
-    requireNoFieldErrors(parsed, validationError);
+    const result = authRegisterConfirmationResendBodyValidator.schema.create(payload);
+    if (Object.keys(result.errors).length > 0) {
+      throw validationError(result.errors);
+    }
+    const parsed = result.validatedObject;
 
     const supabase = getSupabaseClient();
     const emailRedirectTo = resolveRegisterEmailRedirectTo();
@@ -175,8 +183,11 @@ function createAccountFlows(deps) {
   async function login(payload) {
     ensureConfigured();
 
-    const parsed = validators.loginInput(payload);
-    requireNoFieldErrors(parsed, validationError);
+    const result = authLoginPasswordBodyValidator.schema.create(payload);
+    if (Object.keys(result.errors).length > 0) {
+      throw validationError(result.errors);
+    }
+    const parsed = result.validatedObject;
 
     const supabase = getSupabaseClient();
     const response = await supabase.auth.signInWithPassword({
@@ -201,10 +212,13 @@ function createAccountFlows(deps) {
   async function requestOtpLogin(payload) {
     ensureConfigured();
 
-    const parsed = validators.forgotPasswordInput(payload);
-    requireNoFieldErrors(parsed, validationError);
+    const result = authLoginOtpRequestBodyValidator.schema.create(payload);
+    if (Object.keys(result.errors).length > 0) {
+      throw validationError(result.errors);
+    }
+    const parsed = result.validatedObject;
 
-    const emailRedirectTo = resolveOtpEmailRedirectTo(payload?.returnTo);
+    const emailRedirectTo = resolveOtpEmailRedirectTo(parsed.returnTo);
     const supabase = getSupabaseClient();
     let response;
     try {
@@ -250,22 +264,41 @@ function createAccountFlows(deps) {
   async function verifyOtpLogin(payload) {
     ensureConfigured();
 
-    const parsed = parseOtpLoginVerifyPayload(payload);
-    requireNoFieldErrors(parsed, validationError);
+    const result = authLoginOtpVerifyBodyValidator.schema.patch(payload);
+    if (Object.keys(result.errors).length > 0) {
+      throw validationError(result.errors);
+    }
+    const parsed = result.validatedObject;
+    const fieldErrors = {};
+    const token = String(parsed.token || "").trim();
+    const tokenHash = String(parsed.tokenHash || "").trim();
+    const type = String(parsed.type || "email").trim().toLowerCase();
+
+    if (!token && !tokenHash) {
+      fieldErrors.token = "One-time code is required.";
+    }
+
+    if (!tokenHash && !parsed.email) {
+      fieldErrors.email = "Email is required.";
+    }
+
+    if (Object.keys(fieldErrors).length > 0) {
+      throw validationError(fieldErrors);
+    }
 
     const supabase = getSupabaseClient();
     let response;
     try {
-      if (parsed.tokenHash) {
+      if (tokenHash) {
         response = await supabase.auth.verifyOtp({
-          token_hash: parsed.tokenHash,
-          type: parsed.type
+          token_hash: tokenHash,
+          type
         });
       } else {
         response = await supabase.auth.verifyOtp({
           email: parsed.email,
-          token: parsed.token,
-          type: parsed.type
+          token,
+          type
         });
       }
     } catch (error) {

--- a/packages/auth-provider-supabase-core/src/server/lib/authInputParsers.js
+++ b/packages/auth-provider-supabase-core/src/server/lib/authInputParsers.js
@@ -1,30 +1,7 @@
 import { AppError } from "@jskit-ai/kernel/server/runtime/errors";
-import {
-  AUTH_ACCESS_TOKEN_MAX_LENGTH,
-  AUTH_RECOVERY_TOKEN_MAX_LENGTH,
-  AUTH_REFRESH_TOKEN_MAX_LENGTH
-} from "@jskit-ai/auth-core/shared/authConstraints";
 import { normalizeOAuthProviderList } from "@jskit-ai/auth-core/shared/oauthProviders";
-import { validators } from "@jskit-ai/auth-core/server/validators";
 import { normalizeOAuthProviderFromCatalog } from "./oauthProviderCatalog.js";
 import { validationError } from "./authErrorMappers.js";
-
-const OTP_VERIFY_TYPE = "email";
-const SESSION_PAIR_REQUIRED_ERRORS = Object.freeze({
-  accessToken: "Access token is required when a refresh token is provided.",
-  refreshToken: "Refresh token is required when an access token is provided."
-});
-
-function applySessionPairValidation(accessToken, refreshToken, fieldErrors) {
-  if ((accessToken && !refreshToken) || (!accessToken && refreshToken)) {
-    if (!accessToken) {
-      fieldErrors.accessToken = SESSION_PAIR_REQUIRED_ERRORS.accessToken;
-    }
-    if (!refreshToken) {
-      fieldErrors.refreshToken = SESSION_PAIR_REQUIRED_ERRORS.refreshToken;
-    }
-  }
-}
 
 function resolveConfiguredOAuthProviders(options = {}) {
   return normalizeOAuthProviderList(options.providerIds, { fallback: [] });
@@ -51,154 +28,6 @@ function normalizeOAuthProviderInput(value, options = {}) {
   });
 }
 
-function validatePasswordRecoveryPayload(payload) {
-  const code = String(payload?.code || "").trim();
-  const tokenHash = String(payload?.tokenHash || "").trim();
-  const type = String(payload?.type || "recovery")
-    .trim()
-    .toLowerCase();
-  const accessToken = String(payload?.accessToken || "").trim();
-  const refreshToken = String(payload?.refreshToken || "").trim();
-
-  const fieldErrors = {};
-
-  if (type !== "recovery") {
-    fieldErrors.type = "Only recovery password reset links are supported.";
-  }
-
-  if (code.length > AUTH_RECOVERY_TOKEN_MAX_LENGTH) {
-    fieldErrors.code = "Recovery code is too long.";
-  }
-
-  if (tokenHash.length > AUTH_RECOVERY_TOKEN_MAX_LENGTH) {
-    fieldErrors.tokenHash = "Recovery token is too long.";
-  }
-
-  if (accessToken.length > AUTH_ACCESS_TOKEN_MAX_LENGTH) {
-    fieldErrors.accessToken = "Access token is too long.";
-  }
-
-  if (refreshToken.length > AUTH_REFRESH_TOKEN_MAX_LENGTH) {
-    fieldErrors.refreshToken = "Refresh token is too long.";
-  }
-
-  applySessionPairValidation(accessToken, refreshToken, fieldErrors);
-
-  const hasCode = Boolean(code);
-  const hasTokenHash = Boolean(tokenHash);
-  const hasSessionPair = Boolean(accessToken && refreshToken);
-
-  if (!hasCode && !hasTokenHash && !hasSessionPair) {
-    fieldErrors.recovery = "Recovery token is required.";
-  }
-
-  return {
-    code,
-    tokenHash,
-    type,
-    accessToken,
-    refreshToken,
-    hasCode,
-    hasTokenHash,
-    hasSessionPair,
-    fieldErrors
-  };
-}
-
-function parseOAuthCompletePayload(payload = {}, options = {}) {
-  const code = String(payload.code || "").trim();
-  const accessToken = String(payload.accessToken || "").trim();
-  const refreshToken = String(payload.refreshToken || "").trim();
-  const errorCode = String(payload.error || payload.error_code || "").trim();
-  const errorDescription = String(payload.errorDescription || payload.error_description || "").trim();
-  const fieldErrors = {};
-
-  if (code.length > AUTH_RECOVERY_TOKEN_MAX_LENGTH) {
-    fieldErrors.code = "OAuth code is too long.";
-  }
-
-  if (errorCode.length > 128) {
-    fieldErrors.error = "OAuth error code is too long.";
-  }
-
-  if (errorDescription.length > 1024) {
-    fieldErrors.errorDescription = "OAuth error description is too long.";
-  }
-
-  if (accessToken.length > AUTH_ACCESS_TOKEN_MAX_LENGTH) {
-    fieldErrors.accessToken = "Access token is too long.";
-  }
-
-  if (refreshToken.length > AUTH_REFRESH_TOKEN_MAX_LENGTH) {
-    fieldErrors.refreshToken = "Refresh token is too long.";
-  }
-
-  applySessionPairValidation(accessToken, refreshToken, fieldErrors);
-
-  const hasSessionPair = Boolean(accessToken && refreshToken);
-  const provider =
-    !hasSessionPair || code || errorCode
-      ? normalizeOAuthProviderInput(payload.provider || options.defaultProvider, options)
-      : null;
-
-  if (!code && !errorCode && !hasSessionPair) {
-    fieldErrors.code = "OAuth code is required when access/refresh tokens are not provided.";
-  }
-
-  return {
-    provider,
-    code,
-    accessToken,
-    refreshToken,
-    hasSessionPair,
-    errorCode,
-    errorDescription,
-    fieldErrors
-  };
-}
-
-function parseOtpLoginVerifyPayload(payload = {}) {
-  const parsedEmail = validators.forgotPasswordInput(payload);
-  const token = String(payload?.token || "").trim();
-  const tokenHash = String(payload?.tokenHash || "").trim();
-  const type = String(payload?.type || OTP_VERIFY_TYPE)
-    .trim()
-    .toLowerCase();
-  const fieldErrors = {
-    ...parsedEmail.fieldErrors
-  };
-
-  if (type !== OTP_VERIFY_TYPE) {
-    fieldErrors.type = "Only email OTP verification is supported.";
-  }
-
-  if (!token && !tokenHash) {
-    fieldErrors.token = "One-time code is required.";
-  }
-
-  if (token && token.length > AUTH_RECOVERY_TOKEN_MAX_LENGTH) {
-    fieldErrors.token = "One-time code is too long.";
-  }
-
-  if (tokenHash && tokenHash.length > AUTH_RECOVERY_TOKEN_MAX_LENGTH) {
-    fieldErrors.tokenHash = "One-time token hash is too long.";
-  }
-
-  if (token && parsedEmail.fieldErrors.email) {
-    fieldErrors.email = parsedEmail.fieldErrors.email;
-  } else if (tokenHash) {
-    delete fieldErrors.email;
-  }
-
-  return {
-    email: parsedEmail.email,
-    token,
-    tokenHash,
-    type,
-    fieldErrors
-  };
-}
-
 function mapOAuthCallbackError(errorCode) {
   const normalizedCode = String(errorCode || "")
     .trim()
@@ -213,8 +42,5 @@ function mapOAuthCallbackError(errorCode) {
 
 export {
   normalizeOAuthProviderInput,
-  validatePasswordRecoveryPayload,
-  parseOAuthCompletePayload,
-  parseOtpLoginVerifyPayload,
   mapOAuthCallbackError
 };

--- a/packages/auth-provider-supabase-core/src/server/lib/oauthFlows.js
+++ b/packages/auth-provider-supabase-core/src/server/lib/oauthFlows.js
@@ -1,4 +1,6 @@
 import { AppError } from "@jskit-ai/kernel/server/runtime/errors";
+import { authLoginOAuthStartParamsValidator, authLoginOAuthStartQueryValidator } from "@jskit-ai/auth-core/shared/commands/authLoginOAuthStartCommand";
+import { authLoginOAuthCompleteBodyValidator } from "@jskit-ai/auth-core/shared/commands/authLoginOAuthCompleteCommand";
 
 function createOauthFlows(deps) {
   const {
@@ -13,7 +15,6 @@ function createOauthFlows(deps) {
     mapAuthError,
     setSessionFromRequestCookies,
     buildOAuthLinkRedirectUrl,
-    parseOAuthCompletePayload,
     validationError,
     mapOAuthCallbackError,
     mapRecoveryError,
@@ -50,8 +51,22 @@ function createOauthFlows(deps) {
   async function oauthStart(payload = {}) {
     ensureConfigured();
 
-    const provider = normalizeOAuthProviderInput(payload.provider || authOAuthDefaultProvider);
-    const returnTo = normalizeReturnToPath(payload.returnTo, { fallback: "/" });
+    const paramsResult = authLoginOAuthStartParamsValidator.schema.patch({
+      provider: payload.provider || authOAuthDefaultProvider
+    });
+    if (Object.keys(paramsResult.errors).length > 0) {
+      throw validationError(paramsResult.errors);
+    }
+
+    const queryResult = authLoginOAuthStartQueryValidator.schema.patch({
+      returnTo: payload.returnTo
+    });
+    if (Object.keys(queryResult.errors).length > 0) {
+      throw validationError(queryResult.errors);
+    }
+
+    const provider = normalizeOAuthProviderInput(paramsResult.validatedObject.provider);
+    const returnTo = normalizeReturnToPath(queryResult.validatedObject.returnTo, { fallback: "/" });
     const redirectTo = buildOAuthLoginRedirectUrl({
       appPublicUrl,
       provider,
@@ -72,9 +87,23 @@ function createOauthFlows(deps) {
   async function startProviderLink(request, payload = {}) {
     ensureConfigured();
 
+    const paramsResult = authLoginOAuthStartParamsValidator.schema.patch({
+      provider: payload.provider || authOAuthDefaultProvider
+    });
+    if (Object.keys(paramsResult.errors).length > 0) {
+      throw validationError(paramsResult.errors);
+    }
+
+    const queryResult = authLoginOAuthStartQueryValidator.schema.patch({
+      returnTo: payload.returnTo
+    });
+    if (Object.keys(queryResult.errors).length > 0) {
+      throw validationError(queryResult.errors);
+    }
+
+    const provider = normalizeOAuthProviderInput(paramsResult.validatedObject.provider);
+    const returnTo = normalizeReturnToPath(queryResult.validatedObject.returnTo, { fallback: "/" });
     const supabase = getSupabaseClient();
-    const provider = normalizeOAuthProviderInput(payload.provider || authOAuthDefaultProvider);
-    const returnTo = normalizeReturnToPath(payload.returnTo, { fallback: "/" });
     await setSessionFromRequestCookies(request, {
       supabaseClient: supabase
     });
@@ -102,25 +131,55 @@ function createOauthFlows(deps) {
   async function oauthComplete(payload = {}) {
     ensureConfigured();
 
-    const parsed = parseOAuthCompletePayload(payload);
-    if (Object.keys(parsed.fieldErrors).length > 0) {
-      throw validationError(parsed.fieldErrors);
+    const result = authLoginOAuthCompleteBodyValidator.schema.patch(payload);
+    if (Object.keys(result.errors).length > 0) {
+      throw validationError(result.errors);
+    }
+    const parsed = result.validatedObject;
+    const code = String(parsed.code || "").trim();
+    const accessToken = String(parsed.accessToken || "").trim();
+    const refreshToken = String(parsed.refreshToken || "").trim();
+    const errorCode = String(parsed.error || parsed.error_code || "").trim();
+    const errorDescription = String(parsed.errorDescription || parsed.error_description || "").trim();
+    const hasSessionPair = Boolean(accessToken && refreshToken);
+    const fieldErrors = {};
+
+    if ((accessToken && !refreshToken) || (!accessToken && refreshToken)) {
+      if (!accessToken) {
+        fieldErrors.accessToken = "Access token is required when a refresh token is provided.";
+      }
+      if (!refreshToken) {
+        fieldErrors.refreshToken = "Refresh token is required when an access token is provided.";
+      }
     }
 
-    if (parsed.errorCode) {
-      throw mapOAuthCallbackError(parsed.errorCode, parsed.errorDescription);
+    if (!code && !errorCode && !hasSessionPair) {
+      fieldErrors.code = "OAuth code is required when access/refresh tokens are not provided.";
+    }
+
+    if (Object.keys(fieldErrors).length > 0) {
+      throw validationError(fieldErrors);
+    }
+
+    const provider =
+      !hasSessionPair || code || errorCode
+        ? normalizeOAuthProviderInput(parsed.provider || authOAuthDefaultProvider)
+        : null;
+
+    if (errorCode) {
+      throw mapOAuthCallbackError(errorCode, errorDescription);
     }
 
     const supabase = getSupabaseClient();
     let response;
     try {
-      if (parsed.hasSessionPair) {
+      if (hasSessionPair) {
         response = await supabase.auth.setSession({
-          access_token: parsed.accessToken,
-          refresh_token: parsed.refreshToken
+          access_token: accessToken,
+          refresh_token: refreshToken
         });
       } else {
-        response = await supabase.auth.exchangeCodeForSession(parsed.code);
+        response = await supabase.auth.exchangeCodeForSession(code);
       }
     } catch (error) {
       throw mapRecoveryError(error);
@@ -133,7 +192,7 @@ function createOauthFlows(deps) {
     const profile = await syncProfileFromSupabaseUser(response.data.user, response.data.user.email);
 
     return {
-      provider: parsed.provider,
+      provider,
       profile,
       session: response.data.session
     };

--- a/packages/auth-provider-supabase-core/src/server/lib/passwordSecurityFlows.js
+++ b/packages/auth-provider-supabase-core/src/server/lib/passwordSecurityFlows.js
@@ -1,20 +1,20 @@
 import { AppError } from "@jskit-ai/kernel/server/runtime/errors";
+import { authPasswordResetRequestBodyValidator } from "@jskit-ai/auth-core/shared/commands/authPasswordResetRequestCommand";
+import { authPasswordRecoveryCompleteBodyValidator } from "@jskit-ai/auth-core/shared/commands/authPasswordRecoveryCompleteCommand";
+import { authPasswordResetBodyValidator } from "@jskit-ai/auth-core/shared/commands/authPasswordResetCommand";
 import {
   requireAuthUser,
   requireAuthSession,
-  requireAuthUserSession,
-  requireNoFieldErrors
+  requireAuthUserSession
 } from "./flowGuards.js";
 
 function createPasswordSecurityFlows(deps) {
   const {
     ensureConfigured,
-    validators,
     validationError,
     getSupabaseClient,
     passwordResetRedirectUrl,
     mapAuthError,
-    validatePasswordRecoveryPayload,
     mapRecoveryError,
     syncProfileFromSupabaseUser,
     setSessionFromRequestCookies,
@@ -38,8 +38,11 @@ function createPasswordSecurityFlows(deps) {
   async function requestPasswordReset(payload) {
     ensureConfigured();
 
-    const parsed = validators.forgotPasswordInput(payload);
-    requireNoFieldErrors(parsed, validationError);
+    const result = authPasswordResetRequestBodyValidator.schema.create(payload);
+    if (Object.keys(result.errors).length > 0) {
+      throw validationError(result.errors);
+    }
+    const parsed = result.validatedObject;
 
     const supabase = getSupabaseClient();
     const options = { redirectTo: passwordResetRedirectUrl };
@@ -65,23 +68,51 @@ function createPasswordSecurityFlows(deps) {
   async function completePasswordRecovery(payload) {
     ensureConfigured();
 
-    const parsed = validatePasswordRecoveryPayload(payload);
-    requireNoFieldErrors(parsed, validationError);
+    const result = authPasswordRecoveryCompleteBodyValidator.schema.patch(payload);
+    if (Object.keys(result.errors).length > 0) {
+      throw validationError(result.errors);
+    }
+    const parsed = result.validatedObject;
+    const code = String(parsed.code || "").trim();
+    const tokenHash = String(parsed.tokenHash || "").trim();
+    const accessToken = String(parsed.accessToken || "").trim();
+    const refreshToken = String(parsed.refreshToken || "").trim();
+    const hasCode = Boolean(code);
+    const hasTokenHash = Boolean(tokenHash);
+    const hasSessionPair = Boolean(accessToken && refreshToken);
+    const fieldErrors = {};
+
+    if ((accessToken && !refreshToken) || (!accessToken && refreshToken)) {
+      if (!accessToken) {
+        fieldErrors.accessToken = "Access token is required when a refresh token is provided.";
+      }
+      if (!refreshToken) {
+        fieldErrors.refreshToken = "Refresh token is required when an access token is provided.";
+      }
+    }
+
+    if (!hasCode && !hasTokenHash && !hasSessionPair) {
+      fieldErrors.recovery = "Recovery token is required.";
+    }
+
+    if (Object.keys(fieldErrors).length > 0) {
+      throw validationError(fieldErrors);
+    }
 
     const supabase = getSupabaseClient();
     let response;
     try {
-      if (parsed.hasCode) {
-        response = await supabase.auth.exchangeCodeForSession(parsed.code);
-      } else if (parsed.hasTokenHash) {
+      if (hasCode) {
+        response = await supabase.auth.exchangeCodeForSession(code);
+      } else if (hasTokenHash) {
         response = await supabase.auth.verifyOtp({
           type: "recovery",
-          token_hash: parsed.tokenHash
+          token_hash: tokenHash
         });
       } else {
         response = await supabase.auth.setSession({
-          access_token: parsed.accessToken,
-          refresh_token: parsed.refreshToken
+          access_token: accessToken,
+          refresh_token: refreshToken
         });
       }
       /* c8 ignore next 3 -- defensive: supabase-js usually surfaces failures via response.error. */
@@ -105,8 +136,11 @@ function createPasswordSecurityFlows(deps) {
   async function resetPassword(request, payload) {
     ensureConfigured();
 
-    const parsed = validators.resetPasswordInput(payload);
-    requireNoFieldErrors(parsed, validationError);
+    const result = authPasswordResetBodyValidator.schema.create(payload);
+    if (Object.keys(result.errors).length > 0) {
+      throw validationError(result.errors);
+    }
+    const parsed = result.validatedObject;
 
     const supabase = getSupabaseClient();
     const sessionResponse = await setSessionFromRequestCookies(request, {

--- a/packages/auth-provider-supabase-core/src/server/lib/service.js
+++ b/packages/auth-provider-supabase-core/src/server/lib/service.js
@@ -7,7 +7,6 @@ import {
 } from "@jskit-ai/auth-core/shared/authMethods";
 import { normalizeEmail } from "@jskit-ai/auth-core/server/utils";
 import { normalizeRecordId } from "@jskit-ai/kernel/shared/support/normalize";
-import { validators } from "@jskit-ai/auth-core/server/validators";
 import {
   isTransientAuthMessage,
   isTransientSupabaseError,
@@ -23,9 +22,6 @@ import {
 import { displayNameFromEmail, resolveDisplayName, resolveDisplayNameFromClaims } from "./authProfileNames.js";
 import {
   normalizeOAuthProviderInput as normalizeOAuthProviderInputFromCatalog,
-  validatePasswordRecoveryPayload,
-  parseOAuthCompletePayload as parseOAuthCompletePayloadFromCatalog,
-  parseOtpLoginVerifyPayload,
   mapOAuthCallbackError
 } from "./authInputParsers.js";
 import {
@@ -162,13 +158,6 @@ function createService(options) {
 
   function normalizeOAuthProviderInput(value) {
     return normalizeOAuthProviderInputFromCatalog(value, {
-      providerIds: authOAuthProviderIds,
-      defaultProvider: authOAuthDefaultProvider
-    });
-  }
-
-  function parseOAuthCompletePayload(payload) {
-    return parseOAuthCompletePayloadFromCatalog(payload, {
       providerIds: authOAuthProviderIds,
       defaultProvider: authOAuthDefaultProvider
     });
@@ -589,7 +578,6 @@ function createService(options) {
 
   const { register, resendRegisterConfirmation, login, requestOtpLogin, verifyOtpLogin, updateDisplayName } = createAccountFlows({
     ensureConfigured,
-    validators,
     validationError,
     getSupabaseClient,
     displayNameFromEmail,
@@ -601,7 +589,6 @@ function createService(options) {
     appPublicUrl,
     isTransientSupabaseError,
     isUserNotFoundLikeAuthError,
-    parseOtpLoginVerifyPayload,
     mapOtpVerifyError,
     setSessionFromRequestCookies,
     mapProfileUpdateError,
@@ -620,7 +607,6 @@ function createService(options) {
     mapAuthError,
     setSessionFromRequestCookies,
     buildOAuthLinkRedirectUrl: buildOAuthLinkRedirectUrlWithCatalog,
-    parseOAuthCompletePayload,
     validationError,
     mapOAuthCallbackError,
     mapRecoveryError,
@@ -642,12 +628,10 @@ function createService(options) {
     getSecurityStatus
   } = createPasswordSecurityFlows({
     ensureConfigured,
-    validators,
     validationError,
     getSupabaseClient,
     passwordResetRedirectUrl,
     mapAuthError,
-    validatePasswordRecoveryPayload,
     mapRecoveryError,
     syncProfileFromSupabaseUser,
     setSessionFromRequestCookies,
@@ -895,7 +879,6 @@ function createService(options) {
 }
 
 const __testables = {
-  validatePasswordRecoveryPayload,
   displayNameFromEmail,
   resolveDisplayName,
   resolveDisplayNameFromClaims,
@@ -918,8 +901,6 @@ const __testables = {
   buildOAuthLoginRedirectUrl,
   buildOAuthLinkRedirectUrl,
   normalizeOAuthProviderInput: normalizeOAuthProviderInputFromCatalog,
-  parseOAuthCompletePayload: parseOAuthCompletePayloadFromCatalog,
-  parseOtpLoginVerifyPayload,
   mapOAuthCallbackError,
   resolveSupabaseOAuthProviderCatalog,
   resolveOAuthProviderQueryParams,

--- a/packages/auth-provider-supabase-core/src/server/lib/test-utils.js
+++ b/packages/auth-provider-supabase-core/src/server/lib/test-utils.js
@@ -26,10 +26,7 @@ export {
 
 export {
   normalizeOAuthProviderInput,
-  parseOAuthCompletePayload,
-  parseOtpLoginVerifyPayload,
-  mapOAuthCallbackError,
-  validatePasswordRecoveryPayload
+  mapOAuthCallbackError
 } from "./authInputParsers.js";
 
 export {

--- a/packages/auth-provider-supabase-core/test/authInputParsers.test.js
+++ b/packages/auth-provider-supabase-core/test/authInputParsers.test.js
@@ -1,36 +1,23 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { parseOAuthCompletePayload } from "../src/server/lib/authInputParsers.js";
+import { normalizeOAuthProviderInput } from "../src/server/lib/authInputParsers.js";
 
-test("parseOAuthCompletePayload accepts provider-less session pairs", () => {
-  const parsed = parseOAuthCompletePayload(
-    {
-      accessToken: "access-token",
-      refreshToken: "refresh-token"
-    },
-    {
-      providerIds: [],
-      defaultProvider: null
-    }
-  );
+test("normalizeOAuthProviderInput uses the configured default provider", () => {
+  const provider = normalizeOAuthProviderInput("", {
+    providerIds: ["github", "google"],
+    defaultProvider: "github"
+  });
 
-  assert.equal(parsed.hasSessionPair, true);
-  assert.equal(parsed.provider, null);
-  assert.deepEqual(parsed.fieldErrors, {});
+  assert.equal(provider, "github");
 });
 
-test("parseOAuthCompletePayload still requires OAuth provider for code exchanges", () => {
+test("normalizeOAuthProviderInput rejects oauth sign-in when no providers are configured", () => {
   assert.throws(
     () =>
-      parseOAuthCompletePayload(
-        {
-          code: "oauth-code"
-        },
-        {
-          providerIds: [],
-          defaultProvider: null
-        }
-      ),
+      normalizeOAuthProviderInput("github", {
+        providerIds: [],
+        defaultProvider: null
+      }),
     (error) => {
       assert.equal(error?.status, 400);
       assert.equal(String(error?.details?.fieldErrors?.provider || "").length > 0, true);

--- a/packages/crud-core/src/server/listFilters.js
+++ b/packages/crud-core/src/server/listFilters.js
@@ -305,20 +305,48 @@ const FILTER_TYPE_SERVER_HANDLERS = Object.freeze({
   })
 });
 
-function buildFilterQueryFieldDefinition(filter = {}, { invalidValues = CRUD_LIST_FILTER_INVALID_VALUES_REJECT } = {}) {
+function normalizeCrudListFilterQueryFieldInput(filterDefinition = null) {
+  if (!filterDefinition || typeof filterDefinition !== "object" || Array.isArray(filterDefinition)) {
+    throw new TypeError("createCrudListFilterQueryField requires a normalized filter definition object.");
+  }
+
+  const key = normalizeText(filterDefinition.key);
+  const type = normalizeText(filterDefinition.type);
+  const queryKey = normalizeText(filterDefinition.queryKey);
+  if (!key || !type || !queryKey) {
+    throw new TypeError(
+      "createCrudListFilterQueryField requires a normalized filter definition from defineCrudListFilters(...)."
+    );
+  }
+  if (!FILTER_TYPE_SERVER_HANDLERS[type]) {
+    throw new TypeError(`Unsupported CRUD list filter type "${type}".`);
+  }
+
+  return filterDefinition;
+}
+
+function createCrudListFilterQueryField(filterDefinition = {}, {
+  invalidValues = CRUD_LIST_FILTER_INVALID_VALUES_REJECT
+} = {}) {
   const invalidValueMode = normalizeCrudListFilterInvalidValues(invalidValues);
+  const filter = normalizeCrudListFilterQueryFieldInput(filterDefinition);
   const filterContract = Object.freeze({
     filter,
     invalidValues: invalidValueMode
   });
 
-  const queryFieldDefinition = {
+  return Object.freeze({
     type: CRUD_LIST_FILTER_QUERY_TYPE,
     filterContract
-  };
+  });
+}
 
+function buildFilterQueryFieldDefinition(filterDefinition = {}, { invalidValues = CRUD_LIST_FILTER_INVALID_VALUES_REJECT } = {}) {
+  const filter = normalizeCrudListFilterQueryFieldInput(filterDefinition);
   return {
-    [filter.queryKey]: queryFieldDefinition
+    [filter.queryKey]: createCrudListFilterQueryField(filter, {
+      invalidValues
+    })
   };
 }
 
@@ -373,6 +401,10 @@ crudListFilterSchemaFactory.addType(CRUD_LIST_FILTER_QUERY_TYPE, Object.assign(
   }
 ));
 
+function createCrudListFilterQuerySchema(structure = {}) {
+  return crudListFilterSchemaFactory(structure);
+}
+
 function buildFilterQuerySchemaDefinition(filterEntries = [], {
   invalidValues = CRUD_LIST_FILTER_INVALID_VALUES_REJECT
 } = {}) {
@@ -385,7 +417,7 @@ function buildFilterQuerySchemaDefinition(filterEntries = [], {
   }
 
   return Object.freeze({
-    schema: crudListFilterSchemaFactory(structure),
+    schema: createCrudListFilterQuerySchema(structure),
     mode: "patch"
   });
 }
@@ -504,5 +536,7 @@ function createCrudListFilters(definitions = {}, { columns = {}, apply = {} } = 
 export {
   CRUD_LIST_FILTER_INVALID_VALUES_REJECT,
   CRUD_LIST_FILTER_INVALID_VALUES_DISCARD,
+  createCrudListFilterQueryField,
+  createCrudListFilterQuerySchema,
   createCrudListFilters
 };

--- a/packages/crud-core/test/listFilters.test.js
+++ b/packages/crud-core/test/listFilters.test.js
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { createSchema } from "json-rest-schema";
 import { compileRouteValidator } from "@jskit-ai/kernel/_testable";
+import { defineCrudListFilters } from "@jskit-ai/kernel/shared/support/crudListFilters";
 import {
   composeSchemaDefinitions,
   cursorPaginationQueryValidator
@@ -10,6 +11,8 @@ import { listSearchQueryValidator } from "../src/server/listQueryValidators.js";
 import {
   CRUD_LIST_FILTER_INVALID_VALUES_REJECT,
   CRUD_LIST_FILTER_INVALID_VALUES_DISCARD,
+  createCrudListFilterQueryField,
+  createCrudListFilterQuerySchema,
   createCrudListFilters
 } from "../src/server/listFilters.js";
 
@@ -23,6 +26,8 @@ function composeSchemaDefinition(...definitions) {
 test("crud-core exposes createCrudListFilters through the public package export", async () => {
   const module = await import("@jskit-ai/crud-core/server/listFilters");
   assert.equal(typeof module.createCrudListFilters, "function");
+  assert.equal(typeof module.createCrudListFilterQueryField, "function");
+  assert.equal(typeof module.createCrudListFilterQuerySchema, "function");
   assert.equal(module.CRUD_LIST_FILTER_INVALID_VALUES_REJECT, CRUD_LIST_FILTER_INVALID_VALUES_REJECT);
   assert.equal(module.CRUD_LIST_FILTER_INVALID_VALUES_DISCARD, CRUD_LIST_FILTER_INVALID_VALUES_DISCARD);
 });
@@ -285,6 +290,77 @@ test("createCrudListFilters query validator stays mergeable with search and curs
   });
 
   assert.deepEqual(compiled.schema.querystring.required || [], []);
+});
+
+test("createCrudListFilterQueryField keeps route query params explicit while reusing filter semantics", () => {
+  const filters = defineCrudListFilters({
+    status: {
+      type: "enum",
+      label: "Status",
+      options: [
+        { value: "active", label: "Active" },
+        { value: "archived", label: "Archived" }
+      ]
+    },
+    arrivalDate: {
+      type: "dateRange",
+      label: "Arrival Date"
+    }
+  });
+
+  const explicitFilterQueryValidator = Object.freeze({
+    schema: createCrudListFilterQuerySchema({
+      status: createCrudListFilterQueryField(filters.status, {
+        invalidValues: CRUD_LIST_FILTER_INVALID_VALUES_REJECT
+      }),
+      arrivalDate: createCrudListFilterQueryField(filters.arrivalDate, {
+        invalidValues: CRUD_LIST_FILTER_INVALID_VALUES_REJECT
+      })
+    }),
+    mode: "patch"
+  });
+
+  const compiled = compileRouteValidator({
+    query: composeSchemaDefinition(
+      cursorPaginationQueryValidator,
+      listSearchQueryValidator,
+      explicitFilterQueryValidator
+    )
+  });
+  const transportSchema = explicitFilterQueryValidator.schema.toJsonSchema({
+    mode: explicitFilterQueryValidator.mode
+  });
+
+  assert.deepEqual(compiled.schema.querystring.required || [], []);
+  assert.equal(transportSchema.type, "object");
+  assert.equal(transportSchema.properties.status.enum[0], "active");
+  assert.equal(
+    transportSchema.properties.arrivalDate.pattern,
+    "^(?:\\d{4}-\\d{2}-\\d{2}(?:\\.\\.(?:\\d{4}-\\d{2}-\\d{2})?)?|\\.\\.\\d{4}-\\d{2}-\\d{2})$"
+  );
+  assert.deepEqual(explicitFilterQueryValidator.schema.patch({
+    status: "active",
+    arrivalDate: "2026-04-01..2026-04-30"
+  }), {
+    validatedObject: {
+      status: "active",
+      arrivalDate: {
+        from: "2026-04-01",
+        to: "2026-04-30"
+      }
+    },
+    errors: {}
+  });
+});
+
+test("createCrudListFilterQueryField requires normalized filter definitions", () => {
+  assert.throws(
+    () => createCrudListFilterQueryField({
+      type: "enum",
+      label: "Status"
+    }),
+    /normalized filter definition/
+  );
 });
 
 test("createCrudListFilters requires explicit invalid-value mode for new query validators", () => {


### PR DESCRIPTION
## Summary
- finish assistant-runtime route/action validation follow-ups and add route-path regression coverage
- collapse auth-provider-supabase flows onto the shared auth command/schema contracts
- document the CRUD filter validation exception and refresh generated agent docs

## Verification
- `npm --workspaces --if-present test`
- `npm run agent-docs:build`
