### PR TITLE
Tighten scaffolding guidance and logging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6520,28 +6520,28 @@
     },
     "packages/agent-docs": {
       "name": "@jskit-ai/agent-docs",
-      "version": "0.1.21",
+      "version": "0.1.22",
       "engines": {
         "node": "20.x"
       }
     },
     "packages/assistant": {
       "name": "@jskit-ai/assistant",
-      "version": "0.1.69",
+      "version": "0.1.70",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.60"
+        "@jskit-ai/kernel": "0.1.61"
       }
     },
     "packages/assistant-core": {
       "name": "@jskit-ai/assistant-core",
-      "version": "0.1.36",
+      "version": "0.1.37",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.60",
-        "@jskit-ai/http-runtime": "0.1.59",
-        "@jskit-ai/kernel": "0.1.60",
-        "@jskit-ai/resource-core": "0.1.5",
-        "@jskit-ai/resource-crud-core": "0.1.5",
-        "@jskit-ai/users-core": "0.1.70",
+        "@jskit-ai/database-runtime": "0.1.61",
+        "@jskit-ai/http-runtime": "0.1.60",
+        "@jskit-ai/kernel": "0.1.61",
+        "@jskit-ai/resource-core": "0.1.6",
+        "@jskit-ai/resource-crud-core": "0.1.6",
+        "@jskit-ai/users-core": "0.1.71",
         "@tanstack/vue-query": "^5.90.5",
         "dompurify": "^3.3.3",
         "json-rest-schema": "1.x.x",
@@ -6614,15 +6614,15 @@
     },
     "packages/assistant-runtime": {
       "name": "@jskit-ai/assistant-runtime",
-      "version": "0.1.31",
+      "version": "0.1.32",
       "dependencies": {
-        "@jskit-ai/assistant-core": "0.1.36",
-        "@jskit-ai/database-runtime": "0.1.60",
-        "@jskit-ai/http-runtime": "0.1.59",
-        "@jskit-ai/kernel": "0.1.60",
-        "@jskit-ai/shell-web": "0.1.59",
-        "@jskit-ai/users-core": "0.1.70",
-        "@jskit-ai/users-web": "0.1.75",
+        "@jskit-ai/assistant-core": "0.1.37",
+        "@jskit-ai/database-runtime": "0.1.61",
+        "@jskit-ai/http-runtime": "0.1.60",
+        "@jskit-ai/kernel": "0.1.61",
+        "@jskit-ai/shell-web": "0.1.60",
+        "@jskit-ai/users-core": "0.1.71",
+        "@jskit-ai/users-web": "0.1.76",
         "@tanstack/vue-query": "^5.90.5",
         "json-rest-schema": "1.x.x",
         "vuetify": "^4.0.0"
@@ -6692,21 +6692,21 @@
     },
     "packages/auth-core": {
       "name": "@jskit-ai/auth-core",
-      "version": "0.1.59",
+      "version": "0.1.60",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0",
-        "@jskit-ai/kernel": "0.1.60",
+        "@jskit-ai/kernel": "0.1.61",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/auth-provider-supabase-core": {
       "name": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.59",
+      "version": "0.1.60",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.59",
-        "@jskit-ai/kernel": "0.1.60",
+        "@jskit-ai/auth-core": "0.1.60",
+        "@jskit-ai/kernel": "0.1.61",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0",
         "json-rest-schema": "1.x.x",
@@ -6715,12 +6715,12 @@
     },
     "packages/auth-web": {
       "name": "@jskit-ai/auth-web",
-      "version": "0.1.61",
+      "version": "0.1.62",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.59",
-        "@jskit-ai/http-runtime": "0.1.59",
-        "@jskit-ai/kernel": "0.1.60",
-        "@jskit-ai/shell-web": "0.1.59",
+        "@jskit-ai/auth-core": "0.1.60",
+        "@jskit-ai/http-runtime": "0.1.60",
+        "@jskit-ai/kernel": "0.1.61",
+        "@jskit-ai/shell-web": "0.1.60",
         "@mdi/js": "^7.4.47",
         "@tanstack/vue-query": "^5.90.5",
         "pinia": "^3.0.4",
@@ -6784,38 +6784,38 @@
     },
     "packages/console-core": {
       "name": "@jskit-ai/console-core",
-      "version": "0.1.23",
+      "version": "0.1.24",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.59",
-        "@jskit-ai/database-runtime": "0.1.60",
-        "@jskit-ai/http-runtime": "0.1.59",
-        "@jskit-ai/kernel": "0.1.60",
-        "@jskit-ai/resource-crud-core": "0.1.5",
-        "@jskit-ai/users-core": "0.1.70",
+        "@jskit-ai/auth-core": "0.1.60",
+        "@jskit-ai/database-runtime": "0.1.61",
+        "@jskit-ai/http-runtime": "0.1.60",
+        "@jskit-ai/kernel": "0.1.61",
+        "@jskit-ai/resource-crud-core": "0.1.6",
+        "@jskit-ai/users-core": "0.1.71",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/console-web": {
       "name": "@jskit-ai/console-web",
-      "version": "0.1.28",
+      "version": "0.1.29",
       "dependencies": {
-        "@jskit-ai/auth-web": "0.1.61",
-        "@jskit-ai/console-core": "0.1.23",
-        "@jskit-ai/shell-web": "0.1.59"
+        "@jskit-ai/auth-web": "0.1.62",
+        "@jskit-ai/console-core": "0.1.24",
+        "@jskit-ai/shell-web": "0.1.60"
       }
     },
     "packages/crud-core": {
       "name": "@jskit-ai/crud-core",
-      "version": "0.1.68",
+      "version": "0.1.69",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.60",
-        "@jskit-ai/http-runtime": "0.1.59",
-        "@jskit-ai/kernel": "0.1.60",
-        "@jskit-ai/realtime": "0.1.59",
-        "@jskit-ai/resource-crud-core": "0.1.5",
-        "@jskit-ai/shell-web": "0.1.59",
-        "@jskit-ai/users-core": "0.1.70",
-        "@jskit-ai/users-web": "0.1.75",
+        "@jskit-ai/database-runtime": "0.1.61",
+        "@jskit-ai/http-runtime": "0.1.60",
+        "@jskit-ai/kernel": "0.1.61",
+        "@jskit-ai/realtime": "0.1.60",
+        "@jskit-ai/resource-crud-core": "0.1.6",
+        "@jskit-ai/shell-web": "0.1.60",
+        "@jskit-ai/users-core": "0.1.71",
+        "@jskit-ai/users-web": "0.1.76",
         "@tanstack/vue-query": "^5.90.5",
         "json-rest-schema": "1.x.x"
       },
@@ -6885,82 +6885,82 @@
     },
     "packages/crud-server-generator": {
       "name": "@jskit-ai/crud-server-generator",
-      "version": "0.1.68",
+      "version": "0.1.69",
       "dependencies": {
         "@babel/parser": "^7.29.2",
-        "@jskit-ai/crud-core": "0.1.68",
-        "@jskit-ai/database-runtime": "0.1.60",
-        "@jskit-ai/http-runtime": "0.1.59",
-        "@jskit-ai/json-rest-api-core": "0.1.5",
-        "@jskit-ai/kernel": "0.1.60",
-        "@jskit-ai/resource-crud-core": "0.1.5",
+        "@jskit-ai/crud-core": "0.1.69",
+        "@jskit-ai/database-runtime": "0.1.61",
+        "@jskit-ai/http-runtime": "0.1.60",
+        "@jskit-ai/json-rest-api-core": "0.1.6",
+        "@jskit-ai/kernel": "0.1.61",
+        "@jskit-ai/resource-crud-core": "0.1.6",
         "recast": "^0.23.11"
       }
     },
     "packages/crud-ui-generator": {
       "name": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.43",
+      "version": "0.1.44",
       "dependencies": {
-        "@jskit-ai/crud-core": "0.1.68",
-        "@jskit-ai/kernel": "0.1.60",
-        "@jskit-ai/resource-crud-core": "0.1.5"
+        "@jskit-ai/crud-core": "0.1.69",
+        "@jskit-ai/kernel": "0.1.61",
+        "@jskit-ai/resource-crud-core": "0.1.6"
       }
     },
     "packages/database-runtime": {
       "name": "@jskit-ai/database-runtime",
-      "version": "0.1.60",
+      "version": "0.1.61",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.60"
+        "@jskit-ai/kernel": "0.1.61"
       }
     },
     "packages/database-runtime-mysql": {
       "name": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.59",
+      "version": "0.1.60",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.60",
-        "@jskit-ai/kernel": "0.1.60"
+        "@jskit-ai/database-runtime": "0.1.61",
+        "@jskit-ai/kernel": "0.1.61"
       }
     },
     "packages/database-runtime-postgres": {
       "name": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.59",
+      "version": "0.1.60",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.60"
+        "@jskit-ai/database-runtime": "0.1.61"
       }
     },
     "packages/feature-server-generator": {
       "name": "@jskit-ai/feature-server-generator",
-      "version": "0.1.2"
+      "version": "0.1.3"
     },
     "packages/http-runtime": {
       "name": "@jskit-ai/http-runtime",
-      "version": "0.1.59",
+      "version": "0.1.60",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.60",
+        "@jskit-ai/kernel": "0.1.61",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/json-rest-api-core": {
       "name": "@jskit-ai/json-rest-api-core",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.60",
+        "@jskit-ai/kernel": "0.1.61",
         "hooked-api": "1.x.x",
         "json-rest-api": "1.x.x"
       }
     },
     "packages/kernel": {
       "name": "@jskit-ai/kernel",
-      "version": "0.1.60",
+      "version": "0.1.61",
       "dependencies": {
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/realtime": {
       "name": "@jskit-ai/realtime",
-      "version": "0.1.59",
+      "version": "0.1.60",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.60",
+        "@jskit-ai/kernel": "0.1.61",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",
@@ -6972,24 +6972,24 @@
     },
     "packages/resource-core": {
       "name": "@jskit-ai/resource-core",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.60"
+        "@jskit-ai/kernel": "0.1.61"
       }
     },
     "packages/resource-crud-core": {
       "name": "@jskit-ai/resource-crud-core",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.60",
-        "@jskit-ai/resource-core": "0.1.5"
+        "@jskit-ai/kernel": "0.1.61",
+        "@jskit-ai/resource-core": "0.1.6"
       }
     },
     "packages/shell-web": {
       "name": "@jskit-ai/shell-web",
-      "version": "0.1.59",
+      "version": "0.1.60",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.60",
+        "@jskit-ai/kernel": "0.1.61",
         "@mdi/js": "^7.4.47",
         "@tanstack/vue-query": "^5.90.5",
         "pinia": "^3.0.4",
@@ -7053,25 +7053,25 @@
     },
     "packages/storage-runtime": {
       "name": "@jskit-ai/storage-runtime",
-      "version": "0.1.59",
+      "version": "0.1.60",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.60",
+        "@jskit-ai/kernel": "0.1.61",
         "unstorage": "^1.17.3"
       }
     },
     "packages/ui-generator": {
       "name": "@jskit-ai/ui-generator",
-      "version": "0.1.43",
+      "version": "0.1.44",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.60",
-        "@jskit-ai/shell-web": "0.1.59"
+        "@jskit-ai/kernel": "0.1.61",
+        "@jskit-ai/shell-web": "0.1.60"
       }
     },
     "packages/uploads-image-web": {
       "name": "@jskit-ai/uploads-image-web",
-      "version": "0.1.38",
+      "version": "0.1.39",
       "dependencies": {
-        "@jskit-ai/uploads-runtime": "0.1.38",
+        "@jskit-ai/uploads-runtime": "0.1.39",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",
@@ -7084,37 +7084,37 @@
     },
     "packages/uploads-runtime": {
       "name": "@jskit-ai/uploads-runtime",
-      "version": "0.1.38",
+      "version": "0.1.39",
       "dependencies": {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.60"
+        "@jskit-ai/kernel": "0.1.61"
       }
     },
     "packages/users-core": {
       "name": "@jskit-ai/users-core",
-      "version": "0.1.70",
+      "version": "0.1.71",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.59",
-        "@jskit-ai/database-runtime": "0.1.60",
-        "@jskit-ai/http-runtime": "0.1.59",
-        "@jskit-ai/json-rest-api-core": "0.1.5",
-        "@jskit-ai/kernel": "0.1.60",
-        "@jskit-ai/resource-core": "0.1.5",
-        "@jskit-ai/resource-crud-core": "0.1.5",
-        "@jskit-ai/uploads-runtime": "0.1.38",
+        "@jskit-ai/auth-core": "0.1.60",
+        "@jskit-ai/database-runtime": "0.1.61",
+        "@jskit-ai/http-runtime": "0.1.60",
+        "@jskit-ai/json-rest-api-core": "0.1.6",
+        "@jskit-ai/kernel": "0.1.61",
+        "@jskit-ai/resource-core": "0.1.6",
+        "@jskit-ai/resource-crud-core": "0.1.6",
+        "@jskit-ai/uploads-runtime": "0.1.39",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/users-web": {
       "name": "@jskit-ai/users-web",
-      "version": "0.1.75",
+      "version": "0.1.76",
       "dependencies": {
-        "@jskit-ai/http-runtime": "0.1.59",
-        "@jskit-ai/kernel": "0.1.60",
-        "@jskit-ai/realtime": "0.1.59",
-        "@jskit-ai/shell-web": "0.1.59",
-        "@jskit-ai/uploads-image-web": "0.1.38",
-        "@jskit-ai/users-core": "0.1.70",
+        "@jskit-ai/http-runtime": "0.1.60",
+        "@jskit-ai/kernel": "0.1.61",
+        "@jskit-ai/realtime": "0.1.60",
+        "@jskit-ai/shell-web": "0.1.60",
+        "@jskit-ai/uploads-image-web": "0.1.39",
+        "@jskit-ai/users-core": "0.1.71",
         "@mdi/js": "^7.4.47",
         "@tanstack/vue-query": "5.92.12",
         "vuetify": "^4.0.0"
@@ -7185,29 +7185,29 @@
     },
     "packages/workspaces-core": {
       "name": "@jskit-ai/workspaces-core",
-      "version": "0.1.36",
+      "version": "0.1.37",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.59",
-        "@jskit-ai/database-runtime": "0.1.60",
-        "@jskit-ai/http-runtime": "0.1.59",
-        "@jskit-ai/json-rest-api-core": "0.1.5",
-        "@jskit-ai/kernel": "0.1.60",
-        "@jskit-ai/resource-core": "0.1.5",
-        "@jskit-ai/resource-crud-core": "0.1.5",
-        "@jskit-ai/users-core": "0.1.70",
+        "@jskit-ai/auth-core": "0.1.60",
+        "@jskit-ai/database-runtime": "0.1.61",
+        "@jskit-ai/http-runtime": "0.1.60",
+        "@jskit-ai/json-rest-api-core": "0.1.6",
+        "@jskit-ai/kernel": "0.1.61",
+        "@jskit-ai/resource-core": "0.1.6",
+        "@jskit-ai/resource-crud-core": "0.1.6",
+        "@jskit-ai/users-core": "0.1.71",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/workspaces-web": {
       "name": "@jskit-ai/workspaces-web",
-      "version": "0.1.36",
+      "version": "0.1.37",
       "dependencies": {
-        "@jskit-ai/http-runtime": "0.1.59",
-        "@jskit-ai/kernel": "0.1.60",
-        "@jskit-ai/shell-web": "0.1.59",
-        "@jskit-ai/users-core": "0.1.70",
-        "@jskit-ai/users-web": "0.1.75",
-        "@jskit-ai/workspaces-core": "0.1.36",
+        "@jskit-ai/http-runtime": "0.1.60",
+        "@jskit-ai/kernel": "0.1.61",
+        "@jskit-ai/shell-web": "0.1.60",
+        "@jskit-ai/users-core": "0.1.71",
+        "@jskit-ai/users-web": "0.1.76",
+        "@jskit-ai/workspaces-core": "0.1.37",
         "@mdi/js": "^7.4.47",
         "@tanstack/vue-query": "5.92.12",
         "vuetify": "^4.0.0"
@@ -7278,7 +7278,7 @@
     },
     "tooling/config-eslint": {
       "name": "@jskit-ai/config-eslint",
-      "version": "0.1.59",
+      "version": "0.1.60",
       "dependencies": {
         "@eslint/js": "^9.39.1",
         "eslint-plugin-vue": "^10.5.1",
@@ -7296,7 +7296,7 @@
     },
     "tooling/create-app": {
       "name": "@jskit-ai/create-app",
-      "version": "0.1.68",
+      "version": "0.1.69",
       "bin": {
         "jskit-create-app": "bin/jskit-create-app.js"
       },
@@ -7306,18 +7306,18 @@
     },
     "tooling/jskit-catalog": {
       "name": "@jskit-ai/jskit-catalog",
-      "version": "0.1.68",
+      "version": "0.1.69",
       "engines": {
         "node": "20.x"
       }
     },
     "tooling/jskit-cli": {
       "name": "@jskit-ai/jskit-cli",
-      "version": "0.2.69",
+      "version": "0.2.70",
       "dependencies": {
-        "@jskit-ai/jskit-catalog": "0.1.68",
-        "@jskit-ai/kernel": "0.1.60",
-        "@jskit-ai/shell-web": "0.1.59"
+        "@jskit-ai/jskit-catalog": "0.1.69",
+        "@jskit-ai/kernel": "0.1.61",
+        "@jskit-ai/shell-web": "0.1.60"
       },
       "bin": {
         "jskit": "bin/jskit.js"

--- a/packages/agent-docs/package.json
+++ b/packages/agent-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/agent-docs",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "description": "Distributed JSKIT agent workflows, guides, and generated reference maps.",
   "type": "module",
   "files": [

--- a/packages/agent-docs/patterns/INDEX.md
+++ b/packages/agent-docs/patterns/INDEX.md
@@ -14,8 +14,12 @@ How to use it:
   - `placements.md`
 - surfaces, app/admin/home/console, "which surface", route ownership, placement visibility
   - `surfaces.md`
+- page, route page, placeholder page, screen stub, menu-linked page, `ui-generator page`, `list-placements`
+  - `page-scaffolding.md`
 - child crud, nested crud, embedded list, subroute, separate page, parent/child layout
   - `child-cruds.md`
+- crud scaffold, crud server, crud ui, table creation, migrations, `crud-server-generator`, `crud-ui-generator`
+  - `crud-scaffolding.md`
 - CRUD links, record placeholders, `paths.page()`, `resolveViewUrl`, `resolveEditUrl`, `resolveParams`
   - `crud-links.md`
 - `definePage`, redirect, child redirect, settings landing, `redirectToChild`
@@ -37,7 +41,9 @@ How to use it:
 
 - [placements.md](./placements.md)
 - [surfaces.md](./surfaces.md)
+- [page-scaffolding.md](./page-scaffolding.md)
 - [child-cruds.md](./child-cruds.md)
+- [crud-scaffolding.md](./crud-scaffolding.md)
 - [crud-links.md](./crud-links.md)
 - [page-redirects.md](./page-redirects.md)
 - [live-actions.md](./live-actions.md)

--- a/packages/agent-docs/patterns/crud-scaffolding.md
+++ b/packages/agent-docs/patterns/crud-scaffolding.md
@@ -1,0 +1,30 @@
+# CRUD Scaffolding Patterns
+
+Use when:
+
+- creating a new CRUD-backed entity
+- deciding how to create a CRUD table
+- deciding whether to scaffold server first or UI first
+- deciding whether a CRUD needs a migration, a generator, or both
+
+Check first:
+
+- the intended ownership model
+- the real database table shape
+- `jskit show crud-server-generator --details`
+- whether the request is server-only CRUD or server-plus-UI CRUD
+
+Rules:
+
+- For a CRUD-backed entity, start with `jskit generate crud-server-generator scaffold ...`.
+- That server scaffold is the crucial first step even if no CRUD UI will be created yet.
+- Create the real table directly in the database before scaffolding. `crud-server-generator` reads the live table shape.
+- If `crud-server-generator` is going to own the CRUD, do not hand-write a separate CRUD migration for that table. The generator installs and manages the CRUD migration scaffold itself.
+- Do not scaffold CRUD UI, hand-build CRUD routes, or hand-build CRUD endpoints before the server CRUD package and shared resource file exist.
+- Treat the generated shared resource file as the canonical CRUD contract for later UI scaffolding and CRUD behavior changes.
+
+Avoid:
+
+- writing a hand migration for a CRUD table that JSKIT CRUD scaffolding is supposed to own
+- starting with `crud-ui-generator` before the server scaffold exists
+- hand-building CRUD routes or validators that duplicate the generated server resource contract

--- a/packages/agent-docs/patterns/page-scaffolding.md
+++ b/packages/agent-docs/patterns/page-scaffolding.md
@@ -1,0 +1,30 @@
+# Page Scaffolding Patterns
+
+Use when:
+
+- adding a non-CRUD route page
+- adding a placeholder page or screen stub
+- adding a menu-linked page
+- deciding whether a page and its link should be generated or hand-written
+
+Check first:
+
+- the blueprint route family and chosen surface
+- `jskit show ui-generator --details`
+- `jskit list-placements`
+- the nearest existing routed host under `src/pages`
+
+Rules:
+
+- Default to `jskit generate ui-generator page ...` for a new app-owned non-CRUD route page.
+- Let the generator create both the page file and the matching `src/placement.js` entry, then adapt the generated output if needed.
+- If the page link belongs in a non-default outlet, discover the outlet first with `jskit list-placements` and pass `--link-placement`.
+- If the page sits under an existing routed host, check whether `ui-generator page` can infer the correct child placement before writing a custom link by hand.
+- If you do not use `ui-generator page`, state exactly why the generator does not fit before editing code.
+- For a small placeholder route inside an existing route family, update the workboard rather than rewriting the blueprint unless the durable route or surface plan changed.
+
+Avoid:
+
+- hand-writing both `src/pages/...` and `src/placement.js` for a normal non-CRUD page before checking `ui-generator`
+- treating a small page stub as permission to rewrite marketing copy, route architecture, or blueprint scope
+- claiming that no generator exists without checking the actual `jskit` generator inventory first

--- a/packages/agent-docs/templates/APP_BLUEPRINT.md
+++ b/packages/agent-docs/templates/APP_BLUEPRINT.md
@@ -69,6 +69,7 @@ Chunk notes:
 
 - One CRUD is usually one chunk.
 - Platform/auth/shell work may be its own chunk.
+- Prefer vertical slices that produce visible or end-to-end progress the developer can inspect.
 - Each chunk must be independently reviewable and testable.
 
 ## Verification

--- a/packages/agent-docs/templates/app/AGENTS.md
+++ b/packages/agent-docs/templates/app/AGENTS.md
@@ -32,10 +32,10 @@ Before any non-trivial change:
 4. Before editing, print a compact read receipt with:
    - `Read receipt: ...`
    - `Active chunk: ...`
-   - `Generator decision: ...`
+   - `Generator decision: ...` with the exact `jskit` command to run, or the exact generator/placement discovery commands checked and why no generator applies
    - `Relevant patterns: ...`
    - `Active rules from docs: ...`
-5. When files need to be created, prefer `jskit generate ...` over creating them from scratch, even if the generated output will need follow-up adaptation. If not using a generator, say why.
+5. When files need to be created, prefer `jskit generate ...` over creating them from scratch, even if the generated output will need follow-up adaptation. For a new non-CRUD route page or menu-linked screen, default to `jskit generate ui-generator page ...`. If not using a generator, say why.
 6. Do not edit code until the read receipt is printed and the workboard step is complete when it applies.
 
 ## Mandatory Done Gate
@@ -70,6 +70,9 @@ Core rules:
 - Example: if the app is workspace-capable and uses `workspaces-core` plus `workspaces-web`, assume the standard workspace invite flow is part of the baseline package behavior.
 - For baseline package setup, ask plainly for the exact local development values needed for the next install step, but only for the modules or packages that are actually selected.
 - Use the real env var names or option names instead of vague requests for "credentials". Values such as `DB_NAME`, `DB_USER`, `DB_PASSWORD`, `AUTH_SUPABASE_URL`, `AUTH_SUPABASE_PUBLISHABLE_KEY`, and `APP_PUBLIC_URL` are routine setup inputs when the relevant package stack needs them.
+- For CRUD chunks, creating the server CRUD with `jskit generate crud-server-generator scaffold ...` is the crucial first step even if no CRUD UI will be created yet.
+- For a CRUD table that `crud-server-generator` will own, do not hand-write a separate migration. Create the real table directly in the database first, then scaffold the server CRUD so JSKIT can install and manage the CRUD migration scaffold itself.
+- Do not generate CRUD UI or hand-build CRUD routes before the server CRUD package and shared resource file exist.
 - For CRUD chunks, ask the developer which operations are allowed, which fields belong in the list view if one exists, and the intended look of the view and edit/new forms before generating code.
 - Every user-facing screen must pass a Material Design and Vuetify quality review before the chunk is considered done.
 - Any chunk that adds or changes user-facing UI must include a Playwright check that exercises the changed behavior before the chunk is considered done.
@@ -78,7 +81,10 @@ Core rules:
 - In JSKIT apps using the standard auth stack, that means enabling the dev auth bypass in development and using `POST /api/dev-auth/login-as` during Playwright setup.
 - If authenticated UI work has no usable local auth bootstrap path yet, treat that as a testability gap and call it out before the chunk can be considered complete.
 - Do not implement app features before the blueprint has the database, surfaces, ownership model, and route/screen plan written down.
+- Plan implementation work as vertical slices. Each chunk should deliver a user-visible or end-to-end outcome that the developer can recognize in the app or behavior, not just an isolated layer change.
+- Do not churn `.jskit/APP_BLUEPRINT.md` for a small placeholder page or route stub that fits an existing route family unless the durable route/surface plan actually changed. Track request-level movement in `.jskit/WORKBOARD.md` instead.
 - Break planned work into reviewable chunks before implementing. One CRUD is usually one chunk, but auth/platform setup, shell work, and cross-cutting integrations can be their own chunks.
+- Avoid horizontal chunk plans like "all migrations first", "all routes next", or "all UI last" unless platform setup truly forces that order. Prefer slices the developer can inspect as real progress.
 - Do not move to the next chunk until the current chunk has passed implementation, deslop review, JSKIT best-practices review, Material Design/Vuetify review, and verification.
 - If a feature spans more than one chunk, run a final whole-changeset deslop pass, JSKIT pass, Material Design/Vuetify pass, and verification pass after the last chunk.
 - Prefer a fresh review agent for chunk and whole-changeset review when the runtime supports delegation.

--- a/packages/agent-docs/test/appAgentTemplate.test.js
+++ b/packages/agent-docs/test/appAgentTemplate.test.js
@@ -17,6 +17,11 @@ test("app agent template includes mandatory JSKIT start and done gates", async (
   assert.match(body, /Relevant patterns:/);
   assert.match(body, /Active rules from docs:/);
   assert.match(body, /prefer `jskit generate \.\.\.` over creating them from scratch/);
+  assert.match(body, /server CRUD with `jskit generate crud-server-generator scaffold/);
+  assert.match(body, /do not hand-write a separate migration/);
+  assert.match(body, /Do not generate CRUD UI or hand-build CRUD routes before the server CRUD package and shared resource file exist/);
+  assert.match(body, /Plan implementation work as vertical slices/);
+  assert.match(body, /Avoid horizontal chunk plans/);
 
   assert.match(body, /^## Mandatory Done Gate$/m);
   assert.match(body, /Deslop review:/);

--- a/packages/agent-docs/test/crudGuidance.test.js
+++ b/packages/agent-docs/test/crudGuidance.test.js
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+test("workflow and patterns require CRUD server scaffolding before CRUD UI or hand migrations", async () => {
+  const scoping = await readFile(path.join(packageRoot, "workflow/scoping.md"), "utf8");
+  const featureDelivery = await readFile(path.join(packageRoot, "workflow/feature-delivery.md"), "utf8");
+  const review = await readFile(path.join(packageRoot, "workflow/review.md"), "utf8");
+  const patternIndex = await readFile(path.join(packageRoot, "patterns/INDEX.md"), "utf8");
+  const pattern = await readFile(path.join(packageRoot, "patterns/crud-scaffolding.md"), "utf8");
+
+  assert.match(scoping, /exact `jskit generate crud-server-generator scaffold \.\.\.` command/);
+  assert.match(scoping, /Do not plan a separate hand-written CRUD migration/);
+
+  assert.match(featureDelivery, /Create the real table directly in the database before scaffolding/);
+  assert.match(featureDelivery, /do not hand-write a separate migration for that CRUD table/);
+  assert.match(featureDelivery, /Scaffold the server side first with `crud-server-generator`, even if no CRUD UI will be created yet/);
+  assert.match(featureDelivery, /Do not hand-build CRUD routes, CRUD endpoints, or CRUD page trees before `crud-server-generator` has created the server package and shared resource file/);
+
+  assert.match(review, /was `crud-server-generator scaffold` used before any CRUD UI or CRUD route hand-coding/);
+  assert.match(review, /avoid a separate hand-written CRUD migration/);
+
+  assert.match(patternIndex, /crud scaffold, crud server, crud ui, table creation, migrations/);
+  assert.match(pattern, /^# CRUD Scaffolding Patterns$/m);
+  assert.match(pattern, /start with `jskit generate crud-server-generator scaffold \.\.\.`/);
+  assert.match(pattern, /do not hand-write a separate CRUD migration/);
+  assert.match(pattern, /Do not scaffold CRUD UI, hand-build CRUD routes, or hand-build CRUD endpoints before the server CRUD package and shared resource file exist/);
+});

--- a/packages/agent-docs/test/verticalSliceGuidance.test.js
+++ b/packages/agent-docs/test/verticalSliceGuidance.test.js
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+test("workflow and blueprint require vertical-slice chunk planning", async () => {
+  const featureDelivery = await readFile(path.join(packageRoot, "workflow/feature-delivery.md"), "utf8");
+  const blueprintTemplate = await readFile(path.join(packageRoot, "templates/APP_BLUEPRINT.md"), "utf8");
+
+  assert.match(featureDelivery, /Prefer vertical slices/);
+  assert.match(featureDelivery, /user-visible or end-to-end outcome/);
+  assert.match(featureDelivery, /Avoid horizontal plans like "database first, then routes, then UI"/);
+
+  assert.match(blueprintTemplate, /Prefer vertical slices that produce visible or end-to-end progress/);
+});

--- a/packages/agent-docs/workflow/feature-delivery.md
+++ b/packages/agent-docs/workflow/feature-delivery.md
@@ -7,7 +7,9 @@ Chunk rules:
 - One CRUD is usually one chunk.
 - Platform setup, shell/navigation, and cross-cutting integrations may be separate chunks.
 - A chunk must be independently reviewable and testable.
+- Prefer vertical slices. A chunk should usually produce a user-visible or end-to-end outcome, not just a hidden layer-only milestone.
 - If a chunk is too broad to review confidently, split it before coding.
+- Avoid horizontal plans like "database first, then routes, then UI" unless the work is foundational platform setup that genuinely cannot be sliced vertically yet.
 
 For each chunk, follow this order:
 
@@ -18,6 +20,7 @@ For each chunk, follow this order:
    - generator scaffolding
    - custom local code
    - or a combination
+   Record the exact `jskit` commands that will be used if generators or package installs apply.
 4. Implement the smallest correct change.
 5. Deslop the chunk.
 6. Review the chunk against JSKIT reuse and best practices.
@@ -29,11 +32,12 @@ For each chunk, follow this order:
 For CRUD chunks:
 
 1. Decide the table shape first.
-2. If `crud-server-generator` is going to own the CRUD schema, do not hand-write a separate migration for that CRUD table.
-3. Scaffold the server side first with `crud-server-generator`.
-4. Only after the shared resource file exists, scaffold the client side against that resource.
-5. Treat that shared resource file as the canonical CRUD definition. Put field and ownership changes there instead of hand-duplicating derived CRUD validators elsewhere.
-6. Do not guess CRUD operations or screen shape. Ask the developer:
+2. Create the real table directly in the database before scaffolding. `crud-server-generator` reads the live table shape; it does not invent the table for you.
+3. If `crud-server-generator` is going to own the CRUD schema, do not hand-write a separate migration for that CRUD table. The server generator installs and manages the CRUD migration scaffold itself.
+4. Scaffold the server side first with `crud-server-generator`, even if no CRUD UI will be created yet.
+5. Only after the shared resource file exists, scaffold the client side against that resource.
+6. Treat that shared resource file as the canonical CRUD definition. Put field and ownership changes there instead of hand-duplicating derived CRUD validators elsewhere.
+7. Do not guess CRUD operations or screen shape. Ask the developer:
    - which operations are allowed
    - which fields belong in the list view if one exists
    - what the view form should look like
@@ -45,8 +49,13 @@ During implementation:
 - If a selected JSKIT package already ships the required baseline workflow, install and verify that workflow before inventing custom code around it.
 - Ask only about overrides, restrictions, or app-specific additions to packaged baseline workflows.
 - Use generated CRUD/UI scaffolds only after the route and ownership model are decided.
+- Do not hand-build CRUD routes, CRUD endpoints, or CRUD page trees before `crud-server-generator` has created the server package and shared resource file.
+- For app-owned non-CRUD route pages, default to `jskit generate ui-generator page ...` instead of hand-writing both `src/pages/...` and `src/placement.js`.
+- Before hand-writing a route page or placement entry, check `jskit show ui-generator --details` and `jskit list-placements`.
+- If `ui-generator page` applies and you still choose not to use it, stop and explain the exact gap before coding.
 - Keep runtime, UI, and data concerns separated.
 - Avoid “while I’m here” scope creep unless it is required for correctness.
+- Do not turn a small placeholder or route stub into a copy-polish or blueprint-rewrite task unless the developer asked for that broader work.
 
 After the last chunk:
 

--- a/packages/agent-docs/workflow/review.md
+++ b/packages/agent-docs/workflow/review.md
@@ -20,6 +20,9 @@ Before calling a chunk or a whole changeset done, review it in four passes:
    - existing helper/runtime seam available?
    - duplicate local code that should reuse kernel/runtime support?
    - should this have been a package install, generator step, or scaffold extension instead of hand code?
+   - if a generator existed, was the exact `jskit` command used or was the gap documented clearly before hand-coding?
+   - for CRUD work, was `crud-server-generator scaffold` used before any CRUD UI or CRUD route hand-coding?
+   - for CRUD tables owned by JSKIT, did the change avoid a separate hand-written CRUD migration?
    - are surface, route, ownership, and migration choices aligned with JSKIT conventions?
    - package metadata and actual behavior still aligned?
 3. UI standards review

--- a/packages/agent-docs/workflow/scoping.md
+++ b/packages/agent-docs/workflow/scoping.md
@@ -30,11 +30,16 @@ Scoping rules:
 
 - Use `guide/agent/index.md` for fast navigation and `site/guide/index.md` for exact details.
 - Inspect packages and generators before choosing them.
+- Make the generator plan concrete. Name the exact `jskit` commands expected for the chunk, not just a package or a general idea.
+- For non-CRUD route page work, check `jskit show ui-generator --details` and `jskit list-placements` before deciding that custom page or placement code is necessary.
+- For CRUD work, make the server-first plan explicit. Name the exact `jskit generate crud-server-generator scaffold ...` command before any CRUD UI plan.
+- If a CRUD will be owned by `crud-server-generator`, plan around a real table that already exists in the database. Do not plan a separate hand-written CRUD migration for that table.
 - Decide ownership early; do not treat it as a UI-only detail.
 - If Stage 1 platform choices are still provisional, finish them before installing tenancy-sensitive runtime packages.
 - Record which selected JSKIT package-owned workflows are accepted as baseline and which, if any, need custom behavior.
 - Do not ask the developer to redesign package-owned baseline workflows from scratch. Ask only whether the default behavior is accepted or whether the app needs overrides, restrictions, or extensions.
 - Create or refresh `.jskit/WORKBOARD.md` for substantial or multi-chunk work so the request has an explicit execution tracker.
+- Do not rewrite `.jskit/APP_BLUEPRINT.md` for a one-off placeholder page inside an already planned route family unless the durable route plan, surface plan, or ownership model changed.
 - Break delivery into chunks that can be independently reviewed and tested.
 - One CRUD is usually one chunk. Platform setup, shell work, and cross-cutting integrations may also be separate chunks.
 - For each CRUD chunk, decide these before implementation:

--- a/packages/assistant-core/package.descriptor.mjs
+++ b/packages/assistant-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-core",
-  version: "0.1.36",
+  version: "0.1.37",
   kind: "runtime",
   description: "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
   dependsOn: [
@@ -47,11 +47,11 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/http-runtime": "0.1.59",
-        "@jskit-ai/kernel": "0.1.60",
-        "@jskit-ai/resource-core": "0.1.5",
-        "@jskit-ai/resource-crud-core": "0.1.5",
-        "@jskit-ai/users-core": "0.1.70",
+        "@jskit-ai/http-runtime": "0.1.60",
+        "@jskit-ai/kernel": "0.1.61",
+        "@jskit-ai/resource-core": "0.1.6",
+        "@jskit-ai/resource-crud-core": "0.1.6",
+        "@jskit-ai/users-core": "0.1.71",
         "@tanstack/vue-query": "^5.90.5",
         "dompurify": "^3.3.3",
         "json-rest-schema": "1.x.x",

--- a/packages/assistant-core/package.json
+++ b/packages/assistant-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-core",
-  "version": "0.1.36",
+  "version": "0.1.37",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,12 +11,12 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.60",
-    "@jskit-ai/http-runtime": "0.1.59",
-    "@jskit-ai/kernel": "0.1.60",
-    "@jskit-ai/resource-crud-core": "0.1.5",
-    "@jskit-ai/resource-core": "0.1.5",
-    "@jskit-ai/users-core": "0.1.70",
+    "@jskit-ai/database-runtime": "0.1.61",
+    "@jskit-ai/http-runtime": "0.1.60",
+    "@jskit-ai/kernel": "0.1.61",
+    "@jskit-ai/resource-crud-core": "0.1.6",
+    "@jskit-ai/resource-core": "0.1.6",
+    "@jskit-ai/users-core": "0.1.71",
     "@tanstack/vue-query": "^5.90.5",
     "dompurify": "^3.3.3",
     "json-rest-schema": "1.x.x",

--- a/packages/assistant-runtime/package.descriptor.mjs
+++ b/packages/assistant-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-runtime",
-  version: "0.1.31",
+  version: "0.1.32",
   kind: "runtime",
   description: "Shared assistant runtime with per-surface assistant registration.",
   dependsOn: [
@@ -74,13 +74,13 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/assistant-core": "0.1.36",
-        "@jskit-ai/database-runtime": "0.1.60",
-        "@jskit-ai/http-runtime": "0.1.59",
-        "@jskit-ai/kernel": "0.1.60",
-        "@jskit-ai/shell-web": "0.1.59",
-        "@jskit-ai/users-core": "0.1.70",
-        "@jskit-ai/users-web": "0.1.75",
+        "@jskit-ai/assistant-core": "0.1.37",
+        "@jskit-ai/database-runtime": "0.1.61",
+        "@jskit-ai/http-runtime": "0.1.60",
+        "@jskit-ai/kernel": "0.1.61",
+        "@jskit-ai/shell-web": "0.1.60",
+        "@jskit-ai/users-core": "0.1.71",
+        "@jskit-ai/users-web": "0.1.76",
         "@tanstack/vue-query": "^5.90.5",
         "vuetify": "^4.0.0"
       },

--- a/packages/assistant-runtime/package.json
+++ b/packages/assistant-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-runtime",
-  "version": "0.1.31",
+  "version": "0.1.32",
   "type": "module",
   "exports": {
     "./client": "./src/client/index.js",
@@ -8,13 +8,13 @@
     "./server/actionIds": "./src/server/actionIds.js"
   },
   "dependencies": {
-    "@jskit-ai/assistant-core": "0.1.36",
-    "@jskit-ai/database-runtime": "0.1.60",
-    "@jskit-ai/http-runtime": "0.1.59",
-    "@jskit-ai/kernel": "0.1.60",
-    "@jskit-ai/shell-web": "0.1.59",
-    "@jskit-ai/users-core": "0.1.70",
-    "@jskit-ai/users-web": "0.1.75",
+    "@jskit-ai/assistant-core": "0.1.37",
+    "@jskit-ai/database-runtime": "0.1.61",
+    "@jskit-ai/http-runtime": "0.1.60",
+    "@jskit-ai/kernel": "0.1.61",
+    "@jskit-ai/shell-web": "0.1.60",
+    "@jskit-ai/users-core": "0.1.71",
+    "@jskit-ai/users-web": "0.1.76",
     "json-rest-schema": "1.x.x",
     "@tanstack/vue-query": "^5.90.5",
     "vuetify": "^4.0.0"

--- a/packages/assistant/package.descriptor.mjs
+++ b/packages/assistant/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant",
-  version: "0.1.69",
+  version: "0.1.70",
   kind: "generator",
   description: "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
   options: {

--- a/packages/assistant/package.json
+++ b/packages/assistant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant",
-  "version": "0.1.69",
+  "version": "0.1.70",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.60"
+    "@jskit-ai/kernel": "0.1.61"
   }
 }

--- a/packages/auth-core/package.descriptor.mjs
+++ b/packages/auth-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-core",
-  "version": "0.1.59",
+  "version": "0.1.60",
   "kind": "runtime",
   "dependsOn": [
     "@jskit-ai/value-app-config-shared"
@@ -69,7 +69,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.60",
+        "@jskit-ai/kernel": "0.1.61",
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0"

--- a/packages/auth-core/package.json
+++ b/packages/auth-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-core",
-  "version": "0.1.59",
+  "version": "0.1.60",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -46,7 +46,7 @@
     "./shared/commands/authSessionReadCommand": "./src/shared/commands/authSessionReadCommand.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.60",
+    "@jskit-ai/kernel": "0.1.61",
     "@fastify/cookie": "^11.0.2",
     "@fastify/csrf-protection": "^7.1.0",
     "@fastify/rate-limit": "^10.3.0",

--- a/packages/auth-provider-supabase-core/package.descriptor.mjs
+++ b/packages/auth-provider-supabase-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.59",
+  "version": "0.1.60",
   "kind": "runtime",
   "options": {
     "auth-supabase-url": {
@@ -83,8 +83,8 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/auth-core": "0.1.59",
-        "@jskit-ai/kernel": "0.1.60",
+        "@jskit-ai/auth-core": "0.1.60",
+        "@jskit-ai/kernel": "0.1.61",
         "dotenv": "^16.4.5",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0"

--- a/packages/auth-provider-supabase-core/package.json
+++ b/packages/auth-provider-supabase-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.59",
+  "version": "0.1.60",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,8 +12,8 @@
     "./client": "./src/client/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.59",
-    "@jskit-ai/kernel": "0.1.60",
+    "@jskit-ai/auth-core": "0.1.60",
+    "@jskit-ai/kernel": "0.1.61",
     "json-rest-schema": "1.x.x",
     "jose": "^6.1.0",
     "@supabase/supabase-js": "^2.57.4",

--- a/packages/auth-web/package.descriptor.mjs
+++ b/packages/auth-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-web",
-  "version": "0.1.61",
+  "version": "0.1.62",
   "kind": "runtime",
   "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
   "dependsOn": [
@@ -219,10 +219,10 @@ export default Object.freeze({
       "runtime": {
         "@tanstack/vue-query": "5.92.12",
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/auth-core": "0.1.59",
-        "@jskit-ai/http-runtime": "0.1.59",
-        "@jskit-ai/kernel": "0.1.60",
-        "@jskit-ai/shell-web": "0.1.59",
+        "@jskit-ai/auth-core": "0.1.60",
+        "@jskit-ai/http-runtime": "0.1.60",
+        "@jskit-ai/kernel": "0.1.61",
+        "@jskit-ai/shell-web": "0.1.60",
         "vuetify": "^4.0.0"
       },
       "dev": {}

--- a/packages/auth-web/package.json
+++ b/packages/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-web",
-  "version": "0.1.61",
+  "version": "0.1.62",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -18,13 +18,13 @@
   },
   "dependencies": {
     "@tanstack/vue-query": "^5.90.5",
-    "@jskit-ai/auth-core": "0.1.59",
+    "@jskit-ai/auth-core": "0.1.60",
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/kernel": "0.1.60",
-    "@jskit-ai/shell-web": "0.1.59",
+    "@jskit-ai/kernel": "0.1.61",
+    "@jskit-ai/shell-web": "0.1.60",
     "pinia": "^3.0.4",
     "vuetify": "^4.0.0",
-    "@jskit-ai/http-runtime": "0.1.59"
+    "@jskit-ai/http-runtime": "0.1.60"
   },
   "peerDependencies": {
     "vue": "^3.5.13",

--- a/packages/console-core/package.descriptor.mjs
+++ b/packages/console-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-core",
-  version: "0.1.23",
+  version: "0.1.24",
   kind: "runtime",
   description: "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
   dependsOn: [
@@ -74,12 +74,12 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.59",
-        "@jskit-ai/database-runtime": "0.1.60",
-        "@jskit-ai/http-runtime": "0.1.59",
-        "@jskit-ai/kernel": "0.1.60",
-        "@jskit-ai/resource-crud-core": "0.1.5",
-        "@jskit-ai/users-core": "0.1.70"
+        "@jskit-ai/auth-core": "0.1.60",
+        "@jskit-ai/database-runtime": "0.1.61",
+        "@jskit-ai/http-runtime": "0.1.60",
+        "@jskit-ai/kernel": "0.1.61",
+        "@jskit-ai/resource-crud-core": "0.1.6",
+        "@jskit-ai/users-core": "0.1.71"
       },
       dev: {}
     },

--- a/packages/console-core/package.json
+++ b/packages/console-core/package.json
@@ -1,17 +1,17 @@
 {
   "name": "@jskit-ai/console-core",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.59",
-    "@jskit-ai/database-runtime": "0.1.60",
-    "@jskit-ai/http-runtime": "0.1.59",
-    "@jskit-ai/kernel": "0.1.60",
-    "@jskit-ai/resource-crud-core": "0.1.5",
-    "@jskit-ai/users-core": "0.1.70",
+    "@jskit-ai/auth-core": "0.1.60",
+    "@jskit-ai/database-runtime": "0.1.61",
+    "@jskit-ai/http-runtime": "0.1.60",
+    "@jskit-ai/kernel": "0.1.61",
+    "@jskit-ai/resource-crud-core": "0.1.6",
+    "@jskit-ai/users-core": "0.1.71",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/console-web/package.descriptor.mjs
+++ b/packages/console-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-web",
-  version: "0.1.28",
+  version: "0.1.29",
   kind: "runtime",
   description: "Authenticated console surface scaffold and surface policy wiring.",
   dependsOn: [
@@ -74,9 +74,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-web": "0.1.61",
-        "@jskit-ai/console-core": "0.1.23",
-        "@jskit-ai/shell-web": "0.1.59",
+        "@jskit-ai/auth-web": "0.1.62",
+        "@jskit-ai/console-core": "0.1.24",
+        "@jskit-ai/shell-web": "0.1.60",
       },
       dev: {}
     },

--- a/packages/console-web/package.json
+++ b/packages/console-web/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/console-web",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-web": "0.1.61",
-    "@jskit-ai/console-core": "0.1.23",
-    "@jskit-ai/shell-web": "0.1.59"
+    "@jskit-ai/auth-web": "0.1.62",
+    "@jskit-ai/console-core": "0.1.24",
+    "@jskit-ai/shell-web": "0.1.60"
   }
 }

--- a/packages/crud-core/package.descriptor.mjs
+++ b/packages/crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-core",
-  version: "0.1.68",
+  version: "0.1.69",
   kind: "runtime",
   description: "Shared CRUD helpers used by CRUD modules.",
   dependsOn: [
@@ -28,7 +28,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/crud-core": "0.1.68"
+        "@jskit-ai/crud-core": "0.1.69"
       },
       dev: {}
     },

--- a/packages/crud-core/package.json
+++ b/packages/crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-core",
-  "version": "0.1.68",
+  "version": "0.1.69",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -28,15 +28,15 @@
   },
   "dependencies": {
     "@tanstack/vue-query": "^5.90.5",
-    "@jskit-ai/database-runtime": "0.1.60",
-    "@jskit-ai/http-runtime": "0.1.59",
-    "@jskit-ai/kernel": "0.1.60",
+    "@jskit-ai/database-runtime": "0.1.61",
+    "@jskit-ai/http-runtime": "0.1.60",
+    "@jskit-ai/kernel": "0.1.61",
     "json-rest-schema": "1.x.x",
-    "@jskit-ai/realtime": "0.1.59",
-    "@jskit-ai/resource-crud-core": "0.1.5",
-    "@jskit-ai/shell-web": "0.1.59",
-    "@jskit-ai/users-core": "0.1.70",
-    "@jskit-ai/users-web": "0.1.75"
+    "@jskit-ai/realtime": "0.1.60",
+    "@jskit-ai/resource-crud-core": "0.1.6",
+    "@jskit-ai/shell-web": "0.1.60",
+    "@jskit-ai/users-core": "0.1.71",
+    "@jskit-ai/users-web": "0.1.76"
   },
   "peerDependencies": {
     "vue": "^3.5.13",

--- a/packages/crud-server-generator/package.descriptor.mjs
+++ b/packages/crud-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-server-generator",
-  version: "0.1.68",
+  version: "0.1.69",
   kind: "generator",
   description: "CRUD server generator with routes, actions, and persistence scaffolding.",
   options: {
@@ -152,14 +152,14 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.59",
-        "@jskit-ai/crud-core": "0.1.68",
-        "@jskit-ai/database-runtime": "0.1.60",
-        "@jskit-ai/http-runtime": "0.1.59",
-        "@jskit-ai/json-rest-api-core": "0.1.5",
-        "@jskit-ai/kernel": "0.1.60",
-        "@jskit-ai/realtime": "0.1.59",
-        "@jskit-ai/resource-crud-core": "0.1.5",
+        "@jskit-ai/auth-core": "0.1.60",
+        "@jskit-ai/crud-core": "0.1.69",
+        "@jskit-ai/database-runtime": "0.1.61",
+        "@jskit-ai/http-runtime": "0.1.60",
+        "@jskit-ai/json-rest-api-core": "0.1.6",
+        "@jskit-ai/kernel": "0.1.61",
+        "@jskit-ai/realtime": "0.1.60",
+        "@jskit-ai/resource-crud-core": "0.1.6",
         "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}"
       },
       dev: {}

--- a/packages/crud-server-generator/package.json
+++ b/packages/crud-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-server-generator",
-  "version": "0.1.68",
+  "version": "0.1.69",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,12 +13,12 @@
   },
   "dependencies": {
     "@babel/parser": "^7.29.2",
-    "@jskit-ai/crud-core": "0.1.68",
-    "@jskit-ai/database-runtime": "0.1.60",
-    "@jskit-ai/http-runtime": "0.1.59",
-    "@jskit-ai/json-rest-api-core": "0.1.5",
-    "@jskit-ai/kernel": "0.1.60",
-    "@jskit-ai/resource-crud-core": "0.1.5",
+    "@jskit-ai/crud-core": "0.1.69",
+    "@jskit-ai/database-runtime": "0.1.61",
+    "@jskit-ai/http-runtime": "0.1.60",
+    "@jskit-ai/json-rest-api-core": "0.1.6",
+    "@jskit-ai/kernel": "0.1.61",
+    "@jskit-ai/resource-crud-core": "0.1.6",
     "recast": "^0.23.11"
   }
 }

--- a/packages/crud-ui-generator/package.descriptor.mjs
+++ b/packages/crud-ui-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-ui-generator",
-  version: "0.1.43",
+  version: "0.1.44",
   kind: "generator",
   description: "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
   options: {
@@ -180,7 +180,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.75"
+        "@jskit-ai/users-web": "0.1.76"
       },
       dev: {}
     },

--- a/packages/crud-ui-generator/package.json
+++ b/packages/crud-ui-generator/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@jskit-ai/crud-ui-generator",
-  "version": "0.1.43",
+  "version": "0.1.44",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/crud-core": "0.1.68",
-    "@jskit-ai/kernel": "0.1.60",
-    "@jskit-ai/resource-crud-core": "0.1.5"
+    "@jskit-ai/crud-core": "0.1.69",
+    "@jskit-ai/kernel": "0.1.61",
+    "@jskit-ai/resource-crud-core": "0.1.6"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/database-runtime-mysql/package.descriptor.mjs
+++ b/packages/database-runtime-mysql/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-mysql",
-  version: "0.1.59",
+  version: "0.1.60",
   kind: "runtime",
   options: {
     "db-host": {
@@ -91,7 +91,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.60",
+        "@jskit-ai/database-runtime": "0.1.61",
         "mysql2": "^3.11.2"
       },
       dev: {}

--- a/packages/database-runtime-mysql/package.json
+++ b/packages/database-runtime-mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-mysql",
-  "version": "0.1.59",
+  "version": "0.1.60",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,7 +12,7 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.60",
-    "@jskit-ai/kernel": "0.1.60"
+    "@jskit-ai/database-runtime": "0.1.61",
+    "@jskit-ai/kernel": "0.1.61"
   }
 }

--- a/packages/database-runtime-postgres/package.descriptor.mjs
+++ b/packages/database-runtime-postgres/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-postgres",
-  version: "0.1.59",
+  version: "0.1.60",
   kind: "runtime",
   options: {
     "db-host": {
@@ -91,7 +91,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.60",
+        "@jskit-ai/database-runtime": "0.1.61",
         "pg": "^8.13.1"
       },
       dev: {}

--- a/packages/database-runtime-postgres/package.json
+++ b/packages/database-runtime-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-postgres",
-  "version": "0.1.59",
+  "version": "0.1.60",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,6 +12,6 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.60"
+    "@jskit-ai/database-runtime": "0.1.61"
   }
 }

--- a/packages/database-runtime/package.descriptor.mjs
+++ b/packages/database-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime",
-  version: "0.1.60",
+  version: "0.1.61",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -58,7 +58,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.60",
+        "@jskit-ai/kernel": "0.1.61",
         "dotenv": "^16.4.5",
         "knex": "^3.1.0"
       },

--- a/packages/database-runtime/package.json
+++ b/packages/database-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime",
-  "version": "0.1.60",
+  "version": "0.1.61",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -25,6 +25,6 @@
     "./shared/transactions": "./src/shared/transactions.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.60"
+    "@jskit-ai/kernel": "0.1.61"
   }
 }

--- a/packages/feature-server-generator/package.descriptor.mjs
+++ b/packages/feature-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/feature-server-generator",
-  version: "0.1.2",
+  version: "0.1.3",
   kind: "generator",
   description: "Scaffold substantial non-CRUD server feature packages with provider, actions, service, and optional persistence seams.",
   options: {
@@ -153,10 +153,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.60",
-        "@jskit-ai/database-runtime-mysql": "0.1.59",
-        "@jskit-ai/json-rest-api-core": "0.1.5",
-        "@jskit-ai/kernel": "0.1.60",
+        "@jskit-ai/database-runtime": "0.1.61",
+        "@jskit-ai/database-runtime-mysql": "0.1.60",
+        "@jskit-ai/json-rest-api-core": "0.1.6",
+        "@jskit-ai/kernel": "0.1.61",
         "json-rest-schema": "1.x.x",
         "@local/${option:feature-name|kebab}": "file:packages/${option:feature-name|kebab}"
       },

--- a/packages/feature-server-generator/package.json
+++ b/packages/feature-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/feature-server-generator",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "module",
   "scripts": {
     "test": "node --test"

--- a/packages/http-runtime/package.descriptor.mjs
+++ b/packages/http-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/http-runtime",
-  "version": "0.1.59",
+  "version": "0.1.60",
   "kind": "runtime",
   "dependsOn": [],
   "capabilities": {
@@ -67,7 +67,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.60"
+        "@jskit-ai/kernel": "0.1.61"
       },
       "dev": {}
     },

--- a/packages/http-runtime/package.json
+++ b/packages/http-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/http-runtime",
-  "version": "0.1.59",
+  "version": "0.1.60",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -18,7 +18,7 @@
     "./shared/validators/operationValidation": "./src/shared/validators/operationValidation.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.60",
+    "@jskit-ai/kernel": "0.1.61",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/json-rest-api-core/package.descriptor.mjs
+++ b/packages/json-rest-api-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/json-rest-api-core",
-  version: "0.1.5",
+  version: "0.1.6",
   kind: "runtime",
   description: "Shared internal json-rest-api host runtime for JSKIT server packages.",
   dependsOn: [

--- a/packages/json-rest-api-core/package.json
+++ b/packages/json-rest-api-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/json-rest-api-core",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,6 +11,6 @@
   "dependencies": {
     "hooked-api": "1.x.x",
     "json-rest-api": "1.x.x",
-    "@jskit-ai/kernel": "0.1.60"
+    "@jskit-ai/kernel": "0.1.61"
   }
 }

--- a/packages/json-rest-api-core/src/server/jsonRestApiHost.js
+++ b/packages/json-rest-api-core/src/server/jsonRestApiHost.js
@@ -370,7 +370,9 @@ async function createJsonRestApiHost({ knex }) {
 
   const api = new Api({
     name: "jskit-internal-json-rest-api",
-    logLevel: "error"
+    logging: {
+      level: "error"
+    }
   });
 
   await api.use(RestApiPlugin, {

--- a/packages/json-rest-api-core/test/entrypoints.boundary.test.js
+++ b/packages/json-rest-api-core/test/entrypoints.boundary.test.js
@@ -133,6 +133,30 @@ test("createJsonRestApiHost installs normalizeRecordId as the default resource i
   assert.equal(api.vars.normalizeId(7.5), null);
 });
 
+test("createJsonRestApiHost configures the internal json-rest logger at error level", async () => {
+  const fakeKnex = Object.assign(() => {}, {
+    client: {
+      config: {
+        client: "sqlite3"
+      }
+    },
+    async raw() {
+      return [
+        {
+          version: "3.35.5"
+        }
+      ];
+    },
+    transaction() {}
+  });
+
+  const api = await createJsonRestApiHost({
+    knex: fakeKnex
+  });
+
+  assert.equal(api.options.logging.level, "error");
+});
+
 test("shared query/document helpers build json-rest-api request shapes", () => {
   assert.deepEqual(
     buildJsonRestQueryParams("contacts", {

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/kernel",
-  "version": "0.1.60",
+  "version": "0.1.61",
   "type": "module",
   "dependencies": {
     "json-rest-schema": "1.x.x"

--- a/packages/realtime/package.descriptor.mjs
+++ b/packages/realtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/realtime",
-  version: "0.1.59",
+  version: "0.1.60",
   kind: "runtime",
   description: "Thin, generic realtime runtime wrappers for socket.io server and client.",
   options: {
@@ -94,7 +94,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.60",
+        "@jskit-ai/kernel": "0.1.61",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/realtime",
-  "version": "0.1.59",
+  "version": "0.1.60",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@socket.io/redis-adapter": "^8.3.0",
-    "@jskit-ai/kernel": "0.1.60",
+    "@jskit-ai/kernel": "0.1.61",
     "redis": "^5.8.2",
     "socket.io": "^4.8.3",
     "socket.io-client": "^4.8.3"

--- a/packages/resource-core/package.descriptor.mjs
+++ b/packages/resource-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/resource-core",
-  version: "0.1.5",
+  version: "0.1.6",
   kind: "runtime",
   description: "Generic resource-definition helpers and schema-definition normalization.",
   dependsOn: [
@@ -22,7 +22,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/resource-core": "0.1.5"
+        "@jskit-ai/resource-core": "0.1.6"
       },
       dev: {}
     },

--- a/packages/resource-core/package.json
+++ b/packages/resource-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/resource-core",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./shared/resource": "./src/shared/resource.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.60"
+    "@jskit-ai/kernel": "0.1.61"
   }
 }

--- a/packages/resource-crud-core/package.descriptor.mjs
+++ b/packages/resource-crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/resource-crud-core",
-  version: "0.1.5",
+  version: "0.1.6",
   kind: "runtime",
   description: "CRUD-specific resource-definition helpers and namespace support.",
   dependsOn: [
@@ -23,7 +23,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/resource-crud-core": "0.1.5"
+        "@jskit-ai/resource-crud-core": "0.1.6"
       },
       dev: {}
     },

--- a/packages/resource-crud-core/package.json
+++ b/packages/resource-crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/resource-crud-core",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./shared/crudResource": "./src/shared/crudResource.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.60",
-    "@jskit-ai/resource-core": "0.1.5"
+    "@jskit-ai/kernel": "0.1.61",
+    "@jskit-ai/resource-core": "0.1.6"
   }
 }

--- a/packages/shell-web/package.descriptor.mjs
+++ b/packages/shell-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/shell-web",
-  version: "0.1.59",
+  version: "0.1.60",
   kind: "runtime",
   description: "Web shell layout runtime with outlet-based placement contributions.",
   dependsOn: [],
@@ -122,7 +122,7 @@ export default Object.freeze({
       runtime: {
         "@mdi/js": "^7.4.47",
         "@tanstack/vue-query": "^5.90.5",
-        "@jskit-ai/kernel": "0.1.60",
+        "@jskit-ai/kernel": "0.1.61",
         "vuetify": "^4.0.0"
       },
       dev: {}

--- a/packages/shell-web/package.json
+++ b/packages/shell-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/shell-web",
-  "version": "0.1.59",
+  "version": "0.1.60",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -25,7 +25,7 @@
   "dependencies": {
     "@mdi/js": "^7.4.47",
     "@tanstack/vue-query": "^5.90.5",
-    "@jskit-ai/kernel": "0.1.60",
+    "@jskit-ai/kernel": "0.1.61",
     "pinia": "^3.0.4",
     "vuetify": "^4.0.0"
   },

--- a/packages/storage-runtime/package.descriptor.mjs
+++ b/packages/storage-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/storage-runtime",
-  version: "0.1.59",
+  version: "0.1.60",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -50,7 +50,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.60",
+        "@jskit-ai/kernel": "0.1.61",
         "unstorage": "^1.17.3"
       },
       dev: {}

--- a/packages/storage-runtime/package.json
+++ b/packages/storage-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/storage-runtime",
-  "version": "0.1.59",
+  "version": "0.1.60",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./server/providers/StorageRuntimeServiceProvider": "./src/server/providers/StorageRuntimeServiceProvider.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.60",
+    "@jskit-ai/kernel": "0.1.61",
     "unstorage": "^1.17.3"
   }
 }

--- a/packages/ui-generator/package.descriptor.mjs
+++ b/packages/ui-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/ui-generator",
-  version: "0.1.43",
+  version: "0.1.44",
   kind: "generator",
   description: "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
   options: {
@@ -278,7 +278,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.75"
+        "@jskit-ai/users-web": "0.1.76"
       },
       dev: {}
     },

--- a/packages/ui-generator/package.json
+++ b/packages/ui-generator/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/ui-generator",
-  "version": "0.1.43",
+  "version": "0.1.44",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.60",
-    "@jskit-ai/shell-web": "0.1.59"
+    "@jskit-ai/kernel": "0.1.61",
+    "@jskit-ai/shell-web": "0.1.60"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/uploads-image-web/package.descriptor.mjs
+++ b/packages/uploads-image-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-image-web",
-  version: "0.1.38",
+  version: "0.1.39",
   kind: "runtime",
   description: "Reusable client-side image upload runtime with pre-upload image editing.",
   dependsOn: [
@@ -65,7 +65,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/uploads-runtime": "0.1.38",
+        "@jskit-ai/uploads-runtime": "0.1.39",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-image-web/package.json
+++ b/packages/uploads-image-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-image-web",
-  "version": "0.1.38",
+  "version": "0.1.39",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,7 +13,7 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/uploads-runtime": "0.1.38",
+    "@jskit-ai/uploads-runtime": "0.1.39",
     "@uppy/compressor": "^3.1.0",
     "@uppy/core": "^5.2.0",
     "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-runtime/package.descriptor.mjs
+++ b/packages/uploads-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-runtime",
-  version: "0.1.38",
+  version: "0.1.39",
   kind: "runtime",
   description: "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
   dependsOn: [
@@ -71,7 +71,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.60"
+        "@jskit-ai/kernel": "0.1.61"
       },
       dev: {}
     },

--- a/packages/uploads-runtime/package.json
+++ b/packages/uploads-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-runtime",
-  "version": "0.1.38",
+  "version": "0.1.39",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,6 +16,6 @@
   },
   "dependencies": {
     "@fastify/multipart": "^9.4.0",
-    "@jskit-ai/kernel": "0.1.60"
+    "@jskit-ai/kernel": "0.1.61"
   }
 }

--- a/packages/users-core/package.descriptor.mjs
+++ b/packages/users-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-core",
-  version: "0.1.70",
+  version: "0.1.71",
   kind: "runtime",
   description: "Users/account runtime plus HTTP routes for account features.",
   dependsOn: [
@@ -132,16 +132,16 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.59",
-        "@jskit-ai/crud-core": "0.1.68",
-        "@jskit-ai/database-runtime": "0.1.60",
-        "@jskit-ai/http-runtime": "0.1.59",
-        "@jskit-ai/json-rest-api-core": "0.1.5",
-        "@jskit-ai/kernel": "0.1.60",
-        "@jskit-ai/resource-core": "0.1.5",
-        "@jskit-ai/resource-crud-core": "0.1.5",
+        "@jskit-ai/auth-core": "0.1.60",
+        "@jskit-ai/crud-core": "0.1.69",
+        "@jskit-ai/database-runtime": "0.1.61",
+        "@jskit-ai/http-runtime": "0.1.60",
+        "@jskit-ai/json-rest-api-core": "0.1.6",
+        "@jskit-ai/kernel": "0.1.61",
+        "@jskit-ai/resource-core": "0.1.6",
+        "@jskit-ai/resource-crud-core": "0.1.6",
         "@local/users": "file:packages/users",
-        "@jskit-ai/uploads-runtime": "0.1.38"
+        "@jskit-ai/uploads-runtime": "0.1.39"
       },
       dev: {}
     },

--- a/packages/users-core/package.json
+++ b/packages/users-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-core",
-  "version": "0.1.70",
+  "version": "0.1.71",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,14 +11,14 @@
     "./shared/resources/userSettingsResource": "./src/shared/resources/userSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.59",
-    "@jskit-ai/database-runtime": "0.1.60",
-    "@jskit-ai/http-runtime": "0.1.59",
-    "@jskit-ai/json-rest-api-core": "0.1.5",
-    "@jskit-ai/kernel": "0.1.60",
-    "@jskit-ai/resource-crud-core": "0.1.5",
-    "@jskit-ai/resource-core": "0.1.5",
-    "@jskit-ai/uploads-runtime": "0.1.38",
+    "@jskit-ai/auth-core": "0.1.60",
+    "@jskit-ai/database-runtime": "0.1.61",
+    "@jskit-ai/http-runtime": "0.1.60",
+    "@jskit-ai/json-rest-api-core": "0.1.6",
+    "@jskit-ai/kernel": "0.1.61",
+    "@jskit-ai/resource-crud-core": "0.1.6",
+    "@jskit-ai/resource-core": "0.1.6",
+    "@jskit-ai/uploads-runtime": "0.1.39",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/users-web/package.descriptor.mjs
+++ b/packages/users-web/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { HOME_COG_OUTLET } from "./src/shared/toolsOutletContracts.js";
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-web",
-  version: "0.1.75",
+  version: "0.1.76",
   kind: "runtime",
   description: "Users web module: account/profile UI plus shared users web widgets.",
   dependsOn: [
@@ -183,12 +183,12 @@ export default Object.freeze({
       runtime: {
         "@tanstack/vue-query": "5.92.12",
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/http-runtime": "0.1.59",
-        "@jskit-ai/realtime": "0.1.59",
-        "@jskit-ai/kernel": "0.1.60",
-        "@jskit-ai/shell-web": "0.1.59",
-        "@jskit-ai/uploads-image-web": "0.1.38",
-        "@jskit-ai/users-core": "0.1.70",
+        "@jskit-ai/http-runtime": "0.1.60",
+        "@jskit-ai/realtime": "0.1.60",
+        "@jskit-ai/kernel": "0.1.61",
+        "@jskit-ai/shell-web": "0.1.60",
+        "@jskit-ai/uploads-image-web": "0.1.39",
+        "@jskit-ai/users-core": "0.1.71",
         vuetify: "^4.0.0"
       },
       dev: {}

--- a/packages/users-web/package.json
+++ b/packages/users-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-web",
-  "version": "0.1.75",
+  "version": "0.1.76",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -34,12 +34,12 @@
   "dependencies": {
     "@tanstack/vue-query": "5.92.12",
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/http-runtime": "0.1.59",
-    "@jskit-ai/kernel": "0.1.60",
-    "@jskit-ai/realtime": "0.1.59",
-    "@jskit-ai/shell-web": "0.1.59",
-    "@jskit-ai/uploads-image-web": "0.1.38",
-    "@jskit-ai/users-core": "0.1.70",
+    "@jskit-ai/http-runtime": "0.1.60",
+    "@jskit-ai/kernel": "0.1.61",
+    "@jskit-ai/realtime": "0.1.60",
+    "@jskit-ai/shell-web": "0.1.60",
+    "@jskit-ai/uploads-image-web": "0.1.39",
+    "@jskit-ai/users-core": "0.1.71",
     "vuetify": "^4.0.0"
   },
   "peerDependencies": {

--- a/packages/workspaces-core/package.descriptor.mjs
+++ b/packages/workspaces-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-core",
-  version: "0.1.36",
+  version: "0.1.37",
   kind: "runtime",
   description: "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
   dependsOn: [
@@ -116,10 +116,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/json-rest-api-core": "0.1.5",
-        "@jskit-ai/resource-core": "0.1.5",
-        "@jskit-ai/resource-crud-core": "0.1.5",
-        "@jskit-ai/users-core": "0.1.70"
+        "@jskit-ai/json-rest-api-core": "0.1.6",
+        "@jskit-ai/resource-core": "0.1.6",
+        "@jskit-ai/resource-crud-core": "0.1.6",
+        "@jskit-ai/users-core": "0.1.71"
       },
       dev: {}
     },

--- a/packages/workspaces-core/package.json
+++ b/packages/workspaces-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-core",
-  "version": "0.1.36",
+  "version": "0.1.37",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -17,14 +17,14 @@
     "./shared/resources/workspaceSettingsResource": "./src/shared/resources/workspaceSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.59",
-    "@jskit-ai/database-runtime": "0.1.60",
-    "@jskit-ai/http-runtime": "0.1.59",
-    "@jskit-ai/json-rest-api-core": "0.1.5",
-    "@jskit-ai/kernel": "0.1.60",
-    "@jskit-ai/resource-crud-core": "0.1.5",
-    "@jskit-ai/resource-core": "0.1.5",
-    "@jskit-ai/users-core": "0.1.70",
+    "@jskit-ai/auth-core": "0.1.60",
+    "@jskit-ai/database-runtime": "0.1.61",
+    "@jskit-ai/http-runtime": "0.1.60",
+    "@jskit-ai/json-rest-api-core": "0.1.6",
+    "@jskit-ai/kernel": "0.1.61",
+    "@jskit-ai/resource-crud-core": "0.1.6",
+    "@jskit-ai/resource-core": "0.1.6",
+    "@jskit-ai/users-core": "0.1.71",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/workspaces-web/package.descriptor.mjs
+++ b/packages/workspaces-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-web",
-  version: "0.1.36",
+  version: "0.1.37",
   kind: "runtime",
   description: "Workspace web module: workspace selector, tools widget, workspace surfaces, and members/settings UI.",
   dependsOn: [
@@ -166,8 +166,8 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/workspaces-core": "0.1.36",
-        "@jskit-ai/users-web": "0.1.75",
+        "@jskit-ai/workspaces-core": "0.1.37",
+        "@jskit-ai/users-web": "0.1.76",
         "vuetify": "^4.0.0"
       },
       dev: {}

--- a/packages/workspaces-web/package.json
+++ b/packages/workspaces-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-web",
-  "version": "0.1.36",
+  "version": "0.1.37",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -15,12 +15,12 @@
   "dependencies": {
     "@tanstack/vue-query": "5.92.12",
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/http-runtime": "0.1.59",
-    "@jskit-ai/kernel": "0.1.60",
-    "@jskit-ai/shell-web": "0.1.59",
-    "@jskit-ai/users-core": "0.1.70",
-    "@jskit-ai/users-web": "0.1.75",
-    "@jskit-ai/workspaces-core": "0.1.36",
+    "@jskit-ai/http-runtime": "0.1.60",
+    "@jskit-ai/kernel": "0.1.61",
+    "@jskit-ai/shell-web": "0.1.60",
+    "@jskit-ai/users-core": "0.1.71",
+    "@jskit-ai/users-web": "0.1.76",
+    "@jskit-ai/workspaces-core": "0.1.37",
     "vuetify": "^4.0.0"
   },
   "peerDependencies": {

--- a/tooling/config-eslint/package.json
+++ b/tooling/config-eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/config-eslint",
-  "version": "0.1.59",
+  "version": "0.1.60",
   "description": "Shared flat ESLint presets for JSKIT projects.",
   "type": "module",
   "files": [

--- a/tooling/create-app/package.descriptor.mjs
+++ b/tooling/create-app/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/create-app",
-  "version": "0.1.68",
+  "version": "0.1.69",
   "dependsOn": [],
   "capabilities": {
     "provides": [

--- a/tooling/create-app/package.json
+++ b/tooling/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/create-app",
-  "version": "0.1.68",
+  "version": "0.1.69",
   "description": "Scaffold minimal JSKIT app shells.",
   "type": "module",
   "files": [

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -6,11 +6,11 @@
   "packages": [
     {
       "packageId": "@jskit-ai/assistant",
-      "version": "0.1.69",
+      "version": "0.1.70",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant",
-        "version": "0.1.69",
+        "version": "0.1.70",
         "kind": "generator",
         "description": "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
         "options": {
@@ -356,11 +356,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-core",
-      "version": "0.1.36",
+      "version": "0.1.37",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-core",
-        "version": "0.1.36",
+        "version": "0.1.37",
         "kind": "runtime",
         "description": "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
         "dependsOn": [
@@ -408,11 +408,11 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/http-runtime": "0.1.59",
-              "@jskit-ai/kernel": "0.1.60",
-              "@jskit-ai/resource-core": "0.1.5",
-              "@jskit-ai/resource-crud-core": "0.1.5",
-              "@jskit-ai/users-core": "0.1.70",
+              "@jskit-ai/http-runtime": "0.1.60",
+              "@jskit-ai/kernel": "0.1.61",
+              "@jskit-ai/resource-core": "0.1.6",
+              "@jskit-ai/resource-crud-core": "0.1.6",
+              "@jskit-ai/users-core": "0.1.71",
               "@tanstack/vue-query": "^5.90.5",
               "dompurify": "^3.3.3",
               "json-rest-schema": "1.x.x",
@@ -433,11 +433,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-runtime",
-      "version": "0.1.31",
+      "version": "0.1.32",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-runtime",
-        "version": "0.1.31",
+        "version": "0.1.32",
         "kind": "runtime",
         "description": "Shared assistant runtime with per-surface assistant registration.",
         "dependsOn": [
@@ -512,13 +512,13 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/assistant-core": "0.1.36",
-              "@jskit-ai/database-runtime": "0.1.60",
-              "@jskit-ai/http-runtime": "0.1.59",
-              "@jskit-ai/kernel": "0.1.60",
-              "@jskit-ai/shell-web": "0.1.59",
-              "@jskit-ai/users-core": "0.1.70",
-              "@jskit-ai/users-web": "0.1.75",
+              "@jskit-ai/assistant-core": "0.1.37",
+              "@jskit-ai/database-runtime": "0.1.61",
+              "@jskit-ai/http-runtime": "0.1.60",
+              "@jskit-ai/kernel": "0.1.61",
+              "@jskit-ai/shell-web": "0.1.60",
+              "@jskit-ai/users-core": "0.1.71",
+              "@jskit-ai/users-web": "0.1.76",
               "@tanstack/vue-query": "^5.90.5",
               "vuetify": "^4.0.0"
             },
@@ -575,11 +575,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-core",
-      "version": "0.1.59",
+      "version": "0.1.60",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-core",
-        "version": "0.1.59",
+        "version": "0.1.60",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/value-app-config-shared"
@@ -647,7 +647,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.60",
+              "@jskit-ai/kernel": "0.1.61",
               "@fastify/cookie": "^11.0.2",
               "@fastify/csrf-protection": "^7.1.0",
               "@fastify/rate-limit": "^10.3.0"
@@ -665,11 +665,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.59",
+      "version": "0.1.60",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-supabase-core",
-        "version": "0.1.59",
+        "version": "0.1.60",
         "kind": "runtime",
         "options": {
           "auth-supabase-url": {
@@ -751,8 +751,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.59",
-              "@jskit-ai/kernel": "0.1.60",
+              "@jskit-ai/auth-core": "0.1.60",
+              "@jskit-ai/kernel": "0.1.61",
               "dotenv": "^16.4.5",
               "@supabase/supabase-js": "^2.57.4",
               "jose": "^6.1.0"
@@ -817,11 +817,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-web",
-      "version": "0.1.61",
+      "version": "0.1.62",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-web",
-        "version": "0.1.61",
+        "version": "0.1.62",
         "kind": "runtime",
         "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
         "dependsOn": [
@@ -1047,10 +1047,10 @@
             "runtime": {
               "@tanstack/vue-query": "5.92.12",
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/auth-core": "0.1.59",
-              "@jskit-ai/http-runtime": "0.1.59",
-              "@jskit-ai/kernel": "0.1.60",
-              "@jskit-ai/shell-web": "0.1.59",
+              "@jskit-ai/auth-core": "0.1.60",
+              "@jskit-ai/http-runtime": "0.1.60",
+              "@jskit-ai/kernel": "0.1.61",
+              "@jskit-ai/shell-web": "0.1.60",
               "vuetify": "^4.0.0"
             },
             "dev": {}
@@ -1120,11 +1120,11 @@
     },
     {
       "packageId": "@jskit-ai/console-core",
-      "version": "0.1.23",
+      "version": "0.1.24",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-core",
-        "version": "0.1.23",
+        "version": "0.1.24",
         "kind": "runtime",
         "description": "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
         "dependsOn": [
@@ -1197,12 +1197,12 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.59",
-              "@jskit-ai/database-runtime": "0.1.60",
-              "@jskit-ai/http-runtime": "0.1.59",
-              "@jskit-ai/kernel": "0.1.60",
-              "@jskit-ai/resource-crud-core": "0.1.5",
-              "@jskit-ai/users-core": "0.1.70"
+              "@jskit-ai/auth-core": "0.1.60",
+              "@jskit-ai/database-runtime": "0.1.61",
+              "@jskit-ai/http-runtime": "0.1.60",
+              "@jskit-ai/kernel": "0.1.61",
+              "@jskit-ai/resource-crud-core": "0.1.6",
+              "@jskit-ai/users-core": "0.1.71"
             },
             "dev": {}
           },
@@ -1227,11 +1227,11 @@
     },
     {
       "packageId": "@jskit-ai/console-web",
-      "version": "0.1.28",
+      "version": "0.1.29",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-web",
-        "version": "0.1.28",
+        "version": "0.1.29",
         "kind": "runtime",
         "description": "Authenticated console surface scaffold and surface policy wiring.",
         "dependsOn": [
@@ -1310,9 +1310,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-web": "0.1.61",
-              "@jskit-ai/console-core": "0.1.23",
-              "@jskit-ai/shell-web": "0.1.59"
+              "@jskit-ai/auth-web": "0.1.62",
+              "@jskit-ai/console-core": "0.1.24",
+              "@jskit-ai/shell-web": "0.1.60"
             },
             "dev": {}
           },
@@ -1409,11 +1409,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-core",
-      "version": "0.1.68",
+      "version": "0.1.69",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-core",
-        "version": "0.1.68",
+        "version": "0.1.69",
         "kind": "runtime",
         "description": "Shared CRUD helpers used by CRUD modules.",
         "dependsOn": [
@@ -1442,7 +1442,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/crud-core": "0.1.68"
+              "@jskit-ai/crud-core": "0.1.69"
             },
             "dev": {}
           },
@@ -1456,11 +1456,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-server-generator",
-      "version": "0.1.68",
+      "version": "0.1.69",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-server-generator",
-        "version": "0.1.68",
+        "version": "0.1.69",
         "kind": "generator",
         "description": "CRUD server generator with routes, actions, and persistence scaffolding.",
         "options": {
@@ -1619,14 +1619,14 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.59",
-              "@jskit-ai/crud-core": "0.1.68",
-              "@jskit-ai/database-runtime": "0.1.60",
-              "@jskit-ai/http-runtime": "0.1.59",
-              "@jskit-ai/json-rest-api-core": "0.1.5",
-              "@jskit-ai/kernel": "0.1.60",
-              "@jskit-ai/realtime": "0.1.59",
-              "@jskit-ai/resource-crud-core": "0.1.5",
+              "@jskit-ai/auth-core": "0.1.60",
+              "@jskit-ai/crud-core": "0.1.69",
+              "@jskit-ai/database-runtime": "0.1.61",
+              "@jskit-ai/http-runtime": "0.1.60",
+              "@jskit-ai/json-rest-api-core": "0.1.6",
+              "@jskit-ai/kernel": "0.1.61",
+              "@jskit-ai/realtime": "0.1.60",
+              "@jskit-ai/resource-crud-core": "0.1.6",
               "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}"
             },
             "dev": {}
@@ -1754,11 +1754,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.43",
+      "version": "0.1.44",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-ui-generator",
-        "version": "0.1.43",
+        "version": "0.1.44",
         "kind": "generator",
         "description": "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
         "options": {
@@ -1948,7 +1948,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.75"
+              "@jskit-ai/users-web": "0.1.76"
             },
             "dev": {}
           },
@@ -2181,11 +2181,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime",
-      "version": "0.1.60",
+      "version": "0.1.61",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime",
-        "version": "0.1.60",
+        "version": "0.1.61",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -2242,7 +2242,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.60",
+              "@jskit-ai/kernel": "0.1.61",
               "dotenv": "^16.4.5",
               "knex": "^3.1.0"
             },
@@ -2277,11 +2277,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.59",
+      "version": "0.1.60",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-mysql",
-        "version": "0.1.59",
+        "version": "0.1.60",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -2371,7 +2371,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.60",
+              "@jskit-ai/database-runtime": "0.1.61",
               "mysql2": "^3.11.2"
             },
             "dev": {}
@@ -2442,11 +2442,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.59",
+      "version": "0.1.60",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-postgres",
-        "version": "0.1.59",
+        "version": "0.1.60",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -2536,7 +2536,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.60",
+              "@jskit-ai/database-runtime": "0.1.61",
               "pg": "^8.13.1"
             },
             "dev": {}
@@ -2607,11 +2607,11 @@
     },
     {
       "packageId": "@jskit-ai/feature-server-generator",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/feature-server-generator",
-        "version": "0.1.2",
+        "version": "0.1.3",
         "kind": "generator",
         "description": "Scaffold substantial non-CRUD server feature packages with provider, actions, service, and optional persistence seams.",
         "options": {
@@ -2775,10 +2775,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.60",
-              "@jskit-ai/database-runtime-mysql": "0.1.59",
-              "@jskit-ai/json-rest-api-core": "0.1.5",
-              "@jskit-ai/kernel": "0.1.60",
+              "@jskit-ai/database-runtime": "0.1.61",
+              "@jskit-ai/database-runtime-mysql": "0.1.60",
+              "@jskit-ai/json-rest-api-core": "0.1.6",
+              "@jskit-ai/kernel": "0.1.61",
               "json-rest-schema": "1.x.x",
               "@local/${option:feature-name|kebab}": "file:packages/${option:feature-name|kebab}"
             },
@@ -2891,11 +2891,11 @@
     },
     {
       "packageId": "@jskit-ai/http-runtime",
-      "version": "0.1.59",
+      "version": "0.1.60",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/http-runtime",
-        "version": "0.1.59",
+        "version": "0.1.60",
         "kind": "runtime",
         "dependsOn": [],
         "capabilities": {
@@ -2961,7 +2961,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.60"
+              "@jskit-ai/kernel": "0.1.61"
             },
             "dev": {}
           },
@@ -2975,11 +2975,11 @@
     },
     {
       "packageId": "@jskit-ai/json-rest-api-core",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/json-rest-api-core",
-        "version": "0.1.5",
+        "version": "0.1.6",
         "kind": "runtime",
         "description": "Shared internal json-rest-api host runtime for JSKIT server packages.",
         "dependsOn": [
@@ -3039,11 +3039,11 @@
     },
     {
       "packageId": "@jskit-ai/realtime",
-      "version": "0.1.59",
+      "version": "0.1.60",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/realtime",
-        "version": "0.1.59",
+        "version": "0.1.60",
         "kind": "runtime",
         "description": "Thin, generic realtime runtime wrappers for socket.io server and client.",
         "options": {
@@ -3138,7 +3138,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.60",
+              "@jskit-ai/kernel": "0.1.61",
               "@socket.io/redis-adapter": "^8.3.0",
               "redis": "^5.8.2",
               "socket.io": "^4.8.3",
@@ -3187,11 +3187,11 @@
     },
     {
       "packageId": "@jskit-ai/resource-core",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/resource-core",
-        "version": "0.1.5",
+        "version": "0.1.6",
         "kind": "runtime",
         "description": "Generic resource-definition helpers and schema-definition normalization.",
         "dependsOn": [
@@ -3214,7 +3214,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/resource-core": "0.1.5"
+              "@jskit-ai/resource-core": "0.1.6"
             },
             "dev": {}
           },
@@ -3229,11 +3229,11 @@
     },
     {
       "packageId": "@jskit-ai/resource-crud-core",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/resource-crud-core",
-        "version": "0.1.5",
+        "version": "0.1.6",
         "kind": "runtime",
         "description": "CRUD-specific resource-definition helpers and namespace support.",
         "dependsOn": [
@@ -3257,7 +3257,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/resource-crud-core": "0.1.5"
+              "@jskit-ai/resource-crud-core": "0.1.6"
             },
             "dev": {}
           },
@@ -3272,11 +3272,11 @@
     },
     {
       "packageId": "@jskit-ai/shell-web",
-      "version": "0.1.59",
+      "version": "0.1.60",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/shell-web",
-        "version": "0.1.59",
+        "version": "0.1.60",
         "kind": "runtime",
         "description": "Web shell layout runtime with outlet-based placement contributions.",
         "dependsOn": [],
@@ -3413,7 +3413,7 @@
             "runtime": {
               "@mdi/js": "^7.4.47",
               "@tanstack/vue-query": "^5.90.5",
-              "@jskit-ai/kernel": "0.1.60",
+              "@jskit-ai/kernel": "0.1.61",
               "vuetify": "^4.0.0"
             },
             "dev": {}
@@ -3598,11 +3598,11 @@
     },
     {
       "packageId": "@jskit-ai/storage-runtime",
-      "version": "0.1.59",
+      "version": "0.1.60",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/storage-runtime",
-        "version": "0.1.59",
+        "version": "0.1.60",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -3651,7 +3651,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.60",
+              "@jskit-ai/kernel": "0.1.61",
               "unstorage": "^1.17.3"
             },
             "dev": {}
@@ -3667,11 +3667,11 @@
     },
     {
       "packageId": "@jskit-ai/ui-generator",
-      "version": "0.1.43",
+      "version": "0.1.44",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/ui-generator",
-        "version": "0.1.43",
+        "version": "0.1.44",
         "kind": "generator",
         "description": "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
         "options": {
@@ -3970,7 +3970,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.75"
+              "@jskit-ai/users-web": "0.1.76"
             },
             "dev": {}
           },
@@ -3985,11 +3985,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-image-web",
-      "version": "0.1.38",
+      "version": "0.1.39",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-image-web",
-        "version": "0.1.38",
+        "version": "0.1.39",
         "kind": "runtime",
         "description": "Reusable client-side image upload runtime with pre-upload image editing.",
         "dependsOn": [
@@ -4053,7 +4053,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/uploads-runtime": "0.1.38",
+              "@jskit-ai/uploads-runtime": "0.1.39",
               "@uppy/compressor": "^3.1.0",
               "@uppy/core": "^5.2.0",
               "@uppy/dashboard": "^5.1.1",
@@ -4073,11 +4073,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-runtime",
-      "version": "0.1.38",
+      "version": "0.1.39",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-runtime",
-        "version": "0.1.38",
+        "version": "0.1.39",
         "kind": "runtime",
         "description": "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
         "dependsOn": [
@@ -4147,7 +4147,7 @@
           "dependencies": {
             "runtime": {
               "@fastify/multipart": "^9.4.0",
-              "@jskit-ai/kernel": "0.1.60"
+              "@jskit-ai/kernel": "0.1.61"
             },
             "dev": {}
           },
@@ -4162,11 +4162,11 @@
     },
     {
       "packageId": "@jskit-ai/users-core",
-      "version": "0.1.70",
+      "version": "0.1.71",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-core",
-        "version": "0.1.70",
+        "version": "0.1.71",
         "kind": "runtime",
         "description": "Users/account runtime plus HTTP routes for account features.",
         "dependsOn": [
@@ -4296,16 +4296,16 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.59",
-              "@jskit-ai/crud-core": "0.1.68",
-              "@jskit-ai/database-runtime": "0.1.60",
-              "@jskit-ai/http-runtime": "0.1.59",
-              "@jskit-ai/json-rest-api-core": "0.1.5",
-              "@jskit-ai/kernel": "0.1.60",
-              "@jskit-ai/resource-core": "0.1.5",
-              "@jskit-ai/resource-crud-core": "0.1.5",
+              "@jskit-ai/auth-core": "0.1.60",
+              "@jskit-ai/crud-core": "0.1.69",
+              "@jskit-ai/database-runtime": "0.1.61",
+              "@jskit-ai/http-runtime": "0.1.60",
+              "@jskit-ai/json-rest-api-core": "0.1.6",
+              "@jskit-ai/kernel": "0.1.61",
+              "@jskit-ai/resource-core": "0.1.6",
+              "@jskit-ai/resource-crud-core": "0.1.6",
               "@local/users": "file:packages/users",
-              "@jskit-ai/uploads-runtime": "0.1.38"
+              "@jskit-ai/uploads-runtime": "0.1.39"
             },
             "dev": {}
           },
@@ -4522,11 +4522,11 @@
     },
     {
       "packageId": "@jskit-ai/users-web",
-      "version": "0.1.75",
+      "version": "0.1.76",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-web",
-        "version": "0.1.75",
+        "version": "0.1.76",
         "kind": "runtime",
         "description": "Users web module: account/profile UI plus shared users web widgets.",
         "dependsOn": [
@@ -4722,12 +4722,12 @@
             "runtime": {
               "@tanstack/vue-query": "5.92.12",
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/http-runtime": "0.1.59",
-              "@jskit-ai/realtime": "0.1.59",
-              "@jskit-ai/kernel": "0.1.60",
-              "@jskit-ai/shell-web": "0.1.59",
-              "@jskit-ai/uploads-image-web": "0.1.38",
-              "@jskit-ai/users-core": "0.1.70",
+              "@jskit-ai/http-runtime": "0.1.60",
+              "@jskit-ai/realtime": "0.1.60",
+              "@jskit-ai/kernel": "0.1.61",
+              "@jskit-ai/shell-web": "0.1.60",
+              "@jskit-ai/uploads-image-web": "0.1.39",
+              "@jskit-ai/users-core": "0.1.71",
               "vuetify": "^4.0.0"
             },
             "dev": {}
@@ -4877,11 +4877,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-core",
-      "version": "0.1.36",
+      "version": "0.1.37",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-core",
-        "version": "0.1.36",
+        "version": "0.1.37",
         "kind": "runtime",
         "description": "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
         "dependsOn": [
@@ -4996,10 +4996,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/json-rest-api-core": "0.1.5",
-              "@jskit-ai/resource-core": "0.1.5",
-              "@jskit-ai/resource-crud-core": "0.1.5",
-              "@jskit-ai/users-core": "0.1.70"
+              "@jskit-ai/json-rest-api-core": "0.1.6",
+              "@jskit-ai/resource-core": "0.1.6",
+              "@jskit-ai/resource-crud-core": "0.1.6",
+              "@jskit-ai/users-core": "0.1.71"
             },
             "dev": {}
           },
@@ -5171,11 +5171,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-web",
-      "version": "0.1.36",
+      "version": "0.1.37",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-web",
-        "version": "0.1.36",
+        "version": "0.1.37",
         "kind": "runtime",
         "description": "Workspace web module: workspace selector, tools widget, workspace surfaces, and members/settings UI.",
         "dependsOn": [
@@ -5362,8 +5362,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/workspaces-core": "0.1.36",
-              "@jskit-ai/users-web": "0.1.75",
+              "@jskit-ai/workspaces-core": "0.1.37",
+              "@jskit-ai/users-web": "0.1.76",
               "vuetify": "^4.0.0"
             },
             "dev": {}

--- a/tooling/jskit-catalog/package.json
+++ b/tooling/jskit-catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-catalog",
-  "version": "0.1.68",
+  "version": "0.1.69",
   "description": "Published metadata catalog for JSKIT package descriptors.",
   "type": "module",
   "files": [

--- a/tooling/jskit-cli/package.json
+++ b/tooling/jskit-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-cli",
-  "version": "0.2.69",
+  "version": "0.2.70",
   "description": "Bundle and package orchestration CLI for JSKIT apps.",
   "type": "module",
   "files": [
@@ -20,9 +20,9 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/jskit-catalog": "0.1.68",
-    "@jskit-ai/kernel": "0.1.60",
-    "@jskit-ai/shell-web": "0.1.59"
+    "@jskit-ai/jskit-catalog": "0.1.69",
+    "@jskit-ai/kernel": "0.1.61",
+    "@jskit-ai/shell-web": "0.1.60"
   },
   "engines": {
     "node": "20.x"


### PR DESCRIPTION
## Summary
- tighten JSKIT agent guidance around generator-first page/CRUD scaffolding and vertical-slice planning
- add the matching agent-docs tests and pattern docs
- fix the internal json-rest host logger option shape and roll the dependent package/catalog version metadata forward

## Testing
- node --test packages/json-rest-api-core/test/entrypoints.boundary.test.js
- node --test packages/agent-docs/test/appAgentTemplate.test.js packages/agent-docs/test/crudGuidance.test.js packages/agent-docs/test/verticalSliceGuidance.test.js