### PR TITLE
Avoid eager realtime optional bindings

### DIFF
--- a/packages/realtime/src/server/RealtimeServiceProvider.js
+++ b/packages/realtime/src/server/RealtimeServiceProvider.js
@@ -471,20 +471,29 @@ async function resolveActorWorkspaceIds(workspaceMembershipsRepository, actorId)
     .filter(Boolean);
 }
 
+function resolveOptionalScopeBinding(scope, token = "") {
+  if (!scope || typeof scope.has !== "function" || typeof scope.make !== "function") {
+    return null;
+  }
+
+  const normalizedToken = String(token || "").trim();
+  if (!normalizedToken || scope.has(normalizedToken) !== true) {
+    return null;
+  }
+
+  return scope.make(normalizedToken);
+}
+
 function registerRealtimeSocketAudienceBootstrap(scope, io, logger) {
   if (!io || typeof io.on !== "function") {
     return;
   }
 
-  const authService =
-    scope && typeof scope.has === "function" && scope.has("authService") ? scope.make("authService") : null;
-  const workspaceMembershipsRepository =
-    scope && typeof scope.has === "function" && scope.has("internal.repository.workspace-memberships")
-      ? scope.make("internal.repository.workspace-memberships")
-      : null;
-
   io.on("connection", async (socket) => {
     try {
+      const authService = resolveOptionalScopeBinding(scope, "authService");
+      const workspaceMembershipsRepository = resolveOptionalScopeBinding(scope, "internal.repository.workspace-memberships");
+
       socket.join(REALTIME_ROOM_ALL_CLIENTS);
       logger.debug(
         {

--- a/packages/realtime/test/providerRuntime.test.js
+++ b/packages/realtime/test/providerRuntime.test.js
@@ -125,6 +125,25 @@ test("RealtimeServiceProvider boot starts socket io and shutdown closes it", asy
   await provider.shutdown(app);
 });
 
+test("RealtimeServiceProvider boot does not eagerly resolve optional auth/workspace bindings", async () => {
+  const app = createSingletonApp();
+  app.instance("jskit.fastify", {
+    server: createServer()
+  });
+  app.singleton("authService", () => {
+    throw new Error("authService should not resolve during realtime boot");
+  });
+  app.singleton("internal.repository.workspace-memberships", () => {
+    throw new Error("workspace memberships repository should not resolve during realtime boot");
+  });
+
+  const provider = new RealtimeServiceProvider();
+  provider.register(app);
+
+  await assert.doesNotReject(() => provider.boot(app));
+  await provider.shutdown(app);
+});
+
 test("RealtimeClientProvider registers runtime realtime client api", () => {
   const app = createSingletonApp();
   const provider = new RealtimeClientProvider();


### PR DESCRIPTION
## Summary
- defer optional auth and workspace repository resolution until realtime socket connections are handled
- add coverage proving realtime boot does not eagerly resolve optional bindings

## Verification
- node --test packages/realtime/test/providerRuntime.test.js
- npm --workspaces --if-present test