### PR TITLE
Refine runtime wiring and settings scaffolds

### DIFF
--- a/packages/agent-docs/guide/agent/app-setup/users.md
+++ b/packages/agent-docs/guide/agent/app-setup/users.md
@@ -212,13 +212,17 @@ The account route itself is very small:
 <template>
   <AccountSettingsClientElement />
 </template>
+
+<script setup>
+import AccountSettingsClientElement from "@jskit-ai/users-web/client/components/AccountSettingsClientElement";
+</script>
 ```
 
 That is a very JSKIT-style file.
 
 - the route policy is app-owned
 - the page wrapper is app-owned
-- the heavy UI is delegated to a reusable client element
+- the heavy UI is delegated to a package-owned reusable client element
 
 So the route is simple, but it is already a real authenticated account screen rather than a placeholder card.
 
@@ -228,18 +232,21 @@ The account page is backed by:
 
 ```text
 src/components/account/settings/
-  AccountSettingsClientElement.vue
   AccountSettingsProfileSection.vue
   AccountSettingsPreferencesSection.vue
   AccountSettingsNotificationsSection.vue
 ```
 
-The top-level `AccountSettingsClientElement.vue` uses `useAccountSettingsRuntime()` from `users-web` and wires those sections into a tabbed settings experience.
+Those three section components stay app-owned so you can reshape the actual UI freely.
+
+The host itself now lives in `users-web` and resolves every account section through the `account-settings:sections` placement target, including the default `profile`, `preferences`, and `notifications` entries.
+
+So the screen follows the same rule as the rest of JSKIT UI: sections are added by placement rather than being hardcoded into an app-owned host component.
 
 That is worth noticing because the guide has now reached a new level of scaffolding:
 
 - earlier chapters mostly introduced shells and routes
-- this chapter introduces real app-owned feature UI that is already split into reusable sections
+- this chapter introduces app-owned leaf section UI while the generic section host stays in the package
 
 ## Under the hood
 

--- a/packages/agent-docs/reference/autogen/packages/auth-provider-supabase-core.md
+++ b/packages/agent-docs/reference/autogen/packages/auth-provider-supabase-core.md
@@ -244,6 +244,7 @@ Local functions
 - `resolveCommonDependencies(scope)`
 - `resolveRuntimeEnv(scope)`
 - `resolveOptionalRepositories(scope)`
+- `isDeferredJsonRestBootGap(app, error)`
 - `applyAuthServiceDecorators(scope, authService)`
 
 ### root

--- a/packages/agent-docs/reference/autogen/packages/crud-server-generator.md
+++ b/packages/agent-docs/reference/autogen/packages/crud-server-generator.md
@@ -132,6 +132,7 @@ Local functions
 - `requireVariableDeclarator(programNode, variableName = "", context = "crud-server-generator scaffold-field")`
 - `requireCrudResourceConfigObject(programNode, context = "crud-server-generator scaffold-field")`
 - `requireResourceSchemaObject(programNode, context = "crud-server-generator scaffold-field")`
+- `assertNoExplicitCrudSchemaOverrides(resourceObject, context = "crud-server-generator scaffold-field")`
 - `findObjectPropertyByName(objectNode, propertyName = "")`
 - `hasObjectProperty(objectNode, propertyName = "")`
 - `insertObjectProperty(objectNode, propertyName = "", valueExpressionSource = "", { context = "crud-server-generator scaffold-field", insertBeforeComputed = false } = {})`

--- a/packages/agent-docs/reference/autogen/packages/json-rest-api-core.md
+++ b/packages/agent-docs/reference/autogen/packages/json-rest-api-core.md
@@ -24,7 +24,7 @@ Exports
 - `JSON_REST_AUTOFILTER_PRESETS`
 - `addResourceIfMissing(api, scopeName, resourceConfig)`
 - `buildJsonRestQueryParams(resourceType = "", query = {}, { include = undefined } = {})`
-- `createJsonApiInputRecord(resourceType = "", attributes = {}, { id = null, relationships = null } = {})`
+- `createJsonApiInputRecord(resourceType = "", attributes = {}, { id = null, relationships = null, resource = null } = {})`
 - `createJsonApiRelationship(resourceType = "", id = null)`
 - `createJsonRestResourceScopeOptions(resource = {}, { writeSerializers = {}, normalizeId = null } = {})`
 - `createJsonRestContext(context = null)`
@@ -42,6 +42,7 @@ Local functions
 - `normalizeJsonRestText(value, { fallback = "" } = {})`
 - `normalizeJsonRestObject(value)`
 - `normalizeJsonRestList(value)`
+- `extractJsonApiInputRelationships(attributes = {}, resource = null, relationships = null)`
 - `normalizeJsonApiResourceObject(resource = {})`
 - `buildJsonApiIncludedIndex(payload = {})`
 - `simplifyJsonApiRelationshipData(data, { includedIndex = null, seen = null } = {})`

--- a/packages/agent-docs/reference/autogen/packages/kernel.md
+++ b/packages/agent-docs/reference/autogen/packages/kernel.md
@@ -878,6 +878,7 @@ Exports
 - `registerRoutes(fastify, { routes = [], app = null, applyRoutePolicy = defaultApplyRoutePolicy, missingHandler = defaultMissingHandler, enableRequestScope = true, requestScopeProperty = "scope", requestActionExecutorProperty = "executeAction", actionExecutorToken = "actionExecutor", requestActionDefaultChannel = "api", requestActionDefaultSurface = "", requestScopeIdPrefix = "http", requestIdResolver = null, middleware = {} } = {})`
 Local functions
 - `toFastifyRouteOptions(route)`
+- `shouldStripFastifyBodySchema(route = null, schema = null)`
 - `normalizeHeaderValue(value)`
 - `normalizeMediaType(value = "")`
 - `routeDefinesRequestBody(route = null)`

--- a/packages/agent-docs/reference/autogen/packages/users-web.md
+++ b/packages/agent-docs/reference/autogen/packages/users-web.md
@@ -18,7 +18,6 @@ Use this on demand; do not load the full index at startup.
 Exports
 - `ACCOUNT_SETTINGS_SECTION_TARGET`
 - `EMPTY_ACCOUNT_SETTINGS_SECTIONS`
-- `RESERVED_ACCOUNT_SETTINGS_SECTION_VALUES`
 - `normalizeAccountSettingsSectionEntry(entry = null)`
 - `resolveAccountSettingsSections(entries = [])`
 - `sortAccountSettingsSections(entries = [])`
@@ -28,6 +27,13 @@ Exports
 Exports
 - `createUsersBootstrapUserHandler()`
 - `registerUsersBootstrapPayloadHandlers(app)`
+
+### `src/client/components/AccountSettingsClientElement.vue`
+Exports
+- None
+Local functions
+- `normalizeSection(value)`
+- `readRouteSection()`
 
 ### `src/client/components/ProfileClientElement.vue`
 Exports
@@ -433,6 +439,7 @@ Exports
 ### `src/client/index.js`
 Exports
 - `UsersWebClientProvider`
+- `AccountSettingsClientElement`
 - `clientProviders`
 
 ### `src/client/lib/bootstrap.js`
@@ -485,13 +492,6 @@ Exports
 - `HOME_COG_OUTLET`
 
 ### templates
-
-### `templates/src/components/account/settings/AccountSettingsClientElement.vue`
-Exports
-- None
-Local functions
-- `normalizeSection(value)`
-- `readRouteSection()`
 
 ### `templates/src/components/account/settings/AccountSettingsNotificationsSection.vue`
 Exports

--- a/packages/agent-docs/reference/autogen/packages/workspaces-web.md
+++ b/packages/agent-docs/reference/autogen/packages/workspaces-web.md
@@ -333,7 +333,6 @@ Local functions
 - `normalizePendingInvitesCount(value)`
 - `resolveReturnTo()`
 - `resolveReturnToHref()`
-- `countPendingInvites(entries = [])`
 
 ### `templates/packages/main/src/client/components/AccountSettingsInvitesSection.vue`
 Exports

--- a/packages/agent-docs/reference/autogen/tooling/jskit-cli.md
+++ b/packages/agent-docs/reference/autogen/tooling/jskit-cli.md
@@ -368,6 +368,8 @@ Local functions
 ### `src/server/commandHandlers/appCommands/linkLocalPackages.js`
 Exports
 - `runAppLinkLocalPackagesCommand(ctx = {}, { appRoot = "", options = {}, stdout })`
+Local functions
+- `maybeLinkCompanionPackages({ appRoot = "", repoRoot = "", stdout })`
 
 ### `src/server/commandHandlers/appCommands/release.js`
 Exports

--- a/packages/agent-docs/site/guide/app-setup/users.md
+++ b/packages/agent-docs/site/guide/app-setup/users.md
@@ -259,13 +259,17 @@ The account route itself is very small:
 <template>
   <AccountSettingsClientElement />
 </template>
+
+<script setup>
+import AccountSettingsClientElement from "@jskit-ai/users-web/client/components/AccountSettingsClientElement";
+</script>
 ```
 
 That is a very JSKIT-style file.
 
 - the route policy is app-owned
 - the page wrapper is app-owned
-- the heavy UI is delegated to a reusable client element
+- the heavy UI is delegated to a package-owned reusable client element
 
 So the route is simple, but it is already a real authenticated account screen rather than a placeholder card.
 
@@ -275,18 +279,21 @@ The account page is backed by:
 
 ```text
 src/components/account/settings/
-  AccountSettingsClientElement.vue
   AccountSettingsProfileSection.vue
   AccountSettingsPreferencesSection.vue
   AccountSettingsNotificationsSection.vue
 ```
 
-The top-level `AccountSettingsClientElement.vue` uses `useAccountSettingsRuntime()` from `users-web` and wires those sections into a tabbed settings experience.
+Those three section components stay app-owned so you can reshape the actual UI freely.
+
+The host itself now lives in `users-web` and resolves every account section through the `account-settings:sections` placement target, including the default `profile`, `preferences`, and `notifications` entries.
+
+So the screen follows the same rule as the rest of JSKIT UI: sections are added by placement rather than being hardcoded into an app-owned host component.
 
 That is worth noticing because the guide has now reached a new level of scaffolding:
 
 - earlier chapters mostly introduced shells and routes
-- this chapter introduces real app-owned feature UI that is already split into reusable sections
+- this chapter introduces app-owned leaf section UI while the generic section host stays in the package
 
 ## Under the hood
 

--- a/packages/auth-provider-supabase-core/src/server/providers/AuthSupabaseServiceProvider.js
+++ b/packages/auth-provider-supabase-core/src/server/providers/AuthSupabaseServiceProvider.js
@@ -9,6 +9,7 @@ import { buildAuthActions } from "../lib/actions/auth.contributor.js";
 const AUTH_PROFILE_MODE_STANDALONE = "standalone";
 const AUTH_PROFILE_MODE_USERS = "users";
 const SUPPORTED_AUTH_PROFILE_MODES = Object.freeze([AUTH_PROFILE_MODE_STANDALONE, AUTH_PROFILE_MODE_USERS]);
+const INTERNAL_JSON_REST_API = "internal.json-rest-api";
 
 function splitCsv(value) {
   return String(value || "")
@@ -186,6 +187,21 @@ function resolveOptionalRepositories(scope) {
   return repositories;
 }
 
+function isDeferredJsonRestBootGap(app, error) {
+  const hasUserProfilesRepository = typeof app?.has === "function" && app.has("internal.repository.user-profiles");
+  const hasJsonRestApi = typeof app?.has === "function" && app.has(INTERNAL_JSON_REST_API);
+  const message = String(error?.message || "");
+  const causeMessage = String(error?.cause?.message || "");
+  const combined = `${message}\n${causeMessage}`;
+
+  return (
+    hasUserProfilesRepository &&
+    !hasJsonRestApi &&
+    /internal\.json-rest-api/.test(combined) &&
+    /not registered/i.test(combined)
+  );
+}
+
 function applyAuthServiceDecorators(scope, authService) {
   let decoratedAuthService = authService;
 
@@ -315,7 +331,18 @@ class AuthSupabaseServiceProvider {
       return;
     }
 
-    app.make("authService");
+    try {
+      app.make("authService");
+    } catch (error) {
+      // In users mode, repo bindings can exist after register() while the json-rest host
+      // token is still unavailable until json-rest-api.core.boot(). Defer eager authService
+      // materialization only for that exact lifecycle gap; every other configuration error
+      // should still fail fast during boot.
+      if (isDeferredJsonRestBootGap(app, error)) {
+        return;
+      }
+      throw error;
+    }
   }
 }
 

--- a/packages/auth-provider-supabase-core/test/providerRuntime.test.js
+++ b/packages/auth-provider-supabase-core/test/providerRuntime.test.js
@@ -3,6 +3,7 @@ import test from "node:test";
 import { createApplication } from "@jskit-ai/kernel/_testable";
 import { registerAuthServiceDecorator } from "@jskit-ai/auth-core/server/authServiceDecoratorRegistry";
 import { ActionRuntimeServiceProvider } from "@jskit-ai/kernel/server/actions";
