### PR TITLE
feat(crud-ui): refine child-page routing and docs

### DIFF
--- a/packages/agent-docs/guide/agent/app-setup/multi-homing.md
+++ b/packages/agent-docs/guide/agent/app-setup/multi-homing.md
@@ -47,6 +47,12 @@ npm install
 npm run db:migrate
 ```
 
+**Important: This Block Is Only The Fresh Workspace Install Path**
+
+These commands are complete only if the app was already on `tenancyMode = "personal"` when `users-web` / `users-core` were originally installed, or if you already ran the recovery `npx jskit update package users-core` step above.
+
+If you changed tenancy after installing users, do not skip that update. The workspace packages add workspace runtime and routes, but `users-core` is what rewrites the app-local users scaffold into its workspace-aware shape.
+
 `workspaces-core` adds the server-side workspace runtime and schema migrations. `workspaces-web` adds the workspace-facing client surfaces, shell placements, and app-owned route files.
 
 If you want to inspect that package before installing it, this is a very good moment to use the CLI chapter's inspection command:
@@ -306,6 +312,30 @@ Concretely, that route tree works like this:
 - `w/[workspaceSlug]/admin/workspace/settings.vue` is a section shell. It does not own the actual settings fields. It owns the card frame, the left-side settings menu outlet, and the nested `<RouterView />` where child settings pages render.
 - `w/[workspaceSlug]/admin/workspace/settings/index.vue` is intentionally almost empty. Its job is to make `/admin/workspace/settings` a real route today and give you a clean place to redirect or add child settings pages later.
 
+If you want to add a real workspace settings child page at this point, use the normal page generator under that route tree:
+
+```bash
+npx jskit generate ui-generator page \
+  w/[workspaceSlug]/admin/workspace/settings/billing/index.vue \
+  --name "Billing"
+```
+
+That command does two things:
+
+- it creates `src/pages/w/[workspaceSlug]/admin/workspace/settings/billing/index.vue`
+- it also appends the matching workspace settings menu entry into `src/placement.js`
+
+The reason JSKIT can wire that link automatically is that the workspace settings shell already exposes a named placement outlet with a default link renderer:
+
+```vue
+<ShellOutlet
+  target="admin-settings:primary-menu"
+  default-link-component-token="local.main.ui.surface-aware-menu-link-item"
+/>
+```
+
+`target="admin-settings:primary-menu"` tells the generator which settings menu host owns those child links. `default-link-component-token="local.main.ui.surface-aware-menu-link-item"` tells it which local menu-link component to use unless you override it. So a page generated under `w/[workspaceSlug]/admin/workspace/settings/...` automatically lands in the left-side workspace settings menu without you hand-writing the placement entry.
+
 ### Workspace pages are prepared for missing-workspace states
 
 The starter workspace pages already use a dedicated unavailable-state helper:
@@ -557,6 +587,35 @@ That one block explains a lot of the new shell behavior.
 - the top-right area can show a pending-invites cue
 - the admin surface gets workspace tools in the top-right area
 - the admin workspace settings menu is now another nested placement host with both `Settings` and `Members`
+
+If you want to add your own app-owned page into that top cog menu, first ask JSKIT which placement targets exist:
+
+```bash
+npx jskit list-placements
+```
+
+In a workspace-enabled app, that list now includes:
+
+```text
+- admin-cog:primary-menu [package:@jskit-ai/workspaces-web:src/client/components/UsersWorkspaceToolsWidget.vue]
+```
+
+If you want more context than the raw target list, `npx jskit show @jskit-ai/workspaces-web --details` also shows that same outlet plus the default `Settings` and `Members` entries already targeting it.
+
+Once you know the outlet id, generate the page like this:
+
+```bash
+npx jskit generate ui-generator page \
+  w/[workspaceSlug]/admin/catalogue/index.vue \
+  --name "Catalogue" \
+  --link-placement admin-cog:primary-menu
+```
+
+That command creates `src/pages/w/[workspaceSlug]/admin/catalogue/index.vue` and appends the matching link entry into `src/placement.js`.
+
+`--link-placement` is necessary here because this route is just a normal `admin` page. It is **not** a child page under a local host like `w/[workspaceSlug]/admin/workspace/settings.vue`, so the generator has no nested settings outlet to infer automatically. If you omit `--link-placement`, the new page link falls back to the app's default shell menu outlet instead of the cog menu.
+
+You also do **not** need `--link-component-token` here. `admin-cog:primary-menu` already declares `local.main.ui.surface-aware-menu-link-item` as its default link renderer, so JSKIT reuses that automatically when it writes the placement entry.
 
 So the placement system from the shell chapter is still doing the same job as before. The app just has a richer routing and tenancy context now.
 

--- a/packages/agent-docs/guide/agent/app-setup/users.md
+++ b/packages/agent-docs/guide/agent/app-setup/users.md
@@ -343,6 +343,14 @@ Under the hood, `users-core` wires those contributors into the users-backed prof
 
 The next chapter uses exactly that pattern. `workspaces-core` registers a contributor so the workspace layer can react when a new user enters the system.
 
+One forward-looking warning matters here. If this app later changes from `tenancyMode = "none"` to `personal` or `workspaces`, the app-local users scaffold written by `users-core` also needs to be refreshed. The multi-homing chapter calls out that recovery step explicitly with:
+
+```bash
+npx jskit update package users-core
+```
+
+That is not only a workspace-package concern. The generated `packages/users/...` scaffold itself changes shape when tenancy becomes workspace-aware.
+
 ## Summary
 
 This chapter is where the app stopped treating signed-in people as only Supabase identities and started treating them as real JSKIT users.

--- a/packages/agent-docs/guide/agent/generators/crud-generators.md
+++ b/packages/agent-docs/guide/agent/generators/crud-generators.md
@@ -16,8 +16,8 @@ So the real order is always:
 This chapter uses three examples, in increasing complexity:
 
 - `contacts`: the baseline full CRUD walkthrough
-- `addresses`: a child CRUD with its own routed list page
-- `comments`: a child CRUD that lives inside the parent page, with only the child routes being routed
+- `addresses`: a child CRUD with its own routed list page reached from the parent record view
+- `comments`: a child CRUD that lives under the parent record host as a child page
 
 The examples assume the guide app already has the database and workspace/admin setup from the earlier chapters. That is why the route roots below live under `w/[workspaceSlug]/admin/...`.
 
@@ -350,7 +350,7 @@ That is the shape to learn first.
 
 Now move to a child CRUD with its own URL.
 
-This is the right pattern when the child collection deserves its own list page.
+This is the right pattern when the child collection deserves its own list page, but should still be reached from a specific parent record.
 
 Example route:
 
@@ -358,11 +358,22 @@ Example route:
 .../contacts/3/addresses
 ```
 
-In the guide app's real route tree, that becomes:
+In the guide app's real route tree, the visible URL becomes:
 
 ```text
 w/[workspaceSlug]/admin/contacts/[contactId]/addresses
 ```
+
+This example is intentionally **not** an in-page child list and **not** a contact subtab.
+
+The intended UX is:
+
+- `addresses` gets its own routed list page
+- the page lives under a specific contact
+- the user reaches it from an explicit link or button on the contact view
+- it does **not** appear in the global left menu
+
+That makes it different from the later `comments` example, where the child list stays inside the parent page.
 
 ### Step 1: create the child table
 
@@ -382,11 +393,15 @@ CREATE TABLE addresses (
   created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
   updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   KEY idx_addresses_workspace_id (workspace_id),
-  KEY idx_addresses_contact_id (contact_id)
+  KEY idx_addresses_contact_id (contact_id),
+  CONSTRAINT fk_addresses_contact_id
+    FOREIGN KEY (contact_id) REFERENCES contacts(id)
 );
 ```
 
 The important extra column here is `contact_id`. This is what makes the CRUD a child of a contact instead of a top-level resource.
+
+The foreign key is not optional in this example. It is what lets `crud-server-generator` emit `contactId` as a real lookup relation in `packages/addresses/src/shared/addressResource.js`.
 
 ### Step 2: scaffold the server package
 
@@ -398,17 +413,104 @@ npx jskit generate crud-server-generator scaffold \
   --table-name addresses
 ```
 
-### Step 3: scaffold the UI at the child route root
+Then install the generated local package:
+
+```bash
+npm install
+```
+
+If you are developing against a local JSKIT checkout, relink your app to the local packages before you run the UI:
+
+```bash
+npm run devlinks
+```
+
+### Step 3: refine the generated lookup metadata by hand
+
+Open `packages/addresses/src/shared/addressResource.js` and add `labelKey: "fullName"` to the generated `contactId` relation:
+
+```js
+contactId: {
+  type: "id",
+  required: true,
+  search: true,
+  relation: {
+    kind: "lookup",
+    namespace: "contacts",
+    valueKey: "id",
+    labelKey: "fullName"
+  },
+  belongsTo: "contacts",
+  as: "contact",
+  ui: { formControl: "autocomplete" },
+  ...
+}
+```
+
+This part is still manual today.
+
+The scaffold can infer the lookup **relationship** from the foreign key, but it cannot infer which contact field should be used as the human-readable label. Without `labelKey: "fullName"`, the page falls back to generic headings like `Addresses for Contact #1`.
+
+### Step 4: scaffold the UI route tree
 
 ```bash
 npx jskit generate crud-ui-generator crud \
   w/[workspaceSlug]/admin/contacts/[contactId]/addresses \
   --resource-file packages/addresses/src/shared/addressResource.js \
   --id-param addressId \
+  --parent-title contextual \
   --display-fields label,line1,postcode
 ```
 
