### PR TITLE
Use portable semver for runtime deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3644,11 +3644,11 @@
       }
     },
     "../json-rest-api": {
-      "version": "1.0.23",
+      "version": "1.0.24",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "hooked-api": "^1.0.24",
-        "json-rest-schema": "^1.0.13",
+        "json-rest-schema": "^1.0.14",
         "semver": "^7.7.2"
       },
       "devDependencies": {
@@ -9008,7 +9008,7 @@
       }
     },
     "../json-rest-schema": {
-      "version": "1.0.13",
+      "version": "1.0.14",
       "license": "GPL-3.0-only",
       "dependencies": {
         "flatted": "^3.3.3"
@@ -19806,7 +19806,7 @@
         "@jskit-ai/users-core": "0.1.65",
         "@tanstack/vue-query": "^5.90.5",
         "dompurify": "^3.3.3",
-        "json-rest-schema": "file:../../../json-rest-schema",
+        "json-rest-schema": "1.x.x",
         "marked": "^17.0.4",
         "openai": "^6.22.0",
         "vuetify": "^4.0.0"
@@ -19883,7 +19883,7 @@
         "@jskit-ai/users-core": "0.1.65",
         "@jskit-ai/users-web": "0.1.70",
         "@tanstack/vue-query": "^5.90.5",
-        "json-rest-schema": "file:../../../json-rest-schema",
+        "json-rest-schema": "1.x.x",
         "vuetify": "^4.0.0"
       }
     },
@@ -20182,15 +20182,15 @@
       "version": "0.1.0",
       "dependencies": {
         "@jskit-ai/kernel": "0.1.55",
-        "hooked-api": "file:../../../hooked-api",
-        "json-rest-api": "file:../../../json-rest-api"
+        "hooked-api": "1.x.x",
+        "json-rest-api": "1.x.x"
       }
     },
     "packages/kernel": {
       "name": "@jskit-ai/kernel",
       "version": "0.1.55",
       "dependencies": {
-        "json-rest-schema": "file:../../../json-rest-schema"
+        "json-rest-schema": "1.x.x"
       }
     },
     "packages/realtime": {
@@ -20329,7 +20329,7 @@
         "@jskit-ai/resource-core": "0.1.0",
         "@jskit-ai/resource-crud-core": "0.1.0",
         "@jskit-ai/uploads-runtime": "0.1.33",
-        "json-rest-schema": "file:../../../json-rest-schema"
+        "json-rest-schema": "1.x.x"
       }
     },
     "packages/users-web": {
@@ -20418,7 +20418,7 @@
         "@jskit-ai/resource-core": "0.1.0",
         "@jskit-ai/resource-crud-core": "0.1.0",
         "@jskit-ai/users-core": "0.1.65",
-        "json-rest-schema": "file:../../../json-rest-schema"
+        "json-rest-schema": "1.x.x"
       }
     },
     "packages/workspaces-web": {

--- a/packages/assistant-core/package.descriptor.mjs
+++ b/packages/assistant-core/package.descriptor.mjs
@@ -54,7 +54,7 @@ export default Object.freeze({
         "@jskit-ai/users-core": "0.1.65",
         "@tanstack/vue-query": "^5.90.5",
         "dompurify": "^3.3.3",
-        "json-rest-schema": "^1.0.13",
+        "json-rest-schema": "1.x.x",
         "marked": "^17.0.4",
         "openai": "^6.22.0",
         "vuetify": "^4.0.0"

--- a/packages/assistant-core/package.json
+++ b/packages/assistant-core/package.json
@@ -19,7 +19,7 @@
     "@jskit-ai/users-core": "0.1.65",
     "@tanstack/vue-query": "^5.90.5",
     "dompurify": "^3.3.3",
-    "json-rest-schema": "file:../../../json-rest-schema",
+    "json-rest-schema": "1.x.x",
     "marked": "^17.0.4",
     "openai": "^6.22.0",
     "vuetify": "^4.0.0"

--- a/packages/assistant-core/test/packageDescriptor.test.js
+++ b/packages/assistant-core/test/packageDescriptor.test.js
@@ -7,7 +7,7 @@ test("assistant-core advertises a portable json-rest-schema runtime dependency f
 
   assert.match(
     specifier,
-    /^[~^]?\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/,
+    /^(?:[~^]?\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?|\d+\.x\.x)$/,
     "assistant-core descriptor must not write a repo-local file: dependency into app package.json"
   );
 });

--- a/packages/assistant-runtime/package.json
+++ b/packages/assistant-runtime/package.json
@@ -15,7 +15,7 @@
     "@jskit-ai/shell-web": "0.1.54",
     "@jskit-ai/users-core": "0.1.65",
     "@jskit-ai/users-web": "0.1.70",
-    "json-rest-schema": "file:../../../json-rest-schema",
+    "json-rest-schema": "1.x.x",
     "@tanstack/vue-query": "^5.90.5",
     "vuetify": "^4.0.0"
   }

--- a/packages/json-rest-api-core/package.json
+++ b/packages/json-rest-api-core/package.json
@@ -9,8 +9,8 @@
     "./server/jsonRestApiHost": "./src/server/jsonRestApiHost.js"
   },
   "dependencies": {
-    "hooked-api": "file:../../../hooked-api",
-    "json-rest-api": "file:../../../json-rest-api",
+    "hooked-api": "1.x.x",
+    "json-rest-api": "1.x.x",
     "@jskit-ai/kernel": "0.1.55"
   }
 }

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.55",
   "type": "module",
   "dependencies": {
-    "json-rest-schema": "file:../../../json-rest-schema"
+    "json-rest-schema": "1.x.x"
   },
   "scripts": {
     "test": "node --test"

--- a/packages/users-core/package.json
+++ b/packages/users-core/package.json
@@ -19,6 +19,6 @@
     "@jskit-ai/resource-crud-core": "0.1.0",
     "@jskit-ai/resource-core": "0.1.0",
     "@jskit-ai/uploads-runtime": "0.1.33",
-    "json-rest-schema": "file:../../../json-rest-schema"
+    "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/workspaces-core/package.json
+++ b/packages/workspaces-core/package.json
@@ -25,6 +25,6 @@
     "@jskit-ai/resource-crud-core": "0.1.0",
     "@jskit-ai/resource-core": "0.1.0",
     "@jskit-ai/users-core": "0.1.65",
-    "json-rest-schema": "file:../../../json-rest-schema"
+    "json-rest-schema": "1.x.x"
   }
 }

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -415,7 +415,7 @@
               "@jskit-ai/users-core": "0.1.65",
               "@tanstack/vue-query": "^5.90.5",
               "dompurify": "^3.3.3",
-              "json-rest-schema": "^1.0.13",
+              "json-rest-schema": "1.x.x",
               "marked": "^17.0.4",
               "openai": "^6.22.0",
               "vuetify": "^4.0.0"


### PR DESCRIPTION
## Summary
- replace repo-local `file:` specs for `json-rest-api`, `json-rest-schema`, and `hooked-api` with portable `1.x.x` ranges
- align assistant descriptor metadata and its portability test with the new published dependency shape
- refresh lockfile and catalog output so generated metadata matches the manifests

## Verification
- `npm pack` on affected packages and inspect packed `package.json`
- `node --test packages/assistant-core/test/packageDescriptor.test.js`
- `npm run verify:local`