+import { createProviderClass } from "../../kernel/shared/runtime/application.js";
 import { AuthSupabaseServiceProvider } from "../src/server/providers/AuthSupabaseServiceProvider.js";
 
 function createAppConfigFixture() {
@@ -403,6 +404,81 @@ test("auth supabase provider rejects dev auth bypass without internal.repository
       }),
     (error) => isBootFailureWithCause(error, /requires internal\.repository\.user-profiles with findById\(\) and findByEmail\(\)/)
   );
+});
+
+test("auth supabase provider defers eager dev auth materialization until json-rest host is available", async () => {
+  const DeferredUserProfilesRepositoryProvider = createProviderClass({
+    id: "aaa.deferred-user-profiles-repository",
+    register(app) {
+      app.singleton("internal.repository.user-profiles", (scope) => {
+        const api = scope.make("internal.json-rest-api");
+
+        return {
+          api,
+          async findById() {
+            return null;
+          },
+          async findByEmail() {
+            return null;
+          }
+        };
+      });
+    }
+  });
+
+  const DeferredJsonRestApiProvider = createProviderClass({
+    id: "json-rest-api.core",
+    boot(app) {
+      app.instance("internal.json-rest-api", {
+        scopes: new Map()
+      });
+    }
+  });
+
+  const app = createApplication();
+  app.instance("appConfig", createAppConfigFixture());
+  app.instance("jskit.env", {
+    AUTH_DEV_BYPASS_ENABLED: "true",
+    AUTH_DEV_BYPASS_SECRET: "dev-bootstrap-secret",
+    AUTH_PROFILE_MODE: "users",
+    APP_PUBLIC_URL: "http://localhost:5173",
+    NODE_ENV: "development"
+  });
+  app.instance("jskit.logger", {
+    info() {},
+    warn() {},
+    error() {},
+    debug() {}
+  });
+  app.instance("domainEvents", {
+    async publish() {}
+  });
+  app.instance("users.profile.sync.service", {
+    async findByIdentity() {
+      return null;
+    },
+    async syncIdentityProfile(profile) {
+      return {
+        id: 1,
+        authProvider: String(profile?.authProvider || "supabase"),
+        authProviderUserSid: String(profile?.authProviderUserSid || "user-1"),
+        email: String(profile?.email || "test@example.com"),
+        displayName: String(profile?.displayName || "Test User")
+      };
+    }
+  });
+
+  await app.start({
+    providers: [
+      ActionRuntimeServiceProvider,
+      DeferredUserProfilesRepositoryProvider,
+      AuthSupabaseServiceProvider,
+      DeferredJsonRestApiProvider
+    ]
+  });
+
+  const authService = app.make("authService");
+  assert.equal(typeof authService?.devLoginAs, "function");
 });
 
 test("auth supabase provider reads oauth providers from appConfig.auth.oauth", async () => {

--- a/packages/crud-core/src/server/repositorySupport.js
+++ b/packages/crud-core/src/server/repositorySupport.js
@@ -341,6 +341,10 @@ function mapRecordRow(row, fieldKeys = [], overrides = {}, { recordIdKeys = [] }
     }
 
     const rawValue = row[columnName];
+    if (rawValue === undefined) {
+      continue;
+    }
+
     if (recordIdKeySet.has(normalizedKey)) {
       const normalizedIdValue = normalizeDbRecordId(rawValue, { fallback: null });
       mapped[normalizedKey] = normalizedIdValue || rawValue;

--- a/packages/crud-core/test/repositorySupport.test.js
+++ b/packages/crud-core/test/repositorySupport.test.js
@@ -126,6 +126,18 @@ test("mapRecordRow remaps rows by key/column pairs", () => {
   });
 });
 
+test("mapRecordRow omits keys whose source column is absent", () => {
+  const row = { some_column: 1 };
+  const mapped = mapRecordRow(row, ["someKey", "virtualField"], {
+    someKey: "some_column",
+    virtualField: "virtual_field"
+  });
+
+  assert.deepEqual(mapped, {
+    someKey: 1
+  });
+});
+
 test("buildWritePayload respects defined keys", () => {
   const payload = buildWritePayload(
     { foo: "bar", missing: true },

--- a/packages/crud-server-generator/templates/src/local-package/server/repository.js
+++ b/packages/crud-server-generator/templates/src/local-package/server/repository.js
@@ -41,7 +41,9 @@ function createRepository({ api, knex } = {}) {
   async function createDocument(payload = {}, options = {}) {
     return api.resources.${option:namespace|camel}.post(
       {
-        inputRecord: createJsonApiInputRecord(RESOURCE_TYPE, payload),
+        inputRecord: createJsonApiInputRecord(RESOURCE_TYPE, payload, {
+          resource
+        }),
         transaction: options?.trx || null,
         simplified: false
       },
@@ -64,6 +66,9 @@ function createRepository({ api, knex } = {}) {
             {
               ...sourcePatch,
               updatedAt: new Date()
+            },
+            {
+              resource
             }
           ),
           transaction: options?.trx || null,

--- a/packages/crud-ui-generator/package.descriptor.mjs
+++ b/packages/crud-ui-generator/package.descriptor.mjs
@@ -353,7 +353,7 @@ export default Object.freeze({
         position: "bottom",
         skipIfContains: "__JSKIT_UI_MENU_MARKER__",
         value:
-          "\n// __JSKIT_UI_MENU_MARKER__\n{\n  addPlacement({\n    id: \"__JSKIT_UI_MENU_PLACEMENT_ID__\",\n    target: \"__JSKIT_UI_MENU_PLACEMENT_TARGET__\",\n    surfaces: [\"__JSKIT_UI_SURFACE_ID__\"],\n    order: 155,\n    componentToken: \"__JSKIT_UI_MENU_COMPONENT_TOKEN__\",\n    props: {\n      label: \"__JSKIT_UI_MENU_LABEL__\",\n      surface: \"__JSKIT_UI_SURFACE_ID__\",\n      scopedSuffix: \"__JSKIT_UI_MENU_WORKSPACE_SUFFIX__\",\n      unscopedSuffix: \"__JSKIT_UI_MENU_NON_WORKSPACE_SUFFIX__\",\n__JSKIT_UI_MENU_TO_PROP_LINE__    },\n__JSKIT_UI_MENU_WHEN_LINE__  });\n}\n",
+          "\n// __JSKIT_UI_MENU_MARKER__\n{\n  addPlacement({\n    id: \"__JSKIT_UI_MENU_PLACEMENT_ID__\",\n    target: \"__JSKIT_UI_MENU_PLACEMENT_TARGET__\",\n    surfaces: [\"__JSKIT_UI_SURFACE_ID__\"],\n    order: 155,\n    componentToken: \"__JSKIT_UI_MENU_COMPONENT_TOKEN__\",\n    props: {\n      label: \"__JSKIT_UI_MENU_LABEL__\",\n      icon: \"__JSKIT_UI_MENU_ICON__\",\n      surface: \"__JSKIT_UI_SURFACE_ID__\",\n      scopedSuffix: \"__JSKIT_UI_MENU_WORKSPACE_SUFFIX__\",\n      unscopedSuffix: \"__JSKIT_UI_MENU_NON_WORKSPACE_SUFFIX__\",\n__JSKIT_UI_MENU_TO_PROP_LINE__    },\n__JSKIT_UI_MENU_WHEN_LINE__  });\n}\n",
         reason: "Append generated CRUD list-page placement.",
         category: "crud-ui-generator",
         id: "crud-ui-placement-menu",

--- a/packages/crud-ui-generator/src/server/buildTemplateContext.js
+++ b/packages/crud-ui-generator/src/server/buildTemplateContext.js
@@ -59,6 +59,7 @@ const DEFAULT_OPERATIONS = normalizeText(descriptor?.options?.operations?.defaul
 const DEFAULT_LIST_HIDDEN_FIELD_KEYS = new Set(["createdAt", "updatedAt"]);
 const DEFAULT_FORM_COMPONENT_FILE = "CrudAddEditForm.vue";
 const DEFAULT_FORM_FIELDS_FILE = "CrudAddEditFormFields.js";
+const DEFAULT_GENERATED_LINK_ICON = "mdi-view-list-outline";
 
 function splitTextIntoWords(value = "") {
   const normalized = String(value || "")
@@ -659,6 +660,7 @@ async function buildUiTemplateContext({ appRoot, options } = {}) {
     __JSKIT_UI_MENU_PLACEMENT_ID__: String(pageLinkTarget?.pageTarget?.placementId || ""),
     __JSKIT_UI_MENU_PLACEMENT_TARGET__: String(pageLinkTarget?.placementTarget?.id || ""),
     __JSKIT_UI_MENU_COMPONENT_TOKEN__: String(pageLinkTarget?.componentToken || ""),
+    __JSKIT_UI_MENU_ICON__: DEFAULT_GENERATED_LINK_ICON,
     __JSKIT_UI_MENU_WORKSPACE_SUFFIX__: String(pageLinkTarget?.pageTarget?.routeUrlSuffix || ""),
     __JSKIT_UI_MENU_NON_WORKSPACE_SUFFIX__: String(pageLinkTarget?.pageTarget?.routeUrlSuffix || ""),
     __JSKIT_UI_MENU_WHEN_LINE__: String(pageLinkTarget?.whenLine || ""),

--- a/packages/crud-ui-generator/test/buildTemplateContext.test.js
+++ b/packages/crud-ui-generator/test/buildTemplateContext.test.js
@@ -628,7 +628,8 @@ test("buildUiTemplateContext infers tab placement and relative link-to from the 
     });
 
     assert.equal(context.__JSKIT_UI_MENU_PLACEMENT_TARGET__, "catalog:sub-pages");
-    assert.equal(context.__JSKIT_UI_MENU_COMPONENT_TOKEN__, "local.main.ui.tab-link-item");
+    assert.equal(context.__JSKIT_UI_MENU_COMPONENT_TOKEN__, "local.main.ui.surface-aware-menu-link-item");
+    assert.equal(context.__JSKIT_UI_MENU_ICON__, "mdi-view-list-outline");
     assert.equal(context.__JSKIT_UI_MENU_TO_PROP_LINE__, "      to: \"./products\",\n");
     assert.equal(context.__JSKIT_UI_MENU_WORKSPACE_SUFFIX__, "/catalog/products");
   });

--- a/packages/crud-ui-generator/test/packageDescriptor.test.js
+++ b/packages/crud-ui-generator/test/packageDescriptor.test.js
@@ -12,3 +12,10 @@ test("crud-ui-generator operations option exposes structured csv-enum metadata",
   assert.equal(descriptor.options?.operations?.defaultValue, "list,view,new,edit");
   assert.equal(descriptor.metadata?.generatorSubcommands?.crud?.optionNames?.includes("operations"), true);
 });
+
+test("crud-ui-generator placement scaffold includes an explicit stock icon prop", () => {
+  const placementMutation = descriptor?.mutations?.text?.find(
+    (entry) => String(entry?.id || "").trim() === "crud-ui-placement-menu"
+  );
+  assert.match(String(placementMutation?.value || ""), /icon: "__JSKIT_UI_MENU_ICON__"/);
+});

--- a/packages/json-rest-api-core/src/server/jsonRestApiHost.js
+++ b/packages/json-rest-api-core/src/server/jsonRestApiHost.js
@@ -63,6 +63,9 @@ function cloneJsonRestResourceValue(value, { writeSerializers = {} } = {}) {
 
   if (isPlainJsonRestObject(next.storage)) {
     const serializerKey = normalizeJsonRestText(next.storage.writeSerializer).toLowerCase();
+    if (next.storage.virtual === true) {
+      next.virtual = true;
+    }
     if (serializerKey) {
       const serializer = writeSerializers[serializerKey];
       if (typeof serializer !== "function") {
@@ -195,16 +198,68 @@ function buildJsonRestQueryParams(resourceType = "", query = {}, { include = und
   return queryParams;
 }
 
-function createJsonApiInputRecord(resourceType = "", attributes = {}, { id = null, relationships = null } = {}) {
-  const normalizedRelationships = normalizeJsonRestObject(relationships);
+function extractJsonApiInputRelationships(attributes = {}, resource = null, relationships = null) {
+  const normalizedAttributes = {
+    ...normalizeJsonRestObject(attributes)
+  };
+  const normalizedRelationships = {
+    ...normalizeJsonRestObject(relationships)
+  };
+  const resourceSchema = normalizeJsonRestObject(resource?.schema);
+
+  for (const [fieldName, fieldDefinition] of Object.entries(resourceSchema)) {
+    if (!Object.hasOwn(normalizedAttributes, fieldName)) {
+      continue;
+    }
+
+    const normalizedFieldDefinition = normalizeJsonRestObject(fieldDefinition);
+    const relationshipType = normalizeJsonRestText(normalizedFieldDefinition.belongsTo);
+    if (!relationshipType) {
+      continue;
+    }
+
+    const relationshipName = normalizeJsonRestText(normalizedFieldDefinition.as, {
+      fallback: fieldName
+    });
+    if (!relationshipName) {
+      continue;
+    }
+
+    const relationshipValue = normalizedAttributes[fieldName];
+    delete normalizedAttributes[fieldName];
+
+    if (relationshipValue === undefined) {
+      continue;
+    }
+
+    if (!Object.hasOwn(normalizedRelationships, relationshipName)) {
+      normalizedRelationships[relationshipName] = createJsonApiRelationship(
+        relationshipType,
+        relationshipValue
+      );
+    }
+  }
+
+  return {
+    attributes: normalizedAttributes,
+    relationships: normalizedRelationships
+  };
+}
+
+function createJsonApiInputRecord(
+  resourceType = "",
+  attributes = {},
+  { id = null, relationships = null, resource = null } = {}
+) {
+  const normalizedInput = extractJsonApiInputRelationships(attributes, resource, relationships);
   return {
     data: {
       type: normalizeJsonRestText(resourceType),
       ...(id == null ? {} : { id: String(id) }),
-      attributes: {
-        ...normalizeJsonRestObject(attributes)
-      },
-      ...(Object.keys(normalizedRelationships).length < 1 ? {} : { relationships: normalizedRelationships })
+      attributes: normalizedInput.attributes,
+      ...(Object.keys(normalizedInput.relationships).length < 1
+        ? {}
+        : { relationships: normalizedInput.relationships })
     }
   };
 }

--- a/packages/json-rest-api-core/test/entrypoints.boundary.test.js
+++ b/packages/json-rest-api-core/test/entrypoints.boundary.test.js
@@ -166,6 +166,42 @@ test("shared query/document helpers build json-rest-api request shapes", () => {
   );
 
   assert.deepEqual(
+    createJsonApiInputRecord("products", {
+      serviceId: "9",
+      name: "Style Groom"
+    }, {
+      resource: {
+        schema: {
+          serviceId: {
+            type: "id",
+            belongsTo: "services",
+            as: "service"
+          },
+          name: {
+            type: "string"
+          }
+        }
+      }
+    }),
+    {
+      data: {
+        type: "products",
+        attributes: {
+          name: "Style Groom"
+        },
+        relationships: {
+          service: {
+            data: {
+              type: "services",
+              id: "9"
+            }
+          }
+        }
+      }
+    }
+  );
+
+  assert.deepEqual(
     simplifyJsonApiDocument({
       data: [
         {
@@ -237,6 +273,17 @@ test("createJsonRestResourceScopeOptions clones canonical resource metadata and 
             required: true
           })
         })
+      }),
+      bookingSteps: Object.freeze({
+        type: "array",
+        storage: Object.freeze({
+          virtual: true
+        }),
+        operations: Object.freeze({
+          output: Object.freeze({
+            required: false
+          })
+        })
       })
     }),
     operations: Object.freeze({
@@ -259,6 +306,7 @@ test("createJsonRestResourceScopeOptions clones canonical resource metadata and 
   assert.equal(result.schema.createdAt.storage.column, "created_at");
   assert.equal(result.schema.createdAt.storage.serialize, serializer);
   assert.equal(result.schema.createdAt.storage.writeSerializer, undefined);
+  assert.equal(result.schema.bookingSteps.virtual, true);
   assert.equal(result.normalizeId, normalizeId);
   assert.equal(result.schema.name.maxLength, 190);
   assert.equal(result.schema.name.operations.output.required, true);

--- a/packages/kernel/server/http/lib/kernel.test.js
+++ b/packages/kernel/server/http/lib/kernel.test.js
@@ -760,6 +760,51 @@ test("registerRoutes attaches request.input when route input transforms are conf
   assert.equal(reply.statusCode, 200);
 });
 
+test("registerRoutes strips Fastify body schemas when JSKIT runtime body validation is present", () => {
+  const fastify = createFastifyStub();
+
+  registerRoutes(fastify, {
+    routes: [
+      {
+        method: "POST",
+        path: "/body-schema-runtime-validation",
+        schema: {
+          body: {
+            type: "object",
+            properties: {
+              flag: {
+                anyOf: [{ type: "boolean" }, { type: "null" }]
+              }
+            }
+          },
+          querystring: {
+            type: "object",
+            properties: {
+              limit: { type: "integer" }
+            }
+          }
+        },
+        input: {
+          body: (body) => ({
+            flag: body?.flag ?? null
+          })
+        },
+        handler: async (_request, reply) => {
+          reply.code(200).send({ ok: true });
+        }
+      }
+    ]
+  });
+
+  assert.equal(Object.prototype.hasOwnProperty.call(fastify.routes[0].schema, "body"), false);
+  assert.deepEqual(fastify.routes[0].schema.querystring, {
+    type: "object",
+    properties: {
+      limit: { type: "integer" }
+    }
+  });
+});
+
 test("registerRoutes applies transport request transforms before route input normalization", async () => {
   const fastify = createFastifyStub();
 

--- a/packages/kernel/server/http/lib/routeRegistration.js
+++ b/packages/kernel/server/http/lib/routeRegistration.js
@@ -17,6 +17,9 @@ const JSON_API_CONTENT_TYPE = "application/vnd.api+json";
 function toFastifyRouteOptions(route) {
   const sourceRoute = normalizeObject(route);
   const schema = cloneRouteSchema(sourceRoute.schema);
+  if (shouldStripFastifyBodySchema(sourceRoute, schema)) {
+    delete schema.body;
+  }
   const existingConfig = normalizeObject(sourceRoute.config);
   const transportKind = normalizeText(sourceRoute?.transport?.kind).toLowerCase();
   const existingTransportConfig =
@@ -46,6 +49,18 @@ function toFastifyRouteOptions(route) {
         : {})
     }
   };
+}
+
+function shouldStripFastifyBodySchema(route = null, schema = null) {
+  if (!route || !schema || typeof schema !== "object" || Array.isArray(schema)) {
+    return false;
+  }
+
+  if (!Object.prototype.hasOwnProperty.call(schema, "body")) {
+    return false;
+  }
+
+  return typeof route?.input?.body === "function";
 }
 
 function normalizeHeaderValue(value) {

--- a/packages/kernel/server/support/pageTargets.js
+++ b/packages/kernel/server/support/pageTargets.js
@@ -19,9 +19,11 @@ import { resolveRequiredAppRoot, toPosixPath } from "./path.js";
 import { loadAppConfigFromModuleUrl } from "./appConfigFiles.js";
 
 const DEFAULT_PAGE_LINK_COMPONENT_TOKEN = "local.main.ui.surface-aware-menu-link-item";
-const DEFAULT_SUBPAGE_LINK_COMPONENT_TOKEN = "local.main.ui.tab-link-item";
+const DEFAULT_SUBPAGE_LINK_COMPONENT_TOKEN = "local.main.ui.surface-aware-menu-link-item";
 const PAGE_ROOT_PREFIX = "src/pages/";
 const ROUTER_VIEW_TAG_PATTERN = /<RouterView\b/i;
+const SECTION_CONTAINER_SHELL_TAG_PATTERN = /<SectionContainerShell\b/i;
+const TABS_SLOT_PATTERN = /<template\b[^>]*(?:#tabs|v-slot:tabs)\b[^>]*>([\s\S]*?)<\/template>/i;
 
 function normalizeRelativeFilePath(value = "") {
   return String(value || "")
@@ -430,7 +432,6 @@ function resolveSubpagesHostTargetFromPageSource(source = "") {
   if (!ROUTER_VIEW_TAG_PATTERN.test(sourceText)) {
     return null;
   }
-
   const discoveredTargets = discoverShellOutletTargetsFromVueSource(sourceText, {
     context: "subpages host"
   });
@@ -444,8 +445,25 @@ function resolveSubpagesHostTargetFromPageSource(source = "") {
     return null;
   }
 
+  let isSectionSubpagesHost = false;
+  if (SECTION_CONTAINER_SHELL_TAG_PATTERN.test(sourceText)) {
+    const tabsSlotMatch = TABS_SLOT_PATTERN.exec(sourceText);
+    if (tabsSlotMatch) {
+      const tabsTargets = discoverShellOutletTargetsFromVueSource(String(tabsSlotMatch[1] || ""), {
+        context: "subpages host tabs slot"
+      });
+      const tabTargetIds = Array.isArray(tabsTargets.targets)
+        ? tabsTargets.targets.map((entry) => normalizeShellOutletTargetId(entry?.id)).filter(Boolean)
+        : [];
+      if (tabTargetIds.length === 1 && tabTargetIds[0] === normalizeShellOutletTargetId(target.id)) {
+        isSectionSubpagesHost = true;
+      }
+    }
+  }
+
   return Object.freeze({
-    id: target.id
+    id: target.id,
+    isSectionSubpagesHost
   });
 }
 
@@ -594,16 +612,11 @@ function resolveInferredPageLinkTo({
   const parentTargetId = normalizePlacementTargetId(parentHost);
   const placementTargetId = normalizePlacementTargetId(placementTarget);
   if (parentTargetId && parentTargetId === placementTargetId) {
-    const inferredLinkTo = resolveRelativeLinkToFromParent(pageTarget, parentHost);
-    if (inferredLinkTo) {
-      return inferredLinkTo;
-    }
-  }
-
-  if (normalizeText(parentHost?.pageShape) === "index") {
-    const inferredLinkTo = resolveRelativeLinkToFromParent(pageTarget, parentHost);
-    if (inferredLinkTo) {
-      return inferredLinkTo;
+    if (parentHost?.isSectionSubpagesHost === true) {
+      const inferredLinkTo = resolveRelativeLinkToFromParent(pageTarget, parentHost);
+      if (inferredLinkTo) {
+        return inferredLinkTo;
+      }
     }
   }
 
@@ -633,7 +646,11 @@ function resolveInferredPageLinkComponentToken({
 
   const parentTargetId = normalizePlacementTargetId(parentHost);
   const placementTargetId = normalizePlacementTargetId(placementTarget);
-  if (parentTargetId && parentTargetId === placementTargetId) {
+  if (
+    parentHost?.isSectionSubpagesHost === true &&
+    parentTargetId &&
+    parentTargetId === placementTargetId
+  ) {
     return normalizeText(subpageComponentToken) || DEFAULT_SUBPAGE_LINK_COMPONENT_TOKEN;
   }
 
@@ -681,6 +698,12 @@ async function resolvePageLinkTargetDetails({
     defaultComponentToken,
     subpageComponentToken
   });
+  const parentTargetId = normalizePlacementTargetId(parentHost);
+  const placementTargetId = normalizePlacementTargetId(placementTarget);
+  const preservesRelativeSubpageLinks =
+    parentHost?.isSectionSubpagesHost === true &&
+    Boolean(parentTargetId) &&
+    parentTargetId === placementTargetId;
 
   return Object.freeze({
     pageTarget: resolvedPageTarget,
@@ -693,7 +716,9 @@ async function resolvePageLinkTargetDetails({
       pageTarget: resolvedPageTarget,
       parentHost,
       placementTarget,
-      suppressImplicitRelativeLinks: resolvedComponentToken === (normalizeText(defaultComponentToken) || DEFAULT_PAGE_LINK_COMPONENT_TOKEN)
+      suppressImplicitRelativeLinks:
+        resolvedComponentToken === (normalizeText(defaultComponentToken) || DEFAULT_PAGE_LINK_COMPONENT_TOKEN) &&
+        preservesRelativeSubpageLinks !== true
     })
   });
 }

--- a/packages/kernel/server/support/pageTargets.test.js
+++ b/packages/kernel/server/support/pageTargets.test.js
@@ -354,7 +354,7 @@ test("resolvePageLinkTargetDetails inherits a file-route parent subpages host", 
 
     assert.equal(details.parentHost?.id, "contact-view:sub-pages");
     assert.equal(details.placementTarget.id, "contact-view:sub-pages");
-    assert.equal(details.componentToken, "local.main.ui.tab-link-item");
+    assert.equal(details.componentToken, "local.main.ui.surface-aware-menu-link-item");
     assert.equal(details.linkTo, "./notes");
   });
 });
@@ -422,7 +422,7 @@ test("resolvePageLinkTargetDetails inherits an index-route parent subpages host 
     assert.equal(details.parentHost?.id, "customer-view:sub-pages");
     assert.equal(details.parentHost?.pageFile, "src/pages/admin/customers/[customerId]/index.vue");
     assert.equal(details.placementTarget.id, "customer-view:sub-pages");
-    assert.equal(details.componentToken, "local.main.ui.tab-link-item");
+    assert.equal(details.componentToken, "local.main.ui.surface-aware-menu-link-item");
     assert.equal(details.linkTo, "./pets");
   });
 });

--- a/packages/shell-web/src/client/components/ShellTabLinkItem.vue
+++ b/packages/shell-web/src/client/components/ShellTabLinkItem.vue
@@ -7,6 +7,7 @@ import {
   resolveSurfaceNavigationTargetFromPlacementContext,
   useWebPlacementContext
 } from "../placement/index.js";
+import { resolveMenuLinkIcon } from "../lib/menuIcons.js";
 import {
   normalizeMenuLinkPathname,
   resolveMenuLinkTarget
@@ -18,6 +19,10 @@ const props = defineProps({
     default: ""
   },
   to: {
+    type: String,
+    default: ""
+  },
+  icon: {
     type: String,
     default: ""
   },
@@ -88,6 +93,14 @@ const resolvedTarget = computed(() => {
   };
 });
 
+const resolvedIcon = computed(() =>
+  resolveMenuLinkIcon({
+    icon: props.icon,
+    label: props.label,
+    to: resolvedTarget.value.href || resolvedTo.value
+  })
+);
+
 const isActive = computed(() => {
   if (!resolvedTarget.value.sameOrigin) {
     return false;
@@ -111,6 +124,7 @@ const isActive = computed(() => {
     size="small"
     :to="resolvedTarget.sameOrigin ? resolvedTarget.href : undefined"
     :href="resolvedTarget.sameOrigin ? undefined : resolvedTarget.href"
+    :prepend-icon="resolvedIcon || undefined"
     :active="isActive"
     :disabled="disabled"
     color="primary"

--- a/packages/shell-web/templates/src/components/menus/TabLinkItem.vue
+++ b/packages/shell-web/templates/src/components/menus/TabLinkItem.vue
@@ -10,6 +10,10 @@ const props = defineProps({
     type: String,
     default: ""
   },
+  icon: {
+    type: String,
+    default: ""
+  },
   surface: {
     type: String,
     default: ""

--- a/packages/shell-web/test/linkItemScaffoldContract.test.js
+++ b/packages/shell-web/test/linkItemScaffoldContract.test.js
@@ -71,6 +71,7 @@ test("shell-web scaffolds app-owned local link-item wrappers under src/component
   assert.match(tabWrapperSource, /@jskit-ai\/shell-web\/client\/components\/ShellTabLinkItem/);
   assert.match(menuWrapperSource, /exact:\s*\{/);
   assert.match(surfaceAwareWrapperSource, /exact:\s*\{/);
+  assert.match(tabWrapperSource, /icon:\s*\{/);
 
   assert.deepEqual(findFileMutation("shell-web-component-menu-link-item"), {
     from: "templates/src/components/menus/MenuLinkItem.vue",
@@ -129,7 +130,7 @@ test("shell-web scaffolds app-owned local link-item wrappers under src/component
   assert.equal(await readLocalLinkItemComponentSource("local.main.ui.tab-link-item"), tabWrapperSource);
 });
 
-test("shell-web generic menu link items support exact route matching", async () => {
+test("shell-web generic link items support the expected shared route and icon behavior", async () => {
   const shellMenuSource = await readFile(
     path.join(PACKAGE_DIR, "src", "client", "components", "ShellMenuLinkItem.vue"),
     "utf8"
@@ -138,11 +139,18 @@ test("shell-web generic menu link items support exact route matching", async () 
     path.join(PACKAGE_DIR, "src", "client", "components", "ShellSurfaceAwareMenuLinkItem.vue"),
     "utf8"
   );
+  const shellTabSource = await readFile(
+    path.join(PACKAGE_DIR, "src", "client", "components", "ShellTabLinkItem.vue"),
+    "utf8"
+  );
 
   assert.match(shellMenuSource, /exact:\s*\{/);
   assert.match(shellMenuSource, /:exact="props\.exact"/);
   assert.match(shellSurfaceAwareSource, /exact:\s*\{/);
   assert.match(shellSurfaceAwareSource, /:exact="props\.exact"/);
+  assert.match(shellTabSource, /icon:\s*\{/);
+  assert.match(shellTabSource, /resolveMenuLinkIcon/);
+  assert.match(shellTabSource, /:prepend-icon="resolvedIcon \|\| undefined"/);
 });
 
 test("shell-web binds the local link-item wrapper tokens into MainClientProvider", () => {

--- a/packages/ui-generator/src/server/buildTemplateContext.js
+++ b/packages/ui-generator/src/server/buildTemplateContext.js
@@ -3,6 +3,8 @@ import {
   resolvePageTargetDetails
 } from "@jskit-ai/kernel/server/support";
 
+const DEFAULT_GENERATED_LINK_ICON = "mdi-view-list-outline";
+
 function resolveLinkToPropLine(linkTo = "") {
   if (!linkTo) {
     return "";
@@ -34,6 +36,7 @@ async function buildUiPageTemplateContext({
     __JSKIT_UI_LINK_PLACEMENT_ID__: pageTarget.placementId,
     __JSKIT_UI_LINK_PLACEMENT_TARGET__: String(linkTarget.placementTarget?.id || ""),
     __JSKIT_UI_LINK_COMPONENT_TOKEN__: String(linkTarget.componentToken || ""),
+    __JSKIT_UI_LINK_ICON__: DEFAULT_GENERATED_LINK_ICON,
     __JSKIT_UI_LINK_WORKSPACE_SUFFIX__: pageTarget.routeUrlSuffix,
     __JSKIT_UI_LINK_NON_WORKSPACE_SUFFIX__: pageTarget.routeUrlSuffix,
     __JSKIT_UI_LINK_WHEN_LINE__: String(linkTarget.whenLine || ""),

--- a/packages/ui-generator/src/server/subcommands/page.js
+++ b/packages/ui-generator/src/server/subcommands/page.js
@@ -31,6 +31,7 @@ function renderPageLinkPlacementBlock({
     `    componentToken: "${context.__JSKIT_UI_LINK_COMPONENT_TOKEN__}",\n` +
     "    props: {\n" +
     `      label: "${label}",\n` +
+    `      icon: "${context.__JSKIT_UI_LINK_ICON__}",\n` +
     `      surface: "${surface}",\n` +
     `      scopedSuffix: "${context.__JSKIT_UI_LINK_WORKSPACE_SUFFIX__}",\n` +
     `      unscopedSuffix: "${context.__JSKIT_UI_LINK_NON_WORKSPACE_SUFFIX__}",\n` +

--- a/packages/ui-generator/src/server/subcommands/pageSupport.js
+++ b/packages/ui-generator/src/server/subcommands/pageSupport.js
@@ -25,15 +25,15 @@ import {
 
 const DEFAULT_SUBPAGES_POSITION = "sub-pages";
 const SECTION_CONTAINER_SHELL_COMPONENT = "SectionContainerShell";
-const TAB_LINK_COMPONENT_TOKEN = "local.main.ui.tab-link-item";
+const SUBPAGES_LINK_COMPONENT_TOKEN = "local.main.ui.surface-aware-menu-link-item";
 const DEFAULT_MENU_COMPONENT_DIRECTORY = path.join(DEFAULT_COMPONENT_DIRECTORY, "menus");
-const TAB_LINK_COMPONENT_DEFINITION = findLocalLinkItemDefinition(TAB_LINK_COMPONENT_TOKEN);
+const SUBPAGES_LINK_COMPONENT_DEFINITION = findLocalLinkItemDefinition(SUBPAGES_LINK_COMPONENT_TOKEN);
 
-if (!TAB_LINK_COMPONENT_DEFINITION) {
-  throw new Error(`ui-generator add-subpages could not resolve ${TAB_LINK_COMPONENT_TOKEN} scaffold definition.`);
+if (!SUBPAGES_LINK_COMPONENT_DEFINITION) {
+  throw new Error(`ui-generator add-subpages could not resolve ${SUBPAGES_LINK_COMPONENT_TOKEN} scaffold definition.`);
 }
 
-const TAB_LINK_COMPONENT = TAB_LINK_COMPONENT_DEFINITION.componentName;
+const SUBPAGES_LINK_COMPONENT = SUBPAGES_LINK_COMPONENT_DEFINITION.componentName;
 
 const ROUTE_TAG_PATTERN = /<route\b[^>]*>[\s\S]*?<\/route>\s*/gi;
 const TEMPLATE_TOKEN_PATTERN = /<\/?template\b[^>]*>/gi;
@@ -145,7 +145,7 @@ async function ensureSubpagesSupportScaffold({
   );
   const tabLinkPath = resolvePathWithinApp(
     resolvedAppRoot,
-    path.join(normalizedTabLinkComponentDirectory, `${TAB_LINK_COMPONENT}.vue`),
+    path.join(normalizedTabLinkComponentDirectory, `${SUBPAGES_LINK_COMPONENT}.vue`),
     { context: "ui-generator add-subpages" }
   );
 
@@ -156,7 +156,7 @@ async function ensureSubpagesSupportScaffold({
     );
   }
 
-  const providerRegisterLine = `registerMainClientComponent("${TAB_LINK_COMPONENT_TOKEN}", () => ${TAB_LINK_COMPONENT});`;
+  const providerRegisterLine = `registerMainClientComponent("${SUBPAGES_LINK_COMPONENT_TOKEN}", () => ${SUBPAGES_LINK_COMPONENT});`;
   const providerHasTabLinkRegistration = providerSource.includes(providerRegisterLine);
   const touchedFiles = new Set();
   const supportFiles = [
@@ -168,7 +168,7 @@ async function ensureSubpagesSupportScaffold({
   if (!providerHasTabLinkRegistration) {
     supportFiles.push({
       path: tabLinkPath,
-      desiredSource: await readLocalLinkItemComponentSource(TAB_LINK_COMPONENT_DEFINITION)
+      desiredSource: await readLocalLinkItemComponentSource(SUBPAGES_LINK_COMPONENT_DEFINITION)
     });
   }
 
@@ -191,7 +191,7 @@ async function ensureSubpagesSupportScaffold({
     touchedFiles.add(supportFile.path.relativePath);
   }
 
-  const providerImportLine = `import ${TAB_LINK_COMPONENT} from "/${toPosixPath(path.join(normalizedTabLinkComponentDirectory, `${TAB_LINK_COMPONENT}.vue`))}";`;
+  const providerImportLine = `import ${SUBPAGES_LINK_COMPONENT} from "/${toPosixPath(path.join(normalizedTabLinkComponentDirectory, `${SUBPAGES_LINK_COMPONENT}.vue`))}";`;
   if (providerHasTabLinkRegistration) {
     return Object.freeze({
       touchedFiles: [...touchedFiles].sort((left, right) => left.localeCompare(right)),
@@ -313,7 +313,7 @@ function renderSubpagesTemplate({
     "<template>",
     renderSectionContainerOpenTag({ title, subtitle }),
     "    <template #tabs>",
-    `      <ShellOutlet target="${normalizedTarget}" default-link-component-token="${TAB_LINK_COMPONENT_TOKEN}" />`,
+    `      <ShellOutlet target="${normalizedTarget}" default-link-component-token="${SUBPAGES_LINK_COMPONENT_TOKEN}" />`,
     "    </template>"
   ];
 
@@ -483,8 +483,8 @@ export {
   DEFAULT_SUBPAGES_POSITION,
   DEFAULT_COMPONENT_DIRECTORY,
   SECTION_CONTAINER_SHELL_COMPONENT,
-  TAB_LINK_COMPONENT,
-  TAB_LINK_COMPONENT_TOKEN,
+  SUBPAGES_LINK_COMPONENT,
+  SUBPAGES_LINK_COMPONENT_TOKEN,
   resolvePageTargetDetails,
   resolveNearestParentSubpagesHost,
   deriveDefaultSubpagesHost,

--- a/packages/ui-generator/test/addSubpagesSubcommand.test.js
+++ b/packages/ui-generator/test/addSubpagesSubcommand.test.js
@@ -97,7 +97,7 @@ test("ui-generator add-subpages derives the default target from an index-route p
 
     assert.deepEqual(result.touchedFiles, [
       "packages/main/src/client/providers/MainClientProvider.js",
-      "src/components/menus/TabLinkItem.vue",
+      "src/components/menus/SurfaceAwareMenuLinkItem.vue",
       "src/components/SectionContainerShell.vue",
       `src/pages/${targetFile}`
     ]);
@@ -105,12 +105,12 @@ test("ui-generator add-subpages derives the default target from an index-route p
     const pageSource = await readPageFile(appRoot, targetFile);
     assert.match(
       pageSource,
-      /<ShellOutlet target="practice:sub-pages" default-link-component-token="local\.main\.ui\.tab-link-item" \/>/
+      /<ShellOutlet target="practice:sub-pages" default-link-component-token="local\.main\.ui\.surface-aware-menu-link-item" \/>/
     );
     assert.match(pageSource, /<RouterView \/>/);
     assert.equal(
-      await readFile(path.join(appRoot, "src", "components", "menus", "TabLinkItem.vue"), "utf8"),
-      await readLocalLinkItemComponentSource("local.main.ui.tab-link-item")
+      await readFile(path.join(appRoot, "src", "components", "menus", "SurfaceAwareMenuLinkItem.vue"), "utf8"),
+      await readLocalLinkItemComponentSource("local.main.ui.surface-aware-menu-link-item")
     );
   });
 });
@@ -132,7 +132,7 @@ test("ui-generator add-subpages derives the default target from a dynamic file-r
     const pageSource = await readPageFile(appRoot, targetFile);
     assert.match(
       pageSource,
-      /<ShellOutlet target="contacts-contact-id:sub-pages" default-link-component-token="local\.main\.ui\.tab-link-item" \/>/
+      /<ShellOutlet target="contacts-contact-id:sub-pages" default-link-component-token="local\.main\.ui\.surface-aware-menu-link-item" \/>/
     );
   });
 });
@@ -154,7 +154,7 @@ test("ui-generator add-subpages derives the default target from a nested route p
     const pageSource = await readPageFile(appRoot, targetFile);
     assert.match(
       pageSource,
-      /<ShellOutlet target="catalog-products:sub-pages" default-link-component-token="local\.main\.ui\.tab-link-item" \/>/
+      /<ShellOutlet target="catalog-products:sub-pages" default-link-component-token="local\.main\.ui\.surface-aware-menu-link-item" \/>/
     );
   });
 });
@@ -199,7 +199,7 @@ test("ui-generator add-subpages supports explicit target host:position", async (
     const pageSource = await readPageFile(appRoot, targetFile);
     assert.match(
       pageSource,
-      /<ShellOutlet target="practice-hub:secondary-tabs" default-link-component-token="local\.main\.ui\.tab-link-item" \/>/
+      /<ShellOutlet target="practice-hub:secondary-tabs" default-link-component-token="local\.main\.ui\.surface-aware-menu-link-item" \/>/
     );
   });
 });
@@ -211,7 +211,7 @@ test("ui-generator add-subpages does not rewrite existing scaffold support compo
     const targetFile = "w/[workspaceSlug]/admin/practice/index.vue";
     await writePageFile(appRoot, targetFile);
     const customSectionShellSource = `<template><section class="custom-shell"><slot /></section></template>\n`;
-    const customTabLinkSource = `<template><button class="custom-tab-link"><slot /></button></template>\n`;
+    const customSurfaceAwareLinkSource = `<template><button class="custom-surface-aware-link"><slot /></button></template>\n`;
     await writeFile(
       path.join(appRoot, "src", "components", "SectionContainerShell.vue"),
       customSectionShellSource,
@@ -219,8 +219,8 @@ test("ui-generator add-subpages does not rewrite existing scaffold support compo
     );
     await mkdir(path.join(appRoot, "src", "components", "menus"), { recursive: true });
     await writeFile(
-      path.join(appRoot, "src", "components", "menus", "TabLinkItem.vue"),
-      customTabLinkSource,
+      path.join(appRoot, "src", "components", "menus", "SurfaceAwareMenuLinkItem.vue"),
+      customSurfaceAwareLinkSource,
       "utf8"
     );
 
@@ -242,8 +242,8 @@ test("ui-generator add-subpages does not rewrite existing scaffold support compo
       customSectionShellSource
     );
     assert.equal(
-      await readFile(path.join(appRoot, "src", "components", "menus", "TabLinkItem.vue"), "utf8"),
-      customTabLinkSource
+      await readFile(path.join(appRoot, "src", "components", "menus", "SurfaceAwareMenuLinkItem.vue"), "utf8"),
+      customSurfaceAwareLinkSource
     );
   });
 });
@@ -332,7 +332,7 @@ test("ui-generator add-subpages accepts target files with a src/pages prefix", a
     const pageSource = await readFile(path.join(appRoot, targetFile), "utf8");
     assert.match(
       pageSource,
-      /<ShellOutlet target="practice:sub-pages" default-link-component-token="local\.main\.ui\.tab-link-item" \/>/
+      /<ShellOutlet target="practice:sub-pages" default-link-component-token="local\.main\.ui\.surface-aware-menu-link-item" \/>/
     );
     assert.match(pageSource, /<RouterView \/>/);
   });

--- a/packages/ui-generator/test/buildTemplateContext.test.js
+++ b/packages/ui-generator/test/buildTemplateContext.test.js
@@ -250,6 +250,7 @@ test("buildUiPageTemplateContext supports explicit link component token and link
       }
     });
     assert.equal(context.__JSKIT_UI_LINK_COMPONENT_TOKEN__, "local.main.ui.tab-link-item");
+    assert.equal(context.__JSKIT_UI_LINK_ICON__, "mdi-view-list-outline");
     assert.equal(context.__JSKIT_UI_LINK_WORKSPACE_SUFFIX__, "/contacts/[contactId]/notes");
     assert.equal(context.__JSKIT_UI_LINK_NON_WORKSPACE_SUFFIX__, "/contacts/[contactId]/notes");
     assert.equal(context.__JSKIT_UI_LINK_TO_PROP_LINE__, "      to: \"./notes\",\n");
@@ -314,7 +315,8 @@ test("buildUiPageTemplateContext infers subpage link placement, tab token, and l
     });
 
     assert.equal(context.__JSKIT_UI_LINK_PLACEMENT_TARGET__, "contact-view:sub-pages");
-    assert.equal(context.__JSKIT_UI_LINK_COMPONENT_TOKEN__, "local.main.ui.tab-link-item");
+    assert.equal(context.__JSKIT_UI_LINK_COMPONENT_TOKEN__, "local.main.ui.surface-aware-menu-link-item");
+    assert.equal(context.__JSKIT_UI_LINK_ICON__, "mdi-view-list-outline");
     assert.equal(context.__JSKIT_UI_LINK_TO_PROP_LINE__, "      to: \"./notes\",\n");
   });
 });
@@ -352,7 +354,7 @@ test("buildUiPageTemplateContext inherits a file-route parent host for deeper de
     });
 
     assert.equal(context.__JSKIT_UI_LINK_PLACEMENT_TARGET__, "contact-view:sub-pages");
-    assert.equal(context.__JSKIT_UI_LINK_COMPONENT_TOKEN__, "local.main.ui.tab-link-item");
+    assert.equal(context.__JSKIT_UI_LINK_COMPONENT_TOKEN__, "local.main.ui.surface-aware-menu-link-item");
     assert.equal(context.__JSKIT_UI_LINK_TO_PROP_LINE__, "      to: \"./notes/history\",\n");
   });
 });
@@ -390,7 +392,8 @@ test("buildUiPageTemplateContext infers subpage link placement from an index-rou
     });
 
     assert.equal(context.__JSKIT_UI_LINK_PLACEMENT_TARGET__, "catalog:sub-pages");
-    assert.equal(context.__JSKIT_UI_LINK_COMPONENT_TOKEN__, "local.main.ui.tab-link-item");
+    assert.equal(context.__JSKIT_UI_LINK_COMPONENT_TOKEN__, "local.main.ui.surface-aware-menu-link-item");
+    assert.equal(context.__JSKIT_UI_LINK_ICON__, "mdi-view-list-outline");
     assert.equal(context.__JSKIT_UI_LINK_TO_PROP_LINE__, "      to: \"./products\",\n");
   });
 });
@@ -441,7 +444,7 @@ test("buildUiPageTemplateContext finds the nearest index-route parent host", asy
     });
 
     assert.equal(context.__JSKIT_UI_LINK_PLACEMENT_TARGET__, "catalog-products:sub-pages");
-    assert.equal(context.__JSKIT_UI_LINK_COMPONENT_TOKEN__, "local.main.ui.tab-link-item");
+    assert.equal(context.__JSKIT_UI_LINK_COMPONENT_TOKEN__, "local.main.ui.surface-aware-menu-link-item");
     assert.equal(context.__JSKIT_UI_LINK_TO_PROP_LINE__, "      to: \"./variants\",\n");
   });
 });
@@ -479,7 +482,7 @@ test("buildUiPageTemplateContext infers subpage link placement from an index rou
     });
 
     assert.equal(context.__JSKIT_UI_LINK_PLACEMENT_TARGET__, "customer-view:sub-pages");
-    assert.equal(context.__JSKIT_UI_LINK_COMPONENT_TOKEN__, "local.main.ui.tab-link-item");
+    assert.equal(context.__JSKIT_UI_LINK_COMPONENT_TOKEN__, "local.main.ui.surface-aware-menu-link-item");
     assert.equal(context.__JSKIT_UI_LINK_TO_PROP_LINE__, "      to: \"./pets\",\n");
     assert.equal(context.__JSKIT_UI_LINK_WORKSPACE_SUFFIX__, "/customers/[customerId]/pets");
   });

--- a/packages/ui-generator/test/pageSubcommand.test.js
+++ b/packages/ui-generator/test/pageSubcommand.test.js
@@ -162,6 +162,7 @@ test("ui-generator page subcommand supports link placement options", async () =>
     const placementSource = await readFile(path.join(appRoot, "src", "placement.js"), "utf8");
     assert.match(placementSource, /target: "shell-layout:top-right"/);
     assert.match(placementSource, /componentToken: "local\.main\.ui\.tab-link-item"/);
+    assert.match(placementSource, /icon: "mdi-view-list-outline"/);
     assert.match(placementSource, /to: "\.\/notes"/);
   });
 });
@@ -196,7 +197,8 @@ test("ui-generator page subcommand infers subpage link placement, tab token, and
 
     const placementSource = await readFile(path.join(appRoot, "src", "placement.js"), "utf8");
     assert.match(placementSource, /target: "contact-view:sub-pages"/);
-    assert.match(placementSource, /componentToken: "local\.main\.ui\.tab-link-item"/);
+    assert.match(placementSource, /componentToken: "local\.main\.ui\.surface-aware-menu-link-item"/);
+    assert.match(placementSource, /icon: "mdi-view-list-outline"/);
     assert.match(placementSource, /to: "\.\/notes"/);
   });
 });
@@ -246,7 +248,7 @@ test("ui-generator page subcommand prefers the nearest index-route parent host",
 
     const placementSource = await readFile(path.join(appRoot, "src", "placement.js"), "utf8");
     assert.match(placementSource, /target: "catalog-products:sub-pages"/);
-    assert.match(placementSource, /componentToken: "local\.main\.ui\.tab-link-item"/);
+    assert.match(placementSource, /componentToken: "local\.main\.ui\.surface-aware-menu-link-item"/);
     assert.match(placementSource, /to: "\.\/variants"/);
   });
 });

--- a/packages/users-web/package.descriptor.mjs
+++ b/packages/users-web/package.descriptor.mjs
@@ -47,6 +47,10 @@ export default Object.freeze({
           summary: "Exports users-web client provider class."
         },
         {
+          subpath: "./client/components/AccountSettingsClientElement",
+          summary: "Exports the package-owned account settings host that renders placement-backed account sections."
+        },
+        {
           subpath: "./client/components/ProfileClientElement",
           summary: "Exports profile settings client element scaffold component."
         },
@@ -91,10 +95,6 @@ export default Object.freeze({
           summary: "Exports the shared users-web HTTP client with credentials and CSRF behavior."
         },
         {
-          subpath: "./client/composables/useAccountSettingsRuntime",
-          summary: "Exports account settings runtime composable for app-owned settings UI."
-        },
-        {
           subpath: "./client/account-settings/sections",
           summary: "Exports placement-backed account settings section helpers."
         }
@@ -119,7 +119,7 @@ export default Object.freeze({
           {
             target: "account-settings:sections",
             surfaces: ["account"],
-            source: "templates/src/components/account/settings/AccountSettingsClientElement.vue"
+            source: "src/client/components/AccountSettingsClientElement.vue"
           }
         ],
         contributions: [
@@ -149,6 +149,30 @@ export default Object.freeze({
             componentToken: "local.main.ui.surface-aware-menu-link-item",
             when: "auth.authenticated === true",
             source: "mutations.text#users-web-home-tools-placement"
+          },
+          {
+            id: "users.account.settings.profile",
+            target: "account-settings:sections",
+            surfaces: ["account"],
+            order: 100,
+            componentToken: "local.main.account-settings.section.profile",
+            source: "mutations.text#users-web-account-settings-sections-placement"
+          },
+          {
+            id: "users.account.settings.preferences",
+            target: "account-settings:sections",
+            surfaces: ["account"],
+            order: 200,
+            componentToken: "local.main.account-settings.section.preferences",
+            source: "mutations.text#users-web-account-settings-sections-placement"
+          },
+          {
+            id: "users.account.settings.notifications",
+            target: "account-settings:sections",
+            surfaces: ["account"],
+            order: 300,
+            componentToken: "local.main.account-settings.section.notifications",
+            source: "mutations.text#users-web-account-settings-sections-placement"
           }
         ]
       }
@@ -184,13 +208,6 @@ export default Object.freeze({
         reason: "Install app-owned account surface root page scaffold.",
         category: "users-web",
         id: "users-web-page-account-root"
-      },
-      {
-        from: "templates/src/components/account/settings/AccountSettingsClientElement.vue",
-        to: "src/components/account/settings/AccountSettingsClientElement.vue",
-        reason: "Install app-owned account settings container component scaffold.",
-        category: "users-web",
-        id: "users-web-component-account-settings-root"
       },
       {
         from: "templates/src/components/account/settings/AccountSettingsProfileSection.vue",
@@ -247,6 +264,77 @@ export default Object.freeze({
         reason: "Append users-web home tools widget and settings menu placements into app-owned placement registry.",
         category: "users-web",
         id: "users-web-home-tools-placement"
+      },
+      {
+        op: "append-text",
+        file: "src/placement.js",
+        position: "bottom",
+        skipIfContains: "id: \"users.account.settings.profile\"",
+        value:
+          "\naddPlacement({\n  id: \"users.account.settings.profile\",\n  target: \"account-settings:sections\",\n  surfaces: [\"account\"],\n  order: 100,\n  componentToken: \"local.main.account-settings.section.profile\",\n  props: {\n    title: \"Profile\",\n    value: \"profile\",\n    usesSharedRuntime: true\n  }\n});\n\naddPlacement({\n  id: \"users.account.settings.preferences\",\n  target: \"account-settings:sections\",\n  surfaces: [\"account\"],\n  order: 200,\n  componentToken: \"local.main.account-settings.section.preferences\",\n  props: {\n    title: \"Preferences\",\n    value: \"preferences\",\n    usesSharedRuntime: true\n  }\n});\n\naddPlacement({\n  id: \"users.account.settings.notifications\",\n  target: \"account-settings:sections\",\n  surfaces: [\"account\"],\n  order: 300,\n  componentToken: \"local.main.account-settings.section.notifications\",\n  props: {\n    title: \"Notifications\",\n    value: \"notifications\",\n    usesSharedRuntime: true\n  }\n});\n",
+        reason: "Append users-web account settings section placements into the app-owned placement registry.",
+        category: "users-web",
+        id: "users-web-account-settings-sections-placement"
+      },
+      {
+        op: "append-text",
+        file: "packages/main/src/client/providers/MainClientProvider.js",
+        position: "top",
+        skipIfContains: "import AccountSettingsProfileSection from \"/src/components/account/settings/AccountSettingsProfileSection.vue\";",
+        value: "import AccountSettingsProfileSection from \"/src/components/account/settings/AccountSettingsProfileSection.vue\";\n",
+        reason: "Bind the app-owned account profile settings section into local main client provider imports.",
+        category: "users-web",
+        id: "users-web-main-client-provider-account-settings-profile-import"
+      },
+      {
+        op: "append-text",
+        file: "packages/main/src/client/providers/MainClientProvider.js",
+        position: "top",
+        skipIfContains: "import AccountSettingsPreferencesSection from \"/src/components/account/settings/AccountSettingsPreferencesSection.vue\";",
+        value: "import AccountSettingsPreferencesSection from \"/src/components/account/settings/AccountSettingsPreferencesSection.vue\";\n",
+        reason: "Bind the app-owned account preferences settings section into local main client provider imports.",
+        category: "users-web",
+        id: "users-web-main-client-provider-account-settings-preferences-import"
+      },
+      {
+        op: "append-text",
+        file: "packages/main/src/client/providers/MainClientProvider.js",
+        position: "top",
+        skipIfContains: "import AccountSettingsNotificationsSection from \"/src/components/account/settings/AccountSettingsNotificationsSection.vue\";",
+        value: "import AccountSettingsNotificationsSection from \"/src/components/account/settings/AccountSettingsNotificationsSection.vue\";\n",
+        reason: "Bind the app-owned account notifications settings section into local main client provider imports.",
+        category: "users-web",
+        id: "users-web-main-client-provider-account-settings-notifications-import"
+      },
+      {
+        op: "append-text",
+        file: "packages/main/src/client/providers/MainClientProvider.js",
+        position: "bottom",
+        skipIfContains: "registerMainClientComponent(\"local.main.account-settings.section.profile\", () => AccountSettingsProfileSection);",
+        value: "\nregisterMainClientComponent(\"local.main.account-settings.section.profile\", () => AccountSettingsProfileSection);\n",
+        reason: "Bind the app-owned account profile settings section token into local main client provider registry.",
+        category: "users-web",
+        id: "users-web-main-client-provider-account-settings-profile-register"
+      },
+      {
+        op: "append-text",
+        file: "packages/main/src/client/providers/MainClientProvider.js",
+        position: "bottom",
+        skipIfContains: "registerMainClientComponent(\"local.main.account-settings.section.preferences\", () => AccountSettingsPreferencesSection);",
+        value: "\nregisterMainClientComponent(\"local.main.account-settings.section.preferences\", () => AccountSettingsPreferencesSection);\n",
+        reason: "Bind the app-owned account preferences settings section token into local main client provider registry.",
+        category: "users-web",
+        id: "users-web-main-client-provider-account-settings-preferences-register"
+      },
+      {
+        op: "append-text",
+        file: "packages/main/src/client/providers/MainClientProvider.js",
+        position: "bottom",
+        skipIfContains: "registerMainClientComponent(\"local.main.account-settings.section.notifications\", () => AccountSettingsNotificationsSection);",
+        value: "\nregisterMainClientComponent(\"local.main.account-settings.section.notifications\", () => AccountSettingsNotificationsSection);\n",
+        reason: "Bind the app-owned account notifications settings section token into local main client provider registry.",
+        category: "users-web",
+        id: "users-web-main-client-provider-account-settings-notifications-register"
       }
     ]
   }

--- a/packages/users-web/package.json
+++ b/packages/users-web/package.json
@@ -7,6 +7,7 @@
   },
   "exports": {
     "./client": "./src/client/index.js",
+    "./client/components/AccountSettingsClientElement": "./src/client/components/AccountSettingsClientElement.vue",
     "./client/account-settings/sections": "./src/client/account-settings/sections.js",
     "./client/composables/useAddEdit": "./src/client/composables/records/useAddEdit.js",
     "./client/composables/useAccess": "./src/client/composables/useAccess.js",
@@ -24,7 +25,6 @@
     "./client/composables/useView": "./src/client/composables/records/useView.js",
     "./client/composables/useCrudView": "./src/client/composables/records/useCrudView.js",
     "./client/composables/usePagedCollection": "./src/client/composables/usePagedCollection.js",
-    "./client/composables/useAccountSettingsRuntime": "./src/client/composables/useAccountSettingsRuntime.js",
     "./client/composables/usePaths": "./src/client/composables/usePaths.js",
     "./client/composables/runtime/useUiFeedback": "./src/client/composables/runtime/useUiFeedback.js",
     "./client/lib/httpClient": "./src/client/lib/httpClient.js",

--- a/packages/users-web/src/client/account-settings/sections.js
+++ b/packages/users-web/src/client/account-settings/sections.js
@@ -9,11 +9,6 @@ import { useWebPlacementContext } from "@jskit-ai/shell-web/client/placement";
 
 const ACCOUNT_SETTINGS_SECTION_TARGET = "account-settings:sections";
 const EMPTY_ACCOUNT_SETTINGS_SECTIONS = Object.freeze([]);
-const RESERVED_ACCOUNT_SETTINGS_SECTION_VALUES = Object.freeze([
-  "profile",
-  "preferences",
-  "notifications"
-]);
 const WEB_PLACEMENT_RUNTIME_INJECTION_KEY = "jskit.shell-web.runtime.web-placement.client";
 
 function normalizeAccountSettingsSectionEntry(entry = null) {
@@ -53,20 +48,30 @@ function sortAccountSettingsSections(entries = []) {
 }
 
 function resolveAccountSettingsSections(entries = []) {
-  const seen = new Set(RESERVED_ACCOUNT_SETTINGS_SECTION_VALUES);
   const normalized = [];
 
   for (const entry of Array.isArray(entries) ? entries : []) {
     const resolved = normalizeAccountSettingsSectionEntry(entry);
-    if (!resolved || seen.has(resolved.value)) {
+    if (!resolved) {
       continue;
     }
 
-    seen.add(resolved.value);
     normalized.push(resolved);
   }
 
-  return sortAccountSettingsSections(normalized);
+  const sorted = sortAccountSettingsSections(normalized);
+  const seen = new Set();
+  const deduplicated = [];
+  for (const entry of sorted) {
+    if (seen.has(entry.value)) {
+      continue;
+    }
+
+    seen.add(entry.value);
+    deduplicated.push(entry);
+  }
+
+  return Object.freeze(deduplicated);
 }
 
 function useAccountSettingsSections() {
@@ -114,7 +119,6 @@ function useAccountSettingsSections() {
 export {
   ACCOUNT_SETTINGS_SECTION_TARGET,
   EMPTY_ACCOUNT_SETTINGS_SECTIONS,
-  RESERVED_ACCOUNT_SETTINGS_SECTION_VALUES,
   normalizeAccountSettingsSectionEntry,
   resolveAccountSettingsSections,
   sortAccountSettingsSections,

--- a/packages/users-web/src/client/components/AccountSettingsClientElement.vue
+++ b/packages/users-web/src/client/components/AccountSettingsClientElement.vue
@@ -2,55 +2,25 @@
 import { computed } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import { normalizeOneOf } from "@jskit-ai/kernel/shared/support/normalize";
-import { useAccountSettingsRuntime } from "@jskit-ai/users-web/client/composables/useAccountSettingsRuntime";
-import { useAccountSettingsSections } from "@jskit-ai/users-web/client/account-settings/sections";
-import AccountSettingsProfileSection from "./AccountSettingsProfileSection.vue";
-import AccountSettingsPreferencesSection from "./AccountSettingsPreferencesSection.vue";
-import AccountSettingsNotificationsSection from "./AccountSettingsNotificationsSection.vue";
+import { useAccountSettingsRuntime } from "../composables/useAccountSettingsRuntime.js";
+import { useAccountSettingsSections } from "../account-settings/sections.js";
 
 const runtime = useAccountSettingsRuntime();
 const route = useRoute();
 const router = useRouter();
-const extensionSections = useAccountSettingsSections();
-
-const sections = computed(() => {
-  const nextSections = [
-    { title: "Profile", value: "profile", component: AccountSettingsProfileSection, usesSharedRuntime: true, order: 100 },
-    {
-      title: "Preferences",
-      value: "preferences",
-      component: AccountSettingsPreferencesSection,
-      usesSharedRuntime: true,
-      order: 200
-    },
-    {
-      title: "Notifications",
-      value: "notifications",
-      component: AccountSettingsNotificationsSection,
-      usesSharedRuntime: true,
-      order: 300
-    }
-  ];
-
-  for (const entry of extensionSections.value) {
-    nextSections.push(entry);
+const sections = useAccountSettingsSections();
+const sectionValues = computed(() => Object.freeze(sections.value.map((section) => section.value)));
+const defaultSection = computed(() => {
+  if (sectionValues.value.includes("profile")) {
+    return "profile";
   }
 
-  return Object.freeze(
-    nextSections.sort((left, right) => {
-      const orderDelta = Number(left.order || 0) - Number(right.order || 0);
-      if (orderDelta !== 0) {
-        return orderDelta;
-      }
-      return String(left.value || "").localeCompare(String(right.value || ""));
-    })
-  );
+  return sectionValues.value[0] || "";
 });
-const sectionValues = computed(() => Object.freeze(sections.value.map((section) => section.value)));
 
 function normalizeSection(value) {
   const source = Array.isArray(value) ? value[0] : value;
-  return normalizeOneOf(source, sectionValues.value, "profile");
+  return normalizeOneOf(source, sectionValues.value, defaultSection.value);
 }
 
 function readRouteSection() {
@@ -64,14 +34,14 @@ const activeTab = computed({
   set(nextValue) {
     const normalizedSection = normalizeSection(nextValue);
     const currentSection = readRouteSection();
-    if (normalizedSection === currentSection) {
+    if (!normalizedSection || normalizedSection === currentSection) {
       return;
     }
 
     const nextQuery = {
       ...route.query
     };
-    if (normalizedSection === "profile") {
+    if (normalizedSection === defaultSection.value) {
       delete nextQuery.section;
     } else {
       nextQuery.section = normalizedSection;
@@ -107,6 +77,9 @@ const activeTab = computed({
         <template v-if="runtime.loadingSettings.value">
           <v-skeleton-loader type="text@2, list-item-two-line@4" class="mb-4" />
           <v-skeleton-loader type="text@2, paragraph, button" />
+        </template>
+        <template v-else-if="sections.length < 1">
+          <p class="text-body-2 text-medium-emphasis mb-0">No account settings sections are registered.</p>
         </template>
         <template v-else>
           <v-progress-linear v-if="runtime.refreshingSettings.value" indeterminate class="mb-4" />

--- a/packages/users-web/src/client/index.js
+++ b/packages/users-web/src/client/index.js
@@ -1,6 +1,7 @@
 import { UsersWebClientProvider } from "./providers/UsersWebClientProvider.js";
 
 export { UsersWebClientProvider } from "./providers/UsersWebClientProvider.js";
+export { default as AccountSettingsClientElement } from "./components/AccountSettingsClientElement.vue";
 
 const clientProviders = Object.freeze([UsersWebClientProvider]);
 

--- a/packages/users-web/templates/src/pages/account/index.vue
+++ b/packages/users-web/templates/src/pages/account/index.vue
@@ -13,5 +13,5 @@
 </template>
 
 <script setup>
-import AccountSettingsClientElement from "../../components/account/settings/AccountSettingsClientElement.vue";
+import AccountSettingsClientElement from "@jskit-ai/users-web/client/components/AccountSettingsClientElement";
 </script>

--- a/packages/users-web/test/accountSettingsSections.test.js
+++ b/packages/users-web/test/accountSettingsSections.test.js
@@ -16,12 +16,12 @@ test("resolveAccountSettingsSections normalizes, deduplicates, and sorts placeme
 
   const resolved = resolveAccountSettingsSections([
     {
-      id: "users.notifications.duplicate",
+      id: "users.profile.duplicate",
       order: 999,
       component: SectionA,
       props: {
-        value: "notifications",
-        title: "Ignore duplicate"
+        value: "profile",
+        title: "Profile duplicate"
       }
     },
     {
@@ -37,8 +37,18 @@ test("resolveAccountSettingsSections normalizes, deduplicates, and sorts placeme
       id: "invalid.missing-component",
       order: 250,
       props: {
-        value: "profile",
+        value: "broken",
         title: "Broken missing component"
+      }
+    },
+    {
+      id: "users.profile",
+      order: 100,
+      component: SectionB,
+      props: {
+        value: "profile",
+        title: "Profile",
+        usesSharedRuntime: true
       }
     },
     {
@@ -70,8 +80,9 @@ test("resolveAccountSettingsSections normalizes, deduplicates, and sorts placeme
       usesSharedRuntime: entry.usesSharedRuntime
     })),
     [
+      { value: "invites", title: "Second duplicate", order: 100, usesSharedRuntime: false },
+      { value: "profile", title: "Profile", order: 100, usesSharedRuntime: true },
       { value: "security", title: "Security", order: 350, usesSharedRuntime: true },
-      { value: "invites", title: "Invites", order: 400, usesSharedRuntime: false }
     ]
   );
 });

--- a/packages/users-web/test/exportsContract.test.js
+++ b/packages/users-web/test/exportsContract.test.js
@@ -15,6 +15,7 @@ test("users-web exports are explicit and aligned with production/template usage"
     packageId: "@jskit-ai/users-web",
     requiredExports: [
       "./client",
+      "./client/components/AccountSettingsClientElement",
       "./client/account-settings/sections",
       "./client/composables/useAddEdit",
       "./client/composables/useCommand",

--- a/packages/users-web/test/settingsPlacementContract.test.js
+++ b/packages/users-web/test/settingsPlacementContract.test.js
@@ -80,6 +80,28 @@ test("users-web home tools widget exposes home-cog outlet", async () => {
   assert.match(source, /:default-link-component-token="HOME_COG_OUTLET\.defaultLinkComponentToken"/);
 });
 
+test("users-web account page template uses the package-owned account settings host", async () => {
+  const source = await readFile(path.join(PACKAGE_DIR, "templates", "src", "pages", "account", "index.vue"), "utf8");
+
+  assert.match(
+    source,
+    /import AccountSettingsClientElement from "@jskit-ai\/users-web\/client\/components\/AccountSettingsClientElement";/
+  );
+  assert.doesNotMatch(source, /components\/account\/settings\/AccountSettingsClientElement\.vue/);
+});
+
+test("users-web package-owned account settings host is fully placement-backed", async () => {
+  const source = await readFile(
+    path.join(PACKAGE_DIR, "src", "client", "components", "AccountSettingsClientElement.vue"),
+    "utf8"
+  );
+
+  assert.match(source, /useAccountSettingsSections/);
+  assert.doesNotMatch(source, /AccountSettingsProfileSection/);
+  assert.doesNotMatch(source, /AccountSettingsPreferencesSection/);
+  assert.doesNotMatch(source, /AccountSettingsNotificationsSection/);
+});
+
 test("users-web descriptor metadata advertises home cog outlet and standard home settings placements", () => {
   assert.deepEqual(
     readOutlets("home-cog:primary-menu"),
@@ -98,7 +120,7 @@ test("users-web descriptor metadata advertises home cog outlet and standard home
       {
         target: "account-settings:sections",
         surfaces: ["account"],
-        source: "templates/src/components/account/settings/AccountSettingsClientElement.vue"
+        source: "src/client/components/AccountSettingsClientElement.vue"
       }
     ]
   );
@@ -130,6 +152,27 @@ test("users-web descriptor metadata advertises home cog outlet and standard home
     source: "mutations.text#users-web-home-tools-placement"
   });
   assert.equal(findContribution("users.home.settings.general"), null);
+  expectContribution("users.account.settings.profile", {
+    target: "account-settings:sections",
+    surfaces: ["account"],
+    order: 100,
+    componentToken: "local.main.account-settings.section.profile",
+    source: "mutations.text#users-web-account-settings-sections-placement"
+  });
+  expectContribution("users.account.settings.preferences", {
+    target: "account-settings:sections",
+    surfaces: ["account"],
+    order: 200,
+    componentToken: "local.main.account-settings.section.preferences",
+    source: "mutations.text#users-web-account-settings-sections-placement"
+  });
+  expectContribution("users.account.settings.notifications", {
+    target: "account-settings:sections",
+    surfaces: ["account"],
+    order: 300,
+    componentToken: "local.main.account-settings.section.notifications",
+    source: "mutations.text#users-web-account-settings-sections-placement"
+  });
 
   expectTextMutation("users-web-home-tools-placement", {
     reason: "Append users-web home tools widget and settings menu placements into app-owned placement registry.",
@@ -143,6 +186,22 @@ test("users-web descriptor metadata advertises home cog outlet and standard home
       'componentToken: "local.main.ui.surface-aware-menu-link-item"',
       'scopedSuffix: "/settings"',
       'unscopedSuffix: "/settings"'
+    ]
+  });
+  expectTextMutation("users-web-account-settings-sections-placement", {
+    reason: "Append users-web account settings section placements into the app-owned placement registry.",
+    category: "users-web",
+    skipIfContains: 'id: "users.account.settings.profile"',
+    snippets: [
+      'id: "users.account.settings.profile"',
+      'componentToken: "local.main.account-settings.section.profile"',
+      'value: "profile"',
+      'id: "users.account.settings.preferences"',
+      'componentToken: "local.main.account-settings.section.preferences"',
+      'value: "preferences"',
+      'id: "users.account.settings.notifications"',
+      'componentToken: "local.main.account-settings.section.notifications"',
+      'value: "notifications"'
     ]
   });
 
@@ -159,6 +218,99 @@ test("users-web descriptor metadata advertises home cog outlet and standard home
     ]
   });
 
+  assert.equal(findFileMutation("users-web-component-account-settings-root"), null);
   assert.equal(findFileMutation("users-web-component-account-settings-invites"), null);
+  assert.deepEqual(findFileMutation("users-web-component-account-settings-profile"), {
+    from: "templates/src/components/account/settings/AccountSettingsProfileSection.vue",
+    to: "src/components/account/settings/AccountSettingsProfileSection.vue",
+    reason: "Install app-owned account settings profile section scaffold.",
+    category: "users-web",
+    id: "users-web-component-account-settings-profile"
+  });
+  assert.deepEqual(findFileMutation("users-web-component-account-settings-preferences"), {
+    from: "templates/src/components/account/settings/AccountSettingsPreferencesSection.vue",
+    to: "src/components/account/settings/AccountSettingsPreferencesSection.vue",
+    reason: "Install app-owned account settings preferences section scaffold.",
+    category: "users-web",
+    id: "users-web-component-account-settings-preferences"
+  });
+  assert.deepEqual(findFileMutation("users-web-component-account-settings-notifications"), {
+    from: "templates/src/components/account/settings/AccountSettingsNotificationsSection.vue",
+    to: "src/components/account/settings/AccountSettingsNotificationsSection.vue",
+    reason: "Install app-owned account settings notifications section scaffold.",
+    category: "users-web",
+    id: "users-web-component-account-settings-notifications"
+  });
+  assert.deepEqual(findTextMutation("users-web-main-client-provider-account-settings-profile-import"), {
+    op: "append-text",
+    file: "packages/main/src/client/providers/MainClientProvider.js",
+    position: "top",
+    skipIfContains:
+      "import AccountSettingsProfileSection from \"/src/components/account/settings/AccountSettingsProfileSection.vue\";",
+    value: "import AccountSettingsProfileSection from \"/src/components/account/settings/AccountSettingsProfileSection.vue\";\n",
+    reason: "Bind the app-owned account profile settings section into local main client provider imports.",
+    category: "users-web",
+    id: "users-web-main-client-provider-account-settings-profile-import"
+  });
+  assert.deepEqual(findTextMutation("users-web-main-client-provider-account-settings-preferences-import"), {
+    op: "append-text",
+    file: "packages/main/src/client/providers/MainClientProvider.js",
+    position: "top",
+    skipIfContains:
+      "import AccountSettingsPreferencesSection from \"/src/components/account/settings/AccountSettingsPreferencesSection.vue\";",
+    value:
+      "import AccountSettingsPreferencesSection from \"/src/components/account/settings/AccountSettingsPreferencesSection.vue\";\n",
+    reason: "Bind the app-owned account preferences settings section into local main client provider imports.",
+    category: "users-web",
+    id: "users-web-main-client-provider-account-settings-preferences-import"
+  });
+  assert.deepEqual(findTextMutation("users-web-main-client-provider-account-settings-notifications-import"), {
+    op: "append-text",
+    file: "packages/main/src/client/providers/MainClientProvider.js",
+    position: "top",
+    skipIfContains:
+      "import AccountSettingsNotificationsSection from \"/src/components/account/settings/AccountSettingsNotificationsSection.vue\";",
+    value:
+      "import AccountSettingsNotificationsSection from \"/src/components/account/settings/AccountSettingsNotificationsSection.vue\";\n",
+    reason: "Bind the app-owned account notifications settings section into local main client provider imports.",
+    category: "users-web",
+    id: "users-web-main-client-provider-account-settings-notifications-import"
+  });
+  assert.deepEqual(findTextMutation("users-web-main-client-provider-account-settings-profile-register"), {
+    op: "append-text",
+    file: "packages/main/src/client/providers/MainClientProvider.js",
+    position: "bottom",
+    skipIfContains:
+      "registerMainClientComponent(\"local.main.account-settings.section.profile\", () => AccountSettingsProfileSection);",
+    value:
+      "\nregisterMainClientComponent(\"local.main.account-settings.section.profile\", () => AccountSettingsProfileSection);\n",
+    reason: "Bind the app-owned account profile settings section token into local main client provider registry.",
+    category: "users-web",
+    id: "users-web-main-client-provider-account-settings-profile-register"
+  });
+  assert.deepEqual(findTextMutation("users-web-main-client-provider-account-settings-preferences-register"), {
+    op: "append-text",
+    file: "packages/main/src/client/providers/MainClientProvider.js",
+    position: "bottom",
+    skipIfContains:
+      "registerMainClientComponent(\"local.main.account-settings.section.preferences\", () => AccountSettingsPreferencesSection);",
+    value:
+      "\nregisterMainClientComponent(\"local.main.account-settings.section.preferences\", () => AccountSettingsPreferencesSection);\n",
+    reason: "Bind the app-owned account preferences settings section token into local main client provider registry.",
+    category: "users-web",
+    id: "users-web-main-client-provider-account-settings-preferences-register"
+  });
+  assert.deepEqual(findTextMutation("users-web-main-client-provider-account-settings-notifications-register"), {
+    op: "append-text",
+    file: "packages/main/src/client/providers/MainClientProvider.js",
+    position: "bottom",
+    skipIfContains:
+      "registerMainClientComponent(\"local.main.account-settings.section.notifications\", () => AccountSettingsNotificationsSection);",
+    value:
+      "\nregisterMainClientComponent(\"local.main.account-settings.section.notifications\", () => AccountSettingsNotificationsSection);\n",
+    reason: "Bind the app-owned account notifications settings section token into local main client provider registry.",
+    category: "users-web",
+    id: "users-web-main-client-provider-account-settings-notifications-register"
+  });
 
 });

--- a/packages/workspaces-web/templates/packages/main/src/client/components/AccountPendingInvitesCue.vue
+++ b/packages/workspaces-web/templates/packages/main/src/client/components/AccountPendingInvitesCue.vue
@@ -1,7 +1,6 @@
 <script setup>
 import { computed } from "vue";
 import { useRoute } from "vue-router";
-import { useQuery } from "@tanstack/vue-query";
 import { mdiEmailAlertOutline } from "@mdi/js";
 import { appendQueryString } from "@jskit-ai/kernel/shared/support";
 import {
@@ -41,68 +40,13 @@ function resolveReturnToHref() {
   return resolveReturnTo();
 }
 
-function countPendingInvites(entries = []) {
-  if (!Array.isArray(entries)) {
-    return 0;
-  }
-
-  let total = 0;
-  for (const entry of entries) {
-    if (!entry || typeof entry !== "object") {
-      continue;
-    }
-    total += 1;
-  }
-  return total;
-}
-
 const authenticated = computed(() => placementContext.value?.auth?.authenticated === true);
-
-const bootstrapSummaryQuery = useQuery({
-  queryKey: ["local-main", "account", "invites-cue", "bootstrap"],
-  enabled: authenticated,
-  staleTime: 5_000,
-  refetchInterval: 15_000,
-  queryFn: async () => {
-    const response = await fetch("/api/bootstrap", {
-      method: "GET",
-      credentials: "include",
-      headers: {
-        accept: "application/json"
-      }
-    });
-    if (!response.ok) {
-      throw new Error(`Bootstrap request failed with status ${response.status}.`);
-    }
-
-    return response.json();
-  }
-});
-
 const placementPendingInvitesCount = computed(() =>
   normalizePendingInvitesCount(placementContext.value?.pendingInvitesCount)
 );
-const bootstrapPendingInvitesCount = computed(() => {
-  const payload = bootstrapSummaryQuery.data.value;
-  const invitesEnabled = payload?.app?.features?.workspaceInvites === true;
-  if (!invitesEnabled) {
-    return 0;
-  }
-
-  return countPendingInvites(payload?.pendingInvites);
-});
-const pendingInvitesCount = computed(() =>
-  Math.max(placementPendingInvitesCount.value, bootstrapPendingInvitesCount.value)
-);
-
+const pendingInvitesCount = computed(() => placementPendingInvitesCount.value);
 const placementWorkspaceInvitesEnabled = computed(() => placementContext.value?.workspaceInvitesEnabled === true);
-const bootstrapWorkspaceInvitesEnabled = computed(() => {
-  const payload = bootstrapSummaryQuery.data.value;
-  return payload?.app?.features?.workspaceInvites === true;
-});
-const workspaceInvitesEnabled = computed(
-  () => placementWorkspaceInvitesEnabled.value || bootstrapWorkspaceInvitesEnabled.value
-);
+const workspaceInvitesEnabled = computed(() => placementWorkspaceInvitesEnabled.value);
 
 const isVisible = computed(() => {
   return (

--- a/packages/workspaces-web/test/settingsPlacementContract.test.js
+++ b/packages/workspaces-web/test/settingsPlacementContract.test.js
@@ -67,6 +67,25 @@ test("workspaces-web installs an app-owned account invites section wrapper", asy
   });
 });
 
+test("workspaces-web installs an account invites cue scaffold that reads placement runtime state", async () => {
+  const source = await readFile(
+    path.join(PACKAGE_DIR, "templates", "packages", "main", "src", "client", "components", "AccountPendingInvitesCue.vue"),
+    "utf8"
+  );
+
+  assert.doesNotMatch(source, /\bfetch\s*\(/);
+  assert.doesNotMatch(source, /\buseQuery\b/);
+  assert.match(source, /placementContext\.value\?\.pendingInvitesCount/);
+  assert.match(source, /placementContext\.value\?\.workspaceInvitesEnabled/);
+  assert.deepEqual(findFileMutation("users-web-main-component-account-pending-invites-cue"), {
+    from: "templates/packages/main/src/client/components/AccountPendingInvitesCue.vue",
+    to: "packages/main/src/client/components/AccountPendingInvitesCue.vue",
+    reason: "Install app-owned account pending invites cue component scaffold.",
+    category: "workspaces-web",
+    id: "users-web-main-component-account-pending-invites-cue"
+  });
+});
+
 test("workspaces-web admin settings index template is a simple developer-owned stub", async () => {
   const source = await readFile(
     path.join(PACKAGE_DIR, "templates", "src", "pages", "admin", "workspace", "settings", "index.vue"),

--- a/tooling/jskit-cli/src/server/commandHandlers/appCommands/linkLocalPackages.js
+++ b/tooling/jskit-cli/src/server/commandHandlers/appCommands/linkLocalPackages.js
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { mkdir, rm, symlink } from "node:fs/promises";
+import { lstat, mkdir, readFile, readlink, rm, symlink } from "node:fs/promises";
 import {
   discoverLocalPackageMap,
   fileExists,
@@ -7,6 +7,117 @@ import {
   resolveLocalRepoRoot,
   resolveSymlinkType
 } from "./shared.js";
+
+const COMPANION_PACKAGES = Object.freeze([
+  Object.freeze({
+    packageName: "json-rest-schema",
+    repoDirName: "json-rest-schema"
+  }),
+  Object.freeze({
+    packageName: "json-rest-stores",
+    repoDirName: "json-rest-stores"
+  })
+]);
+
+function collectDeclaredPackageNames(packageJson = {}) {
+  const names = new Set();
+  const sections = [
+    packageJson?.dependencies,
+    packageJson?.devDependencies,
+    packageJson?.optionalDependencies,
+    packageJson?.peerDependencies
+  ];
+
+  for (const section of sections) {
+    if (!section || typeof section !== "object" || Array.isArray(section)) {
+      continue;
+    }
+
+    for (const packageName of Object.keys(section)) {
+      const normalizedPackageName = String(packageName || "").trim();
+      if (normalizedPackageName) {
+        names.add(normalizedPackageName);
+      }
+    }
+  }
+
+  return names;
+}
+
+async function verifySymlinkTarget(targetPath = "", sourceDir = "", {
+  packageName = ""
+} = {}) {
+  const stats = await lstat(targetPath);
+  if (!stats.isSymbolicLink()) {
+    throw new Error(`[link-local] expected ${packageName || targetPath} to be a symlink after linking.`);
+  }
+
+  const linkedTarget = await readlink(targetPath);
+  if (linkedTarget !== sourceDir) {
+    throw new Error(
+      `[link-local] expected ${packageName || targetPath} to link to ${sourceDir}, got ${linkedTarget}.`
+    );
+  }
+}
+
+async function maybeLinkCompanionPackages({
+  appRoot = "",
+  repoRoot = "",
+  stdout,
+  createCliError
+}) {
+  const companionRoot = path.dirname(repoRoot);
+  const appPackageJsonPath = path.join(appRoot, "package.json");
+  let appPackageJson = {};
+  try {
+    appPackageJson = JSON.parse(await readFile(appPackageJsonPath, "utf8"));
+  } catch {
+    appPackageJson = {};
+  }
+  const declaredPackageNames = collectDeclaredPackageNames(appPackageJson);
+  let linkedCount = 0;
+
+  for (const companion of COMPANION_PACKAGES) {
+    if (!declaredPackageNames.has(companion.packageName)) {
+      continue;
+    }
+
+    const sourceDir = path.join(companionRoot, companion.repoDirName);
+    const packageJsonPath = path.join(sourceDir, "package.json");
+    if (!(await fileExists(packageJsonPath))) {
+      throw createCliError(
+        `[link-local] companion package ${companion.packageName} is declared by the app but local source was not found at ${sourceDir}.`,
+        { exitCode: 1 }
+      );
+    }
+
+    let packageJson = {};
+    try {
+      packageJson = JSON.parse(await readFile(packageJsonPath, "utf8"));
+    } catch {
+      continue;
+    }
+
+    if (String(packageJson?.name || "").trim() !== companion.packageName) {
+      throw createCliError(
+        `[link-local] companion source at ${sourceDir} does not match expected package ${companion.packageName}.`,
+        { exitCode: 1 }
+      );
+    }
+
+    const targetPath = path.join(appRoot, "node_modules", companion.packageName);
+    await mkdir(path.dirname(targetPath), { recursive: true });
+    await rm(targetPath, { recursive: true, force: true });
+    await symlink(sourceDir, targetPath, resolveSymlinkType());
+    await verifySymlinkTarget(targetPath, sourceDir, {
+      packageName: companion.packageName
+    });
+    stdout.write(`[link-local] linked ${companion.packageName} -> ${sourceDir}\n`);
+    linkedCount += 1;
+  }
+
+  return linkedCount;
+}
 
 async function runAppLinkLocalPackagesCommand(ctx = {}, { appRoot = "", options = {}, stdout }) {
   const { createCliError } = ctx;
@@ -50,6 +161,13 @@ async function runAppLinkLocalPackagesCommand(ctx = {}, { appRoot = "", options 
     });
     linkedCount += 1;
   }
+
+  linkedCount += await maybeLinkCompanionPackages({
+    appRoot,
+    repoRoot,
+    stdout,
+    createCliError
+  });
 
   if (await fileExists(viteCacheDirectory)) {
     await rm(viteCacheDirectory, { recursive: true, force: true });

--- a/tooling/jskit-cli/test/appCommand.test.js
+++ b/tooling/jskit-cli/test/appCommand.test.js
@@ -348,11 +348,98 @@ test("jskit app link-local-packages links local repo packages, refreshes bins, a
   await withTempDir(async (cwd) => {
     const appRoot = path.join(cwd, "app");
     const repoRoot = path.join(cwd, "jskit-ai");
+    const schemaRepoRoot = path.join(cwd, "json-rest-schema");
+    const storesRepoRoot = path.join(cwd, "json-rest-stores");
 
-    await createMinimalApp(appRoot);
+    await createMinimalApp(appRoot, {
+      dependencies: {
+        "json-rest-schema": "1.0.0",
+        "json-rest-stores": "1.0.0"
+      }
+    });
     await mkdir(path.join(appRoot, "node_modules", "@jskit-ai"), { recursive: true });
     await mkdir(path.join(appRoot, "node_modules", ".vite"), { recursive: true });
     await writeFile(path.join(appRoot, "node_modules", ".vite", "stale.txt"), "stale\n", "utf8");
+
+    const shellWebRoot = path.join(repoRoot, "packages", "shell-web");
+    await mkdir(shellWebRoot, { recursive: true });
+    await writeFile(
+      path.join(shellWebRoot, "package.json"),
+      `${JSON.stringify({ name: "@jskit-ai/shell-web", version: "0.1.0" }, null, 2)}\n`,
+      "utf8"
+    );
+
+    const cliRoot = path.join(repoRoot, "tooling", "jskit-cli");
+    await mkdir(path.join(cliRoot, "bin"), { recursive: true });
+    await writeFile(
+      path.join(cliRoot, "package.json"),
+      `${JSON.stringify(
+        {
+          name: "@jskit-ai/jskit-cli",
+          version: "0.1.0",
+          bin: {
+            jskit: "./bin/jskit.js"
+          }
+        },
+        null,
+        2
+      )}\n`,
+      "utf8"
+    );
+    await writeFile(path.join(cliRoot, "bin", "jskit.js"), "#!/usr/bin/env node\n", "utf8");
+
+    await mkdir(schemaRepoRoot, { recursive: true });
+    await writeFile(
+      path.join(schemaRepoRoot, "package.json"),
+      `${JSON.stringify({ name: "json-rest-schema", version: "1.0.0" }, null, 2)}\n`,
+      "utf8"
+    );
+    await mkdir(storesRepoRoot, { recursive: true });
+    await writeFile(
+      path.join(storesRepoRoot, "package.json"),
+      `${JSON.stringify({ name: "json-rest-stores", version: "1.0.0" }, null, 2)}\n`,
+      "utf8"
+    );
+
+    const result = runCli({
+      cwd: appRoot,
+      args: ["app", "link-local-packages", "--repo-root", repoRoot]
+    });
+
+    assert.equal(result.status, 0, String(result.stderr || ""));
+
+    const linkedShellWeb = path.join(appRoot, "node_modules", "@jskit-ai", "shell-web");
+    const linkedCli = path.join(appRoot, "node_modules", "@jskit-ai", "jskit-cli");
+    const linkedJsonRestSchema = path.join(appRoot, "node_modules", "json-rest-schema");
+    const linkedJsonRestStores = path.join(appRoot, "node_modules", "json-rest-stores");
+    const jskitBin = path.join(appRoot, "node_modules", ".bin", "jskit");
+
+    assert.equal((await lstat(linkedShellWeb)).isSymbolicLink(), true);
+    assert.equal((await lstat(linkedCli)).isSymbolicLink(), true);
+    assert.equal((await lstat(linkedJsonRestSchema)).isSymbolicLink(), true);
+    assert.equal((await lstat(linkedJsonRestStores)).isSymbolicLink(), true);
+    assert.equal((await lstat(jskitBin)).isSymbolicLink(), true);
+    assert.equal(await readlink(linkedShellWeb), shellWebRoot);
+    assert.equal(await readlink(linkedCli), cliRoot);
+    assert.equal(await readlink(linkedJsonRestSchema), schemaRepoRoot);
+    assert.equal(await readlink(linkedJsonRestStores), storesRepoRoot);
+    assert.equal(await readlink(jskitBin), "../@jskit-ai/jskit-cli/bin/jskit.js");
+
+    await assert.rejects(lstat(path.join(appRoot, "node_modules", ".vite")), /ENOENT/);
+  });
+});
+
+test("jskit app link-local-packages fails when a declared companion package has no local repo source", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "app");
+    const repoRoot = path.join(cwd, "jskit-ai");
+
+    await createMinimalApp(appRoot, {
+      dependencies: {
+        "json-rest-schema": "1.0.0"
+      }
+    });
+    await mkdir(path.join(appRoot, "node_modules", "@jskit-ai"), { recursive: true });
 
     const shellWebRoot = path.join(repoRoot, "packages", "shell-web");
     await mkdir(shellWebRoot, { recursive: true });
@@ -386,20 +473,11 @@ test("jskit app link-local-packages links local repo packages, refreshes bins, a
       args: ["app", "link-local-packages", "--repo-root", repoRoot]
     });
 
-    assert.equal(result.status, 0, String(result.stderr || ""));
-
-    const linkedShellWeb = path.join(appRoot, "node_modules", "@jskit-ai", "shell-web");
-    const linkedCli = path.join(appRoot, "node_modules", "@jskit-ai", "jskit-cli");
-    const jskitBin = path.join(appRoot, "node_modules", ".bin", "jskit");
-
-    assert.equal((await lstat(linkedShellWeb)).isSymbolicLink(), true);
-    assert.equal((await lstat(linkedCli)).isSymbolicLink(), true);
-    assert.equal((await lstat(jskitBin)).isSymbolicLink(), true);
-    assert.equal(await readlink(linkedShellWeb), shellWebRoot);
-    assert.equal(await readlink(linkedCli), cliRoot);
-    assert.equal(await readlink(jskitBin), "../@jskit-ai/jskit-cli/bin/jskit.js");
-
-    await assert.rejects(lstat(path.join(appRoot, "node_modules", ".vite")), /ENOENT/);
+    assert.equal(result.status, 1);
+    assert.match(
+      String(result.stderr || result.stdout || ""),
+      /companion package json-rest-schema is declared by the app but local source was not found/
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- tighten runtime wiring around deferred json-rest boot, JSON:API input record relationship extraction, and CRUD repository support
- refine page target inference, account settings section placement scaffolds, and related shell/users-web components
- improve local package linking, generator template output, and refresh the staged docs/reference artifacts

## Testing
- not run in this step

## Notes
- Per request, `npm verify` was not run.