### PR TITLE
chore(release): refresh workspace package versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1282,6 +1282,10 @@
       "resolved": "packages/database-runtime-postgres",
       "link": true
     },
+    "node_modules/@jskit-ai/feature-server-generator": {
+      "resolved": "packages/feature-server-generator",
+      "link": true
+    },
     "node_modules/@jskit-ai/http-runtime": {
       "resolved": "packages/http-runtime",
       "link": true
@@ -6516,28 +6520,28 @@
     },
     "packages/agent-docs": {
       "name": "@jskit-ai/agent-docs",
-      "version": "0.1.19",
+      "version": "0.1.20",
       "engines": {
         "node": "20.x"
       }
     },
     "packages/assistant": {
       "name": "@jskit-ai/assistant",
-      "version": "0.1.67",
+      "version": "0.1.68",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.58"
+        "@jskit-ai/kernel": "0.1.59"
       }
     },
     "packages/assistant-core": {
       "name": "@jskit-ai/assistant-core",
-      "version": "0.1.34",
+      "version": "0.1.35",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.58",
-        "@jskit-ai/http-runtime": "0.1.57",
-        "@jskit-ai/kernel": "0.1.58",
-        "@jskit-ai/resource-core": "0.1.3",
-        "@jskit-ai/resource-crud-core": "0.1.3",
-        "@jskit-ai/users-core": "0.1.68",
+        "@jskit-ai/database-runtime": "0.1.59",
+        "@jskit-ai/http-runtime": "0.1.58",
+        "@jskit-ai/kernel": "0.1.59",
+        "@jskit-ai/resource-core": "0.1.4",
+        "@jskit-ai/resource-crud-core": "0.1.4",
+        "@jskit-ai/users-core": "0.1.69",
         "@tanstack/vue-query": "^5.90.5",
         "dompurify": "^3.3.3",
         "json-rest-schema": "1.x.x",
@@ -6610,15 +6614,15 @@
     },
     "packages/assistant-runtime": {
       "name": "@jskit-ai/assistant-runtime",
-      "version": "0.1.29",
+      "version": "0.1.30",
       "dependencies": {
-        "@jskit-ai/assistant-core": "0.1.34",
-        "@jskit-ai/database-runtime": "0.1.58",
-        "@jskit-ai/http-runtime": "0.1.57",
-        "@jskit-ai/kernel": "0.1.58",
-        "@jskit-ai/shell-web": "0.1.57",
-        "@jskit-ai/users-core": "0.1.68",
-        "@jskit-ai/users-web": "0.1.73",
+        "@jskit-ai/assistant-core": "0.1.35",
+        "@jskit-ai/database-runtime": "0.1.59",
+        "@jskit-ai/http-runtime": "0.1.58",
+        "@jskit-ai/kernel": "0.1.59",
+        "@jskit-ai/shell-web": "0.1.58",
+        "@jskit-ai/users-core": "0.1.69",
+        "@jskit-ai/users-web": "0.1.74",
         "@tanstack/vue-query": "^5.90.5",
         "json-rest-schema": "1.x.x",
         "vuetify": "^4.0.0"
@@ -6688,21 +6692,21 @@
     },
     "packages/auth-core": {
       "name": "@jskit-ai/auth-core",
-      "version": "0.1.57",
+      "version": "0.1.58",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0",
-        "@jskit-ai/kernel": "0.1.58",
+        "@jskit-ai/kernel": "0.1.59",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/auth-provider-supabase-core": {
       "name": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.57",
+      "version": "0.1.58",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.57",
-        "@jskit-ai/kernel": "0.1.58",
+        "@jskit-ai/auth-core": "0.1.58",
+        "@jskit-ai/kernel": "0.1.59",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0",
         "json-rest-schema": "1.x.x"
@@ -6710,12 +6714,12 @@
     },
     "packages/auth-web": {
       "name": "@jskit-ai/auth-web",
-      "version": "0.1.59",
+      "version": "0.1.60",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.57",
-        "@jskit-ai/http-runtime": "0.1.57",
-        "@jskit-ai/kernel": "0.1.58",
-        "@jskit-ai/shell-web": "0.1.57",
+        "@jskit-ai/auth-core": "0.1.58",
+        "@jskit-ai/http-runtime": "0.1.58",
+        "@jskit-ai/kernel": "0.1.59",
+        "@jskit-ai/shell-web": "0.1.58",
         "@mdi/js": "^7.4.47",
         "@tanstack/vue-query": "^5.90.5",
         "pinia": "^3.0.4",
@@ -6779,38 +6783,38 @@
     },
     "packages/console-core": {
       "name": "@jskit-ai/console-core",
-      "version": "0.1.21",
+      "version": "0.1.22",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.57",
-        "@jskit-ai/database-runtime": "0.1.58",
-        "@jskit-ai/http-runtime": "0.1.57",
-        "@jskit-ai/kernel": "0.1.58",
-        "@jskit-ai/resource-crud-core": "0.1.3",
-        "@jskit-ai/users-core": "0.1.68",
+        "@jskit-ai/auth-core": "0.1.58",
+        "@jskit-ai/database-runtime": "0.1.59",
+        "@jskit-ai/http-runtime": "0.1.58",
+        "@jskit-ai/kernel": "0.1.59",
+        "@jskit-ai/resource-crud-core": "0.1.4",
+        "@jskit-ai/users-core": "0.1.69",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/console-web": {
       "name": "@jskit-ai/console-web",
-      "version": "0.1.26",
+      "version": "0.1.27",
       "dependencies": {
-        "@jskit-ai/auth-web": "0.1.59",
-        "@jskit-ai/console-core": "0.1.21",
-        "@jskit-ai/shell-web": "0.1.57"
+        "@jskit-ai/auth-web": "0.1.60",
+        "@jskit-ai/console-core": "0.1.22",
+        "@jskit-ai/shell-web": "0.1.58"
       }
     },
     "packages/crud-core": {
       "name": "@jskit-ai/crud-core",
-      "version": "0.1.66",
+      "version": "0.1.67",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.58",
-        "@jskit-ai/http-runtime": "0.1.57",
-        "@jskit-ai/kernel": "0.1.58",
-        "@jskit-ai/realtime": "0.1.57",
-        "@jskit-ai/resource-crud-core": "0.1.3",
-        "@jskit-ai/shell-web": "0.1.57",
-        "@jskit-ai/users-core": "0.1.68",
-        "@jskit-ai/users-web": "0.1.73",
+        "@jskit-ai/database-runtime": "0.1.59",
+        "@jskit-ai/http-runtime": "0.1.58",
+        "@jskit-ai/kernel": "0.1.59",
+        "@jskit-ai/realtime": "0.1.58",
+        "@jskit-ai/resource-crud-core": "0.1.4",
+        "@jskit-ai/shell-web": "0.1.58",
+        "@jskit-ai/users-core": "0.1.69",
+        "@jskit-ai/users-web": "0.1.74",
         "@tanstack/vue-query": "^5.90.5",
         "json-rest-schema": "1.x.x"
       },
@@ -6880,78 +6884,82 @@
     },
     "packages/crud-server-generator": {
       "name": "@jskit-ai/crud-server-generator",
-      "version": "0.1.66",
+      "version": "0.1.67",
       "dependencies": {
         "@babel/parser": "^7.29.2",
-        "@jskit-ai/crud-core": "0.1.66",
-        "@jskit-ai/database-runtime": "0.1.58",
-        "@jskit-ai/http-runtime": "0.1.57",
-        "@jskit-ai/json-rest-api-core": "0.1.3",
-        "@jskit-ai/kernel": "0.1.58",
-        "@jskit-ai/resource-crud-core": "0.1.3",
+        "@jskit-ai/crud-core": "0.1.67",
+        "@jskit-ai/database-runtime": "0.1.59",
+        "@jskit-ai/http-runtime": "0.1.58",
+        "@jskit-ai/json-rest-api-core": "0.1.4",
+        "@jskit-ai/kernel": "0.1.59",
+        "@jskit-ai/resource-crud-core": "0.1.4",
         "recast": "^0.23.11"
       }
     },
     "packages/crud-ui-generator": {
       "name": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.41",
+      "version": "0.1.42",
       "dependencies": {
-        "@jskit-ai/crud-core": "0.1.66",
-        "@jskit-ai/kernel": "0.1.58",
-        "@jskit-ai/resource-crud-core": "0.1.3"
+        "@jskit-ai/crud-core": "0.1.67",
+        "@jskit-ai/kernel": "0.1.59",
+        "@jskit-ai/resource-crud-core": "0.1.4"
       }
     },
     "packages/database-runtime": {
       "name": "@jskit-ai/database-runtime",
-      "version": "0.1.58",
+      "version": "0.1.59",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.58"
+        "@jskit-ai/kernel": "0.1.59"
       }
     },
     "packages/database-runtime-mysql": {
       "name": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.57",
+      "version": "0.1.58",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.58",
-        "@jskit-ai/kernel": "0.1.58"
+        "@jskit-ai/database-runtime": "0.1.59",
+        "@jskit-ai/kernel": "0.1.59"
       }
     },
     "packages/database-runtime-postgres": {
       "name": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.57",
+      "version": "0.1.58",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.58"
+        "@jskit-ai/database-runtime": "0.1.59"
       }
