### PR TITLE
Enforce direct table ownership contracts

### DIFF
--- a/packages/agent-docs/patterns/crud-scaffolding.md
+++ b/packages/agent-docs/patterns/crud-scaffolding.md
@@ -17,14 +17,17 @@ Check first:
 Rules:
 
 - For a CRUD-backed entity, start with `jskit generate crud-server-generator scaffold ...`.
+- Unless the table is already owned by a JSKIT baseline package or is an explicit narrow exception recorded in `.jskit/table-ownership.json`, every persisted app-owned table must go through that server CRUD step first.
 - That server scaffold is the crucial first step even if no CRUD UI will be created yet.
 - Create the real table directly in the database before scaffolding. `crud-server-generator` reads the live table shape.
 - If `crud-server-generator` is going to own the CRUD, do not hand-write a separate CRUD migration for that table. The generator installs and manages the CRUD migration scaffold itself.
 - Do not scaffold CRUD UI, hand-build CRUD routes, or hand-build CRUD endpoints before the server CRUD package and shared resource file exist.
 - Treat the generated shared resource file as the canonical CRUD contract for later UI scaffolding and CRUD behavior changes.
+- `feature-server-generator` is not the default lane for ordinary persisted entities. Use it for workflows or orchestration that sit on top of CRUD-owned tables, or for rare explicit non-CRUD exceptions.
 
 Avoid:
 
 - writing a hand migration for a CRUD table that JSKIT CRUD scaffolding is supposed to own
 - starting with `crud-ui-generator` before the server scaffold exists
 - hand-building CRUD routes or validators that duplicate the generated server resource contract
+- letting a new app-owned table exist in the live database without either generated CRUD ownership or a documented `.jskit/table-ownership.json` exception

--- a/packages/agent-docs/templates/app/AGENTS.md
+++ b/packages/agent-docs/templates/app/AGENTS.md
@@ -71,8 +71,12 @@ Core rules:
 - For baseline package setup, ask plainly for the exact local development values needed for the next install step, but only for the modules or packages that are actually selected.
 - Use the real env var names or option names instead of vague requests for "credentials". Values such as `DB_NAME`, `DB_USER`, `DB_PASSWORD`, `AUTH_SUPABASE_URL`, `AUTH_SUPABASE_PUBLISHABLE_KEY`, and `APP_PUBLIC_URL` are routine setup inputs when the relevant package stack needs them.
 - For CRUD chunks, creating the server CRUD with `jskit generate crud-server-generator scaffold ...` is the crucial first step even if no CRUD UI will be created yet.
+- Unless a table is already owned by a JSKIT baseline package or is an explicit narrow exception recorded in `.jskit/table-ownership.json`, every persisted app-owned table must have its own server CRUD package created first with `jskit generate crud-server-generator scaffold ...`, even if no CRUD UI will ever exist.
+- Treat that as a hard invariant, not a style preference. If a persisted app-owned table does not have generated CRUD ownership, `jskit doctor` is expected to fail.
 - For a CRUD table that `crud-server-generator` will own, do not hand-write a separate migration. Create the real table directly in the database first, then scaffold the server CRUD so JSKIT can install and manage the CRUD migration scaffold itself.
 - Do not generate CRUD UI or hand-build CRUD routes before the server CRUD package and shared resource file exist.
+- `feature-server-generator` is for workflows, orchestration, and other non-CRUD server features. Do not use it as the starting point for ordinary persisted entity tables.
+- Keep direct knex minimal and exceptional. Outside generated CRUD packages and explicit weird-custom feature lanes, app-owned runtime code should use internal `json-rest-api` seams instead of talking to knex directly.
 - For CRUD chunks, ask the developer which operations are allowed, which fields belong in the list view if one exists, and the intended look of the view and edit/new forms before generating code.
 - Every user-facing screen must pass a Material Design and Vuetify quality review before the chunk is considered done.
 - Any chunk that adds or changes user-facing UI must include a Playwright check that exercises the changed behavior before the chunk is considered done.

