### PR TITLE
Tighten assistant and workspace input helpers

### DIFF
--- a/packages/assistant-runtime/src/server/registerRoutes.js
+++ b/packages/assistant-runtime/src/server/registerRoutes.js
@@ -140,6 +140,22 @@ function resolveRouteRequestState(
   });
 }
 
+function buildChatStreamActionInput(routeInput = {}, requestBody = {}) {
+  const actionInput = {
+    ...routeInput,
+    messageId: requestBody.messageId,
+    input: requestBody.input
+  };
+
+  for (const key of ["conversationId", "history", "clientContext"]) {
+    if (Object.prototype.hasOwnProperty.call(requestBody, key)) {
+      actionInput[key] = requestBody[key];
+    }
+  }
+
+  return actionInput;
+}
+
 function registerSettingsRoutes(
   router,
   resolveCurrentAppConfig,
@@ -338,14 +354,7 @@ function registerRuntimeRoutes(
           context: {
             surface: routeState.hostSurfaceId
           },
-          input: {
-            ...routeState.actionInput,
-            messageId: requestBody.messageId,
-            conversationId: requestBody.conversationId,
-            input: requestBody.input,
-            history: requestBody.history,
-            clientContext: requestBody.clientContext
-          },
+          input: buildChatStreamActionInput(routeState.actionInput, requestBody),
           deps: {
             streamWriter,
             abortSignal: abortController.signal

--- a/packages/assistant-runtime/test/lazyAppConfig.test.js
+++ b/packages/assistant-runtime/test/lazyAppConfig.test.js
@@ -156,6 +156,7 @@ test("registerRoutes resolves appConfig lazily when handlers run", async () => {
 
 test("registerRoutes returns clear AppError payload for pre-stream assistant failures", async () => {
   let currentAppConfig = null;
+  let capturedInput = null;
   const workspaceScopeSupport = createWorkspaceServerScopeSupport();
   const testApp = createAssistantTestApp({
     workspaceScopeSupport,
@@ -210,7 +211,8 @@ test("registerRoutes returns clear AppError payload for pre-stream assistant fai
           history: []
         }
       },
-      executeAction: async () => {
+      executeAction: async ({ input }) => {
+        capturedInput = input;
         throw new AppError(503, "Assistant provider is not configured.");
       }
     },
@@ -221,6 +223,13 @@ test("registerRoutes returns clear AppError payload for pre-stream assistant fai
   assert.deepEqual(reply.payload, {
     error: "Assistant provider is not configured.",
     code: "APP_ERROR"
+  });
+  assert.deepEqual(capturedInput, {
+    targetSurfaceId: "admin",
+    workspaceSlug: "dogandgroom",
+    messageId: "msg_1",
+    input: "hello",
+    history: []
   });
 });
 

--- a/packages/workspaces-web/src/client/support/workspaceScopeSupport.js
+++ b/packages/workspaces-web/src/client/support/workspaceScopeSupport.js
@@ -1,3 +1,4 @@
+import { unref } from "vue";
 import { getClientAppConfig } from "@jskit-ai/kernel/client";
 import { normalizeText } from "@jskit-ai/kernel/shared/support/normalize";
 import {
@@ -6,18 +7,10 @@ import {
 
 const WORKSPACES_WEB_SCOPE_SUPPORT_INJECTION_KEY = "jskit.workspaces.web.scope-support";
 
-function unwrapRefValue(value) {
-  if (value && typeof value === "object" && Object.hasOwn(value, "value")) {
-    return value.value;
-  }
-
-  return value;
-}
-
 function readWorkspaceRouteScope(routeContext = {}) {
-  const placementContext = unwrapRefValue(routeContext?.placementContext);
-  const currentSurfaceId = normalizeText(unwrapRefValue(routeContext?.currentSurfaceId)).toLowerCase();
-  const routePath = normalizeText(unwrapRefValue(routeContext?.routePath));
+  const placementContext = unref(routeContext?.placementContext);
+  const currentSurfaceId = normalizeText(unref(routeContext?.currentSurfaceId)).toLowerCase();
+  const routePath = normalizeText(unref(routeContext?.routePath));
   const workspaceSlug = extractWorkspaceSlugFromSurfacePathname(
     placementContext,
     currentSurfaceId,

--- a/packages/workspaces-web/test/workspaceScopeSupport.test.js
+++ b/packages/workspaces-web/test/workspaceScopeSupport.test.js
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { computed, ref } from "vue";
 import {
   createWorkspaceScopeSupport,
   readWorkspaceRouteScope
@@ -7,31 +8,25 @@ import {
 
 test("readWorkspaceRouteScope extracts workspace slug from the current dynamic surface path", () => {
   const scope = readWorkspaceRouteScope({
-    placementContext: {
-      value: {
-        surfaceConfig: {
-          defaultSurfaceId: "app",
-          surfacesById: {
-            app: {
-              id: "app",
-              routeBase: "w/[workspaceSlug]",
-              requiresWorkspace: true
-            },
-            admin: {
-              id: "admin",
-              routeBase: "w/[workspaceSlug]/admin",
-              requiresWorkspace: true
-            }
+    placementContext: ref({
+      surfaceConfig: {
+        defaultSurfaceId: "app",
+        surfacesById: {
+          app: {
+            id: "app",
+            routeBase: "w/[workspaceSlug]",
+            requiresWorkspace: true
+          },
+          admin: {
+            id: "admin",
+            routeBase: "w/[workspaceSlug]/admin",
+            requiresWorkspace: true
           }
         }
       }
-    },
-    currentSurfaceId: {
-      value: "admin"
-    },
-    routePath: {
-      value: "/w/acme/admin/settings"
-    }
+    }),
+    currentSurfaceId: computed(() => "admin"),
+    routePath: computed(() => "/w/acme/admin/settings")
   });
 
   assert.deepEqual(scope, {
@@ -46,26 +41,20 @@ test("workspace scope support exposes the shared route-scope reader", () => {
   assert.equal(typeof support.readRouteScope, "function");
   assert.deepEqual(
     support.readRouteScope({
-      placementContext: {
-        value: {
-          surfaceConfig: {
-            defaultSurfaceId: "app",
-            surfacesById: {
-              app: {
-                id: "app",
-                routeBase: "w/[workspaceSlug]",
-                requiresWorkspace: true
-              }
+      placementContext: ref({
+        surfaceConfig: {
+          defaultSurfaceId: "app",
+          surfacesById: {
+            app: {
+              id: "app",
+              routeBase: "w/[workspaceSlug]",
+              requiresWorkspace: true
             }
           }
         }
-      },
-      currentSurfaceId: {
-        value: "app"
-      },
-      routePath: {
-        value: "/w/dogandgroom"
-      }
+      }),
+      currentSurfaceId: computed(() => "app"),
+      routePath: computed(() => "/w/dogandgroom")
     }),
     {
       workspaceSlug: "dogandgroom"


### PR DESCRIPTION
## Summary
- make assistant stream action input composition explicit and preserve optional request-body fields only when present
- switch workspace scope support to Vue-native unref handling and update tests to use real refs/computed values

## Verification
- node --test packages/assistant-runtime/test/lazyAppConfig.test.js packages/workspaces-web/test/workspaceScopeSupport.test.js
- npm --workspaces --if-present test