### PR TITLE
Standardize schema contract naming

### DIFF
--- a/FLOW.md
+++ b/FLOW.md
@@ -39,21 +39,29 @@ const patchBodySchema = createSchema({
   // patch fields...
 });
 
-const recordOutput = deepFreeze({
+const recordOutputValidator = deepFreeze({
   schema: recordOutputSchema,
   mode: "replace"
 });
 
-const listOutput = createCursorListValidator(recordOutput);
+const listOutputValidator = createCursorListValidator(recordOutputValidator);
 
-const createBody = deepFreeze({
+const createBodyValidator = deepFreeze({
   schema: createBodySchema,
   mode: "create"
 });
 
-const patchBody = deepFreeze({
+const patchBodyValidator = deepFreeze({
   schema: patchBodySchema,
   mode: "patch"
+});
+
+const deleteOutputValidator = deepFreeze({
+  schema: createSchema({
+    id: { type: "string", required: true },
+    deleted: { type: "boolean", required: true }
+  }),
+  mode: "replace"
 });
 
 const resource = deepFreeze({
@@ -63,25 +71,25 @@ const resource = deepFreeze({
   operations: {
     list: {
       method: "GET",
-      output: listOutput
+      output: listOutputValidator
     },
     view: {
       method: "GET",
-      output: recordOutput
+      output: recordOutputValidator
     },
     create: {
       method: "POST",
-      body: createBody,
-      output: recordOutput
+      body: createBodyValidator,
+      output: recordOutputValidator
     },
     patch: {
       method: "PATCH",
-      body: patchBody,
-      output: recordOutput
+      body: patchBodyValidator,
+      output: recordOutputValidator
     },
     delete: {
       method: "DELETE",
-      output: deleteOutput
+      output: deleteOutputValidator
     }
   }
 });

--- a/LAST_ITEMS.md
+++ b/LAST_ITEMS.md
@@ -1,7 +1,7 @@
 # Last Items
 
 - [x] 1. Convert `assistant-runtime` route param composition to real schema definitions.
-  - Current problem: `packages/assistant-runtime/src/server/registerRoutes.js` still builds `params` as validator arrays like `[workspaceScopeSupport.params, assistantSurfaceRouteParams]`.
+  - Fixed: `packages/assistant-runtime/src/server/registerRoutes.js` now composes route params into a single schema definition object.
   - Why it matters: the route layer now expects a single schema definition object, and the real router path throws on this shape.
 
 - [x] 2. Convert `assistant-runtime` action input composition to real schema definitions.

--- a/packages/agent-docs/reference/autogen/KERNEL_MAP.md
+++ b/packages/agent-docs/reference/autogen/KERNEL_MAP.md
@@ -446,7 +446,7 @@ Exports
 - `requireServiceMethod(service, methodName, contributorId, { serviceLabel } = {})`
 - `resolveRequest(context)`
 - `hasPermission`
-- `EMPTY_INPUT_VALIDATOR`
+- `emptyInputValidator`
 
 ### `actions/actionDefinitions.js`
 Exports

--- a/packages/agent-docs/reference/autogen/packages/assistant-runtime.md
+++ b/packages/agent-docs/reference/autogen/packages/assistant-runtime.md
@@ -79,8 +79,8 @@ Local functions
 
 ### `src/server/inputSchemas.js`
 Exports
-- `assistantSurfaceRouteParams`
-- `assistantTargetSurfaceInput`
+- `assistantSurfaceRouteParamsValidator`
+- `assistantTargetSurfaceInputValidator`
 
 ### `src/server/registerRoutes.js`
 Exports

--- a/packages/agent-docs/reference/autogen/packages/auth-core.md
+++ b/packages/agent-docs/reference/autogen/packages/auth-core.md
@@ -224,17 +224,17 @@ Exports
 - `authMethodIdValidator`
 - `authMethodKindValidator`
 - `oauthReturnToValidator`
-- `okResponseValidator`
-- `okMessageResponseValidator`
-- `registerResponseValidator`
-- `loginResponseValidator`
-- `otpVerifyResponseValidator`
-- `oauthCompleteResponseValidator`
-- `devLoginAsResponseValidator`
-- `logoutResponseValidator`
-- `oauthProviderCatalogEntryValidator`
-- `sessionResponseValidator`
-- `sessionUnavailableResponseValidator`
+- `okOutputValidator`
+- `okMessageOutputValidator`
+- `registerOutputValidator`
+- `loginOutputValidator`
+- `otpVerifyOutputValidator`
+- `oauthCompleteOutputValidator`
+- `devLoginAsOutputValidator`
+- `logoutOutputValidator`
+- `oauthProviderCatalogEntryOutputValidator`
+- `sessionOutputValidator`
+- `sessionUnavailableOutputValidator`
 - `createCommandMessages({ fields = {}, defaultMessage = "Invalid value." } = {})`
 
 ### `src/shared/commands/authDevLoginAsCommand.js`
@@ -246,7 +246,7 @@ Exports
 ### `src/shared/commands/authLoginOAuthCompleteCommand.js`
 Exports
 - `authLoginOAuthCompleteBodyValidator`
-- `oauthCompleteResponseValidator`
+- `oauthCompleteOutputValidator`
 - `AUTH_LOGIN_OAUTH_COMPLETE_MESSAGES`
 - `authLoginOAuthCompleteCommand`
 
@@ -254,62 +254,62 @@ Exports
 Exports
 - `authLoginOAuthStartParamsValidator`
 - `authLoginOAuthStartQueryValidator`
-- `authLoginOAuthStartResponseValidator`
+- `authLoginOAuthStartOutputValidator`
 - `AUTH_LOGIN_OAUTH_START_MESSAGES`
 - `authLoginOAuthStartCommand`
 
 ### `src/shared/commands/authLoginOtpRequestCommand.js`
 Exports
 - `authLoginOtpRequestBodyValidator`
-- `okMessageResponseValidator`
+- `okMessageOutputValidator`
 - `AUTH_LOGIN_OTP_REQUEST_MESSAGES`
 - `authLoginOtpRequestCommand`
 
 ### `src/shared/commands/authLoginOtpVerifyCommand.js`
 Exports
 - `authLoginOtpVerifyBodyValidator`
-- `otpVerifyResponseValidator`
+- `otpVerifyOutputValidator`
 - `AUTH_LOGIN_OTP_VERIFY_MESSAGES`
 - `authLoginOtpVerifyCommand`
 
 ### `src/shared/commands/authLoginPasswordCommand.js`
 Exports
 - `authLoginPasswordBodyValidator`
-- `loginResponseValidator`
+- `loginOutputValidator`
 - `AUTH_LOGIN_PASSWORD_MESSAGES`
 - `authLoginPasswordCommand`
 
 ### `src/shared/commands/authLogoutCommand.js`
 Exports
-- `logoutResponseValidator`
+- `logoutOutputValidator`
 - `AUTH_LOGOUT_MESSAGES`
 - `authLogoutCommand`
 
 ### `src/shared/commands/authPasswordRecoveryCompleteCommand.js`
 Exports
 - `authPasswordRecoveryCompleteBodyValidator`
-- `okResponseValidator`
+- `okOutputValidator`
 - `AUTH_PASSWORD_RECOVERY_COMPLETE_MESSAGES`
 - `authPasswordRecoveryCompleteCommand`
 
 ### `src/shared/commands/authPasswordResetCommand.js`
 Exports
 - `authPasswordResetBodyValidator`
-- `okMessageResponseValidator`
+- `okMessageOutputValidator`
 - `AUTH_PASSWORD_RESET_MESSAGES`
 - `authPasswordResetCommand`
 
 ### `src/shared/commands/authPasswordResetRequestCommand.js`
 Exports
 - `authPasswordResetRequestBodyValidator`
-- `okMessageResponseValidator`
+- `okMessageOutputValidator`
 - `AUTH_PASSWORD_RESET_REQUEST_MESSAGES`
 - `authPasswordResetRequestCommand`
 
 ### `src/shared/commands/authRegisterCommand.js`
 Exports
 - `authRegisterBodyValidator`
-- `registerResponseValidator`
+- `registerOutputValidator`
 - `AUTH_REGISTER_MESSAGES`
 - `authRegisterCommand`
 
@@ -321,8 +321,8 @@ Exports
 
 ### `src/shared/commands/authSessionReadCommand.js`
 Exports
-- `sessionResponseValidator`
-- `sessionUnavailableResponseValidator`
+- `sessionOutputValidator`
+- `sessionUnavailableOutputValidator`
 - `AUTH_SESSION_READ_MESSAGES`
 - `authSessionReadCommand`
 

--- a/packages/agent-docs/reference/autogen/packages/kernel.md
+++ b/packages/agent-docs/reference/autogen/packages/kernel.md
@@ -21,7 +21,7 @@ Exports
 - `requireServiceMethod(service, methodName, contributorId, { serviceLabel } = {})`
 - `resolveRequest(context)`
 - `hasPermission`
-- `EMPTY_INPUT_VALIDATOR`
+- `emptyInputValidator`
 
 ### `shared/actions/actionDefinitions.js`
 Exports

--- a/packages/agent-docs/reference/autogen/packages/users-core.md
+++ b/packages/agent-docs/reference/autogen/packages/users-core.md
@@ -277,7 +277,7 @@ Exports
 - `USER_SETTINGS_NOTIFICATION_KEYS`
 - `USER_SETTINGS_PREFERENCE_KEYS`
 - `userSettingsOutputSchema`
-- `userSettingsOutputDefinition`
+- `userSettingsOutputValidator`
 - `userSettingsResource`
 
 ### `src/shared/settings.js`

--- a/packages/assistant-core/src/shared/assistantResource.js
+++ b/packages/assistant-core/src/shared/assistantResource.js
@@ -162,7 +162,7 @@ const conversationRecordSchema = createSchema({
   }
 });
 
-const conversationRecordOutputDefinition = deepFreeze({
+const conversationRecordOutputValidator = deepFreeze({
   schema: conversationRecordSchema,
   mode: "replace"
 });
@@ -251,7 +251,27 @@ const conversationMessagesQuerySchema = createSchema({
   }
 });
 
-const conversationMessagesOutputDefinition = deepFreeze({
+const assistantChatStreamBodyValidator = deepFreeze({
+  schema: chatStreamBodySchema,
+  mode: "create"
+});
+
+const assistantConversationsListQueryValidator = deepFreeze({
+  schema: conversationsListQuerySchema,
+  mode: "patch"
+});
+
+const assistantConversationMessagesParamsValidator = deepFreeze({
+  schema: conversationMessagesParamsSchema,
+  mode: "patch"
+});
+
+const assistantConversationMessagesQueryValidator = deepFreeze({
+  schema: conversationMessagesQuerySchema,
+  mode: "patch"
+});
+
+const conversationMessagesListOutputValidator = deepFreeze({
   schema: createSchema({
     page: {
       type: "integer",
@@ -292,30 +312,18 @@ const assistantResource = deepFreeze({
   operations: {
     chatStream: {
       method: "POST",
-      body: {
-        schema: chatStreamBodySchema,
-        mode: "create"
-      }
+      body: assistantChatStreamBodyValidator
     },
     conversationsList: {
       method: "GET",
-      query: {
-        schema: conversationsListQuerySchema,
-        mode: "patch"
-      },
-      output: createCursorListValidator(conversationRecordOutputDefinition)
+      query: assistantConversationsListQueryValidator,
+      output: createCursorListValidator(conversationRecordOutputValidator)
     },
     conversationMessagesList: {
       method: "GET",
-      params: {
-        schema: conversationMessagesParamsSchema,
-        mode: "patch"
-      },
-      query: {
-        schema: conversationMessagesQuerySchema,
-        mode: "patch"
-      },
-      output: conversationMessagesOutputDefinition
+      params: assistantConversationMessagesParamsValidator,
+      query: assistantConversationMessagesQueryValidator,
+      output: conversationMessagesListOutputValidator
     }
   }
 });

--- a/packages/assistant-core/src/shared/assistantSettingsResource.js
+++ b/packages/assistant-core/src/shared/assistantSettingsResource.js
@@ -51,26 +51,32 @@ const assistantConfigPatchSchema = createSchema({
   }
 });
 
+const assistantConfigViewOutputValidator = deepFreeze({
+  schema: assistantConfigRecordSchema,
+  mode: "replace"
+});
+
+const assistantConfigPatchBodyValidator = deepFreeze({
+  schema: assistantConfigPatchSchema,
+  mode: "patch"
+});
+
+const assistantConfigPatchOutputValidator = deepFreeze({
+  schema: assistantConfigRecordSchema,
+  mode: "replace"
+});
+
 const assistantConfigResource = deepFreeze({
   namespace: "assistantConfig",
   operations: {
     view: {
       method: "GET",
-      output: {
-        schema: assistantConfigRecordSchema,
-        mode: "replace"
-      }
+      output: assistantConfigViewOutputValidator
     },
     patch: {
       method: "PATCH",
-      body: {
-        schema: assistantConfigPatchSchema,
-        mode: "patch"
-      },
-      output: {
-        schema: assistantConfigRecordSchema,
-        mode: "replace"
-      }
+      body: assistantConfigPatchBodyValidator,
+      output: assistantConfigPatchOutputValidator
     }
   }
 });

--- a/packages/assistant-runtime/src/server/actions.js
+++ b/packages/assistant-runtime/src/server/actions.js
@@ -10,9 +10,9 @@ import {
   assistantResource
 } from "@jskit-ai/assistant-core/shared";
 import { actionIds } from "./actionIds.js";
-import { assistantTargetSurfaceInput } from "./inputSchemas.js";
+import { assistantTargetSurfaceInputValidator } from "./inputSchemas.js";
 
-const runtimeConversationsListQueryInput = deepFreeze({
+const runtimeConversationsListQueryInputValidator = deepFreeze({
   schema: createSchema({
     query: {
       type: "object",
@@ -23,15 +23,15 @@ const runtimeConversationsListQueryInput = deepFreeze({
   mode: "patch"
 });
 
-const runtimeConversationsListInput = composeSchemaDefinitions(
-  [assistantTargetSurfaceInput, runtimeConversationsListQueryInput],
+const runtimeConversationsListInputValidator = composeSchemaDefinitions(
+  [assistantTargetSurfaceInputValidator, runtimeConversationsListQueryInputValidator],
   {
     mode: "patch",
     context: "assistant-runtime conversations list action input"
   }
 );
 
-const runtimeConversationMessagesListQueryInput = deepFreeze({
+const runtimeConversationMessagesListQueryInputValidator = deepFreeze({
   schema: createSchema({
     query: {
       type: "object",
@@ -42,11 +42,11 @@ const runtimeConversationMessagesListQueryInput = deepFreeze({
   mode: "patch"
 });
 
-const runtimeConversationMessagesListInput = composeSchemaDefinitions(
+const runtimeConversationMessagesListInputValidator = composeSchemaDefinitions(
   [
-    assistantTargetSurfaceInput,
+    assistantTargetSurfaceInputValidator,
     assistantResource.operations.conversationMessagesList.params,
-    runtimeConversationMessagesListQueryInput
+    runtimeConversationMessagesListQueryInputValidator
   ],
   {
     mode: "patch",
@@ -54,9 +54,9 @@ const runtimeConversationMessagesListInput = composeSchemaDefinitions(
   }
 );
 
-const runtimeChatStreamInput = composeSchemaDefinitions(
+const runtimeChatStreamInputValidator = composeSchemaDefinitions(
   [
-    assistantTargetSurfaceInput,
+    assistantTargetSurfaceInputValidator,
     assistantResource.operations.chatStream.body
   ],
   {
@@ -65,9 +65,9 @@ const runtimeChatStreamInput = composeSchemaDefinitions(
   }
 );
 
-const settingsReadInput = assistantTargetSurfaceInput;
+const settingsReadInputValidator = assistantTargetSurfaceInputValidator;
 
-const settingsUpdatePatchInput = deepFreeze({
+const settingsUpdatePatchInputValidator = deepFreeze({
   schema: createSchema({
     patch: {
       type: "object",
@@ -78,8 +78,8 @@ const settingsUpdatePatchInput = deepFreeze({
   mode: "patch"
 });
 
-const settingsUpdateInput = composeSchemaDefinitions(
-  [assistantTargetSurfaceInput, settingsUpdatePatchInput],
+const settingsUpdateInputValidator = composeSchemaDefinitions(
+  [assistantTargetSurfaceInputValidator, settingsUpdatePatchInputValidator],
   {
     mode: "patch",
     context: "assistant-runtime settings update action input"
@@ -96,7 +96,7 @@ const assistantActions = Object.freeze([
     permission: {
       require: "authenticated"
     },
-    input: runtimeChatStreamInput,
+    input: runtimeChatStreamInputValidator,
     idempotency: "optional",
     audit: {
       actionName: actionIds.chatStream
@@ -119,7 +119,7 @@ const assistantActions = Object.freeze([
     permission: {
       require: "authenticated"
     },
-    input: runtimeConversationsListInput,
+    input: runtimeConversationsListInputValidator,
     output: assistantResource.operations.conversationsList.output,
     idempotency: "none",
     audit: {
@@ -142,7 +142,7 @@ const assistantActions = Object.freeze([
     permission: {
       require: "authenticated"
     },
-    input: runtimeConversationMessagesListInput,
+    input: runtimeConversationMessagesListInputValidator,
     output: assistantResource.operations.conversationMessagesList.output,
     idempotency: "none",
     audit: {
@@ -165,7 +165,7 @@ const assistantActions = Object.freeze([
     permission: {
       require: "authenticated"
     },
-    input: settingsReadInput,
+    input: settingsReadInputValidator,
     output: assistantConfigResource.operations.view.output,
     idempotency: "none",
     audit: {
@@ -187,7 +187,7 @@ const assistantActions = Object.freeze([
     permission: {
       require: "authenticated"
     },
-    input: settingsUpdateInput,
+    input: settingsUpdateInputValidator,
     output: assistantConfigResource.operations.patch.output,
     idempotency: "optional",
     audit: {

--- a/packages/assistant-runtime/src/server/inputSchemas.js
+++ b/packages/assistant-runtime/src/server/inputSchemas.js
@@ -28,17 +28,17 @@ const assistantTargetSurfaceInputSchema = createSchema({
   }
 });
 
-const assistantSurfaceRouteParams = deepFreeze({
+const assistantSurfaceRouteParamsValidator = deepFreeze({
   schema: assistantSurfaceRouteParamsSchema,
   mode: "patch"
 });
 
-const assistantTargetSurfaceInput = deepFreeze({
+const assistantTargetSurfaceInputValidator = deepFreeze({
   schema: assistantTargetSurfaceInputSchema,
   mode: "patch"
 });
 
 export {
-  assistantSurfaceRouteParams,
-  assistantTargetSurfaceInput
+  assistantSurfaceRouteParamsValidator,
+  assistantTargetSurfaceInputValidator
 };

--- a/packages/assistant-runtime/src/server/registerRoutes.js
+++ b/packages/assistant-runtime/src/server/registerRoutes.js
@@ -16,7 +16,7 @@ import {
 } from "@jskit-ai/assistant-core/server";
 import { resolveAssistantSurfaceConfig } from "../shared/assistantSurfaces.js";
 import { actionIds } from "./actionIds.js";
-import { assistantSurfaceRouteParams } from "./inputSchemas.js";
+import { assistantSurfaceRouteParamsValidator } from "./inputSchemas.js";
 import { resolveWorkspaceServerScopeSupport } from "./support/workspaceScopeSupport.js";
 
 function requireWorkspaceAssistantRouteParams(workspaceScopeSupport = null) {
@@ -25,7 +25,7 @@ function requireWorkspaceAssistantRouteParams(workspaceScopeSupport = null) {
   }
 
   return composeSchemaDefinitions(
-    [workspaceScopeSupport.params, assistantSurfaceRouteParams],
+    [workspaceScopeSupport.params, assistantSurfaceRouteParamsValidator],
     {
       mode: "patch",
       context: "assistant-runtime workspace surface route params"
@@ -152,7 +152,7 @@ function registerSettingsRoutes(
   const routePath = `${routeBase}/:surfaceId/settings`;
   const params = requiresWorkspace === true
     ? requireWorkspaceAssistantRouteParams(workspaceScopeSupport)
-    : assistantSurfaceRouteParams;
+    : assistantSurfaceRouteParamsValidator;
 
   router.register(
     "GET",
@@ -246,7 +246,7 @@ function registerRuntimeRoutes(
   const surfaceRouteBase = `${routeBase}/:surfaceId`;
   const params = requiresWorkspace === true
     ? requireWorkspaceAssistantRouteParams(workspaceScopeSupport)
-    : assistantSurfaceRouteParams;
+    : assistantSurfaceRouteParamsValidator;
   const conversationMessagesParams = composeSchemaDefinitions(
     [params, assistantResource.operations.conversationMessagesList.params],
     {

--- a/packages/auth-core/src/shared/commands/authCommandValidators.js
+++ b/packages/auth-core/src/shared/commands/authCommandValidators.js
@@ -130,14 +130,14 @@ const authRefreshTokenValidator = deepFreeze({
   ...authRefreshTokenFieldDefinition
 });
 
-const okResponseValidator = deepFreeze({
+const okOutputValidator = deepFreeze({
   schema: createSchema({
     ok: { type: "boolean", required: true }
   }),
   mode: "replace"
 });
 
-const okMessageResponseValidator = deepFreeze({
+const okMessageOutputValidator = deepFreeze({
   schema: createSchema({
     ok: { type: "boolean", required: true },
     message: { type: "string", required: true, minLength: 1 }
@@ -145,7 +145,7 @@ const okMessageResponseValidator = deepFreeze({
   mode: "replace"
 });
 
-const registerResponseValidator = deepFreeze({
+const registerOutputValidator = deepFreeze({
   schema: createSchema({
     ok: { type: "boolean", required: true },
     requiresEmailConfirmation: { type: "boolean", required: true },
@@ -155,7 +155,7 @@ const registerResponseValidator = deepFreeze({
   mode: "replace"
 });
 
-const loginResponseValidator = deepFreeze({
+const loginOutputValidator = deepFreeze({
   schema: createSchema({
     ok: { type: "boolean", required: true },
     username: { type: "string", required: true, minLength: 1, maxLength: 120 }
@@ -163,7 +163,7 @@ const loginResponseValidator = deepFreeze({
   mode: "replace"
 });
 
-const otpVerifyResponseValidator = deepFreeze({
+const otpVerifyOutputValidator = deepFreeze({
   schema: createSchema({
     ok: { type: "boolean", required: true },
     username: { type: "string", required: true, minLength: 1, maxLength: 120 },
@@ -172,7 +172,7 @@ const otpVerifyResponseValidator = deepFreeze({
   mode: "replace"
 });
 
-const oauthCompleteResponseValidator = deepFreeze({
+const oauthCompleteOutputValidator = deepFreeze({
   schema: createSchema({
     ok: { type: "boolean", required: true },
     provider: { ...oauthProviderFieldDefinition, required: false },
@@ -182,7 +182,7 @@ const oauthCompleteResponseValidator = deepFreeze({
   mode: "replace"
 });
 
-const devLoginAsResponseValidator = deepFreeze({
+const devLoginAsOutputValidator = deepFreeze({
   schema: createSchema({
     ok: { type: "boolean", required: true },
     userId: { type: "string", required: true, minLength: 1 },
@@ -192,7 +192,7 @@ const devLoginAsResponseValidator = deepFreeze({
   mode: "replace"
 });
 
-const logoutResponseValidator = deepFreeze({
+const logoutOutputValidator = deepFreeze({
   schema: createSchema({
     ok: { type: "boolean", required: true }
   }),
@@ -204,12 +204,12 @@ const oauthProviderCatalogEntrySchema = createSchema({
   label: { type: "string", required: true, minLength: 1, maxLength: 120 }
 });
 
-const oauthProviderCatalogEntryValidator = deepFreeze({
+const oauthProviderCatalogEntryOutputValidator = deepFreeze({
   schema: oauthProviderCatalogEntrySchema,
   mode: "replace"
 });
 
-const sessionResponseSchema = createSchema({
+const sessionOutputSchema = createSchema({
   authenticated: { type: "boolean", required: true },
   username: { type: "string", required: false, minLength: 1, maxLength: 120 },
   email: { ...authEmailFieldDefinition, required: false },
@@ -235,12 +235,12 @@ const sessionResponseSchema = createSchema({
   }
 });
 
-const sessionResponseValidator = deepFreeze({
-  schema: sessionResponseSchema,
+const sessionOutputValidator = deepFreeze({
+  schema: sessionOutputSchema,
   mode: "replace"
 });
 
-const sessionUnavailableResponseSchema = createSchema({
+const sessionUnavailableOutputSchema = createSchema({
   error: { type: "string", required: true, minLength: 1 },
   csrfToken: { type: "string", required: true, minLength: 1 },
   oauthProviders: {
@@ -255,8 +255,8 @@ const sessionUnavailableResponseSchema = createSchema({
   }
 });
 
-const sessionUnavailableResponseValidator = deepFreeze({
-  schema: sessionUnavailableResponseSchema,
+const sessionUnavailableOutputValidator = deepFreeze({
+  schema: sessionUnavailableOutputSchema,
   mode: "replace"
 });
 
@@ -297,16 +297,16 @@ export {
   authMethodIdValidator,
   authMethodKindValidator,
   oauthReturnToValidator,
-  okResponseValidator,
-  okMessageResponseValidator,
-  registerResponseValidator,
-  loginResponseValidator,
-  otpVerifyResponseValidator,
-  oauthCompleteResponseValidator,
-  devLoginAsResponseValidator,
-  logoutResponseValidator,
-  oauthProviderCatalogEntryValidator,
-  sessionResponseValidator,
-  sessionUnavailableResponseValidator,
+  okOutputValidator,
+  okMessageOutputValidator,
+  registerOutputValidator,
+  loginOutputValidator,
+  otpVerifyOutputValidator,
+  oauthCompleteOutputValidator,
+  devLoginAsOutputValidator,
+  logoutOutputValidator,
+  oauthProviderCatalogEntryOutputValidator,
+  sessionOutputValidator,
+  sessionUnavailableOutputValidator,
   createCommandMessages
 };

--- a/packages/auth-core/src/shared/commands/authDevLoginAsCommand.js
+++ b/packages/auth-core/src/shared/commands/authDevLoginAsCommand.js
@@ -4,7 +4,7 @@ import { deepFreeze } from "@jskit-ai/kernel/shared/support/deepFreeze";
 import {
   authEmailValidator,
   createCommandMessages,
-  devLoginAsResponseValidator
+  devLoginAsOutputValidator
 } from "./authCommandValidators.js";
 
 const AUTH_DEV_LOGIN_AS_MESSAGES = createCommandMessages({
@@ -47,7 +47,7 @@ const authDevLoginAsCommand = deepFreeze({
   operation: {
     method: "POST",
     body: authDevLoginAsBodyValidator,
-    response: devLoginAsResponseValidator,
+    response: devLoginAsOutputValidator,
     messages: AUTH_DEV_LOGIN_AS_MESSAGES,
     idempotent: false,
     invalidates: ["auth.session.read"]

--- a/packages/auth-core/src/shared/commands/authLoginOAuthCompleteCommand.js
+++ b/packages/auth-core/src/shared/commands/authLoginOAuthCompleteCommand.js
@@ -5,7 +5,7 @@ import {
   authRecoveryTokenFieldDefinition,
   authRefreshTokenFieldDefinition,
   createCommandMessages,
-  oauthCompleteResponseValidator,
+  oauthCompleteOutputValidator,
   oauthProviderFieldDefinition
 } from "./authCommandValidators.js";
 
@@ -47,7 +47,7 @@ const authLoginOAuthCompleteCommand = deepFreeze({
   operation: {
     method: "POST",
     body: authLoginOAuthCompleteBodyValidator,
-    response: oauthCompleteResponseValidator,
+    response: oauthCompleteOutputValidator,
     messages: AUTH_LOGIN_OAUTH_COMPLETE_MESSAGES,
     idempotent: false,
     invalidates: ["auth.session.read"]
@@ -56,7 +56,7 @@ const authLoginOAuthCompleteCommand = deepFreeze({
 
 export {
   authLoginOAuthCompleteBodyValidator,
-  oauthCompleteResponseValidator,
+  oauthCompleteOutputValidator,
   AUTH_LOGIN_OAUTH_COMPLETE_MESSAGES,
   authLoginOAuthCompleteCommand
 };

--- a/packages/auth-core/src/shared/commands/authLoginOAuthStartCommand.js
+++ b/packages/auth-core/src/shared/commands/authLoginOAuthStartCommand.js
@@ -36,7 +36,7 @@ const authLoginOAuthStartQueryValidator = deepFreeze({
   messages: AUTH_LOGIN_OAUTH_START_MESSAGES
 });
 
-const authLoginOAuthStartResponseValidator = deepFreeze({
+const authLoginOAuthStartOutputValidator = deepFreeze({
   schema: createSchema({
     provider: { ...oauthProviderFieldDefinition, required: true },
     returnTo: { ...oauthReturnToFieldDefinition, required: true },
@@ -51,7 +51,7 @@ const authLoginOAuthStartCommand = deepFreeze({
     method: "GET",
     params: authLoginOAuthStartParamsValidator,
     query: authLoginOAuthStartQueryValidator,
-    response: authLoginOAuthStartResponseValidator,
+    response: authLoginOAuthStartOutputValidator,
     messages: AUTH_LOGIN_OAUTH_START_MESSAGES,
     idempotent: true,
     invalidates: []
@@ -61,7 +61,7 @@ const authLoginOAuthStartCommand = deepFreeze({
 export {
   authLoginOAuthStartParamsValidator,
   authLoginOAuthStartQueryValidator,
-  authLoginOAuthStartResponseValidator,
+  authLoginOAuthStartOutputValidator,
   AUTH_LOGIN_OAUTH_START_MESSAGES,
   authLoginOAuthStartCommand
 };

--- a/packages/auth-core/src/shared/commands/authLoginOtpRequestCommand.js
+++ b/packages/auth-core/src/shared/commands/authLoginOtpRequestCommand.js
@@ -4,7 +4,7 @@ import {
   authEmailFieldDefinition,
   createCommandMessages,
   oauthReturnToFieldDefinition,
-  okMessageResponseValidator
+  okMessageOutputValidator
 } from "./authCommandValidators.js";
 
 const AUTH_LOGIN_OTP_REQUEST_MESSAGES = createCommandMessages({
@@ -36,7 +36,7 @@ const authLoginOtpRequestCommand = deepFreeze({
   operation: {
     method: "POST",
     body: authLoginOtpRequestBodyValidator,
-    response: okMessageResponseValidator,
+    response: okMessageOutputValidator,
     messages: AUTH_LOGIN_OTP_REQUEST_MESSAGES,
     idempotent: false,
     invalidates: []
@@ -45,7 +45,7 @@ const authLoginOtpRequestCommand = deepFreeze({
 
 export {
   authLoginOtpRequestBodyValidator,
-  okMessageResponseValidator,
+  okMessageOutputValidator,
   AUTH_LOGIN_OTP_REQUEST_MESSAGES,
   authLoginOtpRequestCommand
 };

--- a/packages/auth-core/src/shared/commands/authLoginOtpVerifyCommand.js
+++ b/packages/auth-core/src/shared/commands/authLoginOtpVerifyCommand.js
@@ -4,7 +4,7 @@ import {
   authEmailValidator,
   authRecoveryTokenValidator,
   createCommandMessages,
-  otpVerifyResponseValidator
+  otpVerifyOutputValidator
 } from "./authCommandValidators.js";
 
 const AUTH_LOGIN_OTP_VERIFY_MESSAGES = createCommandMessages({
@@ -56,7 +56,7 @@ const authLoginOtpVerifyCommand = deepFreeze({
   operation: {
     method: "POST",
     body: authLoginOtpVerifyBodyValidator,
-    response: otpVerifyResponseValidator,
+    response: otpVerifyOutputValidator,
     messages: AUTH_LOGIN_OTP_VERIFY_MESSAGES,
     idempotent: false,
     invalidates: ["auth.session.read"]
@@ -65,7 +65,7 @@ const authLoginOtpVerifyCommand = deepFreeze({
 
 export {
   authLoginOtpVerifyBodyValidator,
-  otpVerifyResponseValidator,
+  otpVerifyOutputValidator,
   AUTH_LOGIN_OTP_VERIFY_MESSAGES,
   authLoginOtpVerifyCommand
 };

--- a/packages/auth-core/src/shared/commands/authLoginPasswordCommand.js
+++ b/packages/auth-core/src/shared/commands/authLoginPasswordCommand.js
@@ -4,7 +4,7 @@ import {
   authEmailFieldDefinition,
   authLoginPasswordFieldDefinition,
   createCommandMessages,
-  loginResponseValidator
+  loginOutputValidator
 } from "./authCommandValidators.js";
 
 const AUTH_LOGIN_PASSWORD_MESSAGES = createCommandMessages({
@@ -37,7 +37,7 @@ const authLoginPasswordCommand = deepFreeze({
   operation: {
     method: "POST",
     body: authLoginPasswordBodyValidator,
-    response: loginResponseValidator,
+    response: loginOutputValidator,
     messages: AUTH_LOGIN_PASSWORD_MESSAGES,
     idempotent: false,
     invalidates: ["auth.session.read"]
@@ -46,7 +46,7 @@ const authLoginPasswordCommand = deepFreeze({
 
 export {
   authLoginPasswordBodyValidator,
-  loginResponseValidator,
+  loginOutputValidator,
   AUTH_LOGIN_PASSWORD_MESSAGES,
   authLoginPasswordCommand
 };

--- a/packages/auth-core/src/shared/commands/authLogoutCommand.js
+++ b/packages/auth-core/src/shared/commands/authLogoutCommand.js
@@ -1,6 +1,6 @@
 import {
   createCommandMessages,
-  logoutResponseValidator
+  logoutOutputValidator
 } from "./authCommandValidators.js";
 import { deepFreeze } from "@jskit-ai/kernel/shared/support/deepFreeze";
 
@@ -10,7 +10,7 @@ const authLogoutCommand = deepFreeze({
   command: "auth.logout",
   operation: {
     method: "POST",
-    response: logoutResponseValidator,
+    response: logoutOutputValidator,
     messages: AUTH_LOGOUT_MESSAGES,
     idempotent: false,
     invalidates: ["auth.session.read"]
@@ -18,7 +18,7 @@ const authLogoutCommand = deepFreeze({
 });
 
 export {
-  logoutResponseValidator,
+  logoutOutputValidator,
   AUTH_LOGOUT_MESSAGES,
   authLogoutCommand
 };

--- a/packages/auth-core/src/shared/commands/authPasswordRecoveryCompleteCommand.js
+++ b/packages/auth-core/src/shared/commands/authPasswordRecoveryCompleteCommand.js
@@ -5,7 +5,7 @@ import {
   authRecoveryTokenValidator,
   authRefreshTokenValidator,
   createCommandMessages,
-  okResponseValidator
+  okOutputValidator
 } from "./authCommandValidators.js";
 
 const AUTH_PASSWORD_RECOVERY_COMPLETE_MESSAGES = createCommandMessages({
@@ -62,7 +62,7 @@ const authPasswordRecoveryCompleteCommand = deepFreeze({
   operation: {
     method: "POST",
     body: authPasswordRecoveryCompleteBodyValidator,
-    response: okResponseValidator,
+    response: okOutputValidator,
     messages: AUTH_PASSWORD_RECOVERY_COMPLETE_MESSAGES,
     idempotent: false,
     invalidates: ["auth.session.read"]
@@ -71,7 +71,7 @@ const authPasswordRecoveryCompleteCommand = deepFreeze({
 
 export {
   authPasswordRecoveryCompleteBodyValidator,
-  okResponseValidator,
+  okOutputValidator,
   AUTH_PASSWORD_RECOVERY_COMPLETE_MESSAGES,
   authPasswordRecoveryCompleteCommand
 };

--- a/packages/auth-core/src/shared/commands/authPasswordResetCommand.js
+++ b/packages/auth-core/src/shared/commands/authPasswordResetCommand.js
@@ -3,7 +3,7 @@ import { deepFreeze } from "@jskit-ai/kernel/shared/support/deepFreeze";
 import {
   authPasswordFieldDefinition,
   createCommandMessages,
-  okMessageResponseValidator
+  okMessageOutputValidator
 } from "./authCommandValidators.js";
 
 const AUTH_PASSWORD_RESET_MESSAGES = createCommandMessages({
@@ -29,7 +29,7 @@ const authPasswordResetCommand = deepFreeze({
   operation: {
     method: "POST",
     body: authPasswordResetBodyValidator,
-    response: okMessageResponseValidator,
+    response: okMessageOutputValidator,
     messages: AUTH_PASSWORD_RESET_MESSAGES,
     idempotent: false,
     invalidates: ["auth.session.read"]
@@ -38,7 +38,7 @@ const authPasswordResetCommand = deepFreeze({
 
 export {
   authPasswordResetBodyValidator,
-  okMessageResponseValidator,
+  okMessageOutputValidator,
   AUTH_PASSWORD_RESET_MESSAGES,
   authPasswordResetCommand
 };

--- a/packages/auth-core/src/shared/commands/authPasswordResetRequestCommand.js
+++ b/packages/auth-core/src/shared/commands/authPasswordResetRequestCommand.js
@@ -3,7 +3,7 @@ import { deepFreeze } from "@jskit-ai/kernel/shared/support/deepFreeze";
 import {
   authEmailFieldDefinition,
   createCommandMessages,
-  okMessageResponseValidator
+  okMessageOutputValidator
 } from "./authCommandValidators.js";
 
 const AUTH_PASSWORD_RESET_REQUEST_MESSAGES = createCommandMessages({
@@ -30,7 +30,7 @@ const authPasswordResetRequestCommand = deepFreeze({
   operation: {
     method: "POST",
     body: authPasswordResetRequestBodyValidator,
-    response: okMessageResponseValidator,
+    response: okMessageOutputValidator,
     messages: AUTH_PASSWORD_RESET_REQUEST_MESSAGES,
     idempotent: false,
     invalidates: []
@@ -39,7 +39,7 @@ const authPasswordResetRequestCommand = deepFreeze({
 
 export {
   authPasswordResetRequestBodyValidator,
-  okMessageResponseValidator,
+  okMessageOutputValidator,
   AUTH_PASSWORD_RESET_REQUEST_MESSAGES,
   authPasswordResetRequestCommand
 };

--- a/packages/auth-core/src/shared/commands/authRegisterCommand.js
+++ b/packages/auth-core/src/shared/commands/authRegisterCommand.js
@@ -4,7 +4,7 @@ import {
   authEmailFieldDefinition,
   authPasswordFieldDefinition,
   createCommandMessages,
-  registerResponseValidator
+  registerOutputValidator
 } from "./authCommandValidators.js";
 
 const AUTH_REGISTER_MESSAGES = createCommandMessages({
@@ -37,7 +37,7 @@ const authRegisterCommand = deepFreeze({
   operation: {
     method: "POST",
     body: authRegisterBodyValidator,
-    response: registerResponseValidator,
+    response: registerOutputValidator,
     messages: AUTH_REGISTER_MESSAGES,
     idempotent: false,
     invalidates: ["auth.session.read"]
@@ -46,7 +46,7 @@ const authRegisterCommand = deepFreeze({
 
 export {
   authRegisterBodyValidator,
-  registerResponseValidator,
+  registerOutputValidator,
   AUTH_REGISTER_MESSAGES,
   authRegisterCommand
 };

--- a/packages/auth-core/src/shared/commands/authRegisterConfirmationResendCommand.js
+++ b/packages/auth-core/src/shared/commands/authRegisterConfirmationResendCommand.js
@@ -3,7 +3,7 @@ import { deepFreeze } from "@jskit-ai/kernel/shared/support/deepFreeze";
 import {
   authEmailFieldDefinition,
   createCommandMessages,
-  okMessageResponseValidator
+  okMessageOutputValidator
 } from "./authCommandValidators.js";
 
 const AUTH_REGISTER_CONFIRMATION_RESEND_MESSAGES = createCommandMessages({
@@ -30,7 +30,7 @@ const authRegisterConfirmationResendCommand = deepFreeze({
   operation: {
     method: "POST",
     body: authRegisterConfirmationResendBodyValidator,
-    response: okMessageResponseValidator,
+    response: okMessageOutputValidator,
     messages: AUTH_REGISTER_CONFIRMATION_RESEND_MESSAGES,
     idempotent: false,
     invalidates: []

--- a/packages/auth-core/src/shared/commands/authSessionReadCommand.js
+++ b/packages/auth-core/src/shared/commands/authSessionReadCommand.js
@@ -1,7 +1,7 @@
 import {
   createCommandMessages,
-  sessionResponseValidator,
-  sessionUnavailableResponseValidator
+  sessionOutputValidator,
+  sessionUnavailableOutputValidator
 } from "./authCommandValidators.js";
 import { deepFreeze } from "@jskit-ai/kernel/shared/support/deepFreeze";
 
@@ -11,8 +11,8 @@ const authSessionReadCommand = deepFreeze({
   command: "auth.session.read",
   operation: {
     method: "GET",
-    response: sessionResponseValidator,
-    unavailableResponse: sessionUnavailableResponseValidator,
+    response: sessionOutputValidator,
+    unavailableResponse: sessionUnavailableOutputValidator,
     messages: AUTH_SESSION_READ_MESSAGES,
     idempotent: true,
     invalidates: []
@@ -20,8 +20,8 @@ const authSessionReadCommand = deepFreeze({
 });
 
 export {
-  sessionResponseValidator,
-  sessionUnavailableResponseValidator,
+  sessionOutputValidator,
+  sessionUnavailableOutputValidator,
   AUTH_SESSION_READ_MESSAGES,
   authSessionReadCommand
 };

--- a/packages/auth-provider-supabase-core/src/server/lib/actions/auth.contributor.js
+++ b/packages/auth-provider-supabase-core/src/server/lib/actions/auth.contributor.js
@@ -1,6 +1,6 @@
 import { createSchema } from "json-rest-schema";
 import {
-  EMPTY_INPUT_VALIDATOR
+  emptyInputValidator
 } from "@jskit-ai/kernel/shared/actions/actionContributorHelpers";
 import {
   composeSchemaDefinitions
@@ -232,7 +232,7 @@ const authActionsAfterDevLogin = Object.freeze([
     kind: "command",
     channels: ["api", "automation", "internal"],
     surfacesFrom: "enabled",
-    input: EMPTY_INPUT_VALIDATOR,
+    input: emptyInputValidator,
     output: authLogoutOutput,
     idempotency: "none",
     audit: {
@@ -257,7 +257,7 @@ const authActionsAfterDevLogin = Object.freeze([
     kind: "query",
     channels: ["api", "internal"],
     surfacesFrom: "enabled",
-    input: EMPTY_INPUT_VALIDATOR,
+    input: emptyInputValidator,
     idempotency: "none",
     audit: {
       actionName: "auth.session.read"

--- a/packages/console-core/src/server/consoleSettings/consoleSettingsActions.js
+++ b/packages/console-core/src/server/consoleSettings/consoleSettingsActions.js
@@ -1,5 +1,5 @@
 import {
-  EMPTY_INPUT_VALIDATOR
+  emptyInputValidator
 } from "@jskit-ai/kernel/shared/actions/actionContributorHelpers";
 import { consoleSettingsResource } from "../../shared/resources/consoleSettingsResource.js";
 
@@ -13,7 +13,7 @@ const consoleSettingsActions = Object.freeze([
     permission: {
       require: "authenticated"
     },
-    input: EMPTY_INPUT_VALIDATOR,
+    input: emptyInputValidator,
     output: consoleSettingsResource.operations.view.output,
     idempotency: "none",
     audit: {

--- a/packages/console-core/src/shared/resources/consoleSettingsResource.js
+++ b/packages/console-core/src/shared/resources/consoleSettingsResource.js
@@ -15,9 +15,24 @@ const consoleSettingsOutputSchema = createSchema({
   }
 });
 
-const consoleSettingsOutputDefinition = deepFreeze({
+const consoleSettingsOutputValidator = deepFreeze({
   schema: consoleSettingsOutputSchema,
   mode: "replace"
+});
+
+const consoleSettingsCreateBodyValidator = deepFreeze({
+  schema: consoleSettingsBodySchema,
+  mode: "create"
+});
+
+const consoleSettingsReplaceBodyValidator = deepFreeze({
+  schema: consoleSettingsBodySchema,
+  mode: "replace"
+});
+
+const consoleSettingsPatchBodyValidator = deepFreeze({
+  schema: consoleSettingsPatchBodySchema,
+  mode: "patch"
 });
 
 const CONSOLE_SETTINGS_OPERATION_MESSAGES = createOperationMessages();
@@ -28,39 +43,30 @@ const consoleSettingsResource = deepFreeze({
     view: {
       method: "GET",
       messages: CONSOLE_SETTINGS_OPERATION_MESSAGES,
-      output: consoleSettingsOutputDefinition
+      output: consoleSettingsOutputValidator
     },
     list: {
       method: "GET",
       messages: CONSOLE_SETTINGS_OPERATION_MESSAGES,
-      output: createCursorListValidator(consoleSettingsOutputDefinition)
+      output: createCursorListValidator(consoleSettingsOutputValidator)
     },
     create: {
       method: "POST",
       messages: CONSOLE_SETTINGS_OPERATION_MESSAGES,
-      body: {
-        schema: consoleSettingsBodySchema,
-        mode: "create"
-      },
-      output: consoleSettingsOutputDefinition
+      body: consoleSettingsCreateBodyValidator,
+      output: consoleSettingsOutputValidator
     },
     replace: {
       method: "PUT",
       messages: CONSOLE_SETTINGS_OPERATION_MESSAGES,
-      body: {
-        schema: consoleSettingsBodySchema,
-        mode: "replace"
-      },
-      output: consoleSettingsOutputDefinition
+      body: consoleSettingsReplaceBodyValidator,
+      output: consoleSettingsOutputValidator
     },
     patch: {
       method: "PATCH",
       messages: CONSOLE_SETTINGS_OPERATION_MESSAGES,
-      body: {
-        schema: consoleSettingsPatchBodySchema,
-        mode: "patch"
-      },
-      output: consoleSettingsOutputDefinition
+      body: consoleSettingsPatchBodyValidator,
+      output: consoleSettingsOutputValidator
     }
   }
 });

--- a/packages/crud-server-generator/src/shared/crud/crudResource.js
+++ b/packages/crud-server-generator/src/shared/crud/crudResource.js
@@ -101,24 +101,24 @@ const patchBodySchema = createSchema({
   }
 });
 
-const recordOutput = deepFreeze({
+const recordOutputValidator = deepFreeze({
   schema: recordOutputSchema,
   mode: "replace"
 });
 
-const listOutput = createCursorListValidator(recordOutput);
+const listOutputValidator = createCursorListValidator(recordOutputValidator);
 
-const createBody = deepFreeze({
+const createBodyValidator = deepFreeze({
   schema: createBodySchema,
   mode: "create"
 });
 
-const patchBody = deepFreeze({
+const patchBodyValidator = deepFreeze({
   schema: patchBodySchema,
   mode: "patch"
 });
 
-const deleteOutput = deepFreeze({
+const deleteOutputValidator = deepFreeze({
   schema: createSchema({
     id: {
       type: "string",
@@ -158,25 +158,25 @@ const crudResource = deepFreeze({
         events: ["crud.record.changed"]
       },
       method: "GET",
-      output: listOutput
+      output: listOutputValidator
     },
     view: {
       method: "GET",
-      output: recordOutput
+      output: recordOutputValidator
     },
     create: {
       method: "POST",
-      body: createBody,
-      output: recordOutput
+      body: createBodyValidator,
+      output: recordOutputValidator
     },
     patch: {
       method: "PATCH",
-      body: patchBody,
-      output: recordOutput
+      body: patchBodyValidator,
+      output: recordOutputValidator
     },
     delete: {
       method: "DELETE",
-      output: deleteOutput
+      output: deleteOutputValidator
     }
   }
 });

--- a/packages/crud-server-generator/templates/src/local-package/shared/crudResource.js
+++ b/packages/crud-server-generator/templates/src/local-package/shared/crudResource.js
@@ -23,24 +23,24 @@ const patchBodySchema = createSchema({
 __JSKIT_CRUD_RESOURCE_PATCH_SCHEMA_PROPERTIES__
 });
 
-const recordOutput = deepFreeze({
+const recordOutputValidator = deepFreeze({
   schema: recordOutputSchema,
   mode: "replace"
 });
 
-const listOutput = createCursorListValidator(recordOutput);
+const listOutputValidator = createCursorListValidator(recordOutputValidator);
 
-const createBody = deepFreeze({
+const createBodyValidator = deepFreeze({
   schema: createBodySchema,
   mode: "create"
 });
 
-const patchBody = deepFreeze({
+const patchBodyValidator = deepFreeze({
   schema: patchBodySchema,
   mode: "patch"
 });
 
-const deleteOutput = deepFreeze({
+const deleteOutputValidator = deepFreeze({
   schema: createSchema({
     id: {
       type: "string",
@@ -80,25 +80,25 @@ const resource = deepFreeze({
         events: ["${option:namespace|snake}.record.changed"]
       },
       method: "GET",
-      output: listOutput
+      output: listOutputValidator
     },
     view: {
       method: "GET",
-      output: recordOutput
+      output: recordOutputValidator
     },
     create: {
       method: "POST",
-      body: createBody,
-      output: recordOutput
+      body: createBodyValidator,
+      output: recordOutputValidator
     },
     patch: {
       method: "PATCH",
-      body: patchBody,
-      output: recordOutput
+      body: patchBodyValidator,
+      output: recordOutputValidator
     },
     delete: {
       method: "DELETE",
-      output: deleteOutput
+      output: deleteOutputValidator
     }
   }
 });

--- a/packages/crud-server-generator/test-support/templateServerFixture.js
+++ b/packages/crud-server-generator/test-support/templateServerFixture.js
@@ -245,19 +245,27 @@ const patchBodySchema = createSchema({
   }
 });
 
-const recordOutput = deepFreeze({
+const recordOutputValidator = deepFreeze({
   schema: recordOutputSchema,
   mode: "replace"
 });
 
-const createBody = deepFreeze({
+const createBodyValidator = deepFreeze({
   schema: createBodySchema,
   mode: "create"
 });
 
-const patchBody = deepFreeze({
+const patchBodyValidator = deepFreeze({
   schema: patchBodySchema,
   mode: "patch"
+});
+
+const deleteOutputValidator = deepFreeze({
+  schema: createSchema({
+    id: { type: "string", required: true },
+    deleted: { type: "boolean", required: true }
+  }),
+  mode: "replace"
 });
 
 const resource = deepFreeze({
@@ -266,27 +274,21 @@ const resource = deepFreeze({
   idColumn: "id",
   operations: {
     list: {
-      output: createCursorListValidator(recordOutput)
+      output: createCursorListValidator(recordOutputValidator)
     },
     view: {
-      output: recordOutput
+      output: recordOutputValidator
     },
     create: {
-      body: createBody,
-      output: recordOutput
+      body: createBodyValidator,
+      output: recordOutputValidator
     },
     patch: {
-      body: patchBody,
-      output: recordOutput
+      body: patchBodyValidator,
+      output: recordOutputValidator
     },
     delete: {
-      output: deepFreeze({
-        schema: createSchema({
-          id: { type: "string", required: true },
-          deleted: { type: "boolean", required: true }
-        }),
-        mode: "replace"
-      })
+      output: deleteOutputValidator
     }
   }
 });

--- a/packages/crud-server-generator/test/addFieldSubcommand.test.js
+++ b/packages/crud-server-generator/test/addFieldSubcommand.test.js
@@ -48,17 +48,17 @@ const patchBodySchema = createSchema({
   }
 });
 
-const recordOutput = deepFreeze({
+const recordOutputValidator = deepFreeze({
   schema: recordOutputSchema,
   mode: "replace"
 });
 
-const createBody = deepFreeze({
+const createBodyValidator = deepFreeze({
   schema: createBodySchema,
   mode: "create"
 });
 
-const patchBody = deepFreeze({
+const patchBodyValidator = deepFreeze({
   schema: patchBodySchema,
   mode: "patch"
 });
@@ -68,10 +68,10 @@ const resource = deepFreeze({
   tableName: "contacts",
   idColumn: "id",
   operations: {
-    list: { method: "GET", output: createCursorListValidator(recordOutput) },
-    view: { method: "GET", output: recordOutput },
-    create: { method: "POST", body: createBody, output: recordOutput },
-    patch: { method: "PATCH", body: patchBody, output: recordOutput }
+    list: { method: "GET", output: createCursorListValidator(recordOutputValidator) },
+    view: { method: "GET", output: recordOutputValidator },
+    create: { method: "POST", body: createBodyValidator, output: recordOutputValidator },
+    patch: { method: "PATCH", body: patchBodyValidator, output: recordOutputValidator }
   }
 });
 

--- a/packages/kernel/server/actions/ActionRuntimeServiceProvider.test.js
+++ b/packages/kernel/server/actions/ActionRuntimeServiceProvider.test.js
@@ -3,7 +3,7 @@ import test from "node:test";
 import { createSchema } from "json-rest-schema";
 
 import {
-  EMPTY_INPUT_VALIDATOR
+  emptyInputValidator
 } from "../../shared/actions/actionContributorHelpers.js";
 import {
   ActionRuntimeServiceProvider,
@@ -162,7 +162,7 @@ test("ActionRuntimeServiceProvider registers SurfaceRuntime from appConfig when 
       kind: "query",
       channels: ["internal"],
       surfacesFrom: "enabled",
-      input: EMPTY_INPUT_VALIDATOR,
+      input: emptyInputValidator,
       idempotency: "none",
       audit: { actionName: "test.surfaces.from.appconfig" },
       observability: {},
@@ -198,7 +198,7 @@ test("ActionRuntimeServiceProvider materializes custom surfacesFrom aliases regi
       kind: "query",
       channels: ["internal"],
       surfacesFrom: "workspace",
-      input: EMPTY_INPUT_VALIDATOR,
+      input: emptyInputValidator,
       idempotency: "none",
       audit: { actionName: "test.workspace.alias" },
       observability: {},
@@ -235,7 +235,7 @@ test("ActionRuntimeServiceProvider does not infer service method bindings from a
       dependencies: {
         customerService: "test.customer.service"
       },
-      input: EMPTY_INPUT_VALIDATOR,
+      input: emptyInputValidator,
       idempotency: "optional",
       audit: { actionName: "test.customer.create" },
       observability: {},
@@ -268,7 +268,7 @@ test("app.actions + resolveActionContributors provide canonical contributor wiri
       kind: "query",
       channels: ["internal"],
       surfaces: ["app"],
-      input: EMPTY_INPUT_VALIDATOR,
+      input: emptyInputValidator,
       idempotency: "none",
       audit: { actionName: "alpha.one" },
       observability: {},
@@ -285,7 +285,7 @@ test("app.actions + resolveActionContributors provide canonical contributor wiri
       kind: "query",
       channels: ["internal"],
       surfaces: ["app"],
-      input: EMPTY_INPUT_VALIDATOR,
+      input: emptyInputValidator,
       idempotency: "none",
       audit: { actionName: "beta.one" },
       observability: {},
@@ -328,7 +328,7 @@ test("action runtime execute merges static and per-execution dependencies", asyn
       dependencies: {
         staticService: "test.static.service"
       },
-      input: EMPTY_INPUT_VALIDATOR,
+      input: emptyInputValidator,
       idempotency: "none",
       audit: { actionName: "test.deps.merge" },
       observability: {},
@@ -372,7 +372,7 @@ test("app.actions accepts custom action domains", () => {
       kind: "query",
       channels: ["internal"],
       surfaces: ["app"],
-      input: EMPTY_INPUT_VALIDATOR,
+      input: emptyInputValidator,
       idempotency: "none",
       audit: { actionName: "custom.domain.check" },
       observability: {},
@@ -399,7 +399,7 @@ test("app.action registers a single action with default contributor id", () => {
     kind: "query",
     channels: ["internal"],
     surfaces: ["app"],
-    input: EMPTY_INPUT_VALIDATOR,
+    input: emptyInputValidator,
     idempotency: "none",
     audit: { actionName: "test.single" },
     observability: {},
@@ -423,7 +423,7 @@ test("app.actions requires an array", () => {
   assert.throws(() => app.actions({}), /requires an array/);
 });
 
-test("EMPTY_INPUT_VALIDATOR allows empty input and rejects unexpected fields", async () => {
+test("emptyInputValidator allows empty input and rejects unexpected fields", async () => {
   const app = createSingletonApp();
   const provider = new ActionRuntimeServiceProvider();
   provider.register(app);
@@ -442,7 +442,7 @@ test("EMPTY_INPUT_VALIDATOR allows empty input and rejects unexpected fields", a
       kind: "query",
       channels: ["internal"],
       surfaces: ["app"],
-      input: EMPTY_INPUT_VALIDATOR,
+      input: emptyInputValidator,
       idempotency: "none",
       audit: { actionName: "test.empty-input" },
       observability: {},
@@ -509,7 +509,7 @@ test("app.actions rejects invalid domain identifiers", () => {
           kind: "query",
           channels: ["internal"],
           surfaces: ["app"],
-          input: EMPTY_INPUT_VALIDATOR,
+          input: emptyInputValidator,
           idempotency: "none",
           audit: { actionName: "invalid.domain" },
           observability: {},
@@ -541,7 +541,7 @@ test("app.actions rejects unsupported surfacesFrom aliases", () => {
       kind: "query",
       channels: ["internal"],
       surfacesFrom: "workspace",
-      input: EMPTY_INPUT_VALIDATOR,
+      input: emptyInputValidator,
       idempotency: "none",
       audit: { actionName: "workspace.alias.invalid" },
       observability: {},

--- a/packages/kernel/shared/actions/actionContributorHelpers.js
+++ b/packages/kernel/shared/actions/actionContributorHelpers.js
@@ -13,7 +13,7 @@ function resolveRequest(context) {
   return context?.requestMeta?.request || null;
 }
 
-const EMPTY_INPUT_VALIDATOR = Object.freeze({
+const emptyInputValidator = Object.freeze({
   schema: createSchema({}),
   mode: "replace"
 });
@@ -24,5 +24,5 @@ export {
   requireServiceMethod,
   resolveRequest,
   hasPermission,
-  EMPTY_INPUT_VALIDATOR
+  emptyInputValidator
 };

--- a/packages/users-core/src/server/accountProfile/accountProfileActions.js
+++ b/packages/users-core/src/server/accountProfile/accountProfileActions.js
@@ -1,6 +1,6 @@
 import { createSchema } from "json-rest-schema";
 import {
-  EMPTY_INPUT_VALIDATOR,
+  emptyInputValidator,
   resolveRequest
 } from "@jskit-ai/kernel/shared/actions/actionContributorHelpers";
 import { deepFreeze } from "@jskit-ai/kernel/shared/support/deepFreeze";
@@ -41,7 +41,7 @@ const accountProfileActions = deepFreeze([
     permission: {
       require: "authenticated"
     },
-    input: EMPTY_INPUT_VALIDATOR,
+    input: emptyInputValidator,
     output: userSettingsResource.operations.view.output,
     idempotency: "none",
     audit: {

--- a/packages/users-core/src/shared/resources/userProfileResource.js
+++ b/packages/users-core/src/shared/resources/userProfileResource.js
@@ -6,10 +6,10 @@ import {
   userProfileOutputSchema
 } from "./accountSettingsSchemas.js";
 import {
-  userSettingsOutputDefinition
+  userSettingsOutputValidator
 } from "./userSettingsResource.js";
 
-const userProfileOutput = deepFreeze({
+const userProfileOutputValidator = deepFreeze({
   schema: userProfileOutputSchema,
   mode: "replace"
 });
@@ -23,7 +23,7 @@ const userProfileBodySchema = createSchema({
   }
 });
 
-const avatarUploadBody = deepFreeze({
+const avatarUploadBodyValidator = deepFreeze({
   schema: createSchema({
     mimeType: {
       type: "string",
@@ -53,7 +53,7 @@ const avatarUploadBody = deepFreeze({
   mode: "patch"
 });
 
-const avatarDeleteBody = deepFreeze({
+const avatarDeleteBodyValidator = deepFreeze({
   schema: createSchema({}),
   mode: "patch"
 });
@@ -66,12 +66,12 @@ const userProfileResource = deepFreeze({
     view: {
       method: "GET",
       messages: USER_PROFILE_OPERATION_MESSAGES,
-      output: userProfileOutput
+      output: userProfileOutputValidator
     },
     list: {
       method: "GET",
       messages: USER_PROFILE_OPERATION_MESSAGES,
-      output: createCursorListValidator(userProfileOutput)
+      output: createCursorListValidator(userProfileOutputValidator)
     },
     create: {
       method: "POST",
@@ -80,7 +80,7 @@ const userProfileResource = deepFreeze({
         schema: userProfileBodySchema,
         mode: "create"
       },
-      output: userProfileOutput
+      output: userProfileOutputValidator
     },
     replace: {
       method: "PUT",
@@ -89,7 +89,7 @@ const userProfileResource = deepFreeze({
         schema: userProfileBodySchema,
         mode: "replace"
       },
-      output: userProfileOutput
+      output: userProfileOutputValidator
     },
     patch: {
       method: "PATCH",
@@ -98,19 +98,19 @@ const userProfileResource = deepFreeze({
         schema: userProfileBodySchema,
         mode: "patch"
       },
-      output: userProfileOutput
+      output: userProfileOutputValidator
     },
     avatarUpload: {
       method: "POST",
       messages: USER_PROFILE_OPERATION_MESSAGES,
-      body: avatarUploadBody,
-      output: userSettingsOutputDefinition
+      body: avatarUploadBodyValidator,
+      output: userSettingsOutputValidator
     },
     avatarDelete: {
       method: "DELETE",
       messages: USER_PROFILE_OPERATION_MESSAGES,
-      body: avatarDeleteBody,
-      output: userSettingsOutputDefinition
+      body: avatarDeleteBodyValidator,
+      output: userSettingsOutputValidator
     }
   }
 });

--- a/packages/users-core/src/shared/resources/userSettingsResource.js
+++ b/packages/users-core/src/shared/resources/userSettingsResource.js
@@ -138,12 +138,12 @@ const userSettingsOutputSchema = createSchema({
   }
 });
 
-const userSettingsOutputDefinition = deepFreeze({
+const userSettingsOutputValidator = deepFreeze({
   schema: userSettingsOutputSchema,
   mode: "replace"
 });
 
-const passwordMethodToggleOutputDefinition = deepFreeze({
+const passwordMethodToggleOutputValidator = deepFreeze({
   schema: createSchema({
     securityStatus: {
       type: "object",
@@ -159,7 +159,7 @@ const passwordMethodToggleOutputDefinition = deepFreeze({
   mode: "replace"
 });
 
-const oauthUnlinkOutputDefinition = deepFreeze({
+const oauthUnlinkOutputValidator = deepFreeze({
   schema: createSchema({
     securityStatus: {
       type: "object",
@@ -170,7 +170,7 @@ const oauthUnlinkOutputDefinition = deepFreeze({
   mode: "replace"
 });
 
-const passwordChangeBodyDefinition = deepFreeze({
+const passwordChangeBodyValidator = deepFreeze({
   schema: createSchema({
     currentPassword: {
       type: "string",
@@ -204,7 +204,7 @@ const passwordChangeBodyDefinition = deepFreeze({
   mode: "create"
 });
 
-const passwordChangeOutputDefinition = deepFreeze({
+const passwordChangeOutputValidator = deepFreeze({
   schema: createSchema({
     ok: { type: "boolean", required: true },
     message: { type: "string", required: true, minLength: 1 }
@@ -212,7 +212,7 @@ const passwordChangeOutputDefinition = deepFreeze({
   mode: "replace"
 });
 
-const passwordMethodToggleBodyDefinition = deepFreeze({
+const passwordMethodToggleBodyValidator = deepFreeze({
   schema: createSchema({
     enabled: {
       type: "boolean",
@@ -227,7 +227,7 @@ const passwordMethodToggleBodyDefinition = deepFreeze({
   mode: "patch"
 });
 
-const oauthProviderParamsDefinition = deepFreeze({
+const oauthProviderParamsValidator = deepFreeze({
   schema: createSchema({
     provider: {
       type: "string",
@@ -243,7 +243,7 @@ const oauthProviderParamsDefinition = deepFreeze({
   mode: "patch"
 });
 
-const oauthProviderQueryDefinition = deepFreeze({
+const oauthProviderQueryValidator = deepFreeze({
   schema: createSchema({
     returnTo: {
       type: "string",
@@ -257,7 +257,7 @@ const oauthProviderQueryDefinition = deepFreeze({
   mode: "patch"
 });
 
-const oauthLinkStartOutputDefinition = deepFreeze({
+const oauthLinkStartOutputValidator = deepFreeze({
   schema: createSchema({
     provider: { type: "string", required: true, minLength: 2, maxLength: 64 },
     returnTo: { type: "string", required: true, minLength: 1 },
@@ -266,14 +266,14 @@ const oauthLinkStartOutputDefinition = deepFreeze({
   mode: "replace"
 });
 
-const logoutOtherSessionsOutputDefinition = deepFreeze({
+const logoutOtherSessionsOutputValidator = deepFreeze({
   schema: createSchema({
     ok: { type: "boolean", required: true }
   }),
   mode: "replace"
 });
 
-const emptyBodyDefinition = deepFreeze({
+const emptyBodyValidator = deepFreeze({
   schema: createSchema({}),
   mode: "patch"
 });
@@ -286,12 +286,12 @@ const userSettingsResource = deepFreeze({
     view: {
       method: "GET",
       messages: USER_SETTINGS_OPERATION_MESSAGES,
-      output: userSettingsOutputDefinition
+      output: userSettingsOutputValidator
     },
     list: {
       method: "GET",
       messages: USER_SETTINGS_OPERATION_MESSAGES,
-      output: createCursorListValidator(userSettingsOutputDefinition)
+      output: createCursorListValidator(userSettingsOutputValidator)
     },
     create: {
       method: "POST",
@@ -300,7 +300,7 @@ const userSettingsResource = deepFreeze({
         schema: userSettingsBodySchema,
         mode: "create"
       },
-      output: userSettingsOutputDefinition
+      output: userSettingsOutputValidator
     },
     replace: {
       method: "PUT",
@@ -309,7 +309,7 @@ const userSettingsResource = deepFreeze({
         schema: userSettingsBodySchema,
         mode: "replace"
       },
-      output: userSettingsOutputDefinition
+      output: userSettingsOutputValidator
     },
     patch: {
       method: "PATCH",
@@ -318,7 +318,7 @@ const userSettingsResource = deepFreeze({
         schema: userSettingsBodySchema,
         mode: "patch"
       },
-      output: userSettingsOutputDefinition
+      output: userSettingsOutputValidator
     },
     preferencesUpdate: {
       method: "PATCH",
@@ -327,7 +327,7 @@ const userSettingsResource = deepFreeze({
         schema: userSettingsPreferencesSchema,
         mode: "patch"
       },
-      output: userSettingsOutputDefinition
+      output: userSettingsOutputValidator
     },
     notificationsUpdate: {
       method: "PATCH",
@@ -336,38 +336,38 @@ const userSettingsResource = deepFreeze({
         schema: userSettingsNotificationsSchema,
         mode: "patch"
       },
-      output: userSettingsOutputDefinition
+      output: userSettingsOutputValidator
     },
     passwordChange: {
       method: "POST",
       messages: USER_SETTINGS_OPERATION_MESSAGES,
-      body: passwordChangeBodyDefinition,
-      output: passwordChangeOutputDefinition
+      body: passwordChangeBodyValidator,
+      output: passwordChangeOutputValidator
     },
     passwordMethodToggle: {
       method: "PATCH",
       messages: USER_SETTINGS_OPERATION_MESSAGES,
-      body: passwordMethodToggleBodyDefinition,
-      output: passwordMethodToggleOutputDefinition
+      body: passwordMethodToggleBodyValidator,
+      output: passwordMethodToggleOutputValidator
     },
     oauthLinkStart: {
       method: "GET",
       messages: USER_SETTINGS_OPERATION_MESSAGES,
-      params: oauthProviderParamsDefinition,
-      query: oauthProviderQueryDefinition,
-      output: oauthLinkStartOutputDefinition
+      params: oauthProviderParamsValidator,
+      query: oauthProviderQueryValidator,
+      output: oauthLinkStartOutputValidator
     },
     oauthUnlink: {
       method: "DELETE",
       messages: USER_SETTINGS_OPERATION_MESSAGES,
-      params: oauthProviderParamsDefinition,
-      output: oauthUnlinkOutputDefinition
+      params: oauthProviderParamsValidator,
+      output: oauthUnlinkOutputValidator
     },
     logoutOtherSessions: {
       method: "POST",
       messages: USER_SETTINGS_OPERATION_MESSAGES,
-      body: emptyBodyDefinition,
-      output: logoutOtherSessionsOutputDefinition
+      body: emptyBodyValidator,
+      output: logoutOtherSessionsOutputValidator
     }
   }
 });
@@ -378,6 +378,6 @@ export {
   USER_SETTINGS_NOTIFICATION_KEYS,
   USER_SETTINGS_PREFERENCE_KEYS,
   userSettingsOutputSchema,
-  userSettingsOutputDefinition,
+  userSettingsOutputValidator,
   userSettingsResource
 };

--- a/packages/users-core/templates/packages/users/src/shared/userResource.js
+++ b/packages/users-core/templates/packages/users/src/shared/userResource.js
@@ -34,12 +34,12 @@ const recordOutputSchema = createSchema({
 
 const createBodySchema = createSchema({});
 
-const recordOutput = deepFreeze({
+const recordOutputValidator = deepFreeze({
   schema: recordOutputSchema,
   mode: "replace"
 });
 
-const createBody = deepFreeze({
+const createBodyValidator = deepFreeze({
   schema: createBodySchema,
   mode: "create"
 });
@@ -51,16 +51,16 @@ const resource = deepFreeze({
   operations: {
     list: {
       method: "GET",
-      output: createCursorListValidator(recordOutput)
+      output: createCursorListValidator(recordOutputValidator)
     },
     view: {
       method: "GET",
-      output: recordOutput
+      output: recordOutputValidator
     },
     create: {
       method: "POST",
-      body: createBody,
-      output: recordOutput
+      body: createBodyValidator,
+      output: recordOutputValidator
     }
   }
 });

--- a/packages/workspaces-core/src/server/workspaceDirectory/workspaceDirectoryActions.js
+++ b/packages/workspaces-core/src/server/workspaceDirectory/workspaceDirectoryActions.js
@@ -1,5 +1,5 @@
 import {
-  EMPTY_INPUT_VALIDATOR,
+  emptyInputValidator,
   resolveRequest
 } from "@jskit-ai/kernel/shared/actions/actionContributorHelpers";
 import { composeSchemaDefinitions } from "@jskit-ai/kernel/shared/validators";
@@ -53,7 +53,7 @@ const workspaceDirectoryActions = Object.freeze([
     permission: {
       require: "authenticated"
     },
-    input: EMPTY_INPUT_VALIDATOR,
+    input: emptyInputValidator,
     output: workspaceResource.operations.list.output,
     idempotency: "none",
     audit: {

--- a/packages/workspaces-core/src/server/workspacePendingInvitations/workspacePendingInvitationsActions.js
+++ b/packages/workspaces-core/src/server/workspacePendingInvitations/workspacePendingInvitationsActions.js
@@ -1,5 +1,5 @@
 import {
-  EMPTY_INPUT_VALIDATOR
+  emptyInputValidator
 } from "@jskit-ai/kernel/shared/actions/actionContributorHelpers";
 import { workspaceMembersResource } from "../../shared/resources/workspaceMembersResource.js";
 import { workspacePendingInvitationsResource } from "../../shared/resources/workspacePendingInvitationsResource.js";
@@ -15,7 +15,7 @@ const workspacePendingInvitationsActions = Object.freeze([
     permission: {
       require: "authenticated"
     },
-    input: EMPTY_INPUT_VALIDATOR,
+    input: emptyInputValidator,
     output: workspacePendingInvitationsResource.operations.list.output,
     idempotency: "none",
     audit: {

--- a/packages/workspaces-core/src/shared/resources/workspacePendingInvitationsResource.js
+++ b/packages/workspaces-core/src/shared/resources/workspacePendingInvitationsResource.js
@@ -15,7 +15,7 @@ const pendingInviteRecordSchema = createSchema({
   token: { type: "string", required: true, minLength: 1 }
 });
 
-const pendingInvitationsListOutputDefinition = deepFreeze({
+const pendingInvitationsListOutputValidator = deepFreeze({
   schema: createSchema({
     pendingInvites: {
       type: "array",
@@ -35,7 +35,7 @@ const workspacePendingInvitationsResource = deepFreeze({
     list: {
       method: "GET",
       messages: WORKSPACE_PENDING_INVITATIONS_MESSAGES,
-      output: pendingInvitationsListOutputDefinition
+      output: pendingInvitationsListOutputValidator
     }
   }
 });

--- a/packages/workspaces-core/src/shared/resources/workspaceResource.js
+++ b/packages/workspaces-core/src/shared/resources/workspaceResource.js
@@ -41,12 +41,12 @@ const workspacePatchBodySchema = createSchema({
   }
 });
 
-const responseRecord = deepFreeze({
+const workspaceOutputValidator = deepFreeze({
   schema: workspaceOutputSchema,
   mode: "replace"
 });
 
-const workspaceSummaryOutput = deepFreeze({
+const workspaceListItemOutputValidator = deepFreeze({
   schema: workspaceListItemSchema,
   mode: "replace"
 });
@@ -62,11 +62,11 @@ const resource = deepFreeze({
   operations: {
     view: {
       method: "GET",
-      output: responseRecord
+      output: workspaceOutputValidator
     },
     list: {
       method: "GET",
-      output: createCursorListValidator(workspaceSummaryOutput)
+      output: createCursorListValidator(workspaceListItemOutputValidator)
     },
     create: {
       method: "POST",
@@ -74,7 +74,7 @@ const resource = deepFreeze({
         schema: workspaceCreateBodySchema,
         mode: "create"
       },
-      output: responseRecord
+      output: workspaceOutputValidator
     },
     replace: {
       method: "PUT",
@@ -82,7 +82,7 @@ const resource = deepFreeze({
         schema: workspaceCreateBodySchema,
         mode: "replace"
       },
-      output: responseRecord
+      output: workspaceOutputValidator
     },
     patch: {
       method: "PATCH",
@@ -90,7 +90,7 @@ const resource = deepFreeze({
         schema: workspacePatchBodySchema,
         mode: "patch"
       },
-      output: responseRecord
+      output: workspaceOutputValidator
     }
   }
 });

--- a/packages/workspaces-core/src/shared/resources/workspaceSettingsResource.js
+++ b/packages/workspaces-core/src/shared/resources/workspaceSettingsResource.js
@@ -164,9 +164,24 @@ const workspaceSettingsOutputSchema = createSchema({
   }
 });
 
-const workspaceSettingsOutputDefinition = deepFreeze({
+const workspaceSettingsOutputValidator = deepFreeze({
   schema: workspaceSettingsOutputSchema,
   mode: "replace"
+});
+
+const workspaceSettingsCreateBodyValidator = deepFreeze({
+  schema: workspaceSettingsBodySchema,
+  mode: "create"
+});
+
+const workspaceSettingsReplaceBodyValidator = deepFreeze({
+  schema: workspaceSettingsBodySchema,
+  mode: "replace"
+});
+
+const workspaceSettingsPatchBodyValidator = deepFreeze({
+  schema: workspaceSettingsBodySchema,
+  mode: "patch"
 });
 
 const workspaceSettingsResource = deepFreeze({
@@ -180,35 +195,26 @@ const workspaceSettingsResource = deepFreeze({
   operations: {
     view: {
       method: "GET",
-      output: workspaceSettingsOutputDefinition
+      output: workspaceSettingsOutputValidator
     },
     list: {
       method: "GET",
-      output: createCursorListValidator(workspaceSettingsOutputDefinition)
+      output: createCursorListValidator(workspaceSettingsOutputValidator)
     },
     create: {
       method: "POST",
-      body: {
-        schema: workspaceSettingsBodySchema,
-        mode: "create"
-      },
-      output: workspaceSettingsOutputDefinition
+      body: workspaceSettingsCreateBodyValidator,
+      output: workspaceSettingsOutputValidator
     },
     replace: {
       method: "PUT",
-      body: {
-        schema: workspaceSettingsBodySchema,
-        mode: "replace"
-      },
-      output: workspaceSettingsOutputDefinition
+      body: workspaceSettingsReplaceBodyValidator,
+      output: workspaceSettingsOutputValidator
     },
     patch: {
       method: "PATCH",
-      body: {
-        schema: workspaceSettingsBodySchema,
-        mode: "patch"
-      },
-      output: workspaceSettingsOutputDefinition
+      body: workspaceSettingsPatchBodyValidator,
+      output: workspaceSettingsOutputValidator
     }
   }
 });


### PR DESCRIPTION
## Summary
- standardize `{ schema, mode }` contract variable naming across shared resources, auth commands, assistant runtime, and CRUD templates
- refresh related generator fixtures, tests, and docs/examples to the same naming scheme
- rebuild generated agent-docs references for affected packages

## Verification
- `npm --workspaces --if-present test`
- `npm run agent-docs:build`
