### PR TITLE
Add AI seed bootstrap flow

### DIFF
--- a/packages/agent-docs/guide/agent/app-setup/initial-scaffolding.md
+++ b/packages/agent-docs/guide/agent/app-setup/initial-scaffolding.md
@@ -14,17 +14,63 @@ npm install
 
 The first command creates a new folder called `exampleapp` and fills it with JSKIT's base shell template. The `exampleapp` name is used in a few template replacements, such as the package name and the browser title. The `--tenancy-mode none` flag tells JSKIT to start with the smallest routing model. In this mode, the app is not workspace-aware (more of this later in the guide, when multihoming is introduced). That keeps the first scaffold easier to read because there is no workspace slug handling yet.
 
-If you are working with an AI agent and want the agent to explain the platform options after the scaffold exists, there is also a safe guided path:
+If you are working with an AI agent and want the agent to drive the initial JSKIT setup conversation, there is now a dedicated seed path:
 
 ```bash
-npx @jskit-ai/create-app exampleapp
+npx @jskit-ai/create-app exampleapp --template ai-seed
 cd exampleapp
+```
+
+That seed writes only `AGENTS.md`. It is not a runnable app yet. The agent should use that file to ask the Stage 1 platform questions first, make sure the chosen MySQL or Postgres database already exists or can be created with the developer's local admin access, and then promote the same directory into the real scaffold with:
+
+```bash
+npx @jskit-ai/create-app exampleapp --target . --force --tenancy-mode <mode>
 npm install
 ```
 
-That produces the same minimal scaffold shape, but without writing an explicit `config.tenancyMode` line yet. The important rule is that this does **not** mean tenancy is already decided. Before installing tenancy-sensitive packages such as `workspaces-core` or `workspaces-web`, the agent still needs to finish the Stage 1 platform conversation and then write the chosen tenancy into `config/public.js`. If workspace packages are installed while the app is still effectively on `none`, you fall into the recovery path described later in the multi-homing chapter.
+After that promotion, the overwritten app `AGENTS.md` becomes the source of truth for the normal JSKIT workflow.
 
-After creating the scaffolding (which comes with a package.json file), you will need to run `npm install` to install dependencies.
+After creating the real app scaffolding (the base shell, not the seed wrapper), you will need to run `npm install` to install dependencies.
+
+If you already know you want a small non-workspace baseline right after the scaffold, this is the shortest reproducible path:
+
+```bash
+SUPABASE_URL=...
+SUPABASE_KEY=...
+DB_HOST=127.0.0.1
+DB_PORT=3306
+DB_NAME=exampleapp
+DB_USER=...
+DB_PASSWORD=...
+
+npx @jskit-ai/create-app exampleapp --tenancy-mode none
+cd exampleapp
+npm install
+
+npx jskit add package shell-web
+
+npx jskit add package auth-provider-supabase-core \
+  --auth-supabase-url "$SUPABASE_URL" \
+  --auth-supabase-publishable-key "$SUPABASE_KEY" \
+  --app-public-url "http://localhost:5173"
+
+npx jskit add bundle auth-base
+
+npx jskit add package database-runtime-mysql \
+  --db-host "$DB_HOST" \
+  --db-port "$DB_PORT" \
+  --db-name "$DB_NAME" \
+  --db-user "$DB_USER" \
+  --db-password "$DB_PASSWORD"
+
+npx jskit add package users-web
+npx jskit add package console-web
+
+npm install
+npm run db:migrate
+```
+
+If you want the larger workspace-enabled stack with the first assistant already configured, use [Quickstart](/guide/app-setup/quickstart) instead.
 
 **Try Bash Completion!**
 

--- a/packages/agent-docs/guide/agent/app-setup/quickstart.md
+++ b/packages/agent-docs/guide/agent/app-setup/quickstart.md
@@ -41,6 +41,8 @@ DB_USER=...
 DB_PASSWORD=...
 ```
 
+Before continuing, make sure the MySQL database already exists and that the chosen `DB_USER` / `DB_PASSWORD` can connect to it. If the database does not exist yet, create it first or use a local MySQL account with enough privileges to create it before the runtime install step.
+
 Then run the exact sequence below:
 
 ```bash

