### PR TITLE
Tighten CRUD generator validator imports

### DIFF
--- a/packages/crud-server-generator/src/shared/crud/crudResource.js
+++ b/packages/crud-server-generator/src/shared/crud/crudResource.js
@@ -1,5 +1,5 @@
-import { createSchema } from "json-rest-schema";
 import {
+  createSchema,
   createCursorListValidator,
   RECORD_ID_PATTERN
 } from "@jskit-ai/kernel/shared/validators";

--- a/packages/crud-server-generator/templates/src/local-package/shared/crudResource.js
+++ b/packages/crud-server-generator/templates/src/local-package/shared/crudResource.js
@@ -1,5 +1,5 @@
-import { createSchema } from "json-rest-schema";
 import {
+  createSchema,
   createCursorListValidator,
   RECORD_ID_PATTERN
 } from "@jskit-ai/kernel/shared/validators";

--- a/packages/crud-server-generator/test/templateSymbolConsistency.test.js
+++ b/packages/crud-server-generator/test/templateSymbolConsistency.test.js
@@ -38,3 +38,19 @@ test("shared index template re-exports standardized resource symbol", async () =
     /export\s*\{\s*\$\{option:namespace\|singular\|camel\}Resource\s*\}/s
   );
 });
+
+test("shared resource template uses kernel createSchema export", async () => {
+  const sharedResourceTemplate = await readFile(
+    resolveTemplatePath("src/local-package/shared/crudResource.js"),
+    "utf8"
+  );
+
+  assert.match(
+    sharedResourceTemplate,
+    /import\s*\{\s*createSchema,\s*createCursorListValidator,\s*RECORD_ID_PATTERN\s*\}\s*from\s*"@jskit-ai\/kernel\/shared\/validators";/s
+  );
+  assert.doesNotMatch(
+    sharedResourceTemplate,
+    /from\s*"json-rest-schema";/
+  );
+});