+    },
+    "packages/feature-server-generator": {
+      "name": "@jskit-ai/feature-server-generator",
+      "version": "0.1.1"
     },
     "packages/http-runtime": {
       "name": "@jskit-ai/http-runtime",
-      "version": "0.1.57",
+      "version": "0.1.58",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.58",
+        "@jskit-ai/kernel": "0.1.59",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/json-rest-api-core": {
       "name": "@jskit-ai/json-rest-api-core",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.58",
+        "@jskit-ai/kernel": "0.1.59",
         "hooked-api": "1.x.x",
         "json-rest-api": "1.x.x"
       }
     },
     "packages/kernel": {
       "name": "@jskit-ai/kernel",
-      "version": "0.1.58",
+      "version": "0.1.59",
       "dependencies": {
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/realtime": {
       "name": "@jskit-ai/realtime",
-      "version": "0.1.57",
+      "version": "0.1.58",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.58",
+        "@jskit-ai/kernel": "0.1.59",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",
@@ -6963,24 +6971,24 @@
     },
     "packages/resource-core": {
       "name": "@jskit-ai/resource-core",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.58"
+        "@jskit-ai/kernel": "0.1.59"
       }
     },
     "packages/resource-crud-core": {
       "name": "@jskit-ai/resource-crud-core",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.58",
-        "@jskit-ai/resource-core": "0.1.3"
+        "@jskit-ai/kernel": "0.1.59",
+        "@jskit-ai/resource-core": "0.1.4"
       }
     },
     "packages/shell-web": {
       "name": "@jskit-ai/shell-web",
-      "version": "0.1.57",
+      "version": "0.1.58",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.58",
+        "@jskit-ai/kernel": "0.1.59",
         "@mdi/js": "^7.4.47",
         "@tanstack/vue-query": "^5.90.5",
         "pinia": "^3.0.4",
@@ -7044,25 +7052,25 @@
     },
     "packages/storage-runtime": {
       "name": "@jskit-ai/storage-runtime",
-      "version": "0.1.57",
+      "version": "0.1.58",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.58",
+        "@jskit-ai/kernel": "0.1.59",
         "unstorage": "^1.17.3"
       }
     },
     "packages/ui-generator": {
       "name": "@jskit-ai/ui-generator",
-      "version": "0.1.41",
+      "version": "0.1.42",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.58",
-        "@jskit-ai/shell-web": "0.1.57"
+        "@jskit-ai/kernel": "0.1.59",
+        "@jskit-ai/shell-web": "0.1.58"
       }
     },
     "packages/uploads-image-web": {
       "name": "@jskit-ai/uploads-image-web",
-      "version": "0.1.36",
+      "version": "0.1.37",
       "dependencies": {
-        "@jskit-ai/uploads-runtime": "0.1.36",
+        "@jskit-ai/uploads-runtime": "0.1.37",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",
@@ -7075,37 +7083,37 @@
     },
     "packages/uploads-runtime": {
       "name": "@jskit-ai/uploads-runtime",
-      "version": "0.1.36",
+      "version": "0.1.37",
       "dependencies": {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.58"
+        "@jskit-ai/kernel": "0.1.59"
       }
     },
     "packages/users-core": {
       "name": "@jskit-ai/users-core",
-      "version": "0.1.68",
+      "version": "0.1.69",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.57",
-        "@jskit-ai/database-runtime": "0.1.58",
-        "@jskit-ai/http-runtime": "0.1.57",
-        "@jskit-ai/json-rest-api-core": "0.1.3",
-        "@jskit-ai/kernel": "0.1.58",
-        "@jskit-ai/resource-core": "0.1.3",
-        "@jskit-ai/resource-crud-core": "0.1.3",
-        "@jskit-ai/uploads-runtime": "0.1.36",
+        "@jskit-ai/auth-core": "0.1.58",
+        "@jskit-ai/database-runtime": "0.1.59",
+        "@jskit-ai/http-runtime": "0.1.58",
+        "@jskit-ai/json-rest-api-core": "0.1.4",
+        "@jskit-ai/kernel": "0.1.59",
+        "@jskit-ai/resource-core": "0.1.4",
+        "@jskit-ai/resource-crud-core": "0.1.4",
+        "@jskit-ai/uploads-runtime": "0.1.37",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/users-web": {
       "name": "@jskit-ai/users-web",
-      "version": "0.1.73",
+      "version": "0.1.74",
       "dependencies": {
-        "@jskit-ai/http-runtime": "0.1.57",
-        "@jskit-ai/kernel": "0.1.58",
-        "@jskit-ai/realtime": "0.1.57",
-        "@jskit-ai/shell-web": "0.1.57",
-        "@jskit-ai/uploads-image-web": "0.1.36",
-        "@jskit-ai/users-core": "0.1.68",
+        "@jskit-ai/http-runtime": "0.1.58",
+        "@jskit-ai/kernel": "0.1.59",
+        "@jskit-ai/realtime": "0.1.58",
+        "@jskit-ai/shell-web": "0.1.58",
+        "@jskit-ai/uploads-image-web": "0.1.37",
+        "@jskit-ai/users-core": "0.1.69",
         "@mdi/js": "^7.4.47",
         "@tanstack/vue-query": "5.92.12",
         "vuetify": "^4.0.0"
@@ -7176,29 +7184,29 @@
     },
     "packages/workspaces-core": {
       "name": "@jskit-ai/workspaces-core",
-      "version": "0.1.34",
+      "version": "0.1.35",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.57",
-        "@jskit-ai/database-runtime": "0.1.58",
-        "@jskit-ai/http-runtime": "0.1.57",
-        "@jskit-ai/json-rest-api-core": "0.1.3",
-        "@jskit-ai/kernel": "0.1.58",
-        "@jskit-ai/resource-core": "0.1.3",
-        "@jskit-ai/resource-crud-core": "0.1.3",
-        "@jskit-ai/users-core": "0.1.68",
+        "@jskit-ai/auth-core": "0.1.58",
+        "@jskit-ai/database-runtime": "0.1.59",
+        "@jskit-ai/http-runtime": "0.1.58",
+        "@jskit-ai/json-rest-api-core": "0.1.4",
+        "@jskit-ai/kernel": "0.1.59",
+        "@jskit-ai/resource-core": "0.1.4",
+        "@jskit-ai/resource-crud-core": "0.1.4",
+        "@jskit-ai/users-core": "0.1.69",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/workspaces-web": {
       "name": "@jskit-ai/workspaces-web",
-      "version": "0.1.34",
+      "version": "0.1.35",
       "dependencies": {
-        "@jskit-ai/http-runtime": "0.1.57",
-        "@jskit-ai/kernel": "0.1.58",
-        "@jskit-ai/shell-web": "0.1.57",
-        "@jskit-ai/users-core": "0.1.68",
-        "@jskit-ai/users-web": "0.1.73",
-        "@jskit-ai/workspaces-core": "0.1.34",
+        "@jskit-ai/http-runtime": "0.1.58",
+        "@jskit-ai/kernel": "0.1.59",
+        "@jskit-ai/shell-web": "0.1.58",
+        "@jskit-ai/users-core": "0.1.69",
+        "@jskit-ai/users-web": "0.1.74",
+        "@jskit-ai/workspaces-core": "0.1.35",
         "@mdi/js": "^7.4.47",
         "@tanstack/vue-query": "5.92.12",
         "vuetify": "^4.0.0"
@@ -7269,7 +7277,7 @@
     },
     "tooling/config-eslint": {
       "name": "@jskit-ai/config-eslint",
-      "version": "0.1.57",
+      "version": "0.1.58",
       "dependencies": {
         "@eslint/js": "^9.39.1",
         "eslint-plugin-vue": "^10.5.1",
@@ -7287,7 +7295,7 @@
     },
     "tooling/create-app": {
       "name": "@jskit-ai/create-app",
-      "version": "0.1.66",
+      "version": "0.1.67",
       "bin": {
         "jskit-create-app": "bin/jskit-create-app.js"
       },
@@ -7297,18 +7305,18 @@
     },
     "tooling/jskit-catalog": {
       "name": "@jskit-ai/jskit-catalog",
-      "version": "0.1.66",
+      "version": "0.1.67",
       "engines": {
         "node": "20.x"
       }
     },
     "tooling/jskit-cli": {
       "name": "@jskit-ai/jskit-cli",
-      "version": "0.2.67",
+      "version": "0.2.68",
       "dependencies": {
-        "@jskit-ai/jskit-catalog": "0.1.66",
-        "@jskit-ai/kernel": "0.1.58",
-        "@jskit-ai/shell-web": "0.1.57"
+        "@jskit-ai/jskit-catalog": "0.1.67",
+        "@jskit-ai/kernel": "0.1.59",
+        "@jskit-ai/shell-web": "0.1.58"
       },
       "bin": {
         "jskit": "bin/jskit.js"

--- a/packages/agent-docs/package.json
+++ b/packages/agent-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/agent-docs",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "description": "Distributed JSKIT agent workflows, guides, and generated reference maps.",
   "type": "module",
   "files": [

--- a/packages/assistant-core/package.descriptor.mjs
+++ b/packages/assistant-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-core",
-  version: "0.1.34",
+  version: "0.1.35",
   kind: "runtime",
   description: "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
   dependsOn: [
@@ -47,11 +47,11 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/http-runtime": "0.1.57",
-        "@jskit-ai/kernel": "0.1.58",
-        "@jskit-ai/resource-core": "0.1.3",
-        "@jskit-ai/resource-crud-core": "0.1.3",
-        "@jskit-ai/users-core": "0.1.68",
+        "@jskit-ai/http-runtime": "0.1.58",
+        "@jskit-ai/kernel": "0.1.59",
+        "@jskit-ai/resource-core": "0.1.4",
+        "@jskit-ai/resource-crud-core": "0.1.4",
+        "@jskit-ai/users-core": "0.1.69",
         "@tanstack/vue-query": "^5.90.5",
         "dompurify": "^3.3.3",
         "json-rest-schema": "1.x.x",

--- a/packages/assistant-core/package.json
+++ b/packages/assistant-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-core",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,12 +11,12 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.58",
-    "@jskit-ai/http-runtime": "0.1.57",
-    "@jskit-ai/kernel": "0.1.58",
-    "@jskit-ai/resource-crud-core": "0.1.3",
-    "@jskit-ai/resource-core": "0.1.3",
-    "@jskit-ai/users-core": "0.1.68",
+    "@jskit-ai/database-runtime": "0.1.59",
+    "@jskit-ai/http-runtime": "0.1.58",
+    "@jskit-ai/kernel": "0.1.59",
+    "@jskit-ai/resource-crud-core": "0.1.4",
+    "@jskit-ai/resource-core": "0.1.4",
+    "@jskit-ai/users-core": "0.1.69",
     "@tanstack/vue-query": "^5.90.5",
     "dompurify": "^3.3.3",
     "json-rest-schema": "1.x.x",

--- a/packages/assistant-runtime/package.descriptor.mjs
+++ b/packages/assistant-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-runtime",
-  version: "0.1.29",
+  version: "0.1.30",
   kind: "runtime",
   description: "Shared assistant runtime with per-surface assistant registration.",
   dependsOn: [
@@ -74,13 +74,13 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/assistant-core": "0.1.34",
-        "@jskit-ai/database-runtime": "0.1.58",
-        "@jskit-ai/http-runtime": "0.1.57",
-        "@jskit-ai/kernel": "0.1.58",
-        "@jskit-ai/shell-web": "0.1.57",
-        "@jskit-ai/users-core": "0.1.68",
-        "@jskit-ai/users-web": "0.1.73",
+        "@jskit-ai/assistant-core": "0.1.35",
+        "@jskit-ai/database-runtime": "0.1.59",
+        "@jskit-ai/http-runtime": "0.1.58",
+        "@jskit-ai/kernel": "0.1.59",
+        "@jskit-ai/shell-web": "0.1.58",
+        "@jskit-ai/users-core": "0.1.69",
+        "@jskit-ai/users-web": "0.1.74",
         "@tanstack/vue-query": "^5.90.5",
         "vuetify": "^4.0.0"
       },

--- a/packages/assistant-runtime/package.json
+++ b/packages/assistant-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-runtime",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "type": "module",
   "exports": {
     "./client": "./src/client/index.js",
@@ -8,13 +8,13 @@
     "./server/actionIds": "./src/server/actionIds.js"
   },
   "dependencies": {
-    "@jskit-ai/assistant-core": "0.1.34",
-    "@jskit-ai/database-runtime": "0.1.58",
-    "@jskit-ai/http-runtime": "0.1.57",
-    "@jskit-ai/kernel": "0.1.58",
-    "@jskit-ai/shell-web": "0.1.57",
-    "@jskit-ai/users-core": "0.1.68",
-    "@jskit-ai/users-web": "0.1.73",
+    "@jskit-ai/assistant-core": "0.1.35",
+    "@jskit-ai/database-runtime": "0.1.59",
+    "@jskit-ai/http-runtime": "0.1.58",
+    "@jskit-ai/kernel": "0.1.59",
+    "@jskit-ai/shell-web": "0.1.58",
+    "@jskit-ai/users-core": "0.1.69",
+    "@jskit-ai/users-web": "0.1.74",
     "json-rest-schema": "1.x.x",
     "@tanstack/vue-query": "^5.90.5",
     "vuetify": "^4.0.0"

--- a/packages/assistant/package.descriptor.mjs
+++ b/packages/assistant/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant",
-  version: "0.1.67",
+  version: "0.1.68",
   kind: "generator",
   description: "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
   options: {

--- a/packages/assistant/package.json
+++ b/packages/assistant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant",
-  "version": "0.1.67",
+  "version": "0.1.68",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.58"
+    "@jskit-ai/kernel": "0.1.59"
   }
 }

--- a/packages/auth-core/package.descriptor.mjs
+++ b/packages/auth-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-core",
-  "version": "0.1.57",
+  "version": "0.1.58",
   "kind": "runtime",
   "dependsOn": [
     "@jskit-ai/value-app-config-shared"
@@ -69,7 +69,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.58",
+        "@jskit-ai/kernel": "0.1.59",
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0"

--- a/packages/auth-core/package.json
+++ b/packages/auth-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-core",
-  "version": "0.1.57",
+  "version": "0.1.58",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -46,7 +46,7 @@
     "./shared/commands/authSessionReadCommand": "./src/shared/commands/authSessionReadCommand.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.58",
+    "@jskit-ai/kernel": "0.1.59",
     "@fastify/cookie": "^11.0.2",
     "@fastify/csrf-protection": "^7.1.0",
     "@fastify/rate-limit": "^10.3.0",

--- a/packages/auth-provider-supabase-core/package.descriptor.mjs
+++ b/packages/auth-provider-supabase-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.57",
+  "version": "0.1.58",
   "kind": "runtime",
   "options": {
     "auth-supabase-url": {
@@ -83,8 +83,8 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/auth-core": "0.1.57",
-        "@jskit-ai/kernel": "0.1.58",
+        "@jskit-ai/auth-core": "0.1.58",
+        "@jskit-ai/kernel": "0.1.59",
         "dotenv": "^16.4.5",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0"

--- a/packages/auth-provider-supabase-core/package.json
+++ b/packages/auth-provider-supabase-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.57",
+  "version": "0.1.58",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,8 +12,8 @@
     "./client": "./src/client/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.57",
-    "@jskit-ai/kernel": "0.1.58",
+    "@jskit-ai/auth-core": "0.1.58",
+    "@jskit-ai/kernel": "0.1.59",
     "json-rest-schema": "1.x.x",
     "jose": "^6.1.0",
     "@supabase/supabase-js": "^2.57.4"

--- a/packages/auth-web/package.descriptor.mjs
+++ b/packages/auth-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-web",
-  "version": "0.1.59",
+  "version": "0.1.60",
   "kind": "runtime",
   "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
   "dependsOn": [
@@ -219,10 +219,10 @@ export default Object.freeze({
       "runtime": {
         "@tanstack/vue-query": "5.92.12",
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/auth-core": "0.1.57",
-        "@jskit-ai/http-runtime": "0.1.57",
-        "@jskit-ai/kernel": "0.1.58",
-        "@jskit-ai/shell-web": "0.1.57",
+        "@jskit-ai/auth-core": "0.1.58",
+        "@jskit-ai/http-runtime": "0.1.58",
+        "@jskit-ai/kernel": "0.1.59",
+        "@jskit-ai/shell-web": "0.1.58",
         "vuetify": "^4.0.0"
       },
       "dev": {}

--- a/packages/auth-web/package.json
+++ b/packages/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-web",
-  "version": "0.1.59",
+  "version": "0.1.60",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -18,13 +18,13 @@
   },
   "dependencies": {
     "@tanstack/vue-query": "^5.90.5",
-    "@jskit-ai/auth-core": "0.1.57",
+    "@jskit-ai/auth-core": "0.1.58",
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/kernel": "0.1.58",
-    "@jskit-ai/shell-web": "0.1.57",
+    "@jskit-ai/kernel": "0.1.59",
+    "@jskit-ai/shell-web": "0.1.58",
     "pinia": "^3.0.4",
     "vuetify": "^4.0.0",
-    "@jskit-ai/http-runtime": "0.1.57"
+    "@jskit-ai/http-runtime": "0.1.58"
   },
   "peerDependencies": {
     "vue": "^3.5.13",

--- a/packages/console-core/package.descriptor.mjs
+++ b/packages/console-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-core",
-  version: "0.1.21",
+  version: "0.1.22",
   kind: "runtime",
   description: "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
   dependsOn: [
@@ -74,12 +74,12 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.57",
-        "@jskit-ai/database-runtime": "0.1.58",
-        "@jskit-ai/http-runtime": "0.1.57",
-        "@jskit-ai/kernel": "0.1.58",
-        "@jskit-ai/resource-crud-core": "0.1.3",
-        "@jskit-ai/users-core": "0.1.68"
+        "@jskit-ai/auth-core": "0.1.58",
+        "@jskit-ai/database-runtime": "0.1.59",
+        "@jskit-ai/http-runtime": "0.1.58",
+        "@jskit-ai/kernel": "0.1.59",
+        "@jskit-ai/resource-crud-core": "0.1.4",
+        "@jskit-ai/users-core": "0.1.69"
       },
       dev: {}
     },

--- a/packages/console-core/package.json
+++ b/packages/console-core/package.json
@@ -1,17 +1,17 @@
 {
   "name": "@jskit-ai/console-core",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.57",
-    "@jskit-ai/database-runtime": "0.1.58",
-    "@jskit-ai/http-runtime": "0.1.57",
-    "@jskit-ai/kernel": "0.1.58",
-    "@jskit-ai/resource-crud-core": "0.1.3",
-    "@jskit-ai/users-core": "0.1.68",
+    "@jskit-ai/auth-core": "0.1.58",
+    "@jskit-ai/database-runtime": "0.1.59",
+    "@jskit-ai/http-runtime": "0.1.58",
+    "@jskit-ai/kernel": "0.1.59",
+    "@jskit-ai/resource-crud-core": "0.1.4",
+    "@jskit-ai/users-core": "0.1.69",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/console-web/package.descriptor.mjs
+++ b/packages/console-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-web",
-  version: "0.1.26",
+  version: "0.1.27",
   kind: "runtime",
   description: "Authenticated console surface scaffold and surface policy wiring.",
   dependsOn: [
@@ -74,9 +74,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-web": "0.1.59",
-        "@jskit-ai/console-core": "0.1.21",
-        "@jskit-ai/shell-web": "0.1.57",
+        "@jskit-ai/auth-web": "0.1.60",
+        "@jskit-ai/console-core": "0.1.22",
+        "@jskit-ai/shell-web": "0.1.58",
       },
       dev: {}
     },

--- a/packages/console-web/package.json
+++ b/packages/console-web/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/console-web",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-web": "0.1.59",
-    "@jskit-ai/console-core": "0.1.21",
-    "@jskit-ai/shell-web": "0.1.57"
+    "@jskit-ai/auth-web": "0.1.60",
+    "@jskit-ai/console-core": "0.1.22",
+    "@jskit-ai/shell-web": "0.1.58"
   }
 }

--- a/packages/crud-core/package.descriptor.mjs
+++ b/packages/crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-core",
-  version: "0.1.66",
+  version: "0.1.67",
   kind: "runtime",
   description: "Shared CRUD helpers used by CRUD modules.",
   dependsOn: [
@@ -28,7 +28,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/crud-core": "0.1.66"
+        "@jskit-ai/crud-core": "0.1.67"
       },
       dev: {}
     },

--- a/packages/crud-core/package.json
+++ b/packages/crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-core",
-  "version": "0.1.66",
+  "version": "0.1.67",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -28,15 +28,15 @@
   },
   "dependencies": {
     "@tanstack/vue-query": "^5.90.5",
-    "@jskit-ai/database-runtime": "0.1.58",
-    "@jskit-ai/http-runtime": "0.1.57",
-    "@jskit-ai/kernel": "0.1.58",
+    "@jskit-ai/database-runtime": "0.1.59",
+    "@jskit-ai/http-runtime": "0.1.58",
+    "@jskit-ai/kernel": "0.1.59",
     "json-rest-schema": "1.x.x",
-    "@jskit-ai/realtime": "0.1.57",
-    "@jskit-ai/resource-crud-core": "0.1.3",
-    "@jskit-ai/shell-web": "0.1.57",
-    "@jskit-ai/users-core": "0.1.68",
-    "@jskit-ai/users-web": "0.1.73"
+    "@jskit-ai/realtime": "0.1.58",
+    "@jskit-ai/resource-crud-core": "0.1.4",
+    "@jskit-ai/shell-web": "0.1.58",
+    "@jskit-ai/users-core": "0.1.69",
+    "@jskit-ai/users-web": "0.1.74"
   },
   "peerDependencies": {
     "vue": "^3.5.13",

--- a/packages/crud-server-generator/package.descriptor.mjs
+++ b/packages/crud-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-server-generator",
-  version: "0.1.66",
+  version: "0.1.67",
   kind: "generator",
   description: "CRUD server generator with routes, actions, and persistence scaffolding.",
   options: {
@@ -152,14 +152,14 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.57",
-        "@jskit-ai/crud-core": "0.1.66",
-        "@jskit-ai/database-runtime": "0.1.58",
-        "@jskit-ai/http-runtime": "0.1.57",
-        "@jskit-ai/json-rest-api-core": "0.1.3",
-        "@jskit-ai/kernel": "0.1.58",
-        "@jskit-ai/realtime": "0.1.57",
-        "@jskit-ai/resource-crud-core": "0.1.3",
+        "@jskit-ai/auth-core": "0.1.58",
+        "@jskit-ai/crud-core": "0.1.67",
+        "@jskit-ai/database-runtime": "0.1.59",
+        "@jskit-ai/http-runtime": "0.1.58",
+        "@jskit-ai/json-rest-api-core": "0.1.4",
+        "@jskit-ai/kernel": "0.1.59",
+        "@jskit-ai/realtime": "0.1.58",
+        "@jskit-ai/resource-crud-core": "0.1.4",
         "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}"
       },
       dev: {}

--- a/packages/crud-server-generator/package.json
+++ b/packages/crud-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-server-generator",
-  "version": "0.1.66",
+  "version": "0.1.67",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,12 +13,12 @@
   },
   "dependencies": {
     "@babel/parser": "^7.29.2",
-    "@jskit-ai/crud-core": "0.1.66",
-    "@jskit-ai/database-runtime": "0.1.58",
-    "@jskit-ai/http-runtime": "0.1.57",
-    "@jskit-ai/json-rest-api-core": "0.1.3",
-    "@jskit-ai/kernel": "0.1.58",
-    "@jskit-ai/resource-crud-core": "0.1.3",
+    "@jskit-ai/crud-core": "0.1.67",
+    "@jskit-ai/database-runtime": "0.1.59",
+    "@jskit-ai/http-runtime": "0.1.58",
+    "@jskit-ai/json-rest-api-core": "0.1.4",
+    "@jskit-ai/kernel": "0.1.59",
+    "@jskit-ai/resource-crud-core": "0.1.4",
     "recast": "^0.23.11"
   }
 }

--- a/packages/crud-ui-generator/package.descriptor.mjs
+++ b/packages/crud-ui-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-ui-generator",
-  version: "0.1.41",
+  version: "0.1.42",
   kind: "generator",
   description: "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
   options: {
@@ -180,7 +180,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.73"
+        "@jskit-ai/users-web": "0.1.74"
       },
       dev: {}
     },

--- a/packages/crud-ui-generator/package.json
+++ b/packages/crud-ui-generator/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@jskit-ai/crud-ui-generator",
-  "version": "0.1.41",
+  "version": "0.1.42",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/crud-core": "0.1.66",
-    "@jskit-ai/kernel": "0.1.58",
-    "@jskit-ai/resource-crud-core": "0.1.3"
+    "@jskit-ai/crud-core": "0.1.67",
+    "@jskit-ai/kernel": "0.1.59",
+    "@jskit-ai/resource-crud-core": "0.1.4"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/database-runtime-mysql/package.descriptor.mjs
+++ b/packages/database-runtime-mysql/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-mysql",
-  version: "0.1.57",
+  version: "0.1.58",
   kind: "runtime",
   options: {
     "db-host": {
@@ -91,7 +91,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.58",
+        "@jskit-ai/database-runtime": "0.1.59",
         "mysql2": "^3.11.2"
       },
       dev: {}

--- a/packages/database-runtime-mysql/package.json
+++ b/packages/database-runtime-mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-mysql",
-  "version": "0.1.57",
+  "version": "0.1.58",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,7 +12,7 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.58",
-    "@jskit-ai/kernel": "0.1.58"
+    "@jskit-ai/database-runtime": "0.1.59",
+    "@jskit-ai/kernel": "0.1.59"
   }
 }

--- a/packages/database-runtime-postgres/package.descriptor.mjs
+++ b/packages/database-runtime-postgres/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-postgres",
-  version: "0.1.57",
+  version: "0.1.58",
   kind: "runtime",
   options: {
     "db-host": {
@@ -91,7 +91,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.58",
+        "@jskit-ai/database-runtime": "0.1.59",
         "pg": "^8.13.1"
       },
       dev: {}

--- a/packages/database-runtime-postgres/package.json
+++ b/packages/database-runtime-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-postgres",
-  "version": "0.1.57",
+  "version": "0.1.58",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,6 +12,6 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.58"
+    "@jskit-ai/database-runtime": "0.1.59"
   }
 }

--- a/packages/database-runtime/package.descriptor.mjs
+++ b/packages/database-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime",
-  version: "0.1.58",
+  version: "0.1.59",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -58,7 +58,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.58",
+        "@jskit-ai/kernel": "0.1.59",
         "dotenv": "^16.4.5",
         "knex": "^3.1.0"
       },

--- a/packages/database-runtime/package.json
+++ b/packages/database-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime",
-  "version": "0.1.58",
+  "version": "0.1.59",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -25,6 +25,6 @@
     "./shared/transactions": "./src/shared/transactions.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.58"
+    "@jskit-ai/kernel": "0.1.59"
   }
 }

--- a/packages/feature-server-generator/package.descriptor.mjs
+++ b/packages/feature-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/feature-server-generator",
-  version: "0.1.0",
+  version: "0.1.1",
   kind: "generator",
   description: "Scaffold substantial non-CRUD server feature packages with provider, actions, service, and optional persistence seams.",
   options: {
@@ -153,10 +153,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.58",
-        "@jskit-ai/database-runtime-mysql": "0.1.57",
-        "@jskit-ai/json-rest-api-core": "0.1.3",
-        "@jskit-ai/kernel": "0.1.58",
+        "@jskit-ai/database-runtime": "0.1.59",
+        "@jskit-ai/database-runtime-mysql": "0.1.58",
+        "@jskit-ai/json-rest-api-core": "0.1.4",
+        "@jskit-ai/kernel": "0.1.59",
         "json-rest-schema": "1.x.x",
         "@local/${option:feature-name|kebab}": "file:packages/${option:feature-name|kebab}"
       },

--- a/packages/feature-server-generator/package.json
+++ b/packages/feature-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/feature-server-generator",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "scripts": {
     "test": "node --test"

--- a/packages/http-runtime/package.descriptor.mjs
+++ b/packages/http-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/http-runtime",
-  "version": "0.1.57",
+  "version": "0.1.58",
   "kind": "runtime",
   "dependsOn": [],
   "capabilities": {
@@ -67,7 +67,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.58"
+        "@jskit-ai/kernel": "0.1.59"
       },
       "dev": {}
     },

--- a/packages/http-runtime/package.json
+++ b/packages/http-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/http-runtime",
-  "version": "0.1.57",
+  "version": "0.1.58",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -18,7 +18,7 @@
     "./shared/validators/operationValidation": "./src/shared/validators/operationValidation.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.58",
+    "@jskit-ai/kernel": "0.1.59",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/json-rest-api-core/package.descriptor.mjs
+++ b/packages/json-rest-api-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/json-rest-api-core",
-  version: "0.1.3",
+  version: "0.1.4",
   kind: "runtime",
   description: "Shared internal json-rest-api host runtime for JSKIT server packages.",
   dependsOn: [

--- a/packages/json-rest-api-core/package.json
+++ b/packages/json-rest-api-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/json-rest-api-core",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,6 +11,6 @@
   "dependencies": {
     "hooked-api": "1.x.x",
     "json-rest-api": "1.x.x",
-    "@jskit-ai/kernel": "0.1.58"
+    "@jskit-ai/kernel": "0.1.59"
   }
 }

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/kernel",
-  "version": "0.1.58",
+  "version": "0.1.59",
   "type": "module",
   "dependencies": {
     "json-rest-schema": "1.x.x"

--- a/packages/realtime/package.descriptor.mjs
+++ b/packages/realtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/realtime",
-  version: "0.1.57",
+  version: "0.1.58",
   kind: "runtime",
   description: "Thin, generic realtime runtime wrappers for socket.io server and client.",
   options: {
@@ -94,7 +94,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.58",
+        "@jskit-ai/kernel": "0.1.59",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/realtime",
-  "version": "0.1.57",
+  "version": "0.1.58",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@socket.io/redis-adapter": "^8.3.0",
-    "@jskit-ai/kernel": "0.1.58",
+    "@jskit-ai/kernel": "0.1.59",
     "redis": "^5.8.2",
     "socket.io": "^4.8.3",
     "socket.io-client": "^4.8.3"

--- a/packages/resource-core/package.descriptor.mjs
+++ b/packages/resource-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/resource-core",
-  version: "0.1.3",
+  version: "0.1.4",
   kind: "runtime",
   description: "Generic resource-definition helpers and schema-definition normalization.",
   dependsOn: [
@@ -22,7 +22,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/resource-core": "0.1.3"
+        "@jskit-ai/resource-core": "0.1.4"
       },
       dev: {}
     },

--- a/packages/resource-core/package.json
+++ b/packages/resource-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/resource-core",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./shared/resource": "./src/shared/resource.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.58"
+    "@jskit-ai/kernel": "0.1.59"
   }
 }

