### PR TITLE
Refresh package versions and catalog metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20252,28 +20252,28 @@
     },
     "packages/agent-docs": {
       "name": "@jskit-ai/agent-docs",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "engines": {
         "node": "20.x"
       }
     },
     "packages/assistant": {
       "name": "@jskit-ai/assistant",
-      "version": "0.1.66",
+      "version": "0.1.67",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.57"
+        "@jskit-ai/kernel": "0.1.58"
       }
     },
     "packages/assistant-core": {
       "name": "@jskit-ai/assistant-core",
-      "version": "0.1.33",
+      "version": "0.1.34",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.57",
-        "@jskit-ai/http-runtime": "0.1.56",
-        "@jskit-ai/kernel": "0.1.57",
-        "@jskit-ai/resource-core": "0.1.2",
-        "@jskit-ai/resource-crud-core": "0.1.2",
-        "@jskit-ai/users-core": "0.1.67",
+        "@jskit-ai/database-runtime": "0.1.58",
+        "@jskit-ai/http-runtime": "0.1.57",
+        "@jskit-ai/kernel": "0.1.58",
+        "@jskit-ai/resource-core": "0.1.3",
+        "@jskit-ai/resource-crud-core": "0.1.3",
+        "@jskit-ai/users-core": "0.1.68",
         "@tanstack/vue-query": "^5.90.5",
         "dompurify": "^3.3.3",
         "json-rest-schema": "1.x.x",
@@ -20346,15 +20346,15 @@
     },
     "packages/assistant-runtime": {
       "name": "@jskit-ai/assistant-runtime",
-      "version": "0.1.28",
+      "version": "0.1.29",
       "dependencies": {
-        "@jskit-ai/assistant-core": "0.1.33",
-        "@jskit-ai/database-runtime": "0.1.57",
-        "@jskit-ai/http-runtime": "0.1.56",
-        "@jskit-ai/kernel": "0.1.57",
-        "@jskit-ai/shell-web": "0.1.56",
-        "@jskit-ai/users-core": "0.1.67",
-        "@jskit-ai/users-web": "0.1.72",
+        "@jskit-ai/assistant-core": "0.1.34",
+        "@jskit-ai/database-runtime": "0.1.58",
+        "@jskit-ai/http-runtime": "0.1.57",
+        "@jskit-ai/kernel": "0.1.58",
+        "@jskit-ai/shell-web": "0.1.57",
+        "@jskit-ai/users-core": "0.1.68",
+        "@jskit-ai/users-web": "0.1.73",
         "@tanstack/vue-query": "^5.90.5",
         "json-rest-schema": "1.x.x",
         "vuetify": "^4.0.0"
@@ -20424,21 +20424,21 @@
     },
     "packages/auth-core": {
       "name": "@jskit-ai/auth-core",
-      "version": "0.1.56",
+      "version": "0.1.57",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0",
-        "@jskit-ai/kernel": "0.1.57",
+        "@jskit-ai/kernel": "0.1.58",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/auth-provider-supabase-core": {
       "name": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.56",
+      "version": "0.1.57",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.56",
-        "@jskit-ai/kernel": "0.1.57",
+        "@jskit-ai/auth-core": "0.1.57",
+        "@jskit-ai/kernel": "0.1.58",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0",
         "json-rest-schema": "1.x.x"
@@ -20446,12 +20446,12 @@
     },
     "packages/auth-web": {
       "name": "@jskit-ai/auth-web",
-      "version": "0.1.58",
+      "version": "0.1.59",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.56",
-        "@jskit-ai/http-runtime": "0.1.56",
-        "@jskit-ai/kernel": "0.1.57",
-        "@jskit-ai/shell-web": "0.1.56",
+        "@jskit-ai/auth-core": "0.1.57",
+        "@jskit-ai/http-runtime": "0.1.57",
+        "@jskit-ai/kernel": "0.1.58",
+        "@jskit-ai/shell-web": "0.1.57",
         "@mdi/js": "^7.4.47",
         "@tanstack/vue-query": "^5.90.5",
         "pinia": "^3.0.4",
@@ -20515,38 +20515,38 @@
     },
     "packages/console-core": {
       "name": "@jskit-ai/console-core",
-      "version": "0.1.20",
+      "version": "0.1.21",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.56",
-        "@jskit-ai/database-runtime": "0.1.57",
-        "@jskit-ai/http-runtime": "0.1.56",
-        "@jskit-ai/kernel": "0.1.57",
-        "@jskit-ai/resource-crud-core": "0.1.2",
-        "@jskit-ai/users-core": "0.1.67",
+        "@jskit-ai/auth-core": "0.1.57",
+        "@jskit-ai/database-runtime": "0.1.58",
+        "@jskit-ai/http-runtime": "0.1.57",
+        "@jskit-ai/kernel": "0.1.58",
+        "@jskit-ai/resource-crud-core": "0.1.3",
+        "@jskit-ai/users-core": "0.1.68",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/console-web": {
       "name": "@jskit-ai/console-web",
-      "version": "0.1.25",
+      "version": "0.1.26",
       "dependencies": {
-        "@jskit-ai/auth-web": "0.1.58",
-        "@jskit-ai/console-core": "0.1.20",
-        "@jskit-ai/shell-web": "0.1.56"
+        "@jskit-ai/auth-web": "0.1.59",
+        "@jskit-ai/console-core": "0.1.21",
+        "@jskit-ai/shell-web": "0.1.57"
       }
     },
     "packages/crud-core": {
       "name": "@jskit-ai/crud-core",
-      "version": "0.1.65",
+      "version": "0.1.66",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.57",
-        "@jskit-ai/http-runtime": "0.1.56",
-        "@jskit-ai/kernel": "0.1.57",
-        "@jskit-ai/realtime": "0.1.56",
-        "@jskit-ai/resource-crud-core": "0.1.2",
-        "@jskit-ai/shell-web": "0.1.56",
-        "@jskit-ai/users-core": "0.1.67",
-        "@jskit-ai/users-web": "0.1.72",
+        "@jskit-ai/database-runtime": "0.1.58",
+        "@jskit-ai/http-runtime": "0.1.57",
+        "@jskit-ai/kernel": "0.1.58",
+        "@jskit-ai/realtime": "0.1.57",
+        "@jskit-ai/resource-crud-core": "0.1.3",
+        "@jskit-ai/shell-web": "0.1.57",
+        "@jskit-ai/users-core": "0.1.68",
+        "@jskit-ai/users-web": "0.1.73",
         "@tanstack/vue-query": "^5.90.5",
         "json-rest-schema": "1.x.x"
       },
@@ -20616,78 +20616,78 @@
     },
     "packages/crud-server-generator": {
       "name": "@jskit-ai/crud-server-generator",
-      "version": "0.1.65",
+      "version": "0.1.66",
       "dependencies": {
         "@babel/parser": "^7.29.2",
-        "@jskit-ai/crud-core": "0.1.65",
-        "@jskit-ai/database-runtime": "0.1.57",
-        "@jskit-ai/http-runtime": "0.1.56",
-        "@jskit-ai/json-rest-api-core": "0.1.2",
-        "@jskit-ai/kernel": "0.1.57",
-        "@jskit-ai/resource-crud-core": "0.1.2",
+        "@jskit-ai/crud-core": "0.1.66",
+        "@jskit-ai/database-runtime": "0.1.58",
+        "@jskit-ai/http-runtime": "0.1.57",
+        "@jskit-ai/json-rest-api-core": "0.1.3",
+        "@jskit-ai/kernel": "0.1.58",
+        "@jskit-ai/resource-crud-core": "0.1.3",
         "recast": "^0.23.11"
       }
     },
     "packages/crud-ui-generator": {
       "name": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.40",
+      "version": "0.1.41",
       "dependencies": {
-        "@jskit-ai/crud-core": "0.1.65",
-        "@jskit-ai/kernel": "0.1.57",
-        "@jskit-ai/resource-crud-core": "0.1.2"
+        "@jskit-ai/crud-core": "0.1.66",
+        "@jskit-ai/kernel": "0.1.58",
+        "@jskit-ai/resource-crud-core": "0.1.3"
       }
     },
     "packages/database-runtime": {
       "name": "@jskit-ai/database-runtime",
-      "version": "0.1.57",
+      "version": "0.1.58",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.57"
+        "@jskit-ai/kernel": "0.1.58"
       }
     },
     "packages/database-runtime-mysql": {
       "name": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.56",
+      "version": "0.1.57",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.57",
-        "@jskit-ai/kernel": "0.1.57"
+        "@jskit-ai/database-runtime": "0.1.58",
+        "@jskit-ai/kernel": "0.1.58"
       }
     },
     "packages/database-runtime-postgres": {
       "name": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.56",
+      "version": "0.1.57",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.57"
+        "@jskit-ai/database-runtime": "0.1.58"
       }
     },
     "packages/http-runtime": {
       "name": "@jskit-ai/http-runtime",
-      "version": "0.1.56",
+      "version": "0.1.57",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.57",
+        "@jskit-ai/kernel": "0.1.58",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/json-rest-api-core": {
       "name": "@jskit-ai/json-rest-api-core",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.57",
+        "@jskit-ai/kernel": "0.1.58",
         "hooked-api": "1.x.x",
         "json-rest-api": "1.x.x"
       }
     },
     "packages/kernel": {
       "name": "@jskit-ai/kernel",
-      "version": "0.1.57",
+      "version": "0.1.58",
       "dependencies": {
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/realtime": {
       "name": "@jskit-ai/realtime",
-      "version": "0.1.56",
+      "version": "0.1.57",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.57",
+        "@jskit-ai/kernel": "0.1.58",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",
@@ -20699,24 +20699,24 @@
     },
     "packages/resource-core": {
       "name": "@jskit-ai/resource-core",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.57"
+        "@jskit-ai/kernel": "0.1.58"
       }
     },
     "packages/resource-crud-core": {
       "name": "@jskit-ai/resource-crud-core",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.57",
-        "@jskit-ai/resource-core": "0.1.2"
+        "@jskit-ai/kernel": "0.1.58",
+        "@jskit-ai/resource-core": "0.1.3"
       }
     },
     "packages/shell-web": {
       "name": "@jskit-ai/shell-web",
-      "version": "0.1.56",
+      "version": "0.1.57",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.57",
+        "@jskit-ai/kernel": "0.1.58",
         "@mdi/js": "^7.4.47",
         "@tanstack/vue-query": "^5.90.5",
         "pinia": "^3.0.4",
@@ -20780,25 +20780,25 @@
     },
     "packages/storage-runtime": {
       "name": "@jskit-ai/storage-runtime",
-      "version": "0.1.56",
+      "version": "0.1.57",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.57",
+        "@jskit-ai/kernel": "0.1.58",
         "unstorage": "^1.17.3"
       }
     },
     "packages/ui-generator": {
       "name": "@jskit-ai/ui-generator",
-      "version": "0.1.40",
+      "version": "0.1.41",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.57",
-        "@jskit-ai/shell-web": "0.1.56"
+        "@jskit-ai/kernel": "0.1.58",
+        "@jskit-ai/shell-web": "0.1.57"
       }
     },
     "packages/uploads-image-web": {
       "name": "@jskit-ai/uploads-image-web",
-      "version": "0.1.35",
+      "version": "0.1.36",
       "dependencies": {
-        "@jskit-ai/uploads-runtime": "0.1.35",
+        "@jskit-ai/uploads-runtime": "0.1.36",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",
@@ -20811,37 +20811,37 @@
     },
     "packages/uploads-runtime": {
       "name": "@jskit-ai/uploads-runtime",
-      "version": "0.1.35",
+      "version": "0.1.36",
       "dependencies": {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.57"
+        "@jskit-ai/kernel": "0.1.58"
       }
     },
     "packages/users-core": {
       "name": "@jskit-ai/users-core",
-      "version": "0.1.67",
+      "version": "0.1.68",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.56",
-        "@jskit-ai/database-runtime": "0.1.57",
-        "@jskit-ai/http-runtime": "0.1.56",
-        "@jskit-ai/json-rest-api-core": "0.1.2",
-        "@jskit-ai/kernel": "0.1.57",
-        "@jskit-ai/resource-core": "0.1.2",
-        "@jskit-ai/resource-crud-core": "0.1.2",
-        "@jskit-ai/uploads-runtime": "0.1.35",
+        "@jskit-ai/auth-core": "0.1.57",
+        "@jskit-ai/database-runtime": "0.1.58",
+        "@jskit-ai/http-runtime": "0.1.57",
+        "@jskit-ai/json-rest-api-core": "0.1.3",
+        "@jskit-ai/kernel": "0.1.58",
+        "@jskit-ai/resource-core": "0.1.3",
+        "@jskit-ai/resource-crud-core": "0.1.3",
+        "@jskit-ai/uploads-runtime": "0.1.36",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/users-web": {
       "name": "@jskit-ai/users-web",
-      "version": "0.1.72",
+      "version": "0.1.73",
       "dependencies": {
-        "@jskit-ai/http-runtime": "0.1.56",
-        "@jskit-ai/kernel": "0.1.57",
-        "@jskit-ai/realtime": "0.1.56",
-        "@jskit-ai/shell-web": "0.1.56",
-        "@jskit-ai/uploads-image-web": "0.1.35",
-        "@jskit-ai/users-core": "0.1.67",
+        "@jskit-ai/http-runtime": "0.1.57",
+        "@jskit-ai/kernel": "0.1.58",
+        "@jskit-ai/realtime": "0.1.57",
+        "@jskit-ai/shell-web": "0.1.57",
+        "@jskit-ai/uploads-image-web": "0.1.36",
+        "@jskit-ai/users-core": "0.1.68",
         "@mdi/js": "^7.4.47",
         "@tanstack/vue-query": "5.92.12",
         "vuetify": "^4.0.0"
@@ -20912,29 +20912,29 @@
     },
     "packages/workspaces-core": {
       "name": "@jskit-ai/workspaces-core",
-      "version": "0.1.33",
+      "version": "0.1.34",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.56",
-        "@jskit-ai/database-runtime": "0.1.57",
-        "@jskit-ai/http-runtime": "0.1.56",
-        "@jskit-ai/json-rest-api-core": "0.1.2",
-        "@jskit-ai/kernel": "0.1.57",
-        "@jskit-ai/resource-core": "0.1.2",
-        "@jskit-ai/resource-crud-core": "0.1.2",
-        "@jskit-ai/users-core": "0.1.67",
+        "@jskit-ai/auth-core": "0.1.57",
+        "@jskit-ai/database-runtime": "0.1.58",
+        "@jskit-ai/http-runtime": "0.1.57",
+        "@jskit-ai/json-rest-api-core": "0.1.3",
+        "@jskit-ai/kernel": "0.1.58",
+        "@jskit-ai/resource-core": "0.1.3",
+        "@jskit-ai/resource-crud-core": "0.1.3",
+        "@jskit-ai/users-core": "0.1.68",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/workspaces-web": {
       "name": "@jskit-ai/workspaces-web",
-      "version": "0.1.33",
+      "version": "0.1.34",
       "dependencies": {
-        "@jskit-ai/http-runtime": "0.1.56",
-        "@jskit-ai/kernel": "0.1.57",
-        "@jskit-ai/shell-web": "0.1.56",
-        "@jskit-ai/users-core": "0.1.67",
-        "@jskit-ai/users-web": "0.1.72",
-        "@jskit-ai/workspaces-core": "0.1.33",
+        "@jskit-ai/http-runtime": "0.1.57",
+        "@jskit-ai/kernel": "0.1.58",
+        "@jskit-ai/shell-web": "0.1.57",
+        "@jskit-ai/users-core": "0.1.68",
+        "@jskit-ai/users-web": "0.1.73",
+        "@jskit-ai/workspaces-core": "0.1.34",
         "@mdi/js": "^7.4.47",
         "@tanstack/vue-query": "5.92.12",
         "vuetify": "^4.0.0"
@@ -21005,7 +21005,7 @@
     },
     "tooling/config-eslint": {
       "name": "@jskit-ai/config-eslint",
-      "version": "0.1.56",
+      "version": "0.1.57",
       "dependencies": {
         "@eslint/js": "^9.39.1",
         "eslint-plugin-vue": "^10.5.1",
@@ -21023,7 +21023,7 @@
     },
     "tooling/create-app": {
       "name": "@jskit-ai/create-app",
-      "version": "0.1.65",
+      "version": "0.1.66",
       "bin": {
         "jskit-create-app": "bin/jskit-create-app.js"
       },
@@ -21033,18 +21033,18 @@
     },
     "tooling/jskit-catalog": {
       "name": "@jskit-ai/jskit-catalog",
-      "version": "0.1.65",
+      "version": "0.1.66",
       "engines": {
         "node": "20.x"
       }
     },
     "tooling/jskit-cli": {
       "name": "@jskit-ai/jskit-cli",
-      "version": "0.2.66",
+      "version": "0.2.67",
       "dependencies": {
-        "@jskit-ai/jskit-catalog": "0.1.65",
-        "@jskit-ai/kernel": "0.1.57",
-        "@jskit-ai/shell-web": "0.1.56"
+        "@jskit-ai/jskit-catalog": "0.1.66",
+        "@jskit-ai/kernel": "0.1.58",
+        "@jskit-ai/shell-web": "0.1.57"
       },
       "bin": {
         "jskit": "bin/jskit.js"

--- a/packages/agent-docs/package.json
+++ b/packages/agent-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/agent-docs",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "Distributed JSKIT agent workflows, guides, and generated reference maps.",
   "type": "module",
   "files": [

--- a/packages/assistant-core/package.descriptor.mjs
+++ b/packages/assistant-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-core",
-  version: "0.1.33",
+  version: "0.1.34",
   kind: "runtime",
   description: "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
   dependsOn: [
@@ -47,11 +47,11 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/http-runtime": "0.1.56",
-        "@jskit-ai/kernel": "0.1.57",
-        "@jskit-ai/resource-core": "0.1.2",
-        "@jskit-ai/resource-crud-core": "0.1.2",
-        "@jskit-ai/users-core": "0.1.67",
+        "@jskit-ai/http-runtime": "0.1.57",
+        "@jskit-ai/kernel": "0.1.58",
+        "@jskit-ai/resource-core": "0.1.3",
+        "@jskit-ai/resource-crud-core": "0.1.3",
+        "@jskit-ai/users-core": "0.1.68",
         "@tanstack/vue-query": "^5.90.5",
         "dompurify": "^3.3.3",
         "json-rest-schema": "1.x.x",

--- a/packages/assistant-core/package.json
+++ b/packages/assistant-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-core",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,12 +11,12 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.57",
-    "@jskit-ai/http-runtime": "0.1.56",
-    "@jskit-ai/kernel": "0.1.57",
-    "@jskit-ai/resource-crud-core": "0.1.2",
-    "@jskit-ai/resource-core": "0.1.2",
-    "@jskit-ai/users-core": "0.1.67",
+    "@jskit-ai/database-runtime": "0.1.58",
+    "@jskit-ai/http-runtime": "0.1.57",
+    "@jskit-ai/kernel": "0.1.58",
+    "@jskit-ai/resource-crud-core": "0.1.3",
+    "@jskit-ai/resource-core": "0.1.3",
+    "@jskit-ai/users-core": "0.1.68",
     "@tanstack/vue-query": "^5.90.5",
     "dompurify": "^3.3.3",
     "json-rest-schema": "1.x.x",

--- a/packages/assistant-runtime/package.descriptor.mjs
+++ b/packages/assistant-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-runtime",
-  version: "0.1.28",
+  version: "0.1.29",
   kind: "runtime",
   description: "Shared assistant runtime with per-surface assistant registration.",
   dependsOn: [
@@ -74,13 +74,13 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/assistant-core": "0.1.33",
-        "@jskit-ai/database-runtime": "0.1.57",
-        "@jskit-ai/http-runtime": "0.1.56",
-        "@jskit-ai/kernel": "0.1.57",
-        "@jskit-ai/shell-web": "0.1.56",
-        "@jskit-ai/users-core": "0.1.67",
-        "@jskit-ai/users-web": "0.1.72",
+        "@jskit-ai/assistant-core": "0.1.34",
+        "@jskit-ai/database-runtime": "0.1.58",
+        "@jskit-ai/http-runtime": "0.1.57",
+        "@jskit-ai/kernel": "0.1.58",
+        "@jskit-ai/shell-web": "0.1.57",
+        "@jskit-ai/users-core": "0.1.68",
+        "@jskit-ai/users-web": "0.1.73",
         "@tanstack/vue-query": "^5.90.5",
         "vuetify": "^4.0.0"
       },

--- a/packages/assistant-runtime/package.json
+++ b/packages/assistant-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-runtime",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "type": "module",
   "exports": {
     "./client": "./src/client/index.js",
@@ -8,13 +8,13 @@
     "./server/actionIds": "./src/server/actionIds.js"
   },
   "dependencies": {
-    "@jskit-ai/assistant-core": "0.1.33",
-    "@jskit-ai/database-runtime": "0.1.57",
-    "@jskit-ai/http-runtime": "0.1.56",
-    "@jskit-ai/kernel": "0.1.57",
-    "@jskit-ai/shell-web": "0.1.56",
-    "@jskit-ai/users-core": "0.1.67",
-    "@jskit-ai/users-web": "0.1.72",
+    "@jskit-ai/assistant-core": "0.1.34",
+    "@jskit-ai/database-runtime": "0.1.58",
+    "@jskit-ai/http-runtime": "0.1.57",
+    "@jskit-ai/kernel": "0.1.58",
+    "@jskit-ai/shell-web": "0.1.57",
+    "@jskit-ai/users-core": "0.1.68",
+    "@jskit-ai/users-web": "0.1.73",
     "json-rest-schema": "1.x.x",
     "@tanstack/vue-query": "^5.90.5",
     "vuetify": "^4.0.0"

--- a/packages/assistant/package.descriptor.mjs
+++ b/packages/assistant/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant",
-  version: "0.1.66",
+  version: "0.1.67",
   kind: "generator",
   description: "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
   options: {

--- a/packages/assistant/package.json
+++ b/packages/assistant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant",
-  "version": "0.1.66",
+  "version": "0.1.67",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.57"
+    "@jskit-ai/kernel": "0.1.58"
   }
 }

--- a/packages/auth-core/package.descriptor.mjs
+++ b/packages/auth-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-core",
-  "version": "0.1.56",
+  "version": "0.1.57",
   "kind": "runtime",
   "dependsOn": [
     "@jskit-ai/value-app-config-shared"
@@ -69,7 +69,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.57",
+        "@jskit-ai/kernel": "0.1.58",
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0"

--- a/packages/auth-core/package.json
+++ b/packages/auth-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-core",
-  "version": "0.1.56",
+  "version": "0.1.57",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -46,7 +46,7 @@
     "./shared/commands/authSessionReadCommand": "./src/shared/commands/authSessionReadCommand.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.57",
+    "@jskit-ai/kernel": "0.1.58",
     "@fastify/cookie": "^11.0.2",
     "@fastify/csrf-protection": "^7.1.0",
     "@fastify/rate-limit": "^10.3.0",

--- a/packages/auth-provider-supabase-core/package.descriptor.mjs
+++ b/packages/auth-provider-supabase-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.56",
+  "version": "0.1.57",
   "kind": "runtime",
   "options": {
     "auth-supabase-url": {
@@ -83,8 +83,8 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/auth-core": "0.1.56",
-        "@jskit-ai/kernel": "0.1.57",
+        "@jskit-ai/auth-core": "0.1.57",
+        "@jskit-ai/kernel": "0.1.58",
         "dotenv": "^16.4.5",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0"

--- a/packages/auth-provider-supabase-core/package.json
+++ b/packages/auth-provider-supabase-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.56",
+  "version": "0.1.57",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,8 +12,8 @@
     "./client": "./src/client/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.56",
-    "@jskit-ai/kernel": "0.1.57",
+    "@jskit-ai/auth-core": "0.1.57",
+    "@jskit-ai/kernel": "0.1.58",
     "json-rest-schema": "1.x.x",
     "jose": "^6.1.0",
     "@supabase/supabase-js": "^2.57.4"

--- a/packages/auth-web/package.descriptor.mjs
+++ b/packages/auth-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-web",
-  "version": "0.1.58",
+  "version": "0.1.59",
   "kind": "runtime",
   "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
   "dependsOn": [
@@ -219,10 +219,10 @@ export default Object.freeze({
       "runtime": {
         "@tanstack/vue-query": "5.92.12",
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/auth-core": "0.1.56",
-        "@jskit-ai/http-runtime": "0.1.56",
-        "@jskit-ai/kernel": "0.1.57",
-        "@jskit-ai/shell-web": "0.1.56",
+        "@jskit-ai/auth-core": "0.1.57",
+        "@jskit-ai/http-runtime": "0.1.57",
+        "@jskit-ai/kernel": "0.1.58",
+        "@jskit-ai/shell-web": "0.1.57",
         "vuetify": "^4.0.0"
       },
       "dev": {}

--- a/packages/auth-web/package.json
+++ b/packages/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-web",
-  "version": "0.1.58",
+  "version": "0.1.59",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -18,13 +18,13 @@
   },
   "dependencies": {
     "@tanstack/vue-query": "^5.90.5",
-    "@jskit-ai/auth-core": "0.1.56",
+    "@jskit-ai/auth-core": "0.1.57",
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/kernel": "0.1.57",
-    "@jskit-ai/shell-web": "0.1.56",
+    "@jskit-ai/kernel": "0.1.58",
+    "@jskit-ai/shell-web": "0.1.57",
     "pinia": "^3.0.4",
     "vuetify": "^4.0.0",
-    "@jskit-ai/http-runtime": "0.1.56"
+    "@jskit-ai/http-runtime": "0.1.57"
   },
   "peerDependencies": {
     "vue": "^3.5.13",

--- a/packages/console-core/package.descriptor.mjs
+++ b/packages/console-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-core",
-  version: "0.1.20",
+  version: "0.1.21",
   kind: "runtime",
   description: "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
   dependsOn: [
@@ -74,12 +74,12 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.56",
-        "@jskit-ai/database-runtime": "0.1.57",
-        "@jskit-ai/http-runtime": "0.1.56",
-        "@jskit-ai/kernel": "0.1.57",
-        "@jskit-ai/resource-crud-core": "0.1.2",
-        "@jskit-ai/users-core": "0.1.67"
+        "@jskit-ai/auth-core": "0.1.57",
+        "@jskit-ai/database-runtime": "0.1.58",
+        "@jskit-ai/http-runtime": "0.1.57",
+        "@jskit-ai/kernel": "0.1.58",
+        "@jskit-ai/resource-crud-core": "0.1.3",
+        "@jskit-ai/users-core": "0.1.68"
       },
       dev: {}
     },

--- a/packages/console-core/package.json
+++ b/packages/console-core/package.json
@@ -1,17 +1,17 @@
 {
   "name": "@jskit-ai/console-core",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.56",
-    "@jskit-ai/database-runtime": "0.1.57",
-    "@jskit-ai/http-runtime": "0.1.56",
-    "@jskit-ai/kernel": "0.1.57",
-    "@jskit-ai/resource-crud-core": "0.1.2",
-    "@jskit-ai/users-core": "0.1.67",
+    "@jskit-ai/auth-core": "0.1.57",
+    "@jskit-ai/database-runtime": "0.1.58",
+    "@jskit-ai/http-runtime": "0.1.57",
+    "@jskit-ai/kernel": "0.1.58",
+    "@jskit-ai/resource-crud-core": "0.1.3",
+    "@jskit-ai/users-core": "0.1.68",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/console-web/package.descriptor.mjs
+++ b/packages/console-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-web",
-  version: "0.1.25",
+  version: "0.1.26",
   kind: "runtime",
   description: "Authenticated console surface scaffold and surface policy wiring.",
   dependsOn: [
@@ -74,9 +74,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-web": "0.1.58",
-        "@jskit-ai/console-core": "0.1.20",
-        "@jskit-ai/shell-web": "0.1.56",
+        "@jskit-ai/auth-web": "0.1.59",
+        "@jskit-ai/console-core": "0.1.21",
+        "@jskit-ai/shell-web": "0.1.57",
       },
       dev: {}
     },

--- a/packages/console-web/package.json
+++ b/packages/console-web/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/console-web",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-web": "0.1.58",
-    "@jskit-ai/console-core": "0.1.20",
-    "@jskit-ai/shell-web": "0.1.56"
+    "@jskit-ai/auth-web": "0.1.59",
+    "@jskit-ai/console-core": "0.1.21",
+    "@jskit-ai/shell-web": "0.1.57"
   }
 }

--- a/packages/crud-core/package.descriptor.mjs
+++ b/packages/crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-core",
-  version: "0.1.65",
+  version: "0.1.66",
   kind: "runtime",
   description: "Shared CRUD helpers used by CRUD modules.",
   dependsOn: [
@@ -28,7 +28,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/crud-core": "0.1.65"
+        "@jskit-ai/crud-core": "0.1.66"
       },
       dev: {}
     },

--- a/packages/crud-core/package.json
+++ b/packages/crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-core",
-  "version": "0.1.65",
+  "version": "0.1.66",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -28,15 +28,15 @@
   },
   "dependencies": {
     "@tanstack/vue-query": "^5.90.5",
-    "@jskit-ai/database-runtime": "0.1.57",
-    "@jskit-ai/http-runtime": "0.1.56",
-    "@jskit-ai/kernel": "0.1.57",
+    "@jskit-ai/database-runtime": "0.1.58",
+    "@jskit-ai/http-runtime": "0.1.57",
+    "@jskit-ai/kernel": "0.1.58",
     "json-rest-schema": "1.x.x",
-    "@jskit-ai/realtime": "0.1.56",
-    "@jskit-ai/resource-crud-core": "0.1.2",
-    "@jskit-ai/shell-web": "0.1.56",
-    "@jskit-ai/users-core": "0.1.67",
-    "@jskit-ai/users-web": "0.1.72"
+    "@jskit-ai/realtime": "0.1.57",
+    "@jskit-ai/resource-crud-core": "0.1.3",
+    "@jskit-ai/shell-web": "0.1.57",
+    "@jskit-ai/users-core": "0.1.68",
+    "@jskit-ai/users-web": "0.1.73"
   },
   "peerDependencies": {
     "vue": "^3.5.13",

--- a/packages/crud-server-generator/package.descriptor.mjs
+++ b/packages/crud-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-server-generator",
-  version: "0.1.65",
+  version: "0.1.66",
   kind: "generator",
   description: "CRUD server generator with routes, actions, and persistence scaffolding.",
   options: {
@@ -152,14 +152,14 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.56",
-        "@jskit-ai/crud-core": "0.1.65",
-        "@jskit-ai/database-runtime": "0.1.57",
-        "@jskit-ai/http-runtime": "0.1.56",
-        "@jskit-ai/json-rest-api-core": "0.1.2",
-        "@jskit-ai/kernel": "0.1.57",
-        "@jskit-ai/realtime": "0.1.56",
-        "@jskit-ai/resource-crud-core": "0.1.2",
+        "@jskit-ai/auth-core": "0.1.57",
+        "@jskit-ai/crud-core": "0.1.66",
+        "@jskit-ai/database-runtime": "0.1.58",
+        "@jskit-ai/http-runtime": "0.1.57",
+        "@jskit-ai/json-rest-api-core": "0.1.3",
+        "@jskit-ai/kernel": "0.1.58",
+        "@jskit-ai/realtime": "0.1.57",
+        "@jskit-ai/resource-crud-core": "0.1.3",
         "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}"
       },
       dev: {}

--- a/packages/crud-server-generator/package.json
+++ b/packages/crud-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-server-generator",
-  "version": "0.1.65",
+  "version": "0.1.66",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,12 +13,12 @@
   },
   "dependencies": {
     "@babel/parser": "^7.29.2",
-    "@jskit-ai/crud-core": "0.1.65",
-    "@jskit-ai/database-runtime": "0.1.57",
-    "@jskit-ai/http-runtime": "0.1.56",
-    "@jskit-ai/json-rest-api-core": "0.1.2",
-    "@jskit-ai/kernel": "0.1.57",
-    "@jskit-ai/resource-crud-core": "0.1.2",
+    "@jskit-ai/crud-core": "0.1.66",
+    "@jskit-ai/database-runtime": "0.1.58",
+    "@jskit-ai/http-runtime": "0.1.57",
+    "@jskit-ai/json-rest-api-core": "0.1.3",
+    "@jskit-ai/kernel": "0.1.58",
+    "@jskit-ai/resource-crud-core": "0.1.3",
     "recast": "^0.23.11"
   }
 }

--- a/packages/crud-ui-generator/package.descriptor.mjs
+++ b/packages/crud-ui-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-ui-generator",
-  version: "0.1.40",
+  version: "0.1.41",
   kind: "generator",
   description: "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
   options: {
@@ -168,7 +168,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.72"
+        "@jskit-ai/users-web": "0.1.73"
       },
       dev: {}
     },

--- a/packages/crud-ui-generator/package.json
+++ b/packages/crud-ui-generator/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@jskit-ai/crud-ui-generator",
-  "version": "0.1.40",
+  "version": "0.1.41",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/crud-core": "0.1.65",
-    "@jskit-ai/kernel": "0.1.57",
-    "@jskit-ai/resource-crud-core": "0.1.2"
+    "@jskit-ai/crud-core": "0.1.66",
+    "@jskit-ai/kernel": "0.1.58",
+    "@jskit-ai/resource-crud-core": "0.1.3"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/database-runtime-mysql/package.descriptor.mjs
+++ b/packages/database-runtime-mysql/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-mysql",
-  version: "0.1.56",
+  version: "0.1.57",
   kind: "runtime",
   options: {
     "db-host": {
@@ -91,7 +91,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.57",
+        "@jskit-ai/database-runtime": "0.1.58",
         "mysql2": "^3.11.2"
       },
       dev: {}

--- a/packages/database-runtime-mysql/package.json
+++ b/packages/database-runtime-mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-mysql",
-  "version": "0.1.56",
+  "version": "0.1.57",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,7 +12,7 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.57",
-    "@jskit-ai/kernel": "0.1.57"
+    "@jskit-ai/database-runtime": "0.1.58",
+    "@jskit-ai/kernel": "0.1.58"
   }
 }

--- a/packages/database-runtime-postgres/package.descriptor.mjs
+++ b/packages/database-runtime-postgres/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-postgres",
-  version: "0.1.56",
+  version: "0.1.57",
   kind: "runtime",
   options: {
     "db-host": {
@@ -91,7 +91,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.57",
+        "@jskit-ai/database-runtime": "0.1.58",
         "pg": "^8.13.1"
       },
       dev: {}

--- a/packages/database-runtime-postgres/package.json
+++ b/packages/database-runtime-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-postgres",
-  "version": "0.1.56",
+  "version": "0.1.57",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,6 +12,6 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.57"
+    "@jskit-ai/database-runtime": "0.1.58"
   }
 }

--- a/packages/database-runtime/package.descriptor.mjs
+++ b/packages/database-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime",
-  version: "0.1.57",
+  version: "0.1.58",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -58,7 +58,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.57",
+        "@jskit-ai/kernel": "0.1.58",
         "dotenv": "^16.4.5",
         "knex": "^3.1.0"
       },

--- a/packages/database-runtime/package.json
+++ b/packages/database-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime",
-  "version": "0.1.57",
+  "version": "0.1.58",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -25,6 +25,6 @@
     "./shared/transactions": "./src/shared/transactions.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.57"
+    "@jskit-ai/kernel": "0.1.58"
   }
 }

--- a/packages/http-runtime/package.descriptor.mjs
+++ b/packages/http-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/http-runtime",
-  "version": "0.1.56",
+  "version": "0.1.57",
   "kind": "runtime",
   "dependsOn": [],
   "capabilities": {
@@ -67,7 +67,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.57"
+        "@jskit-ai/kernel": "0.1.58"
       },
       "dev": {}
     },

--- a/packages/http-runtime/package.json
+++ b/packages/http-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/http-runtime",
-  "version": "0.1.56",
+  "version": "0.1.57",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -18,7 +18,7 @@
     "./shared/validators/operationValidation": "./src/shared/validators/operationValidation.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.57",
+    "@jskit-ai/kernel": "0.1.58",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/json-rest-api-core/package.descriptor.mjs
+++ b/packages/json-rest-api-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/json-rest-api-core",
-  version: "0.1.2",
+  version: "0.1.3",
   kind: "runtime",
   description: "Shared internal json-rest-api host runtime for JSKIT server packages.",
   dependsOn: [

--- a/packages/json-rest-api-core/package.json
+++ b/packages/json-rest-api-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/json-rest-api-core",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,6 +11,6 @@
   "dependencies": {
     "hooked-api": "1.x.x",
     "json-rest-api": "1.x.x",
-    "@jskit-ai/kernel": "0.1.57"
+    "@jskit-ai/kernel": "0.1.58"
   }
 }

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/kernel",
-  "version": "0.1.57",
+  "version": "0.1.58",
   "type": "module",
   "dependencies": {
     "json-rest-schema": "1.x.x"

--- a/packages/realtime/package.descriptor.mjs
+++ b/packages/realtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/realtime",
-  version: "0.1.56",
+  version: "0.1.57",
   kind: "runtime",
   description: "Thin, generic realtime runtime wrappers for socket.io server and client.",
   options: {
@@ -94,7 +94,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.57",
+        "@jskit-ai/kernel": "0.1.58",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/realtime",
-  "version": "0.1.56",
+  "version": "0.1.57",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@socket.io/redis-adapter": "^8.3.0",
-    "@jskit-ai/kernel": "0.1.57",
+    "@jskit-ai/kernel": "0.1.58",
     "redis": "^5.8.2",
     "socket.io": "^4.8.3",
     "socket.io-client": "^4.8.3"

--- a/packages/resource-core/package.descriptor.mjs
+++ b/packages/resource-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/resource-core",
-  version: "0.1.2",
+  version: "0.1.3",
   kind: "runtime",
   description: "Generic resource-definition helpers and schema-definition normalization.",
   dependsOn: [
@@ -22,7 +22,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/resource-core": "0.1.2"
+        "@jskit-ai/resource-core": "0.1.3"
       },
       dev: {}
     },

--- a/packages/resource-core/package.json
+++ b/packages/resource-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/resource-core",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./shared/resource": "./src/shared/resource.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.57"
+    "@jskit-ai/kernel": "0.1.58"
   }
 }

