### PR TITLE
Add console navigation entry and docs updates

### DIFF
--- a/packages/agent-docs/guide/agent/app-setup/multi-homing.md
+++ b/packages/agent-docs/guide/agent/app-setup/multi-homing.md
@@ -612,6 +612,27 @@ For this chapter's `tenancyMode = "personal"` setup, that contributor now does r
 
 So even in this chapter, the package boundary is already correct: users owns user creation/sync, and workspaces reacts through an extension point.
 
+### Workspace auth context comes from the auth policy resolver registry
+
+There is a second registry seam in this chapter that matters just as much for the runtime model.
+
+Workspace-aware routes do not hard-code workspace lookup inside the auth plugin itself. Instead, `workspaces-core` registers an auth policy context resolver contribution, and `auth-core` composes the registered resolvers at request time.
+
+The important consequence is:
+
+- `auth-core` stays generic
+- `workspaces-core` contributes workspace-specific context
+- the request only resolves workspace membership and permissions when a route actually asks for auth context or permissions
+
+So the flow is:
+
+1. a workspace-aware route declares auth and, when needed, permission requirements
+2. the auth policy runtime authenticates the actor
+3. the composed auth policy context resolver asks the workspace layer for the current workspace context
+4. the request gains normalized `workspace`, `membership`, and `permissions` values
+
+That is why the workspace package does not need to patch the auth plugin directly, and it is also why this setup scales better than a one-off global hook. It uses the same tagged-registry pattern as other JSKIT extension seams, but for request-time auth context instead of bootstrap payloads or lifecycle events.
+
 ### Why this chapter is the real routing pivot
 
 Earlier chapters added features inside a flat top-level app.

--- a/packages/agent-docs/reference/autogen/packages/auth-core.md
+++ b/packages/agent-docs/reference/autogen/packages/auth-core.md
@@ -40,6 +40,7 @@ Exports
 - `AUTH_POLICY_CONTEXT_RESOLVER_TAG`
 - `registerAuthPolicyContextResolver(app, token, factory)`
 - `resolveAuthPolicyContextResolvers(scope)`
+- `resolveComposedAuthPolicyContextResolver(scope)`
 - `mergeAuthPolicyContexts(contexts = [])`
 - `composeAuthPolicyContextResolvers(resolvers = [])`
 Local functions

--- a/packages/agent-docs/reference/autogen/packages/auth-web.md
+++ b/packages/agent-docs/reference/autogen/packages/auth-web.md
@@ -214,6 +214,9 @@ Exports
 ### `src/server/providers/AuthWebServiceProvider.js`
 Exports
 - `AuthWebServiceProvider`
+Local functions
+- `parseBoolean(value, fallback = false)`
+- `resolveDevAuthBootstrapEnabled(scope)`
 
 ### `src/server/routes/authRoutes.js`
 Exports

--- a/packages/agent-docs/site/guide/app-setup/multi-homing.md
+++ b/packages/agent-docs/site/guide/app-setup/multi-homing.md
@@ -750,6 +750,27 @@ For this chapter's `tenancyMode = "personal"` setup, that contributor now does r
 
 So even in this chapter, the package boundary is already correct: users owns user creation/sync, and workspaces reacts through an extension point.
 
+### Workspace auth context comes from the auth policy resolver registry
+
+There is a second registry seam in this chapter that matters just as much for the runtime model.
+
+Workspace-aware routes do not hard-code workspace lookup inside the auth plugin itself. Instead, `workspaces-core` registers an auth policy context resolver contribution, and `auth-core` composes the registered resolvers at request time.
+
+The important consequence is:
+
+- `auth-core` stays generic
+- `workspaces-core` contributes workspace-specific context
+- the request only resolves workspace membership and permissions when a route actually asks for auth context or permissions
+
+So the flow is:
+
+1. a workspace-aware route declares auth and, when needed, permission requirements
+2. the auth policy runtime authenticates the actor
+3. the composed auth policy context resolver asks the workspace layer for the current workspace context
+4. the request gains normalized `workspace`, `membership`, and `permissions` values
+
+That is why the workspace package does not need to patch the auth plugin directly, and it is also why this setup scales better than a one-off global hook. It uses the same tagged-registry pattern as other JSKIT extension seams, but for request-time auth context instead of bootstrap payloads or lifecycle events.
+
 ### Why this chapter is the real routing pivot
 
 Earlier chapters added features inside a flat top-level app.

--- a/packages/console-web/package.descriptor.mjs
+++ b/packages/console-web/package.descriptor.mjs
@@ -50,6 +50,15 @@ export default Object.freeze({
         ],
         contributions: [
           {
+            id: "console.web.profile.menu.console",
+            target: "auth-profile-menu:primary-menu",
+            surfaces: ["*"],
+            order: 600,
+            componentToken: "auth.web.profile.menu.link-item",
+            when: "auth.authenticated === true && surfaceAccess.consoleowner === true && surface !== \"console\"",
+            source: "mutations.text#console-web-profile-menu-console-placement"
+          },
+          {
             id: "console.web.menu.settings",
             target: "shell-layout:primary-menu",
             surfaces: ["console"],
@@ -138,6 +147,17 @@ export default Object.freeze({
         reason: "Register console surface definition once console-web is installed.",
         category: "console-web",
         id: "console-web-surface-config-console"
+      },
+      {
+        op: "append-text",
+        file: "src/placement.js",
+        position: "bottom",
+        skipIfContains: "id: \"console.web.profile.menu.console\"",
+        value:
+          "\naddPlacement({\n  id: \"console.web.profile.menu.console\",\n  target: \"auth-profile-menu:primary-menu\",\n  surfaces: [\"*\"],\n  order: 600,\n  componentToken: \"auth.web.profile.menu.link-item\",\n  props: {\n    label: \"Go to console\",\n    to: \"/console\",\n    icon: \"mdi-console-network-outline\"\n  },\n  when: ({ auth, surfaceAccess, surface }) => {\n    return auth?.authenticated === true && surfaceAccess?.consoleowner === true && surface !== \"console\";\n  }\n});\n",
+        reason: "Append owner-only console navigation entry into the authenticated profile menu outside the console surface.",
+        category: "console-web",
+        id: "console-web-profile-menu-console-placement"
       },
       {
         op: "append-text",

--- a/packages/console-web/test/packageDescriptor.test.js
+++ b/packages/console-web/test/packageDescriptor.test.js
@@ -74,6 +74,12 @@ test("console-web wires console surface policy into app config", () => {
   assert.equal(findTextMutation("console-web-surface-config-console")?.file, "config/public.js");
   assert.match(findTextMutation("console-web-surface-config-console")?.value || "", /accessPolicyId: "console_owner"/);
   assert.match(findTextMutation("console-web-surface-config-console")?.value || "", /icon: "mdi-console-network-outline"/);
+  assert.equal(findTextMutation("console-web-profile-menu-console-placement")?.file, "src/placement.js");
+  assert.match(findTextMutation("console-web-profile-menu-console-placement")?.value || "", /label: "Go to console"/);
+  assert.match(
+    findTextMutation("console-web-profile-menu-console-placement")?.value || "",
+    /surfaceAccess\?\.consoleowner === true && surface !== "console"/
+  );
   assert.equal(findTextMutation("console-web-console-settings-placement")?.file, "src/placement.js");
 });
 


### PR DESCRIPTION
## Summary
- add the console navigation package descriptor menu entry and matching test coverage
- update multi-homing guidance and related auth package generated docs

## Verification
- npm --workspaces --if-present test