--- a/packages/agent-docs/test/appAgentTemplate.test.js
+++ b/packages/agent-docs/test/appAgentTemplate.test.js
@@ -18,8 +18,12 @@ test("app agent template includes mandatory JSKIT start and done gates", async (
   assert.match(body, /Active rules from docs:/);
   assert.match(body, /prefer `jskit generate \.\.\.` over creating them from scratch/);
   assert.match(body, /server CRUD with `jskit generate crud-server-generator scaffold/);
+  assert.match(body, /every persisted app-owned table must have its own server CRUD package/);
+  assert.match(body, /`jskit doctor` is expected to fail/);
   assert.match(body, /do not hand-write a separate migration/);
   assert.match(body, /Do not generate CRUD UI or hand-build CRUD routes before the server CRUD package and shared resource file exist/);
+  assert.match(body, /`feature-server-generator` is for workflows, orchestration, and other non-CRUD server features/);
+  assert.match(body, /Keep direct knex minimal and exceptional/);
   assert.match(body, /Plan implementation work as vertical slices/);
   assert.match(body, /Avoid horizontal chunk plans/);
 

--- a/packages/agent-docs/test/crudGuidance.test.js
+++ b/packages/agent-docs/test/crudGuidance.test.js
@@ -14,19 +14,27 @@ test("workflow and patterns require CRUD server scaffolding before CRUD UI or ha
   const pattern = await readFile(path.join(packageRoot, "patterns/crud-scaffolding.md"), "utf8");
 
   assert.match(scoping, /exact `jskit generate crud-server-generator scaffold \.\.\.` command/);
+  assert.match(scoping, /Before accepting a new persisted app-owned table, decide whether it is CRUD-owned or a narrow explicit exception/);
   assert.match(scoping, /Do not plan a separate hand-written CRUD migration/);
 
   assert.match(featureDelivery, /Create the real table directly in the database before scaffolding/);
+  assert.match(featureDelivery, /every persisted app-owned table must have a server CRUD package/);
   assert.match(featureDelivery, /do not hand-write a separate migration for that CRUD table/);
   assert.match(featureDelivery, /Scaffold the server side first with `crud-server-generator`, even if no CRUD UI will be created yet/);
   assert.match(featureDelivery, /Do not hand-build CRUD routes, CRUD endpoints, or CRUD page trees before `crud-server-generator` has created the server package and shared resource file/);
+  assert.match(featureDelivery, /`feature-server-generator` is for non-CRUD workflows and orchestration/);
+  assert.match(featureDelivery, /Keep direct knex exceptional and minimal/);
 
   assert.match(review, /was `crud-server-generator scaffold` used before any CRUD UI or CRUD route hand-coding/);
+  assert.match(review, /does every live app-owned table now have either declared generated\/package CRUD ownership or an explicit narrow `.jskit\/table-ownership\.json` exception/);
+  assert.match(review, /is any direct app-owned knex usage limited to generated CRUD packages or explicit weird-custom feature lanes/);
   assert.match(review, /avoid a separate hand-written CRUD migration/);
 
   assert.match(patternIndex, /crud scaffold, crud server, crud ui, table creation, migrations/);
   assert.match(pattern, /^# CRUD Scaffolding Patterns$/m);
   assert.match(pattern, /start with `jskit generate crud-server-generator scaffold \.\.\.`/);
+  assert.match(pattern, /every persisted app-owned table must go through that server CRUD step first/);
   assert.match(pattern, /do not hand-write a separate CRUD migration/);
   assert.match(pattern, /Do not scaffold CRUD UI, hand-build CRUD routes, or hand-build CRUD endpoints before the server CRUD package and shared resource file exist/);
+  assert.match(pattern, /`feature-server-generator` is not the default lane for ordinary persisted entities/);
 });

--- a/packages/agent-docs/workflow/feature-delivery.md
+++ b/packages/agent-docs/workflow/feature-delivery.md
@@ -33,11 +33,12 @@ For CRUD chunks:
 
 1. Decide the table shape first.
 2. Create the real table directly in the database before scaffolding. `crud-server-generator` reads the live table shape; it does not invent the table for you.
-3. If `crud-server-generator` is going to own the CRUD schema, do not hand-write a separate migration for that CRUD table. The server generator installs and manages the CRUD migration scaffold itself.
-4. Scaffold the server side first with `crud-server-generator`, even if no CRUD UI will be created yet.
-5. Only after the shared resource file exists, scaffold the client side against that resource.
-6. Treat that shared resource file as the canonical CRUD definition. Put field and ownership changes there instead of hand-duplicating derived CRUD validators elsewhere.
-7. Do not guess CRUD operations or screen shape. Ask the developer:
+3. Unless the table is already owned by a JSKIT baseline package or is a narrow explicit exception recorded in `.jskit/table-ownership.json`, every persisted app-owned table must have a server CRUD package. Do not let a new table exist without that ownership decision.
+4. If `crud-server-generator` is going to own the CRUD schema, do not hand-write a separate migration for that CRUD table. The server generator installs and manages the CRUD migration scaffold itself.
+5. Scaffold the server side first with `crud-server-generator`, even if no CRUD UI will be created yet.
+6. Only after the shared resource file exists, scaffold the client side against that resource.
+7. Treat that shared resource file as the canonical CRUD definition. Put field and ownership changes there instead of hand-duplicating derived CRUD validators elsewhere.
+8. Do not guess CRUD operations or screen shape. Ask the developer:
    - which operations are allowed
    - which fields belong in the list view if one exists
    - what the view form should look like
@@ -50,10 +51,12 @@ During implementation:
 - Ask only about overrides, restrictions, or app-specific additions to packaged baseline workflows.
 - Use generated CRUD/UI scaffolds only after the route and ownership model are decided.
 - Do not hand-build CRUD routes, CRUD endpoints, or CRUD page trees before `crud-server-generator` has created the server package and shared resource file.
+- `feature-server-generator` is for non-CRUD workflows and orchestration. Do not use it as the first persistence lane for ordinary entity tables.
 - For app-owned non-CRUD route pages, default to `jskit generate ui-generator page ...` instead of hand-writing both `src/pages/...` and `src/placement.js`.
 - Before hand-writing a route page or placement entry, check `jskit show ui-generator --details` and `jskit list-placements`.
 - If `ui-generator page` applies and you still choose not to use it, stop and explain the exact gap before coding.
 - Keep runtime, UI, and data concerns separated.
+- Keep direct knex exceptional and minimal. Outside generated CRUD packages and explicit weird-custom feature lanes, app-owned runtime code should stay on internal `json-rest-api` seams.
 - Avoid “while I’m here” scope creep unless it is required for correctness.
 - Do not turn a small placeholder or route stub into a copy-polish or blueprint-rewrite task unless the developer asked for that broader work.
 

--- a/packages/agent-docs/workflow/review.md
+++ b/packages/agent-docs/workflow/review.md
@@ -23,6 +23,8 @@ Before calling a chunk or a whole changeset done, review it in four passes:
    - if a generator existed, was the exact `jskit` command used or was the gap documented clearly before hand-coding?
    - for CRUD work, was `crud-server-generator scaffold` used before any CRUD UI or CRUD route hand-coding?
    - for CRUD tables owned by JSKIT, did the change avoid a separate hand-written CRUD migration?
+   - does every live app-owned table now have either declared generated/package CRUD ownership or an explicit narrow `.jskit/table-ownership.json` exception?
+   - is any direct app-owned knex usage limited to generated CRUD packages or explicit weird-custom feature lanes?
    - are surface, route, ownership, and migration choices aligned with JSKIT conventions?
    - package metadata and actual behavior still aligned?
 3. UI standards review

--- a/packages/agent-docs/workflow/scoping.md
+++ b/packages/agent-docs/workflow/scoping.md
@@ -33,6 +33,7 @@ Scoping rules:
 - Make the generator plan concrete. Name the exact `jskit` commands expected for the chunk, not just a package or a general idea.
 - For non-CRUD route page work, check `jskit show ui-generator --details` and `jskit list-placements` before deciding that custom page or placement code is necessary.
 - For CRUD work, make the server-first plan explicit. Name the exact `jskit generate crud-server-generator scaffold ...` command before any CRUD UI plan.
+- Before accepting a new persisted app-owned table, decide whether it is CRUD-owned or a narrow explicit exception. If it is not already owned by a JSKIT baseline package, the default answer should be server CRUD ownership.
 - If a CRUD will be owned by `crud-server-generator`, plan around a real table that already exists in the database. Do not plan a separate hand-written CRUD migration for that table.
 - Decide ownership early; do not treat it as a UI-only detail.
 - If Stage 1 platform choices are still provisional, finish them before installing tenancy-sensitive runtime packages.

--- a/packages/assistant-runtime/package.descriptor.mjs
+++ b/packages/assistant-runtime/package.descriptor.mjs
@@ -42,6 +42,27 @@ export default Object.freeze({
     }
   },
   metadata: {
+    jskit: {
+      tableOwnership: {
+        tables: [
+          {
+            tableName: "assistant_config",
+            provenance: "runtime-package",
+            ownerKind: "package-runtime"
+          },
+          {
+            tableName: "assistant_conversations",
+            provenance: "runtime-package",
+            ownerKind: "package-runtime"
+          },
+          {
+            tableName: "assistant_messages",
+            provenance: "runtime-package",
+            ownerKind: "package-runtime"
+          }
+        ]
+      }
+    },
     apiSummary: {
       surfaces: [
         {

--- a/packages/console-core/package.descriptor.mjs
+++ b/packages/console-core/package.descriptor.mjs
@@ -36,6 +36,17 @@ export default Object.freeze({
     }
   },
   metadata: {
+    jskit: {
+      tableOwnership: {
+        tables: [
+          {
+            tableName: "console_settings",
+            provenance: "runtime-package",
+            ownerKind: "package-runtime"
+          }
+        ]
+      }
+    },
     apiSummary: {
       surfaces: [
         {

--- a/packages/crud-server-generator/templates/src/local-package/package.descriptor.mjs
+++ b/packages/crud-server-generator/templates/src/local-package/package.descriptor.mjs
@@ -35,6 +35,18 @@ export default Object.freeze({
     }
   },
   metadata: {
+    jskit: {
+      scaffoldShape: "crud-server-v1",
+      tableOwnership: {
+        tables: [
+          {
+            tableName: __JSKIT_CRUD_TABLE_NAME__,
+            provenance: "crud-server-generator",
+            ownerKind: "crud-package"
+          }
+        ]
+      }
+    },
     apiSummary: {
       surfaces: [
         {

--- a/packages/crud-server-generator/test/scaffoldDescriptorTemplate.test.js
+++ b/packages/crud-server-generator/test/scaffoldDescriptorTemplate.test.js
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const TEST_DIRECTORY = path.dirname(fileURLToPath(import.meta.url));
+const PACKAGE_ROOT = path.resolve(TEST_DIRECTORY, "..");
+
+test("crud server scaffold descriptor template records table ownership provenance", async () => {
+  const source = await readFile(
+    path.join(PACKAGE_ROOT, "templates/src/local-package/package.descriptor.mjs"),
+    "utf8"
+  );
+
+  assert.match(source, /scaffoldShape: "crud-server-v1"/);
+  assert.match(source, /tableName: __JSKIT_CRUD_TABLE_NAME__/);
+  assert.match(source, /provenance: "crud-server-generator"/);
+  assert.match(source, /ownerKind: "crud-package"/);
+});

--- a/packages/http-runtime/src/shared/clientRuntime/jsonApiResourceTransport.js
+++ b/packages/http-runtime/src/shared/clientRuntime/jsonApiResourceTransport.js
@@ -7,6 +7,10 @@ import {
   resolveJsonApiTransportTypes
 } from "../validators/jsonApiTransport.js";
 import { encodeJsonApiResourceQueryObject } from "../validators/jsonApiQueryTransport.js";
+import {
+  resolveRelationshipFieldKey,
+  simplifyJsonApiResourceWithRelationshipIds
+} from "../support/jsonApiSimplify.js";
 
 function isRecord(value) {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
@@ -98,16 +102,6 @@ function encodeJsonApiResourceQuery(query, transport = null) {
   });
 }
 
-function resolveRelationshipFieldKey(relationshipName = "", lookupFieldMap = null) {
-  const normalizedRelationshipName = normalizeText(relationshipName);
-  const explicitFieldKey = normalizeText(lookupFieldMap?.[normalizedRelationshipName]);
-  if (explicitFieldKey) {
-    return explicitFieldKey;
-  }
-
-  return normalizedRelationshipName ? `${normalizedRelationshipName}Id` : "";
-}
-
 function createIncludedResourceIndex(document = {}) {
   const index = new Map();
 
@@ -135,9 +129,7 @@ function simplifyRelationshipResource(linkage = {}, options = {}) {
   const resourceKey = `${type}:${id}`;
   const includedResource = options.includedResourceIndex?.get(resourceKey);
   if (!includedResource) {
-    return {
-      id
-    };
+    return null;
   }
 
   return simplifyResourceObject(includedResource, options);
@@ -145,10 +137,9 @@ function simplifyRelationshipResource(linkage = {}, options = {}) {
 
 function simplifyResourceObject(resource = {}, options = {}) {
   const normalizedResource = isRecord(resource) ? normalizeObject(resource) : {};
-  const simplified = {
-    id: normalizedResource.id == null ? "" : String(normalizedResource.id),
-    ...(normalizeObject(normalizedResource.attributes))
-  };
+  const simplified = simplifyJsonApiResourceWithRelationshipIds(normalizedResource, {
+    lookupFieldMap: options.lookupFieldMap || null
+  });
   const lookupContainerKey = normalizeText(options.lookupContainerKey, {
     fallback: "lookups"
   });

--- a/packages/http-runtime/src/shared/support/jsonApiSimplify.js
+++ b/packages/http-runtime/src/shared/support/jsonApiSimplify.js
@@ -1,0 +1,39 @@
+import { isRecord, normalizeObject, normalizeText } from "@jskit-ai/kernel/shared/support/normalize";
+
+function resolveRelationshipFieldKey(relationshipName = "", lookupFieldMap = null) {
+  const normalizedRelationshipName = normalizeText(relationshipName);
+  const explicitFieldKey = normalizeText(lookupFieldMap?.[normalizedRelationshipName]);
+  if (explicitFieldKey) {
+    return explicitFieldKey;
+  }
+
+  return normalizedRelationshipName ? `${normalizedRelationshipName}Id` : "";
+}
+
+function simplifyJsonApiResourceWithRelationshipIds(resource = {}, { lookupFieldMap = null } = {}) {
+  const normalizedResource = isRecord(resource) ? normalizeObject(resource) : {};
+  const simplified = {
+    id: normalizedResource.id == null ? "" : String(normalizedResource.id),
+    ...(normalizeObject(normalizedResource.attributes))
+  };
+
+  for (const [relationshipName, relationshipValue] of Object.entries(normalizeObject(normalizedResource.relationships))) {
+    const relationshipData = relationshipValue?.data;
+    if (Array.isArray(relationshipData)) {
+      continue;
+    }
+
+    const fieldKey = resolveRelationshipFieldKey(relationshipName, lookupFieldMap);
+    if (!fieldKey || Object.hasOwn(simplified, fieldKey)) {
+      continue;
+    }
+    simplified[fieldKey] = relationshipData?.id == null ? null : String(relationshipData.id);
+  }
+
+  return simplified;
+}
+
+export {
+  resolveRelationshipFieldKey,
+  simplifyJsonApiResourceWithRelationshipIds
+};

--- a/packages/http-runtime/src/shared/validators/jsonApiTransport.js
+++ b/packages/http-runtime/src/shared/validators/jsonApiTransport.js
@@ -1,4 +1,5 @@
 import { normalizeArray, normalizeObject, normalizeText } from "@jskit-ai/kernel/shared/support/normalize";
+import { simplifyJsonApiResourceWithRelationshipIds } from "../support/jsonApiSimplify.js";
 
 const JSON_API_CONTENT_TYPE = "application/vnd.api+json";
 
@@ -441,11 +442,7 @@ function createJsonApiErrorDocumentFromFailure({
 }
 
 function simplifyJsonApiResourceObject(resource = {}) {
-  const normalized = normalizeJsonApiResourceObject(resource);
-  return {
-    id: normalized.id == null ? "" : normalized.id,
-    ...(normalized.attributes || {})
-  };
+  return simplifyJsonApiResourceWithRelationshipIds(normalizeJsonApiResourceObject(resource));
 }
 
 function simplifyJsonApiDocument(payload = {}) {

--- a/packages/http-runtime/test/client.test.js
+++ b/packages/http-runtime/test/client.test.js
@@ -236,6 +236,57 @@ test("request decodes json:api relationship includes into JSKIT lookups and fore
   });
 });
 
+test("request keeps relationship foreign-key fields even when related resources are not included", async () => {
+  const fetchImpl = async () =>
+    mockResponse({
+      contentType: "application/vnd.api+json",
+      data: {
+        data: {
+          type: "pets",
+          id: "729900",
+          attributes: {
+            name: "Daisy"
+          },
+          relationships: {
+            contact: {
+              data: {
+                type: "contacts",
+                id: "552252"
+              }
+            },
+            breed: {
+              data: {
+                type: "breeds",
+                id: "2"
+              }
+            }
+          }
+        }
+      }
+    });
+
+  const client = createHttpClient({ fetchImpl });
+  const payload = await client.request("/api/pets/729900", {
+    method: "GET",
+    transport: {
+      kind: "jsonapi-resource",
+      responseType: "pets",
+      responseKind: "record",
+      lookupFieldMap: {
+        contact: "contactId",
+        breed: "breedId"
+      }
+    }
+  });
+
+  assert.deepEqual(payload, {
+    id: "729900",
+    name: "Daisy",
+    contactId: "552252",
+    breedId: "2"
+  });
+});
+
 test("request recursively decodes nested included relationships for collection-style lookups", async () => {
   const fetchImpl = async () =>
     mockResponse({

--- a/packages/http-runtime/test/jsonApiTransport.test.js
+++ b/packages/http-runtime/test/jsonApiTransport.test.js
@@ -173,6 +173,40 @@ test("simplifyJsonApiDocument keeps flat-record behavior for resource and collec
   );
 });
 
+test("simplifyJsonApiDocument preserves single-relationship foreign key ids without lookup hydration", () => {
+  assert.deepEqual(
+    simplifyJsonApiDocument({
+      data: {
+        type: "workspace-memberships",
+        id: "11",
+        attributes: {
+          status: "active"
+        },
+        relationships: {
+          workspace: {
+            data: {
+              type: "workspaces",
+              id: "7"
+            }
+          },
+          user: {
+            data: {
+              type: "userProfiles",
+              id: "9"
+            }
+          }
+        }
+      }
+    }),
+    {
+      id: "11",
+      status: "active",
+      workspaceId: "7",
+      userId: "9"
+    }
+  );
+});
+
 test("createJsonApiErrorDocumentFromFailure maps field errors and validation issues to JSON:API errors", () => {
   assert.deepEqual(
     createJsonApiErrorDocumentFromFailure({

--- a/packages/users-core/package.descriptor.mjs
+++ b/packages/users-core/package.descriptor.mjs
@@ -43,6 +43,17 @@ export default Object.freeze({
     }
   },
   metadata: {
+    jskit: {
+      tableOwnership: {
+        tables: [
+          {
+            tableName: "user_settings",
+            provenance: "runtime-package",
+            ownerKind: "package-runtime"
+          }
+        ]
+      }
+    },
     apiSummary: {
       surfaces: [
         {

--- a/packages/users-core/templates/packages/users-workspace/package.descriptor.mjs
+++ b/packages/users-core/templates/packages/users-workspace/package.descriptor.mjs
@@ -36,6 +36,18 @@ export default Object.freeze({
     }
   },
   metadata: {
+    jskit: {
+      scaffoldShape: "users-core-crud-v1",
+      tableOwnership: {
+        tables: [
+          {
+            tableName: "users",
+            provenance: "users-core-template",
+            ownerKind: "baseline-crud"
+          }
+        ]
+      }
+    },
     apiSummary: {
       surfaces: [
         {

--- a/packages/users-core/templates/packages/users/package.descriptor.mjs
+++ b/packages/users-core/templates/packages/users/package.descriptor.mjs
@@ -35,6 +35,18 @@ export default Object.freeze({
     }
   },
   metadata: {
+    jskit: {
+      scaffoldShape: "users-core-crud-v1",
+      tableOwnership: {
+        tables: [
+          {
+            tableName: "users",
+            provenance: "users-core-template",
+            ownerKind: "baseline-crud"
+          }
+        ]
+      }
+    },
     apiSummary: {
       surfaces: [
         {

--- a/packages/users-core/test/usersPackageScaffoldContract.test.js
+++ b/packages/users-core/test/usersPackageScaffoldContract.test.js
@@ -78,6 +78,9 @@ test("users-core base users package templates stay aligned with non-workspace ap
   assert.doesNotMatch(packageDescriptorSource, /@jskit-ai\/workspaces-core/);
   assert.match(packageDescriptorSource, /@jskit-ai\/json-rest-api-core/);
   assert.match(packageDescriptorSource, /json-rest-api\.core/);
+  assert.match(packageDescriptorSource, /scaffoldShape: "users-core-crud-v1"/);
+  assert.match(packageDescriptorSource, /tableName: "users"/);
+  assert.match(packageDescriptorSource, /provenance: "users-core-template"/);
   assert.doesNotMatch(packageDescriptorSource, /server\/actionIds/);
   assert.match(providerSource, /surface: "home"/);
   assert.doesNotMatch(providerSource, /routeSurfaceRequiresWorkspace/);
@@ -138,6 +141,9 @@ test("users-core workspace users package templates stay aligned with workspace a
   assert.match(packageDescriptorSource, /@jskit-ai\/workspaces-core/);
   assert.match(packageDescriptorSource, /@jskit-ai\/json-rest-api-core/);
   assert.match(packageDescriptorSource, /json-rest-api\.core/);
+  assert.match(packageDescriptorSource, /scaffoldShape: "users-core-crud-v1"/);
+  assert.match(packageDescriptorSource, /tableName: "users"/);
+  assert.match(packageDescriptorSource, /provenance: "users-core-template"/);
   assert.doesNotMatch(packageDescriptorSource, /server\/actionIds/);
   assert.match(providerSource, /surface: "admin"/);
   assert.match(providerSource, /routeSurfaceRequiresWorkspace/);

--- a/packages/workspaces-core/package.descriptor.mjs
+++ b/packages/workspaces-core/package.descriptor.mjs
@@ -34,6 +34,32 @@ export default Object.freeze({
     }
   },
   metadata: {
+    jskit: {
+      tableOwnership: {
+        tables: [
+          {
+            tableName: "workspaces",
+            provenance: "runtime-package",
+            ownerKind: "package-runtime"
+          },
+          {
+            tableName: "workspace_memberships",
+            provenance: "runtime-package",
+            ownerKind: "package-runtime"
+          },
+          {
+            tableName: "workspace_settings",
+            provenance: "runtime-package",
+            ownerKind: "package-runtime"
+          },
+          {
+            tableName: "workspace_invites",
+            provenance: "runtime-package",
+            ownerKind: "package-runtime"
+          }
+        ]
+      }
+    },
     apiSummary: {
       surfaces: [
         {

--- a/packages/workspaces-core/src/server/common/repositories/workspaceMembershipsRepository.js
+++ b/packages/workspaces-core/src/server/common/repositories/workspaceMembershipsRepository.js
@@ -289,16 +289,13 @@ function createRepository({ api, knex } = {}) {
       return [];
     }
 
-    const rows = await queryMemberships(
-      {
-        user: normalizedUserId,
-        status: "active"
-      },
-      options
-    );
+    const rows = await queryMemberships({
+      user: normalizedUserId,
+      status: "active"
+    }, options);
 
     return rows
-      .map((row) => normalizeDbRecordId(row?.workspace?.id || row?.workspaceId, { fallback: null }))
+      .map((row) => normalizeDbRecordId(row?.workspaceId, { fallback: null }))
       .filter(Boolean);
   }
 

--- a/packages/workspaces-core/test/workspaceMembershipsRepository.test.js
+++ b/packages/workspaces-core/test/workspaceMembershipsRepository.test.js
@@ -72,11 +72,24 @@ function createWorkspaceMembershipsApiStub({
           }
 
           if (Object.hasOwn(filters, "user") && Object.hasOwn(filters, "status")) {
+            const includeWorkspace = Array.isArray(queryParams?.include) && queryParams.include.includes("workspace");
             const rows = [...rowByComposite.values()].filter((row) => (
               String(row?.user?.id || "") === String(filters.user) &&
               String(row?.status || "") === String(filters.status)
             ));
-            return asCollectionDocument(rows.map((row) => toWorkspaceMembershipRow(row)));
+            return asCollectionDocument(rows.map((row) => {
+              if (includeWorkspace) {
+                return toWorkspaceMembershipRow(row);
+              }
+
+              return {
+                ...toWorkspaceMembershipRow({
+                  ...row,
+                  workspace: null
+                }),
+                workspaceId: row?.workspace?.id == null ? null : String(row.workspace.id)
+              };
+            }));
           }
 
           return asCollectionDocument([]);
@@ -251,7 +264,7 @@ test("workspaceMembershipsRepository.listActiveWorkspaceIdsByUserId returns norm
     createdAt: "2026-03-09 00:26:35.710",
     updatedAt: "2026-03-10 00:26:35.710"
   };
-  const { api } = createWorkspaceMembershipsApiStub({
+  const { api, state } = createWorkspaceMembershipsApiStub({
     rowByComposite: new Map([["7:9", membershipRow]])
   });
   const repository = createRepository({ api, knex: createKnexStub() });
@@ -259,4 +272,12 @@ test("workspaceMembershipsRepository.listActiveWorkspaceIdsByUserId returns norm
   const workspaceIds = await repository.listActiveWorkspaceIdsByUserId("9");
 
   assert.deepEqual(workspaceIds, ["7"]);
+  assert.deepEqual(state.queryCalls, [
+    {
+      filters: {
+        user: "9",
+        status: "active"
+      }
+    }
+  ]);
 });

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -480,6 +480,27 @@
           }
         },
         "metadata": {
+          "jskit": {
+            "tableOwnership": {
+              "tables": [
+                {
+                  "tableName": "assistant_config",
+                  "provenance": "runtime-package",
+                  "ownerKind": "package-runtime"
+                },
+                {
+                  "tableName": "assistant_conversations",
+                  "provenance": "runtime-package",
+                  "ownerKind": "package-runtime"
+                },
+                {
+                  "tableName": "assistant_messages",
+                  "provenance": "runtime-package",
+                  "ownerKind": "package-runtime"
+                }
+              ]
+            }
+          },
           "apiSummary": {
             "surfaces": [
               {
@@ -1159,6 +1180,17 @@
           }
         },
         "metadata": {
+          "jskit": {
+            "tableOwnership": {
+              "tables": [
+                {
+                  "tableName": "console_settings",
+                  "provenance": "runtime-package",
+                  "ownerKind": "package-runtime"
+                }
+              ]
+            }
+          },
           "apiSummary": {
             "surfaces": [
               {
@@ -4208,6 +4240,17 @@
           }
         },
         "metadata": {
+          "jskit": {
+            "tableOwnership": {
+              "tables": [
+                {
+                  "tableName": "user_settings",
+                  "provenance": "runtime-package",
+                  "ownerKind": "package-runtime"
+                }
+              ]
+            }
+          },
           "apiSummary": {
             "surfaces": [
               {
@@ -4914,6 +4957,32 @@
           }
         },
         "metadata": {
+          "jskit": {
+            "tableOwnership": {
+              "tables": [
+                {
+                  "tableName": "workspaces",
+                  "provenance": "runtime-package",
+                  "ownerKind": "package-runtime"
+                },
+                {
+                  "tableName": "workspace_memberships",
+                  "provenance": "runtime-package",
+                  "ownerKind": "package-runtime"
+                },
+                {
+                  "tableName": "workspace_settings",
+                  "provenance": "runtime-package",
+                  "ownerKind": "package-runtime"
+                },
+                {
+                  "tableName": "workspace_invites",
+                  "provenance": "runtime-package",
+                  "ownerKind": "package-runtime"
+                }
+              ]
+            }
+          },
           "apiSummary": {
             "surfaces": [
               {

--- a/tooling/jskit-cli/src/server/commandHandlers/health.js
+++ b/tooling/jskit-cli/src/server/commandHandlers/health.js
@@ -2,6 +2,8 @@ import {
   readdir,
   readFile
 } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { importFreshModuleFromAbsolutePath } from "@jskit-ai/kernel/server/support";
 import {
   ensureArray,
   ensureObject,
@@ -81,12 +83,39 @@ function createHealthCommands(ctx = {}) {
     "useCrudAddEdit"
   ]);
   const FEATURE_SERVER_SCAFFOLD_SHAPE = "feature-server-v1";
+  const CRUD_SERVER_SCAFFOLD_SHAPE = "crud-server-v1";
+  const USERS_CORE_BASELINE_CRUD_SCAFFOLD_SHAPE = "users-core-crud-v1";
   const FEATURE_SERVER_DEFAULT_LANE = "default";
   const FEATURE_SERVER_JSON_REST_MODE = "json-rest";
   const FEATURE_SERVER_PERSISTENT_MODES = new Set([
     "json-rest",
     "custom-knex"
   ]);
+  const TABLE_OWNERSHIP_RELATIVE_PATH = ".jskit/table-ownership.json";
+  const TABLE_OWNERSHIP_VERSION = 1;
+  const TABLE_OWNERSHIP_EXCEPTION_CATEGORIES = new Set([
+    "audit-log",
+    "join-table",
+    "outbox",
+    "projection-cache",
+    "workflow-state"
+  ]);
+  const TABLE_OWNERSHIP_AUXILIARY_INHERITED_OWNER_EXCEPTION_CATEGORIES = new Set([
+    "audit-log",
+    "join-table",
+    "outbox",
+    "projection-cache"
+  ]);
+  const KNEX_SYSTEM_TABLE_NAMES = new Set([
+    "knex_migrations",
+    "knex_migrations_lock"
+  ]);
+  const DIRECT_OWNER_COLUMNS = Object.freeze({
+    user: "user_id",
+    workspace: "workspace_id"
+  });
+  const DIRECT_OWNER_KINDS = Object.freeze(Object.keys(DIRECT_OWNER_COLUMNS));
+  const CRUD_OWNERSHIP_FILTER_LITERAL_PATTERN = /\bownershipFilter\s*:\s*"([A-Za-z_]+)"/u;
   const FEATURE_SERVER_COMPLEX_MARKER_RELATIVE_PATHS = Object.freeze([
     "src/server/inputSchemas.js",
     "src/server/actions.js",
@@ -108,6 +137,13 @@ function createHealthCommands(ctx = {}) {
   ]);
   const MAIN_SERVER_DOMAIN_FILE_PATTERN =
     /^src\/server\/(?!(?:index|MainServiceProvider|loadAppConfig)\.[A-Za-z0-9]+$).+/u;
+  const APP_LOCAL_DIRECT_KNEX_PATTERN_ENTRIES = Object.freeze([
+    { pattern: /\bjskit\.database\.knex\b/u, label: "jskit.database.knex" },
+    { pattern: /\bcreateWithTransaction\s*\(/u, label: "createWithTransaction(...)" },
+    { pattern: /\bknex\s*\(/u, label: "knex(...)" },
+    { pattern: /\bknex\./u, label: "knex." },
+    { pattern: /from\s+["']knex["']/u, label: 'import "knex"' }
+  ]);
 
   function collectDescriptorContainerTokens({ packageId, side, values, issues }) {
     const declaredTokens = new Set();
@@ -545,6 +581,516 @@ function createHealthCommands(ctx = {}) {
     };
   }
 
+  function normalizeJskitMetadata(descriptor = {}) {
+    return ensureObject(ensureObject(ensureObject(descriptor).metadata).jskit);
+  }
+
+  function normalizeOwnedTableEntries(packageEntry) {
+    const packageId = String(packageEntry?.packageId || "").trim();
+    const packagePath = resolvePackageDisplayPath(packageEntry);
+    const metadata = normalizeJskitMetadata(packageEntry?.descriptor);
+    const tableOwnership = ensureObject(metadata.tableOwnership);
+    const normalized = [];
+
+    for (const rawEntry of ensureArray(tableOwnership.tables)) {
+      const entry = ensureObject(rawEntry);
+      const tableName = String(entry.tableName || "").trim().toLowerCase();
+      if (!tableName) {
+        continue;
+      }
+      normalized.push({
+        packageId,
+        packagePath,
+        tableName,
+        provenance: String(entry.provenance || "").trim().toLowerCase(),
+        ownerKind: String(entry.ownerKind || "").trim().toLowerCase()
+      });
+    }
+
+    return normalized;
+  }
+
+  function packageAllowsDirectKnexUsage(packageEntry) {
+    const featureMetadata = normalizeFeatureLaneMetadata(packageEntry?.descriptor);
+    if (
+      featureMetadata.scaffoldShape === FEATURE_SERVER_SCAFFOLD_SHAPE &&
+      featureMetadata.scaffoldMode === "custom-knex" &&
+      featureMetadata.lane === "weird-custom"
+    ) {
+      return true;
+    }
+
+    const jskitMetadata = normalizeJskitMetadata(packageEntry?.descriptor);
+    const scaffoldShape = String(jskitMetadata.scaffoldShape || "").trim();
+    if (
+      scaffoldShape === CRUD_SERVER_SCAFFOLD_SHAPE ||
+      scaffoldShape === USERS_CORE_BASELINE_CRUD_SCAFFOLD_SHAPE
+    ) {
+      return true;
+    }
+
+    return normalizeOwnedTableEntries(packageEntry).some((entry) =>
+      entry.provenance === "crud-server-generator" || entry.provenance === "users-core-template"
+    );
+  }
+
+  function packageRequiresCrudOwnershipProvenance(packageEntry) {
+    const descriptor = ensureObject(packageEntry?.descriptor);
+    const providedCapabilities = ensureArray(ensureObject(descriptor.capabilities).provides)
+      .map((value) => String(value || "").trim())
+      .filter(Boolean);
+    return providedCapabilities.some((value) => value.startsWith("crud."));
+  }
+
+  function normalizeTableOwnershipExceptionEntries(rawValue = {}) {
+    const source = ensureObject(rawValue);
+    const exceptions = [];
+    for (const rawEntry of ensureArray(source.exceptions)) {
+      const entry = ensureObject(rawEntry);
+      const tableName = String(entry.tableName || "").trim().toLowerCase();
+      const category = String(entry.category || "").trim().toLowerCase();
+      const owner = String(entry.owner || "").trim();
+      const reason = String(entry.reason || "").trim();
+      exceptions.push({
+        tableName,
+        category,
+        owner,
+        reason
+      });
+    }
+    return {
+      version: Number(source.version || 0),
+      exceptions
+    };
+  }
+
+  async function loadTableOwnershipExceptionConfig({ appRoot, issues }) {
+    const absolutePath = path.join(appRoot, TABLE_OWNERSHIP_RELATIVE_PATH);
+    if (!(await fileExists(absolutePath))) {
+      return {
+        exists: false,
+        exceptions: []
+      };
+    }
+
+    let parsed = null;
+    try {
+      parsed = JSON.parse(await readFile(absolutePath, "utf8"));
+    } catch (error) {
+      issues.push(
+        `[table-ownership:invalid-exception-file] ${TABLE_OWNERSHIP_RELATIVE_PATH} is not valid JSON: ${error instanceof Error ? error.message : String(error)}`
+      );
+      return {
+        exists: true,
+        exceptions: []
+      };
+    }
+
+    const config = normalizeTableOwnershipExceptionEntries(parsed);
+    if (config.version !== TABLE_OWNERSHIP_VERSION) {
+      issues.push(
+        `[table-ownership:invalid-exception-file] ${TABLE_OWNERSHIP_RELATIVE_PATH} must declare version ${TABLE_OWNERSHIP_VERSION}.`
+      );
+    }
+
+    const seenTables = new Set();
+    for (const entry of config.exceptions) {
+      if (!entry.tableName) {
+        issues.push(
+          `[table-ownership:invalid-exception-file] ${TABLE_OWNERSHIP_RELATIVE_PATH} contains an exception without tableName.`
+        );
+        continue;
+      }
+      if (!TABLE_OWNERSHIP_EXCEPTION_CATEGORIES.has(entry.category)) {
+        issues.push(
+          `[table-ownership:invalid-exception-file] ${TABLE_OWNERSHIP_RELATIVE_PATH} table "${entry.tableName}" must use one of: ${sortStrings([...TABLE_OWNERSHIP_EXCEPTION_CATEGORIES]).join(", ")}.`
+        );
+      }
+      if (!entry.owner) {
+        issues.push(
+          `[table-ownership:invalid-exception-file] ${TABLE_OWNERSHIP_RELATIVE_PATH} table "${entry.tableName}" must include owner.`
+        );
+      }
+      if (!entry.reason) {
+        issues.push(
+          `[table-ownership:invalid-exception-file] ${TABLE_OWNERSHIP_RELATIVE_PATH} table "${entry.tableName}" must include reason.`
+        );
+      }
+      if (seenTables.has(entry.tableName)) {
+        issues.push(
+          `[table-ownership:invalid-exception-file] ${TABLE_OWNERSHIP_RELATIVE_PATH} declares table "${entry.tableName}" more than once.`
+        );
+        continue;
+      }
+      seenTables.add(entry.tableName);
+    }
+
+    return {
+      exists: true,
+      exceptions: config.exceptions
+    };
+  }
+
+  function normalizeKnexRawRows(rawResult = null) {
+    if (Array.isArray(rawResult)) {
+      if (rawResult.length > 0 && Array.isArray(rawResult[0])) {
+        return rawResult[0];
+      }
+      return rawResult;
+    }
+
+    if (Array.isArray(rawResult?.rows)) {
+      return rawResult.rows;
+    }
+
+    return [];
+  }
+
+  function normalizeDbIdentifier(value = "") {
+    return String(value || "").trim().toLowerCase();
+  }
+
+  function setMapValue(map, key, defaultValueFactory) {
+    if (!map.has(key)) {
+      map.set(key, defaultValueFactory());
+    }
+    return map.get(key);
+  }
+
+  async function loadAppKnexConfig(appRoot) {
+    const knexfilePath = path.join(appRoot, "knexfile.js");
+    if (!(await fileExists(knexfilePath))) {
+      return null;
+    }
+
+    const moduleNamespace = await importFreshModuleFromAbsolutePath(knexfilePath);
+    const exported =
+      moduleNamespace?.default ??
+      moduleNamespace?.config ??
+      moduleNamespace;
+    const config =
+      typeof exported === "function"
+        ? await exported()
+        : ensureObject(exported);
+
+    return {
+      config: ensureObject(config),
+      path: knexfilePath
+    };
+  }
+
+  function loadAppKnexFactory(appRoot) {
+    const requireFromApp = createRequire(path.join(appRoot, "package.json"));
+    const moduleValue = requireFromApp("knex");
+    const knexFactory =
+      typeof moduleValue === "function"
+        ? moduleValue
+        : typeof moduleValue?.default === "function"
+          ? moduleValue.default
+          : null;
+    if (!knexFactory) {
+      throw new Error("App-local knex package resolved but did not expose a callable factory.");
+    }
+    return knexFactory;
+  }
+
+  async function resolveLiveDatabaseSchema(appRoot) {
+    const loadedKnexConfig = await loadAppKnexConfig(appRoot);
+    if (!loadedKnexConfig) {
+      return {
+        applicable: false,
+        tableNames: [],
+        columnsByTable: new Map(),
+        foreignKeysByTable: new Map()
+      };
+    }
+
+    const knexFactory = loadAppKnexFactory(appRoot);
+    const knex = knexFactory(loadedKnexConfig.config);
+
+    try {
+      const clientId = String(loadedKnexConfig.config.client || "").trim().toLowerCase();
+      let tableRows = [];
+      let columnRows = [];
+      let foreignKeyRows = [];
+      if (clientId.startsWith("mysql")) {
+        tableRows = normalizeKnexRawRows(await knex.raw(
+          "SELECT TABLE_NAME AS tableName FROM information_schema.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_TYPE = 'BASE TABLE' ORDER BY TABLE_NAME"
+        ));
+        columnRows = normalizeKnexRawRows(await knex.raw(
+          "SELECT TABLE_NAME AS tableName, COLUMN_NAME AS columnName FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = DATABASE() ORDER BY TABLE_NAME, ORDINAL_POSITION"
+        ));
+        foreignKeyRows = normalizeKnexRawRows(await knex.raw(
+          "SELECT TABLE_NAME AS tableName, COLUMN_NAME AS columnName, REFERENCED_TABLE_NAME AS referencedTableName, REFERENCED_COLUMN_NAME AS referencedColumnName FROM information_schema.KEY_COLUMN_USAGE WHERE TABLE_SCHEMA = DATABASE() AND REFERENCED_TABLE_NAME IS NOT NULL ORDER BY TABLE_NAME, CONSTRAINT_NAME, ORDINAL_POSITION"
+        ));
+      } else if (clientId === "pg" || clientId.startsWith("postgres")) {
+        tableRows = normalizeKnexRawRows(await knex.raw(
+          'SELECT tablename AS "tableName" FROM pg_tables WHERE schemaname = current_schema() ORDER BY tablename'
+        ));
+        columnRows = normalizeKnexRawRows(await knex.raw(
+          'SELECT table_name AS "tableName", column_name AS "columnName" FROM information_schema.columns WHERE table_schema = current_schema() ORDER BY table_name, ordinal_position'
+        ));
+        foreignKeyRows = normalizeKnexRawRows(await knex.raw(
+          'SELECT kcu.table_name AS "tableName", kcu.column_name AS "columnName", ccu.table_name AS "referencedTableName", ccu.column_name AS "referencedColumnName" FROM information_schema.table_constraints tc JOIN information_schema.key_column_usage kcu ON tc.constraint_name = kcu.constraint_name AND tc.table_schema = kcu.table_schema JOIN information_schema.constraint_column_usage ccu ON ccu.constraint_name = tc.constraint_name AND ccu.table_schema = tc.table_schema WHERE tc.constraint_type = \'FOREIGN KEY\' AND tc.table_schema = current_schema() ORDER BY kcu.table_name, kcu.constraint_name, kcu.ordinal_position'
+        ));
+      } else {
+        throw new Error(`Unsupported knex client for doctor table ownership audit: ${clientId || "<empty>"}.`);
+      }
+
+      const tableNames = sortStrings(
+        tableRows
+          .map((row) => normalizeDbIdentifier(
+            ensureObject(row).tableName || ensureObject(row).TABLE_NAME || ensureObject(row).tablename
+          ))
+          .filter(Boolean)
+          .filter((tableName) => !KNEX_SYSTEM_TABLE_NAMES.has(tableName))
+      );
+      const liveTableNameSet = new Set(tableNames);
+      const columnsByTable = new Map();
+      const foreignKeysByTable = new Map();
+
+      for (const tableName of tableNames) {
+        columnsByTable.set(tableName, new Set());
+        foreignKeysByTable.set(tableName, []);
+      }
+
+      for (const rawRow of columnRows) {
+        const row = ensureObject(rawRow);
+        const tableName = normalizeDbIdentifier(row.tableName || row.TABLE_NAME || row.tablename);
+        const columnName = normalizeDbIdentifier(row.columnName || row.COLUMN_NAME || row.columnname);
+        if (!tableName || !columnName || !liveTableNameSet.has(tableName)) {
+          continue;
+        }
+        setMapValue(columnsByTable, tableName, () => new Set()).add(columnName);
+      }
+
+      for (const rawRow of foreignKeyRows) {
+        const row = ensureObject(rawRow);
+        const tableName = normalizeDbIdentifier(row.tableName || row.TABLE_NAME || row.tablename);
+        const columnName = normalizeDbIdentifier(row.columnName || row.COLUMN_NAME || row.columnname);
+        const referencedTableName = normalizeDbIdentifier(
+          row.referencedTableName || row.REFERENCED_TABLE_NAME || row.referencedtablename
+        );
+        const referencedColumnName = normalizeDbIdentifier(
+          row.referencedColumnName || row.REFERENCED_COLUMN_NAME || row.referencedcolumnname
+        );
+        if (!tableName || !referencedTableName || !liveTableNameSet.has(tableName)) {
+          continue;
+        }
+        setMapValue(foreignKeysByTable, tableName, () => []).push({
+          columnName,
+          referencedTableName,
+          referencedColumnName
+        });
+      }
+
+      return {
+        applicable: true,
+        tableNames,
+        columnsByTable,
+        foreignKeysByTable
+      };
+    } finally {
+      if (knex && typeof knex.destroy === "function") {
+        await knex.destroy();
+      }
+    }
+  }
+
+  function collectInstalledOwnedTables({ installedPackageIds = [], packageRegistry, issues }) {
+    const ownersByTable = new Map();
+
+    for (const packageId of ensureArray(installedPackageIds)) {
+      const packageEntry = packageRegistry.get(packageId) || null;
+      if (!packageEntry) {
+        continue;
+      }
+
+      for (const ownershipEntry of normalizeOwnedTableEntries(packageEntry)) {
+        const existing = ownersByTable.get(ownershipEntry.tableName);
+        if (existing) {
+          issues.push(
+            `[table-ownership:duplicate-owner] table "${ownershipEntry.tableName}" is claimed by both ${existing.packagePath} and ${ownershipEntry.packagePath}.`
+          );
+          continue;
+        }
+        ownersByTable.set(ownershipEntry.tableName, ownershipEntry);
+      }
+    }
+
+    return ownersByTable;
+  }
+
+  function normalizeDirectOwnerKinds(columnNames = new Set()) {
+    const normalizedColumns = columnNames instanceof Set ? columnNames : new Set();
+    const ownerKinds = new Set();
+    for (const ownerKind of DIRECT_OWNER_KINDS) {
+      if (normalizedColumns.has(DIRECT_OWNER_COLUMNS[ownerKind])) {
+        ownerKinds.add(ownerKind);
+      }
+    }
+    return ownerKinds;
+  }
+
+  function resolveRequiredOwnerKindsFromOwnershipFilter(ownershipFilter = "") {
+    const normalizedFilter = normalizeDbIdentifier(ownershipFilter);
+    if (normalizedFilter === "user") {
+      return new Set(["user"]);
+    }
+    if (normalizedFilter === "workspace") {
+      return new Set(["workspace"]);
+    }
+    if (normalizedFilter === "workspace_user") {
+      return new Set(["workspace", "user"]);
+    }
+    return new Set();
+  }
+
+  function subtractStringSet(source = new Set(), valuesToSubtract = new Set()) {
+    const result = new Set();
+    const sourceSet = source instanceof Set ? source : new Set();
+    const subtractSet = valuesToSubtract instanceof Set ? valuesToSubtract : new Set();
+    for (const value of sourceSet) {
+      if (!subtractSet.has(value)) {
+        result.add(value);
+      }
+    }
+    return result;
+  }
+
+  function formatOwnerColumns(ownerKinds = new Set()) {
+    const normalizedKinds = ownerKinds instanceof Set ? ownerKinds : new Set();
+    return sortStrings(
+      [...normalizedKinds]
+        .map((ownerKind) => DIRECT_OWNER_COLUMNS[ownerKind] || "")
+        .filter(Boolean)
+    )
+      .map((columnName) => `"${columnName}"`)
+      .join(", ");
+  }
+
+  async function resolveAppLocalCrudOwnershipFilters({ appRoot, appLocalRegistry }) {
+    const ownershipByTable = new Map();
+    const packageEntries = sortStrings([...appLocalRegistry.keys()])
+      .map((packageId) => appLocalRegistry.get(packageId))
+      .filter(Boolean);
+
+    for (const packageEntry of packageEntries) {
+      if (!packageRequiresCrudOwnershipProvenance(packageEntry)) {
+        continue;
+      }
+
+      const providerPath = resolvePrimaryServerProviderPath(packageEntry);
+      if (!providerPath || !(await fileExists(providerPath))) {
+        continue;
+      }
+
+      const sourceText = await readFile(providerPath, "utf8");
+      const match = CRUD_OWNERSHIP_FILTER_LITERAL_PATTERN.exec(sourceText);
+      if (!match) {
+        continue;
+      }
+      const ownershipFilter = normalizeDbIdentifier(match[1]);
+      const requiredOwnerKinds = resolveRequiredOwnerKindsFromOwnershipFilter(ownershipFilter);
+
+      for (const ownershipEntry of normalizeOwnedTableEntries(packageEntry)) {
+        ownershipByTable.set(ownershipEntry.tableName, {
+          tableName: ownershipEntry.tableName,
+          ownershipFilter,
+          requiredOwnerKinds,
+          packagePath: resolvePackageDisplayPath(packageEntry),
+          providerPath: normalizeRelativePath(appRoot, providerPath)
+        });
+      }
+    }
+
+    return ownershipByTable;
+  }
+
+  function resolveReachableOwnerKinds(tableName, {
+    directOwnerKindsByTable,
+    foreignKeysByTable,
+    memo = new Map(),
+    visiting = new Set()
+  } = {}) {
+    const normalizedTableName = normalizeDbIdentifier(tableName);
+    if (!normalizedTableName) {
+      return new Set();
+    }
+    if (memo.has(normalizedTableName)) {
+      return memo.get(normalizedTableName);
+    }
+    if (visiting.has(normalizedTableName)) {
+      return new Set();
+    }
+
+    visiting.add(normalizedTableName);
+    const resolved = new Set(directOwnerKindsByTable.get(normalizedTableName) || []);
+    for (const foreignKey of ensureArray(foreignKeysByTable.get(normalizedTableName))) {
+      const parentTableName = normalizeDbIdentifier(foreignKey?.referencedTableName);
+      if (!parentTableName) {
+        continue;
+      }
+      for (const ownerKind of resolveReachableOwnerKinds(parentTableName, {
+        directOwnerKindsByTable,
+        foreignKeysByTable,
+        memo,
+        visiting
+      })) {
+        resolved.add(ownerKind);
+      }
+    }
+    visiting.delete(normalizedTableName);
+    memo.set(normalizedTableName, resolved);
+    return resolved;
+  }
+
+  function findInheritedOwnerChain(tableName, ownerKind, {
+    directOwnerKindsByTable,
+    foreignKeysByTable
+  } = {}) {
+    const normalizedTableName = normalizeDbIdentifier(tableName);
+    const normalizedOwnerKind = normalizeDbIdentifier(ownerKind);
+    if (!normalizedTableName || !normalizedOwnerKind) {
+      return [];
+    }
+
+    const visited = new Set([normalizedTableName]);
+    const queue = [{
+      tableName: normalizedTableName,
+      path: [normalizedTableName]
+    }];
+
+    while (queue.length > 0) {
+      const current = queue.shift();
+      const currentTableName = normalizeDbIdentifier(current?.tableName);
+      if (!currentTableName) {
+        continue;
+      }
+
+      for (const foreignKey of ensureArray(foreignKeysByTable.get(currentTableName))) {
+        const parentTableName = normalizeDbIdentifier(foreignKey?.referencedTableName);
+        if (!parentTableName || visited.has(parentTableName)) {
+          continue;
+        }
+        const nextPath = [
+          ...ensureArray(current?.path),
+          parentTableName
+        ];
+        if ((directOwnerKindsByTable.get(parentTableName) || new Set()).has(normalizedOwnerKind)) {
+          return nextPath;
+        }
+        visited.add(parentTableName);
+        queue.push({
+          tableName: parentTableName,
+          path: nextPath
+        });
+      }
+    }
+
+    return [];
+  }
+
   function isFeatureLanePersistenceImportSource(sourcePath = "") {
     const normalizedSourcePath = String(sourcePath || "").trim();
     if (!normalizedSourcePath) {
@@ -841,6 +1387,229 @@ function createHealthCommands(ctx = {}) {
       appLocalRegistry,
       warnings
     });
+  }
+
+  async function collectCrudOwnershipMetadataIssues({ appLocalRegistry, issues }) {
+    const packageEntries = sortStrings([...appLocalRegistry.keys()])
+      .map((packageId) => appLocalRegistry.get(packageId))
+      .filter(Boolean);
+
+    for (const packageEntry of packageEntries) {
+      if (!packageRequiresCrudOwnershipProvenance(packageEntry)) {
+        continue;
+      }
+
+      const packagePath = resolvePackageDisplayPath(packageEntry);
+      const metadata = normalizeJskitMetadata(packageEntry?.descriptor);
+      const scaffoldShape = String(metadata.scaffoldShape || "").trim();
+      const ownedTables = normalizeOwnedTableEntries(packageEntry);
+      if (ownedTables.length < 1) {
+        issues.push(
+          `${packagePath}: [crud-ownership:missing-metadata] CRUD package is missing metadata.jskit.tableOwnership.tables. App-owned CRUD tables must be claimed by generator/baseline ownership metadata so doctor can audit live DB tables.`
+        );
+        continue;
+      }
+
+      const allowedProvenances = String(packageEntry?.packageId || "").trim() === "@local/users"
+        ? new Set(["crud-server-generator", "users-core-template"])
+        : new Set(["crud-server-generator"]);
+      if (
+        scaffoldShape &&
+        scaffoldShape !== CRUD_SERVER_SCAFFOLD_SHAPE &&
+        scaffoldShape !== USERS_CORE_BASELINE_CRUD_SCAFFOLD_SHAPE
+      ) {
+        issues.push(
+          `${packagePath}: [crud-ownership:unsupported-shape] CRUD package declares unsupported metadata.jskit.scaffoldShape="${scaffoldShape}". Use crud-server-generator for app-owned CRUDs, or the JSKIT baseline users scaffold where applicable.`
+        );
+      }
+
+      for (const ownedTable of ownedTables) {
+        if (!allowedProvenances.has(ownedTable.provenance)) {
+          issues.push(
+            `${packagePath}: [crud-ownership:unsupported-provenance] table "${ownedTable.tableName}" is claimed with provenance "${ownedTable.provenance || "<empty>"}". App-owned CRUD tables must come from crud-server-generator (or users-core-template for @local/users).`
+          );
+        }
+      }
+    }
+  }
+
+  async function collectAppLocalDirectKnexIssues({ appRoot, appLocalRegistry, issues }) {
+    const packageEntries = sortStrings([...appLocalRegistry.keys()])
+      .map((packageId) => appLocalRegistry.get(packageId))
+      .filter(Boolean);
+
+    for (const packageEntry of packageEntries) {
+      const featureMetadata = normalizeFeatureLaneMetadata(packageEntry?.descriptor);
+      if (featureMetadata.scaffoldShape === FEATURE_SERVER_SCAFFOLD_SHAPE) {
+        continue;
+      }
+      if (packageAllowsDirectKnexUsage(packageEntry)) {
+        continue;
+      }
+
+      const rootDir = String(packageEntry?.rootDir || "").trim();
+      if (!rootDir) {
+        continue;
+      }
+
+      const serverFilePaths = [];
+      await collectAppSourceFiles(path.join(rootDir, "src", "server"), undefined, serverFilePaths);
+      serverFilePaths.sort((left, right) => left.localeCompare(right));
+
+      for (const absolutePath of serverFilePaths) {
+        const sourceText = await readFile(absolutePath, "utf8");
+        const match = findFirstPatternMatch(sourceText, APP_LOCAL_DIRECT_KNEX_PATTERN_ENTRIES);
+        if (!match) {
+          continue;
+        }
+
+        const relativePath = normalizeRelativePath(appRoot, absolutePath);
+        issues.push(
+          `${relativePath}:${match.lineNumber}: [persistence-lane:direct-knex] app-owned runtime code must stay on generated CRUD or internal json-rest-api by default. Direct knex is only allowed in explicit weird-custom feature-server lanes and approved baseline CRUD packages.`
+        );
+      }
+    }
+  }
+
+  async function collectTableOwnershipDoctorIssues({
+    appRoot,
+    installedPackageIds,
+    packageRegistry,
+    appLocalRegistry,
+    issues
+  }) {
+    await collectCrudOwnershipMetadataIssues({
+      appLocalRegistry,
+      issues
+    });
+    await collectAppLocalDirectKnexIssues({
+      appRoot,
+      appLocalRegistry,
+      issues
+    });
+
+    const exceptionConfig = await loadTableOwnershipExceptionConfig({
+      appRoot,
+      issues
+    });
+
+    let liveSchema = null;
+    try {
+      const resolved = await resolveLiveDatabaseSchema(appRoot);
+      if (!resolved.applicable) {
+        return;
+      }
+      liveSchema = resolved;
+    } catch (error) {
+      issues.push(
+        `[table-ownership:db-introspection-unavailable] doctor could not inspect live database tables via knexfile.js: ${error instanceof Error ? error.message : String(error)}`
+      );
+      return;
+    }
+
+    const liveTables = ensureArray(liveSchema?.tableNames);
+    const columnsByTable = liveSchema?.columnsByTable instanceof Map ? liveSchema.columnsByTable : new Map();
+    const foreignKeysByTable = liveSchema?.foreignKeysByTable instanceof Map ? liveSchema.foreignKeysByTable : new Map();
+    const ownedTablesByName = collectInstalledOwnedTables({
+      installedPackageIds,
+      packageRegistry,
+      issues
+    });
+    const crudOwnershipByTable = await resolveAppLocalCrudOwnershipFilters({
+      appRoot,
+      appLocalRegistry
+    });
+    const exceptionEntriesByName = new Map();
+    for (const entry of exceptionConfig.exceptions) {
+      if (entry.tableName) {
+        exceptionEntriesByName.set(entry.tableName, entry);
+      }
+    }
+    const directOwnerKindsByTable = new Map(
+      liveTables.map((tableName) => [
+        tableName,
+        normalizeDirectOwnerKinds(columnsByTable.get(tableName) || new Set())
+      ])
+    );
+    const reachableOwnerKindsMemo = new Map();
+
+    for (const tableName of liveTables) {
+      if (ownedTablesByName.has(tableName)) {
+        if (exceptionEntriesByName.has(tableName)) {
+          issues.push(
+            `[table-ownership:duplicate-exception] table "${tableName}" is both package-owned and listed in ${TABLE_OWNERSHIP_RELATIVE_PATH}. Remove the exception entry.`
+          );
+        }
+        continue;
+      }
+      if (exceptionEntriesByName.has(tableName)) {
+        continue;
+      }
+
+      issues.push(
+        `[table-ownership:missing-owner] live database table "${tableName}" has no declared owner. Create a server CRUD with jskit generate crud-server-generator scaffold ..., or add a narrow explicit exception in ${TABLE_OWNERSHIP_RELATIVE_PATH}.`
+      );
+    }
+
+    for (const tableName of liveTables) {
+      if (!ownedTablesByName.has(tableName) && !exceptionEntriesByName.has(tableName)) {
+        continue;
+      }
+
+      const directOwnerKinds = directOwnerKindsByTable.get(tableName) || new Set();
+      const reachableOwnerKinds = resolveReachableOwnerKinds(tableName, {
+        directOwnerKindsByTable,
+        foreignKeysByTable,
+        memo: reachableOwnerKindsMemo
+      });
+      const inheritedOwnerKinds = subtractStringSet(reachableOwnerKinds, directOwnerKinds);
+      const exceptionEntry = exceptionEntriesByName.get(tableName) || null;
+      const allowsAuxiliaryInheritedOwnership =
+        exceptionEntry &&
+        TABLE_OWNERSHIP_AUXILIARY_INHERITED_OWNER_EXCEPTION_CATEGORIES.has(exceptionEntry.category);
+
+      const crudOwnership = crudOwnershipByTable.get(tableName) || null;
+      if (crudOwnership) {
+        const missingRequiredOwnerKinds = subtractStringSet(crudOwnership.requiredOwnerKinds, directOwnerKinds);
+        if (missingRequiredOwnerKinds.size > 0) {
+          issues.push(
+            `${crudOwnership.providerPath}: [crud-ownership:missing-owner-columns] ownershipFilter "${crudOwnership.ownershipFilter}" requires live table "${tableName}" to carry direct owner column(s) ${formatOwnerColumns(missingRequiredOwnerKinds)}. JSKIT CRUD ownership must be materialized on the row, not recovered through joins.`
+          );
+        }
+      }
+
+      if (inheritedOwnerKinds.size < 1 || allowsAuxiliaryInheritedOwnership) {
+        continue;
+      }
+
+      for (const ownerKind of sortStrings([...inheritedOwnerKinds])) {
+        const inheritedPath = findInheritedOwnerChain(tableName, ownerKind, {
+          directOwnerKindsByTable,
+          foreignKeysByTable
+        });
+        const formattedPath = inheritedPath.length > 1
+          ? inheritedPath.join(" -> ")
+          : tableName;
+        const ownerColumnName = DIRECT_OWNER_COLUMNS[ownerKind];
+        const exceptionSuffix = exceptionEntry
+          ? ` ${TABLE_OWNERSHIP_RELATIVE_PATH} category "${exceptionEntry.category}" does not exempt inherited ownership.`
+          : "";
+        issues.push(
+          `[table-ownership:inherited-owner] live database table "${tableName}" reaches ${ownerKind} ownership only via foreign-key chain ${formattedPath} but lacks direct owner column "${ownerColumnName}". Materialize the owner on the row instead of filtering through parent relationships.${exceptionSuffix}`
+        );
+      }
+    }
+
+    for (const exceptionEntry of exceptionConfig.exceptions) {
+      if (!exceptionEntry.tableName) {
+        continue;
+      }
+      if (!liveTables.includes(exceptionEntry.tableName)) {
+        issues.push(
+          `[table-ownership:stale-exception] ${TABLE_OWNERSHIP_RELATIVE_PATH} declares table "${exceptionEntry.tableName}" but that table does not exist in the live database.`
+        );
+      }
+    }
   }
 
   function hasTopLevelObjectProperty(sourceText = "", propertyName = "") {
@@ -1320,6 +2089,13 @@ function createHealthCommands(ctx = {}) {
       appLocalRegistry,
       issues,
       warnings
+    });
+    await collectTableOwnershipDoctorIssues({
+      appRoot,
+      installedPackageIds: Object.keys(installed),
+      packageRegistry: combinedPackageRegistry,
+      appLocalRegistry,
+      issues
     });
 
     const payload = {

--- a/tooling/jskit-cli/test/doctorTableOwnershipValidation.test.js
+++ b/tooling/jskit-cli/test/doctorTableOwnershipValidation.test.js
@@ -1,0 +1,707 @@
+import assert from "node:assert/strict";
+import {
+  mkdir,
+  writeFile
+} from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import test from "node:test";
+import { withTempDir } from "../../testUtils/tempDir.mjs";
+import { createCliRunner } from "../../testUtils/runCli.js";
+
+const CLI_PATH = fileURLToPath(new URL("../bin/jskit.js", import.meta.url));
+const runCli = createCliRunner(CLI_PATH);
+
+async function createMinimalApp(appRoot, { name = "tmp-app" } = {}) {
+  await mkdir(appRoot, { recursive: true });
+  await writeFile(
+    path.join(appRoot, "package.json"),
+    `${JSON.stringify(
+      {
+        name,
+        version: "0.1.0",
+        private: true,
+        type: "module"
+      },
+      null,
+      2
+    )}\n`,
+    "utf8"
+  );
+}
+
+async function writeAppFile(appRoot, relativePath, sourceText) {
+  const absolutePath = path.join(appRoot, relativePath);
+  await mkdir(path.dirname(absolutePath), { recursive: true });
+  await writeFile(absolutePath, sourceText, "utf8");
+}
+
+async function installFakeKnex(appRoot, {
+  tables = [],
+  columns = {},
+  foreignKeys = []
+} = {}) {
+  const normalizedColumns = Object.fromEntries(
+    Object.entries(columns).map(([tableName, columnNames]) => [
+      tableName,
+      Array.isArray(columnNames) ? columnNames : []
+    ])
+  );
+  await writeAppFile(
+    appRoot,
+    "node_modules/knex/package.json",
+    `${JSON.stringify(
+      {
+        name: "knex",
+        version: "0.0.0-test",
+        main: "index.js"
+      },
+      null,
+      2
+    )}\n`
+  );
+
+  await writeAppFile(
+    appRoot,
+    "node_modules/knex/index.js",
+    `module.exports = function createKnex() {
+  const tables = ${JSON.stringify(tables)};
+  const columns = ${JSON.stringify(normalizedColumns)};
+  const foreignKeys = ${JSON.stringify(foreignKeys)};
+  return {
+    async raw(sql) {
+      if (/information_schema\\.TABLES/i.test(String(sql || ""))) {
+        return [tables.map((tableName) => ({ tableName })), []];
+      }
+      if (/information_schema\\.COLUMNS/i.test(String(sql || ""))) {
+        return [Object.entries(columns).flatMap(([tableName, columnNames]) => columnNames.map((columnName) => ({ tableName, columnName }))), []];
+      }
+      if (/information_schema\\.KEY_COLUMN_USAGE/i.test(String(sql || ""))) {
+        return [foreignKeys.map((entry) => ({ ...entry })), []];
+      }
+      if (/pg_tables/i.test(String(sql || ""))) {
+        return {
+          rows: tables.map((tableName) => ({ tableName }))
+        };
+      }
+      if (/information_schema\\.columns/i.test(String(sql || ""))) {
+        return {
+          rows: Object.entries(columns).flatMap(([tableName, columnNames]) => columnNames.map((columnName) => ({ tableName, columnName })))
+        };
+      }
+      if (/constraint_type\\s*=\\s*'FOREIGN KEY'/i.test(String(sql || ""))) {
+        return {
+          rows: foreignKeys.map((entry) => ({ ...entry }))
+        };
+      }
+      throw new Error("Unexpected raw query: " + String(sql || ""));
+    },
+    async destroy() {}
+  };
+};
+`
+  );
+}
+
+async function writeKnexfile(appRoot, { client = "mysql2" } = {}) {
+  await writeAppFile(
+    appRoot,
+    "knexfile.js",
+    `export default {
+  client: ${JSON.stringify(client)},
+  connection: {}
+};
+`
+  );
+}
+
+async function writeLockFile(appRoot, installedPackageIds = []) {
+  const installedPackages = Object.fromEntries(
+    installedPackageIds.map((packageId) => [packageId, {}])
+  );
+  await writeAppFile(
+    appRoot,
+    ".jskit/lock.json",
+    `${JSON.stringify(
+      {
+        lockVersion: 1,
+        installedPackages
+      },
+      null,
+      2
+    )}\n`
+  );
+}
+
+async function writePackageDescriptor(appRoot, packageDirectoryName, descriptorSource, extraFiles = {}) {
+  await writeAppFile(
+    appRoot,
+    `packages/${packageDirectoryName}/package.json`,
+    `${JSON.stringify(
+      {
+        name: `@local/${packageDirectoryName}`,
+        version: "0.1.0",
+        type: "module"
+      },
+      null,
+      2
+    )}\n`
+  );
+  await writeAppFile(appRoot, `packages/${packageDirectoryName}/package.descriptor.mjs`, descriptorSource);
+
+  for (const [relativePath, body] of Object.entries(extraFiles)) {
+    await writeAppFile(appRoot, `packages/${packageDirectoryName}/${relativePath}`, body);
+  }
+}
+
+function createCrudProviderStub(ownershipFilter = "public", className = "CrudProvider") {
+  return `const CRUD_MODULE_CONFIG = Object.freeze({
+  ownershipFilter: ${JSON.stringify(ownershipFilter)}
+});
+class ${className} {}
+export { ${className} };
+`;
+}
+
+test("doctor accepts live tables owned by generated CRUD metadata", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "doctor-table-ownership-crud-app");
+    await createMinimalApp(appRoot, { name: "doctor-table-ownership-crud-app" });
+    await installFakeKnex(appRoot, { tables: ["contacts"] });
+    await writeKnexfile(appRoot);
+    await writeLockFile(appRoot, ["@local/contacts"]);
+
+    await writePackageDescriptor(
+      appRoot,
+      "contacts",
+      `export default Object.freeze({
+  packageId: "@local/contacts",
+  version: "0.1.0",
+  kind: "runtime",
+  capabilities: {
+    provides: ["crud.contacts"],
+    requires: []
+  },
+  runtime: {
+    server: {
+      providers: [
+        {
+          entrypoint: "src/server/ContactsProvider.js",
+          export: "ContactsProvider"
+        }
+      ]
+    }
+  },
+  metadata: {
+    jskit: {
+      scaffoldShape: "crud-server-v1",
+      tableOwnership: {
+        tables: [
+          {
+            tableName: "contacts",
+            provenance: "crud-server-generator",
+            ownerKind: "crud-package"
+          }
+        ]
+      }
+    },
+    apiSummary: {
+      containerTokens: {
+        server: ["repository.contacts", "crud.contacts"]
+      }
+    }
+  },
+  mutations: {
+    files: []
+      }
+});
+`,
+      {
+        "src/server/ContactsProvider.js": createCrudProviderStub("public", "ContactsProvider")
+      }
+    );
+
+    const doctorResult = runCli({
+      cwd: appRoot,
+      args: ["doctor", "--json"]
+    });
+
+    assert.equal(doctorResult.status, 0, String(doctorResult.stderr || ""));
+    const payload = JSON.parse(String(doctorResult.stdout || "{}"));
+    assert.deepEqual(payload.issues, []);
+  });
+});
+
+test("doctor flags live tables without CRUD/package ownership or explicit exception", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "doctor-table-ownership-missing-app");
+    await createMinimalApp(appRoot, { name: "doctor-table-ownership-missing-app" });
+    await installFakeKnex(appRoot, { tables: ["contacts"] });
+    await writeKnexfile(appRoot);
+
+    const doctorResult = runCli({
+      cwd: appRoot,
+      args: ["doctor", "--json"]
+    });
+
+    assert.equal(doctorResult.status, 1, String(doctorResult.stderr || ""));
+    const payload = JSON.parse(String(doctorResult.stdout || "{}"));
+    assert.match(
+      String(payload.issues[0] || ""),
+      /\[table-ownership:missing-owner\] live database table "contacts" has no declared owner/
+    );
+  });
+});
+
+test("doctor accepts explicit narrow non-CRUD table exceptions", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "doctor-table-ownership-exception-app");
+    await createMinimalApp(appRoot, { name: "doctor-table-ownership-exception-app" });
+    await installFakeKnex(appRoot, { tables: ["user_program_assignments"] });
+    await writeKnexfile(appRoot);
+    await writeAppFile(
+      appRoot,
+      ".jskit/table-ownership.json",
+      `${JSON.stringify(
+        {
+          version: 1,
+          exceptions: [
+            {
+              tableName: "user_program_assignments",
+              category: "workflow-state",
+              owner: "packages/program-assignment",
+              reason: "Workflow-owned assignment aggregate."
+            }
+          ]
+        },
+        null,
+        2
+      )}\n`
+    );
+
+    const doctorResult = runCli({
+      cwd: appRoot,
+      args: ["doctor", "--json"]
+    });
+
+    assert.equal(doctorResult.status, 0, String(doctorResult.stderr || ""));
+    const payload = JSON.parse(String(doctorResult.stdout || "{}"));
+    assert.deepEqual(payload.issues, []);
+  });
+});
+
+test("doctor rejects invalid table exception categories", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "doctor-table-ownership-invalid-exception-app");
+    await createMinimalApp(appRoot, { name: "doctor-table-ownership-invalid-exception-app" });
+    await installFakeKnex(appRoot, { tables: ["user_program_assignments"] });
+    await writeKnexfile(appRoot);
+    await writeAppFile(
+      appRoot,
+      ".jskit/table-ownership.json",
+      `${JSON.stringify(
+        {
+          version: 1,
+          exceptions: [
+            {
+              tableName: "user_program_assignments",
+              category: "misc",
+              owner: "packages/program-assignment",
+              reason: "Should fail."
+            }
+          ]
+        },
+        null,
+        2
+      )}\n`
+    );
+
+    const doctorResult = runCli({
+      cwd: appRoot,
+      args: ["doctor", "--json"]
+    });
+
+    assert.equal(doctorResult.status, 1, String(doctorResult.stderr || ""));
+    const payload = JSON.parse(String(doctorResult.stdout || "{}"));
+    assert.match(
+      String(payload.issues[0] || ""),
+      /\.jskit\/table-ownership\.json table "user_program_assignments" must use one of:/
+    );
+  });
+});
+
+test("doctor allows the baseline users package provenance for the users table", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "doctor-table-ownership-users-app");
+    await createMinimalApp(appRoot, { name: "doctor-table-ownership-users-app" });
+    await installFakeKnex(appRoot, { tables: ["users"] });
+    await writeKnexfile(appRoot);
+    await writeLockFile(appRoot, ["@local/users"]);
+
+    await writePackageDescriptor(
+      appRoot,
+      "users",
+      `export default Object.freeze({
+  packageId: "@local/users",
+  version: "0.1.0",
+  kind: "runtime",
+  capabilities: {
+    provides: ["crud.users"],
+    requires: []
+  },
+  runtime: {
+    server: {
+      providers: [
+        {
+          entrypoint: "src/server/UsersProvider.js",
+          export: "UsersProvider"
+        }
+      ]
+    }
+  },
+  metadata: {
+    jskit: {
+      scaffoldShape: "users-core-crud-v1",
+      tableOwnership: {
+        tables: [
+          {
+            tableName: "users",
+            provenance: "users-core-template",
+            ownerKind: "baseline-crud"
+          }
+        ]
+      }
+    },
+    apiSummary: {
+      containerTokens: {
+        server: ["repository.users", "crud.users"]
+      }
+    }
+  },
+  mutations: {
+    files: []
+  }
+});
+`,
+      {
+        "src/server/UsersProvider.js": createCrudProviderStub("public", "UsersProvider")
+      }
+    );
+
+    const doctorResult = runCli({
+      cwd: appRoot,
+      args: ["doctor", "--json"]
+    });
+
+    assert.equal(doctorResult.status, 0, String(doctorResult.stderr || ""));
+    const payload = JSON.parse(String(doctorResult.stdout || "{}"));
+    assert.deepEqual(payload.issues, []);
+  });
+});
+
+test("doctor flags direct knex in app-owned packages outside explicit exception lanes", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "doctor-direct-knex-app");
+    await createMinimalApp(appRoot, { name: "doctor-direct-knex-app" });
+    await installFakeKnex(appRoot, { tables: ["reports_cache"] });
+    await writeKnexfile(appRoot);
+    await writeAppFile(
+      appRoot,
+      ".jskit/table-ownership.json",
+      `${JSON.stringify(
+        {
+          version: 1,
+          exceptions: [
+            {
+              tableName: "reports_cache",
+              category: "projection-cache",
+              owner: "packages/reporting-engine",
+              reason: "Projection cache owned by reporting workflow."
+            }
+          ]
+        },
+        null,
+        2
+      )}\n`
+    );
+
+    await writePackageDescriptor(
+      appRoot,
+      "reporting-engine",
+      `export default Object.freeze({
+  packageId: "@local/reporting-engine",
+  version: "0.1.0",
+  kind: "runtime",
+  capabilities: {
+    provides: ["feature.reporting-engine"],
+    requires: []
+  },
+  runtime: {
+    server: {
+      providers: [
+        {
+          entrypoint: "src/server/ReportingEngineProvider.js",
+          export: "ReportingEngineProvider"
+        }
+      ]
+    }
+  },
+  metadata: {
+    apiSummary: {
+      containerTokens: {
+        server: ["feature.reporting-engine.service"]
+      }
+    }
+  },
+  mutations: {
+    files: []
+  }
+});
+`,
+      {
+        "src/server/ReportingEngineProvider.js": "class ReportingEngineProvider {}\nexport { ReportingEngineProvider };\n",
+        "src/server/repository.js": "function createRepository({ knex } = {}) { return knex(\"reports_cache\"); }\nexport { createRepository };\n"
+      }
+    );
+
+    const doctorResult = runCli({
+      cwd: appRoot,
+      args: ["doctor", "--json"]
+    });
+
+    assert.equal(doctorResult.status, 1, String(doctorResult.stderr || ""));
+    const payload = JSON.parse(String(doctorResult.stdout || "{}"));
+    assert.match(
+      payload.issues.join("\n"),
+      /\[persistence-lane:direct-knex\] app-owned runtime code must stay on generated CRUD or internal json-rest-api by default/
+    );
+  });
+});
+
+test("doctor flags CRUD tables whose ownership filter requires a direct owner column", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "doctor-crud-missing-owner-column-app");
+    await createMinimalApp(appRoot, { name: "doctor-crud-missing-owner-column-app" });
+    await installFakeKnex(appRoot, {
+      tables: ["contacts"],
+      columns: {
+        contacts: ["id", "name"]
+      }
+    });
+    await writeKnexfile(appRoot);
+    await writeLockFile(appRoot, ["@local/contacts"]);
+
+    await writePackageDescriptor(
+      appRoot,
+      "contacts",
+      `export default Object.freeze({
+  packageId: "@local/contacts",
+  version: "0.1.0",
+  kind: "runtime",
+  capabilities: {
+    provides: ["crud.contacts"],
+    requires: []
+  },
+  runtime: {
+    server: {
+      providers: [
+        {
+          entrypoint: "src/server/ContactsProvider.js",
+          export: "ContactsProvider"
+        }
+      ]
+    }
+  },
+  metadata: {
+    jskit: {
+      scaffoldShape: "crud-server-v1",
+      tableOwnership: {
+        tables: [
+          {
+            tableName: "contacts",
+            provenance: "crud-server-generator",
+            ownerKind: "crud-package"
+          }
+        ]
+      }
+    }
+  },
+  mutations: {
+    files: []
+  }
+});
+`,
+      {
+        "src/server/ContactsProvider.js": createCrudProviderStub("workspace", "ContactsProvider")
+      }
+    );
+
+    const doctorResult = runCli({
+      cwd: appRoot,
+      args: ["doctor", "--json"]
+    });
+
+    assert.equal(doctorResult.status, 1, String(doctorResult.stderr || ""));
+    const payload = JSON.parse(String(doctorResult.stdout || "{}"));
+    assert.match(
+      payload.issues.join("\n"),
+      /ContactsProvider\.js: \[crud-ownership:missing-owner-columns\] ownershipFilter "workspace" requires live table "contacts" to carry direct owner column\(s\) "workspace_id"/
+    );
+  });
+});
+
+test("doctor flags workflow-state tables that inherit user ownership through parent foreign keys", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "doctor-inherited-owner-workflow-app");
+    await createMinimalApp(appRoot, { name: "doctor-inherited-owner-workflow-app" });
+    await installFakeKnex(appRoot, {
+      tables: ["user_program_assignments", "user_program_assignment_revisions"],
+      columns: {
+        user_program_assignments: ["id", "user_id"],
+        user_program_assignment_revisions: ["id", "user_program_assignment_id"]
+      },
+      foreignKeys: [
+        {
+          tableName: "user_program_assignment_revisions",
+          columnName: "user_program_assignment_id",
+          referencedTableName: "user_program_assignments",
+          referencedColumnName: "id"
+        }
+      ]
+    });
+    await writeKnexfile(appRoot);
+    await writeAppFile(
+      appRoot,
+      ".jskit/table-ownership.json",
+      `${JSON.stringify(
+        {
+          version: 1,
+          exceptions: [
+            {
+              tableName: "user_program_assignments",
+              category: "workflow-state",
+              owner: "packages/program-assignment",
+              reason: "Assignment aggregate."
+            },
+            {
+              tableName: "user_program_assignment_revisions",
+              category: "workflow-state",
+              owner: "packages/program-assignment",
+              reason: "Assignment revision history."
+            }
+          ]
+        },
+        null,
+        2
+      )}\n`
+    );
+
+    const doctorResult = runCli({
+      cwd: appRoot,
+      args: ["doctor", "--json"]
+    });
+
+    assert.equal(doctorResult.status, 1, String(doctorResult.stderr || ""));
+    const payload = JSON.parse(String(doctorResult.stdout || "{}"));
+    assert.match(
+      payload.issues.join("\n"),
+      /\[table-ownership:inherited-owner\] live database table "user_program_assignment_revisions" reaches user ownership only via foreign-key chain user_program_assignment_revisions -> user_program_assignments but lacks direct owner column "user_id"\. Materialize the owner on the row instead of filtering through parent relationships\. .jskit\/table-ownership\.json category "workflow-state" does not exempt inherited ownership\./
+    );
+  });
+});
+
+test("doctor allows auxiliary join tables to inherit ownership without direct owner columns", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "doctor-inherited-owner-join-table-app");
+    await createMinimalApp(appRoot, { name: "doctor-inherited-owner-join-table-app" });
+    await installFakeKnex(appRoot, {
+      tables: ["products", "product_booking_steps"],
+      columns: {
+        products: ["id", "workspace_id"],
+        product_booking_steps: ["id", "product_id"]
+      },
+      foreignKeys: [
+        {
+          tableName: "product_booking_steps",
+          columnName: "product_id",
+          referencedTableName: "products",
+          referencedColumnName: "id"
+        }
+      ]
+    });
+    await writeKnexfile(appRoot);
+    await writeLockFile(appRoot, ["@local/products"]);
+    await writePackageDescriptor(
+      appRoot,
+      "products",
+      `export default Object.freeze({
+  packageId: "@local/products",
+  version: "0.1.0",
+  kind: "runtime",
+  capabilities: {
+    provides: ["crud.products"],
+    requires: []
+  },
+  runtime: {
+    server: {
+      providers: [
+        {
+          entrypoint: "src/server/ProductsProvider.js",
+          export: "ProductsProvider"
+        }
+      ]
+    }
+  },
+  metadata: {
+    jskit: {
+      scaffoldShape: "crud-server-v1",
+      tableOwnership: {
+        tables: [
+          {
+            tableName: "products",
+            provenance: "crud-server-generator",
+            ownerKind: "crud-package"
+          }
+        ]
+      }
+    }
+  },
+  mutations: {
+    files: []
+  }
+});
+`,
+      {
+        "src/server/ProductsProvider.js": createCrudProviderStub("workspace", "ProductsProvider")
+      }
+    );
+    await writeAppFile(
+      appRoot,
+      ".jskit/table-ownership.json",
+      `${JSON.stringify(
+        {
+          version: 1,
+          exceptions: [
+            {
+              tableName: "product_booking_steps",
+              category: "join-table",
+              owner: "packages/products",
+              reason: "Link table between products and booking steps."
+            }
+          ]
+        },
+        null,
+        2
+      )}\n`
+    );
+
+    const doctorResult = runCli({
+      cwd: appRoot,
+      args: ["doctor", "--json"]
+    });
+
+    assert.equal(doctorResult.status, 0, String(doctorResult.stderr || ""));
+    const payload = JSON.parse(String(doctorResult.stdout || "{}"));
+    assert.deepEqual(payload.issues, []);
+  });
+});


### PR DESCRIPTION
## Summary
- make doctor inspect live DB columns and foreign keys, then fail CRUD tables that lack the direct owner columns required by their ownership contract
- fail inherited ownership through parent FK chains unless the table is a narrow auxiliary exception such as a join table
- share JSON:API relationship-id simplification between server and client, update workspace membership lookup behavior, and refresh the ownership metadata/docs/catalog that support the stricter checks

## Testing
- node --test tooling/jskit-cli/test/doctorTableOwnershipValidation.test.js
- node --test tooling/jskit-cli/test/doctorFeatureLaneValidation.test.js tooling/jskit-cli/test/doctorCrudTransportValidation.test.js
- node --test packages/http-runtime/test/jsonApiTransport.test.js packages/http-runtime/test/client.test.js packages/workspaces-core/test/workspaceMembershipsRepository.test.js
- npx jskit doctor --json (dogandgroom)
- npx jskit doctor --json (convict)

## Notes
- did not run `npm run verify`