--- a/packages/resource-crud-core/package.descriptor.mjs
+++ b/packages/resource-crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/resource-crud-core",
-  version: "0.1.2",
+  version: "0.1.3",
   kind: "runtime",
   description: "CRUD-specific resource-definition helpers and namespace support.",
   dependsOn: [
@@ -23,7 +23,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/resource-crud-core": "0.1.2"
+        "@jskit-ai/resource-crud-core": "0.1.3"
       },
       dev: {}
     },

--- a/packages/resource-crud-core/package.json
+++ b/packages/resource-crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/resource-crud-core",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./shared/crudResource": "./src/shared/crudResource.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.57",
-    "@jskit-ai/resource-core": "0.1.2"
+    "@jskit-ai/kernel": "0.1.58",
+    "@jskit-ai/resource-core": "0.1.3"
   }
 }

--- a/packages/shell-web/package.descriptor.mjs
+++ b/packages/shell-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/shell-web",
-  version: "0.1.56",
+  version: "0.1.57",
   kind: "runtime",
   description: "Web shell layout runtime with outlet-based placement contributions.",
   dependsOn: [],
@@ -122,7 +122,7 @@ export default Object.freeze({
       runtime: {
         "@mdi/js": "^7.4.47",
         "@tanstack/vue-query": "^5.90.5",
-        "@jskit-ai/kernel": "0.1.57",
+        "@jskit-ai/kernel": "0.1.58",
         "vuetify": "^4.0.0"
       },
       dev: {}

--- a/packages/shell-web/package.json
+++ b/packages/shell-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/shell-web",
-  "version": "0.1.56",
+  "version": "0.1.57",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -25,7 +25,7 @@
   "dependencies": {
     "@mdi/js": "^7.4.47",
     "@tanstack/vue-query": "^5.90.5",
-    "@jskit-ai/kernel": "0.1.57",
+    "@jskit-ai/kernel": "0.1.58",
     "pinia": "^3.0.4",
     "vuetify": "^4.0.0"
   },

--- a/packages/storage-runtime/package.descriptor.mjs
+++ b/packages/storage-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/storage-runtime",
-  version: "0.1.56",
+  version: "0.1.57",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -50,7 +50,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.57",
+        "@jskit-ai/kernel": "0.1.58",
         "unstorage": "^1.17.3"
       },
       dev: {}

--- a/packages/storage-runtime/package.json
+++ b/packages/storage-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/storage-runtime",
-  "version": "0.1.56",
+  "version": "0.1.57",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./server/providers/StorageRuntimeServiceProvider": "./src/server/providers/StorageRuntimeServiceProvider.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.57",
+    "@jskit-ai/kernel": "0.1.58",
     "unstorage": "^1.17.3"
   }
 }