--- a/packages/resource-crud-core/package.descriptor.mjs
+++ b/packages/resource-crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/resource-crud-core",
-  version: "0.1.3",
+  version: "0.1.4",
   kind: "runtime",
   description: "CRUD-specific resource-definition helpers and namespace support.",
   dependsOn: [
@@ -23,7 +23,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/resource-crud-core": "0.1.3"
+        "@jskit-ai/resource-crud-core": "0.1.4"
       },
       dev: {}
     },

--- a/packages/resource-crud-core/package.json
+++ b/packages/resource-crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/resource-crud-core",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./shared/crudResource": "./src/shared/crudResource.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.58",
-    "@jskit-ai/resource-core": "0.1.3"
+    "@jskit-ai/kernel": "0.1.59",
+    "@jskit-ai/resource-core": "0.1.4"
   }
 }

--- a/packages/shell-web/package.descriptor.mjs
+++ b/packages/shell-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/shell-web",
-  version: "0.1.57",
+  version: "0.1.58",
   kind: "runtime",
   description: "Web shell layout runtime with outlet-based placement contributions.",
   dependsOn: [],
@@ -122,7 +122,7 @@ export default Object.freeze({
       runtime: {
         "@mdi/js": "^7.4.47",
         "@tanstack/vue-query": "^5.90.5",
-        "@jskit-ai/kernel": "0.1.58",
+        "@jskit-ai/kernel": "0.1.59",
         "vuetify": "^4.0.0"
       },
       dev: {}

--- a/packages/shell-web/package.json
+++ b/packages/shell-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/shell-web",
-  "version": "0.1.57",
+  "version": "0.1.58",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -25,7 +25,7 @@
   "dependencies": {
     "@mdi/js": "^7.4.47",
     "@tanstack/vue-query": "^5.90.5",
-    "@jskit-ai/kernel": "0.1.58",
+    "@jskit-ai/kernel": "0.1.59",
     "pinia": "^3.0.4",
     "vuetify": "^4.0.0"
   },

--- a/packages/storage-runtime/package.descriptor.mjs
+++ b/packages/storage-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/storage-runtime",
-  version: "0.1.57",
+  version: "0.1.58",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -50,7 +50,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.58",
+        "@jskit-ai/kernel": "0.1.59",
         "unstorage": "^1.17.3"
       },
       dev: {}

--- a/packages/storage-runtime/package.json
+++ b/packages/storage-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/storage-runtime",
-  "version": "0.1.57",
+  "version": "0.1.58",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./server/providers/StorageRuntimeServiceProvider": "./src/server/providers/StorageRuntimeServiceProvider.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.58",
+    "@jskit-ai/kernel": "0.1.59",
     "unstorage": "^1.17.3"
   }
 }

