### PR TITLE
Add base-ref aware doctor and UI verification flows

### DIFF
--- a/packages/agent-docs/guide/agent/app-setup/authentication.md
+++ b/packages/agent-docs/guide/agent/app-setup/authentication.md
@@ -1030,6 +1030,14 @@ npx jskit app verify-ui \
   --auth-mode dev-auth-login-as
 ```
 
+For local pre-merge review, the next step after recording that Playwright run is usually:
+
+```bash
+npx jskit doctor --against origin/main
+```
+
+Advanced CI pipelines can use the same `--against` contract too, but JSKIT does not scaffold hosted auth/database/browser verification by default.
+
 That flow is preferable to driving the real sign-in form in feature tests because it keeps the test focused on the UI feature being added, not on an external auth dependency. If a chunk changes user-facing UI and the flow requires login, the expected JSKIT review standard is:
 
 - use Playwright

--- a/packages/agent-docs/guide/agent/app-setup/initial-scaffolding.md
+++ b/packages/agent-docs/guide/agent/app-setup/initial-scaffolding.md
@@ -151,6 +151,8 @@ That matters because JSKIT maintenance policy changes over time. If the scaffold
 
 `jskit app verify` is worth noticing specifically. Linting, tests, and builds check your source code and runtime behavior. The JSKIT part of that flow runs `doctor`, which checks JSKIT-managed app state: installed package visibility, lock-file-backed managed files, and other JSKIT-specific health rules. It is there because a JSKIT app is not only code. It is also a descriptor-driven managed project.
 
+The starter scaffold also writes `.github/workflows/verify.yml`. That workflow stays intentionally small: it runs `npm run verify` for the normal GitHub Actions gate and leaves browser/auth/database-heavy review flows to app-specific local or CI setups. The `--against <base-ref>` review mode exists in the CLI for local pre-merge checks and for advanced CI pipelines, but it is not assumed by the starter scaffold.
+
 The surface-specific script names are also worth noticing early, even in this tiny app. `dev:home`, `server:home`, and `build:home` are the first concrete places where surface selection shows up in the scaffold. They work by setting `VITE_SURFACE=home` on the client side and `SERVER_SURFACE=home` on the server side. In this first chapter, where `home` is the only surface, those variants behave almost the same as the default commands. Later, once more surfaces exist, those scripts become the simplest way to run or build just one surface at a time.
 
 ### App surfaces in JSKIT

--- a/packages/agent-docs/guide/agent/app-setup/working-with-the-jskit-cli.md
+++ b/packages/agent-docs/guide/agent/app-setup/working-with-the-jskit-cli.md
@@ -80,6 +80,8 @@ This gives you a clean ownership split:
 
 That split is worth keeping in mind through the rest of the guide. When you see `npm run verify`, that is now shorthand for "run the app's JSKIT baseline verification policy, then any app-specific extra verification hook".
 
+The starter scaffold also includes `.github/workflows/verify.yml`. That workflow is intentionally conservative: it runs `npm run verify` and does not assume that every app can stand up full browser, auth, seed-data, and database verification inside hosted CI.
+
 If your app uses a non-default npm registry for JSKIT packages, pass it to the maintained CLI command rather than hard-coding it in the scaffold. For example:
 
 ```bash
@@ -746,6 +748,20 @@ That command does two things:
 - writes a receipt describing the verified feature, auth mode, and current dirty UI file set
 
 `doctor` then compares the current changed UI files to that receipt. If you edit the UI again afterwards, the receipt is stale and `doctor` tells you to rerun `jskit app verify-ui`.
+
+For local pre-merge review, use `--against <base-ref>` so JSKIT compares against the branch delta instead of only the current dirty worktree. The common shape is:
+
+```bash
+npx jskit doctor --against origin/main
+```
+
+If the UI changed, the normal local sequence is:
+
+1. run the targeted Playwright flow locally
+2. record it with `jskit app verify-ui ...`
+3. run `jskit doctor --against <base-ref>`
+
+Advanced CI pipelines can also use `--against <base-ref>`, but that is intentionally app-specific. JSKIT does not scaffold hosted browser/auth/database verification by default, because many real apps need secrets, seeded databases, local auth bypass, or environment-specific bootstrap paths that do not belong in a one-size-fits-all template.
 
 ### Why `--json` exists
 

--- a/packages/agent-docs/patterns/ui-testing.md
+++ b/packages/agent-docs/patterns/ui-testing.md
@@ -12,6 +12,8 @@ Rules:
 - Any chunk that adds or changes user-facing UI must include a Playwright flow that exercises the changed behavior before the chunk is done.
 - Record that Playwright run with `jskit app verify-ui --command "<playwright command>" --feature "<label>" --auth-mode <mode>`.
 - `jskit doctor` expects `.jskit/verification/ui.json` to match the current dirty UI file set when UI files are changed.
+- For local pre-merge review, follow the recorded Playwright run with `jskit doctor --against <base-ref>` so `doctor` compares against the branch delta instead of only the local dirty worktree.
+- Advanced CI setups may also use `--against <base-ref>`, but JSKIT does not scaffold hosted browser/auth/database verification by default.
 - Do not rely on a live external auth provider for Playwright verification of normal app features.
 - For authenticated UI in the standard JSKIT auth stack, use the development-only dev auth bypass route instead.
 - The standard route is `POST /api/dev-auth/login-as`.
@@ -29,6 +31,12 @@ npx jskit app verify-ui \
   --command "npx playwright test tests/e2e/contacts.spec.ts -g filters" \
   --feature "contacts filters" \
   --auth-mode dev-auth-login-as