--- a/packages/agent-docs/site/guide/app-setup/database-layer.md
+++ b/packages/agent-docs/site/guide/app-setup/database-layer.md
@@ -31,6 +31,8 @@ If you are already continuing from the previous chapter, you are already in the 
 <DocsTerminalTip label="MySQL" title="Create The Database First">
 Before installing the database runtime, make sure a real MySQL database already exists and that you know its connection details.
 
+If you are using the `ai-seed` flow, this should already have been resolved during the seed-stage conversation. Do not promote the app scaffold or move into the runtime install step while the database is still hypothetical.
+
 At minimum, keep these ready:
 
 - host

--- a/packages/agent-docs/site/guide/app-setup/initial-scaffolding.md
+++ b/packages/agent-docs/site/guide/app-setup/initial-scaffolding.md
@@ -12,17 +12,63 @@ npm install
 
 The first command creates a new folder called `exampleapp` and fills it with JSKIT's base shell template. The `exampleapp` name is used in a few template replacements, such as the package name and the browser title. The `--tenancy-mode none` flag tells JSKIT to start with the smallest routing model. In this mode, the app is not workspace-aware (more of this later in the guide, when multihoming is introduced). That keeps the first scaffold easier to read because there is no workspace slug handling yet.
 
-If you are working with an AI agent and want the agent to explain the platform options after the scaffold exists, there is also a safe guided path:
+If you are working with an AI agent and want the agent to drive the initial JSKIT setup conversation, there is now a dedicated seed path:
 
 ```bash
-npx @jskit-ai/create-app exampleapp
+npx @jskit-ai/create-app exampleapp --template ai-seed
 cd exampleapp
+```
+
+That seed writes only `AGENTS.md`. It is not a runnable app yet. The agent should use that file to ask the Stage 1 platform questions first, make sure the chosen MySQL or Postgres database already exists or can be created with the developer's local admin access, and then promote the same directory into the real scaffold with:
+
+```bash
+npx @jskit-ai/create-app exampleapp --target . --force --tenancy-mode <mode>
 npm install
 ```
 
-That produces the same minimal scaffold shape, but without writing an explicit `config.tenancyMode` line yet. The important rule is that this does **not** mean tenancy is already decided. Before installing tenancy-sensitive packages such as `workspaces-core` or `workspaces-web`, the agent still needs to finish the Stage 1 platform conversation and then write the chosen tenancy into `config/public.js`. If workspace packages are installed while the app is still effectively on `none`, you fall into the recovery path described later in the multi-homing chapter.
+After that promotion, the overwritten app `AGENTS.md` becomes the source of truth for the normal JSKIT workflow.
 
-After creating the scaffolding (which comes with a package.json file), you will need to run `npm install` to install dependencies.
+After creating the real app scaffolding (the base shell, not the seed wrapper), you will need to run `npm install` to install dependencies.
+
+If you already know you want a small non-workspace baseline right after the scaffold, this is the shortest reproducible path:
+
+```bash
+SUPABASE_URL=...
+SUPABASE_KEY=...
+DB_HOST=127.0.0.1
+DB_PORT=3306
+DB_NAME=exampleapp
+DB_USER=...
+DB_PASSWORD=...
+
+npx @jskit-ai/create-app exampleapp --tenancy-mode none
+cd exampleapp
+npm install
+
+npx jskit add package shell-web
+
+npx jskit add package auth-provider-supabase-core \
+  --auth-supabase-url "$SUPABASE_URL" \
+  --auth-supabase-publishable-key "$SUPABASE_KEY" \
+  --app-public-url "http://localhost:5173"
+
+npx jskit add bundle auth-base
+
+npx jskit add package database-runtime-mysql \
+  --db-host "$DB_HOST" \
+  --db-port "$DB_PORT" \
+  --db-name "$DB_NAME" \
+  --db-user "$DB_USER" \
+  --db-password "$DB_PASSWORD"
+
+npx jskit add package users-web
+npx jskit add package console-web
+
+npm install
+npm run db:migrate
+```
+
+If you want the larger workspace-enabled stack with the first assistant already configured, use [Quickstart](/guide/app-setup/quickstart) instead.
 
 <DocsTerminalTip title="Try Bash Completion!">
 