-That gives you a proper child CRUD with its own list, view, new, and edit pages under the contact route.
+That gives you a normal child route tree:
+
+- `w/[workspaceSlug]/admin/contacts/[contactId]/addresses/index.vue`
+- `w/[workspaceSlug]/admin/contacts/[contactId]/addresses/new.vue`
+- `w/[workspaceSlug]/admin/contacts/[contactId]/addresses/[addressId]/index.vue`
+- `w/[workspaceSlug]/admin/contacts/[contactId]/addresses/[addressId]/edit.vue`
+- shared `_components` files under the same route root
+
+### Step 5: remove the generated shell placement by hand
+
+`crud-ui-generator` currently generates a list-page placement block in `src/placement.js`.
+
+For this example, that block is **not** what you want.
+
+Delete the generated `addresses` placement block from `src/placement.js`.
+
+It will be the block added for the `w/[workspaceSlug]/admin/contacts/[contactId]/addresses` page link.
+
+Depending on what outlets already exist in the app, that block may try to place `Addresses` in the shell menu or in the contact subpages outlet. For this example, remove it either way and keep navigation manual from the contact view.
+
+This is an intentional manual cleanup for now:
+
+- keep the routed pages
+- remove the auto menu link
+- navigate to the page from the contact view instead
+
+### Step 6: add a manual link from the contact view
+
+Open `src/pages/w/[workspaceSlug]/admin/contacts/[contactId]/index.vue` and add a button that links to `./addresses`.
+
+The simplest version is:
+
+```vue
+<v-btn
+  color="primary"
+  variant="tonal"
+  :to="{ path: view.resolveParams(UI_ADDRESSES_URL), query: $route.query }"
+>
+  Addresses
+</v-btn>
+```
+
+Then define the URL template in the script:
+
+```js
+const UI_ADDRESSES_URL = "./addresses";
+```
+
+That gives you a standalone child page with a clear entry point from the parent contact view, without mixing record-scoped pages into the global shell menu.
 
 ### The important refinement: parent title handling
 
@@ -416,8 +518,8 @@ This is where nested CRUD starts to feel real.
 
 An addresses list page should not show a generic heading like `Addresses`. It should usually show whose addresses these are, for example:
 
-- `Jane Smith's addresses`
-- `Acme Pty Ltd's addresses`
+- `Addresses for Jane Smith`
+- `Addresses for Acme Pty Ltd`
 
 The awkward case is when there are **no child rows yet**. If the list is empty, you cannot derive the parent title from the first address record.
 
@@ -433,37 +535,36 @@ const parentTitle = useCrudListParentTitle({
 });
 ```
 
-That helper does the nice thing automatically:
+That helper does the right thing automatically:
 
-- if the child list already has rows, it derives the parent title from the first child record
+- if the child list already has rows, it derives the parent title from the first child record when lookup data is available
 - if the child list is empty, it loads the parent record directly
 
-This is exactly the pattern used in the real app codebase for nested CRUD lists like a contact's pets. It avoids the common broken state where an empty child list loses all context about the parent it belongs to.
-
-So the `addresses` example is important because it teaches the first truly practical nested-CRUD problem:
+So the `addresses` example is important because it teaches the first truly practical child-page problem:
 
 - the route is child-scoped
 - the data is child-scoped
-- but the page still needs a reliable parent identity even when the child list is empty
+- the page is reached from a parent action, not from the main shell menu
+- the page still needs a reliable parent identity even when the child list is empty
 
-## Example 3: `comments` in-page
+## Example 3: `comments` under the contact host
 
 This is the advanced example.
 
-Sometimes a child resource is real enough to deserve its own CRUD operations, but **not** important enough to deserve its own full-screen list page.
+Sometimes a child resource should stay attached to the parent record, but still deserves its own routed child page.
 
 Comments are a good example:
 
 - they matter
 - they need persistence
-- they may need `view`, `new`, or `edit` routes
-- but the main screen is still the contact view page
+- they benefit from their own list, `new`, `view`, and `edit` routes
+- but they still belong inside the contact experience rather than as a top-level destination
 
 So the pattern is:
 
 - keep the contact page as the real host
-- render the comments list inside that page
-- route only the child operations underneath it
+- keep the child route tree under that host
+- let the generated placement surface the comments page as a contact child page
 
 ### Step 1: create the table
 
@@ -474,12 +575,13 @@ CREATE TABLE comments (
   id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
   workspace_id BIGINT UNSIGNED NOT NULL,
   contact_id BIGINT UNSIGNED NOT NULL,
-  author_user_id BIGINT UNSIGNED NULL,
   body TEXT NOT NULL,
   created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
   updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   KEY idx_comments_workspace_id (workspace_id),
-  KEY idx_comments_contact_id (contact_id)
+  KEY idx_comments_contact_id (contact_id),
+  CONSTRAINT fk_comments_contact_id
+    FOREIGN KEY (contact_id) REFERENCES contacts(id)
 );
 ```
 
@@ -493,7 +595,45 @@ npx jskit generate crud-server-generator scaffold \
   --table-name comments
 ```
 
-### Step 3: make the parent page able to host routed children
+Then install the generated local package:
+
+```bash
+npm install
+```
+
+If you are developing against a local JSKIT checkout, relink the app before you run the UI:
+
+```bash
+npm run devlinks
+```
+
+### Step 3: refine the generated lookup metadata by hand
+
+Open `packages/comments/src/shared/commentResource.js` and add `labelKey: "fullName"` to the generated `contactId` relation:
+
+```js
+contactId: {
+  type: "id",
+  required: true,
+  search: true,
+  relation: {
+    kind: "lookup",
+    namespace: "contacts",
+    valueKey: "id",
+    labelKey: "fullName"
+  },
+  belongsTo: "contacts",
+  as: "contact",
+  ui: { formControl: "autocomplete" },
+  ...
+}
+```
+
+This is the same manual refinement used in the `addresses` example: the scaffold can infer the lookup relationship from the foreign key, but it cannot infer which parent field should be used as the display label.
+
+The next command also makes the parent-title mode explicit on purpose. That way changing the heading behavior later is just changing the value and rerunning with `--force`, not adding a new flag.
+
+### Step 4: make the parent page able to host routed children
 
 If the contact view page should stay visible while child comment routes render underneath it, first upgrade it into a routed host:
 
@@ -509,63 +649,71 @@ That is the point where the comments example deliberately overlaps with the `ui-
 - CRUD scaffolding for the comments resource
 - a routed host in the parent contact page
 
-### Step 4: generate only the routed child operations
+### Step 4.5: make `comments` the default child page
 
-Now generate the comments UI without a list page:
+This is a very common next step.
+
+If the contact page should open directly on `Comments`, add an explicit redirect to the contact host page:
+
+```vue
+<script setup>
+import { redirectToChild } from "@jskit-ai/kernel/client/pageRedirects";
+
+definePage({
+  redirect: redirectToChild("comments")
+});
+</script>
+```
+
+In this example, that edit belongs in:
+
+```text
+src/pages/w/[workspaceSlug]/admin/contacts/[contactId]/index.vue
+```
+
+This is the recommended pattern. Do **not** try to infer the default child page from placement order or "the first tab". Keep it explicit.
+
+When this redirect is present:
+
+- opening `/w/<workspaceSlug>/admin/contacts/<contactId>` lands on `/w/<workspaceSlug>/admin/contacts/<contactId>/comments`
+- the parent contact page still stays visible
+- the child page renders underneath it
+
+That last point matters. The contact page is still the host page. The redirect only changes which child route becomes the default landing destination.
+
+### Step 5: generate the full child CRUD page
+
+Now generate the comments UI under the contact host:
 
 ```bash
 npx jskit generate crud-ui-generator crud \
   w/[workspaceSlug]/admin/contacts/[contactId]/index/comments \
   --resource-file packages/comments/src/shared/commentResource.js \
-  --operations view,new,edit \
-  --id-param commentId
+  --id-param commentId \
+  --parent-title none \
+  --display-fields body
 ```
 
-This is the key move.
+Do **not** pass `--operations view,new,edit` here. That would omit the list page and leave you with only child operation routes.
 
-By leaving `list` out:
+`--parent-title none` is the important difference from `addresses`.
 
-- you do **not** generate a standalone comments list page
-- the host contact page stays responsible for showing the comment list
-- the generated child routes still handle things like `new`, `view`, and `edit`
+The contact host page already shows the parent identity, so a generated heading like `Comments for Tony Mobily` is redundant. If you later decide you do want that heading, rerun the same command with `--parent-title contextual --force`.
 
-### What the host page does
+This command gives you:
 
-The host page then renders the comment list directly, usually with lower-level CRUD composables such as:
+- `w/[workspaceSlug]/admin/contacts/[contactId]/index/comments/index.vue`
+- `w/[workspaceSlug]/admin/contacts/[contactId]/index/comments/new.vue`
+- `w/[workspaceSlug]/admin/contacts/[contactId]/index/comments/[commentId]/index.vue`
+- `w/[workspaceSlug]/admin/contacts/[contactId]/index/comments/[commentId]/edit.vue`
 