--- a/packages/ui-generator/package.descriptor.mjs
+++ b/packages/ui-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/ui-generator",
-  version: "0.1.41",
+  version: "0.1.42",
   kind: "generator",
   description: "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
   options: {
@@ -278,7 +278,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.73"
+        "@jskit-ai/users-web": "0.1.74"
       },
       dev: {}
     },

--- a/packages/ui-generator/package.json
+++ b/packages/ui-generator/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/ui-generator",
-  "version": "0.1.41",
+  "version": "0.1.42",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.58",
-    "@jskit-ai/shell-web": "0.1.57"
+    "@jskit-ai/kernel": "0.1.59",
+    "@jskit-ai/shell-web": "0.1.58"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/uploads-image-web/package.descriptor.mjs
+++ b/packages/uploads-image-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-image-web",
-  version: "0.1.36",
+  version: "0.1.37",
   kind: "runtime",
   description: "Reusable client-side image upload runtime with pre-upload image editing.",
   dependsOn: [
@@ -65,7 +65,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/uploads-runtime": "0.1.36",
+        "@jskit-ai/uploads-runtime": "0.1.37",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-image-web/package.json
+++ b/packages/uploads-image-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-image-web",
-  "version": "0.1.36",
+  "version": "0.1.37",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,7 +13,7 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/uploads-runtime": "0.1.36",
+    "@jskit-ai/uploads-runtime": "0.1.37",
     "@uppy/compressor": "^3.1.0",
     "@uppy/core": "^5.2.0",
     "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-runtime/package.descriptor.mjs
+++ b/packages/uploads-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-runtime",
-  version: "0.1.36",
+  version: "0.1.37",
   kind: "runtime",
   description: "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
   dependsOn: [
@@ -71,7 +71,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.58"
+        "@jskit-ai/kernel": "0.1.59"
       },
       dev: {}
     },

