### PR TITLE
Tighten catalog and descriptor metadata

### DIFF
--- a/packages/assistant-core/package.descriptor.mjs
+++ b/packages/assistant-core/package.descriptor.mjs
@@ -50,7 +50,7 @@ export default Object.freeze({
         "@jskit-ai/users-core": "0.1.65",
         "@tanstack/vue-query": "^5.90.5",
         "dompurify": "^3.3.3",
-        "json-rest-schema": "file:../../../json-rest-schema",
+        "json-rest-schema": "^1.0.13",
         "marked": "^17.0.4",
         "openai": "^6.22.0",
         "vuetify": "^4.0.0"

--- a/packages/assistant-core/test/packageDescriptor.test.js
+++ b/packages/assistant-core/test/packageDescriptor.test.js
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import descriptor from "../package.descriptor.mjs";
+
+test("assistant-core advertises a portable json-rest-schema runtime dependency for app installs", () => {
+  const specifier = String(descriptor?.mutations?.dependencies?.runtime?.["json-rest-schema"] || "");
+
+  assert.match(
+    specifier,
+    /^[~^]?\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/,
+    "assistant-core descriptor must not write a repo-local file: dependency into app package.json"
+  );
+});

--- a/packages/console-web/package.descriptor.mjs
+++ b/packages/console-web/package.descriptor.mjs
@@ -143,7 +143,7 @@ export default Object.freeze({
         position: "bottom",
         skipIfContains: "config.surfaceDefinitions.console = {",
         value:
-          "\nconfig.surfaceDefinitions.console = {\n  id: \"console\",\n  label: \"Console\",\n  pagesRoot: \"console\",\n  enabled: true,\n  requiresAuth: true,\n  requiresWorkspace: false,\n  accessPolicyId: \"console_owner\",\n  icon: \"mdi-console-network-outline\",\n  origin: \"\"\n};\n",
+          "\nconfig.surfaceDefinitions.console = {\n  id: \"console\",\n  label: \"Console\",\n  pagesRoot: \"console\",\n  enabled: true,\n  requiresAuth: true,\n  requiresWorkspace: false,\n  accessPolicyId: \"console_owner\",\n  icon: \"mdi-console-network-outline\",\n  showInSurfaceSwitchMenu: false,\n  origin: \"\"\n};\n",
         reason: "Register console surface definition once console-web is installed.",
         category: "console-web",
         id: "console-web-surface-config-console"

--- a/packages/console-web/test/packageDescriptor.test.js
+++ b/packages/console-web/test/packageDescriptor.test.js
@@ -74,6 +74,7 @@ test("console-web wires console surface policy into app config", () => {
   assert.equal(findTextMutation("console-web-surface-config-console")?.file, "config/public.js");
   assert.match(findTextMutation("console-web-surface-config-console")?.value || "", /accessPolicyId: "console_owner"/);
   assert.match(findTextMutation("console-web-surface-config-console")?.value || "", /icon: "mdi-console-network-outline"/);
+  assert.match(findTextMutation("console-web-surface-config-console")?.value || "", /showInSurfaceSwitchMenu: false/);
   assert.equal(findTextMutation("console-web-profile-menu-console-placement")?.file, "src/placement.js");
   assert.match(findTextMutation("console-web-profile-menu-console-placement")?.value || "", /label: "Go to console"/);
   assert.match(

--- a/packages/workspaces-web/test/profileSurfaceMenuLinks.test.js
+++ b/packages/workspaces-web/test/profileSurfaceMenuLinks.test.js
@@ -206,3 +206,37 @@ test("resolveProfileSurfaceMenuLinks includes gated non-workspace switches only 
   assert.equal(nonOwnerLinks.some((entry) => entry.id === "surface-switch.ops"), false);
   assert.equal(ownerLinks.some((entry) => entry.id === "surface-switch.ops"), true);
 });
+
+test("resolveProfileSurfaceMenuLinks excludes surfaces hidden from the generic switch menu", () => {
+  const context = createPlacementContext({
+    workspace: {
+      id: 1,
+      slug: "acme"
+    },
+    workspaces: [
+      {
+        id: 1,
+        slug: "acme"
+      }
+    ]
+  });
+
+  context.surfaceConfig.enabledSurfaceIds = ["home", "app", "admin", "console"];
+  context.surfaceConfig.surfacesById.console = {
+    id: "console",
+    enabled: true,
+    pagesRoot: "console",
+    routeBase: "/console",
+    requiresAuth: true,
+    requiresWorkspace: false,
+    accessPolicyId: "public",
+    showInSurfaceSwitchMenu: false
+  };
+
+  const links = resolveProfileSurfaceMenuLinks({
+    context,
+    surface: "app"
+  });
+
+  assert.equal(links.some((entry) => entry.id === "surface-switch.console"), false);
+});

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -411,7 +411,7 @@
               "@jskit-ai/users-core": "0.1.65",
               "@tanstack/vue-query": "^5.90.5",
               "dompurify": "^3.3.3",
-              "json-rest-schema": "file:../../../json-rest-schema",
+              "json-rest-schema": "^1.0.13",
               "marked": "^17.0.4",
               "openai": "^6.22.0",
               "vuetify": "^4.0.0"
@@ -1124,6 +1124,7 @@
         "kind": "runtime",
         "description": "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
         "dependsOn": [
+          "@jskit-ai/auth-core",
           "@jskit-ai/database-runtime",
           "@jskit-ai/http-runtime",
           "@jskit-ai/users-core"
@@ -1191,6 +1192,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
+              "@jskit-ai/auth-core": "0.1.54",
               "@jskit-ai/database-runtime": "0.1.55",
               "@jskit-ai/http-runtime": "0.1.54",
               "@jskit-ai/kernel": "0.1.55",
@@ -1273,6 +1275,17 @@
                 }
               ],
               "contributions": [
+                {
+                  "id": "console.web.profile.menu.console",
+                  "target": "auth-profile-menu:primary-menu",
+                  "surfaces": [
+                    "*"
+                  ],
+                  "order": 600,
+                  "componentToken": "auth.web.profile.menu.link-item",
+                  "when": "auth.authenticated === true && surfaceAccess.consoleowner === true && surface !== \"console\"",
+                  "source": "mutations.text#console-web-profile-menu-console-placement"
+                },
                 {
                   "id": "console.web.menu.settings",
                   "target": "shell-layout:primary-menu",
@@ -1359,10 +1372,20 @@
               "file": "config/public.js",
               "position": "bottom",
               "skipIfContains": "config.surfaceDefinitions.console = {",
-              "value": "\nconfig.surfaceDefinitions.console = {\n  id: \"console\",\n  label: \"Console\",\n  pagesRoot: \"console\",\n  enabled: true,\n  requiresAuth: true,\n  requiresWorkspace: false,\n  accessPolicyId: \"console_owner\",\n  icon: \"mdi-console-network-outline\",\n  origin: \"\"\n};\n",
+              "value": "\nconfig.surfaceDefinitions.console = {\n  id: \"console\",\n  label: \"Console\",\n  pagesRoot: \"console\",\n  enabled: true,\n  requiresAuth: true,\n  requiresWorkspace: false,\n  accessPolicyId: \"console_owner\",\n  icon: \"mdi-console-network-outline\",\n  showInSurfaceSwitchMenu: false,\n  origin: \"\"\n};\n",
               "reason": "Register console surface definition once console-web is installed.",
               "category": "console-web",
               "id": "console-web-surface-config-console"
+            },
+            {
+              "op": "append-text",
+              "file": "src/placement.js",
+              "position": "bottom",
+              "skipIfContains": "id: \"console.web.profile.menu.console\"",
+              "value": "\naddPlacement({\n  id: \"console.web.profile.menu.console\",\n  target: \"auth-profile-menu:primary-menu\",\n  surfaces: [\"*\"],\n  order: 600,\n  componentToken: \"auth.web.profile.menu.link-item\",\n  props: {\n    label: \"Go to console\",\n    to: \"/console\",\n    icon: \"mdi-console-network-outline\"\n  },\n  when: ({ auth, surfaceAccess, surface }) => {\n    return auth?.authenticated === true && surfaceAccess?.consoleowner === true && surface !== \"console\";\n  }\n});\n",
+              "reason": "Append owner-only console navigation entry into the authenticated profile menu outside the console surface.",
+              "category": "console-web",
+              "id": "console-web-profile-menu-console-placement"
             },
             {
               "op": "append-text",
@@ -2851,12 +2874,17 @@
               {
                 "subpath": "./client/error",
                 "summary": "Exports default error policy and runtime error reporter hook."
+              },
+              {
+                "subpath": "./client/bootstrap",
+                "summary": "Exports the shared client bootstrap handler registry used to extend /api/bootstrap handling."
               }
             ],
             "containerTokens": {
               "server": [],
               "client": [
                 "runtime.web-placement.client",
+                "runtime.web-bootstrap.client",
                 "runtime.web-error.client",
                 "runtime.web-error.presentation-store.client",
                 "shell.web.query-client"


### PR DESCRIPTION
## Summary
- switch assistant-core package metadata from a local json-rest-schema file path to the published portable version
- hide console from the generic surface switch menu and add explicit owner-only console profile menu placement metadata
- refresh catalog metadata and add matching descriptor/menu tests

## Verification
- node --test packages/console-web/test/packageDescriptor.test.js packages/workspaces-web/test/profileSurfaceMenuLinks.test.js packages/assistant-core/test/packageDescriptor.test.js
- npm --workspaces --if-present test