-- `useCrudList()`
-- `useCrudAddEdit()`
-- `useCrudView()` when needed
-
-There is one more runtime worth knowing about early:
-
-- `useCommand()`
-
-Use it for live actions that are **not** full forms, such as:
-
-- checkbox toggles
-- archive / reopen buttons
-- quick PATCH / POST / DELETE actions on one record
-
-So the practical split is:
-
-- `useCrudList()` / `useCrudView()`
-  - routed list/view loading
-- `useCrudAddEdit()`
-  - real create/edit forms
-- `useCommand()`
-  - live actions inside the page
-
-The `todo` app uses that last pattern for "mark item done" checkboxes. The deeper best-practices explanation is in [Advanced CRUDs](/guide/generators/advanced-cruds).
-
-That is the same general pattern already used in the real app for embedded child records like pet notes: the record list lives inside the main view page, while routed child pages handle the operations that still deserve their own URLs.
-
-This pattern is useful when the child records are supporting detail rather than a destination in their own right.
+Because this route root lives under `.../[contactId]/index/comments`, the generated placement is the desired one here: `Comments` appears as a child page under the contact host.
 
 That is the real lesson of the `comments` example:
 
-- a child CRUD does **not** have to mean "make another full-screen list page"
-- you can keep the parent page as the main experience and route only the child operations that benefit from their own URLs
+- the contact page stays the routed host
+- the child CRUD gets its own list page
+- the route still stays under the parent record experience
 
 ## When `scaffold-field` matters
 
@@ -597,8 +745,8 @@ It patches the canonical `schema` inside the shared resource file. That matters 
 The important thing is not memorizing commands. It is learning the three shapes:
 
 - `contacts`: a normal top-level CRUD
-- `addresses`: a child CRUD with its own routed list page
-- `comments`: a child CRUD that lives inside the parent page, with only the child operations routed
+- `addresses`: a child CRUD with its own routed list page reached from the parent record view
+- `comments`: a child CRUD that lives under the parent record host as a child page
 
 Once you understand those three shapes, the two generator packages stop feeling like separate tools.
 

--- a/packages/agent-docs/guide/agent/generators/ui-generators.md
+++ b/packages/agent-docs/guide/agent/generators/ui-generators.md
@@ -257,6 +257,37 @@ The route page is still a normal page file. What changes is the inferred placeme
 
 So JSKIT is not switching to a different generator. It is switching the inferred placement behavior because the route tree now has a routed host above the new page.
 
+### Making a child page the default landing route
+
+This is important enough to state explicitly: if a routed host has child pages, and you want the bare parent URL to open one child immediately, use an explicit redirect.
+
+Do **not** try to make the app "guess the first tab". Do **not** infer it from placement order. Keep the target explicit.
+
+The standard pattern is:
+
+```vue
+<script setup>
+import { redirectToChild } from "@jskit-ai/kernel/client/pageRedirects";
+
+definePage({
+  redirect: redirectToChild("exports")
+});
+</script>
+```
+
+If this is placed on the host page, opening `/reports` lands on `/reports/exports`.
+
+This is also the right pattern when the host page still renders shared content such as a title, tabs, summary panel, or `RouterView`. The parent route remains the host, and the child page simply becomes the default destination under it.
+
+Why this is the recommended pattern:
+
+- the destination is explicit and stable
+- it survives later placement reordering
+- it does not depend on which child link happens to render first
+- it is easy to change later by editing one child segment
+
+This is one of the most common things people want once they start using child-page hosts. Treat it as normal JSKIT routing, not a special hack.
+
 ## Nested pages under an `index.vue` host
 
 Once `Reports` is a host, create a child page under it:

--- a/packages/agent-docs/patterns/page-redirects.md
+++ b/packages/agent-docs/patterns/page-redirects.md
@@ -6,16 +6,18 @@ Use when:
 - writing `definePage({ redirect: ... })`
 - seeding settings landing pages such as `/home/settings`
 - wiring a section shell that should land on a real child page first
+- making a routed host page open a default child tab such as `comments`
 
 Check first:
 
-- whether the page is only a landing route for child pages
+- whether the page is only a landing route for child pages or a host page that should always land on one child first
 - whether the destination child route is explicit and stable
 - whether the redirect should preserve incoming query and hash
 
 Rules:
 
 - For “index page lands on child page” redirects, use `redirectToChild()` from `@jskit-ai/kernel/client/pageRedirects`.
+- The same helper is also the explicit pattern for “this host page should open child X by default”.
 - Do not hand-build child redirects with string surgery such as `` `${String(to.path || "").replace(/\\/$/, "")}/general` ``.
 - Keep the destination explicit. Do not infer it from placements, menu order, or “first child page wins” behavior.
 - If the redirect is just “go to this child page”, prefer:
@@ -27,6 +29,8 @@ definePage({
   redirect: redirectToChild("general")
 });
 ```
+
+- This can live on a host page that still renders its own shell and `RouterView`. The parent route remains matched and the child route renders underneath it.
 
 Why:
 

--- a/packages/agent-docs/reference/autogen/packages/crud-core.md
+++ b/packages/agent-docs/reference/autogen/packages/crud-core.md
@@ -304,6 +304,10 @@ Local functions
 - `createRecordRelationshipsResolver(definition = null)`
 - `createRequestRelationshipMapper(definition = null)`
 - `resolveOutputAttributeExcludeKeys(resource = {})`
+- `resolveLookupContainerKey(resource = {})`
+- `normalizeLookupId(value)`
+- `normalizeIncludedLookupRecord(source = null, fallbackId = null)`
+- `createLookupIncludedResolver(definition = null, { lookupContainerKey = "" } = {})`
 
 ### `src/server/serviceEvents.js`
 Exports

--- a/packages/agent-docs/reference/autogen/packages/crud-ui-generator.md
+++ b/packages/agent-docs/reference/autogen/packages/crud-ui-generator.md
@@ -30,6 +30,7 @@ Local functions
 - `resolveListTargetFile(targetRoot = "")`
 - `parseOperationsOption(options)`
 - `parseDisplayFieldsOption(options)`
+- `parseParentTitleOption(options)`
 - `validateDisplayFieldsForOperation(selectedFieldKeys, fields, operationName)`
 - `filterDisplayFields(selectedFieldKeys, fields)`
 - `rewriteGeneratedBlockIndent(source = "", { trimPrefix = "", addPrefix = "" } = {})`
@@ -46,6 +47,8 @@ Local functions
 - `resolveTargetRootRelativeRoutePath(pageTarget = {})`
 - `resolveMenuToPropLine(linkTo = "")`
 - `resolveCrudRelativePath(namespace = "")`
+- `buildListParentTitleImportLine(parentTitleMode = "contextual")`
+- `buildListHeadingTitleSetup({ parentTitleMode = "contextual", resourceNamespace = "", routeTitle = "Records" } = {})`
 
 ### `src/server/resourceSupport.js`
 Exports

--- a/packages/agent-docs/reference/autogen/packages/users-web.md
+++ b/packages/agent-docs/reference/autogen/packages/users-web.md
@@ -84,6 +84,7 @@ Exports
 ### `src/client/composables/crud/crudJsonApiTransportSupport.js`
 Exports
 - `inferCrudJsonApiTransport(resource = null, { mode = "", operationName = "" } = {})`
+- `inferCrudLookupJsonApiTransport({ namespace = "", apiPath = "" } = {})`
 - `resolveCrudJsonApiTransport(transport = null, resource = null, options = {})`
 - `resolveLookupFieldMap(resource = null)`
 Local functions

--- a/packages/agent-docs/site/guide/app-setup/multi-homing.md
+++ b/packages/agent-docs/site/guide/app-setup/multi-homing.md
@@ -92,6 +92,8 @@ config.tenancyMode = "personal";
 6. Run `npm install`
 7. Run `npm run db:migrate`
 
+The easy part to miss is step 3. If `users-web` / `users-core` were already installed while the app was still on `tenancyMode = "none"`, then changing `config.tenancyMode` and adding only the workspace packages is **not** enough. `npx jskit update package users-core` is required so the app-local `packages/users/...` scaffold is rewritten in its workspace-aware shape too.
+
 I checked the two failure modes while updating this chapter.
 
 - If the app is already in `personal` or `workspaces` mode when you add the workspace packages, JSKIT installs the full workspace scaffold, including:
@@ -137,6 +139,12 @@ npx jskit add package workspaces-web
 npm install
 npm run db:migrate
 ```
+
+<DocsTerminalTip label="Important" title="This Block Is Only The Fresh Workspace Install Path">
+These commands are complete only if the app was already on `tenancyMode = "personal"` when `users-web` / `users-core` were originally installed, or if you already ran the recovery `npx jskit update package users-core` step above.
+
+If you changed tenancy after installing users, do not skip that update. The workspace packages add workspace runtime and routes, but `users-core` is what rewrites the app-local users scaffold into its workspace-aware shape.
+</DocsTerminalTip>
 
 `workspaces-core` adds the server-side workspace runtime and schema migrations. `workspaces-web` adds the workspace-facing client surfaces, shell placements, and app-owned route files.
 
@@ -457,6 +465,30 @@ Concretely, that route tree works like this:
 - `w/[workspaceSlug]/admin/workspace/settings.vue` is a section shell. It does not own the actual settings fields. It owns the card frame, the left-side settings menu outlet, and the nested `<RouterView />` where child settings pages render.
 - `w/[workspaceSlug]/admin/workspace/settings/index.vue` is intentionally almost empty. Its job is to make `/admin/workspace/settings` a real route today and give you a clean place to redirect or add child settings pages later.
 