--- a/packages/agent-docs/site/guide/app-setup/quickstart.md
+++ b/packages/agent-docs/site/guide/app-setup/quickstart.md
@@ -39,6 +39,8 @@ DB_USER=...
 DB_PASSWORD=...
 ```
 
+Before continuing, make sure the MySQL database already exists and that the chosen `DB_USER` / `DB_PASSWORD` can connect to it. If the database does not exist yet, create it first or use a local MySQL account with enough privileges to create it before the runtime install step.
+
 Then run the exact sequence below:
 
 ```bash

--- a/packages/agent-docs/site/vibe-guide.md
+++ b/packages/agent-docs/site/vibe-guide.md
@@ -1,251 +1,101 @@
 ---
 title: Vibe Guide
-description: "Two reproducible JSKIT starting points: a workspace-enabled app and a simple app."
+description: "The shortest non-technical path into a real JSKIT app."
 ---
 
 # Vibe Guide
 
-This page gives you two reproducible starting points.
+This page is for people who want to build with an AI agent without learning JSKIT first.
 
-- Use the first track if you want the full workspace-enabled app shape.
-- Use the second track if you want a simpler app with no workspace tenancy.
+You do not need to know the framework words. You only need to:
 
-Both tracks assume you are comfortable running commands in a terminal and filling in real values for your own database, Supabase project, and assistant key.
+1. start the seed workspace
+2. describe the app in normal language
+3. answer a few setup questions when the agent asks
 
-## Shared values
+## 1. Start the seed workspace
 
-Both tracks use the same placeholder variables:
-
-```bash
-OPENAI_API_KEY=...
-SUPABASE_URL=...
-SUPABASE_KEY=...
-DB_HOST=127.0.0.1
-DB_PORT=3306
-DB_NAME=testapp
-DB_USER=...
-DB_PASSWORD=...
-```
-
-## Track 1: Workspace-enabled app
-
-Use this if you want:
-
-- personal workspaces
-- the `app` and `admin` workspace surfaces
-- the workspace settings area
-- the admin cog menu
-- the `admin` assistant configured from `console`
+Open a terminal and run:
 
 ```bash
-npx @jskit-ai/create-app testapp --tenancy-mode personal
+npx @jskit-ai/create-app testapp --template ai-seed
 cd testapp
-npm install
-
-npx jskit add package shell-web
-
-npx jskit add package auth-provider-supabase-core \
-  --auth-supabase-url "$SUPABASE_URL" \
-  --auth-supabase-publishable-key "$SUPABASE_KEY" \
-  --app-public-url "http://localhost:5173"
-
-npx jskit add bundle auth-base
-
-npx jskit add package database-runtime-mysql \
-  --db-host "$DB_HOST" \
-  --db-port "$DB_PORT" \
-  --db-name "$DB_NAME" \
-  --db-user "$DB_USER" \
-  --db-password "$DB_PASSWORD"
-
-npx jskit add package users-web
-npx jskit add package console-web
-npx jskit add package workspaces-core
-npx jskit add package workspaces-web
-
-npx jskit generate assistant setup \
-  --surface admin \
-  --settings-surface console \
-  --config-scope global \
-  --ai-provider openai \
-  --ai-api-key "$OPENAI_API_KEY"
-
-npx jskit generate assistant page \
-  w/[workspaceSlug]/admin/assistant/index.vue \
-  --name "Assistant"
-
-npx jskit generate assistant settings-page \
-  console/settings/admin-assistant/index.vue \
-  --surface admin \
-  --name "Admin Assistant" \
-  --link-placement console-settings:primary-menu \
-  --link-component-token local.main.ui.surface-aware-menu-link-item
-
-npm install
-npm run db:migrate
 ```
 
-This gives you:
+That creates a tiny starter folder with one file for the AI to read. It is not the real app yet. That is intentional.
 
-- `/console`
-- `/w/[workspaceSlug]`
-- `/w/[workspaceSlug]/admin`
-- `/w/[workspaceSlug]/admin/assistant`
-- `/console/settings/admin-assistant`
+## 2. Tell the AI what you want in normal language
 
-If this is the track you want, read [Quickstart](/guide/app-setup/quickstart) next. That chapter shows how to add workspace settings pages, admin cog entries, and normal left-menu pages.
+You do not need to know JSKIT terms like tenancy, surfaces, placements, providers, or generators.
 
-## Track 2: Simple app
+Just explain things in human terms, for example:
 
-Use this if you want:
+- what the app should help people do
+- who will use it
+- whether people should sign in
+- whether each customer, business, or team should have its own private area
+- whether you want a staff or admin back office
+- whether you want AI features now, later, or not at all
 