+```
+
+Local pre-merge follow-up:
+
+```bash
+npx jskit doctor --against origin/main
 ```
 
 The Playwright command itself should follow this setup shape when login is needed:

--- a/packages/agent-docs/reference/autogen/tooling/jskit-cli.md
+++ b/packages/agent-docs/reference/autogen/tooling/jskit-cli.md
@@ -701,7 +701,8 @@ Exports
 - `isUiVerificationPath(relativePath = "")`
 - `isValidUiVerificationReceipt(receipt)`
 - `normalizeUiVerificationReceipt(rawReceipt = {})`
-- `resolveChangedUiFilesFromGit(appRoot = "")`
+- `resolveChangedPathsFromGit(appRoot = "", { against = "", pathspecs = ["src", "packages"] } = {})`
+- `resolveChangedUiFilesFromGit(appRoot = "", { against = "" } = {})`
 - `sortUniqueStrings(values = [])`
 Local functions
 - `normalizeText(value = "")`

--- a/packages/agent-docs/site/guide/app-setup/authentication.md
+++ b/packages/agent-docs/site/guide/app-setup/authentication.md
@@ -1043,6 +1043,14 @@ npx jskit app verify-ui \
   --auth-mode dev-auth-login-as
 ```
 
+For local pre-merge review, the next step after recording that Playwright run is usually:
+
+```bash
+npx jskit doctor --against origin/main
+```
+
+Advanced CI pipelines can use the same `--against` contract too, but JSKIT does not scaffold hosted auth/database/browser verification by default.
+
 That flow is preferable to driving the real sign-in form in feature tests because it keeps the test focused on the UI feature being added, not on an external auth dependency. If a chunk changes user-facing UI and the flow requires login, the expected JSKIT review standard is:
 
 - use Playwright

--- a/packages/agent-docs/site/guide/app-setup/initial-scaffolding.md
+++ b/packages/agent-docs/site/guide/app-setup/initial-scaffolding.md
@@ -166,6 +166,8 @@ That matters because JSKIT maintenance policy changes over time. If the scaffold
 
 `jskit app verify` is worth noticing specifically. Linting, tests, and builds check your source code and runtime behavior. The JSKIT part of that flow runs `doctor`, which checks JSKIT-managed app state: installed package visibility, lock-file-backed managed files, and other JSKIT-specific health rules. It is there because a JSKIT app is not only code. It is also a descriptor-driven managed project.
 
+The starter scaffold also writes `.github/workflows/verify.yml`. That workflow stays intentionally small: it runs `npm run verify` for the normal GitHub Actions gate and leaves browser/auth/database-heavy review flows to app-specific local or CI setups. The `--against <base-ref>` review mode exists in the CLI for local pre-merge checks and for advanced CI pipelines, but it is not assumed by the starter scaffold.
+
 The surface-specific script names are also worth noticing early, even in this tiny app. `dev:home`, `server:home`, and `build:home` are the first concrete places where surface selection shows up in the scaffold. They work by setting `VITE_SURFACE=home` on the client side and `SERVER_SURFACE=home` on the server side. In this first chapter, where `home` is the only surface, those variants behave almost the same as the default commands. Later, once more surfaces exist, those scripts become the simplest way to run or build just one surface at a time.
 
 

--- a/packages/agent-docs/site/guide/app-setup/working-with-the-jskit-cli.md
+++ b/packages/agent-docs/site/guide/app-setup/working-with-the-jskit-cli.md
@@ -92,6 +92,8 @@ This gives you a clean ownership split:
 
 That split is worth keeping in mind through the rest of the guide. When you see `npm run verify`, that is now shorthand for "run the app's JSKIT baseline verification policy, then any app-specific extra verification hook".
 