+If you want to add a real workspace settings child page at this point, use the normal page generator under that route tree:
+
+```bash
+npx jskit generate ui-generator page \
+  w/[workspaceSlug]/admin/workspace/settings/billing/index.vue \
+  --name "Billing"
+```
+
+That command does two things:
+
+- it creates `src/pages/w/[workspaceSlug]/admin/workspace/settings/billing/index.vue`
+- it also appends the matching workspace settings menu entry into `src/placement.js`
+
+The reason JSKIT can wire that link automatically is that the workspace settings shell already exposes a named placement outlet with a default link renderer:
+
+```vue
+<ShellOutlet
+  target="admin-settings:primary-menu"
+  default-link-component-token="local.main.ui.surface-aware-menu-link-item"
+/>
+```
+
+`target="admin-settings:primary-menu"` tells the generator which settings menu host owns those child links. `default-link-component-token="local.main.ui.surface-aware-menu-link-item"` tells it which local menu-link component to use unless you override it. So a page generated under `w/[workspaceSlug]/admin/workspace/settings/...` automatically lands in the left-side workspace settings menu without you hand-writing the placement entry.
+
 ### Workspace pages are prepared for missing-workspace states
 
 The starter workspace pages already use a dedicated unavailable-state helper:
@@ -708,6 +740,35 @@ That one block explains a lot of the new shell behavior.
 - the top-right area can show a pending-invites cue
 - the admin surface gets workspace tools in the top-right area
 - the admin workspace settings menu is now another nested placement host with both `Settings` and `Members`
+
+If you want to add your own app-owned page into that top cog menu, first ask JSKIT which placement targets exist:
+
+```bash
+npx jskit list-placements
+```
+
+In a workspace-enabled app, that list now includes:
+
+```text
+- admin-cog:primary-menu [package:@jskit-ai/workspaces-web:src/client/components/UsersWorkspaceToolsWidget.vue]
+```
+
+If you want more context than the raw target list, `npx jskit show @jskit-ai/workspaces-web --details` also shows that same outlet plus the default `Settings` and `Members` entries already targeting it.
+
+Once you know the outlet id, generate the page like this:
+
+```bash
+npx jskit generate ui-generator page \
+  w/[workspaceSlug]/admin/catalogue/index.vue \
+  --name "Catalogue" \
+  --link-placement admin-cog:primary-menu
+```
+
+That command creates `src/pages/w/[workspaceSlug]/admin/catalogue/index.vue` and appends the matching link entry into `src/placement.js`.
+
+`--link-placement` is necessary here because this route is just a normal `admin` page. It is **not** a child page under a local host like `w/[workspaceSlug]/admin/workspace/settings.vue`, so the generator has no nested settings outlet to infer automatically. If you omit `--link-placement`, the new page link falls back to the app's default shell menu outlet instead of the cog menu.
+
+You also do **not** need `--link-component-token` here. `admin-cog:primary-menu` already declares `local.main.ui.surface-aware-menu-link-item` as its default link renderer, so JSKIT reuses that automatically when it writes the placement entry.
 
 So the placement system from the shell chapter is still doing the same job as before. The app just has a richer routing and tenancy context now.
 

--- a/packages/agent-docs/site/guide/app-setup/users.md
+++ b/packages/agent-docs/site/guide/app-setup/users.md
@@ -390,6 +390,14 @@ Under the hood, `users-core` wires those contributors into the users-backed prof
 
 The next chapter uses exactly that pattern. `workspaces-core` registers a contributor so the workspace layer can react when a new user enters the system.
 
+One forward-looking warning matters here. If this app later changes from `tenancyMode = "none"` to `personal` or `workspaces`, the app-local users scaffold written by `users-core` also needs to be refreshed. The multi-homing chapter calls out that recovery step explicitly with:
+
+```bash
+npx jskit update package users-core
+```
+
+That is not only a workspace-package concern. The generated `packages/users/...` scaffold itself changes shape when tenancy becomes workspace-aware.
+
 ## Summary
 
 This chapter is where the app stopped treating signed-in people as only Supabase identities and started treating them as real JSKIT users.

--- a/packages/agent-docs/site/guide/generators/crud-generators.md
+++ b/packages/agent-docs/site/guide/generators/crud-generators.md
@@ -14,8 +14,8 @@ So the real order is always:
 This chapter uses three examples, in increasing complexity:
 
 - `contacts`: the baseline full CRUD walkthrough
-- `addresses`: a child CRUD with its own routed list page
-- `comments`: a child CRUD that lives inside the parent page, with only the child routes being routed
+- `addresses`: a child CRUD with its own routed list page reached from the parent record view
+- `comments`: a child CRUD that lives under the parent record host as a child page
 
 The examples assume the guide app already has the database and workspace/admin setup from the earlier chapters. That is why the route roots below live under `w/[workspaceSlug]/admin/...`.
 
@@ -348,7 +348,7 @@ That is the shape to learn first.
 
 Now move to a child CRUD with its own URL.
 
-This is the right pattern when the child collection deserves its own list page.
+This is the right pattern when the child collection deserves its own list page, but should still be reached from a specific parent record.
 
 Example route:
 
@@ -356,11 +356,22 @@ Example route:
 .../contacts/3/addresses
 ```
 
-In the guide app's real route tree, that becomes:
+In the guide app's real route tree, the visible URL becomes:
 
 ```text
 w/[workspaceSlug]/admin/contacts/[contactId]/addresses
 ```
+
+This example is intentionally **not** an in-page child list and **not** a contact subtab.
+
+The intended UX is:
+
+- `addresses` gets its own routed list page
+- the page lives under a specific contact
+- the user reaches it from an explicit link or button on the contact view
+- it does **not** appear in the global left menu
+
+That makes it different from the later `comments` example, where the child list stays inside the parent page.
 
 ### Step 1: create the child table
 
@@ -380,11 +391,15 @@ CREATE TABLE addresses (
   created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
   updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   KEY idx_addresses_workspace_id (workspace_id),
-  KEY idx_addresses_contact_id (contact_id)
+  KEY idx_addresses_contact_id (contact_id),
+  CONSTRAINT fk_addresses_contact_id
+    FOREIGN KEY (contact_id) REFERENCES contacts(id)
 );
 ```
 
 The important extra column here is `contact_id`. This is what makes the CRUD a child of a contact instead of a top-level resource.
+
+The foreign key is not optional in this example. It is what lets `crud-server-generator` emit `contactId` as a real lookup relation in `packages/addresses/src/shared/addressResource.js`.
 
 ### Step 2: scaffold the server package
 
@@ -396,17 +411,104 @@ npx jskit generate crud-server-generator scaffold \
   --table-name addresses
 ```
 
-### Step 3: scaffold the UI at the child route root
+Then install the generated local package:
+
+```bash
+npm install
+```
+
+If you are developing against a local JSKIT checkout, relink your app to the local packages before you run the UI:
+
+```bash
+npm run devlinks
+```
+
+### Step 3: refine the generated lookup metadata by hand
+
+Open `packages/addresses/src/shared/addressResource.js` and add `labelKey: "fullName"` to the generated `contactId` relation:
+
+```js
+contactId: {
+  type: "id",
+  required: true,
+  search: true,
+  relation: {
+    kind: "lookup",
+    namespace: "contacts",
+    valueKey: "id",
+    labelKey: "fullName"
+  },
+  belongsTo: "contacts",
+  as: "contact",
+  ui: { formControl: "autocomplete" },
+  ...
+}
+```
+
+This part is still manual today.
+
+The scaffold can infer the lookup **relationship** from the foreign key, but it cannot infer which contact field should be used as the human-readable label. Without `labelKey: "fullName"`, the page falls back to generic headings like `Addresses for Contact #1`.
+
+### Step 4: scaffold the UI route tree
 
 ```bash
 npx jskit generate crud-ui-generator crud \
   w/[workspaceSlug]/admin/contacts/[contactId]/addresses \
   --resource-file packages/addresses/src/shared/addressResource.js \
   --id-param addressId \
+  --parent-title contextual \
   --display-fields label,line1,postcode
 ```
 
-That gives you a proper child CRUD with its own list, view, new, and edit pages under the contact route.
+That gives you a normal child route tree:
+
+- `w/[workspaceSlug]/admin/contacts/[contactId]/addresses/index.vue`
+- `w/[workspaceSlug]/admin/contacts/[contactId]/addresses/new.vue`
+- `w/[workspaceSlug]/admin/contacts/[contactId]/addresses/[addressId]/index.vue`
+- `w/[workspaceSlug]/admin/contacts/[contactId]/addresses/[addressId]/edit.vue`
+- shared `_components` files under the same route root
+
+### Step 5: remove the generated shell placement by hand
+
+`crud-ui-generator` currently generates a list-page placement block in `src/placement.js`.
+
+For this example, that block is **not** what you want.
+
+Delete the generated `addresses` placement block from `src/placement.js`.
+
+It will be the block added for the `w/[workspaceSlug]/admin/contacts/[contactId]/addresses` page link.
+
+Depending on what outlets already exist in the app, that block may try to place `Addresses` in the shell menu or in the contact subpages outlet. For this example, remove it either way and keep navigation manual from the contact view.
+
+This is an intentional manual cleanup for now:
+
+- keep the routed pages
+- remove the auto menu link
+- navigate to the page from the contact view instead
+
+### Step 6: add a manual link from the contact view
+
+Open `src/pages/w/[workspaceSlug]/admin/contacts/[contactId]/index.vue` and add a button that links to `./addresses`.
+
+The simplest version is:
+
+```vue
+<v-btn
+  color="primary"
+  variant="tonal"
+  :to="{ path: view.resolveParams(UI_ADDRESSES_URL), query: $route.query }"
+>
+  Addresses
+</v-btn>
+```
+
+Then define the URL template in the script:
+
+```js
+const UI_ADDRESSES_URL = "./addresses";
+```
+
+That gives you a standalone child page with a clear entry point from the parent contact view, without mixing record-scoped pages into the global shell menu.
 
 ### The important refinement: parent title handling
 