-- no workspace tenancy
-- no workspace settings area
-- no workspace admin cog
-- a smaller route and surface model
+Example:
 
-```bash
-npx @jskit-ai/create-app testapp --tenancy-mode none
-cd testapp
-npm install
+> I want a dog grooming booking app. Customers should be able to book appointments. Staff should manage bookings and customer notes. Each business should have its own private area. People should sign in. I want a simple admin area. AI features can wait until later.
 
-npx jskit add package shell-web
+If you do not know the technical words, say that plainly. The agent should translate your goals into the setup it needs.
 
-npx jskit add package auth-provider-supabase-core \
-  --auth-supabase-url "$SUPABASE_URL" \
-  --auth-supabase-publishable-key "$SUPABASE_KEY" \
-  --app-public-url "http://localhost:5173"
+## 3. What the AI will probably ask you
 
-npx jskit add bundle auth-base
+The AI should turn your description into a few practical choices, such as:
 
-npx jskit add package database-runtime-mysql \
-  --db-host "$DB_HOST" \
-  --db-port "$DB_PORT" \
-  --db-name "$DB_NAME" \
-  --db-user "$DB_USER" \
-  --db-password "$DB_PASSWORD"
+- is this a simple app, a normal account-based app, or a team/workspace app?
+- should people sign in?
+- should the app save data in a database?
+- do you want AI features?
 
-npx jskit add package users-web
-npx jskit add package console-web
+If you do not know which database or sign-in system to use, ask for the standard recommendation.
 
-npm install
-npm run db:migrate
-```
+If you do not have a strong reason to choose differently, asking for the standard JSKIT path and MySQL is the safest starting point today.
 
-This gives you a smaller app with:
+## 4. What information you may need to provide
 
-- the normal `home`, `account`, `auth`, and `console` surfaces
-- Supabase-backed login
-- database runtime
-- no workspace-aware `app` or `admin` surfaces
+Once the AI starts setting up the app, it may need some local development values from you.
 
-That last point matters. In a `tenancyMode = "none"` app there is no workspace settings area and no workspace admin cog, so the workspace-specific commands from the Quickstart chapter do not apply to this track.
+Common examples:
 
-## Which one should you pick?
+- local database details
+- sign-in provider project details
+- an AI API key if you want AI features now
 
-Pick the workspace-enabled track if you know the app needs:
+In this flow, those are local setup values for your development environment. They are not the same thing as production launch secrets.
 
-- personal or shared workspaces
-- workspace settings
-- an `admin` surface
-- workspace-specific app pages
+One important point: if the app needs a database, the AI should make sure the database really exists before moving on. If it does not exist yet, the AI should help you stop and sort that out first instead of pretending the setup is done.
 
-Pick the simple track if you want:
+## 5. What happens next
 
-- the smallest app shape
-- no workspace routing
-- fewer surfaces to reason about
+Once the AI has enough answers, it upgrades the seed folder into a real JSKIT app, installs what it needs, and then continues from the normal app instructions.
 
-If you are unsure, pick the workspace-enabled track. It is the one the rest of the hands-on Quickstart flows assume.
+You do not need to manage that handoff manually.
 
-## After bootstrap: keep the app sane
+## 6. How to keep the process sane
 
-If you are going to hand the repo to an AI agent and let it iterate, keep these rules explicit from day one.
+Ask the AI to work in small steps.
 
-### 1. Use JSKIT commands first, not hand-made topology
+Good habits:
 
-- Install baseline capabilities with `jskit add package ...` and `jskit add bundle ...`.
-- For substantial non-CRUD backend work, scaffold a real feature package with `jskit generate feature-server-generator scaffold <feature-name>`.
-- For CRUDs, use the CRUD generators instead of hand-building routes, services, and forms from scratch.
+- ask it to do one feature or one chunk at a time
+- ask it to show you the result in the browser after each chunk
+- ask it to explain technical choices in plain English if you do not understand them
+- do not accept "done" until it has run the project checks
+- if it changed screens or user flows, ask it to run the browser test for that too
 
-If the agent starts inventing file layouts or wiring patterns that JSKIT already has a command for, stop and redirect it back to the CLI.
+You do not need to memorize the JSKIT command names for those checks. The agent should know them.
 