--- a/packages/crud-ui-generator/src/server/resourceSupport.js
+++ b/packages/crud-ui-generator/src/server/resourceSupport.js
@@ -18,6 +18,7 @@ import { normalizeSurfaceId } from "@jskit-ai/kernel/shared/surface/registry";
 import { normalizeText } from "@jskit-ai/kernel/shared/support/normalize";
 
 const JS_IDENTIFIER_PATTERN = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+const JSON_REST_TRANSPORT_EXTENSION_KEY = "x-json-rest-schema";
 
 function requireOption(options, optionName, { context = "ui-generator" } = {}) {
   const value = normalizeText(options?.[optionName]);
@@ -320,6 +321,11 @@ function resolveObjectSchema(
   return source;
 }
 
+function resolveJsonRestCastType(schema = {}) {
+  const source = schema && typeof schema === "object" && !Array.isArray(schema) ? schema : {};
+  return normalizeText(source?.[JSON_REST_TRANSPORT_EXTENSION_KEY]?.castType).toLowerCase();
+}
+
 function resolveSchemaType(schema) {
   const source = resolveUnionSchemaVariant(schema);
   const rawType = source?.type;
@@ -337,10 +343,21 @@ function resolveSchemaType(schema) {
   const hasNullableType = Array.isArray(rawType)
     ? rawType.some((entry) => normalizeText(entry).toLowerCase() === "null")
     : false;
+  const castType = resolveJsonRestCastType(source) || resolveJsonRestCastType(schema);
+  let format = normalizeText(source?.format).toLowerCase();
+  if (!format) {
+    if (castType === "date") {
+      format = "date";
+    } else if (castType === "datetime") {
+      format = "date-time";
+    } else if (castType === "time") {
+      format = "time";
+    }
+  }
 
   return {
     type: schemaType,
-    format: normalizeText(source.format).toLowerCase(),
+    format,
     schema: source,
     nullable: hasNullableAnyOf || hasNullableOneOf || hasNullableType
   };

--- a/packages/crud-ui-generator/test/buildTemplateContext.test.js
+++ b/packages/crud-ui-generator/test/buildTemplateContext.test.js
@@ -348,6 +348,71 @@ const resource = {
 export { resource };
 `;
 
+const TEMPORAL_RESOURCE_SOURCE = `import { createSchema } from "json-rest-schema";
+
+const recordSchema = createSchema({
+  id: { type: "integer", required: true },
+  dob: { type: "date", required: true, nullable: true },
+  appointmentAt: { type: "dateTime", required: true, nullable: true },
+  preferredTime: { type: "time", required: true, nullable: true }
+});
+
+const bodySchema = createSchema({
+  dob: { type: "date", nullable: true },
+  appointmentAt: { type: "dateTime", nullable: true },
+  preferredTime: { type: "time", nullable: true }
+});
+
+const recordListSchema = createSchema({
+  items: {
+    type: "array",
+    required: true,
+    items: recordSchema
+  },
+  nextCursor: { type: "string", nullable: true }
+});
+
+const resource = {
+  namespace: "appointments",
+  operations: {
+    list: {
+      output: {
+        schema: recordListSchema,
+        mode: "replace"
+      }
+    },
+    view: {
+      output: {
+        schema: recordSchema,
+        mode: "replace"
+      }
+    },
+    create: {
+      body: {
+        schema: bodySchema,
+        mode: "create"
+      },
+      output: {
+        schema: recordSchema,
+        mode: "replace"
+      }
+    },
+    patch: {
+      body: {
+        schema: bodySchema,
+        mode: "patch"
+      },
+      output: {
+        schema: recordSchema,
+        mode: "replace"
+      }
+    }
+  }
+};
+
+export { resource };
+`;
+
 function createOptions(overrides = {}) {
   return {
     "target-root": "admin/customers",
@@ -525,6 +590,24 @@ test("buildUiTemplateContext escapes select option bindings safely for Vue attri
       context.__JSKIT_UI_CREATE_FORM_COLUMNS__,
       /:items="\[\{&quot;value&quot;:&quot;dryer&quot;,&quot;label&quot;:&quot;Dryer&quot;\},\{&quot;value&quot;:&quot;pallet racking&quot;,&quot;label&quot;:&quot;Pallet Racking&quot;\},\{&quot;value&quot;:&quot;freezer&quot;,&quot;label&quot;:&quot;Freezer&quot;\},\{&quot;value&quot;:&quot;coolroom&quot;,&quot;label&quot;:&quot;Coolroom&quot;\}\]"/
     );
+  });
+});
+
+test("buildUiTemplateContext maps json-rest temporal cast types to date-aware form inputs", async () => {
+  await withTempApp(async (appRoot) => {
+    await writeResource(appRoot, RESOURCE_FILE, TEMPORAL_RESOURCE_SOURCE);
+
+    const context = await buildUiTemplateContext({
+      appRoot,
+      options: createOptions()
+    });
+
+    assert.match(context.__JSKIT_UI_CREATE_FORM_FIELDS__, /"key":"dob"[\s\S]*"inputType":"date"/);
+    assert.match(context.__JSKIT_UI_CREATE_FORM_FIELDS__, /"key":"appointmentAt"[\s\S]*"inputType":"datetime-local"/);
+    assert.match(context.__JSKIT_UI_CREATE_FORM_FIELDS__, /"key":"preferredTime"[\s\S]*"inputType":"time"/);
+    assert.match(context.__JSKIT_UI_CREATE_FORM_COLUMNS__, /formState\.dob[\s\S]*type="date"/);
+    assert.match(context.__JSKIT_UI_CREATE_FORM_COLUMNS__, /formState\.appointmentAt[\s\S]*type="datetime-local"/);
+    assert.match(context.__JSKIT_UI_CREATE_FORM_COLUMNS__, /formState\.preferredTime[\s\S]*type="time"/);
   });
 });
 

--- a/packages/kernel/shared/validators/index.js
+++ b/packages/kernel/shared/validators/index.js
@@ -1,3 +1,4 @@
+export { createSchema } from "json-rest-schema";
 export { normalizeObjectInput } from "./inputNormalization.js";
 export { composeSchemaDefinitions } from "./composeSchemaDefinitions.js";
 export { createCursorListValidator } from "./createCursorListValidator.js";


### PR DESCRIPTION
## Summary
- re-export  from kernel shared validators so generated CRUD resources use the canonical shared validator surface
- teach CRUD UI generation to recover temporal input types from json-rest transport cast metadata
- add template and build-context coverage for the new contracts

## Verification
- node --test packages/crud-server-generator/test/templateSymbolConsistency.test.js packages/crud-ui-generator/test/buildTemplateContext.test.js
- npm --workspaces --if-present test