### PR TITLE
Unify client bootstrap runtime handling

### DIFF
--- a/packages/auth-web/src/client/providers/bootAuthClientProvider.js
+++ b/packages/auth-web/src/client/providers/bootAuthClientProvider.js
@@ -2,8 +2,8 @@ import { AUTH_GUARD_RUNTIME_INJECTION_KEY } from "../runtime/inject.js";
 import { useAuthStore } from "../stores/useAuthStore.js";
 
 async function bootAuthClientProvider(app) {
-  if (!app || typeof app.make !== "function") {
-    throw new Error("AuthWebClientProvider requires application make().");
+  if (!app || typeof app.make !== "function" || typeof app.has !== "function") {
+    throw new Error("AuthWebClientProvider requires application make()/has().");
   }
 
   const authGuardRuntime = app.make("runtime.auth-guard.client");
@@ -14,6 +14,15 @@ async function bootAuthClientProvider(app) {
   const authStore = useAuthStore(pinia);
   authStore.attachRuntime(authGuardRuntime);
   await authStore.initialize();
+
+  if (app.has("runtime.web-bootstrap.client")) {
+    const bootstrapRuntime = app.make("runtime.web-bootstrap.client");
+    if (bootstrapRuntime && typeof bootstrapRuntime.refresh === "function") {
+      authStore.subscribe(() => {
+        void bootstrapRuntime.refresh("auth.state");
+      });
+    }
+  }
 
   if (!app.has("jskit.client.vue.app")) {
     return;

--- a/packages/auth-web/test/provider.test.js
+++ b/packages/auth-web/test/provider.test.js
@@ -56,7 +56,7 @@ function createAuthRuntimeStub(initialState = {}) {
   };
 }
 
-function createAppDouble({ authGuardRuntime } = {}) {
+function createAppDouble({ authGuardRuntime, bootstrapRuntime = null } = {}) {
   const singletons = new Map();
   const singletonInstances = new Map();
   const provided = [];
@@ -87,6 +87,9 @@ function createAppDouble({ authGuardRuntime } = {}) {
       }
       if (token === "runtime.auth-guard.client") {
         return true;
+      }
+      if (token === "runtime.web-bootstrap.client") {
+        return Boolean(bootstrapRuntime);
       }
       return singletons.has(token) || singletonInstances.has(token);
     },
@@ -123,6 +126,9 @@ function createAppDouble({ authGuardRuntime } = {}) {
       }
       if (token === "runtime.auth-guard.client") {
         return authGuardRuntime;
+      }
+      if (token === "runtime.web-bootstrap.client") {
+        return bootstrapRuntime;
       }
       if (singletonInstances.has(token)) {
         return singletonInstances.get(token);
@@ -162,4 +168,31 @@ test("auth web client boot binds explicit Pinia store state and raw runtime inje
 
   const providedByKey = new Map(app.provided.map((entry) => [entry.key, entry.value]));
   assert.equal(providedByKey.get(AUTH_GUARD_RUNTIME_INJECTION_KEY), authGuardRuntime);
+});
+
+test("auth web client boot refreshes shared bootstrap runtime on auth changes", async () => {
+  const authGuardRuntime = createAuthRuntimeStub({
+    authenticated: false,
+    username: ""
+  });
+  const refreshCalls = [];
+  const app = createAppDouble({
+    authGuardRuntime,
+    bootstrapRuntime: {
+      async refresh(reason) {
+        refreshCalls.push(String(reason || ""));
+        return null;
+      }
+    }
+  });
+
+  await bootAuthClientProvider(app);
+  assert.deepEqual(refreshCalls, []);
+
+  authGuardRuntime.push({
+    authenticated: true,
+    username: "ada"
+  });
+
+  assert.deepEqual(refreshCalls, ["auth.state"]);
 });

--- a/packages/console-core/package.descriptor.mjs
+++ b/packages/console-core/package.descriptor.mjs
@@ -5,6 +5,7 @@ export default Object.freeze({
   kind: "runtime",
   description: "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
   dependsOn: [
+    "@jskit-ai/auth-core",
     "@jskit-ai/database-runtime",
     "@jskit-ai/http-runtime",
     "@jskit-ai/users-core"
@@ -72,6 +73,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
+        "@jskit-ai/auth-core": "0.1.54",
         "@jskit-ai/database-runtime": "0.1.55",
         "@jskit-ai/http-runtime": "0.1.54",
         "@jskit-ai/kernel": "0.1.55",

--- a/packages/console-core/package.json
+++ b/packages/console-core/package.json
@@ -6,6 +6,7 @@
     "test": "node --test"
   },
   "dependencies": {
+    "@jskit-ai/auth-core": "0.1.54",
     "@jskit-ai/database-runtime": "0.1.55",
     "@jskit-ai/http-runtime": "0.1.54",
     "@jskit-ai/kernel": "0.1.55",

--- a/packages/console-core/src/server/consoleAuthServiceDecorator.js
+++ b/packages/console-core/src/server/consoleAuthServiceDecorator.js
@@ -1,0 +1,80 @@
+import { AUTH_PATHS } from "@jskit-ai/auth-core/shared/authPaths";
+import { normalizeRecordId } from "@jskit-ai/kernel/shared/support/normalize";
+
+function normalizeRequestPathname(request = null) {
+  const candidates = [
+    request?.routeOptions?.url,
+    request?.routerPath,
+    request?.url,
+    request?.raw?.url
+  ];
+
+  for (const candidate of candidates) {
+    const raw = String(candidate || "").trim();
+    if (!raw) {
+      continue;
+    }
+    const withoutQuery = raw.split("?")[0];
+    const pathname = withoutQuery.split("#")[0];
+    if (pathname) {
+      return pathname;
+    }
+  }
+
+  return "";
+}
+
+function createConsoleAuthServiceDecorator({ consoleService } = {}) {
+  if (!consoleService || typeof consoleService.ensureInitialConsoleMember !== "function") {
+    throw new Error("createConsoleAuthServiceDecorator requires consoleService.ensureInitialConsoleMember().");
+  }
+
+  let consoleOwnerInitialized = false;
+
+  return Object.freeze({
+    decoratorId: "console.core.authServiceDecorator",
+    order: 0,
+    decorateAuthService(authService) {
+      if (!authService || typeof authService.authenticateRequest !== "function") {
+        return authService;
+      }
+
+      return Object.freeze(
+        Object.assign(Object.create(authService), {
+          async authenticateRequest(request, ...args) {
+            const authResult = await authService.authenticateRequest(request, ...args);
+            if (consoleOwnerInitialized) {
+              return authResult;
+            }
+
+            const requestPathname = normalizeRequestPathname(request);
+            if (requestPathname !== AUTH_PATHS.SESSION) {
+              return authResult;
+            }
+
+            const authenticatedUserId =
+              authResult?.authenticated === true
+                ? normalizeRecordId(authResult?.profile?.id, { fallback: null })
+                : null;
+
+            if (!authenticatedUserId) {
+              return authResult;
+            }
+
+            const ownerUserId = normalizeRecordId(
+              await consoleService.ensureInitialConsoleMember(authenticatedUserId),
+              { fallback: null }
+            );
+            if (ownerUserId) {
+              consoleOwnerInitialized = true;
+            }
+
+            return authResult;
+          }
+        })
+      );
+    }
+  });
+}
+
+export { createConsoleAuthServiceDecorator };

--- a/packages/console-core/src/server/consoleBootstrapContributor.js
+++ b/packages/console-core/src/server/consoleBootstrapContributor.js
@@ -1,8 +1,8 @@
 import { normalizeObject, normalizeRecordId } from "@jskit-ai/kernel/shared/support/normalize";
 
 function createConsoleBootstrapContributor({ consoleService } = {}) {
-  if (!consoleService || typeof consoleService.ensureInitialConsoleMember !== "function") {
-    throw new Error("createConsoleBootstrapContributor requires consoleService.ensureInitialConsoleMember().");
+  if (!consoleService || typeof consoleService.isConsoleOwnerUserId !== "function") {
+    throw new Error("createConsoleBootstrapContributor requires consoleService.isConsoleOwnerUserId().");
   }
 
   return Object.freeze({
@@ -17,11 +17,7 @@ function createConsoleBootstrapContributor({ consoleService } = {}) {
 
       let consoleOwner = false;
       if (authenticatedUserId) {
-        const seededConsoleOwnerUserId = normalizeRecordId(
-          await consoleService.ensureInitialConsoleMember(authenticatedUserId),
-          { fallback: null }
-        );
-        consoleOwner = Boolean(seededConsoleOwnerUserId) && seededConsoleOwnerUserId === authenticatedUserId;
+        consoleOwner = await consoleService.isConsoleOwnerUserId(authenticatedUserId);
       }
 
       return {

--- a/packages/console-core/src/server/consoleSettings/consoleService.js
+++ b/packages/console-core/src/server/consoleSettings/consoleService.js
@@ -5,6 +5,9 @@ function createService({ consoleSettingsRepository } = {}) {
   if (!consoleSettingsRepository || typeof consoleSettingsRepository.ensureOwnerUserId !== "function") {
     throw new Error("consoleService requires consoleSettingsRepository.ensureOwnerUserId().");
   }
+  if (!consoleSettingsRepository || typeof consoleSettingsRepository.getSingleton !== "function") {
+    throw new Error("consoleService requires consoleSettingsRepository.getSingleton().");
+  }
 
   async function ensureInitialConsoleMember(userId, options = {}) {
     const normalizedUserId = normalizeRecordId(userId, { fallback: null });
@@ -13,6 +16,17 @@ function createService({ consoleSettingsRepository } = {}) {
     }
 
     return consoleSettingsRepository.ensureOwnerUserId(normalizedUserId, options);
+  }
+
+  async function isConsoleOwnerUserId(userId, options = {}) {
+    const normalizedUserId = normalizeRecordId(userId, { fallback: null });
+    if (!normalizedUserId) {
+      return false;
+    }
+
+    const settings = await consoleSettingsRepository.getSingleton(options);
+    const ownerUserId = normalizeRecordId(settings?.ownerUserId, { fallback: null });
+    return Boolean(ownerUserId) && ownerUserId === normalizedUserId;
   }
 
   async function requireConsoleOwner(context = {}, options = {}) {
@@ -29,6 +43,7 @@ function createService({ consoleSettingsRepository } = {}) {
 
   return Object.freeze({
     ensureInitialConsoleMember,
+    isConsoleOwnerUserId,
     requireConsoleOwner
   });
 }

--- a/packages/console-core/src/server/registerConsoleCore.js
+++ b/packages/console-core/src/server/registerConsoleCore.js
@@ -1,3 +1,5 @@
+import { registerAuthServiceDecorator } from "@jskit-ai/auth-core/server/authServiceDecoratorRegistry";
+import { createConsoleAuthServiceDecorator } from "./consoleAuthServiceDecorator.js";
 import { createRepository as createConsoleSettingsRepository } from "./consoleSettings/consoleSettingsRepository.js";
 import { registerConsoleCoreActionSurfaceSources } from "./support/consoleActionSurfaces.js";
 
@@ -7,6 +9,12 @@ function registerConsoleCore(app) {
   }
 
   registerConsoleCoreActionSurfaceSources(app);
+
+  registerAuthServiceDecorator(app, "console.core.authServiceDecorator", (scope) =>
+    createConsoleAuthServiceDecorator({
+      consoleService: scope.make("consoleService")
+    })
+  );
 
   app.singleton("consoleSettingsRepository", (scope) => {
     const knex = scope.make("jskit.database.knex");

--- a/packages/console-core/test/bootstrapPayloadIntegration.test.js
+++ b/packages/console-core/test/bootstrapPayloadIntegration.test.js
@@ -19,7 +19,6 @@ function createAuthenticatedProfile(overrides = {}) {
 
 test("bootstrap payload preserves consoleowner for authenticated users after users bootstrap runs", async () => {
   const profile = createAuthenticatedProfile();
-  const ownerSeeds = [];
   const app = createContainer();
 
   app.instance("internal.repository.user-profiles", {
@@ -43,9 +42,8 @@ test("bootstrap payload preserves consoleowner for authenticated users after use
     clearSessionCookies() {}
   });
   app.instance("consoleService", {
-    async ensureInitialConsoleMember(userId) {
-      ownerSeeds.push(String(userId || ""));
-      return String(userId || "");
+    async isConsoleOwnerUserId(userId) {
+      return String(userId || "") === profile.id;
     }
   });
 
@@ -68,7 +66,6 @@ test("bootstrap payload preserves consoleowner for authenticated users after use
     reply: {}
   });
 
-  assert.deepEqual(ownerSeeds, ["12"]);
   assert.equal(payload.session.authenticated, true);
   assert.equal(payload.session.userId, "12");
   assert.deepEqual(payload.surfaceAccess, {

--- a/packages/console-core/test/consoleAuthServiceDecorator.test.js
+++ b/packages/console-core/test/consoleAuthServiceDecorator.test.js
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createConsoleAuthServiceDecorator } from "../src/server/consoleAuthServiceDecorator.js";
+
+test("console auth service decorator seeds first owner during session reads only", async () => {
+  const ownerSeeds = [];
+  const decorator = createConsoleAuthServiceDecorator({
+    consoleService: {
+      async ensureInitialConsoleMember(userId) {
+        ownerSeeds.push(String(userId || ""));
+        return String(userId || "");
+      }
+    }
+  });
+
+  const authService = decorator.decorateAuthService({
+    async authenticateRequest(request) {
+      return {
+        authenticated: true,
+        profile: {
+          id: request.profileId
+        }
+      };
+    }
+  });
+
+  await authService.authenticateRequest({
+    profileId: "12",
+    url: "/api/bootstrap"
+  });
+  await authService.authenticateRequest({
+    profileId: "12",
+    url: "/api/session"
+  });
+  await authService.authenticateRequest({
+    profileId: "99",
+    url: "/api/session"
+  });
+
+  assert.deepEqual(ownerSeeds, ["12"]);
+});
+
+test("console auth service decorator leaves unauthenticated session reads alone", async () => {
+  const decorator = createConsoleAuthServiceDecorator({
+    consoleService: {
+      async ensureInitialConsoleMember() {
+        throw new Error("should not seed owner for anonymous session reads");
+      }
+    }
+  });
+
+  const authService = decorator.decorateAuthService({
+    async authenticateRequest() {
+      return {
+        authenticated: false
+      };
+    }
+  });
+
+  const result = await authService.authenticateRequest({
+    url: "/api/session"
+  });
+
+  assert.equal(result.authenticated, false);
+});

--- a/packages/console-core/test/consoleBootstrapContributor.test.js
+++ b/packages/console-core/test/consoleBootstrapContributor.test.js
@@ -2,13 +2,11 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { createConsoleBootstrapContributor } from "../src/server/consoleBootstrapContributor.js";
 
-test("console bootstrap contributor seeds the initial console owner into the existing bootstrap payload", async () => {
-  const ownerSeeds = [];
+test("console bootstrap contributor exposes consoleowner when the authenticated user already owns the console", async () => {
   const contributor = createConsoleBootstrapContributor({
     consoleService: {
-      async ensureInitialConsoleMember(userId) {
-        ownerSeeds.push(String(userId || ""));
-        return String(userId || "");
+      async isConsoleOwnerUserId(userId) {
+        return String(userId || "") === "12";
       }
     }
   });
@@ -26,7 +24,6 @@ test("console bootstrap contributor seeds the initial console owner into the exi
     }
   });
 
-  assert.deepEqual(ownerSeeds, ["12"]);
   assert.deepEqual(contribution, {
     surfaceAccess: {
       existing: true,
@@ -38,7 +35,7 @@ test("console bootstrap contributor seeds the initial console owner into the exi
 test("console bootstrap contributor exposes a false consoleowner flag for anonymous bootstrap", async () => {
   const contributor = createConsoleBootstrapContributor({
     consoleService: {
-      async ensureInitialConsoleMember() {
+      async isConsoleOwnerUserId() {
         throw new Error("should not be called for anonymous payload");
       }
     }

--- a/packages/console-core/test/consoleService.test.js
+++ b/packages/console-core/test/consoleService.test.js
@@ -9,6 +9,11 @@ function createFixture(initialOwnerUserId = null) {
 
   const service = createService({
     consoleSettingsRepository: {
+      async getSingleton() {
+        return {
+          ownerUserId: state.ownerUserId
+        };
+      },
       async ensureOwnerUserId(userId) {
         const normalizedUserId = String(userId || "");
         if (!state.ownerUserId) {
@@ -31,6 +36,13 @@ test("consoleService seeds the first authenticated user as console owner", async
   assert.equal(firstOwner, "7");
   assert.equal(secondAttempt, "7");
   assert.equal(state.ownerUserId, "7");
+});
+
+test("consoleService.isConsoleOwnerUserId reports current ownership without reseeding", async () => {
+  const { service } = createFixture("7");
+
+  assert.equal(await service.isConsoleOwnerUserId("7"), true);
+  assert.equal(await service.isConsoleOwnerUserId("9"), false);
 });
 
 test("consoleService.requireConsoleOwner denies authenticated non-owners", async () => {

--- a/packages/console-core/test/registerConsoleCore.test.js
+++ b/packages/console-core/test/registerConsoleCore.test.js
@@ -4,8 +4,16 @@ import { registerConsoleCore } from "../src/server/registerConsoleCore.js";
 
 test("registerConsoleCore registers the console action surface alias when action runtime is available", () => {
   const calls = [];
+  const tags = [];
   const app = {
     singleton() {
+      return this;
+    },
+    tag(token, tagName) {
+      tags.push({
+        token: String(token || ""),
+        tagName: String(tagName || "")
+      });
       return this;
     },
     actionSurfaceSource(sourceName, resolver) {
@@ -25,11 +33,20 @@ test("registerConsoleCore registers the console action surface alias when action
       resolverType: "function"
     }
   ]);
+  assert.deepEqual(tags, [
+    {
+      token: "console.core.authServiceDecorator",
+      tagName: "jskit.auth.service.decorators"
+    }
+  ]);
 });
 
 test("registerConsoleCore still works when action runtime has not installed actionSurfaceSource yet", () => {
   const app = {
     singleton() {
+      return this;
+    },
+    tag() {
       return this;
     }
   };

--- a/packages/shell-web/package.descriptor.mjs
+++ b/packages/shell-web/package.descriptor.mjs
@@ -39,12 +39,17 @@ export default Object.freeze({
         {
           subpath: "./client/error",
           summary: "Exports default error policy and runtime error reporter hook."
+        },
+        {
+          subpath: "./client/bootstrap",
+          summary: "Exports the shared client bootstrap handler registry used to extend /api/bootstrap handling."
         }
       ],
       containerTokens: {
         server: [],
         client: [
           "runtime.web-placement.client",
+          "runtime.web-bootstrap.client",
           "runtime.web-error.client",
           "runtime.web-error.presentation-store.client",
           "shell.web.query-client"

--- a/packages/shell-web/package.json
+++ b/packages/shell-web/package.json
@@ -9,6 +9,7 @@
     "./client": "./src/client/index.js",
     "./client/error": "./src/client/error/index.js",
     "./client/placement": "./src/client/placement/index.js",
+    "./client/bootstrap": "./src/client/bootstrap/index.js",
     "./server/support/localLinkItemScaffolds": "./src/server/support/localLinkItemScaffolds.js",
     "./client/navigation/linkResolver": "./src/client/navigation/linkResolver.js",
     "./client/components/ShellLayout": "./src/client/components/ShellLayout.vue",

--- a/packages/shell-web/src/client/bootstrap/bootstrapErrorStatus.js
+++ b/packages/shell-web/src/client/bootstrap/bootstrapErrorStatus.js
@@ -1,0 +1,6 @@
+function resolveBootstrapErrorStatusCode(error) {
+  const statusCode = Number(error?.statusCode || error?.status || 0);
+  return Number.isInteger(statusCode) && statusCode > 0 ? statusCode : 0;
+}
+
+export { resolveBootstrapErrorStatusCode };

--- a/packages/shell-web/src/client/bootstrap/bootstrapPayloadHandlerRegistry.js
+++ b/packages/shell-web/src/client/bootstrap/bootstrapPayloadHandlerRegistry.js
@@ -1,0 +1,68 @@
+const BOOTSTRAP_PAYLOAD_HANDLER_TAG = "runtime.web-bootstrap.handlers.client";
+
+function assertTaggableApp(app, context = "bootstrap payload handler registry") {
+  if (!app || typeof app.singleton !== "function" || typeof app.tag !== "function") {
+    throw new Error(`${context} requires application singleton()/tag().`);
+  }
+}
+
+function registerBootstrapPayloadHandler(app, token, factory) {
+  assertTaggableApp(app, "registerBootstrapPayloadHandler");
+  app.singleton(token, factory);
+  app.tag(token, BOOTSTRAP_PAYLOAD_HANDLER_TAG);
+}
+
+function normalizeBootstrapPayloadHandler(entry) {
+  if (typeof entry === "function") {
+    return Object.freeze({
+      handlerId: String(entry.name || "anonymous"),
+      order: 0,
+      applyBootstrapPayload: entry
+    });
+  }
+
+  if (!entry || typeof entry !== "object" || typeof entry.applyBootstrapPayload !== "function") {
+    return null;
+  }
+
+  return Object.freeze({
+    ...entry,
+    handlerId: String(entry.handlerId || "anonymous"),
+    order: Number.isFinite(entry.order) ? Number(entry.order) : 0
+  });
+}
+
+function resolveBootstrapPayloadHandlers(scope) {
+  if (!scope || typeof scope.resolveTag !== "function") {
+    return [];
+  }
+
+  const rawEntries = scope.resolveTag(BOOTSTRAP_PAYLOAD_HANDLER_TAG);
+  const queue = Array.isArray(rawEntries) ? [...rawEntries] : [rawEntries];
+  const entries = [];
+
+  while (queue.length > 0) {
+    const entry = queue.shift();
+    if (Array.isArray(entry)) {
+      queue.push(...entry);
+      continue;
+    }
+    const normalized = normalizeBootstrapPayloadHandler(entry);
+    if (normalized) {
+      entries.push(normalized);
+    }
+  }
+
+  return entries.sort((left, right) => {
+    if (left.order !== right.order) {
+      return left.order - right.order;
+    }
+    return left.handlerId.localeCompare(right.handlerId);
+  });
+}
+
+export {
+  BOOTSTRAP_PAYLOAD_HANDLER_TAG,
+  registerBootstrapPayloadHandler,
+  resolveBootstrapPayloadHandlers
+};

--- a/packages/shell-web/src/client/bootstrap/index.js
+++ b/packages/shell-web/src/client/bootstrap/index.js
@@ -1,0 +1,6 @@
+export {
+  BOOTSTRAP_PAYLOAD_HANDLER_TAG,
+  registerBootstrapPayloadHandler,
+  resolveBootstrapPayloadHandlers
+} from "./bootstrapPayloadHandlerRegistry.js";
+export { resolveBootstrapErrorStatusCode } from "./bootstrapErrorStatus.js";

--- a/packages/shell-web/src/client/index.js
+++ b/packages/shell-web/src/client/index.js
@@ -16,6 +16,11 @@ export { default as ShellTabLinkItem } from "./components/ShellTabLinkItem.vue";
 export { useShellLayoutState } from "./composables/useShellLayoutState.js";
 export { useShellLayoutStore } from "./stores/useShellLayoutStore.js";
 export { useShellErrorPresentationStore } from "./stores/useShellErrorPresentationStore.js";
+export {
+  BOOTSTRAP_PAYLOAD_HANDLER_TAG,
+  registerBootstrapPayloadHandler,
+  resolveBootstrapPayloadHandlers
+} from "./bootstrap/index.js";
 
 const clientProviders = Object.freeze([ShellWebClientProvider]);
 

--- a/packages/shell-web/src/client/providers/ShellWebClientProvider.js
+++ b/packages/shell-web/src/client/providers/ShellWebClientProvider.js
@@ -24,6 +24,9 @@ import {
 import { createWebPlacementRuntime } from "../placement/runtime.js";
 import { useShellErrorPresentationStore } from "../stores/useShellErrorPresentationStore.js";
 import { buildSurfaceConfigContext } from "../placement/surfaceContext.js";
+import { createShellBootstrapRuntime } from "../runtime/bootstrapRuntime.js";
+import { registerBootstrapPayloadHandler } from "../bootstrap/bootstrapPayloadHandlerRegistry.js";
+import { resolveBootstrapErrorStatusCode } from "../bootstrap/bootstrapErrorStatus.js";
 
 // Keep this constant for diagnostics, but keep import() below as a literal string so Vite can statically analyze it.
 const APP_PLACEMENT_MODULE_SPECIFIER = "/src/placement.js";
@@ -229,12 +232,49 @@ class ShellWebClientProvider {
   static id = "shell.web.client";
 
   register(app) {
-    if (!app || typeof app.singleton !== "function") {
-      throw new Error("ShellWebClientProvider requires application singleton().");
+    if (!app || typeof app.singleton !== "function" || typeof app.tag !== "function") {
+      throw new Error("ShellWebClientProvider requires application singleton()/tag().");
     }
 
     const logger = createSharedProviderLogger(isRecord(app) ? app : null);
+    registerBootstrapPayloadHandler(app, "shell.web.bootstrap.surfaceAccessHandler", () =>
+      Object.freeze({
+        handlerId: "shell.web.bootstrap.surfaceAccess",
+        order: 0,
+        applyBootstrapPayload({ payload = {}, placementRuntime, source } = {}) {
+          placementRuntime.setContext(
+            {
+              surfaceAccess:
+                payload?.surfaceAccess && typeof payload.surfaceAccess === "object" ? payload.surfaceAccess : {}
+            },
+            {
+              source
+            }
+          );
+        },
+        handleBootstrapError({ error, placementRuntime, source } = {}) {
+          if (resolveBootstrapErrorStatusCode(error) !== 401) {
+            return;
+          }
+
+          placementRuntime.setContext(
+            {
+              surfaceAccess: {}
+            },
+            {
+              source
+            }
+          );
+        }
+      })
+    );
     app.singleton("runtime.web-placement.client", () => createWebPlacementRuntime({ app, logger }));
+    app.singleton("runtime.web-bootstrap.client", (scope) =>
+      createShellBootstrapRuntime({
+        app: scope,
+        logger
+      })
+    );
     app.singleton("shell.web.query-client", () => createShellWebQueryClient());
     app.singleton("runtime.web-error.presentation-store.client", () => createErrorPresentationStore());
     app.singleton("runtime.web-error.client", (scope) =>
@@ -284,6 +324,11 @@ class ShellWebClientProvider {
     const errorRuntime = app.make("runtime.web-error.client");
     const errorConfig = await loadAppErrorConfig(logger, errorRuntime);
     applyAppErrorConfig(errorRuntime, errorConfig);
+
+    const bootstrapRuntime = app.make("runtime.web-bootstrap.client");
+    if (bootstrapRuntime && typeof bootstrapRuntime.initialize === "function") {
+      await bootstrapRuntime.initialize();
+    }
 
     if (!app.has("jskit.client.vue.app")) {
       return;

--- a/packages/shell-web/src/client/runtime/bootstrapRuntime.js
+++ b/packages/shell-web/src/client/runtime/bootstrapRuntime.js
@@ -1,0 +1,195 @@
+import { createProviderLogger as createSharedProviderLogger } from "@jskit-ai/kernel/shared/support/providerLogger";
+import { resolveBootstrapPayloadHandlers } from "../bootstrap/bootstrapPayloadHandlerRegistry.js";
+
+const DEFAULT_BOOTSTRAP_PATH = "/api/bootstrap";
+
+function normalizeObject(value) {
+  return value && typeof value === "object" && !Array.isArray(value) ? value : {};
+}
+
+function buildBootstrapUrl({ path = DEFAULT_BOOTSTRAP_PATH, query = {} } = {}) {
+  const normalizedPath = String(path || DEFAULT_BOOTSTRAP_PATH).trim() || DEFAULT_BOOTSTRAP_PATH;
+  const params = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(normalizeObject(query))) {
+    const normalizedKey = String(key || "").trim();
+    const normalizedValue = String(value || "").trim();
+    if (!normalizedKey || !normalizedValue) {
+      continue;
+    }
+    params.set(normalizedKey, normalizedValue);
+  }
+
+  const queryString = params.toString();
+  return queryString ? `${normalizedPath}?${queryString}` : normalizedPath;
+}
+
+function normalizeBootstrapResponseError(response, url) {
+  const error = new Error(`Bootstrap payload request failed with status ${response.status}.`);
+  error.statusCode = Number(response.status || 0);
+  error.url = url;
+  return error;
+}
+
+function createShellBootstrapRuntime({
+  app,
+  logger = null,
+  fetchImplementation = globalThis.fetch,
+  bootstrapPath = DEFAULT_BOOTSTRAP_PATH
+} = {}) {
+  if (!app || typeof app.has !== "function" || typeof app.make !== "function" || typeof app.resolveTag !== "function") {
+    throw new Error("createShellBootstrapRuntime requires application has()/make()/resolveTag().");
+  }
+  if (!app.has("runtime.web-placement.client")) {
+    throw new Error("createShellBootstrapRuntime requires shell-web placement runtime.");
+  }
+
+  const runtimeLogger = logger || createSharedProviderLogger(app);
+  const placementRuntime = app.make("runtime.web-placement.client");
+  const router = app.has("jskit.client.router") ? app.make("jskit.client.router") : null;
+  let initialized = false;
+  let refreshQueue = Promise.resolve();
+
+  async function resolveBootstrapRequest(reason = "manual") {
+    const handlers = resolveBootstrapPayloadHandlers(app);
+    let request = {
+      path: bootstrapPath,
+      query: {},
+      meta: {}
+    };
+
+    for (const handler of handlers) {
+      if (typeof handler.resolveBootstrapRequest !== "function") {
+        continue;
+      }
+
+      const contribution = normalizeObject(
+        await handler.resolveBootstrapRequest({
+          app,
+          router,
+          placementRuntime,
+          reason,
+          request: Object.freeze({
+            path: request.path,
+            query: Object.freeze({ ...request.query }),
+            meta: Object.freeze({ ...request.meta })
+          })
+        })
+      );
+
+      request = {
+        path: String(contribution.path || request.path || bootstrapPath).trim() || bootstrapPath,
+        query: {
+          ...request.query,
+          ...normalizeObject(contribution.query)
+        },
+        meta: {
+          ...request.meta,
+          ...normalizeObject(contribution.meta)
+        }
+      };
+    }
+
+    return Object.freeze({
+      path: request.path,
+      query: Object.freeze({ ...request.query }),
+      meta: Object.freeze({ ...request.meta })
+    });
+  }
+
+  async function applyBootstrapPayload(payload, reason = "manual", request = Object.freeze({})) {
+    const handlers = resolveBootstrapPayloadHandlers(app);
+    const source = `shell-web.bootstrap.${String(reason || "manual").trim() || "manual"}`;
+
+    for (const handler of handlers) {
+      await handler.applyBootstrapPayload({
+        app,
+        router,
+        placementRuntime,
+        payload,
+        request,
+        reason,
+        source
+      });
+    }
+
+    return payload;
+  }
+
+  async function applyBootstrapError(error, reason = "manual", request = Object.freeze({})) {
+    const handlers = resolveBootstrapPayloadHandlers(app);
+    const source = `shell-web.bootstrap.${String(reason || "manual").trim() || "manual"}`;
+
+    for (const handler of handlers) {
+      if (typeof handler.handleBootstrapError !== "function") {
+        continue;
+      }
+
+      await handler.handleBootstrapError({
+        app,
+        router,
+        placementRuntime,
+        error,
+        request,
+        reason,
+        source
+      });
+    }
+  }
+
+  async function performRefresh(reason = "manual") {
+    if (typeof fetchImplementation !== "function") {
+      throw new Error("Bootstrap payload fetch requires a fetch implementation.");
+    }
+
+    const request = await resolveBootstrapRequest(reason);
+    const url = buildBootstrapUrl(request);
+
+    try {
+      const response = await fetchImplementation(url, {
+        method: "GET",
+        credentials: "include",
+        headers: {
+          accept: "application/json"
+        }
+      });
+
+      if (!response.ok) {
+        throw normalizeBootstrapResponseError(response, url);
+      }
+
+      const payload = await response.json();
+      return applyBootstrapPayload(payload, reason, request);
+    } catch (error) {
+      await applyBootstrapError(error, reason, request);
+      runtimeLogger.warn(
+        {
+          reason,
+          error: String(error?.message || error || "unknown error")
+        },
+        "shell-web bootstrap refresh failed."
+      );
+      return null;
+    }
+  }
+
+  function refresh(reason = "manual") {
+    refreshQueue = refreshQueue.then(() => performRefresh(reason));
+    return refreshQueue;
+  }
+
+  async function initialize() {
+    if (initialized) {
+      return null;
+    }
+    initialized = true;
+    return refresh("init");
+  }
+
+  return Object.freeze({
+    initialize,
+    refresh
+  });
+}
+
+export { createShellBootstrapRuntime };

--- a/packages/shell-web/test/bootstrapRuntime.test.js
+++ b/packages/shell-web/test/bootstrapRuntime.test.js
@@ -1,0 +1,187 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { registerBootstrapPayloadHandler } from "../src/client/bootstrap/bootstrapPayloadHandlerRegistry.js";
+import { createShellBootstrapRuntime } from "../src/client/runtime/bootstrapRuntime.js";
+
+function createPlacementRuntime(initialContext = {}) {
+  let context = Object.freeze({ ...initialContext });
+  const listeners = new Set();
+
+  return {
+    getContext() {
+      return context;
+    },
+    setContext(value = {}, { replace = false } = {}) {
+      const next = value && typeof value === "object" ? { ...value } : {};
+      context = Object.freeze(replace ? next : { ...context, ...next });
+      for (const listener of listeners) {
+        listener({
+          type: "context.updated"
+        });
+      }
+      return context;
+    },
+    subscribe(listener) {
+      if (typeof listener === "function") {
+        listeners.add(listener);
+      }
+      return () => {
+        listeners.delete(listener);
+      };
+    }
+  };
+}
+
+function createAppDouble({ placementRuntime, realtimeSocket = null } = {}) {
+  const singletons = new Map();
+  const singletonInstances = new Map();
+  return {
+    singleton(token, factory) {
+      singletons.set(token, factory);
+    },
+    tag(token, tagName) {
+      const current = this._tags.get(tagName) || [];
+      current.push(token);
+      this._tags.set(tagName, current);
+    },
+    resolveTag(tagName) {
+      return (this._tags.get(tagName) || []).map((token) => this.make(token));
+    },
+    _tags: new Map(),
+    has(token) {
+      if (token === "runtime.web-placement.client") {
+        return true;
+      }
+      if (token === "runtime.realtime.client.socket") {
+        return Boolean(realtimeSocket);
+      }
+      return singletons.has(token) || singletonInstances.has(token);
+    },
+    make(token) {
+      if (token === "runtime.web-placement.client") {
+        return placementRuntime;
+      }
+      if (token === "runtime.realtime.client.socket") {
+        return realtimeSocket;
+      }
+      if (singletonInstances.has(token)) {
+        return singletonInstances.get(token);
+      }
+      const factory = singletons.get(token);
+      if (!factory) {
+        throw new Error(`Unknown token ${String(token)}`);
+      }
+      const instance = factory(this);
+      singletonInstances.set(token, instance);
+      return instance;
+    }
+  };
+}
+
+test("shell bootstrap runtime refreshes /api/bootstrap on init and applies registered handlers", async () => {
+  const placementRuntime = createPlacementRuntime({
+    auth: {}
+  });
+  const payloads = [
+    {
+      surfaceAccess: {
+        consoleowner: false
+      }
+    },
+    {
+      surfaceAccess: {
+        consoleowner: true
+      }
+    }
+  ];
+  const calls = [];
+  const observedRequests = [];
+  const observedResolveMeta = [];
+  const app = createAppDouble({ placementRuntime });
+  registerBootstrapPayloadHandler(app, "test.bootstrap.request", () =>
+    Object.freeze({
+      handlerId: "test.bootstrap.request",
+      order: -10,
+      resolveBootstrapRequest() {
+        return {
+          query: {
+            workspaceSlug: "acme"
+          },
+          meta: {
+            path: "/w/acme/dashboard"
+          }
+        };
+      },
+      applyBootstrapPayload({ request }) {
+        observedRequests.push(request);
+      }
+    })
+  );
+  registerBootstrapPayloadHandler(app, "test.bootstrap.request-meta", () =>
+    Object.freeze({
+      handlerId: "test.bootstrap.request-meta",
+      order: -5,
+      resolveBootstrapRequest({ request }) {
+        observedResolveMeta.push(request?.meta?.path || "");
+        return {};
+      },
+      applyBootstrapPayload() {}
+    })
+  );
+  registerBootstrapPayloadHandler(app, "test.bootstrap.surfaceAccess", () =>
+    Object.freeze({
+      handlerId: "test.bootstrap.surfaceAccess",
+      order: 0,
+      applyBootstrapPayload({ payload, placementRuntime: targetRuntime }) {
+        targetRuntime.setContext({
+          surfaceAccess: payload.surfaceAccess || {}
+        });
+      }
+    })
+  );
+
+  const runtime = createShellBootstrapRuntime({
+    app,
+    fetchImplementation: async (url) => {
+      calls.push(String(url || ""));
+      const payload = payloads.shift() || {};
+      return {
+        ok: true,
+        async json() {
+          return payload;
+        }
+      };
+    }
+  });
+
+  await runtime.initialize();
+  assert.deepEqual(placementRuntime.getContext().surfaceAccess, {
+    consoleowner: false
+  });
+  await runtime.refresh("manual");
+  assert.deepEqual(calls, ["/api/bootstrap?workspaceSlug=acme", "/api/bootstrap?workspaceSlug=acme"]);
+  assert.deepEqual(observedResolveMeta, ["/w/acme/dashboard", "/w/acme/dashboard"]);
+  assert.deepEqual(observedRequests, [
+    {
+      path: "/api/bootstrap",
+      query: {
+        workspaceSlug: "acme"
+      },
+      meta: {
+        path: "/w/acme/dashboard"
+      }
+    },
+    {
+      path: "/api/bootstrap",
+      query: {
+        workspaceSlug: "acme"
+      },
+      meta: {
+        path: "/w/acme/dashboard"
+      }
+    }
+  ]);
+  assert.deepEqual(placementRuntime.getContext().surfaceAccess, {
+    consoleowner: true
+  });
+});

--- a/packages/shell-web/test/provider.test.js
+++ b/packages/shell-web/test/provider.test.js
@@ -42,8 +42,14 @@ function createAppDouble({ surfaceRuntime = null } = {}) {
     plugins,
     pinia,
     vueApp,
+    _tags: new Map(),
     singleton(token, factory) {
       singletons.set(token, factory);
+    },
+    tag(token, tagName) {
+      const current = this._tags.get(tagName) || [];
+      current.push(token);
+      this._tags.set(tagName, current);
     },
     has(token) {
       if (token === "jskit.client.vue.app") {
@@ -78,51 +84,88 @@ function createAppDouble({ surfaceRuntime = null } = {}) {
       singletonInstances.set(token, instance);
       return instance;
     },
-    resolveTag() {
-      return [];
+    resolveTag(tagName) {
+      return (this._tags.get(tagName) || []).map((token) => this.make(token));
     }
   };
 }
 
+async function withFetchStub(responsePayload, callback) {
+  const previousFetch = globalThis.fetch;
+  globalThis.fetch = async () => ({
+    ok: true,
+    async json() {
+      return responsePayload;
+    }
+  });
+
+  try {
+    return await callback();
+  } finally {
+    if (previousFetch === undefined) {
+      delete globalThis.fetch;
+    } else {
+      globalThis.fetch = previousFetch;
+    }
+  }
+}
+
+async function withFetchImplementation(fetchImplementation, callback) {
+  const previousFetch = globalThis.fetch;
+  globalThis.fetch = fetchImplementation;
+
+  try {
+    return await callback();
+  } finally {
+    if (previousFetch === undefined) {
+      delete globalThis.fetch;
+    } else {
+      globalThis.fetch = previousFetch;
+    }
+  }
+}
+
 test("shell web client provider binds runtime and injects it into Vue app", async () => {
-  const app = createAppDouble();
-  const provider = new ShellWebClientProvider();
+  await withFetchStub({ surfaceAccess: {} }, async () => {
+    const app = createAppDouble();
+    const provider = new ShellWebClientProvider();
 
-  provider.register(app);
-  assert.equal(app.singletons.has("runtime.web-placement.client"), true);
-  assert.equal(app.singletons.has("runtime.web-error.client"), true);
-  assert.equal(app.singletons.has("runtime.web-error.presentation-store.client"), true);
+    provider.register(app);
+    assert.equal(app.singletons.has("runtime.web-placement.client"), true);
+    assert.equal(app.singletons.has("runtime.web-error.client"), true);
+    assert.equal(app.singletons.has("runtime.web-error.presentation-store.client"), true);
 
-  await provider.boot(app);
-  assert.equal(app.plugins.length, 1);
-  assert.equal(typeof app.plugins[0].plugin.install, "function");
-  assert.equal(typeof app.plugins[0].options?.queryClient, "object");
+    await provider.boot(app);
+    assert.equal(app.plugins.length, 1);
+    assert.equal(typeof app.plugins[0].plugin.install, "function");
+    assert.equal(typeof app.plugins[0].options?.queryClient, "object");
 
-  const providedByKey = new Map(app.provided.map((entry) => [entry.key, entry.value]));
+    const providedByKey = new Map(app.provided.map((entry) => [entry.key, entry.value]));
 
-  assert.equal(providedByKey.has("jskit.shell-web.runtime.web-placement.client"), true);
-  assert.equal(providedByKey.has("jskit.shell-web.runtime.web-error.client"), true);
-  assert.equal(providedByKey.has("jskit.shell-web.runtime.web-error.presentation-store.client"), true);
+    assert.equal(providedByKey.has("jskit.shell-web.runtime.web-placement.client"), true);
+    assert.equal(providedByKey.has("jskit.shell-web.runtime.web-error.client"), true);
+    assert.equal(providedByKey.has("jskit.shell-web.runtime.web-error.presentation-store.client"), true);
 
-  const placementRuntime = providedByKey.get("jskit.shell-web.runtime.web-placement.client");
-  assert.equal(typeof placementRuntime.getPlacements, "function");
-  assert.equal(typeof placementRuntime.getContext, "function");
-  assert.equal(typeof placementRuntime.setContext, "function");
-  assert.equal(typeof placementRuntime.getContext().surfaceConfig, "object");
+    const placementRuntime = providedByKey.get("jskit.shell-web.runtime.web-placement.client");
+    assert.equal(typeof placementRuntime.getPlacements, "function");
+    assert.equal(typeof placementRuntime.getContext, "function");
+    assert.equal(typeof placementRuntime.setContext, "function");
+    assert.equal(typeof placementRuntime.getContext().surfaceConfig, "object");
 
-  const errorRuntime = providedByKey.get("jskit.shell-web.runtime.web-error.client");
-  assert.equal(typeof errorRuntime.report, "function");
-  assert.equal(typeof errorRuntime.configure, "function");
+    const errorRuntime = providedByKey.get("jskit.shell-web.runtime.web-error.client");
+    assert.equal(typeof errorRuntime.report, "function");
+    assert.equal(typeof errorRuntime.configure, "function");
 
-  const errorStore = providedByKey.get("jskit.shell-web.runtime.web-error.presentation-store.client");
-  assert.equal(typeof errorStore.getState, "function");
-  assert.equal(typeof errorStore.present, "function");
+    const errorStore = providedByKey.get("jskit.shell-web.runtime.web-error.presentation-store.client");
+    assert.equal(typeof errorStore.getState, "function");
+    assert.equal(typeof errorStore.present, "function");
 
-  const errorPresentationStore = useShellErrorPresentationStore(app.pinia);
-  assert.equal(errorPresentationStore.revision, 0);
-  assert.equal(typeof errorPresentationStore.present, "function");
-  errorStore.present("banner", { message: "Hello" });
-  assert.equal(errorPresentationStore.channels.banner[0].message, "Hello");
+    const errorPresentationStore = useShellErrorPresentationStore(app.pinia);
+    assert.equal(errorPresentationStore.revision, 0);
+    assert.equal(typeof errorPresentationStore.present, "function");
+    errorStore.present("banner", { message: "Hello" });
+    assert.equal(errorPresentationStore.channels.banner[0].message, "Hello");
+  });
 });
 
 test("shell web client provider resolves surface config from client app config", async () => {
@@ -134,35 +177,63 @@ test("shell web client provider resolves surface config from client app config",
   });
 
   try {
-    const app = createAppDouble({
-      surfaceRuntime: {
-        DEFAULT_SURFACE_ID: "app",
-        listEnabledSurfaceIds() {
-          return ["app", "admin", "console"];
-        },
-        listSurfaceDefinitions() {
-          return [
-            { id: "app", pagesRoot: "w/[workspaceSlug]", requiresWorkspace: true, enabled: true },
-            { id: "admin", pagesRoot: "w/[workspaceSlug]/admin", requiresWorkspace: true, enabled: true },
-            { id: "console", pagesRoot: "console", requiresWorkspace: false, enabled: true }
-          ];
+    await withFetchStub({ surfaceAccess: {} }, async () => {
+      const app = createAppDouble({
+        surfaceRuntime: {
+          DEFAULT_SURFACE_ID: "app",
+          listEnabledSurfaceIds() {
+            return ["app", "admin", "console"];
+          },
+          listSurfaceDefinitions() {
+            return [
+              { id: "app", pagesRoot: "w/[workspaceSlug]", requiresWorkspace: true, enabled: true },
+              { id: "admin", pagesRoot: "w/[workspaceSlug]/admin", requiresWorkspace: true, enabled: true },
+              { id: "console", pagesRoot: "console", requiresWorkspace: false, enabled: true }
+            ];
+          }
         }
-      }
-    });
-    const provider = new ShellWebClientProvider();
-    provider.register(app);
+      });
+      const provider = new ShellWebClientProvider();
+      provider.register(app);
 
-    await provider.boot(app);
+      await provider.boot(app);
 
-    const placementRuntime = app.make("runtime.web-placement.client");
-    const context = placementRuntime.getContext();
-    assert.equal(context.surfaceConfig.tenancyMode, "workspaces");
-    assert.equal(context.surfaceConfig.defaultSurfaceId, "app");
-    assert.deepEqual(context.surfaceConfig.enabledSurfaceIds, ["app", "admin", "console"]);
-    assert.deepEqual(context.surfaceAccessPolicies, {
-      public: {}
+      const placementRuntime = app.make("runtime.web-placement.client");
+      const context = placementRuntime.getContext();
+      assert.equal(context.surfaceConfig.tenancyMode, "workspaces");
+      assert.equal(context.surfaceConfig.defaultSurfaceId, "app");
+      assert.deepEqual(context.surfaceConfig.enabledSurfaceIds, ["app", "admin", "console"]);
+      assert.deepEqual(context.surfaceAccessPolicies, {
+        public: {}
+      });
     });
   } finally {
     setClientAppConfig({});
   }
+});
+
+test("shell web client provider clears generic surface access on bootstrap 401", async () => {
+  await withFetchImplementation(async () => ({
+    ok: false,
+    status: 401
+  }), async () => {
+    const app = createAppDouble();
+    const provider = new ShellWebClientProvider();
+    provider.register(app);
+
+    const placementRuntime = app.make("runtime.web-placement.client");
+    placementRuntime.setContext(
+      {
+        surfaceAccess: {
+          consoleowner: true
+        }
+      },
+      {
+        source: "test.seed"
+      }
+    );
+
+    await provider.boot(app);
+    assert.deepEqual(placementRuntime.getContext().surfaceAccess, {});
+  });
 });

--- a/packages/users-web/package.json
+++ b/packages/users-web/package.json
@@ -28,7 +28,6 @@
     "./client/composables/usePaths": "./src/client/composables/usePaths.js",
     "./client/composables/runtime/useUiFeedback": "./src/client/composables/runtime/useUiFeedback.js",
     "./client/lib/httpClient": "./src/client/lib/httpClient.js",
-    "./client/lib/bootstrap": "./src/client/lib/bootstrap.js",
     "./client/lib/permissions": "./src/client/lib/permissions.js",
     "./client/support/contractGuards": "./src/client/support/contractGuards.js"
   },

--- a/packages/users-web/src/client/bootstrap/user-bootstrap-handler.js
+++ b/packages/users-web/src/client/bootstrap/user-bootstrap-handler.js
@@ -1,0 +1,53 @@
+import {
+  registerBootstrapPayloadHandler,
+  resolveBootstrapErrorStatusCode
+} from "@jskit-ai/shell-web/client/bootstrap";
+import { resolvePlacementUserFromBootstrapPayload } from "../lib/bootstrap.js";
+
+function createUsersBootstrapUserHandler() {
+  return Object.freeze({
+    handlerId: "users.web.bootstrap.user",
+    order: 50,
+    applyBootstrapPayload({ payload = {}, placementRuntime, source } = {}) {
+      if (!placementRuntime || typeof placementRuntime.setContext !== "function") {
+        return;
+      }
+
+      const context = placementRuntime.getContext?.() || {};
+      placementRuntime.setContext(
+        {
+          user: resolvePlacementUserFromBootstrapPayload(payload, context?.user)
+        },
+        {
+          source
+        }
+      );
+    },
+    handleBootstrapError({ error, placementRuntime, source } = {}) {
+      if (!placementRuntime || typeof placementRuntime.setContext !== "function") {
+        return;
+      }
+      if (resolveBootstrapErrorStatusCode(error) !== 401) {
+        return;
+      }
+
+      placementRuntime.setContext(
+        {
+          user: null
+        },
+        {
+          source
+        }
+      );
+    }
+  });
+}
+
+function registerUsersBootstrapPayloadHandlers(app) {
+  registerBootstrapPayloadHandler(app, "users.web.bootstrap.user-handler", () => createUsersBootstrapUserHandler());
+}
+
+export {
+  createUsersBootstrapUserHandler,
+  registerUsersBootstrapPayloadHandlers
+};

--- a/packages/users-web/src/client/providers/UsersWebClientProvider.js
+++ b/packages/users-web/src/client/providers/UsersWebClientProvider.js
@@ -1,17 +1,19 @@
 import UsersHomeToolsWidget from "../components/UsersHomeToolsWidget.vue";
 import ProfileClientElement from "../components/ProfileClientElement.vue";
+import { registerUsersBootstrapPayloadHandlers } from "../bootstrap/user-bootstrap-handler.js";
 
 class UsersWebClientProvider {
   static id = "users.web.client";
   static dependsOn = ["shell.web.client"];
 
   register(app) {
-    if (!app || typeof app.singleton !== "function") {
-      throw new Error("UsersWebClientProvider requires application singleton().");
+    if (!app || typeof app.singleton !== "function" || typeof app.tag !== "function") {
+      throw new Error("UsersWebClientProvider requires application singleton()/tag().");
     }
 
     app.singleton("users.web.home.tools.widget", () => UsersHomeToolsWidget);
     app.singleton("users.web.profile.element", () => ProfileClientElement);
+    registerUsersBootstrapPayloadHandlers(app);
   }
 }
 

--- a/packages/users-web/test/bootstrap.test.js
+++ b/packages/users-web/test/bootstrap.test.js
@@ -1,6 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { resolveBootstrapPayloadHandlers } from "@jskit-ai/shell-web/client/bootstrap";
 import { resolvePlacementUserFromBootstrapPayload } from "../src/client/lib/bootstrap.js";
+import {
+  createUsersBootstrapUserHandler,
+  registerUsersBootstrapPayloadHandlers
+} from "../src/client/bootstrap/user-bootstrap-handler.js";
 
 test("resolvePlacementUserFromBootstrapPayload returns null for anonymous sessions", () => {
   assert.equal(
@@ -35,4 +40,129 @@ test("resolvePlacementUserFromBootstrapPayload maps profile fields used by place
     email: "ada@example.com",
     avatarUrl: "https://cdn.example.com/ada.png"
   });
+});
+
+function createPlacementRuntimeDouble() {
+  return {
+    context: Object.freeze({}),
+    getContext() {
+      return this.context;
+    },
+    setContext(patch = {}, { replace = false } = {}) {
+      this.context = Object.freeze(
+        replace
+          ? { ...patch }
+          : {
+              ...this.context,
+              ...patch
+            }
+      );
+      return this.context;
+    }
+  };
+}
+
+function createBootstrapRegistryAppDouble() {
+  const singletons = new Map();
+  const instances = new Map();
+  const tags = new Map();
+
+  return {
+    singleton(token, factory) {
+      singletons.set(token, factory);
+    },
+    tag(token, tagName) {
+      const current = tags.get(tagName) || [];
+      current.push(token);
+      tags.set(tagName, current);
+    },
+    resolveTag(tagName) {
+      return (tags.get(tagName) || []).map((token) => this.make(token));
+    },
+    make(token) {
+      if (instances.has(token)) {
+        return instances.get(token);
+      }
+      const factory = singletons.get(token);
+      if (typeof factory !== "function") {
+        throw new Error(`Unknown token ${String(token)}`);
+      }
+      const instance = factory(this);
+      instances.set(token, instance);
+      return instance;
+    }
+  };
+}
+
+test("users web bootstrap user handler writes placement user", async () => {
+  const handler = createUsersBootstrapUserHandler();
+  const placementRuntime = createPlacementRuntimeDouble();
+  await handler.applyBootstrapPayload({
+    payload: {
+      session: {
+        authenticated: true,
+        userId: "42"
+      },
+      profile: {
+        displayName: "Ada Lovelace",
+        email: "ADA@EXAMPLE.COM",
+        avatar: {
+          effectiveUrl: "https://cdn.example.com/ada.png"
+        }
+      }
+    },
+    placementRuntime,
+    source: "test"
+  });
+
+  assert.deepEqual(placementRuntime.getContext().user, {
+    id: "42",
+    displayName: "Ada Lovelace",
+    name: "Ada Lovelace",
+    email: "ada@example.com",
+    avatarUrl: "https://cdn.example.com/ada.png"
+  });
+});
+
+test("users web bootstrap user handler clears placement user on bootstrap 401 only", async () => {
+  const handler = createUsersBootstrapUserHandler();
+  const placementRuntime = createPlacementRuntimeDouble();
+  placementRuntime.setContext({
+    user: {
+      id: "42",
+      displayName: "Ada Lovelace"
+    }
+  });
+
+  await handler.handleBootstrapError({
+    error: {
+      statusCode: 404
+    },
+    placementRuntime,
+    source: "test"
+  });
+  assert.deepEqual(placementRuntime.getContext().user, {
+    id: "42",
+    displayName: "Ada Lovelace"
+  });
+
+  await handler.handleBootstrapError({
+    error: {
+      statusCode: 401
+    },
+    placementRuntime,
+    source: "test"
+  });
+  assert.equal(placementRuntime.getContext().user, null);
+});
+
+test("registerUsersBootstrapPayloadHandlers registers the users bootstrap user handler", () => {
+  const app = createBootstrapRegistryAppDouble();
+  registerUsersBootstrapPayloadHandlers(app);
+
+  const handlers = resolveBootstrapPayloadHandlers(app);
+  assert.equal(handlers.length, 1);
+  assert.equal(handlers[0]?.handlerId, "users.web.bootstrap.user");
+  assert.equal(typeof handlers[0]?.applyBootstrapPayload, "function");
+  assert.equal(typeof handlers[0]?.handleBootstrapError, "function");
 });

--- a/packages/workspaces-web/src/client/providers/WorkspacesWebClientProvider.js
+++ b/packages/workspaces-web/src/client/providers/WorkspacesWebClientProvider.js
@@ -4,6 +4,7 @@ import UsersWorkspaceToolsWidget from "../components/UsersWorkspaceToolsWidget.v
 import UsersWorkspaceSettingsMenuItem from "../components/UsersWorkspaceSettingsMenuItem.vue";
 import UsersWorkspaceMembersMenuItem from "../components/UsersWorkspaceMembersMenuItem.vue";
 import MembersAdminClientElement from "../components/MembersAdminClientElement.vue";
+import { registerBootstrapPayloadHandler } from "@jskit-ai/shell-web/client/bootstrap";
 import { createBootstrapPlacementRuntime } from "../runtime/bootstrapPlacementRuntime.js";
 import {
   WORKSPACES_WEB_SCOPE_SUPPORT_INJECTION_KEY,
@@ -15,8 +16,8 @@ class WorkspacesWebClientProvider {
   static dependsOn = ["users.web.client"];
 
   register(app) {
-    if (!app || typeof app.singleton !== "function") {
-      throw new Error("WorkspacesWebClientProvider requires application singleton().");
+    if (!app || typeof app.singleton !== "function" || typeof app.tag !== "function") {
+      throw new Error("WorkspacesWebClientProvider requires application singleton()/tag().");
     }
 
     app.singleton("workspaces.web.profile.menu.surface-switch-item", () => UsersProfileSurfaceSwitchMenuItem);
@@ -26,6 +27,22 @@ class WorkspacesWebClientProvider {
     app.singleton("workspaces.web.workspace-members.menu-item", () => UsersWorkspaceMembersMenuItem);
     app.singleton("workspaces.web.members-admin.element", () => MembersAdminClientElement);
     app.singleton("workspaces.web.bootstrap-placement.runtime", (scope) => createBootstrapPlacementRuntime({ app: scope }));
+    registerBootstrapPayloadHandler(app, "workspaces.web.bootstrap.handler", (scope) => {
+      const runtime = scope.make("workspaces.web.bootstrap-placement.runtime");
+      return Object.freeze({
+        handlerId: "workspaces.web.bootstrap",
+        order: 100,
+        resolveBootstrapRequest(input = {}) {
+          return runtime.resolveBootstrapRequest(input);
+        },
+        applyBootstrapPayload(input = {}) {
+          return runtime.applyBootstrapPayload(input);
+        },
+        handleBootstrapError(input = {}) {
+          return runtime.handleBootstrapError(input);
+        }
+      });
+    });
     app.singleton("workspaces.web.scope-support", () => createWorkspaceScopeSupport());
   }
 

--- a/packages/workspaces-web/src/client/runtime/bootstrapPlacementRuntime.js
+++ b/packages/workspaces-web/src/client/runtime/bootstrapPlacementRuntime.js
@@ -2,7 +2,6 @@ import {
   findWorkspaceBySlug,
   normalizeWorkspaceList
 } from "../lib/bootstrap.js";
-import { resolvePlacementUserFromBootstrapPayload } from "@jskit-ai/users-web/client/lib/bootstrap";
 import { normalizePermissionList } from "../lib/permissions.js";
 import {
   persistBootstrapThemePreference,
@@ -22,24 +21,19 @@ import {
 import {
   countPendingInvites,
   createProviderLogger,
-  fetchBootstrapPayload,
   normalizeWorkspaceBootstrapStatus,
   normalizeWorkspaceSlugKey,
-  resolveAuthSignature,
   resolveRequestedWorkspaceBootstrapStatus,
   resolveRouteState
 } from "./bootstrapPlacementRuntimeHelpers.js";
 import { resolveErrorStatusCode } from "../support/runtimeNormalization.js";
 
-function createBootstrapPlacementRuntime({ app, logger = null, fetchBootstrap = fetchBootstrapPayload } = {}) {
+function createBootstrapPlacementRuntime({ app, logger = null } = {}) {
   if (!app || typeof app.has !== "function" || typeof app.make !== "function") {
     throw new Error("createBootstrapPlacementRuntime requires application has()/make().");
   }
   if (!app.has("runtime.web-placement.client")) {
     throw new Error("createBootstrapPlacementRuntime requires shell-web placement runtime.");
-  }
-  if (typeof fetchBootstrap !== "function") {
-    throw new TypeError("createBootstrapPlacementRuntime requires fetchBootstrap(workspaceSlug).");
   }
 
   const runtimeLogger = logger || createProviderLogger(app);
@@ -50,10 +44,9 @@ function createBootstrapPlacementRuntime({ app, logger = null, fetchBootstrap = 
   );
   const socket = app.has("runtime.realtime.client.socket") ? app.make("runtime.realtime.client.socket") : null;
   const cleanup = [];
-  let refreshQueue = Promise.resolve();
   let shutdownRequested = false;
-  let authSignature = resolveAuthSignature(placementRuntime.getContext());
   let lastRouteWorkspaceSlug = resolveRouteState(placementRuntime, router).workspaceSlug;
+  let initialized = false;
   const workspaceBootstrapStatusBySlug = new Map();
   const workspaceBootstrapStatusListeners = new Set();
   const root = typeof globalThis === "object" && globalThis ? globalThis : null;
@@ -68,6 +61,23 @@ function createBootstrapPlacementRuntime({ app, logger = null, fetchBootstrap = 
   cleanup.push(() => {
     routeGuards.shutdown();
   });
+
+  function normalizeBootstrapSource(source = "") {
+    return String(source || "workspaces-web.bootstrap-placement").trim() || "workspaces-web.bootstrap-placement";
+  }
+
+  function shouldApplyWorkspaceColorForContextUpdate(event = {}) {
+    if (event?.type !== "context.updated") {
+      return false;
+    }
+
+    const source = String(event?.source || "").trim().toLowerCase();
+    if (!source) {
+      return false;
+    }
+
+    return source.startsWith("workspaces-web.") && !source.startsWith("workspaces-web.bootstrap-placement");
+  }
 
   function setWorkspaceBootstrapStatus(workspaceSlug = "", status = "", source = "workspaces-web.bootstrap-placement") {
     const workspaceSlugKey = normalizeWorkspaceSlugKey(workspaceSlug);
@@ -94,7 +104,7 @@ function createBootstrapPlacementRuntime({ app, logger = null, fetchBootstrap = 
     const payload = Object.freeze({
       workspaceSlug: workspaceSlugKey,
       status: normalizedStatus,
-      source: String(source || "workspaces-web.bootstrap-placement").trim() || "workspaces-web.bootstrap-placement"
+      source: normalizeBootstrapSource(source)
     });
     for (const listener of workspaceBootstrapStatusListeners) {
       try {
@@ -122,7 +132,7 @@ function createBootstrapPlacementRuntime({ app, logger = null, fetchBootstrap = 
     };
   }
 
-  function writePlacementContext(payload = {}, state = {}, source = "workspaces-web.bootstrap-placement") {
+  function writeWorkspacePlacementContext(payload = {}, state = {}, source = "workspaces-web.bootstrap-placement") {
     const availableWorkspaces = normalizeWorkspaceList(payload?.workspaces);
     const currentWorkspace = findWorkspaceBySlug(availableWorkspaces, state.workspaceSlug);
     const workspaceSettings =
@@ -130,7 +140,6 @@ function createBootstrapPlacementRuntime({ app, logger = null, fetchBootstrap = 
         ? payload.workspaceSettings
         : null;
     const permissions = normalizePermissionList(payload?.permissions);
-    const user = resolvePlacementUserFromBootstrapPayload(payload, state.context?.user);
     const workspaceInvitesEnabled = payload?.app?.features?.workspaceInvites === true;
     const pendingInvitesCount = workspaceInvitesEnabled ? countPendingInvites(payload?.pendingInvites) : 0;
 
@@ -140,8 +149,6 @@ function createBootstrapPlacementRuntime({ app, logger = null, fetchBootstrap = 
         workspaceSettings,
         workspaces: availableWorkspaces,
         permissions,
-        user,
-        surfaceAccess: payload?.surfaceAccess && typeof payload.surfaceAccess === "object" ? payload.surfaceAccess : {},
         pendingInvitesCount,
         workspaceInvitesEnabled
       },
@@ -150,18 +157,15 @@ function createBootstrapPlacementRuntime({ app, logger = null, fetchBootstrap = 
       }
     );
     routeGuards.enforceSurfaceAccessForCurrentRoute();
-    applyWorkspaceColorFromPlacementContext("write");
   }
 
-  function clearPlacementContext(source = "workspaces-web.bootstrap-placement") {
+  function clearWorkspacePlacementContext(source = "workspaces-web.bootstrap-placement") {
     placementRuntime.setContext(
       {
         workspace: null,
         workspaceSettings: null,
         workspaces: [],
         permissions: [],
-        user: null,
-        surfaceAccess: {},
         pendingInvitesCount: 0,
         workspaceInvitesEnabled: false
       },
@@ -252,148 +256,195 @@ function createBootstrapPlacementRuntime({ app, logger = null, fetchBootstrap = 
     }
   }
 
-  async function refresh(reason = "manual") {
+  function applyUnauthenticatedTheme(reason = "manual") {
+    applyThemeFromBootstrapPayload(
+      {
+        session: {
+          authenticated: false
+        }
+      },
+      reason
+    );
+  }
+
+  function normalizeBootstrapRequestContext(request = {}) {
+    const meta = request?.meta && typeof request.meta === "object" ? request.meta : {};
+    const query = request?.query && typeof request.query === "object" ? request.query : {};
+    return Object.freeze({
+      path: String(meta.path || "").trim(),
+      workspaceSlug: normalizeWorkspaceSlugKey(meta.workspaceSlug || query.workspaceSlug)
+    });
+  }
+
+  function isCurrentRequestTarget(request = {}) {
+    const requested = normalizeBootstrapRequestContext(request);
+    const currentState = resolveRouteState(placementRuntime, router);
+    if (requested.path && requested.path !== currentState.path) {
+      return false;
+    }
+    return requested.workspaceSlug === normalizeWorkspaceSlugKey(currentState.workspaceSlug);
+  }
+
+  function resolveBootstrapRequest() {
+    const state = resolveRouteState(placementRuntime, router);
+    const workspaceSlug = normalizeWorkspaceSlugKey(state.workspaceSlug);
+    return Object.freeze({
+      query: workspaceSlug ? Object.freeze({ workspaceSlug }) : Object.freeze({}),
+      meta: Object.freeze({
+        path: state.path,
+        workspaceSlug
+      })
+    });
+  }
+
+  async function applyBootstrapPayload({ payload = {}, reason = "manual", source = "", request = {} } = {}) {
+    if (!isCurrentRequestTarget(request)) {
+      return null;
+    }
+
+    const stateAtApply = resolveRouteState(placementRuntime, router);
+    const normalizedSource = normalizeBootstrapSource(source);
+    writeWorkspacePlacementContext(payload, stateAtApply, normalizedSource);
+    applyThemeFromBootstrapPayload(payload, reason);
+    applyWorkspaceColorFromPlacementContext(reason);
+    if (!stateAtApply.workspaceSlug) {
+      return payload;
+    }
+
+    const sessionAuthenticated = payload?.session?.authenticated === true;
+    if (!sessionAuthenticated) {
+      setWorkspaceBootstrapStatus(stateAtApply.workspaceSlug, WORKSPACE_BOOTSTRAP_STATUS_UNAUTHENTICATED, normalizedSource);
+      return payload;
+    }
+
+    const requestedWorkspaceStatus = resolveRequestedWorkspaceBootstrapStatus(payload, stateAtApply.workspaceSlug);
+    if (requestedWorkspaceStatus) {
+      setWorkspaceBootstrapStatus(stateAtApply.workspaceSlug, requestedWorkspaceStatus, normalizedSource);
+      return payload;
+    }
+
+    const availableWorkspaces = normalizeWorkspaceList(payload?.workspaces);
+    const currentWorkspace = findWorkspaceBySlug(availableWorkspaces, stateAtApply.workspaceSlug);
+    setWorkspaceBootstrapStatus(
+      stateAtApply.workspaceSlug,
+      currentWorkspace ? WORKSPACE_BOOTSTRAP_STATUS_RESOLVED : WORKSPACE_BOOTSTRAP_STATUS_FORBIDDEN,
+      normalizedSource
+    );
+    return payload;
+  }
+
+  async function handleBootstrapError({ error, reason = "manual", source = "", request = {} } = {}) {
+    if (!isCurrentRequestTarget(request)) {
+      return null;
+    }
+
+    const normalizedSource = normalizeBootstrapSource(source);
+    const requested = normalizeBootstrapRequestContext(request);
+    const stateAtApply = resolveRouteState(placementRuntime, router);
+    const statusCode = resolveErrorStatusCode(error);
+
+    if (statusCode === 401) {
+      if (requested.workspaceSlug) {
+        setWorkspaceBootstrapStatus(requested.workspaceSlug, WORKSPACE_BOOTSTRAP_STATUS_UNAUTHENTICATED, normalizedSource);
+      }
+      clearWorkspacePlacementContext(normalizedSource);
+      applyUnauthenticatedTheme(reason);
+      return null;
+    }
+
+    if (statusCode === 403) {
+      if (requested.workspaceSlug) {
+        setWorkspaceBootstrapStatus(requested.workspaceSlug, WORKSPACE_BOOTSTRAP_STATUS_FORBIDDEN, normalizedSource);
+      }
+      if (requested.path === stateAtApply.path) {
+        clearWorkspacePlacementContext(normalizedSource);
+      }
+      return null;
+    }
+
+    if (statusCode === 404) {
+      if (requested.workspaceSlug) {
+        setWorkspaceBootstrapStatus(requested.workspaceSlug, WORKSPACE_BOOTSTRAP_STATUS_NOT_FOUND, normalizedSource);
+      }
+      if (requested.path === stateAtApply.path) {
+        clearWorkspacePlacementContext(normalizedSource);
+      }
+      return null;
+    }
+
+    if (requested.workspaceSlug) {
+      setWorkspaceBootstrapStatus(requested.workspaceSlug, WORKSPACE_BOOTSTRAP_STATUS_ERROR, normalizedSource);
+    }
+
+    runtimeLogger.warn(
+      {
+        reason,
+        error: String(error?.message || error || "unknown error")
+      },
+      "workspaces-web bootstrap placement refresh failed."
+    );
+    return null;
+  }
+
+  function resolveBootstrapRuntime() {
+    if (!app.has("runtime.web-bootstrap.client")) {
+      throw new Error("createBootstrapPlacementRuntime requires shell-web bootstrap runtime.");
+    }
+
+    const bootstrapRuntime = app.make("runtime.web-bootstrap.client");
+    if (!bootstrapRuntime || typeof bootstrapRuntime.refresh !== "function") {
+      throw new Error("createBootstrapPlacementRuntime requires runtime.web-bootstrap.client.refresh().");
+    }
+
+    return bootstrapRuntime;
+  }
+
+  function refresh(reason = "manual") {
     if (shutdownRequested) {
+      return Promise.resolve(null);
+    }
+
+    return resolveBootstrapRuntime().refresh(reason);
+  }
+
+  function enforceCurrentWorkspaceStatus() {
+    const state = resolveRouteState(placementRuntime, router);
+    if (!state.workspaceSlug) {
       return;
     }
 
-    const stateAtStart = resolveRouteState(placementRuntime, router);
-    const source = `workspaces-web.bootstrap-placement.${String(reason || "manual").trim() || "manual"}`;
-    try {
-      const payload = await fetchBootstrap(stateAtStart.workspaceSlug);
-      const stateAtApply = resolveRouteState(placementRuntime, router);
-      if (stateAtStart.path !== stateAtApply.path || stateAtStart.workspaceSlug !== stateAtApply.workspaceSlug) {
-        return;
-      }
-
-      writePlacementContext(payload, stateAtStart, source);
-      applyThemeFromBootstrapPayload(payload, reason);
-      applyWorkspaceColorFromPlacementContext(reason);
-      if (stateAtStart.workspaceSlug) {
-        const sessionAuthenticated = payload?.session?.authenticated === true;
-        if (!sessionAuthenticated) {
-          setWorkspaceBootstrapStatus(stateAtStart.workspaceSlug, WORKSPACE_BOOTSTRAP_STATUS_UNAUTHENTICATED, source);
-          return;
-        }
-
-        const requestedWorkspaceStatus = resolveRequestedWorkspaceBootstrapStatus(payload, stateAtStart.workspaceSlug);
-        if (requestedWorkspaceStatus) {
-          setWorkspaceBootstrapStatus(stateAtStart.workspaceSlug, requestedWorkspaceStatus, source);
-          return;
-        }
-
-        const availableWorkspaces = normalizeWorkspaceList(payload?.workspaces);
-        const currentWorkspace = findWorkspaceBySlug(availableWorkspaces, stateAtStart.workspaceSlug);
-        setWorkspaceBootstrapStatus(
-          stateAtStart.workspaceSlug,
-          currentWorkspace ? WORKSPACE_BOOTSTRAP_STATUS_RESOLVED : WORKSPACE_BOOTSTRAP_STATUS_FORBIDDEN,
-          source
-        );
-      }
-    } catch (error) {
-      const statusCode = resolveErrorStatusCode(error);
-      const stateAtApply = resolveRouteState(placementRuntime, router);
-      const sameWorkspaceRoute =
-        stateAtStart.path === stateAtApply.path && stateAtStart.workspaceSlug === stateAtApply.workspaceSlug;
-
-      if (statusCode === 401) {
-        if (stateAtStart.workspaceSlug) {
-          setWorkspaceBootstrapStatus(stateAtStart.workspaceSlug, WORKSPACE_BOOTSTRAP_STATUS_UNAUTHENTICATED, source);
-        }
-        clearPlacementContext(source);
-        applyThemeFromBootstrapPayload(
-          {
-            session: {
-              authenticated: false
-            }
-          },
-          reason
-        );
-        return;
-      }
-      if (statusCode === 403) {
-        if (stateAtStart.workspaceSlug) {
-          setWorkspaceBootstrapStatus(stateAtStart.workspaceSlug, WORKSPACE_BOOTSTRAP_STATUS_FORBIDDEN, source);
-        }
-        if (sameWorkspaceRoute) {
-          clearPlacementContext(source);
-        }
-        return;
-      }
-      if (statusCode === 404) {
-        if (stateAtStart.workspaceSlug) {
-          setWorkspaceBootstrapStatus(stateAtStart.workspaceSlug, WORKSPACE_BOOTSTRAP_STATUS_NOT_FOUND, source);
-        }
-        if (sameWorkspaceRoute) {
-          clearPlacementContext(source);
-        }
-        return;
-      }
-
-      if (stateAtStart.workspaceSlug) {
-        setWorkspaceBootstrapStatus(stateAtStart.workspaceSlug, WORKSPACE_BOOTSTRAP_STATUS_ERROR, source);
-      }
-
-      runtimeLogger.warn(
-        {
-          reason,
-          error: String(error?.message || error || "unknown error")
-        },
-        "workspaces-web bootstrap placement refresh failed."
-      );
+    const status = getWorkspaceBootstrapStatus(state.workspaceSlug);
+    if (!status) {
+      return;
     }
-  }
 
-  function queueRefresh(reason = "manual") {
-    refreshQueue = refreshQueue
-      .then(() => refresh(reason))
-      .catch((error) => {
-        runtimeLogger.warn(
-          {
-            reason,
-            error: String(error?.message || error || "unknown error")
-          },
-          "workspaces-web bootstrap placement queued refresh failed."
-        );
-      });
-    return refreshQueue;
+    routeGuards.enforceWorkspaceRouteForStatusUpdate({
+      workspaceSlug: state.workspaceSlug,
+      status
+    });
   }
 
   async function initialize() {
+    if (initialized) {
+      return null;
+    }
+    initialized = true;
     routeGuards.installWorkspaceGuardEvaluator();
 
     const contextAtInit = placementRuntime.getContext();
     if (contextAtInit?.auth?.authenticated !== true) {
-      applyThemeFromBootstrapPayload({
-        session: {
-          authenticated: false
-        }
-      }, "init");
+      applyUnauthenticatedTheme("init");
     }
     applyWorkspaceColorFromPlacementContext("init");
+    routeGuards.enforceSurfaceAccessForCurrentRoute();
+    enforceCurrentWorkspaceStatus();
 
     if (typeof placementRuntime.subscribe === "function") {
       const unsubscribePlacement = placementRuntime.subscribe((event = {}) => {
-        if (event.type !== "context.updated") {
+        if (!shouldApplyWorkspaceColorForContextUpdate(event)) {
           return;
         }
-
-        const nextContext = placementRuntime.getContext();
         applyWorkspaceColorFromPlacementContext("context");
-        const nextSignature = resolveAuthSignature(nextContext);
-        if (nextSignature === authSignature) {
-          return;
-        }
-
-        authSignature = nextSignature;
-        if (nextContext?.auth?.authenticated !== true) {
-          applyThemeFromBootstrapPayload({
-            session: {
-              authenticated: false
-            }
-          }, "auth");
-        }
-        void queueRefresh("auth");
       });
       cleanup.push(() => {
         if (typeof unsubscribePlacement === "function") {
@@ -402,16 +453,17 @@ function createBootstrapPlacementRuntime({ app, logger = null, fetchBootstrap = 
       });
     }
 
-    await queueRefresh("init");
-
     if (router && typeof router.afterEach === "function") {
       const removeAfterEach = router.afterEach(() => {
+        routeGuards.enforceSurfaceAccessForCurrentRoute();
+        applyWorkspaceColorFromPlacementContext("route");
+        enforceCurrentWorkspaceStatus();
         const nextWorkspaceSlug = resolveRouteState(placementRuntime, router).workspaceSlug;
         if (nextWorkspaceSlug === lastRouteWorkspaceSlug) {
           return;
         }
         lastRouteWorkspaceSlug = nextWorkspaceSlug;
-        void queueRefresh("route");
+        void refresh("route");
       });
       cleanup.push(() => {
         if (typeof removeAfterEach === "function") {
@@ -422,7 +474,7 @@ function createBootstrapPlacementRuntime({ app, logger = null, fetchBootstrap = 
 
     if (socket && typeof socket.on === "function") {
       const handleBootstrapChanged = () => {
-        void queueRefresh("realtime");
+        void refresh("realtime");
       };
       socket.on("users.bootstrap.changed", handleBootstrapChanged);
       cleanup.push(() => {
@@ -447,7 +499,10 @@ function createBootstrapPlacementRuntime({ app, logger = null, fetchBootstrap = 
   return Object.freeze({
     initialize,
     shutdown,
-    refresh: queueRefresh,
+    refresh,
+    resolveBootstrapRequest,
+    applyBootstrapPayload,
+    handleBootstrapError,
     getWorkspaceBootstrapStatus,
     subscribeWorkspaceBootstrapStatus
   });

--- a/packages/workspaces-web/test/bootstrapPlacementRuntime.test.js
+++ b/packages/workspaces-web/test/bootstrapPlacementRuntime.test.js
@@ -6,6 +6,7 @@ import {
   WORKSPACE_BOOTSTRAP_STATUS_FORBIDDEN,
   WORKSPACE_BOOTSTRAP_STATUS_NOT_FOUND,
   WORKSPACE_BOOTSTRAP_STATUS_RESOLVED,
+  WORKSPACE_BOOTSTRAP_STATUS_UNAUTHENTICATED,
   createBootstrapPlacementRuntime
 } from "../src/client/runtime/bootstrapPlacementRuntime.js";
 
@@ -171,6 +172,17 @@ function createSocketStub() {
   };
 }
 
+function createBootstrapRuntimeStub() {
+  const calls = [];
+  return {
+    async refresh(reason) {
+      calls.push(String(reason || ""));
+      return null;
+    },
+    calls
+  };
+}
+
 function createAppStub(records = {}) {
   const registry = new Map();
   for (const key of Reflect.ownKeys(records)) {
@@ -231,61 +243,84 @@ function createVueAppWithThemeController(themeController) {
   };
 }
 
-test("bootstrap placement runtime writes user/workspace/permissions into placement context", async () => {
+function createBootstrapRequest(path = "/w/acme/dashboard", workspaceSlug = "") {
+  const normalizedPath = resolvePathFromFullPath(path);
+  const normalizedWorkspaceSlug = String(workspaceSlug || "").trim().toLowerCase();
+  return Object.freeze({
+    path: "/api/bootstrap",
+    query: Object.freeze(normalizedWorkspaceSlug ? { workspaceSlug: normalizedWorkspaceSlug } : {}),
+    meta: Object.freeze({
+      path: normalizedPath,
+      workspaceSlug: normalizedWorkspaceSlug
+    })
+  });
+}
+
+function createErrorWithStatus(status, message = "") {
+  const error = new Error(message || `HTTP ${status}`);
+  error.status = status;
+  return error;
+}
+
+test("bootstrap placement runtime contributes workspace slug to shared bootstrap request and writes payload into placement context", async () => {
   const placementRuntime = createPlacementRuntimeStub();
   const router = createRouterStub("/w/acme/dashboard");
-  const fetchCalls = [];
   const runtime = createBootstrapPlacementRuntime({
     app: createAppStub({
       ["runtime.web-placement.client"]: placementRuntime,
+      ["runtime.web-bootstrap.client"]: createBootstrapRuntimeStub(),
       ["jskit.client.router"]: router
-    }),
-    fetchBootstrap: async (workspaceSlug) => {
-      fetchCalls.push(workspaceSlug);
-      return {
-        session: {
-          authenticated: true,
-          userId: "7"
-        },
-        profile: {
-          displayName: "Ada Lovelace",
-          email: "ADA@EXAMPLE.COM",
-          avatar: {
-            effectiveUrl: "https://cdn.example.com/ada.png"
-          }
-        },
-        app: {
-          features: {
-            workspaceInvites: true
-          }
-        },
-        pendingInvites: [
-          { id: "1", workspaceId: "1", token: "a" },
-          { id: "2", workspaceId: "2", token: "b" }
-        ],
-        workspaces: [{ id: "1", slug: "acme", name: "Acme Workspace" }],
-        permissions: ["workspace.settings.view"]
-      };
-    }
+    })
   });
 
   await runtime.initialize();
-  const context = placementRuntime.getContext();
+  const request = runtime.resolveBootstrapRequest();
+  assert.deepEqual(request, {
+    query: {
+      workspaceSlug: "acme"
+    },
+    meta: {
+      path: "/w/acme/dashboard",
+      workspaceSlug: "acme"
+    }
+  });
 
-  assert.deepEqual(fetchCalls, ["acme"]);
+  await runtime.applyBootstrapPayload({
+    request,
+    payload: {
+      session: {
+        authenticated: true,
+        userId: "7"
+      },
+      profile: {
+        displayName: "Ada Lovelace",
+        email: "ADA@EXAMPLE.COM",
+        avatar: {
+          effectiveUrl: "https://cdn.example.com/ada.png"
+        }
+      },
+      app: {
+        features: {
+          workspaceInvites: true
+        }
+      },
+      pendingInvites: [
+        { id: "1", workspaceId: "1", token: "a" },
+        { id: "2", workspaceId: "2", token: "b" }
+      ],
+      workspaces: [{ id: "1", slug: "acme", name: "Acme Workspace" }],
+      permissions: ["workspace.settings.view"]
+    },
+    source: "test.bootstrap"
+  });
+
+  const context = placementRuntime.getContext();
   assert.equal(context.workspace?.slug, "acme");
   assert.equal(Array.isArray(context.workspaces), true);
   assert.equal(context.workspaces.length, 1);
   assert.deepEqual(context.permissions, ["workspace.settings.view"]);
   assert.equal(runtime.getWorkspaceBootstrapStatus("acme"), WORKSPACE_BOOTSTRAP_STATUS_RESOLVED);
   assert.equal(context.workspaceBootstrapStatuses?.acme, WORKSPACE_BOOTSTRAP_STATUS_RESOLVED);
-  assert.deepEqual(context.user, {
-    id: "7",
-    displayName: "Ada Lovelace",
-    name: "Ada Lovelace",
-    email: "ada@example.com",
-    avatarUrl: "https://cdn.example.com/ada.png"
-  });
   assert.equal(context.workspaceInvitesEnabled, true);
   assert.equal(context.pendingInvitesCount, 2);
 });
@@ -294,35 +329,39 @@ test("bootstrap placement runtime resolves workspace slug from pathname when sur
   const placementRuntime = createPlacementRuntimeStub();
   placementRuntime.setContext({}, { replace: true, source: "test.clear" });
   const router = createRouterStub("/w/acme/admin");
-  const fetchCalls = [];
   const runtime = createBootstrapPlacementRuntime({
     app: createAppStub({
       ["runtime.web-placement.client"]: placementRuntime,
+      ["runtime.web-bootstrap.client"]: createBootstrapRuntimeStub(),
       ["jskit.client.router"]: router
-    }),
-    fetchBootstrap: async (workspaceSlug) => {
-      fetchCalls.push(workspaceSlug);
-      return {
-        session: {
-          authenticated: true,
-          userId: "1"
-        },
-        profile: {
-          displayName: "User",
-          email: "user@example.com",
-          avatar: {
-            effectiveUrl: ""
-          }
-        },
-        workspaces: [{ id: "1", slug: "acme", name: "Acme Workspace" }],
-        permissions: ["workspace.settings.view"]
-      };
-    }
+    })
   });
 
   await runtime.initialize();
+  const request = runtime.resolveBootstrapRequest();
+  assert.deepEqual(request.query, {
+    workspaceSlug: "acme"
+  });
 
-  assert.deepEqual(fetchCalls, ["acme"]);
+  await runtime.applyBootstrapPayload({
+    request,
+    payload: {
+      session: {
+        authenticated: true,
+        userId: "1"
+      },
+      profile: {
+        displayName: "User",
+        email: "user@example.com",
+        avatar: {
+          effectiveUrl: ""
+        }
+      },
+      workspaces: [{ id: "1", slug: "acme", name: "Acme Workspace" }],
+      permissions: ["workspace.settings.view"]
+    }
+  });
+
   assert.deepEqual(placementRuntime.getContext().permissions, ["workspace.settings.view"]);
 });
 
@@ -342,28 +381,31 @@ test("bootstrap placement runtime does not mutate placement auth context", async
   const runtime = createBootstrapPlacementRuntime({
     app: createAppStub({
       ["runtime.web-placement.client"]: placementRuntime,
+      ["runtime.web-bootstrap.client"]: createBootstrapRuntimeStub(),
       ["jskit.client.router"]: router
-    }),
-    fetchBootstrap: async () => {
-      return {
-        session: {
-          authenticated: true,
-          userId: "9"
-        },
-        profile: {
-          displayName: "User",
-          email: "user@example.com",
-          avatar: {
-            effectiveUrl: ""
-          }
-        },
-        workspaces: [{ id: "1", slug: "acme", name: "Workspace" }],
-        permissions: []
-      };
-    }
+    })
   });
 
   await runtime.initialize();
+  await runtime.applyBootstrapPayload({
+    request: createBootstrapRequest("/w/acme/dashboard", "acme"),
+    payload: {
+      session: {
+        authenticated: true,
+        userId: "9"
+      },
+      profile: {
+        displayName: "User",
+        email: "user@example.com",
+        avatar: {
+          effectiveUrl: ""
+        }
+      },
+      workspaces: [{ id: "1", slug: "acme", name: "Workspace" }],
+      permissions: []
+    }
+  });
+
   assert.deepEqual(placementRuntime.getContext().auth, {
     authenticated: true,
     oauthDefaultProvider: "github",
@@ -371,235 +413,130 @@ test("bootstrap placement runtime does not mutate placement auth context", async
   });
 });
 
-test("bootstrap placement runtime refetches on route changes and users.bootstrap.changed events", async () => {
+test("bootstrap placement runtime delegates route and realtime refreshes to the shared bootstrap runtime", async () => {
   const placementRuntime = createPlacementRuntimeStub();
   const router = createRouterStub("/w/acme/dashboard");
   const socket = createSocketStub();
-  const fetchCalls = [];
+  const bootstrapRuntime = createBootstrapRuntimeStub();
   const runtime = createBootstrapPlacementRuntime({
     app: createAppStub({
       ["runtime.web-placement.client"]: placementRuntime,
+      ["runtime.web-bootstrap.client"]: bootstrapRuntime,
       ["jskit.client.router"]: router,
       ["runtime.realtime.client.socket"]: socket
-    }),
-    fetchBootstrap: async (workspaceSlug) => {
-      fetchCalls.push(workspaceSlug);
-      return {
-        session: {
-          authenticated: true,
-          userId: "1"
-        },
-        profile: {
-          displayName: "User",
-          email: "user@example.com",
-          avatar: {
-            effectiveUrl: ""
-          }
-        },
-        workspaces: [{ id: "1", slug: workspaceSlug || "acme", name: "Workspace" }],
-        permissions: []
-      };
-    }
+    })
   });
 
   await runtime.initialize();
-  assert.deepEqual(fetchCalls, ["acme"]);
+  assert.deepEqual(bootstrapRuntime.calls, []);
 
   router.currentRoute.value.path = "/w/acme/customers";
   router.currentRoute.value.fullPath = "/w/acme/customers";
   router.emitAfterEach();
   await flushTasks();
-  assert.deepEqual(fetchCalls, ["acme"]);
+  assert.deepEqual(bootstrapRuntime.calls, []);
 
   router.currentRoute.value.path = "/w/zen/dashboard";
   router.currentRoute.value.fullPath = "/w/zen/dashboard";
   router.emitAfterEach();
   await flushTasks();
-  assert.deepEqual(fetchCalls, ["acme", "zen"]);
+  assert.deepEqual(bootstrapRuntime.calls, ["route"]);
 
   socket.emit("users.bootstrap.changed", {});
   await flushTasks();
-  assert.deepEqual(fetchCalls, ["acme", "zen", "zen"]);
+  assert.deepEqual(bootstrapRuntime.calls, ["route", "realtime"]);
 });
 
-test("bootstrap placement runtime refetches when auth context changes", async () => {
+test("bootstrap placement runtime applies theme changes from bootstrap payloads", async () => {
   const placementRuntime = createPlacementRuntimeStub();
   const router = createRouterStub("/w/acme/dashboard");
-  const fetchCalls = [];
-  const runtime = createBootstrapPlacementRuntime({
-    app: createAppStub({
-      ["runtime.web-placement.client"]: placementRuntime,
-      ["jskit.client.router"]: router
-    }),
-    fetchBootstrap: async (workspaceSlug) => {
-      fetchCalls.push(workspaceSlug);
-      return {
-        session: {
-          authenticated: true,
-          userId: "1"
-        },
-        profile: {
-          displayName: "User",
-          email: "user@example.com",
-          avatar: {
-            effectiveUrl: ""
-          }
-        },
-        workspaces: [{ id: "1", slug: workspaceSlug || "acme", name: "Workspace" }],
-        permissions: []
-      };
-    }
-  });
-
-  await runtime.initialize();
-  assert.deepEqual(fetchCalls, ["acme"]);
-
-  placementRuntime.setContext(
-    {
-      auth: {
-        authenticated: true,
-        oauthDefaultProvider: "",
-        oauthProviders: []
-      }
-    },
-    {
-      source: "test.auth"
-    }
-  );
-  await flushTasks();
-  await flushTasks();
-  assert.deepEqual(fetchCalls, ["acme", "acme"]);
-});
-
-test("bootstrap placement runtime applies persisted theme preference for unauthenticated bootstrap payloads", async () => {
-  const placementRuntime = createPlacementRuntimeStub();
-  const router = createRouterStub("/auth/login");
-  const themeController = createVuetifyThemeController("dark");
-  const storage = new Map();
-  storage.set("jskit.themePreference", "dark");
-  const originalWindow = globalThis.window;
-  globalThis.window = {
-    localStorage: {
-      getItem(key) {
-        return storage.get(key) || null;
-      },
-      setItem(key, value) {
-        storage.set(key, value);
-      }
-    }
-  };
-  const runtime = createBootstrapPlacementRuntime({
-    app: createAppStub({
-      ["runtime.web-placement.client"]: placementRuntime,
-      ["jskit.client.router"]: router,
-      ["jskit.client.vue.app"]: createVueAppWithThemeController(themeController)
-    }),
-    fetchBootstrap: async () => {
-      return {
-        session: {
-          authenticated: false
-        },
-        workspaces: [],
-        permissions: []
-      };
-    }
-  });
-
-  try {
-    await runtime.initialize();
-    assert.equal(themeController.global.name.value, "dark");
-  } finally {
-    if (typeof originalWindow === "undefined") {
-      delete globalThis.window;
-    } else {
-      globalThis.window = originalWindow;
-    }
-  }
-});
-
-test("bootstrap placement runtime reapplies theme when bootstrap payload changes", async () => {
-  const placementRuntime = createPlacementRuntimeStub();
-  const router = createRouterStub("/w/acme/dashboard");
-  const socket = createSocketStub();
   const themeController = createVuetifyThemeController("light");
-  let fetchCount = 0;
   const runtime = createBootstrapPlacementRuntime({
     app: createAppStub({
       ["runtime.web-placement.client"]: placementRuntime,
+      ["runtime.web-bootstrap.client"]: createBootstrapRuntimeStub(),
       ["jskit.client.router"]: router,
-      ["runtime.realtime.client.socket"]: socket,
       ["jskit.client.vue.app"]: createVueAppWithThemeController(themeController)
-    }),
-    fetchBootstrap: async (workspaceSlug) => {
-      fetchCount += 1;
-      return {
-        session: {
-          authenticated: true,
-          userId: "1"
-        },
-        profile: {
-          displayName: "User",
-          email: "user@example.com",
-          avatar: {
-            effectiveUrl: ""
-          }
-        },
-        userSettings: {
-          theme: fetchCount === 1 ? "dark" : "light"
-        },
-        workspaces: [{ id: "1", slug: workspaceSlug || "acme", name: "Workspace" }],
-        permissions: []
-      };
-    }
+    })
   });
 
   await runtime.initialize();
+  const request = createBootstrapRequest("/w/acme/dashboard", "acme");
+  await runtime.applyBootstrapPayload({
+    request,
+    payload: {
+      session: {
+        authenticated: true,
+        userId: "1"
+      },
+      userSettings: {
+        theme: "dark"
+      },
+      workspaces: [{ id: "1", slug: "acme", name: "Workspace" }],
+      permissions: []
+    }
+  });
   assert.equal(themeController.global.name.value, "workspace-dark");
 
-  socket.emit("users.bootstrap.changed", {});
-  await flushTasks();
+  await runtime.applyBootstrapPayload({
+    request,
+    payload: {
+      session: {
+        authenticated: true,
+        userId: "1"
+      },
+      userSettings: {
+        theme: "light"
+      },
+      workspaces: [{ id: "1", slug: "acme", name: "Workspace" }],
+      permissions: []
+    }
+  });
   assert.equal(themeController.global.name.value, "workspace-light");
 });
 
-test("bootstrap placement runtime applies workspace palette via Vuetify workspace themes and clears it off workspace routes", async () => {
+test("bootstrap placement runtime applies workspace palette and clears it when leaving workspace routes", async () => {
   const placementRuntime = createPlacementRuntimeStub();
   const router = createRouterStub("/w/acme/dashboard");
   const themeController = createVuetifyThemeController("light");
   const runtime = createBootstrapPlacementRuntime({
     app: createAppStub({
       ["runtime.web-placement.client"]: placementRuntime,
+      ["runtime.web-bootstrap.client"]: createBootstrapRuntimeStub(),
       ["jskit.client.router"]: router,
       ["jskit.client.vue.app"]: createVueAppWithThemeController(themeController)
-    }),
-    fetchBootstrap: async (workspaceSlug) => {
-      return {
-        session: {
-          authenticated: true,
-          userId: "1"
-        },
-        workspaceSettings: {
-          lightPrimaryColor: "#CC3344",
-          lightSecondaryColor: "#884455",
-          lightSurfaceColor: "#F4F4F4",
-          lightSurfaceVariantColor: "#444444",
-          darkPrimaryColor: "#BB2233",
-          darkSecondaryColor: "#557799",
-          darkSurfaceColor: "#202020",
-          darkSurfaceVariantColor: "#A0A0A0"
-        },
-        workspaces: [
-          {
-            id: "1",
-            slug: "acme",
-            name: "Acme Workspace"
-          }
-        ],
-        permissions: []
-      };
-    }
+    })
   });
 
   await runtime.initialize();
+  await runtime.applyBootstrapPayload({
+    request: createBootstrapRequest("/w/acme/dashboard", "acme"),
+    payload: {
+      session: {
+        authenticated: true,
+        userId: "1"
+      },
+      workspaceSettings: {
+        lightPrimaryColor: "#CC3344",
+        lightSecondaryColor: "#884455",
+        lightSurfaceColor: "#F4F4F4",
+        lightSurfaceVariantColor: "#444444",
+        darkPrimaryColor: "#BB2233",
+        darkSecondaryColor: "#557799",
+        darkSurfaceColor: "#202020",
+        darkSurfaceVariantColor: "#A0A0A0"
+      },
+      workspaces: [
+        {
+          id: "1",
+          slug: "acme",
+          name: "Acme Workspace"
+        }
+      ],
+      permissions: []
+    }
+  });
+
   const palette = resolveWorkspaceThemePalette({
     lightPrimaryColor: "#CC3344",
     lightSecondaryColor: "#884455",
@@ -621,7 +558,6 @@ test("bootstrap placement runtime applies workspace palette via Vuetify workspac
   router.currentRoute.value.fullPath = "/home";
   router.emitAfterEach();
   await flushTasks();
-  await flushTasks();
 
   assert.equal(themeController.global.name.value, "light");
 });
@@ -632,24 +568,26 @@ test("bootstrap placement runtime marks workspace slug as not_found and clears w
     {
       workspace: { id: "1", slug: "acme", name: "Acme Workspace" },
       workspaces: [{ id: "1", slug: "acme", name: "Acme Workspace" }],
-      permissions: ["workspace.settings.view"]
+      permissions: ["workspace.settings.view"],
+      surfaceAccess: {
+        consoleowner: true
+      }
     },
     { source: "test.seed" }
   );
-
   const runtime = createBootstrapPlacementRuntime({
     app: createAppStub({
       ["runtime.web-placement.client"]: placementRuntime,
+      ["runtime.web-bootstrap.client"]: createBootstrapRuntimeStub(),
       ["jskit.client.router"]: createRouterStub("/w/acme/dashboard")
-    }),
-    fetchBootstrap: async () => {
-      const error = new Error("Workspace not found.");
-      error.status = 404;
-      throw error;
-    }
+    })
   });
 
   await runtime.initialize();
+  await runtime.handleBootstrapError({
+    request: createBootstrapRequest("/w/acme/dashboard", "acme"),
+    error: createErrorWithStatus(404, "Workspace not found.")
+  });
 
   const context = placementRuntime.getContext();
   assert.equal(runtime.getWorkspaceBootstrapStatus("acme"), WORKSPACE_BOOTSTRAP_STATUS_NOT_FOUND);
@@ -657,56 +595,57 @@ test("bootstrap placement runtime marks workspace slug as not_found and clears w
   assert.equal(context.workspace, null);
   assert.deepEqual(context.workspaces, []);
   assert.deepEqual(context.permissions, []);
-  assert.equal(context.user, null);
   assert.equal(context.pendingInvitesCount, 0);
   assert.equal(context.workspaceInvitesEnabled, false);
+  assert.deepEqual(context.surfaceAccess, {
+    consoleowner: true
+  });
 });
 
-test("bootstrap placement runtime updates status per workspace slug across route changes", async () => {
+test("bootstrap placement runtime tracks status per workspace slug across route changes", async () => {
   const placementRuntime = createPlacementRuntimeStub();
   const router = createRouterStub("/w/acme/dashboard");
+  const bootstrapRuntime = createBootstrapRuntimeStub();
   const runtime = createBootstrapPlacementRuntime({
     app: createAppStub({
       ["runtime.web-placement.client"]: placementRuntime,
+      ["runtime.web-bootstrap.client"]: bootstrapRuntime,
       ["jskit.client.router"]: router
-    }),
-    fetchBootstrap: async (workspaceSlug) => {
-      if (workspaceSlug === "zen") {
-        const error = new Error("Workspace not found.");
-        error.status = 404;
-        throw error;
-      }
-
-      return {
-        session: {
-          authenticated: true,
-          userId: "1"
-        },
-        profile: {
-          displayName: "User",
-          email: "user@example.com",
-          avatar: {
-            effectiveUrl: ""
-          }
-        },
-        workspaces: [{ id: "1", slug: workspaceSlug || "acme", name: "Workspace" }],
-        permissions: []
-      };
-    }
+    })
   });
 
   await runtime.initialize();
+  await runtime.applyBootstrapPayload({
+    request: createBootstrapRequest("/w/acme/dashboard", "acme"),
+    payload: {
+      session: {
+        authenticated: true,
+        userId: "1"
+      },
+      workspaces: [{ id: "1", slug: "acme", name: "Workspace" }],
+      permissions: []
+    }
+  });
+
   assert.equal(runtime.getWorkspaceBootstrapStatus("acme"), WORKSPACE_BOOTSTRAP_STATUS_RESOLVED);
 
   router.currentRoute.value.path = "/w/zen/dashboard";
   router.currentRoute.value.fullPath = "/w/zen/dashboard";
   router.emitAfterEach();
   await flushTasks();
+  assert.deepEqual(bootstrapRuntime.calls, ["route"]);
+
+  await runtime.handleBootstrapError({
+    request: createBootstrapRequest("/w/zen", "zen"),
+    error: createErrorWithStatus(404, "Workspace not found.")
+  });
 
   const context = placementRuntime.getContext();
+  assert.equal(runtime.getWorkspaceBootstrapStatus("acme"), WORKSPACE_BOOTSTRAP_STATUS_RESOLVED);
   assert.equal(runtime.getWorkspaceBootstrapStatus("zen"), WORKSPACE_BOOTSTRAP_STATUS_NOT_FOUND);
+  assert.equal(context.workspaceBootstrapStatuses?.acme, WORKSPACE_BOOTSTRAP_STATUS_RESOLVED);
   assert.equal(context.workspaceBootstrapStatuses?.zen, WORKSPACE_BOOTSTRAP_STATUS_NOT_FOUND);
-  assert.equal(context.workspace, null);
+  assert.deepEqual(router.replaceCalls, ["/w/zen"]);
 });
 
 test("bootstrap placement runtime uses requestedWorkspace status and keeps global workspace list on inaccessible slug", async () => {
@@ -715,32 +654,34 @@ test("bootstrap placement runtime uses requestedWorkspace status and keeps globa
   const runtime = createBootstrapPlacementRuntime({
     app: createAppStub({
       ["runtime.web-placement.client"]: placementRuntime,
+      ["runtime.web-bootstrap.client"]: createBootstrapRuntimeStub(),
       ["jskit.client.router"]: router
-    }),
-    fetchBootstrap: async () => {
-      return {
-        session: {
-          authenticated: true,
-          userId: "4"
-        },
-        profile: {
-          displayName: "Chiara",
-          email: "chiara@example.com",
-          avatar: {
-            effectiveUrl: ""
-          }
-        },
-        workspaces: [{ id: "3", slug: "chiaramobily", name: "Chiara Workspace" }],
-        requestedWorkspace: {
-          slug: "tonymobily",
-          status: "forbidden"
-        },
-        permissions: []
-      };
-    }
+    })
   });
 
   await runtime.initialize();
+  await runtime.applyBootstrapPayload({
+    request: createBootstrapRequest("/w/tonymobily", "tonymobily"),
+    payload: {
+      session: {
+        authenticated: true,
+        userId: "4"
+      },
+      profile: {
+        displayName: "Chiara",
+        email: "chiara@example.com",
+        avatar: {
+          effectiveUrl: ""
+        }
+      },
+      workspaces: [{ id: "3", slug: "chiaramobily", name: "Chiara Workspace" }],
+      requestedWorkspace: {
+        slug: "tonymobily",
+        status: "forbidden"
+      },
+      permissions: []
+    }
+  });
 
   const context = placementRuntime.getContext();
   assert.equal(runtime.getWorkspaceBootstrapStatus("tonymobily"), WORKSPACE_BOOTSTRAP_STATUS_FORBIDDEN);
@@ -757,32 +698,34 @@ test("bootstrap placement runtime uses requestedWorkspace=not_found without forc
   const runtime = createBootstrapPlacementRuntime({
     app: createAppStub({
       ["runtime.web-placement.client"]: placementRuntime,
+      ["runtime.web-bootstrap.client"]: createBootstrapRuntimeStub(),
       ["jskit.client.router"]: router
-    }),
-    fetchBootstrap: async () => {
-      return {
-        session: {
-          authenticated: true,
-          userId: "1"
-        },
-        profile: {
-          displayName: "User",
-          email: "user@example.com",
-          avatar: {
-            effectiveUrl: ""
-          }
-        },
-        workspaces: [{ id: "1", slug: "acme", name: "Acme Workspace" }],
-        requestedWorkspace: {
-          slug: "missing",
-          status: "not_found"
-        },
-        permissions: []
-      };
-    }
+    })
   });
 
   await runtime.initialize();
+  await runtime.applyBootstrapPayload({
+    request: createBootstrapRequest("/w/missing", "missing"),
+    payload: {
+      session: {
+        authenticated: true,
+        userId: "1"
+      },
+      profile: {
+        displayName: "User",
+        email: "user@example.com",
+        avatar: {
+          effectiveUrl: ""
+        }
+      },
+      workspaces: [{ id: "1", slug: "acme", name: "Acme Workspace" }],
+      requestedWorkspace: {
+        slug: "missing",
+        status: "not_found"
+      },
+      permissions: []
+    }
+  });
 
   const context = placementRuntime.getContext();
   assert.equal(runtime.getWorkspaceBootstrapStatus("missing"), WORKSPACE_BOOTSTRAP_STATUS_NOT_FOUND);
@@ -805,21 +748,24 @@ test("bootstrap placement runtime guard wrapper preserves delegated deny outcome
   const runtime = createBootstrapPlacementRuntime({
     app: createAppStub({
       ["runtime.web-placement.client"]: placementRuntime,
+      ["runtime.web-bootstrap.client"]: createBootstrapRuntimeStub(),
       ["jskit.client.router"]: router
-    }),
-    fetchBootstrap: async () => {
-      return {
-        session: {
-          authenticated: true,
-          userId: "1"
-        },
-        workspaces: [{ id: "1", slug: "acme", name: "Acme" }],
-        permissions: []
-      };
-    }
+    })
   });
 
   await runtime.initialize();
+  await runtime.applyBootstrapPayload({
+    request: createBootstrapRequest("/w/acme/dashboard", "acme"),
+    payload: {
+      session: {
+        authenticated: true,
+        userId: "1"
+      },
+      workspaces: [{ id: "1", slug: "acme", name: "Acme" }],
+      permissions: []
+    }
+  });
+
   const evaluator = globalThis[SHELL_GUARD_EVALUATOR_KEY];
   const outcome = evaluator({
     guard: {
@@ -840,30 +786,25 @@ test("bootstrap placement runtime guard wrapper preserves delegated deny outcome
   assert.deepEqual(outcome, delegatedOutcome);
 });
 
-test("bootstrap placement runtime guard wrapper blocks forbidden workspace routes", async () => {
+test("bootstrap placement runtime guard wrapper blocks forbidden workspace routes and redirects nested workspace paths", async () => {
   const placementRuntime = createPlacementRuntimeStub();
-  const router = createRouterStub("/w/acme/dashboard");
-  globalThis[SHELL_GUARD_EVALUATOR_KEY] = () => ({ allow: true, redirectTo: "", reason: "" });
-
+  const router = createRouterStub("/w/acme/admin/workspace/settings?tab=general");
   const runtime = createBootstrapPlacementRuntime({
     app: createAppStub({
       ["runtime.web-placement.client"]: placementRuntime,
+      ["runtime.web-bootstrap.client"]: createBootstrapRuntimeStub(),
       ["jskit.client.router"]: router
-    }),
-    fetchBootstrap: async () => {
-      return {
-        session: {
-          authenticated: true,
-          userId: "1"
-        },
-        workspaces: [],
-        permissions: []
-      };
-    }
+    })
   });
 
   await runtime.initialize();
+  await runtime.handleBootstrapError({
+    request: createBootstrapRequest("/w/acme/admin/workspace/settings?tab=general", "acme"),
+    error: createErrorWithStatus(403, "Forbidden")
+  });
+
   assert.equal(runtime.getWorkspaceBootstrapStatus("acme"), WORKSPACE_BOOTSTRAP_STATUS_FORBIDDEN);
+  assert.deepEqual(router.replaceCalls, ["/w/acme/admin"]);
 
   const evaluator = globalThis[SHELL_GUARD_EVALUATOR_KEY];
   const outcome = evaluator({
@@ -889,21 +830,23 @@ test("bootstrap placement runtime guard wrapper blocks forbidden workspace route
 
 test("bootstrap placement runtime guard wrapper redirects nested not_found routes to workspace surface root", async () => {
   const placementRuntime = createPlacementRuntimeStub();
-  const router = createRouterStub("/w/acme/dashboard");
+  const router = createRouterStub("/w/acme/projects");
   const runtime = createBootstrapPlacementRuntime({
     app: createAppStub({
       ["runtime.web-placement.client"]: placementRuntime,
+      ["runtime.web-bootstrap.client"]: createBootstrapRuntimeStub(),
       ["jskit.client.router"]: router
-    }),
-    fetchBootstrap: async () => {
-      const error = new Error("Not found");
-      error.status = 404;
-      throw error;
-    }
+    })
   });
 
   await runtime.initialize();
+  await runtime.handleBootstrapError({
+    request: createBootstrapRequest("/w/acme/projects", "acme"),
+    error: createErrorWithStatus(404, "Not found")
+  });
+
   assert.equal(runtime.getWorkspaceBootstrapStatus("acme"), WORKSPACE_BOOTSTRAP_STATUS_NOT_FOUND);
+  assert.deepEqual(router.replaceCalls, ["/w/acme"]);
 
   const evaluator = globalThis[SHELL_GUARD_EVALUATOR_KEY];
   const nestedOutcome = evaluator({
@@ -951,45 +894,29 @@ test("bootstrap placement runtime redirects admin nested route to admin root whe
   const runtime = createBootstrapPlacementRuntime({
     app: createAppStub({
       ["runtime.web-placement.client"]: placementRuntime,
+      ["runtime.web-bootstrap.client"]: createBootstrapRuntimeStub(),
       ["jskit.client.router"]: router
-    }),
-    fetchBootstrap: async () => {
-      const error = new Error("Not found");
-      error.status = 404;
-      throw error;
-    }
+    })
   });
 
   await runtime.initialize();
+  await runtime.handleBootstrapError({
+    request: createBootstrapRequest("/w/acme/admin/workspace/settings", "acme"),
+    error: createErrorWithStatus(404, "Not found")
+  });
+
   assert.equal(runtime.getWorkspaceBootstrapStatus("acme"), WORKSPACE_BOOTSTRAP_STATUS_NOT_FOUND);
   assert.deepEqual(router.replaceCalls, ["/w/acme/admin"]);
 });
 
-test("bootstrap placement runtime redirects forbidden workspace route to workspace surface root", async () => {
-  const placementRuntime = createPlacementRuntimeStub();
-  const router = createRouterStub("/w/acme/admin/workspace/settings?tab=general");
-  const runtime = createBootstrapPlacementRuntime({
-    app: createAppStub({
-      ["runtime.web-placement.client"]: placementRuntime,
-      ["jskit.client.router"]: router
-    }),
-    fetchBootstrap: async () => {
-      const error = new Error("Forbidden");
-      error.status = 403;
-      throw error;
-    }
-  });
-
-  await runtime.initialize();
-  assert.equal(runtime.getWorkspaceBootstrapStatus("acme"), WORKSPACE_BOOTSTRAP_STATUS_FORBIDDEN);
-  assert.deepEqual(router.replaceCalls, ["/w/acme/admin"]);
-});
-
-test("bootstrap placement runtime enforces surface access policies after bootstrap refresh", async () => {
+test("bootstrap placement runtime enforces surface access policies after bootstrap payloads", async () => {
   const placementRuntime = createPlacementRuntimeStub();
   placementRuntime.setContext({
     auth: {
       authenticated: true
+    },
+    surfaceAccess: {
+      opsowner: false
     },
     surfaceAccessPolicies: {
       public: {},
@@ -1026,70 +953,43 @@ test("bootstrap placement runtime enforces surface access policies after bootstr
   const runtime = createBootstrapPlacementRuntime({
     app: createAppStub({
       ["runtime.web-placement.client"]: placementRuntime,
+      ["runtime.web-bootstrap.client"]: createBootstrapRuntimeStub(),
       ["jskit.client.router"]: router
-    }),
-    fetchBootstrap: async () => {
-      return {
-        session: {
-          authenticated: true,
-          userId: "1"
-        },
-        workspaces: [],
-        permissions: [],
-        surfaceAccess: {
-          opsowner: false
-        }
-      };
-    }
+    })
   });
 
   await runtime.initialize();
+  await runtime.applyBootstrapPayload({
+    request: createBootstrapRequest("/ops"),
+    payload: {
+      session: {
+        authenticated: true,
+        userId: "1"
+      },
+      workspaces: [],
+      permissions: []
+    }
+  });
+
   assert.deepEqual(router.replaceCalls, ["/home"]);
 });
 
-test("bootstrap placement runtime captures guard evaluator assignments after initialization", async () => {
+test("bootstrap placement runtime handles unauthenticated errors and marks workspace status", async () => {
   const placementRuntime = createPlacementRuntimeStub();
-  const router = createRouterStub("/w/acme/dashboard");
   const runtime = createBootstrapPlacementRuntime({
     app: createAppStub({
       ["runtime.web-placement.client"]: placementRuntime,
-      ["jskit.client.router"]: router
-    }),
-    fetchBootstrap: async () => {
-      return {
-        session: {
-          authenticated: true,
-          userId: "1"
-        },
-        workspaces: [{ id: "1", slug: "acme", name: "Acme" }],
-        permissions: []
-      };
-    }
+      ["runtime.web-bootstrap.client"]: createBootstrapRuntimeStub(),
+      ["jskit.client.router"]: createRouterStub("/w/acme/dashboard")
+    })
   });
 
   await runtime.initialize();
-  const delegatedOutcome = {
-    allow: false,
-    redirectTo: "/auth/login",
-    reason: "auth-required"
-  };
-  globalThis[SHELL_GUARD_EVALUATOR_KEY] = () => delegatedOutcome;
-
-  const evaluator = globalThis[SHELL_GUARD_EVALUATOR_KEY];
-  const outcome = evaluator({
-    guard: {
-      policy: "authenticated"
-    },
-    context: {
-      to: {
-        path: "/w/acme/dashboard",
-        fullPath: "/w/acme/dashboard"
-      },
-      location: {
-        pathname: "/w/acme/dashboard",
-        search: ""
-      }
-    }
+  await runtime.handleBootstrapError({
+    request: createBootstrapRequest("/w/acme/dashboard", "acme"),
+    error: createErrorWithStatus(401, "Unauthenticated")
   });
-  assert.deepEqual(outcome, delegatedOutcome);
+
+  assert.equal(runtime.getWorkspaceBootstrapStatus("acme"), WORKSPACE_BOOTSTRAP_STATUS_UNAUTHENTICATED);
+  assert.equal(placementRuntime.getContext().workspace, null);
 });


### PR DESCRIPTION
## Summary
- add the shared shell bootstrap runtime and payload-handler registry for client bootstrap state
- wire auth, users, and workspaces client providers into the shared bootstrap path
- align console bootstrap/owner resolution with the auth decorator path and refresh package contracts/tests

## Verification
- node --test packages/console-core/test/registerConsoleCore.test.js packages/console-core/test/consoleAuthServiceDecorator.test.js packages/console-core/test/consoleService.test.js packages/console-core/test/consoleBootstrapContributor.test.js packages/console-core/test/bootstrapPayloadIntegration.test.js
- node --test packages/users-web/test/exportsContract.test.js packages/users-web/test/bootstrap.test.js
- npm --workspaces --if-present test