-### 2. Keep `packages/main` boring
+## 7. When you want the technical version
 
-`packages/main` should stay glue-only:
+This page is intentionally simple.
 
-- app composition
-- shell wiring
-- config loading
-- provider registration
+If you want the exact technical command sequences or the deeper framework explanation, use:
 
-Substantial domain logic should live in its own local package under `packages/<feature>/`.
-
-If the agent starts adding feature-sized server code directly under `packages/main`, that is drift, not progress.
-
-### 3. Write down the shape before the churn starts
-
-For anything beyond a tiny tweak:
-
-- create or update `.jskit/APP_BLUEPRINT.md`
-- create or update `.jskit/WORKBOARD.md`
-- work one reviewable chunk at a time
-
-That keeps the agent from mixing platform setup, routing decisions, CRUD generation, and business logic in one unreadable burst.
-
-### 4. Make verification part of the loop, not the cleanup
-
-Before accepting a chunk, run the real checks:
-
-```bash
-npm run verify
-```
-
-If the chunk changed user-facing UI, also run a targeted local Playwright flow and record it:
-
-```bash
-npx jskit app verify-ui \
-  --command "npm run verify:ui" \
-  --feature "<short label>" \
-  --auth-mode <mode>
-```
-
-Then run:
-
-```bash
-npx jskit doctor --against origin/main
-```
-
-That gives `doctor` a concrete UI verification receipt tied to the branch delta, not just a vague claim that "the UI was tested."
-
-### 5. Keep hosted CI simple unless you deliberately build more
-
-The default sane baseline for hosted CI is still:
-
-```bash
-npm run verify
-```
-
-Do not assume GitHub Actions should automatically stand up browser auth, seeded data, and app-specific Playwright flows unless you intentionally built that infrastructure for the app.
-
-### 6. Do not use live login flows for normal UI verification
-
-For Playwright, prefer the app's local development auth bootstrap path such as `POST /api/dev-auth/login-as`.
-
-- use seeded local users
-- keep the browser flow deterministic
-- do not depend on a real Supabase login page for normal feature verification
-
-If the app has no good local auth bootstrap path yet, treat that as a testability gap and fix it early.
-
-### 7. Watch for these drift signals
-
-Stop and correct course if the agent starts doing things like:
-
-- growing `packages/main` into a feature package
-- hand-making a new server topology when a JSKIT generator exists
-- changing UI without a recorded Playwright run
-- bypassing `jskit doctor` because "it works locally"
-- mixing data access, service logic, and UI behavior into the same file because it was faster
-
-The point of vibe coding in JSKIT is not to remove structure. It is to move faster while keeping the structure machine-checkable.
+- [Quickstart](/guide/app-setup/quickstart) for the larger standard stack
+- [Initial Scaffolding](/guide/app-setup/initial-scaffolding) for the base scaffold and the smaller starting stack
+- [Working With The JSKIT CLI](/guide/app-setup/working-with-the-jskit-cli) for maintenance, health checks, and review commands

--- a/packages/agent-docs/workflow/bootstrap.md
+++ b/packages/agent-docs/workflow/bootstrap.md
@@ -40,6 +40,8 @@ Ask setup values plainly:
 - Only ask for setup values that correspond to the modules or packages already chosen for the baseline.
 - When the next package install needs concrete local development values, ask for them directly using the exact env var names or option names.
 - Do not hide behind vague requests for "credentials" or "values after that boundary".
+- If MySQL or Postgres is selected, confirm that the target database already exists before the runtime install, or that the developer has enough local admin or create-database access to create it now.
+- Do not proceed as if `DB_NAME` alone means the database is ready. The actual database must exist before the database runtime install and migration flow can be treated as valid.
 - In this workflow, these are routine setup inputs:
   - If the MySQL runtime is selected: `DB_NAME`, `DB_USER`, `DB_PASSWORD`
   - If the MySQL host or port differs from the local default `127.0.0.1:3306`: `DB_HOST`, `DB_PORT`