--- a/packages/ui-generator/package.descriptor.mjs
+++ b/packages/ui-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/ui-generator",
-  version: "0.1.40",
+  version: "0.1.41",
   kind: "generator",
   description: "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
   options: {
@@ -278,7 +278,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.72"
+        "@jskit-ai/users-web": "0.1.73"
       },
       dev: {}
     },

--- a/packages/ui-generator/package.json
+++ b/packages/ui-generator/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/ui-generator",
-  "version": "0.1.40",
+  "version": "0.1.41",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.57",
-    "@jskit-ai/shell-web": "0.1.56"
+    "@jskit-ai/kernel": "0.1.58",
+    "@jskit-ai/shell-web": "0.1.57"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/uploads-image-web/package.descriptor.mjs
+++ b/packages/uploads-image-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-image-web",
-  version: "0.1.35",
+  version: "0.1.36",
   kind: "runtime",
   description: "Reusable client-side image upload runtime with pre-upload image editing.",
   dependsOn: [
@@ -65,7 +65,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/uploads-runtime": "0.1.35",
+        "@jskit-ai/uploads-runtime": "0.1.36",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-image-web/package.json
+++ b/packages/uploads-image-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-image-web",
-  "version": "0.1.35",
+  "version": "0.1.36",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,7 +13,7 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/uploads-runtime": "0.1.35",
+    "@jskit-ai/uploads-runtime": "0.1.36",
     "@uppy/compressor": "^3.1.0",
     "@uppy/core": "^5.2.0",
     "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-runtime/package.descriptor.mjs
+++ b/packages/uploads-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-runtime",
-  version: "0.1.35",
+  version: "0.1.36",
   kind: "runtime",
   description: "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
   dependsOn: [
@@ -71,7 +71,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.57"
+        "@jskit-ai/kernel": "0.1.58"
       },
       dev: {}
     },