+The starter scaffold also includes `.github/workflows/verify.yml`. That workflow is intentionally conservative: it runs `npm run verify` and does not assume that every app can stand up full browser, auth, seed-data, and database verification inside hosted CI.
+
 If your app uses a non-default npm registry for JSKIT packages, pass it to the maintained CLI command rather than hard-coding it in the scaffold. For example:
 
 ```bash
@@ -758,6 +760,20 @@ That command does two things:
 - writes a receipt describing the verified feature, auth mode, and current dirty UI file set
 
 `doctor` then compares the current changed UI files to that receipt. If you edit the UI again afterwards, the receipt is stale and `doctor` tells you to rerun `jskit app verify-ui`.
+
+For local pre-merge review, use `--against <base-ref>` so JSKIT compares against the branch delta instead of only the current dirty worktree. The common shape is:
+
+```bash
+npx jskit doctor --against origin/main
+```
+
+If the UI changed, the normal local sequence is:
+
+1. run the targeted Playwright flow locally
+2. record it with `jskit app verify-ui ...`
+3. run `jskit doctor --against <base-ref>`
+
+Advanced CI pipelines can also use `--against <base-ref>`, but that is intentionally app-specific. JSKIT does not scaffold hosted browser/auth/database verification by default, because many real apps need secrets, seeded databases, local auth bypass, or environment-specific bootstrap paths that do not belong in a one-size-fits-all template.
 
 ### Why `--json` exists
 

--- a/packages/agent-docs/templates/app/AGENTS.md
+++ b/packages/agent-docs/templates/app/AGENTS.md
@@ -73,7 +73,7 @@ Core rules:
 - For CRUD chunks, ask the developer which operations are allowed, which fields belong in the list view if one exists, and the intended look of the view and edit/new forms before generating code.
 - Every user-facing screen must pass a Material Design and Vuetify quality review before the chunk is considered done.
 - Any chunk that adds or changes user-facing UI must include a Playwright check that exercises the changed behavior before the chunk is considered done.
-- Record that Playwright run with `jskit app verify-ui --command "<playwright command>" --feature "<label>" --auth-mode <mode>` so `jskit doctor` can verify the receipt.
+- Record that Playwright run with `jskit app verify-ui --command "<playwright command>" --feature "<label>" --auth-mode <mode>` so `jskit doctor` can verify the receipt. For local pre-merge review, normally follow it with `jskit doctor --against <base-ref>`. Advanced CI setups may also use `--against <base-ref>`, but that is app-specific.
 - If the UI flow requires login, use the app's development-only auth bypass or session bootstrap path instead of a live external auth login flow.
 - In JSKIT apps using the standard auth stack, that means enabling the dev auth bypass in development and using `POST /api/dev-auth/login-as` during Playwright setup.
 - If authenticated UI work has no usable local auth bootstrap path yet, treat that as a testability gap and call it out before the chunk can be considered complete.

--- a/packages/agent-docs/test/appAgentTemplate.test.js
+++ b/packages/agent-docs/test/appAgentTemplate.test.js
@@ -29,6 +29,7 @@ test("app agent template includes mandatory JSKIT start and done gates", async (
   assert.match(body, /Remaining unverified:/);
   assert.match(body, /Any chunk that adds or changes user-facing UI must include a Playwright check/);
   assert.match(body, /jskit app verify-ui/);
+  assert.match(body, /--against <base-ref>/);
   assert.match(body, /use the app's development-only auth bypass or session bootstrap path/);
   assert.match(body, /POST \/api\/dev-auth\/login-as/);
 });

--- a/packages/agent-docs/test/uiTestingGuidance.test.js
+++ b/packages/agent-docs/test/uiTestingGuidance.test.js
@@ -14,20 +14,26 @@ test("workflow and guide docs require Playwright plus dev auth bypass for authen
 
   assert.match(featureDelivery, /adds or changes user-facing UI must include a Playwright flow/);
   assert.match(featureDelivery, /jskit app verify-ui/);
+  assert.match(featureDelivery, /--against <base-ref>/);
   assert.match(featureDelivery, /\/api\/dev-auth\/login-as/);
   assert.match(featureDelivery, /must not be enabled in production/);
 
   assert.match(review, /any added or changed user-facing UI must be exercised with Playwright/);
+  assert.match(review, /--against <base-ref>/);
   assert.match(review, /development-only .*\/api\/dev-auth\/login-as/);
 
   assert.match(pattern, /^# UI Testing Pattern$/m);
   assert.match(pattern, /jskit app verify-ui/);
+  assert.match(pattern, /--against origin\/main/);
+  assert.match(pattern, /jskit doctor --against origin\/main/);
   assert.match(pattern, /\/api\/dev-auth\/login-as/);
   assert.match(pattern, /AUTH_DEV_BYPASS_ENABLED=true/);
   assert.match(pattern, /csrf-token/);
 
   assert.match(authGuide, /^### Authenticated Playwright testing with the dev auth bypass$/m);
   assert.match(authGuide, /jskit app verify-ui/);
+  assert.match(authGuide, /--against origin\/main/);
+  assert.match(authGuide, /jskit doctor --against origin\/main/);
   assert.match(authGuide, /AUTH_DEV_BYPASS_ENABLED=true/);
   assert.match(authGuide, /POST \/api\/dev-auth\/login-as/);
   assert.match(authGuide, /This is the standard path the agent should use for authenticated browser tests/);

--- a/packages/agent-docs/workflow/feature-delivery.md
+++ b/packages/agent-docs/workflow/feature-delivery.md
@@ -62,6 +62,8 @@ Playwright note:
 
 - When login is required, use a test-only auth bypass or session bootstrap path instead of dependence on a live external auth provider.
 - Record the run through `jskit app verify-ui --command "<playwright command>" --feature "<label>" --auth-mode <mode>` so `jskit doctor` can verify the receipt against the current changed UI files.
+- In local pre-merge review, use `jskit doctor --against <base-ref>` after the recorded Playwright run so JSKIT compares against the branch delta, not only the current dirty worktree.
+- Advanced CI setups may also use `--against <base-ref>`, but JSKIT does not scaffold hosted browser/auth/database verification by default.
 - In the standard JSKIT auth stack, the default development path is `POST /api/dev-auth/login-as`, guarded by `AUTH_DEV_BYPASS_ENABLED=true` and `AUTH_DEV_BYPASS_SECRET=...`.
 - That route is development-only and must not be enabled in production.
 - Because it is still an unsafe POST, fetch `csrfToken` from `/api/session`, send it as the `csrf-token` header, and make the request in the same browser context that will run the Playwright assertions so the session cookies land in the page session.

--- a/packages/agent-docs/workflow/review.md
+++ b/packages/agent-docs/workflow/review.md
@@ -33,6 +33,7 @@ Before calling a chunk or a whole changeset done, review it in four passes:
    - run the widest relevant verification commands for a whole changeset
    - any added or changed user-facing UI must be exercised with Playwright
    - that Playwright run should normally be recorded through `jskit app verify-ui`
+   - for local pre-merge review, prefer following that receipt with `jskit doctor --against <base-ref>`
    - if login is required, use the chosen local test-auth path instead of live external auth
    - in the standard JSKIT auth stack, prefer the development-only `POST /api/dev-auth/login-as` path
    - if there is no usable local auth bootstrap path, explicitly record that as a blocking testability gap

--- a/tooling/create-app/templates/base-shell/tests/server/minimalShell.validator.test.js
+++ b/tooling/create-app/templates/base-shell/tests/server/minimalShell.validator.test.js
@@ -101,6 +101,14 @@ test("latest JSKIT scaffold files are present at the app root", async () => {
   }
 });
 
+test("starter shell keeps the default hosted CI workflow simple", async () => {
+  const workflowSource = await readFile(path.join(APP_ROOT, ".github", "workflows", "verify.yml"), "utf8");
+
+  assert.match(workflowSource, /run: npm run verify/);
+  assert.doesNotMatch(workflowSource, /jskit app verify --against/);
+  assert.doesNotMatch(workflowSource, /jskit app verify-ui/);
+});
+
 test("starter shell does not include the app.manifest scaffold", async () => {
   await assert.rejects(access(path.join(APP_ROOT, "framework/app.manifest.mjs")), /ENOENT/);
 });

--- a/tooling/create-app/test/createApp.test.js
+++ b/tooling/create-app/test/createApp.test.js
@@ -175,6 +175,11 @@ test("create-app scaffolds the base shell with placeholder replacements", async 
     assert.match(gitignore, /node_modules\//);
     assert.match(gitignore, /\.jskit\/verification\//);
 
+    const verifyWorkflow = await readFile(path.join(appRoot, ".github", "workflows", "verify.yml"), "utf8");
+    assert.match(verifyWorkflow, /run: npm run verify/);
+    assert.doesNotMatch(verifyWorkflow, /jskit app verify --against/);
+    assert.doesNotMatch(verifyWorkflow, /jskit app verify-ui/);
+
     const indexHtml = await readFile(path.join(appRoot, "index.html"), "utf8");
     assert.match(indexHtml, /<title>Sample App<\/title>/);
     assert.match(indexHtml, /href="\/favicon\.svg"/);

--- a/tooling/jskit-cli/src/server/commandHandlers/appCommandCatalog.js
+++ b/tooling/jskit-cli/src/server/commandHandlers/appCommandCatalog.js
@@ -30,18 +30,24 @@ const APP_COMMAND_DEFINITIONS = Object.freeze({
   verify: Object.freeze({
     name: "verify",
     summary: "Run the JSKIT baseline app verification flow.",
-    usage: "jskit app verify",
-    options: Object.freeze([]),
+    usage: "jskit app verify [--against <base-ref>]",
+    options: Object.freeze([
+      Object.freeze({
+        label: "--against <base-ref>",
+        description: "Resolve changed-file checks against a branch, tag, or commit in addition to any local dirty UI files."
+      })
+    ]),
     defaults: Object.freeze([
       "Runs npm scripts lint, test, test:client, and build only when those scripts are present.",
       "Runs jskit doctor after the normal app checks.",
+      "Use --against <base-ref> in CI or PR validation so doctor evaluates changed-file checks against the branch delta too.",
       "The scaffolded npm run verify wrapper can append npm run --if-present verify:app afterwards."
     ])
   }),
   "verify-ui": Object.freeze({
     name: "verify-ui",
     summary: "Run a targeted Playwright command and write a UI verification receipt for jskit doctor.",
-    usage: "jskit app verify-ui --command <shell-command> --feature <label> --auth-mode <mode>",
+    usage: "jskit app verify-ui --command <shell-command> --feature <label> --auth-mode <mode> [--against <base-ref>]",
     options: Object.freeze([
       Object.freeze({
         label: "--command <shell-command>",
@@ -54,12 +60,16 @@ const APP_COMMAND_DEFINITIONS = Object.freeze({
       Object.freeze({
         label: "--auth-mode <mode>",
         description: "Auth path used by the Playwright flow: none | dev-auth-login-as | session-bootstrap | custom-local."
+      }),
+      Object.freeze({
+        label: "--against <base-ref>",
+        description: "Record changed UI files against a branch, tag, or commit instead of only the current dirty worktree."
       })
     ]),
     defaults: Object.freeze([
       "Requires a git working tree so the receipt can record the currently changed UI files.",
       "Writes .jskit/verification/ui.json after the command succeeds.",
-      "Doctor expects the receipt to match the current dirty UI file set."
+      "Doctor expects the receipt to match the current dirty UI file set, or the same --against <base-ref> delta when used."
     ])
   }),
   "update-packages": Object.freeze({
@@ -175,6 +185,9 @@ function buildAppCommandOptionMeta(subcommandName = "") {
   }
   if (definition.name === "update-packages" || definition.name === "release") {
     optionMeta.registry = { inputType: "text" };
+  }
+  if (definition.name === "verify" || definition.name === "verify-ui") {
+    optionMeta.against = { inputType: "text" };
   }
   if (definition.name === "verify-ui") {
     optionMeta.command = { inputType: "text" };

--- a/tooling/jskit-cli/src/server/commandHandlers/appCommands/verify.js
+++ b/tooling/jskit-cli/src/server/commandHandlers/appCommands/verify.js
@@ -9,6 +9,9 @@ const BASELINE_VERIFY_SCRIPTS = Object.freeze([
 
 async function runAppVerifyCommand(ctx = {}, { appRoot = "", options = {}, stdout, stderr }) {
   const { createCliError } = ctx;
+  const inlineOptions =
+    options?.inlineOptions && typeof options.inlineOptions === "object" ? options.inlineOptions : {};
+  const against = String(inlineOptions.against || "").trim();
 
   if (options?.dryRun) {
     throw createCliError("jskit app verify does not support --dry-run.", { exitCode: 1 });
@@ -23,7 +26,12 @@ async function runAppVerifyCommand(ctx = {}, { appRoot = "", options = {}, stdou
     });
   }
 
-  await runLocalJskit(appRoot, ["doctor"], {
+  const doctorArgs = ["doctor"];
+  if (against) {
+    doctorArgs.push("--against", against);
+  }
+
+  await runLocalJskit(appRoot, doctorArgs, {
     stdout,
     stderr,
     createCliError

--- a/tooling/jskit-cli/src/server/commandHandlers/appCommands/verifyUi.js
+++ b/tooling/jskit-cli/src/server/commandHandlers/appCommands/verifyUi.js
@@ -24,6 +24,7 @@ async function runAppVerifyUiCommand(ctx = {}, { appRoot = "", options = {}, std
   const command = String(inlineOptions.command || "").trim();
   const feature = String(inlineOptions.feature || "").trim();
   const authMode = String(inlineOptions["auth-mode"] || "").trim();
+  const against = String(inlineOptions.against || "").trim();
 
   if (!command) {
     throw createCliError("jskit app verify-ui requires --command <shell-command>.", {
@@ -52,16 +53,18 @@ async function runAppVerifyUiCommand(ctx = {}, { appRoot = "", options = {}, std
     );
   }
 
-  const changedUiState = resolveChangedUiFilesFromGit(appRoot);
+  const changedUiState = resolveChangedUiFilesFromGit(appRoot, { against });
   if (!changedUiState.available) {
-    throw createCliError("jskit app verify-ui requires a git working tree so it can record changed UI files.", {
-      exitCode: 1
-    });
+    const message = against
+      ? `jskit app verify-ui could not resolve changed UI files against ${JSON.stringify(against)}: ${changedUiState.error || "unknown git error"}.`
+      : "jskit app verify-ui requires a git working tree so it can record changed UI files.";
+    throw createCliError(message, { exitCode: 1 });
   }
   if (changedUiState.paths.length < 1) {
-    throw createCliError("jskit app verify-ui found no changed UI files in src/ or packages/.", {
-      exitCode: 1
-    });
+    const message = against
+      ? `jskit app verify-ui found no changed UI files in src/ or packages/ against ${JSON.stringify(against)}.`
+      : "jskit app verify-ui found no changed UI files in src/ or packages/.";
+    throw createCliError(message, { exitCode: 1 });
   }
 
   runExternalShellCommand(command, {
@@ -84,6 +87,7 @@ async function runAppVerifyUiCommand(ctx = {}, { appRoot = "", options = {}, std
         feature,
         command,
         authMode,
+        ...(against ? { against } : {}),
         changedUiFiles: changedUiState.paths
       },
       null,

--- a/tooling/jskit-cli/src/server/commandHandlers/health.js
+++ b/tooling/jskit-cli/src/server/commandHandlers/health.js
@@ -1154,20 +1154,32 @@ function createHealthCommands(ctx = {}) {
     }
   }
 
-  async function collectUiVerificationDoctorIssues({ appRoot, issues }) {
+  async function collectUiVerificationDoctorIssues({ appRoot, issues, against = "" }) {
     if (!(await directoryLooksLikeJskitAppRoot(appRoot))) {
       return;
     }
 
-    const changedUiState = resolveChangedUiFilesFromGit(appRoot);
-    if (!changedUiState.available || changedUiState.paths.length < 1) {
+    const normalizedAgainst = String(against || "").trim();
+    const changedUiState = resolveChangedUiFilesFromGit(appRoot, {
+      against: normalizedAgainst
+    });
+    if (!changedUiState.available) {
+      if (normalizedAgainst) {
+        issues.push(
+          `[ui:verification] could not resolve changed UI files against ${JSON.stringify(normalizedAgainst)}: ${changedUiState.error || "unknown git error"}`
+        );
+      }
+      return;
+    }
+    if (changedUiState.paths.length < 1) {
       return;
     }
 
     const receiptPath = path.join(appRoot, UI_VERIFICATION_RECEIPT_RELATIVE_PATH);
     if (!(await fileExists(receiptPath))) {
+      const againstSegment = normalizedAgainst ? ` --against ${JSON.stringify(normalizedAgainst)}` : "";
       issues.push(
-        `[ui:verification] changed UI files require a matching ${UI_VERIFICATION_RECEIPT_RELATIVE_PATH} receipt. Run jskit app verify-ui --command "<playwright command>" --feature "<label>" --auth-mode <mode>. Current files: ${changedUiState.paths.join(", ")}`
+        `[ui:verification] changed UI files require a matching ${UI_VERIFICATION_RECEIPT_RELATIVE_PATH} receipt. Run jskit app verify-ui${againstSegment} --command "<playwright command>" --feature "<label>" --auth-mode <mode>. Current files: ${changedUiState.paths.join(", ")}`
       );
       return;
     }
@@ -1186,6 +1198,13 @@ function createHealthCommands(ctx = {}) {
     if (!isValidUiVerificationReceipt(receipt)) {
       issues.push(
         `[ui:verification] ${UI_VERIFICATION_RECEIPT_RELATIVE_PATH} is incomplete. It must include version, runner, recordedAt, feature, command, authMode, and changedUiFiles from jskit app verify-ui.`
+      );
+      return;
+    }
+
+    if (normalizedAgainst && receipt.against !== normalizedAgainst) {
+      issues.push(
+        `[ui:verification] ${UI_VERIFICATION_RECEIPT_RELATIVE_PATH} was recorded against ${JSON.stringify(receipt.against || "<dirty-worktree>")} but doctor is checking against ${JSON.stringify(normalizedAgainst)}. Re-run jskit app verify-ui with the same --against value.`
       );
       return;
     }
@@ -1251,6 +1270,7 @@ function createHealthCommands(ctx = {}) {
 
   async function commandDoctor({ cwd, options, stdout }) {
     const appRoot = await resolveAppRootFromCwd(cwd);
+    const against = String(options?.inlineOptions?.against || "").trim();
     const { lock } = await loadLockFile(appRoot);
     const packageRegistry = await loadPackageRegistry();
     const appLocalRegistry = await loadAppLocalPackageRegistry(appRoot);
@@ -1292,7 +1312,8 @@ function createHealthCommands(ctx = {}) {
     });
     await collectUiVerificationDoctorIssues({
       appRoot,
-      issues
+      issues,
+      against
     });
     await collectFeatureLaneDoctorIssues({
       appRoot,

--- a/tooling/jskit-cli/src/server/core/commandCatalog.js
+++ b/tooling/jskit-cli/src/server/core/commandCatalog.js
@@ -475,14 +475,15 @@ const COMMAND_DESCRIPTORS = Object.freeze({
     defaults: Object.freeze([
       "Validates lock entries, managed files, and registry visibility.",
       "Reports issues as plain text by default.",
-      "Use --json for machine-readable diagnostics."
+      "Use --json for machine-readable diagnostics.",
+      "Use --against <base-ref> when changed-file checks should compare against a branch, tag, or commit."
     ]),
-    fullUse: "jskit doctor [--json]",
+    fullUse: "jskit doctor [--against <base-ref>] [--json]",
     showHelpOnBareInvocation: false,
     handlerName: "commandDoctor",
     allowedFlagKeys: Object.freeze(["json"]),
-    inlineOptionMode: "none",
-    allowedValueOptionNames: Object.freeze([])
+    inlineOptionMode: "enumerated",
+    allowedValueOptionNames: Object.freeze(["against"])
   }),
   "lint-descriptors": Object.freeze({
     command: "lint-descriptors",

--- a/tooling/jskit-cli/src/server/shared/uiVerification.js
+++ b/tooling/jskit-cli/src/server/shared/uiVerification.js
@@ -61,17 +61,26 @@ function readGitPathList(appRoot = "", args = []) {
   if (result?.error || result?.status !== 0) {
     return {
       ok: false,
-      paths: []
+      paths: [],
+      error: normalizeText(result?.stderr) || normalizeText(result?.error?.message)
     };
   }
 
   return {
     ok: true,
-    paths: sortUniqueStrings(String(result.stdout || "").split(/\r?\n/u))
+    paths: sortUniqueStrings(String(result.stdout || "").split(/\r?\n/u)),
+    error: ""
   };
 }
 
-function resolveChangedUiFilesFromGit(appRoot = "") {
+function resolveChangedPathsFromGit(
+  appRoot = "",
+  {
+    against = "",
+    pathspecs = ["src", "packages"]
+  } = {}
+) {
+  const normalizedAgainst = normalizeText(against);
   const gitRepoCheck = spawnSync("git", ["rev-parse", "--is-inside-work-tree"], {
     cwd: appRoot || process.cwd(),
     encoding: "utf8"
@@ -84,26 +93,72 @@ function resolveChangedUiFilesFromGit(appRoot = "") {
   ) {
     return {
       available: false,
-      paths: []
+      paths: [],
+      against: normalizedAgainst,
+      mode: normalizedAgainst ? "against-base-ref" : "dirty-worktree",
+      error: "Current directory is not inside a git work tree."
     };
   }
 
-  const changedPathSets = [
-    readGitPathList(appRoot, ["diff", "--name-only", "--relative", "--cached", "--", "src", "packages"]),
-    readGitPathList(appRoot, ["diff", "--name-only", "--relative", "--", "src", "packages"]),
-    readGitPathList(appRoot, ["ls-files", "--others", "--exclude-standard", "--", "src", "packages"])
-  ];
+  const normalizedPathspecs = sortUniqueStrings(pathspecs);
+  const pathspecArgs = normalizedPathspecs.length > 0 ? ["--", ...normalizedPathspecs] : [];
+  const changedPathSets = [];
+
+  if (normalizedAgainst) {
+    const baseDiff = readGitPathList(appRoot, [
+      "diff",
+      "--name-only",
+      "--relative",
+      `${normalizedAgainst}...HEAD`,
+      ...pathspecArgs
+    ]);
+    if (!baseDiff.ok) {
+      return {
+        available: false,
+        paths: [],
+        against: normalizedAgainst,
+        mode: "against-base-ref",
+        error:
+          baseDiff.error ||
+          `Could not resolve git diff against ${JSON.stringify(normalizedAgainst)}.`
+      };
+    }
+    changedPathSets.push(baseDiff);
+  }
+
+  changedPathSets.push(
+    readGitPathList(appRoot, ["diff", "--name-only", "--relative", "--cached", ...pathspecArgs]),
+    readGitPathList(appRoot, ["diff", "--name-only", "--relative", ...pathspecArgs]),
+    readGitPathList(appRoot, ["ls-files", "--others", "--exclude-standard", ...pathspecArgs])
+  );
 
   const changedPaths = sortUniqueStrings(
     changedPathSets
       .filter((entry) => entry.ok)
       .flatMap((entry) => entry.paths)
-      .filter((relativePath) => isUiVerificationPath(relativePath))
   );
 
   return {
     available: true,
-    paths: changedPaths
+    paths: changedPaths,
+    against: normalizedAgainst,
+    mode: normalizedAgainst ? "against-base-ref" : "dirty-worktree",
+    error: ""
+  };
+}
+
+function resolveChangedUiFilesFromGit(appRoot = "", { against = "" } = {}) {
+  const changedPathState = resolveChangedPathsFromGit(appRoot, {
+    against,
+    pathspecs: ["src", "packages"]
+  });
+  if (!changedPathState.available) {
+    return changedPathState;
+  }
+
+  return {
+    ...changedPathState,
+    paths: changedPathState.paths.filter((relativePath) => isUiVerificationPath(relativePath))
   };
 }
 
@@ -117,6 +172,7 @@ function normalizeUiVerificationReceipt(rawReceipt = {}) {
     feature: normalizeText(receipt.feature),
     command: normalizeText(receipt.command),
     authMode: normalizeText(receipt.authMode),
+    against: normalizeText(receipt.against),
     changedUiFiles: sortUniqueStrings(receipt.changedUiFiles)
   });
 }
@@ -143,6 +199,7 @@ export {
   isUiVerificationPath,
   isValidUiVerificationReceipt,
   normalizeUiVerificationReceipt,
+  resolveChangedPathsFromGit,
   resolveChangedUiFilesFromGit,
   sortUniqueStrings
 };

--- a/tooling/jskit-cli/test/appCommand.test.js
+++ b/tooling/jskit-cli/test/appCommand.test.js
@@ -139,6 +139,40 @@ fs.appendFileSync(process.env.TEST_LOG_PATH, ["npm", ...process.argv.slice(2)].j
   });
 });
 
+test("jskit app verify forwards --against to doctor", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "app");
+    const binDir = path.join(cwd, "bin");
+    const logPath = path.join(cwd, "commands.log");
+
+    await createMinimalApp(appRoot);
+    await installFakeLocalJskit(appRoot, logPath);
+    await installFakeCommand(
+      binDir,
+      "npm",
+      `#!/usr/bin/env node
+const fs = require("node:fs");
+fs.appendFileSync(process.env.TEST_LOG_PATH, ["npm", ...process.argv.slice(2)].join(" ") + "\\n");
+`
+    );
+
+    const result = runCli({
+      cwd: appRoot,
+      args: ["app", "verify", "--against", "origin/main"],
+      env: buildTestEnv(binDir, logPath)
+    });
+
+    assert.equal(result.status, 0, String(result.stderr || ""));
+    assert.deepEqual(await readLogLines(logPath), [
+      "npm run --if-present lint",
+      "npm run --if-present test",
+      "npm run --if-present test:client",
+      "npm run --if-present build",
+      "local-jskit doctor --against origin/main"
+    ]);
+  });
+});
+
 test("jskit app verify-ui runs the provided command and writes a matching UI verification receipt", async () => {
   await withTempDir(async (cwd) => {
     const appRoot = path.join(cwd, "app");
@@ -191,6 +225,97 @@ fs.appendFileSync(process.env.TEST_LOG_PATH, ["npm", ...process.argv.slice(2)].j
     assert.equal(receipt.command, "npm run e2e -- tests/e2e/contacts.spec.ts -g filters");
     assert.equal(receipt.authMode, "dev-auth-login-as");
     assert.deepEqual(receipt.changedUiFiles, ["src/pages/home/contacts/index.vue"]);
+  });
+});
+
+test("jskit app verify-ui can record committed UI changes against a base ref", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "app");
+    const binDir = path.join(cwd, "bin");
+    const logPath = path.join(cwd, "commands.log");
+
+    await createMinimalApp(appRoot, { jskitApp: true });
+    await initializeGitApp(appRoot);
+    runGit(appRoot, ["branch", "baseline"]);
+
+    await mkdir(path.join(appRoot, "src", "pages", "home", "contacts"), { recursive: true });
+    await writeFile(
+      path.join(appRoot, "src", "pages", "home", "contacts", "index.vue"),
+      "<template><div>Contacts</div></template>\n",
+      "utf8"
+    );
+    runGit(appRoot, ["add", "src/pages/home/contacts/index.vue"]);
+    runGit(appRoot, ["commit", "-m", "Add contacts page"]);
+
+    await installFakeCommand(
+      binDir,
+      "npm",
+      `#!/usr/bin/env node
+const fs = require("node:fs");
+fs.appendFileSync(process.env.TEST_LOG_PATH, ["npm", ...process.argv.slice(2)].join(" ") + "\\n");
+`
+    );
+
+    const result = runCli({
+      cwd: appRoot,
+      args: [
+        "app",
+        "verify-ui",
+        "--against",
+        "baseline",
+        "--command",
+        "npm run e2e -- tests/e2e/contacts.spec.ts -g filters",
+        "--feature",
+        "contacts filters",
+        "--auth-mode",
+        "dev-auth-login-as"
+      ],
+      env: buildTestEnv(binDir, logPath)
+    });
+
+    assert.equal(result.status, 0, String(result.stderr || ""));
+    assert.deepEqual(await readLogLines(logPath), [
+      "npm run e2e -- tests/e2e/contacts.spec.ts -g filters"
+    ]);
+
+    const receipt = JSON.parse(await readFile(path.join(appRoot, ".jskit", "verification", "ui.json"), "utf8"));
+    assert.equal(receipt.against, "baseline");
+    assert.deepEqual(receipt.changedUiFiles, ["src/pages/home/contacts/index.vue"]);
+  });
+});
+
+test("jskit app verify-ui fails when --against points at an unknown ref", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "app");
+
+    await createMinimalApp(appRoot, { jskitApp: true });
+    await initializeGitApp(appRoot);
+
+    await mkdir(path.join(appRoot, "src", "pages", "home", "contacts"), { recursive: true });
+    await writeFile(
+      path.join(appRoot, "src", "pages", "home", "contacts", "index.vue"),
+      "<template><div>Contacts</div></template>\n",
+      "utf8"
+    );
+
+    const result = runCli({
+      cwd: appRoot,
+      args: [
+        "app",
+        "verify-ui",
+        "--against",
+        "missing-ref",
+        "--command",
+        "npm run e2e -- tests/e2e/contacts.spec.ts -g filters",
+        "--feature",
+        "contacts filters",
+        "--auth-mode",
+        "dev-auth-login-as"
+      ]
+    });
+
+    assert.equal(result.status, 1, String(result.stdout || ""));
+    assert.match(String(result.stderr || ""), /could not resolve changed UI files against "missing-ref"/);
   });
 });
 

--- a/tooling/jskit-cli/test/completionCommand.test.js
+++ b/tooling/jskit-cli/test/completionCommand.test.js
@@ -118,7 +118,17 @@ test("completion bash __complete__ lists app subcommands and app-specific option
   assert.equal(verifyUiOptionResult.status, 0, String(verifyUiOptionResult.stderr || ""));
   assert.deepEqual(
     String(verifyUiOptionResult.stdout || "").trim().split(/\r?\n/u).filter(Boolean),
-    ["--auth-mode", "--command", "--feature", "--help"]
+    ["--against", "--auth-mode", "--command", "--feature", "--help"]
+  );
+
+  const verifyOptionResult = runCli({
+    args: ["completion", "bash", "__complete__", "4", "--", "npx", "jskit", "app", "verify", "--"]
+  });
+
+  assert.equal(verifyOptionResult.status, 0, String(verifyOptionResult.stderr || ""));
+  assert.deepEqual(
+    String(verifyOptionResult.stdout || "").trim().split(/\r?\n/u).filter(Boolean),
+    ["--against", "--help"]
   );
 });
 

--- a/tooling/jskit-cli/test/doctorUiVerificationReceipt.test.js
+++ b/tooling/jskit-cli/test/doctorUiVerificationReceipt.test.js
@@ -53,6 +53,7 @@ async function writeUiReceipt(appRoot, {
   feature = "contacts list",
   command = "npx playwright test tests/e2e/contacts.spec.ts -g list",
   authMode = "none",
+  against = "",
   changedUiFiles = []
 } = {}) {
   await mkdir(path.join(appRoot, ".jskit", "verification"), { recursive: true });
@@ -66,6 +67,7 @@ async function writeUiReceipt(appRoot, {
         feature,
         command,
         authMode,
+        ...(against ? { against } : {}),
         changedUiFiles
       },
       null,
@@ -167,6 +169,95 @@ test("doctor accepts matching UI verification receipts for the current dirty UI 
     assert.equal(doctorResult.status, 0, String(doctorResult.stderr || ""));
     const payload = JSON.parse(String(doctorResult.stdout || "{}"));
     assert.deepEqual(payload.issues, []);
+  });
+});
+
+test("doctor accepts matching UI verification receipts against a base ref", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "doctor-ui-receipt-against-app");
+    await createMinimalApp(appRoot, { name: "doctor-ui-receipt-against-app" });
+    await initializeGitApp(appRoot);
+    runGit(appRoot, ["branch", "baseline"]);
+
+    await mkdir(path.join(appRoot, "src", "pages", "home", "contacts"), { recursive: true });
+    await writeFile(
+      path.join(appRoot, "src", "pages", "home", "contacts", "index.vue"),
+      "<template><div>Contacts</div></template>\n",
+      "utf8"
+    );
+    runGit(appRoot, ["add", "src/pages/home/contacts/index.vue"]);
+    runGit(appRoot, ["commit", "-m", "Add contacts page"]);
+
+    await writeUiReceipt(appRoot, {
+      against: "baseline",
+      changedUiFiles: ["src/pages/home/contacts/index.vue"]
+    });
+
+    const doctorResult = runCli({
+      cwd: appRoot,
+      args: ["doctor", "--json", "--against", "baseline"]
+    });
+
+    assert.equal(doctorResult.status, 0, String(doctorResult.stderr || ""));
+    const payload = JSON.parse(String(doctorResult.stdout || "{}"));
+    assert.deepEqual(payload.issues, []);
+  });
+});
+
+test("doctor flags receipts recorded against a different base ref", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "doctor-ui-receipt-wrong-base-app");
+    await createMinimalApp(appRoot, { name: "doctor-ui-receipt-wrong-base-app" });
+    await initializeGitApp(appRoot);
+    runGit(appRoot, ["branch", "baseline"]);
+
+    await mkdir(path.join(appRoot, "src", "pages", "home", "contacts"), { recursive: true });
+    await writeFile(
+      path.join(appRoot, "src", "pages", "home", "contacts", "index.vue"),
+      "<template><div>Contacts</div></template>\n",
+      "utf8"
+    );
+    runGit(appRoot, ["add", "src/pages/home/contacts/index.vue"]);
+    runGit(appRoot, ["commit", "-m", "Add contacts page"]);
+
+    await writeUiReceipt(appRoot, {
+      against: "origin/main",
+      changedUiFiles: ["src/pages/home/contacts/index.vue"]
+    });
+
+    const doctorResult = runCli({
+      cwd: appRoot,
+      args: ["doctor", "--json", "--against", "baseline"]
+    });
+
+    assert.equal(doctorResult.status, 1, String(doctorResult.stderr || ""));
+    const payload = JSON.parse(String(doctorResult.stdout || "{}"));
+    assert.equal(payload.issues.length, 1);
+    assert.match(
+      String(payload.issues[0] || ""),
+      /\[ui:verification\] \.jskit\/verification\/ui\.json was recorded against/
+    );
+  });
+});
+
+test("doctor flags an invalid --against ref as a verification issue", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "doctor-ui-receipt-invalid-base-app");
+    await createMinimalApp(appRoot, { name: "doctor-ui-receipt-invalid-base-app" });
+    await initializeGitApp(appRoot);
+
+    const doctorResult = runCli({
+      cwd: appRoot,
+      args: ["doctor", "--json", "--against", "missing-ref"]
+    });
+
+    assert.equal(doctorResult.status, 1, String(doctorResult.stderr || ""));
+    const payload = JSON.parse(String(doctorResult.stdout || "{}"));
+    assert.equal(payload.issues.length, 1);
+    assert.match(
+      String(payload.issues[0] || ""),
+      /\[ui:verification\] could not resolve changed UI files against "missing-ref"/
+    );
   });
 });
 

--- a/tooling/jskit-cli/test/helpUsage.test.js
+++ b/tooling/jskit-cli/test/helpUsage.test.js
@@ -61,6 +61,21 @@ test("jskit app help release prints release-specific options", () => {
   assert.match(stdout, /--dry-run/);
 });
 
+test("jskit app help verify and doctor help mention --against", () => {
+  const verifyResult = runCli({ args: ["app", "help", "verify"] });
+  assert.equal(verifyResult.status, 0, String(verifyResult.stderr || ""));
+  const verifyStdout = String(verifyResult.stdout || "");
+  assertMaxLineLength(verifyStdout);
+  assert.match(verifyStdout, /App subcommand: verify/);
+  assert.match(verifyStdout, /--against <base-ref>/);
+
+  const doctorResult = runCli({ args: ["help", "doctor"] });
+  assert.equal(doctorResult.status, 0, String(doctorResult.stderr || ""));
+  const doctorStdout = String(doctorResult.stdout || "");
+  assertMaxLineLength(doctorStdout);
+  assert.match(doctorStdout, /jskit doctor \[--against <base-ref>\] \[--json\]/);
+});
+
 test("jskit help completion prints completion command help", () => {
   const result = runCli({ args: ["help", "completion"] });
   assert.equal(result.status, 0, String(result.stderr || ""));


### PR DESCRIPTION
## Summary
- add `--against <base-ref>` support to `jskit doctor`, `jskit app verify`, and `jskit app verify-ui`
- teach doctor to compare UI verification receipts against a branch delta as well as the local dirty worktree
- document the intended local pre-merge flow and keep the scaffolded hosted CI workflow intentionally simple

## Validation
- `node --test tooling/jskit-cli/test/appCommand.test.js tooling/jskit-cli/test/completionCommand.test.js tooling/jskit-cli/test/doctorUiVerificationReceipt.test.js tooling/jskit-cli/test/helpUsage.test.js tooling/create-app/test/createApp.test.js tooling/create-app/templates/base-shell/tests/server/minimalShell.validator.test.js packages/agent-docs/test/appAgentTemplate.test.js packages/agent-docs/test/uiTestingGuidance.test.js`

## Not run
- `npm run verify` (intentionally not run)