--- a/packages/uploads-runtime/package.json
+++ b/packages/uploads-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-runtime",
-  "version": "0.1.36",
+  "version": "0.1.37",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,6 +16,6 @@
   },
   "dependencies": {
     "@fastify/multipart": "^9.4.0",
-    "@jskit-ai/kernel": "0.1.58"
+    "@jskit-ai/kernel": "0.1.59"
   }
 }

--- a/packages/users-core/package.descriptor.mjs
+++ b/packages/users-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-core",
-  version: "0.1.68",
+  version: "0.1.69",
   kind: "runtime",
   description: "Users/account runtime plus HTTP routes for account features.",
   dependsOn: [
@@ -132,16 +132,16 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.57",
-        "@jskit-ai/crud-core": "0.1.66",
-        "@jskit-ai/database-runtime": "0.1.58",
-        "@jskit-ai/http-runtime": "0.1.57",
-        "@jskit-ai/json-rest-api-core": "0.1.3",
-        "@jskit-ai/kernel": "0.1.58",
-        "@jskit-ai/resource-core": "0.1.3",
-        "@jskit-ai/resource-crud-core": "0.1.3",
+        "@jskit-ai/auth-core": "0.1.58",
+        "@jskit-ai/crud-core": "0.1.67",
+        "@jskit-ai/database-runtime": "0.1.59",
+        "@jskit-ai/http-runtime": "0.1.58",
+        "@jskit-ai/json-rest-api-core": "0.1.4",
+        "@jskit-ai/kernel": "0.1.59",
+        "@jskit-ai/resource-core": "0.1.4",
+        "@jskit-ai/resource-crud-core": "0.1.4",
         "@local/users": "file:packages/users",
-        "@jskit-ai/uploads-runtime": "0.1.36"
+        "@jskit-ai/uploads-runtime": "0.1.37"
       },
       dev: {}
     },

--- a/packages/users-core/package.json
+++ b/packages/users-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-core",
-  "version": "0.1.68",
+  "version": "0.1.69",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,14 +11,14 @@
     "./shared/resources/userSettingsResource": "./src/shared/resources/userSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.57",