@@ -414,8 +516,8 @@ This is where nested CRUD starts to feel real.
 
 An addresses list page should not show a generic heading like `Addresses`. It should usually show whose addresses these are, for example:
 
-- `Jane Smith's addresses`
-- `Acme Pty Ltd's addresses`
+- `Addresses for Jane Smith`
+- `Addresses for Acme Pty Ltd`
 
 The awkward case is when there are **no child rows yet**. If the list is empty, you cannot derive the parent title from the first address record.
 
@@ -431,37 +533,36 @@ const parentTitle = useCrudListParentTitle({
 });
 ```
 
-That helper does the nice thing automatically:
+That helper does the right thing automatically:
 
-- if the child list already has rows, it derives the parent title from the first child record
+- if the child list already has rows, it derives the parent title from the first child record when lookup data is available
 - if the child list is empty, it loads the parent record directly
 
-This is exactly the pattern used in the real app codebase for nested CRUD lists like a contact's pets. It avoids the common broken state where an empty child list loses all context about the parent it belongs to.
-
-So the `addresses` example is important because it teaches the first truly practical nested-CRUD problem:
+So the `addresses` example is important because it teaches the first truly practical child-page problem:
 
 - the route is child-scoped
 - the data is child-scoped
-- but the page still needs a reliable parent identity even when the child list is empty
+- the page is reached from a parent action, not from the main shell menu
+- the page still needs a reliable parent identity even when the child list is empty
 
-## Example 3: `comments` in-page
+## Example 3: `comments` under the contact host
 
 This is the advanced example.
 
-Sometimes a child resource is real enough to deserve its own CRUD operations, but **not** important enough to deserve its own full-screen list page.
+Sometimes a child resource should stay attached to the parent record, but still deserves its own routed child page.
 
 Comments are a good example:
 
 - they matter
 - they need persistence
-- they may need `view`, `new`, or `edit` routes
-- but the main screen is still the contact view page
+- they benefit from their own list, `new`, `view`, and `edit` routes
+- but they still belong inside the contact experience rather than as a top-level destination
 
 So the pattern is:
 
 - keep the contact page as the real host
-- render the comments list inside that page
-- route only the child operations underneath it
+- keep the child route tree under that host
+- let the generated placement surface the comments page as a contact child page
 
 ### Step 1: create the table
 
@@ -472,12 +573,13 @@ CREATE TABLE comments (
   id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
   workspace_id BIGINT UNSIGNED NOT NULL,
   contact_id BIGINT UNSIGNED NOT NULL,
-  author_user_id BIGINT UNSIGNED NULL,
   body TEXT NOT NULL,
   created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
   updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   KEY idx_comments_workspace_id (workspace_id),
-  KEY idx_comments_contact_id (contact_id)
+  KEY idx_comments_contact_id (contact_id),
+  CONSTRAINT fk_comments_contact_id
+    FOREIGN KEY (contact_id) REFERENCES contacts(id)
 );
 ```
 
@@ -491,7 +593,45 @@ npx jskit generate crud-server-generator scaffold \
   --table-name comments
 ```
 
-### Step 3: make the parent page able to host routed children
+Then install the generated local package:
+
+```bash
+npm install
+```
+
+If you are developing against a local JSKIT checkout, relink the app before you run the UI:
+
+```bash
+npm run devlinks
+```
+
+### Step 3: refine the generated lookup metadata by hand
+
+Open `packages/comments/src/shared/commentResource.js` and add `labelKey: "fullName"` to the generated `contactId` relation:
+
+```js
+contactId: {
+  type: "id",
+  required: true,
+  search: true,
+  relation: {
+    kind: "lookup",
+    namespace: "contacts",
+    valueKey: "id",
+    labelKey: "fullName"
+  },
+  belongsTo: "contacts",
+  as: "contact",
+  ui: { formControl: "autocomplete" },
+  ...
+}
+```
+
+This is the same manual refinement used in the `addresses` example: the scaffold can infer the lookup relationship from the foreign key, but it cannot infer which parent field should be used as the display label.
+
+The next command also makes the parent-title mode explicit on purpose. That way changing the heading behavior later is just changing the value and rerunning with `--force`, not adding a new flag.
+
+### Step 4: make the parent page able to host routed children
 
 If the contact view page should stay visible while child comment routes render underneath it, first upgrade it into a routed host:
 
@@ -507,63 +647,71 @@ That is the point where the comments example deliberately overlaps with the `ui-
 - CRUD scaffolding for the comments resource
 - a routed host in the parent contact page
 
-### Step 4: generate only the routed child operations
+### Step 4.5: make `comments` the default child page
 
-Now generate the comments UI without a list page:
+This is a very common next step.
+
+If the contact page should open directly on `Comments`, add an explicit redirect to the contact host page:
+
+```vue
+<script setup>
+import { redirectToChild } from "@jskit-ai/kernel/client/pageRedirects";
+
+definePage({
+  redirect: redirectToChild("comments")
+});
+</script>
+```
+
+In this example, that edit belongs in:
+
+```text
+src/pages/w/[workspaceSlug]/admin/contacts/[contactId]/index.vue
+```
+
+This is the recommended pattern. Do **not** try to infer the default child page from placement order or "the first tab". Keep it explicit.
+
+When this redirect is present:
+
+- opening `/w/<workspaceSlug>/admin/contacts/<contactId>` lands on `/w/<workspaceSlug>/admin/contacts/<contactId>/comments`
+- the parent contact page still stays visible
+- the child page renders underneath it
+
+That last point matters. The contact page is still the host page. The redirect only changes which child route becomes the default landing destination.
+
+### Step 5: generate the full child CRUD page
+
+Now generate the comments UI under the contact host:
 
 ```bash
 npx jskit generate crud-ui-generator crud \
   w/[workspaceSlug]/admin/contacts/[contactId]/index/comments \
   --resource-file packages/comments/src/shared/commentResource.js \
-  --operations view,new,edit \
-  --id-param commentId
+  --id-param commentId \
+  --parent-title none \
+  --display-fields body
 ```
 
-This is the key move.
+Do **not** pass `--operations view,new,edit` here. That would omit the list page and leave you with only child operation routes.
 
-By leaving `list` out:
+`--parent-title none` is the important difference from `addresses`.
 
-- you do **not** generate a standalone comments list page
-- the host contact page stays responsible for showing the comment list
-- the generated child routes still handle things like `new`, `view`, and `edit`
+The contact host page already shows the parent identity, so a generated heading like `Comments for Tony Mobily` is redundant. If you later decide you do want that heading, rerun the same command with `--parent-title contextual --force`.
 
-### What the host page does
+This command gives you:
 
-The host page then renders the comment list directly, usually with lower-level CRUD composables such as:
+- `w/[workspaceSlug]/admin/contacts/[contactId]/index/comments/index.vue`
+- `w/[workspaceSlug]/admin/contacts/[contactId]/index/comments/new.vue`
+- `w/[workspaceSlug]/admin/contacts/[contactId]/index/comments/[commentId]/index.vue`
+- `w/[workspaceSlug]/admin/contacts/[contactId]/index/comments/[commentId]/edit.vue`
 
-- `useCrudList()`
-- `useCrudAddEdit()`
-- `useCrudView()` when needed
-
-There is one more runtime worth knowing about early:
-
-- `useCommand()`
-
-Use it for live actions that are **not** full forms, such as:
-
-- checkbox toggles
-- archive / reopen buttons
-- quick PATCH / POST / DELETE actions on one record
-
-So the practical split is:
-
-- `useCrudList()` / `useCrudView()`
-  - routed list/view loading
-- `useCrudAddEdit()`
-  - real create/edit forms
-- `useCommand()`
-  - live actions inside the page
-
-The `todo` app uses that last pattern for "mark item done" checkboxes. The deeper best-practices explanation is in [Advanced CRUDs](/guide/generators/advanced-cruds).
-
-That is the same general pattern already used in the real app for embedded child records like pet notes: the record list lives inside the main view page, while routed child pages handle the operations that still deserve their own URLs.
-
-This pattern is useful when the child records are supporting detail rather than a destination in their own right.
+Because this route root lives under `.../[contactId]/index/comments`, the generated placement is the desired one here: `Comments` appears as a child page under the contact host.
 
 That is the real lesson of the `comments` example:
 
-- a child CRUD does **not** have to mean "make another full-screen list page"
-- you can keep the parent page as the main experience and route only the child operations that benefit from their own URLs
+- the contact page stays the routed host
+- the child CRUD gets its own list page
+- the route still stays under the parent record experience
 
 ## When `scaffold-field` matters
 
@@ -595,8 +743,8 @@ It patches the canonical `schema` inside the shared resource file. That matters 
 The important thing is not memorizing commands. It is learning the three shapes:
 
 - `contacts`: a normal top-level CRUD
-- `addresses`: a child CRUD with its own routed list page
-- `comments`: a child CRUD that lives inside the parent page, with only the child operations routed
+- `addresses`: a child CRUD with its own routed list page reached from the parent record view
+- `comments`: a child CRUD that lives under the parent record host as a child page
 
 Once you understand those three shapes, the two generator packages stop feeling like separate tools.
 