--- a/packages/uploads-runtime/package.json
+++ b/packages/uploads-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-runtime",
-  "version": "0.1.35",
+  "version": "0.1.36",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,6 +16,6 @@
   },
   "dependencies": {
     "@fastify/multipart": "^9.4.0",
-    "@jskit-ai/kernel": "0.1.57"
+    "@jskit-ai/kernel": "0.1.58"
   }
 }

--- a/packages/users-core/package.descriptor.mjs
+++ b/packages/users-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-core",
-  version: "0.1.67",
+  version: "0.1.68",
   kind: "runtime",
   description: "Users/account runtime plus HTTP routes for account features.",
   dependsOn: [
@@ -132,16 +132,16 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.56",
-        "@jskit-ai/crud-core": "0.1.65",
-        "@jskit-ai/database-runtime": "0.1.57",
-        "@jskit-ai/http-runtime": "0.1.56",
-        "@jskit-ai/json-rest-api-core": "0.1.2",
-        "@jskit-ai/kernel": "0.1.57",
-        "@jskit-ai/resource-core": "0.1.2",
-        "@jskit-ai/resource-crud-core": "0.1.2",
+        "@jskit-ai/auth-core": "0.1.57",
+        "@jskit-ai/crud-core": "0.1.66",
+        "@jskit-ai/database-runtime": "0.1.58",
+        "@jskit-ai/http-runtime": "0.1.57",
+        "@jskit-ai/json-rest-api-core": "0.1.3",
+        "@jskit-ai/kernel": "0.1.58",
+        "@jskit-ai/resource-core": "0.1.3",
+        "@jskit-ai/resource-crud-core": "0.1.3",
         "@local/users": "file:packages/users",
-        "@jskit-ai/uploads-runtime": "0.1.35"
+        "@jskit-ai/uploads-runtime": "0.1.36"
       },
       dev: {}
     },