--- a/tooling/create-app/src/server/index.js
+++ b/tooling/create-app/src/server/index.js
@@ -220,7 +220,9 @@ function printUsage(stream = process.stderr) {
   stream.write("Usage: jskit-create-app [app-name] [options]\n");
   stream.write("\n");
   stream.write("Options:\n");
-  stream.write(`  --template <name>  Template folder under templates/ (default: ${DEFAULT_TEMPLATE})\n`);
+  stream.write(
+    `  --template <name>  Template folder under templates/ (default: ${DEFAULT_TEMPLATE}; use ai-seed for the minimal AI seed flow)\n`
+  );
   stream.write("  --title <text>     App title used for template replacements\n");
   stream.write("  --target <path>    Target directory (default: ./<app-name>)\n");
   stream.write("  --initial-bundles <preset>  Optional bundle preset: none | auth (default: none)\n");
@@ -609,6 +611,9 @@ export async function runCli(
     });
 
     const targetLabel = toRelativeTargetLabel(path.resolve(cwd), result.targetDirectory);
+    const normalizedTemplateName = normalizeTemplatePathSegments(result.template).join("/");
+    const isAiSeedTemplate = normalizedTemplateName === "ai-seed";
+    const wrotePackageJson = result.touchedFiles.includes("package.json");
     if (result.dryRun) {
       stdout.write(
         `[dry-run] Would create app "${result.appName}" from template "${result.template}" at ${targetLabel}.\n`
@@ -625,10 +630,17 @@ export async function runCli(
       stdout.write("\n");
       stdout.write("Next steps:\n");
       stdout.write(`- cd ${shellQuote(targetLabel)}\n`);
-      stdout.write("- npm install\n");
-      stdout.write("- npm run dev\n");
+      if (isAiSeedTemplate) {
+        stdout.write("- hand the repo to your AI agent and have it read AGENTS.md\n");
+        stdout.write(
+          `- once the Stage 1 shape is clear, let it run npx @jskit-ai/create-app ${shellQuote(result.appName)} --target . --force --tenancy-mode <mode>\n`
+        );
+      } else if (wrotePackageJson) {
+        stdout.write("- npm install\n");
+        stdout.write("- npm run dev\n");
+      }
 
-      if (result.selectedSetupCommands.length > 0) {
+      if (!isAiSeedTemplate && result.selectedSetupCommands.length > 0) {
         stdout.write("\n");
         stdout.write(`Initial framework setup commands (${result.initialBundles}):\n`);
         for (const command of result.selectedSetupCommands) {

--- a/tooling/create-app/templates/ai-seed/AGENTS.md
+++ b/tooling/create-app/templates/ai-seed/AGENTS.md
@@ -1,0 +1,38 @@
+# AI Seed Instructions
+
+This workspace is intentionally only a JSKIT seed scaffold. It is not a real JSKIT app yet.
+
+Use this file only for the initial JSKIT setup conversation.
+
+If you need more JSKIT documentation before the real scaffold exists, use:
+
+- `https://github.com/mobily-enterprises/jskit-ai/blob/main/packages/agent-docs/site/guide/index.md`
+- `https://github.com/mobily-enterprises/jskit-ai/blob/main/packages/agent-docs/site/guide/app-setup/initial-scaffolding.md`
+- `https://github.com/mobily-enterprises/jskit-ai/blob/main/packages/agent-docs/site/guide/app-setup/quickstart.md`
+- `https://github.com/mobily-enterprises/jskit-ai/blob/main/packages/agent-docs/site/guide/app-setup/working-with-the-jskit-cli.md`
+
+What to do now:
+
+1. Ask only the Stage 1 setup questions first:
+   - app purpose
+   - tenancy mode: `none`, `personal`, or `workspaces`
+   - database engine: MySQL or Postgres
+   - auth provider
+   - whether the baseline should include users, console, workspaces, realtime, or assistant
+2. If a database-backed baseline is selected, do not stop at the engine name. Confirm one of these is true before moving on:
+   - the target database already exists and the app connection values are known
+   - or the developer has enough local admin or create-database access for the chosen engine to create it now
+3. Once the baseline package stack is clear, ask plainly for the exact local development setup values needed for the next chosen install step. Use the real env var names or option names instead of vague requests for "credentials".
+4. Treat those values as routine local development setup inputs, not production secrets. Examples:
+   - `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASSWORD`
+   - `AUTH_SUPABASE_URL`, `AUTH_SUPABASE_PUBLISHABLE_KEY`, `APP_PUBLIC_URL`
+   - `OPENAI_API_KEY` if assistant support is selected
+5. For MySQL or Postgres, if the database does not exist yet, ask for whatever local admin or create-database access is needed to create it, then make sure the database exists before promoting the scaffold. Do not move on while the database is still hypothetical.
+6. If assistant support is selected, explain that `OPENAI_API_KEY` can be given now or wired later; the scaffold can still be created first.
+7. Do not hand-write JSKIT runtime files or invent file topology in this seed workspace.
+8. Once the Stage 1 decisions are clear, promote this directory into the real app scaffold by running:
+   `npx @jskit-ai/create-app <app-name> --target . --force --tenancy-mode <mode>`
+   Use the current directory name as `<app-name>` unless the developer explicitly wants a different app name.
+9. After that, run `npm install`.
+10. Then stop, re-read the overwritten `AGENTS.md`, and continue with the normal JSKIT app workflow from that file. Do not rely on memory from the seed stage.
+11. Do not install JSKIT runtime packages until the new app `AGENTS.md` has been re-read.

--- a/tooling/create-app/test/createApp.test.js
+++ b/tooling/create-app/test/createApp.test.js
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { access, mkdir, readFile, symlink, writeFile } from "node:fs/promises";
+import { access, mkdir, readFile, readdir, symlink, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { Writable } from "node:stream";
 import test from "node:test";
@@ -343,6 +343,30 @@ test("create-app scaffolds the base shell with placeholder replacements", async 
   });
 });
 
+test("create-app scaffolds ai-seed as a single AGENTS file with seed guidance", async () => {
+  await withCreateAppTempDir(async (cwd) => {
+    const result = runCli({ cwd, args: ["seed-app", "--template", "ai-seed"] });
+
+    assert.equal(result.status, 0, result.stderr);
+
+    const appRoot = path.join(cwd, "seed-app");
+    const entries = (await readdir(appRoot)).sort();
+    assert.deepEqual(entries, ["AGENTS.md"]);
+
+    const body = await readFile(path.join(appRoot, "AGENTS.md"), "utf8");
+    assert.match(body, /only a JSKIT seed scaffold/);
+    assert.match(body, /site\/guide\/index\.md/);
+    assert.match(body, /DB_PASSWORD/);
+    assert.match(body, /OPENAI_API_KEY/);
+    assert.match(body, /target database already exists/);
+    assert.match(body, /create-app <app-name> --target \. --force --tenancy-mode <mode>/);
+
+    assert.match(result.stdout, /Created app "seed-app" from template "ai-seed"/);
+    assert.match(result.stdout, /have it read AGENTS\.md/);
+    assert.doesNotMatch(result.stdout, /npm run dev/);
+  });
+});
+
 test("create-app rejects template path traversal names", async () => {
   await withCreateAppTempDir(async (cwd) => {
     const traversalResult = runCli({ cwd, args: ["safe-app", "--template", "../base-shell"] });
@@ -361,6 +385,15 @@ test("base-shell app agent wrapper does not hardcode machine-specific jskit path
   const body = await readFile(wrapperPath, "utf8");
   assert.doesNotMatch(body, /Development\/current\/jskit-ai/);
   assert.match(body, /node_modules\/@jskit-ai\/agent-docs\/templates\/app\/AGENTS\.md/);
+});
+
+test("ai-seed agent instructions do not hardcode machine-specific paths and point to JSKIT docs", async () => {
+  const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+  const wrapperPath = path.join(packageRoot, "templates/ai-seed/AGENTS.md");
+  const body = await readFile(wrapperPath, "utf8");
+  assert.doesNotMatch(body, /Development\/current\/jskit-ai/);
+  assert.match(body, /github\.com\/mobily-enterprises\/jskit-ai\/blob\/main\/packages\/agent-docs\/site\/guide\/index\.md/);
+  assert.match(body, /AUTH_SUPABASE_PUBLISHABLE_KEY/);
 });
 
 test("create-app interactive flow captures initial bundle selection in guidance", async () => {


### PR DESCRIPTION
## Summary
- add a minimal `ai-seed` create-app template for the Stage 1 AI setup conversation
- update create-app guidance and tests so the seed flow promotes into the real scaffold only after the app shape and database readiness are resolved
- align the quickstart, initial scaffolding, vibe guide, and bootstrap workflow docs with that seed-first path

## Validation
- `npm run agent-docs:build`
- `node --test tooling/create-app/test/createApp.test.js`

## Not run
- `npm run verify` (intentionally not run)