--- a/packages/agent-docs/site/guide/generators/ui-generators.md
+++ b/packages/agent-docs/site/guide/generators/ui-generators.md
@@ -272,6 +272,37 @@ The route page is still a normal page file. What changes is the inferred placeme
 
 So JSKIT is not switching to a different generator. It is switching the inferred placement behavior because the route tree now has a routed host above the new page.
 
+### Making a child page the default landing route
+
+This is important enough to state explicitly: if a routed host has child pages, and you want the bare parent URL to open one child immediately, use an explicit redirect.
+
+Do **not** try to make the app "guess the first tab". Do **not** infer it from placement order. Keep the target explicit.
+
+The standard pattern is:
+
+```vue
+<script setup>
+import { redirectToChild } from "@jskit-ai/kernel/client/pageRedirects";
+
+definePage({
+  redirect: redirectToChild("exports")
+});
+</script>
+```
+
+If this is placed on the host page, opening `/reports` lands on `/reports/exports`.
+
+This is also the right pattern when the host page still renders shared content such as a title, tabs, summary panel, or `RouterView`. The parent route remains the host, and the child page simply becomes the default destination under it.
+
+Why this is the recommended pattern:
+
+- the destination is explicit and stable
+- it survives later placement reordering
+- it does not depend on which child link happens to render first
+- it is easy to change later by editing one child segment
+
+This is one of the most common things people want once they start using child-page hosts. Treat it as normal JSKIT routing, not a special hack.
+
 ## Nested pages under an `index.vue` host
 
 Once `Reports` is a host, create a child page under it:

--- a/packages/crud-ui-generator/package.descriptor.mjs
+++ b/packages/crud-ui-generator/package.descriptor.mjs
@@ -43,6 +43,15 @@ export default Object.freeze({
       promptLabel: "Route id param",
       promptHint: "Route param used by view and edit pages (default: recordId)."
     },
+    "parent-title": {
+      required: false,
+      inputType: "text",
+      defaultValue: "contextual",
+      validationType: "enum",
+      allowedValues: ["contextual", "none"],
+      promptLabel: "Parent title mode",
+      promptHint: "Whether list pages should show a parent-aware heading: contextual | none."
+    },
     force: {
       required: false,
       inputType: "flag",
@@ -108,6 +117,7 @@ export default Object.freeze({
           "operations",
           "display-fields",
           "id-param",
+          "parent-title",
           "link-placement",
           "link-component-token",
           "namespace",
@@ -130,7 +140,8 @@ export default Object.freeze({
             lines: [
               "npx jskit generate crud-ui-generator crud \\",
               "  admin/catalog/index/products \\",
-              "  --resource-file packages/products/src/shared/productResource.js"
+              "  --resource-file packages/products/src/shared/productResource.js \\",
+              "  --parent-title contextual"
             ]
           },
           {
@@ -141,6 +152,7 @@ export default Object.freeze({
               "  --resource-file packages/pets/src/shared/petResource.js \\",
               "  --id-param petId \\",
               "  --display-fields name,breedId,sex \\",
+              "  --parent-title none \\",
               "  --force"
             ]
           }

--- a/packages/crud-ui-generator/src/server/buildTemplateContext.js
+++ b/packages/crud-ui-generator/src/server/buildTemplateContext.js
@@ -32,6 +32,7 @@ import {
 import descriptor from "../../package.descriptor.mjs";
 
 const DEFAULT_ALLOWED_OPERATIONS = Object.freeze(["list", "view", "new", "edit"]);
+const DEFAULT_ALLOWED_PARENT_TITLE_VALUES = Object.freeze(["contextual", "none"]);
 function resolveAllowedValues(schema = {}, fallbackValues = []) {
   const resolvedValues = [];
   const seen = new Set();
@@ -56,6 +57,14 @@ function resolveAllowedValues(schema = {}, fallbackValues = []) {
 const OPERATION_VALUES = resolveAllowedValues(descriptor?.options?.operations, DEFAULT_ALLOWED_OPERATIONS);
 const ALLOWED_OPERATIONS = new Set(OPERATION_VALUES);
 const DEFAULT_OPERATIONS = normalizeText(descriptor?.options?.operations?.defaultValue) || OPERATION_VALUES.join(",");
+const PARENT_TITLE_VALUES = resolveAllowedValues(
+  descriptor?.options?.["parent-title"],
+  DEFAULT_ALLOWED_PARENT_TITLE_VALUES
+);
+const ALLOWED_PARENT_TITLE_VALUES = new Set(PARENT_TITLE_VALUES);
+const DEFAULT_PARENT_TITLE_MODE = normalizeText(descriptor?.options?.["parent-title"]?.defaultValue).toLowerCase()
+  || PARENT_TITLE_VALUES[0]
+  || "contextual";
 const DEFAULT_LIST_HIDDEN_FIELD_KEYS = new Set(["createdAt", "updatedAt"]);
 const DEFAULT_FORM_COMPONENT_FILE = "CrudAddEditForm.vue";
 const DEFAULT_FORM_FIELDS_FILE = "CrudAddEditFormFields.js";
@@ -220,6 +229,17 @@ function parseDisplayFieldsOption(options) {
   }
 
   return Object.freeze(unique);
+}
+
+function parseParentTitleOption(options) {
+  const parentTitleMode = normalizeText(options?.["parent-title"]).toLowerCase() || DEFAULT_PARENT_TITLE_MODE;
+  if (!ALLOWED_PARENT_TITLE_VALUES.has(parentTitleMode)) {
+    throw new Error(
+      `crud-ui-generator option "parent-title" supports only: ${PARENT_TITLE_VALUES.join(", ")}.`
+    );
+  }
+
+  return parentTitleMode;
 }
 
 function validateDisplayFieldsForOperation(selectedFieldKeys, fields, operationName) {
@@ -461,11 +481,52 @@ function resolveCrudRelativePath(namespace = "") {
   })}`;
 }
 
+function buildListParentTitleImportLine(parentTitleMode = "contextual") {
+  if (parentTitleMode !== "contextual") {
+    return "";
+  }
+
+  return 'import { useCrudListParentTitle } from "@jskit-ai/users-web/client/composables/useCrudListParentTitle";';
+}
+
+function buildListHeadingTitleSetup({
+  parentTitleMode = "contextual",
+  resourceNamespace = "",
+  routeTitle = "Records"
+} = {}) {
+  const normalizedRouteTitle = normalizeText(routeTitle) || "Records";
+  const routeTitleLiteral = JSON.stringify(normalizedRouteTitle);
+  if (parentTitleMode !== "contextual") {
+    return `const listHeadingTitle = computed(() => ${routeTitleLiteral});`;
+  }
+
+  return `const parentTitle = useCrudListParentTitle({
+  listRuntime: records,
+  resource: uiResource,
+  adapter: UI_OPERATION_ADAPTER || undefined,
+  recordIdParam: UI_RECORD_ID_PARAM,
+  queryKeyPrefix: ["ui-generator", "${resourceNamespace}", "list", "parent-title"],
+  placementSource: "ui-generator.${resourceNamespace}.list.parent-title",
+  fallbackLoadError: "Unable to load parent record.",
+  notFoundMessage: "Parent record not found."
+});
+
+const listHeadingTitle = computed(() => {
+  const resolvedParentTitle = String(parentTitle.title || "").trim();
+  if (!resolvedParentTitle) {
+    return ${routeTitleLiteral};
+  }
+
+  return ${JSON.stringify(`${normalizedRouteTitle} for `)} + resolvedParentTitle;
+});`;
+}
+
 async function buildUiTemplateContext({ appRoot, options } = {}) {
   const targetRoot = requireTargetRootOption(options);
   const listTargetFile = resolveListTargetFile(targetRoot);
   const selectedOperations = parseOperationsOption(options);
   const selectedDisplayFields = parseDisplayFieldsOption(options);
+  const parentTitleMode = parseParentTitleOption(options);
   const pageTarget = await resolvePageTargetDetails({
     appRoot,
     targetFile: listTargetFile,
@@ -607,6 +668,13 @@ async function buildUiTemplateContext({ appRoot, options } = {}) {
     __JSKIT_UI_RESOURCE_SINGULAR_TITLE__: resourceLabels.singularTitle,
     __JSKIT_UI_RESOURCE_PLURAL_TITLE__: resourceLabels.pluralTitle,
     __JSKIT_UI_ROUTE_TITLE__: pageTarget.defaultName,
+    __JSKIT_UI_PARENT_TITLE_MODE__: parentTitleMode,
+    __JSKIT_UI_LIST_PARENT_TITLE_IMPORT_LINE__: buildListParentTitleImportLine(parentTitleMode),
+    __JSKIT_UI_LIST_HEADING_TITLE_SETUP__: buildListHeadingTitleSetup({
+      parentTitleMode,
+      resourceNamespace,
+      routeTitle: pageTarget.defaultName
+    }),
     __JSKIT_UI_FORM_COMPONENT_FILE__: DEFAULT_FORM_COMPONENT_FILE,
     __JSKIT_UI_FORM_FIELDS_FILE__: DEFAULT_FORM_FIELDS_FILE,
     __JSKIT_UI_SURFACE_ID__: pageTarget.surfaceId,

--- a/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/ListElement.vue
+++ b/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/ListElement.vue
@@ -89,7 +89,7 @@ __JSKIT_UI_LIST_ROW_COLUMNS__
 
 <script setup>
 import { computed } from "vue";
-import { useCrudListParentTitle } from "@jskit-ai/users-web/client/composables/useCrudListParentTitle";
+__JSKIT_UI_LIST_PARENT_TITLE_IMPORT_LINE__
 import { useCrudList } from "@jskit-ai/users-web/client/composables/useCrudList";
 import { resource as uiResource } from "__JSKIT_UI_RESOURCE_IMPORT_PATH__";
 
@@ -137,25 +137,7 @@ const records = useCrudList({
     : null
 });
 
-const parentTitle = useCrudListParentTitle({
-  listRuntime: records,
-  resource: uiResource,
-  adapter: UI_OPERATION_ADAPTER || undefined,
-  recordIdParam: UI_RECORD_ID_PARAM,
-  queryKeyPrefix: ["ui-generator", "__JSKIT_UI_RESOURCE_NAMESPACE__", "list", "parent-title"],
-  placementSource: "ui-generator.__JSKIT_UI_RESOURCE_NAMESPACE__.list.parent-title",
-  fallbackLoadError: "Unable to load parent record.",
-  notFoundMessage: "Parent record not found."
-});
-
-const listHeadingTitle = computed(() => {
-  const resolvedParentTitle = String(parentTitle.title || "").trim();
-  if (!resolvedParentTitle) {
-    return "__JSKIT_UI_ROUTE_TITLE__";
-  }
-
-  return `__JSKIT_UI_ROUTE_TITLE__ for ${resolvedParentTitle}`;
-});
+__JSKIT_UI_LIST_HEADING_TITLE_SETUP__
 </script>
 
 <style scoped>

--- a/packages/crud-ui-generator/test/buildTemplateContext.test.js
+++ b/packages/crud-ui-generator/test/buildTemplateContext.test.js
@@ -320,6 +320,9 @@ test("buildUiTemplateContext derives CRUD placeholders from the explicit target-
     assert.equal(context.__JSKIT_UI_RESOURCE_SINGULAR_TITLE__, "Customer");
     assert.equal(context.__JSKIT_UI_RESOURCE_PLURAL_TITLE__, "Customers");
     assert.equal(context.__JSKIT_UI_ROUTE_TITLE__, "Customers");
+    assert.equal(context.__JSKIT_UI_PARENT_TITLE_MODE__, "contextual");
+    assert.match(context.__JSKIT_UI_LIST_PARENT_TITLE_IMPORT_LINE__, /useCrudListParentTitle/);
+    assert.match(context.__JSKIT_UI_LIST_HEADING_TITLE_SETUP__, /Customers for /);
     assert.equal(context.__JSKIT_UI_FORM_COMPONENT_FILE__, "CrudAddEditForm.vue");
     assert.equal(context.__JSKIT_UI_FORM_FIELDS_FILE__, "CrudAddEditFormFields.js");
     assert.equal(context.__JSKIT_UI_SURFACE_ID__, "admin");
@@ -347,6 +350,24 @@ test("buildUiTemplateContext derives CRUD placeholders from the explicit target-
     assert.equal(context.__JSKIT_UI_EDIT_PAGE_VIEW_URL__, "\"..\"");
     assert.equal(context.__JSKIT_UI_VIEW_PAGE_LIST_URL__, "\"..\"");
     assert.equal(context.__JSKIT_UI_VIEW_PAGE_EDIT_URL__, "\"./edit\"");
+  });
+});
+
+test("buildUiTemplateContext can suppress parent-title heading generation with parent-title none", async () => {
+  await withTempApp(async (appRoot) => {
+    await writeResource(appRoot, RESOURCE_FILE, FULL_RESOURCE_SOURCE);
+
+    const context = await buildUiTemplateContext({
+      appRoot,
+      options: createOptions({
+        "parent-title": "none"
+      })
+    });
+
+    assert.equal(context.__JSKIT_UI_PARENT_TITLE_MODE__, "none");
+    assert.equal(context.__JSKIT_UI_LIST_PARENT_TITLE_IMPORT_LINE__, "");
+    assert.doesNotMatch(context.__JSKIT_UI_LIST_HEADING_TITLE_SETUP__, /useCrudListParentTitle/);
+    assert.match(context.__JSKIT_UI_LIST_HEADING_TITLE_SETUP__, /computed\(\(\) => "Customers"\)/);
   });
 });
 
@@ -711,6 +732,23 @@ test("buildUiTemplateContext validates operations against the supported CRUD set
           })
         }),
       /operations" supports only: list, view, new, edit/
+    );
+  });
+});
+
+test("buildUiTemplateContext validates parent-title against the supported modes", async () => {
+  await withTempApp(async (appRoot) => {
+    await writeResource(appRoot, RESOURCE_FILE, FULL_RESOURCE_SOURCE);
+
+    await assert.rejects(
+      () =>
+        buildUiTemplateContext({
+          appRoot,
+          options: createOptions({
+            "parent-title": "always"
+          })
+        }),
+      /parent-title" supports only: contextual, none/
     );
   });
 });

--- a/packages/crud-ui-generator/test/packageDescriptor.test.js
+++ b/packages/crud-ui-generator/test/packageDescriptor.test.js
@@ -13,6 +13,16 @@ test("crud-ui-generator operations option exposes structured csv-enum metadata",
   assert.equal(descriptor.metadata?.generatorSubcommands?.crud?.optionNames?.includes("operations"), true);
 });
 
+test("crud-ui-generator parent-title option exposes structured enum metadata", () => {
+  assert.equal(descriptor.options?.["parent-title"]?.validationType, "enum");
+  assert.deepEqual(
+    descriptor.options?.["parent-title"]?.allowedValues,
+    ["contextual", "none"]
+  );
+  assert.equal(descriptor.options?.["parent-title"]?.defaultValue, "contextual");
+  assert.equal(descriptor.metadata?.generatorSubcommands?.crud?.optionNames?.includes("parent-title"), true);
+});
+
 test("crud-ui-generator placement scaffold includes an explicit stock icon prop", () => {
   const placementMutation = descriptor?.mutations?.text?.find(
     (entry) => String(entry?.id || "").trim() === "crud-ui-placement-menu"

--- a/packages/kernel/client/pageRedirects.test.js
+++ b/packages/kernel/client/pageRedirects.test.js
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { createMemoryHistory, createRouter } from "vue-router";
 import { redirectToChild } from "./pageRedirects.js";
 
 test("redirectToChild resolves a child path and preserves incoming query and hash", () => {
@@ -37,4 +38,34 @@ test("redirectToChild uses child query and hash when the target declares them", 
     },
     hash: "#advanced"
   });
+});
+
+test("redirectToChild can live on a host route that also renders a component", async () => {
+  const hostComponent = { name: "ContactHost" };
+  const childComponent = { name: "CommentsPage" };
+
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      {
+        path: "/contacts/:contactId",
+        component: hostComponent,
+        redirect: redirectToChild("comments"),
+        children: [
+          {
+            path: "comments",
+            component: childComponent
+          }
+        ]
+      }
+    ]
+  });
+
+  await router.push("/contacts/1?tab=open#details");
+  await router.isReady();
+
+  assert.equal(router.currentRoute.value.fullPath, "/contacts/1/comments?tab=open#details");
+  assert.equal(router.currentRoute.value.matched.length, 2);
+  assert.equal(router.currentRoute.value.matched[0]?.components?.default, hostComponent);
+  assert.equal(router.currentRoute.value.matched[1]?.components?.default, childComponent);
 });

--- a/packages/users-web/src/client/composables/internal/crudListParentTitleSupport.js
+++ b/packages/users-web/src/client/composables/internal/crudListParentTitleSupport.js
@@ -133,7 +133,11 @@ function resolveCrudListParentTitleFromItems(items = [], descriptor = null) {
   }
 
   for (const item of sourceItems) {
+    const rawParentValue = toRouteParamValue(item?.[descriptor.fieldKey]);
     const resolvedTitle = normalizeText(resolveLookupFieldDisplayValue(item, descriptor.fieldDescriptor));
+    if (resolvedTitle && rawParentValue && resolvedTitle === rawParentValue) {
+      continue;
+    }
     if (resolvedTitle) {
       return resolvedTitle;
     }

--- a/packages/users-web/src/client/composables/runtime/addEditUiRuntime.js
+++ b/packages/users-web/src/client/composables/runtime/addEditUiRuntime.js
@@ -57,19 +57,20 @@ function createAddEditUiRuntime({
       ...currentRouteParams,
       ...asPlainObject(extraParams)
     };
+    const currentRouteRecordId = toResolvedRecordId({
+      routeParams: currentRouteParams,
+      recordIdParam: normalizedRecordIdParam,
+      routeRecordId
+    });
     const resolvedRecordId = toRouteParamValue(sourceParams[normalizedRecordIdParam]) ||
-      toResolvedRecordId({
-        routeParams: currentRouteParams,
-        recordIdParam: normalizedRecordIdParam,
-        routeRecordId
-      });
+      currentRouteRecordId;
     sourceParams[normalizedRecordIdParam] = resolvedRecordId;
     const currentPathname = resolveScopedRoutePathname({
       currentPathname: routePath,
       params: currentRouteParams,
       orderedParamNames: routeParamNames,
       anchorParamName: normalizedRecordIdParam,
-      anchorParamValue: resolvedRecordId,
+      anchorParamValue: currentRouteRecordId,
       anchorMode: "after"
     });
 

--- a/packages/users-web/src/client/composables/useCrudListParentTitle.js
+++ b/packages/users-web/src/client/composables/useCrudListParentTitle.js
@@ -1,6 +1,7 @@
 import { computed, proxyRefs } from "vue";
 import { useRoute } from "vue-router";
 import { normalizeText } from "@jskit-ai/kernel/shared/support/normalize";
+import { inferCrudLookupJsonApiTransport } from "./crud/crudJsonApiTransportSupport.js";
 import {
   resolveRouteParamsSource,
   toRouteParamValue
@@ -59,6 +60,19 @@ function useCrudListParentTitle({
   });
 
   const initialParentDescriptor = parentDescriptor.value || {};
+  const parentTransport = (() => {
+    const baseTransport = inferCrudLookupJsonApiTransport({
+      namespace: initialParentDescriptor.relationNamespace
+    });
+    if (!baseTransport) {
+      return null;
+    }
+
+    return Object.freeze({
+      ...baseTransport,
+      responseKind: "record"
+    });
+  })();
   const normalizedQueryKeyPrefix = normalizeQueryKeyPrefix(queryKeyPrefix);
   const shouldLoadParentRecord = computed(() => {
     const descriptor = parentDescriptor.value;
@@ -70,12 +84,18 @@ function useCrudListParentTitle({
     }
 
     const items = Array.isArray(listRuntime?.items) ? listRuntime.items : [];
-    return items.length < 1;
+    if (items.length < 1) {
+      return true;
+    }
+
+    const listTitle = resolveCrudListParentTitleFromItems(items, descriptor);
+    return !listTitle;
   });
 
   const parentView = viewRuntimeFactory({
     adapter,
     apiUrlTemplate: normalizeText(initialParentDescriptor.apiUrlTemplate),
+    transport: parentTransport,
     readEnabled: shouldLoadParentRecord,
     recordIdParam: normalizeText(initialParentDescriptor.routeParamKey) || "recordId",
     includeRecordIdInQueryKey: true,

--- a/packages/users-web/test/addEditUiRuntime.test.js
+++ b/packages/users-web/test/addEditUiRuntime.test.js
@@ -35,6 +35,23 @@ test("createAddEditUiRuntime resolves view urls for saved payload ids with neste
   assert.equal(runtime.resolveSavedViewUrl({ id: 99 }), "/contacts/7/addresses/99");
 });
 
+test("createAddEditUiRuntime keeps nested child routes stable when the saved child id matches a parent id", () => {
+  const runtime = createAddEditUiRuntime({
+    recordIdParam: "addressId",
+    routeParams: ref({
+      workspaceSlug: "tonymobily",
+      contactId: "1"
+    }),
+    routeParamNames: ref(["workspaceSlug", "contactId"]),
+    routePath: ref("/w/tonymobily/admin/contacts/1/addresses/new"),
+    viewUrlTemplate: "../:addressId",
+    listUrlTemplate: ".."
+  });
+
+  assert.equal(runtime.listUrl.value, "/w/tonymobily/admin/contacts/1/addresses");
+  assert.equal(runtime.resolveSavedViewUrl({ id: 1 }), "/w/tonymobily/admin/contacts/1/addresses/1");
+});
+
 test("createAddEditUiRuntime resolves edit-page relative list and cancel links", () => {
   const runtime = createAddEditUiRuntime({
     recordIdParam: "addressId",

--- a/packages/users-web/test/useCrudListParentTitle.test.js
+++ b/packages/users-web/test/useCrudListParentTitle.test.js
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { createSchema } from "json-rest-schema";
 import { resolveCrudListParentDescriptor, resolveCrudListParentRecordTitle, resolveCrudListParentTitleFromItems } from "../src/client/composables/internal/crudListParentTitleSupport.js";
+import { useCrudListParentTitle } from "../src/client/composables/useCrudListParentTitle.js";
 
 const contactChildResource = Object.freeze({
   contract: {
@@ -106,6 +107,32 @@ test("resolveCrudListParentTitleFromItems uses the hydrated lookup label", () =>
   assert.equal(title, "Jessica Dickinson");
 });
 
+test("resolveCrudListParentTitleFromItems ignores raw lookup ids when no hydrated label is present", () => {
+  const descriptor = resolveCrudListParentDescriptor({
+    resource: contactChildResource,
+    route: {
+      matched: [{ path: "/w/:workspaceSlug/admin/contacts/:contactId/availabilities" }],
+      params: {
+        workspaceSlug: "dogandgroom",
+        contactId: "538779"
+      }
+    },
+    recordIdParam: "availabilityRuleId"
+  });
+
+  const title = resolveCrudListParentTitleFromItems(
+    [
+      {
+        id: 1,
+        contactId: 538779
+      }
+    ],
+    descriptor
+  );
+
+  assert.equal(title, "");
+});
+
 test("resolveCrudListParentRecordTitle falls back to entity label plus id", () => {
   const title = resolveCrudListParentRecordTitle(
     {
@@ -153,4 +180,83 @@ test("resolveCrudListParentDescriptor supports parentRouteParamKey aliases", () 
 
   assert.equal(descriptor?.fieldKey, "staffContactId");
   assert.equal(descriptor?.routeParamKey, "contactId");
+});
+
+test("useCrudListParentTitle loads the parent record when child rows only expose the raw parent id", () => {
+  const runtime = useCrudListParentTitle({
+    listRuntime: {
+      items: [
+        {
+          id: 1,
+          contactId: 538779
+        }
+      ],
+      isInitialLoading: false,
+      loadError: ""
+    },
+    resource: contactChildResource,
+    recordIdParam: "availabilityRuleId",
+    route: {
+      matched: [{ path: "/w/:workspaceSlug/admin/contacts/:contactId/availabilities" }],
+      params: {
+        workspaceSlug: "dogandgroom",
+        contactId: "538779"
+      }
+    },
+    viewRuntimeFactory: () => ({
+      record: {
+        id: 538779,
+        firstName: "Jessica",
+        lastName: "Dickinson"
+      },
+      isLoading: false,
+      loadError: ""
+    })
+  });
+
+  assert.equal(runtime.shouldLoadParentRecord, true);
+  assert.equal(runtime.title, "Jessica Dickinson");
+});
+
+test("useCrudListParentTitle requests the parent through JSON:API record transport", () => {
+  let capturedTransport = null;
+
+  useCrudListParentTitle({
+    listRuntime: {
+      items: [
+        {
+          id: 1,
+          contactId: 538779
+        }
+      ],
+      isInitialLoading: false,
+      loadError: ""
+    },
+    resource: contactChildResource,
+    recordIdParam: "availabilityRuleId",
+    route: {
+      matched: [{ path: "/w/:workspaceSlug/admin/contacts/:contactId/availabilities" }],
+      params: {
+        workspaceSlug: "dogandgroom",
+        contactId: "538779"
+      }
+    },
+    viewRuntimeFactory: (options = {}) => {
+      capturedTransport = options.transport;
+      return {
+        record: {
+          id: 538779,
+          fullName: "Jessica Dickinson"
+        },
+        isLoading: false,
+        loadError: ""
+      };
+    }
+  });
+
+  assert.deepEqual(capturedTransport, {
+    kind: "jsonapi-resource",
+    responseType: "contacts",
+    responseKind: "record"
+  });
 });

--- a/tooling/jskit-cli/src/server/commandHandlers/packageCommands/update.js
+++ b/tooling/jskit-cli/src/server/commandHandlers/packageCommands/update.js
@@ -23,7 +23,9 @@ async function runPackageUpdateCommand(
   const installedPackages = ensureObject(lock.installedPackages);
   const resolvedTargetId = resolveInstalledPackageIdInput(targetId, installedPackages);
   if (!resolvedTargetId) {
-    throw createCliError(`Package is not installed: ${targetId}`);
+    throw createCliError(
+      `Package is not installed: ${targetId}. update package only reapplies packages already recorded in .jskit/lock.json. If you meant to install it, run: jskit add package ${targetId}`
+    );
   }
 
   return runCommandAdd({

--- a/tooling/jskit-cli/test/appOwnedFileMutation.test.js
+++ b/tooling/jskit-cli/test/appOwnedFileMutation.test.js
@@ -212,3 +212,19 @@ test("update package fails when a managed app-owned file is missing on disk", as
     assert.equal(await readFile(lockPath, "utf8"), lockAfterAdd);
   });
 });
+
+test("update package fails with install guidance when the package is not installed", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "update-missing-package-app");
+    await createMinimalApp(appRoot, { name: "update-missing-package-app" });
+
+    const updateResult = runCli({
+      cwd: appRoot,
+      args: ["update", "package", "workspaces-core"]
+    });
+    assert.equal(updateResult.status, 1);
+    assert.match(String(updateResult.stderr || ""), /Package is not installed: workspaces-core/);
+    assert.match(String(updateResult.stderr || ""), /already recorded in \.jskit\/lock\.json/i);
+    assert.match(String(updateResult.stderr || ""), /jskit add package workspaces-core/);
+  });
+});


### PR DESCRIPTION
## Summary
- add parent-title modes to the CRUD UI generator and improve parent-title loading for nested child CRUDs
- stabilize nested add/edit child routing and document explicit child-page redirect patterns
- improve `jskit update package` guidance when a package has not been installed yet

## Testing
- npm --workspace @jskit-ai/crud-ui-generator test -- test/buildTemplateContext.test.js test/packageDescriptor.test.js
- npm --workspace @jskit-ai/users-web test -- test/addEditUiRuntime.test.js test/useCrudListParentTitle.test.js
- npm --workspace @jskit-ai/kernel test -- client/pageRedirects.test.js
- npm --workspace @jskit-ai/jskit-cli test -- test/appOwnedFileMutation.test.js
- npm run agent-docs:build