--- a/packages/users-core/package.json
+++ b/packages/users-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-core",
-  "version": "0.1.67",
+  "version": "0.1.68",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,14 +11,14 @@
     "./shared/resources/userSettingsResource": "./src/shared/resources/userSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.56",
-    "@jskit-ai/database-runtime": "0.1.57",
-    "@jskit-ai/http-runtime": "0.1.56",
-    "@jskit-ai/json-rest-api-core": "0.1.2",
-    "@jskit-ai/kernel": "0.1.57",
-    "@jskit-ai/resource-crud-core": "0.1.2",
-    "@jskit-ai/resource-core": "0.1.2",
-    "@jskit-ai/uploads-runtime": "0.1.35",
+    "@jskit-ai/auth-core": "0.1.57",
+    "@jskit-ai/database-runtime": "0.1.58",
+    "@jskit-ai/http-runtime": "0.1.57",
+    "@jskit-ai/json-rest-api-core": "0.1.3",
+    "@jskit-ai/kernel": "0.1.58",
+    "@jskit-ai/resource-crud-core": "0.1.3",
+    "@jskit-ai/resource-core": "0.1.3",
+    "@jskit-ai/uploads-runtime": "0.1.36",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/users-web/package.descriptor.mjs
+++ b/packages/users-web/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { HOME_COG_OUTLET } from "./src/shared/toolsOutletContracts.js";
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-web",
-  version: "0.1.72",
+  version: "0.1.73",
   kind: "runtime",
   description: "Users web module: account/profile UI plus shared users web widgets.",
   dependsOn: [
@@ -183,12 +183,12 @@ export default Object.freeze({
       runtime: {
         "@tanstack/vue-query": "5.92.12",
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/http-runtime": "0.1.56",
-        "@jskit-ai/realtime": "0.1.56",
-        "@jskit-ai/kernel": "0.1.57",
-        "@jskit-ai/shell-web": "0.1.56",
-        "@jskit-ai/uploads-image-web": "0.1.35",
-        "@jskit-ai/users-core": "0.1.67",
+        "@jskit-ai/http-runtime": "0.1.57",
+        "@jskit-ai/realtime": "0.1.57",
+        "@jskit-ai/kernel": "0.1.58",
+        "@jskit-ai/shell-web": "0.1.57",
+        "@jskit-ai/uploads-image-web": "0.1.36",
+        "@jskit-ai/users-core": "0.1.68",
         vuetify: "^4.0.0"
       },
       dev: {}

--- a/packages/users-web/package.json
+++ b/packages/users-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-web",
-  "version": "0.1.72",
+  "version": "0.1.73",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -34,12 +34,12 @@
   "dependencies": {
     "@tanstack/vue-query": "5.92.12",
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/http-runtime": "0.1.56",
-    "@jskit-ai/kernel": "0.1.57",
-    "@jskit-ai/realtime": "0.1.56",
-    "@jskit-ai/shell-web": "0.1.56",
-    "@jskit-ai/uploads-image-web": "0.1.35",
-    "@jskit-ai/users-core": "0.1.67",
+    "@jskit-ai/http-runtime": "0.1.57",
+    "@jskit-ai/kernel": "0.1.58",
+    "@jskit-ai/realtime": "0.1.57",
+    "@jskit-ai/shell-web": "0.1.57",
+    "@jskit-ai/uploads-image-web": "0.1.36",
+    "@jskit-ai/users-core": "0.1.68",
     "vuetify": "^4.0.0"
   },
   "peerDependencies": {

--- a/packages/workspaces-core/package.descriptor.mjs
+++ b/packages/workspaces-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-core",
-  version: "0.1.33",
+  version: "0.1.34",
   kind: "runtime",
   description: "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
   dependsOn: [
@@ -116,10 +116,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/json-rest-api-core": "0.1.2",
-        "@jskit-ai/resource-core": "0.1.2",
-        "@jskit-ai/resource-crud-core": "0.1.2",
-        "@jskit-ai/users-core": "0.1.67"
+        "@jskit-ai/json-rest-api-core": "0.1.3",
+        "@jskit-ai/resource-core": "0.1.3",
+        "@jskit-ai/resource-crud-core": "0.1.3",
+        "@jskit-ai/users-core": "0.1.68"
       },
       dev: {}
     },

--- a/packages/workspaces-core/package.json
+++ b/packages/workspaces-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-core",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -17,14 +17,14 @@
     "./shared/resources/workspaceSettingsResource": "./src/shared/resources/workspaceSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.56",
-    "@jskit-ai/database-runtime": "0.1.57",
-    "@jskit-ai/http-runtime": "0.1.56",
-    "@jskit-ai/json-rest-api-core": "0.1.2",
-    "@jskit-ai/kernel": "0.1.57",
-    "@jskit-ai/resource-crud-core": "0.1.2",
-    "@jskit-ai/resource-core": "0.1.2",
-    "@jskit-ai/users-core": "0.1.67",
+    "@jskit-ai/auth-core": "0.1.57",
+    "@jskit-ai/database-runtime": "0.1.58",
+    "@jskit-ai/http-runtime": "0.1.57",
+    "@jskit-ai/json-rest-api-core": "0.1.3",
+    "@jskit-ai/kernel": "0.1.58",
+    "@jskit-ai/resource-crud-core": "0.1.3",
+    "@jskit-ai/resource-core": "0.1.3",
+    "@jskit-ai/users-core": "0.1.68",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/workspaces-web/package.descriptor.mjs
+++ b/packages/workspaces-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-web",
-  version: "0.1.33",
+  version: "0.1.34",
   kind: "runtime",
   description: "Workspace web module: workspace selector, tools widget, workspace surfaces, and members/settings UI.",
   dependsOn: [
@@ -166,8 +166,8 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/workspaces-core": "0.1.33",
-        "@jskit-ai/users-web": "0.1.72",
+        "@jskit-ai/workspaces-core": "0.1.34",
+        "@jskit-ai/users-web": "0.1.73",
         "vuetify": "^4.0.0"
       },
       dev: {}

--- a/packages/workspaces-web/package.json
+++ b/packages/workspaces-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-web",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -15,12 +15,12 @@
   "dependencies": {
     "@tanstack/vue-query": "5.92.12",
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/http-runtime": "0.1.56",
-    "@jskit-ai/kernel": "0.1.57",
-    "@jskit-ai/shell-web": "0.1.56",
-    "@jskit-ai/users-core": "0.1.67",
-    "@jskit-ai/users-web": "0.1.72",
-    "@jskit-ai/workspaces-core": "0.1.33",
+    "@jskit-ai/http-runtime": "0.1.57",
+    "@jskit-ai/kernel": "0.1.58",
+    "@jskit-ai/shell-web": "0.1.57",
+    "@jskit-ai/users-core": "0.1.68",
+    "@jskit-ai/users-web": "0.1.73",
+    "@jskit-ai/workspaces-core": "0.1.34",
     "vuetify": "^4.0.0"
   },
   "peerDependencies": {

--- a/tooling/config-eslint/package.json
+++ b/tooling/config-eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/config-eslint",
-  "version": "0.1.56",
+  "version": "0.1.57",
   "description": "Shared flat ESLint presets for JSKIT projects.",
   "type": "module",
   "files": [

--- a/tooling/create-app/package.descriptor.mjs
+++ b/tooling/create-app/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/create-app",
-  "version": "0.1.65",
+  "version": "0.1.66",
   "dependsOn": [],
   "capabilities": {
     "provides": [

--- a/tooling/create-app/package.json
+++ b/tooling/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/create-app",
-  "version": "0.1.65",
+  "version": "0.1.66",
   "description": "Scaffold minimal JSKIT app shells.",
   "type": "module",
   "files": [

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -6,11 +6,11 @@
   "packages": [
     {
       "packageId": "@jskit-ai/assistant",
-      "version": "0.1.66",
+      "version": "0.1.67",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant",
-        "version": "0.1.66",
+        "version": "0.1.67",
         "kind": "generator",
         "description": "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
         "options": {
@@ -356,11 +356,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-core",
-      "version": "0.1.33",
+      "version": "0.1.34",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-core",
-        "version": "0.1.33",
+        "version": "0.1.34",
         "kind": "runtime",
         "description": "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
         "dependsOn": [
@@ -408,11 +408,11 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/http-runtime": "0.1.56",
-              "@jskit-ai/kernel": "0.1.57",
-              "@jskit-ai/resource-core": "0.1.2",
-              "@jskit-ai/resource-crud-core": "0.1.2",
-              "@jskit-ai/users-core": "0.1.67",
+              "@jskit-ai/http-runtime": "0.1.57",
+              "@jskit-ai/kernel": "0.1.58",
+              "@jskit-ai/resource-core": "0.1.3",
+              "@jskit-ai/resource-crud-core": "0.1.3",
+              "@jskit-ai/users-core": "0.1.68",
               "@tanstack/vue-query": "^5.90.5",
               "dompurify": "^3.3.3",
               "json-rest-schema": "1.x.x",
@@ -433,11 +433,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-runtime",
-      "version": "0.1.28",
+      "version": "0.1.29",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-runtime",
-        "version": "0.1.28",
+        "version": "0.1.29",
         "kind": "runtime",
         "description": "Shared assistant runtime with per-surface assistant registration.",
         "dependsOn": [
@@ -512,13 +512,13 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/assistant-core": "0.1.33",
-              "@jskit-ai/database-runtime": "0.1.57",
-              "@jskit-ai/http-runtime": "0.1.56",
-              "@jskit-ai/kernel": "0.1.57",
-              "@jskit-ai/shell-web": "0.1.56",
-              "@jskit-ai/users-core": "0.1.67",
-              "@jskit-ai/users-web": "0.1.72",
+              "@jskit-ai/assistant-core": "0.1.34",
+              "@jskit-ai/database-runtime": "0.1.58",
+              "@jskit-ai/http-runtime": "0.1.57",
+              "@jskit-ai/kernel": "0.1.58",
+              "@jskit-ai/shell-web": "0.1.57",
+              "@jskit-ai/users-core": "0.1.68",
+              "@jskit-ai/users-web": "0.1.73",
               "@tanstack/vue-query": "^5.90.5",
               "vuetify": "^4.0.0"
             },
@@ -575,11 +575,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-core",
-      "version": "0.1.56",
+      "version": "0.1.57",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-core",
-        "version": "0.1.56",
+        "version": "0.1.57",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/value-app-config-shared"
@@ -647,7 +647,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.57",
+              "@jskit-ai/kernel": "0.1.58",
               "@fastify/cookie": "^11.0.2",
               "@fastify/csrf-protection": "^7.1.0",
               "@fastify/rate-limit": "^10.3.0"
@@ -665,11 +665,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.56",
+      "version": "0.1.57",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-supabase-core",
-        "version": "0.1.56",
+        "version": "0.1.57",
         "kind": "runtime",
         "options": {
           "auth-supabase-url": {
@@ -751,8 +751,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.56",
-              "@jskit-ai/kernel": "0.1.57",
+              "@jskit-ai/auth-core": "0.1.57",
+              "@jskit-ai/kernel": "0.1.58",
               "dotenv": "^16.4.5",
               "@supabase/supabase-js": "^2.57.4",
               "jose": "^6.1.0"
@@ -817,11 +817,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-web",
-      "version": "0.1.58",
+      "version": "0.1.59",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-web",
-        "version": "0.1.58",
+        "version": "0.1.59",
         "kind": "runtime",
         "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
         "dependsOn": [
@@ -1047,10 +1047,10 @@
             "runtime": {
               "@tanstack/vue-query": "5.92.12",
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/auth-core": "0.1.56",
-              "@jskit-ai/http-runtime": "0.1.56",
-              "@jskit-ai/kernel": "0.1.57",
-              "@jskit-ai/shell-web": "0.1.56",
+              "@jskit-ai/auth-core": "0.1.57",
+              "@jskit-ai/http-runtime": "0.1.57",
+              "@jskit-ai/kernel": "0.1.58",
+              "@jskit-ai/shell-web": "0.1.57",
               "vuetify": "^4.0.0"
             },
             "dev": {}
@@ -1120,11 +1120,11 @@
     },
     {
       "packageId": "@jskit-ai/console-core",
-      "version": "0.1.20",
+      "version": "0.1.21",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-core",
-        "version": "0.1.20",
+        "version": "0.1.21",
         "kind": "runtime",
         "description": "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
         "dependsOn": [
@@ -1197,12 +1197,12 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.56",
-              "@jskit-ai/database-runtime": "0.1.57",
-              "@jskit-ai/http-runtime": "0.1.56",
-              "@jskit-ai/kernel": "0.1.57",
-              "@jskit-ai/resource-crud-core": "0.1.2",
-              "@jskit-ai/users-core": "0.1.67"
+              "@jskit-ai/auth-core": "0.1.57",
+              "@jskit-ai/database-runtime": "0.1.58",
+              "@jskit-ai/http-runtime": "0.1.57",
+              "@jskit-ai/kernel": "0.1.58",
+              "@jskit-ai/resource-crud-core": "0.1.3",
+              "@jskit-ai/users-core": "0.1.68"
             },
             "dev": {}
           },
@@ -1227,11 +1227,11 @@
     },
     {
       "packageId": "@jskit-ai/console-web",
-      "version": "0.1.25",
+      "version": "0.1.26",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-web",
-        "version": "0.1.25",
+        "version": "0.1.26",
         "kind": "runtime",
         "description": "Authenticated console surface scaffold and surface policy wiring.",
         "dependsOn": [
@@ -1310,9 +1310,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-web": "0.1.58",
-              "@jskit-ai/console-core": "0.1.20",
-              "@jskit-ai/shell-web": "0.1.56"
+              "@jskit-ai/auth-web": "0.1.59",
+              "@jskit-ai/console-core": "0.1.21",
+              "@jskit-ai/shell-web": "0.1.57"
             },
             "dev": {}
           },
@@ -1409,11 +1409,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-core",
-      "version": "0.1.65",
+      "version": "0.1.66",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-core",
-        "version": "0.1.65",
+        "version": "0.1.66",
         "kind": "runtime",
         "description": "Shared CRUD helpers used by CRUD modules.",
         "dependsOn": [
@@ -1442,7 +1442,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/crud-core": "0.1.65"
+              "@jskit-ai/crud-core": "0.1.66"
             },
             "dev": {}
           },
@@ -1456,11 +1456,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-server-generator",
-      "version": "0.1.65",
+      "version": "0.1.66",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-server-generator",
-        "version": "0.1.65",
+        "version": "0.1.66",
         "kind": "generator",
         "description": "CRUD server generator with routes, actions, and persistence scaffolding.",
         "options": {
@@ -1619,14 +1619,14 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.56",
-              "@jskit-ai/crud-core": "0.1.65",
-              "@jskit-ai/database-runtime": "0.1.57",
-              "@jskit-ai/http-runtime": "0.1.56",
-              "@jskit-ai/json-rest-api-core": "0.1.2",
-              "@jskit-ai/kernel": "0.1.57",
-              "@jskit-ai/realtime": "0.1.56",
-              "@jskit-ai/resource-crud-core": "0.1.2",
+              "@jskit-ai/auth-core": "0.1.57",
+              "@jskit-ai/crud-core": "0.1.66",
+              "@jskit-ai/database-runtime": "0.1.58",
+              "@jskit-ai/http-runtime": "0.1.57",
+              "@jskit-ai/json-rest-api-core": "0.1.3",
+              "@jskit-ai/kernel": "0.1.58",
+              "@jskit-ai/realtime": "0.1.57",
+              "@jskit-ai/resource-crud-core": "0.1.3",
               "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}"
             },
             "dev": {}
@@ -1754,11 +1754,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.40",
+      "version": "0.1.41",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-ui-generator",
-        "version": "0.1.40",
+        "version": "0.1.41",
         "kind": "generator",
         "description": "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
         "options": {
@@ -1933,7 +1933,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.72"
+              "@jskit-ai/users-web": "0.1.73"
             },
             "dev": {}
           },
@@ -2166,11 +2166,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime",
-      "version": "0.1.57",
+      "version": "0.1.58",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime",
-        "version": "0.1.57",
+        "version": "0.1.58",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -2227,7 +2227,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.57",
+              "@jskit-ai/kernel": "0.1.58",
               "dotenv": "^16.4.5",
               "knex": "^3.1.0"
             },
@@ -2262,11 +2262,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.56",
+      "version": "0.1.57",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-mysql",
-        "version": "0.1.56",
+        "version": "0.1.57",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -2356,7 +2356,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.57",
+              "@jskit-ai/database-runtime": "0.1.58",
               "mysql2": "^3.11.2"
             },
             "dev": {}
@@ -2427,11 +2427,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.56",
+      "version": "0.1.57",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-postgres",
-        "version": "0.1.56",
+        "version": "0.1.57",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -2521,7 +2521,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.57",
+              "@jskit-ai/database-runtime": "0.1.58",
               "pg": "^8.13.1"
             },
             "dev": {}
@@ -2592,11 +2592,11 @@
     },
     {
       "packageId": "@jskit-ai/http-runtime",
-      "version": "0.1.56",
+      "version": "0.1.57",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/http-runtime",
-        "version": "0.1.56",
+        "version": "0.1.57",
         "kind": "runtime",
         "dependsOn": [],
         "capabilities": {
@@ -2662,7 +2662,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.57"
+              "@jskit-ai/kernel": "0.1.58"
             },
             "dev": {}
           },
@@ -2676,11 +2676,11 @@
     },
     {
       "packageId": "@jskit-ai/json-rest-api-core",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/json-rest-api-core",
-        "version": "0.1.2",
+        "version": "0.1.3",
         "kind": "runtime",
         "description": "Shared internal json-rest-api host runtime for JSKIT server packages.",
         "dependsOn": [
@@ -2740,11 +2740,11 @@
     },
     {
       "packageId": "@jskit-ai/realtime",
-      "version": "0.1.56",
+      "version": "0.1.57",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/realtime",
-        "version": "0.1.56",
+        "version": "0.1.57",
         "kind": "runtime",
         "description": "Thin, generic realtime runtime wrappers for socket.io server and client.",
         "options": {
@@ -2839,7 +2839,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.57",
+              "@jskit-ai/kernel": "0.1.58",
               "@socket.io/redis-adapter": "^8.3.0",
               "redis": "^5.8.2",
               "socket.io": "^4.8.3",
@@ -2888,11 +2888,11 @@
     },
     {
       "packageId": "@jskit-ai/resource-core",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/resource-core",
-        "version": "0.1.2",
+        "version": "0.1.3",
         "kind": "runtime",
         "description": "Generic resource-definition helpers and schema-definition normalization.",
         "dependsOn": [
@@ -2915,7 +2915,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/resource-core": "0.1.2"
+              "@jskit-ai/resource-core": "0.1.3"
             },
             "dev": {}
           },
@@ -2930,11 +2930,11 @@
     },
     {
       "packageId": "@jskit-ai/resource-crud-core",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/resource-crud-core",
-        "version": "0.1.2",
+        "version": "0.1.3",
         "kind": "runtime",
         "description": "CRUD-specific resource-definition helpers and namespace support.",
         "dependsOn": [
@@ -2958,7 +2958,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/resource-crud-core": "0.1.2"
+              "@jskit-ai/resource-crud-core": "0.1.3"
             },
             "dev": {}
           },
@@ -2973,11 +2973,11 @@
     },
     {
       "packageId": "@jskit-ai/shell-web",
-      "version": "0.1.56",
+      "version": "0.1.57",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/shell-web",
-        "version": "0.1.56",
+        "version": "0.1.57",
         "kind": "runtime",
         "description": "Web shell layout runtime with outlet-based placement contributions.",
         "dependsOn": [],
@@ -3114,7 +3114,7 @@
             "runtime": {
               "@mdi/js": "^7.4.47",
               "@tanstack/vue-query": "^5.90.5",
-              "@jskit-ai/kernel": "0.1.57",
+              "@jskit-ai/kernel": "0.1.58",
               "vuetify": "^4.0.0"
             },
             "dev": {}
@@ -3299,11 +3299,11 @@
     },
     {
       "packageId": "@jskit-ai/storage-runtime",
-      "version": "0.1.56",
+      "version": "0.1.57",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/storage-runtime",
-        "version": "0.1.56",
+        "version": "0.1.57",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -3352,7 +3352,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.57",
+              "@jskit-ai/kernel": "0.1.58",
               "unstorage": "^1.17.3"
             },
             "dev": {}
@@ -3368,11 +3368,11 @@
     },
     {
       "packageId": "@jskit-ai/ui-generator",
-      "version": "0.1.40",
+      "version": "0.1.41",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/ui-generator",
-        "version": "0.1.40",
+        "version": "0.1.41",
         "kind": "generator",
         "description": "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
         "options": {
@@ -3671,7 +3671,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.72"
+              "@jskit-ai/users-web": "0.1.73"
             },
             "dev": {}
           },
@@ -3686,11 +3686,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-image-web",
-      "version": "0.1.35",
+      "version": "0.1.36",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-image-web",
-        "version": "0.1.35",
+        "version": "0.1.36",
         "kind": "runtime",
         "description": "Reusable client-side image upload runtime with pre-upload image editing.",
         "dependsOn": [
@@ -3754,7 +3754,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/uploads-runtime": "0.1.35",
+              "@jskit-ai/uploads-runtime": "0.1.36",
               "@uppy/compressor": "^3.1.0",
               "@uppy/core": "^5.2.0",
               "@uppy/dashboard": "^5.1.1",
@@ -3774,11 +3774,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-runtime",
-      "version": "0.1.35",
+      "version": "0.1.36",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-runtime",
-        "version": "0.1.35",
+        "version": "0.1.36",
         "kind": "runtime",
         "description": "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
         "dependsOn": [
@@ -3848,7 +3848,7 @@
           "dependencies": {
             "runtime": {
               "@fastify/multipart": "^9.4.0",
-              "@jskit-ai/kernel": "0.1.57"
+              "@jskit-ai/kernel": "0.1.58"
             },
             "dev": {}
           },
@@ -3863,11 +3863,11 @@
     },
     {
       "packageId": "@jskit-ai/users-core",
-      "version": "0.1.67",
+      "version": "0.1.68",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-core",
-        "version": "0.1.67",
+        "version": "0.1.68",
         "kind": "runtime",
         "description": "Users/account runtime plus HTTP routes for account features.",
         "dependsOn": [
@@ -3997,16 +3997,16 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.56",
-              "@jskit-ai/crud-core": "0.1.65",
-              "@jskit-ai/database-runtime": "0.1.57",
-              "@jskit-ai/http-runtime": "0.1.56",
-              "@jskit-ai/json-rest-api-core": "0.1.2",
-              "@jskit-ai/kernel": "0.1.57",
-              "@jskit-ai/resource-core": "0.1.2",
-              "@jskit-ai/resource-crud-core": "0.1.2",
+              "@jskit-ai/auth-core": "0.1.57",
+              "@jskit-ai/crud-core": "0.1.66",
+              "@jskit-ai/database-runtime": "0.1.58",
+              "@jskit-ai/http-runtime": "0.1.57",
+              "@jskit-ai/json-rest-api-core": "0.1.3",
+              "@jskit-ai/kernel": "0.1.58",
+              "@jskit-ai/resource-core": "0.1.3",
+              "@jskit-ai/resource-crud-core": "0.1.3",
               "@local/users": "file:packages/users",
-              "@jskit-ai/uploads-runtime": "0.1.35"
+              "@jskit-ai/uploads-runtime": "0.1.36"
             },
             "dev": {}
           },
@@ -4223,11 +4223,11 @@
     },
     {
       "packageId": "@jskit-ai/users-web",
-      "version": "0.1.72",
+      "version": "0.1.73",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-web",
-        "version": "0.1.72",
+        "version": "0.1.73",
         "kind": "runtime",
         "description": "Users web module: account/profile UI plus shared users web widgets.",
         "dependsOn": [
@@ -4423,12 +4423,12 @@
             "runtime": {
               "@tanstack/vue-query": "5.92.12",
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/http-runtime": "0.1.56",
-              "@jskit-ai/realtime": "0.1.56",
-              "@jskit-ai/kernel": "0.1.57",
-              "@jskit-ai/shell-web": "0.1.56",
-              "@jskit-ai/uploads-image-web": "0.1.35",
-              "@jskit-ai/users-core": "0.1.67",
+              "@jskit-ai/http-runtime": "0.1.57",
+              "@jskit-ai/realtime": "0.1.57",
+              "@jskit-ai/kernel": "0.1.58",
+              "@jskit-ai/shell-web": "0.1.57",
+              "@jskit-ai/uploads-image-web": "0.1.36",
+              "@jskit-ai/users-core": "0.1.68",
               "vuetify": "^4.0.0"
             },
             "dev": {}
@@ -4578,11 +4578,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-core",
-      "version": "0.1.33",
+      "version": "0.1.34",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-core",
-        "version": "0.1.33",
+        "version": "0.1.34",
         "kind": "runtime",
         "description": "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
         "dependsOn": [
@@ -4697,10 +4697,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/json-rest-api-core": "0.1.2",
-              "@jskit-ai/resource-core": "0.1.2",
-              "@jskit-ai/resource-crud-core": "0.1.2",
-              "@jskit-ai/users-core": "0.1.67"
+              "@jskit-ai/json-rest-api-core": "0.1.3",
+              "@jskit-ai/resource-core": "0.1.3",
+              "@jskit-ai/resource-crud-core": "0.1.3",
+              "@jskit-ai/users-core": "0.1.68"
             },
             "dev": {}
           },
@@ -4872,11 +4872,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-web",
-      "version": "0.1.33",
+      "version": "0.1.34",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-web",
-        "version": "0.1.33",
+        "version": "0.1.34",
         "kind": "runtime",
         "description": "Workspace web module: workspace selector, tools widget, workspace surfaces, and members/settings UI.",
         "dependsOn": [
@@ -5063,8 +5063,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/workspaces-core": "0.1.33",
-              "@jskit-ai/users-web": "0.1.72",
+              "@jskit-ai/workspaces-core": "0.1.34",
+              "@jskit-ai/users-web": "0.1.73",
               "vuetify": "^4.0.0"
             },
             "dev": {}

--- a/tooling/jskit-catalog/package.json
+++ b/tooling/jskit-catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-catalog",
-  "version": "0.1.65",
+  "version": "0.1.66",
   "description": "Published metadata catalog for JSKIT package descriptors.",
   "type": "module",
   "files": [

--- a/tooling/jskit-cli/package.json
+++ b/tooling/jskit-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-cli",
-  "version": "0.2.66",
+  "version": "0.2.67",
   "description": "Bundle and package orchestration CLI for JSKIT apps.",
   "type": "module",
   "files": [
@@ -20,9 +20,9 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/jskit-catalog": "0.1.65",
-    "@jskit-ai/kernel": "0.1.57",
-    "@jskit-ai/shell-web": "0.1.56"
+    "@jskit-ai/jskit-catalog": "0.1.66",
+    "@jskit-ai/kernel": "0.1.58",
+    "@jskit-ai/shell-web": "0.1.57"
   },
   "engines": {
     "node": "20.x"


### PR DESCRIPTION
## Summary
- refresh package versions across runtime, generator, and tooling packages
- update package descriptors to point at the new internal version graph
- regenerate catalog metadata and lockfile to match the current package set

## Verification
- not run (`npm verify` intentionally skipped per request)