-    "@jskit-ai/database-runtime": "0.1.58",
-    "@jskit-ai/http-runtime": "0.1.57",
-    "@jskit-ai/json-rest-api-core": "0.1.3",
-    "@jskit-ai/kernel": "0.1.58",
-    "@jskit-ai/resource-crud-core": "0.1.3",
-    "@jskit-ai/resource-core": "0.1.3",
-    "@jskit-ai/uploads-runtime": "0.1.36",
+    "@jskit-ai/auth-core": "0.1.58",
+    "@jskit-ai/database-runtime": "0.1.59",
+    "@jskit-ai/http-runtime": "0.1.58",
+    "@jskit-ai/json-rest-api-core": "0.1.4",
+    "@jskit-ai/kernel": "0.1.59",
+    "@jskit-ai/resource-crud-core": "0.1.4",
+    "@jskit-ai/resource-core": "0.1.4",
+    "@jskit-ai/uploads-runtime": "0.1.37",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/users-web/package.descriptor.mjs
+++ b/packages/users-web/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { HOME_COG_OUTLET } from "./src/shared/toolsOutletContracts.js";
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-web",
-  version: "0.1.73",
+  version: "0.1.74",
   kind: "runtime",
   description: "Users web module: account/profile UI plus shared users web widgets.",
   dependsOn: [
@@ -183,12 +183,12 @@ export default Object.freeze({
       runtime: {
         "@tanstack/vue-query": "5.92.12",
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/http-runtime": "0.1.57",
-        "@jskit-ai/realtime": "0.1.57",
-        "@jskit-ai/kernel": "0.1.58",
-        "@jskit-ai/shell-web": "0.1.57",
-        "@jskit-ai/uploads-image-web": "0.1.36",
-        "@jskit-ai/users-core": "0.1.68",
+        "@jskit-ai/http-runtime": "0.1.58",
+        "@jskit-ai/realtime": "0.1.58",
+        "@jskit-ai/kernel": "0.1.59",
+        "@jskit-ai/shell-web": "0.1.58",
+        "@jskit-ai/uploads-image-web": "0.1.37",
+        "@jskit-ai/users-core": "0.1.69",
         vuetify: "^4.0.0"
       },
       dev: {}

--- a/packages/users-web/package.json
+++ b/packages/users-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-web",
-  "version": "0.1.73",
+  "version": "0.1.74",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -34,12 +34,12 @@
   "dependencies": {
     "@tanstack/vue-query": "5.92.12",
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/http-runtime": "0.1.57",
-    "@jskit-ai/kernel": "0.1.58",
-    "@jskit-ai/realtime": "0.1.57",
-    "@jskit-ai/shell-web": "0.1.57",
-    "@jskit-ai/uploads-image-web": "0.1.36",
-    "@jskit-ai/users-core": "0.1.68",
+    "@jskit-ai/http-runtime": "0.1.58",
+    "@jskit-ai/kernel": "0.1.59",
+    "@jskit-ai/realtime": "0.1.58",
+    "@jskit-ai/shell-web": "0.1.58",
+    "@jskit-ai/uploads-image-web": "0.1.37",
+    "@jskit-ai/users-core": "0.1.69",
     "vuetify": "^4.0.0"
   },
   "peerDependencies": {

--- a/packages/workspaces-core/package.descriptor.mjs
+++ b/packages/workspaces-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-core",
-  version: "0.1.34",
+  version: "0.1.35",
   kind: "runtime",
   description: "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
   dependsOn: [
@@ -116,10 +116,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/json-rest-api-core": "0.1.3",
-        "@jskit-ai/resource-core": "0.1.3",
-        "@jskit-ai/resource-crud-core": "0.1.3",
-        "@jskit-ai/users-core": "0.1.68"
+        "@jskit-ai/json-rest-api-core": "0.1.4",
+        "@jskit-ai/resource-core": "0.1.4",
+        "@jskit-ai/resource-crud-core": "0.1.4",
+        "@jskit-ai/users-core": "0.1.69"
       },
       dev: {}
     },

--- a/packages/workspaces-core/package.json
+++ b/packages/workspaces-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-core",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -17,14 +17,14 @@
     "./shared/resources/workspaceSettingsResource": "./src/shared/resources/workspaceSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.57",
-    "@jskit-ai/database-runtime": "0.1.58",
-    "@jskit-ai/http-runtime": "0.1.57",
-    "@jskit-ai/json-rest-api-core": "0.1.3",
-    "@jskit-ai/kernel": "0.1.58",
-    "@jskit-ai/resource-crud-core": "0.1.3",
-    "@jskit-ai/resource-core": "0.1.3",
-    "@jskit-ai/users-core": "0.1.68",
+    "@jskit-ai/auth-core": "0.1.58",
+    "@jskit-ai/database-runtime": "0.1.59",
+    "@jskit-ai/http-runtime": "0.1.58",
+    "@jskit-ai/json-rest-api-core": "0.1.4",
+    "@jskit-ai/kernel": "0.1.59",
+    "@jskit-ai/resource-crud-core": "0.1.4",
+    "@jskit-ai/resource-core": "0.1.4",
+    "@jskit-ai/users-core": "0.1.69",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/workspaces-web/package.descriptor.mjs
+++ b/packages/workspaces-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-web",
-  version: "0.1.34",
+  version: "0.1.35",
   kind: "runtime",
   description: "Workspace web module: workspace selector, tools widget, workspace surfaces, and members/settings UI.",
   dependsOn: [
@@ -166,8 +166,8 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/workspaces-core": "0.1.34",
-        "@jskit-ai/users-web": "0.1.73",
+        "@jskit-ai/workspaces-core": "0.1.35",
+        "@jskit-ai/users-web": "0.1.74",
         "vuetify": "^4.0.0"
       },
       dev: {}

--- a/packages/workspaces-web/package.json
+++ b/packages/workspaces-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-web",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -15,12 +15,12 @@
   "dependencies": {
     "@tanstack/vue-query": "5.92.12",
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/http-runtime": "0.1.57",
-    "@jskit-ai/kernel": "0.1.58",
-    "@jskit-ai/shell-web": "0.1.57",
-    "@jskit-ai/users-core": "0.1.68",
-    "@jskit-ai/users-web": "0.1.73",
-    "@jskit-ai/workspaces-core": "0.1.34",
+    "@jskit-ai/http-runtime": "0.1.58",
+    "@jskit-ai/kernel": "0.1.59",
+    "@jskit-ai/shell-web": "0.1.58",
+    "@jskit-ai/users-core": "0.1.69",
+    "@jskit-ai/users-web": "0.1.74",
+    "@jskit-ai/workspaces-core": "0.1.35",
     "vuetify": "^4.0.0"
   },
   "peerDependencies": {

--- a/tooling/config-eslint/package.json
+++ b/tooling/config-eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/config-eslint",
-  "version": "0.1.57",
+  "version": "0.1.58",
   "description": "Shared flat ESLint presets for JSKIT projects.",
   "type": "module",
   "files": [

--- a/tooling/create-app/package.descriptor.mjs
+++ b/tooling/create-app/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/create-app",
-  "version": "0.1.66",
+  "version": "0.1.67",
   "dependsOn": [],
   "capabilities": {
     "provides": [

--- a/tooling/create-app/package.json
+++ b/tooling/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/create-app",
-  "version": "0.1.66",
+  "version": "0.1.67",
   "description": "Scaffold minimal JSKIT app shells.",
   "type": "module",
   "files": [

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -6,11 +6,11 @@
   "packages": [
     {
       "packageId": "@jskit-ai/assistant",
-      "version": "0.1.67",
+      "version": "0.1.68",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant",
-        "version": "0.1.67",
+        "version": "0.1.68",
         "kind": "generator",
         "description": "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
         "options": {
@@ -356,11 +356,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-core",
-      "version": "0.1.34",
+      "version": "0.1.35",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-core",
-        "version": "0.1.34",
+        "version": "0.1.35",
         "kind": "runtime",
         "description": "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
         "dependsOn": [
@@ -408,11 +408,11 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/http-runtime": "0.1.57",
-              "@jskit-ai/kernel": "0.1.58",
-              "@jskit-ai/resource-core": "0.1.3",
-              "@jskit-ai/resource-crud-core": "0.1.3",
-              "@jskit-ai/users-core": "0.1.68",
+              "@jskit-ai/http-runtime": "0.1.58",
+              "@jskit-ai/kernel": "0.1.59",
+              "@jskit-ai/resource-core": "0.1.4",
+              "@jskit-ai/resource-crud-core": "0.1.4",
+              "@jskit-ai/users-core": "0.1.69",
               "@tanstack/vue-query": "^5.90.5",
               "dompurify": "^3.3.3",
               "json-rest-schema": "1.x.x",
@@ -433,11 +433,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-runtime",
-      "version": "0.1.29",
+      "version": "0.1.30",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-runtime",
-        "version": "0.1.29",
+        "version": "0.1.30",
         "kind": "runtime",
         "description": "Shared assistant runtime with per-surface assistant registration.",
         "dependsOn": [
@@ -512,13 +512,13 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/assistant-core": "0.1.34",
-              "@jskit-ai/database-runtime": "0.1.58",
-              "@jskit-ai/http-runtime": "0.1.57",
-              "@jskit-ai/kernel": "0.1.58",
-              "@jskit-ai/shell-web": "0.1.57",
-              "@jskit-ai/users-core": "0.1.68",
-              "@jskit-ai/users-web": "0.1.73",
+              "@jskit-ai/assistant-core": "0.1.35",
+              "@jskit-ai/database-runtime": "0.1.59",
+              "@jskit-ai/http-runtime": "0.1.58",
+              "@jskit-ai/kernel": "0.1.59",
+              "@jskit-ai/shell-web": "0.1.58",
+              "@jskit-ai/users-core": "0.1.69",
+              "@jskit-ai/users-web": "0.1.74",
               "@tanstack/vue-query": "^5.90.5",
               "vuetify": "^4.0.0"
             },
@@ -575,11 +575,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-core",
-      "version": "0.1.57",
+      "version": "0.1.58",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-core",
-        "version": "0.1.57",
+        "version": "0.1.58",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/value-app-config-shared"
@@ -647,7 +647,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.58",
+              "@jskit-ai/kernel": "0.1.59",
               "@fastify/cookie": "^11.0.2",
               "@fastify/csrf-protection": "^7.1.0",
               "@fastify/rate-limit": "^10.3.0"
@@ -665,11 +665,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.57",
+      "version": "0.1.58",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-supabase-core",
-        "version": "0.1.57",
+        "version": "0.1.58",
         "kind": "runtime",
         "options": {
           "auth-supabase-url": {
@@ -751,8 +751,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.57",
-              "@jskit-ai/kernel": "0.1.58",
+              "@jskit-ai/auth-core": "0.1.58",
+              "@jskit-ai/kernel": "0.1.59",
               "dotenv": "^16.4.5",
               "@supabase/supabase-js": "^2.57.4",
               "jose": "^6.1.0"
@@ -817,11 +817,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-web",
-      "version": "0.1.59",
+      "version": "0.1.60",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-web",
-        "version": "0.1.59",
+        "version": "0.1.60",
         "kind": "runtime",
         "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
         "dependsOn": [
@@ -1047,10 +1047,10 @@
             "runtime": {
               "@tanstack/vue-query": "5.92.12",
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/auth-core": "0.1.57",
-              "@jskit-ai/http-runtime": "0.1.57",
-              "@jskit-ai/kernel": "0.1.58",
-              "@jskit-ai/shell-web": "0.1.57",
+              "@jskit-ai/auth-core": "0.1.58",
+              "@jskit-ai/http-runtime": "0.1.58",
+              "@jskit-ai/kernel": "0.1.59",
+              "@jskit-ai/shell-web": "0.1.58",
               "vuetify": "^4.0.0"
             },
             "dev": {}
@@ -1120,11 +1120,11 @@
     },
     {
       "packageId": "@jskit-ai/console-core",
-      "version": "0.1.21",
+      "version": "0.1.22",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-core",
-        "version": "0.1.21",
+        "version": "0.1.22",
         "kind": "runtime",
         "description": "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
         "dependsOn": [
@@ -1197,12 +1197,12 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.57",
-              "@jskit-ai/database-runtime": "0.1.58",
-              "@jskit-ai/http-runtime": "0.1.57",
-              "@jskit-ai/kernel": "0.1.58",
-              "@jskit-ai/resource-crud-core": "0.1.3",
-              "@jskit-ai/users-core": "0.1.68"
+              "@jskit-ai/auth-core": "0.1.58",
+              "@jskit-ai/database-runtime": "0.1.59",
+              "@jskit-ai/http-runtime": "0.1.58",
+              "@jskit-ai/kernel": "0.1.59",
+              "@jskit-ai/resource-crud-core": "0.1.4",
+              "@jskit-ai/users-core": "0.1.69"
             },
             "dev": {}
           },
@@ -1227,11 +1227,11 @@
     },
     {
       "packageId": "@jskit-ai/console-web",
-      "version": "0.1.26",
+      "version": "0.1.27",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-web",
-        "version": "0.1.26",
+        "version": "0.1.27",
         "kind": "runtime",
         "description": "Authenticated console surface scaffold and surface policy wiring.",
         "dependsOn": [
@@ -1310,9 +1310,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-web": "0.1.59",
-              "@jskit-ai/console-core": "0.1.21",
-              "@jskit-ai/shell-web": "0.1.57"
+              "@jskit-ai/auth-web": "0.1.60",
+              "@jskit-ai/console-core": "0.1.22",
+              "@jskit-ai/shell-web": "0.1.58"
             },
             "dev": {}
           },
@@ -1409,11 +1409,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-core",
-      "version": "0.1.66",
+      "version": "0.1.67",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-core",
-        "version": "0.1.66",
+        "version": "0.1.67",
         "kind": "runtime",
         "description": "Shared CRUD helpers used by CRUD modules.",
         "dependsOn": [
@@ -1442,7 +1442,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/crud-core": "0.1.66"
+              "@jskit-ai/crud-core": "0.1.67"
             },
             "dev": {}
           },
@@ -1456,11 +1456,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-server-generator",
-      "version": "0.1.66",
+      "version": "0.1.67",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-server-generator",
-        "version": "0.1.66",
+        "version": "0.1.67",
         "kind": "generator",
         "description": "CRUD server generator with routes, actions, and persistence scaffolding.",
         "options": {
@@ -1619,14 +1619,14 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.57",
-              "@jskit-ai/crud-core": "0.1.66",
-              "@jskit-ai/database-runtime": "0.1.58",
-              "@jskit-ai/http-runtime": "0.1.57",
-              "@jskit-ai/json-rest-api-core": "0.1.3",
-              "@jskit-ai/kernel": "0.1.58",
-              "@jskit-ai/realtime": "0.1.57",
-              "@jskit-ai/resource-crud-core": "0.1.3",
+              "@jskit-ai/auth-core": "0.1.58",
+              "@jskit-ai/crud-core": "0.1.67",
+              "@jskit-ai/database-runtime": "0.1.59",
+              "@jskit-ai/http-runtime": "0.1.58",
+              "@jskit-ai/json-rest-api-core": "0.1.4",
+              "@jskit-ai/kernel": "0.1.59",
+              "@jskit-ai/realtime": "0.1.58",
+              "@jskit-ai/resource-crud-core": "0.1.4",
               "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}"
             },
             "dev": {}
@@ -1754,11 +1754,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.41",
+      "version": "0.1.42",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-ui-generator",
-        "version": "0.1.41",
+        "version": "0.1.42",
         "kind": "generator",
         "description": "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
         "options": {
@@ -1948,7 +1948,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.73"
+              "@jskit-ai/users-web": "0.1.74"
             },
             "dev": {}
           },
@@ -2181,11 +2181,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime",
-      "version": "0.1.58",
+      "version": "0.1.59",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime",
-        "version": "0.1.58",
+        "version": "0.1.59",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -2242,7 +2242,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.58",
+              "@jskit-ai/kernel": "0.1.59",
               "dotenv": "^16.4.5",
               "knex": "^3.1.0"
             },
@@ -2277,11 +2277,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.57",
+      "version": "0.1.58",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-mysql",
-        "version": "0.1.57",
+        "version": "0.1.58",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -2371,7 +2371,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.58",
+              "@jskit-ai/database-runtime": "0.1.59",
               "mysql2": "^3.11.2"
             },
             "dev": {}
@@ -2442,11 +2442,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.57",
+      "version": "0.1.58",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-postgres",
-        "version": "0.1.57",
+        "version": "0.1.58",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -2536,7 +2536,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.58",
+              "@jskit-ai/database-runtime": "0.1.59",
               "pg": "^8.13.1"
             },
             "dev": {}
@@ -2607,11 +2607,11 @@
     },
     {
       "packageId": "@jskit-ai/feature-server-generator",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/feature-server-generator",
-        "version": "0.1.0",
+        "version": "0.1.1",
         "kind": "generator",
         "description": "Scaffold substantial non-CRUD server feature packages with provider, actions, service, and optional persistence seams.",
         "options": {
@@ -2775,10 +2775,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.58",
-              "@jskit-ai/database-runtime-mysql": "0.1.57",
-              "@jskit-ai/json-rest-api-core": "0.1.3",
-              "@jskit-ai/kernel": "0.1.58",
+              "@jskit-ai/database-runtime": "0.1.59",
+              "@jskit-ai/database-runtime-mysql": "0.1.58",
+              "@jskit-ai/json-rest-api-core": "0.1.4",
+              "@jskit-ai/kernel": "0.1.59",
               "json-rest-schema": "1.x.x",
               "@local/${option:feature-name|kebab}": "file:packages/${option:feature-name|kebab}"
             },
@@ -2891,11 +2891,11 @@
     },
     {
       "packageId": "@jskit-ai/http-runtime",
-      "version": "0.1.57",
+      "version": "0.1.58",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/http-runtime",
-        "version": "0.1.57",
+        "version": "0.1.58",
         "kind": "runtime",
         "dependsOn": [],
         "capabilities": {
@@ -2961,7 +2961,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.58"
+              "@jskit-ai/kernel": "0.1.59"
             },
             "dev": {}
           },
@@ -2975,11 +2975,11 @@
     },
     {
       "packageId": "@jskit-ai/json-rest-api-core",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/json-rest-api-core",
-        "version": "0.1.3",
+        "version": "0.1.4",
         "kind": "runtime",
         "description": "Shared internal json-rest-api host runtime for JSKIT server packages.",
         "dependsOn": [
@@ -3039,11 +3039,11 @@
     },
     {
       "packageId": "@jskit-ai/realtime",
-      "version": "0.1.57",
+      "version": "0.1.58",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/realtime",
-        "version": "0.1.57",
+        "version": "0.1.58",
         "kind": "runtime",
         "description": "Thin, generic realtime runtime wrappers for socket.io server and client.",
         "options": {
@@ -3138,7 +3138,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.58",
+              "@jskit-ai/kernel": "0.1.59",
               "@socket.io/redis-adapter": "^8.3.0",
               "redis": "^5.8.2",
               "socket.io": "^4.8.3",
@@ -3187,11 +3187,11 @@
     },
     {
       "packageId": "@jskit-ai/resource-core",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/resource-core",
-        "version": "0.1.3",
+        "version": "0.1.4",
         "kind": "runtime",
         "description": "Generic resource-definition helpers and schema-definition normalization.",
         "dependsOn": [
@@ -3214,7 +3214,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/resource-core": "0.1.3"
+              "@jskit-ai/resource-core": "0.1.4"
             },
             "dev": {}
           },
@@ -3229,11 +3229,11 @@
     },
     {
       "packageId": "@jskit-ai/resource-crud-core",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/resource-crud-core",
-        "version": "0.1.3",
+        "version": "0.1.4",
         "kind": "runtime",
         "description": "CRUD-specific resource-definition helpers and namespace support.",
         "dependsOn": [
@@ -3257,7 +3257,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/resource-crud-core": "0.1.3"
+              "@jskit-ai/resource-crud-core": "0.1.4"
             },
             "dev": {}
           },
@@ -3272,11 +3272,11 @@
     },
     {
       "packageId": "@jskit-ai/shell-web",
-      "version": "0.1.57",
+      "version": "0.1.58",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/shell-web",
-        "version": "0.1.57",
+        "version": "0.1.58",
         "kind": "runtime",
         "description": "Web shell layout runtime with outlet-based placement contributions.",
         "dependsOn": [],
@@ -3413,7 +3413,7 @@
             "runtime": {
               "@mdi/js": "^7.4.47",
               "@tanstack/vue-query": "^5.90.5",
-              "@jskit-ai/kernel": "0.1.58",
+              "@jskit-ai/kernel": "0.1.59",
               "vuetify": "^4.0.0"
             },
             "dev": {}
@@ -3598,11 +3598,11 @@
     },
     {
       "packageId": "@jskit-ai/storage-runtime",
-      "version": "0.1.57",
+      "version": "0.1.58",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/storage-runtime",
-        "version": "0.1.57",
+        "version": "0.1.58",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -3651,7 +3651,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.58",
+              "@jskit-ai/kernel": "0.1.59",
               "unstorage": "^1.17.3"
             },
             "dev": {}
@@ -3667,11 +3667,11 @@
     },
     {
       "packageId": "@jskit-ai/ui-generator",
-      "version": "0.1.41",
+      "version": "0.1.42",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/ui-generator",
-        "version": "0.1.41",
+        "version": "0.1.42",
         "kind": "generator",
         "description": "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
         "options": {
@@ -3970,7 +3970,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.73"
+              "@jskit-ai/users-web": "0.1.74"
             },
             "dev": {}
           },
@@ -3985,11 +3985,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-image-web",
-      "version": "0.1.36",
+      "version": "0.1.37",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-image-web",
-        "version": "0.1.36",
+        "version": "0.1.37",
         "kind": "runtime",
         "description": "Reusable client-side image upload runtime with pre-upload image editing.",
         "dependsOn": [
@@ -4053,7 +4053,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/uploads-runtime": "0.1.36",
+              "@jskit-ai/uploads-runtime": "0.1.37",
               "@uppy/compressor": "^3.1.0",
               "@uppy/core": "^5.2.0",
               "@uppy/dashboard": "^5.1.1",
@@ -4073,11 +4073,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-runtime",
-      "version": "0.1.36",
+      "version": "0.1.37",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-runtime",
-        "version": "0.1.36",
+        "version": "0.1.37",
         "kind": "runtime",
         "description": "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
         "dependsOn": [
@@ -4147,7 +4147,7 @@
           "dependencies": {
             "runtime": {
               "@fastify/multipart": "^9.4.0",
-              "@jskit-ai/kernel": "0.1.58"
+              "@jskit-ai/kernel": "0.1.59"
             },
             "dev": {}
           },
@@ -4162,11 +4162,11 @@
     },
     {
       "packageId": "@jskit-ai/users-core",
-      "version": "0.1.68",
+      "version": "0.1.69",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-core",
-        "version": "0.1.68",
+        "version": "0.1.69",
         "kind": "runtime",
         "description": "Users/account runtime plus HTTP routes for account features.",
         "dependsOn": [
@@ -4296,16 +4296,16 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.57",
-              "@jskit-ai/crud-core": "0.1.66",
-              "@jskit-ai/database-runtime": "0.1.58",
-              "@jskit-ai/http-runtime": "0.1.57",
-              "@jskit-ai/json-rest-api-core": "0.1.3",
-              "@jskit-ai/kernel": "0.1.58",
-              "@jskit-ai/resource-core": "0.1.3",
-              "@jskit-ai/resource-crud-core": "0.1.3",
+              "@jskit-ai/auth-core": "0.1.58",
+              "@jskit-ai/crud-core": "0.1.67",
+              "@jskit-ai/database-runtime": "0.1.59",
+              "@jskit-ai/http-runtime": "0.1.58",
+              "@jskit-ai/json-rest-api-core": "0.1.4",
+              "@jskit-ai/kernel": "0.1.59",
+              "@jskit-ai/resource-core": "0.1.4",
+              "@jskit-ai/resource-crud-core": "0.1.4",
               "@local/users": "file:packages/users",
-              "@jskit-ai/uploads-runtime": "0.1.36"
+              "@jskit-ai/uploads-runtime": "0.1.37"
             },
             "dev": {}
           },
@@ -4522,11 +4522,11 @@
     },
     {
       "packageId": "@jskit-ai/users-web",
-      "version": "0.1.73",
+      "version": "0.1.74",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-web",
-        "version": "0.1.73",
+        "version": "0.1.74",
         "kind": "runtime",
         "description": "Users web module: account/profile UI plus shared users web widgets.",
         "dependsOn": [
@@ -4722,12 +4722,12 @@
             "runtime": {
               "@tanstack/vue-query": "5.92.12",
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/http-runtime": "0.1.57",
-              "@jskit-ai/realtime": "0.1.57",
-              "@jskit-ai/kernel": "0.1.58",
-              "@jskit-ai/shell-web": "0.1.57",
-              "@jskit-ai/uploads-image-web": "0.1.36",
-              "@jskit-ai/users-core": "0.1.68",
+              "@jskit-ai/http-runtime": "0.1.58",
+              "@jskit-ai/realtime": "0.1.58",
+              "@jskit-ai/kernel": "0.1.59",
+              "@jskit-ai/shell-web": "0.1.58",
+              "@jskit-ai/uploads-image-web": "0.1.37",
+              "@jskit-ai/users-core": "0.1.69",
               "vuetify": "^4.0.0"
             },
             "dev": {}
@@ -4877,11 +4877,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-core",
-      "version": "0.1.34",
+      "version": "0.1.35",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-core",
-        "version": "0.1.34",
+        "version": "0.1.35",
         "kind": "runtime",
         "description": "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
         "dependsOn": [
@@ -4996,10 +4996,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/json-rest-api-core": "0.1.3",
-              "@jskit-ai/resource-core": "0.1.3",
-              "@jskit-ai/resource-crud-core": "0.1.3",
-              "@jskit-ai/users-core": "0.1.68"
+              "@jskit-ai/json-rest-api-core": "0.1.4",
+              "@jskit-ai/resource-core": "0.1.4",
+              "@jskit-ai/resource-crud-core": "0.1.4",
+              "@jskit-ai/users-core": "0.1.69"
             },
             "dev": {}
           },
@@ -5171,11 +5171,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-web",
-      "version": "0.1.34",
+      "version": "0.1.35",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-web",
-        "version": "0.1.34",
+        "version": "0.1.35",
         "kind": "runtime",
         "description": "Workspace web module: workspace selector, tools widget, workspace surfaces, and members/settings UI.",
         "dependsOn": [
@@ -5362,8 +5362,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/workspaces-core": "0.1.34",
-              "@jskit-ai/users-web": "0.1.73",
+              "@jskit-ai/workspaces-core": "0.1.35",
+              "@jskit-ai/users-web": "0.1.74",
               "vuetify": "^4.0.0"
             },
             "dev": {}

--- a/tooling/jskit-catalog/package.json
+++ b/tooling/jskit-catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-catalog",
-  "version": "0.1.66",
+  "version": "0.1.67",
   "description": "Published metadata catalog for JSKIT package descriptors.",
   "type": "module",
   "files": [

--- a/tooling/jskit-cli/package.json
+++ b/tooling/jskit-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-cli",
-  "version": "0.2.67",
+  "version": "0.2.68",
   "description": "Bundle and package orchestration CLI for JSKIT apps.",
   "type": "module",
   "files": [
@@ -20,9 +20,9 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/jskit-catalog": "0.1.66",
-    "@jskit-ai/kernel": "0.1.58",
-    "@jskit-ai/shell-web": "0.1.57"
+    "@jskit-ai/jskit-catalog": "0.1.67",
+    "@jskit-ai/kernel": "0.1.59",
+    "@jskit-ai/shell-web": "0.1.58"
   },
   "engines": {
     "node": "20.x"


### PR DESCRIPTION
Bump package and descriptor versions across the workspace, wire the new feature-server-generator package into the lock/catalog, and refresh inter-package dependency pins accordingly.
