### PR TITLE
Support internal CRUD HTTP routes

### DIFF
--- a/packages/agent-docs/guide/agent/generators/advanced-cruds.md
+++ b/packages/agent-docs/guide/agent/generators/advanced-cruds.md
@@ -109,6 +109,35 @@ So if the CRUD resolves to:
 
 This is why ownership is such a foundational choice. It becomes part of the generated server contract, not just the database shape.
 
+### `--internal` changes HTTP exposure, not CRUD ownership
+
+`crud-server-generator scaffold` also supports:
+
+```bash
+--internal
+```
+
+That flag does **not** change:
+
+- the generated repository
+- the generated service
+- the shared resource contract
+- the ownership filter
+- the generated actions
+
+It changes only one thing:
+
+- the generated CRUD HTTP routes are marked internal, so the public HTTP runtime does not register them
+
+This is useful when the entity should already be CRUD-owned but should not have public CRUD URLs yet.
+
+So the distinction is:
+
+- ownership answers "who owns and can see the rows?"
+- `--internal` answers "do the public HTTP CRUD routes exist right now?"
+
+That is why `--internal` is not a permissions shortcut and not a UI setting. It is a server-route exposure choice on top of the same CRUD ownership model.
+
 ### Ownership controls which owner columns are expected
 
 The repository layer ultimately applies visibility through the standard owner columns:

--- a/packages/agent-docs/guide/agent/generators/crud-generators.md
+++ b/packages/agent-docs/guide/agent/generators/crud-generators.md
@@ -262,6 +262,22 @@ npx jskit generate crud-server-generator scaffold \
 
 This creates an app-local package under `packages/contacts/`.
 
+If the table should be CRUD-owned now but should **not** expose public HTTP CRUD routes yet, add:
+
+```bash
+--internal
+```
+
+That keeps the generated repository, service, actions, provider, shared resource, and CRUD migration ownership chain exactly the same. The only difference is that the generated HTTP CRUD routes are marked internal, so the public HTTP runtime does not register them.
+
+Use that when:
+
+- other server modules need a proper CRUD-backed table and shared resource contract
+- you want to avoid direct knex
+- you are not ready to expose list/view/create/update/delete URLs yet
+
+Do **not** use `--internal` as a substitute for ownership or permissions design. It is only about whether the public HTTP CRUD routes exist.
+
 Before generating anything, decide these with the developer:
 
 - which operations are allowed for this CRUD

--- a/packages/agent-docs/patterns/crud-scaffolding.md
+++ b/packages/agent-docs/patterns/crud-scaffolding.md
@@ -19,11 +19,18 @@ Rules:
 - For a CRUD-backed entity, start with `jskit generate crud-server-generator scaffold ...`.
 - Unless the table is already owned by a JSKIT baseline package or is an explicit narrow exception recorded in `.jskit/table-ownership.json`, every persisted app-owned table must go through that server CRUD step first.
 - That server scaffold is the crucial first step even if no CRUD UI will be created yet.
+- If the table should be CRUD-owned now but should not expose public CRUD HTTP routes yet, scaffold it with `jskit generate crud-server-generator scaffold ... --internal` instead of dropping to direct knex or a hand-built pseudo-repository.
 - Create the real table directly in the database before scaffolding. `crud-server-generator` reads the live table shape.
 - If `crud-server-generator` is going to own the CRUD, do not hand-write a separate CRUD migration for that table. The generator installs and manages the CRUD migration scaffold itself.
 - Do not scaffold CRUD UI, hand-build CRUD routes, or hand-build CRUD endpoints before the server CRUD package and shared resource file exist.
 - Treat the generated shared resource file as the canonical CRUD contract for later UI scaffolding and CRUD behavior changes.
 - `feature-server-generator` is not the default lane for ordinary persisted entities. Use it for workflows or orchestration that sit on top of CRUD-owned tables, or for rare explicit non-CRUD exceptions.
+
+Meaning of `--internal`:
+
+- it keeps the generated repository, service, actions, provider, resource, and CRUD migration ownership chain
+- it only suppresses public HTTP CRUD route registration
+- it is not a substitute for ownership columns or action/route permissions
 
 Avoid:
 

--- a/packages/agent-docs/reference/autogen/packages/crud-server-generator.md
+++ b/packages/agent-docs/reference/autogen/packages/crud-server-generator.md
@@ -27,6 +27,7 @@ Local functions
 - `resolveAllowedValues(schema = {}, fallbackValues = [])`
 - `resolveGlobalScaffoldCache()`
 - `asRecord(value)`
+- `resolveInternalRouteOption(options = {})`
 - `normalizeRequestedOwnershipFilter(value, { strict = false } = {})`
 - `inferOwnershipFilterFromSnapshot(snapshot)`
 - `assertOwnershipColumnsForFilter(snapshot, filter)`
@@ -94,7 +95,7 @@ Local functions
 - `renderObjectSchemaDefinition(lines = [], { mode = "patch" } = {})`
 - `renderActionInputExpressions({ surfaceRequiresWorkspace = true } = {})`
 - `renderRouteValidatorConstants({ surfaceRequiresWorkspace = true } = {})`
-- `buildReplacementsFromSnapshot({ namespace = "", snapshot, resolvedOwnershipFilter, surfaceRequiresWorkspace = true, surfaceId = "" })`
+- `buildReplacementsFromSnapshot({ namespace = "", snapshot, resolvedOwnershipFilter, surfaceRequiresWorkspace = true, surfaceId = "", routeInternal = false })`
 - `resolveCrudGenerationTableName(options = {})`
 - `createCacheKey({ appRoot, options })`
 - `buildCrudTemplateContext(input = {})`
@@ -201,7 +202,7 @@ Exports
 - `resource`
 - `createTemplateServerFixture(options = {})`
 Local functions
-- `buildTemplateReplacements({ surfaceRequiresWorkspace = true, requiresNamedPermissions = surfaceRequiresWorkspace === true, surfaceId = surfaceRequiresWorkspace ? "admin" : "home" } = {})`
+- `buildTemplateReplacements({ surfaceRequiresWorkspace = true, requiresNamedPermissions = surfaceRequiresWorkspace === true, surfaceId = surfaceRequiresWorkspace ? "admin" : "home", routeInternal = false } = {})`
 - `applyTemplateReplacements(sourceText = "", options = {})`
 - `buildResourceStubSource()`
 - `renderServerTemplateFile(targetServerDirectory, fileName, options)`

--- a/packages/agent-docs/reference/autogen/packages/kernel.md
+++ b/packages/agent-docs/reference/autogen/packages/kernel.md
@@ -870,6 +870,7 @@ Local functions
 - `normalizeMethod(method)`
 - `normalizePath(pathname)`
 - `normalizeRouterMiddlewareStack(value, { context = "middleware" } = {})`
+- `normalizeRouteInternal(value, { method = "", path = "" } = {})`
 - `normalizeRouteInput(method, path, optionsOrHandler, maybeHandler)`
 
 ### `server/http/lib/routeRegistration.js`

--- a/packages/agent-docs/site/guide/generators/advanced-cruds.md
+++ b/packages/agent-docs/site/guide/generators/advanced-cruds.md
@@ -107,6 +107,35 @@ So if the CRUD resolves to:
 
 This is why ownership is such a foundational choice. It becomes part of the generated server contract, not just the database shape.
 
+### `--internal` changes HTTP exposure, not CRUD ownership
+
+`crud-server-generator scaffold` also supports:
+
+```bash
+--internal
+```
+
+That flag does **not** change:
+
+- the generated repository
+- the generated service
+- the shared resource contract
+- the ownership filter
+- the generated actions
+
+It changes only one thing:
+
+- the generated CRUD HTTP routes are marked internal, so the public HTTP runtime does not register them
+
+This is useful when the entity should already be CRUD-owned but should not have public CRUD URLs yet.
+
+So the distinction is:
+
+- ownership answers "who owns and can see the rows?"
+- `--internal` answers "do the public HTTP CRUD routes exist right now?"
+
+That is why `--internal` is not a permissions shortcut and not a UI setting. It is a server-route exposure choice on top of the same CRUD ownership model.
+
 ### Ownership controls which owner columns are expected
 
 The repository layer ultimately applies visibility through the standard owner columns:

--- a/packages/agent-docs/site/guide/generators/crud-generators.md
+++ b/packages/agent-docs/site/guide/generators/crud-generators.md
@@ -260,6 +260,22 @@ npx jskit generate crud-server-generator scaffold \
 
 This creates an app-local package under `packages/contacts/`.
 
+If the table should be CRUD-owned now but should **not** expose public HTTP CRUD routes yet, add:
+
+```bash
+--internal
+```
+
+That keeps the generated repository, service, actions, provider, shared resource, and CRUD migration ownership chain exactly the same. The only difference is that the generated HTTP CRUD routes are marked internal, so the public HTTP runtime does not register them.
+
+Use that when:
+
+- other server modules need a proper CRUD-backed table and shared resource contract
+- you want to avoid direct knex
+- you are not ready to expose list/view/create/update/delete URLs yet
+
+Do **not** use `--internal` as a substitute for ownership or permissions design. It is only about whether the public HTTP CRUD routes exist.
+
 Before generating anything, decide these with the developer:
 
 - which operations are allowed for this CRUD

--- a/packages/agent-docs/templates/app/AGENTS.md
+++ b/packages/agent-docs/templates/app/AGENTS.md
@@ -73,6 +73,7 @@ Core rules:
 - For CRUD chunks, creating the server CRUD with `jskit generate crud-server-generator scaffold ...` is the crucial first step even if no CRUD UI will be created yet.
 - Unless a table is already owned by a JSKIT baseline package or is an explicit narrow exception recorded in `.jskit/table-ownership.json`, every persisted app-owned table must have its own server CRUD package created first with `jskit generate crud-server-generator scaffold ...`, even if no CRUD UI will ever exist.
 - Treat that as a hard invariant, not a style preference. If a persisted app-owned table does not have generated CRUD ownership, `jskit doctor` is expected to fail.
+- If the table should be CRUD-owned but should not expose public CRUD HTTP routes yet, use `jskit generate crud-server-generator scaffold ... --internal` rather than dropping to direct knex or a hand-built pseudo-repository.
 - For a CRUD table that `crud-server-generator` will own, do not hand-write a separate migration. Create the real table directly in the database first, then scaffold the server CRUD so JSKIT can install and manage the CRUD migration scaffold itself.
 - Do not generate CRUD UI or hand-build CRUD routes before the server CRUD package and shared resource file exist.
 - `feature-server-generator` is for workflows, orchestration, and other non-CRUD server features. Do not use it as the starting point for ordinary persisted entity tables.

--- a/packages/crud-server-generator/package.descriptor.mjs
+++ b/packages/crud-server-generator/package.descriptor.mjs
@@ -56,6 +56,13 @@ export default Object.freeze({
       defaultValue: "",
       promptLabel: "Force overwrite",
       promptHint: "Overwrite generated scaffold files if the namespace package directory already exists."
+    },
+    internal: {
+      required: false,
+      inputType: "flag",
+      defaultValue: "",
+      promptLabel: "Internal HTTP routes",
+      promptHint: "Mark generated CRUD HTTP routes as internal-only so they are not publicly registered."
     }
   },
   optionPolicies: {
@@ -103,7 +110,8 @@ export default Object.freeze({
           "table-name",
           "id-column",
           "directory-prefix",
-          "force"
+          "force",
+          "internal"
         ],
         createTarget: {
           pathTemplate: "packages/${option:namespace|kebab}",

--- a/packages/crud-server-generator/src/server/buildTemplateContext.js
+++ b/packages/crud-server-generator/src/server/buildTemplateContext.js
@@ -15,6 +15,7 @@ import {
   loadAppConfigFromModuleUrl,
   resolveRequiredAppRoot
 } from "@jskit-ai/kernel/server/support";
+import { normalizeBoolean } from "@jskit-ai/kernel/shared/support/normalize";
 import { normalizeCrudLookupNamespace } from "@jskit-ai/kernel/shared/support/crudLookup";
 import { toCamelCase, toSnakeCase } from "@jskit-ai/kernel/shared/support/stringCase";
 import descriptor from "../../package.descriptor.mjs";
@@ -76,6 +77,13 @@ function asRecord(value) {
     return {};
   }
   return value;
+}
+
+function resolveInternalRouteOption(options = {}) {
+  if (!Object.prototype.hasOwnProperty.call(options, "internal")) {
+    return false;
+  }
+  return normalizeBoolean(options.internal);
 }
 
 function normalizeRequestedOwnershipFilter(value, { strict = false } = {}) {
@@ -1823,7 +1831,8 @@ function buildReplacementsFromSnapshot({
   snapshot,
   resolvedOwnershipFilter,
   surfaceRequiresWorkspace = true,
-  surfaceId = ""
+  surfaceId = "",
+  routeInternal = false
 }) {
   const requiresNamedPermissions = surfaceRequiresWorkspace === true;
   const scaffoldColumns = resolveScaffoldColumns(snapshot);
@@ -1888,6 +1897,7 @@ function buildReplacementsFromSnapshot({
     __JSKIT_CRUD_ROUTE_WORKSPACE_SUPPORT_IMPORTS__: renderRouteWorkspaceSupportImports({
       surfaceRequiresWorkspace
     }),
+    __JSKIT_CRUD_ROUTE_INTERNAL_LINE__: routeInternal === true ? "      internal: true," : "",
     __JSKIT_CRUD_ROUTE_CONTRACTS_RESOURCE_ARGS__: surfaceRequiresWorkspace ? ",\n  routeParamsValidator" : "",
     __JSKIT_CRUD_ROUTE_VALIDATOR_CONSTANTS__: renderRouteValidatorConstants({
       surfaceRequiresWorkspace
@@ -1969,7 +1979,8 @@ function createCacheKey({ appRoot, options }) {
       surface: normalizeText(options?.surface),
       ownershipFilter: normalizeText(options?.["ownership-filter"]),
       tableName: normalizeText(options?.["table-name"]),
-      idColumn: normalizeText(options?.["id-column"])
+      idColumn: normalizeText(options?.["id-column"]),
+      internal: resolveInternalRouteOption(options)
     }
   };
 
@@ -2010,13 +2021,15 @@ async function buildCrudTemplateContext(input = {}) {
     options,
     surface: resolvedSurface
   });
+  const routeInternal = resolveInternalRouteOption(options);
 
   return buildReplacementsFromSnapshot({
     namespace,
     snapshot,
     resolvedOwnershipFilter,
     surfaceRequiresWorkspace,
-    surfaceId: resolvedSurface
+    surfaceId: resolvedSurface,
+    routeInternal
   });
 }
 
@@ -2058,7 +2071,8 @@ const __testables = Object.freeze({
   renderActionInputExpressions,
   renderRouteValidatorConstants,
   renderRouteParamsValidatorLine,
-  renderRouteInputLines
+  renderRouteInputLines,
+  resolveInternalRouteOption
 });
 
 export {

--- a/packages/crud-server-generator/templates/src/local-package/server/registerRoutes.js
+++ b/packages/crud-server-generator/templates/src/local-package/server/registerRoutes.js
@@ -38,6 +38,7 @@ function registerRoutes(
     {
       auth: "required",
       surface: normalizedRouteSurface,
+__JSKIT_CRUD_ROUTE_INTERNAL_LINE__
       visibility: checkRouteVisibility(routeOwnershipFilter),
       meta: {
         tags: ["crud"],
@@ -64,6 +65,7 @@ __JSKIT_CRUD_LIST_ROUTE_INPUT_LINES__
     {
       auth: "required",
       surface: normalizedRouteSurface,
+__JSKIT_CRUD_ROUTE_INTERNAL_LINE__
       visibility: checkRouteVisibility(routeOwnershipFilter),
       meta: {
         tags: ["crud"],
@@ -89,6 +91,7 @@ __JSKIT_CRUD_VIEW_ROUTE_INPUT_LINES__
     {
       auth: "required",
       surface: normalizedRouteSurface,
+__JSKIT_CRUD_ROUTE_INTERNAL_LINE__
       visibility: checkRouteVisibility(routeOwnershipFilter),
       meta: {
         tags: ["crud"],
@@ -114,6 +117,7 @@ __JSKIT_CRUD_CREATE_ROUTE_INPUT_LINES__
     {
       auth: "required",
       surface: normalizedRouteSurface,
+__JSKIT_CRUD_ROUTE_INTERNAL_LINE__
       visibility: checkRouteVisibility(routeOwnershipFilter),
       meta: {
         tags: ["crud"],
@@ -139,6 +143,7 @@ __JSKIT_CRUD_UPDATE_ROUTE_INPUT_LINES__
     {
       auth: "required",
       surface: normalizedRouteSurface,
+__JSKIT_CRUD_ROUTE_INTERNAL_LINE__
       visibility: checkRouteVisibility(routeOwnershipFilter),
       meta: {
         tags: ["crud"],

--- a/packages/crud-server-generator/test-support/templateServerFixture.js
+++ b/packages/crud-server-generator/test-support/templateServerFixture.js
@@ -17,7 +17,8 @@ const CRUD_NAMESPACE = Object.freeze({
 function buildTemplateReplacements({
   surfaceRequiresWorkspace = true,
   requiresNamedPermissions = surfaceRequiresWorkspace === true,
-  surfaceId = surfaceRequiresWorkspace ? "admin" : "home"
+  surfaceId = surfaceRequiresWorkspace ? "admin" : "home",
+  routeInternal = false
 } = {}) {
   const routeWorkspaceSupportImports = surfaceRequiresWorkspace
     ? [
@@ -141,6 +142,7 @@ function buildTemplateReplacements({
     ["__JSKIT_CRUD_ROUTE_SURFACE_REQUIRES_WORKSPACE__", String(surfaceRequiresWorkspace === true)],
     ["__JSKIT_CRUD_ROUTE_BASE__", JSON.stringify(surfaceRequiresWorkspace ? "/w/:workspaceSlug" : "/")],
     ["__JSKIT_CRUD_ROUTE_WORKSPACE_SUPPORT_IMPORTS__", routeWorkspaceSupportImports],
+    ["__JSKIT_CRUD_ROUTE_INTERNAL_LINE__", routeInternal === true ? "      internal: true," : ""],
     ["__JSKIT_CRUD_ROUTE_CONTRACTS_RESOURCE_ARGS__", surfaceRequiresWorkspace ? ",\n  routeParamsValidator" : ""],
     ["__JSKIT_CRUD_ROUTE_VALIDATOR_CONSTANTS__", surfaceRequiresWorkspace
       ? [

--- a/packages/crud-server-generator/test/buildTemplateContext.test.js
+++ b/packages/crud-server-generator/test/buildTemplateContext.test.js
@@ -235,6 +235,37 @@ test("resolveOwnershipFilterForGeneration rejects explicit ownership filters whe
   );
 });
 
+test("buildReplacementsFromSnapshot renders an internal route line only when requested", () => {
+  const snapshot = createSnapshot();
+
+  const publicReplacements = __testables.buildReplacementsFromSnapshot({
+    namespace: "customers",
+    snapshot,
+    resolvedOwnershipFilter: "workspace_user",
+    surfaceRequiresWorkspace: true,
+    surfaceId: "admin",
+    routeInternal: false
+  });
+  const internalReplacements = __testables.buildReplacementsFromSnapshot({
+    namespace: "customers",
+    snapshot,
+    resolvedOwnershipFilter: "workspace_user",
+    surfaceRequiresWorkspace: true,
+    surfaceId: "admin",
+    routeInternal: true
+  });
+
+  assert.equal(publicReplacements.__JSKIT_CRUD_ROUTE_INTERNAL_LINE__, "");
+  assert.equal(internalReplacements.__JSKIT_CRUD_ROUTE_INTERNAL_LINE__, "      internal: true,");
+});
+
+test("resolveInternalRouteOption rejects invalid internal flag values instead of silently generating public routes", () => {
+  assert.throws(
+    () => __testables.resolveInternalRouteOption({ internal: "maybe" }),
+    /Boolean field must be true or false/
+  );
+});
+
 test("resolveCrudGenerationTableName defaults table-name from namespace", () => {
   assert.equal(
     __testables.resolveCrudGenerationTableName({

--- a/packages/crud-server-generator/test/packageDescriptor.test.js
+++ b/packages/crud-server-generator/test/packageDescriptor.test.js
@@ -16,8 +16,10 @@ test("crud-server-generator surface option validates against enabled surface ids
     descriptor.options?.["table-name"]?.defaultFromOptionTemplate,
     "${option:namespace}"
   );
+  assert.equal(descriptor.options?.internal?.inputType, "flag");
   assert.equal(descriptor.metadata?.generatorSubcommands?.scaffold?.optionNames?.includes("surface"), true);
   assert.equal(descriptor.metadata?.generatorSubcommands?.scaffold?.optionNames?.includes("force"), true);
+  assert.equal(descriptor.metadata?.generatorSubcommands?.scaffold?.optionNames?.includes("internal"), true);
   assert.equal(descriptor.metadata?.generatorSubcommands?.scaffold?.createTarget?.pathTemplate, "packages/${option:namespace|kebab}");
 });
 

--- a/packages/crud-server-generator/test/routeInputContracts.test.js
+++ b/packages/crud-server-generator/test/routeInputContracts.test.js
@@ -9,12 +9,17 @@ const nonWorkspaceFixture = await createTemplateServerFixture({
   surfaceRequiresWorkspace: false,
   requiresNamedPermissions: false
 });
+const internalFixture = await createTemplateServerFixture({
+  routeInternal: true
+});
 const { registerRoutes: registerWorkspaceRoutes } = await workspaceFixture.importServerModule("registerRoutes.js");
 const { registerRoutes: registerNonWorkspaceRoutes } = await nonWorkspaceFixture.importServerModule("registerRoutes.js");
+const { registerRoutes: registerInternalRoutes } = await internalFixture.importServerModule("registerRoutes.js");
 
 after(async () => {
   await workspaceFixture.cleanup();
   await nonWorkspaceFixture.cleanup();
+  await internalFixture.cleanup();
 });
 
 function createReplyDouble() {
@@ -435,4 +440,35 @@ test("crud view route forwards include query input", async () => {
     recordId: 7,
     include: "vetId"
   });
+});
+
+test("crud routes mark every generated HTTP route as internal when requested", () => {
+  const registeredRoutes = [];
+  const router = {
+    register(method, path, route, handler) {
+      registeredRoutes.push({
+        method,
+        path,
+        route,
+        handler
+      });
+    }
+  };
+  const app = {
+    make(token) {
+      if (token !== "jskit.http.router") {
+        throw new Error(`Unexpected token: ${String(token)}`);
+      }
+      return router;
+    }
+  };
+
+  registerInternalRoutes(app, {
+    routeRelativePath: "/customers"
+  });
+
+  assert.equal(registeredRoutes.length, 5);
+  for (const route of registeredRoutes) {
+    assert.equal(route.route.internal, true);
+  }
 });

--- a/packages/kernel/server/http/lib/kernel.test.js
+++ b/packages/kernel/server/http/lib/kernel.test.js
@@ -506,6 +506,77 @@ test("registerHttpRuntime passes app context so request scope is available", asy
   assert.equal(fastify.setErrorHandlerCalls, 1);
 });
 
+test("createRouter preserves explicit internal route flags", () => {
+  const router = createRouter();
+
+  router.get(
+    "/internal-only",
+    {
+      internal: true
+    },
+    async (_request, reply) => {
+      reply.code(204).send();
+    }
+  );
+
+  const [route] = router.list();
+  assert.equal(route?.internal, true);
+});
+
+test("registerHttpRuntime skips internal routes from public HTTP registration", () => {
+  const app = createApplication();
+  const fastify = createFastifyStub();
+  const router = createRouter();
+
+  router.get(
+    "/internal-only",
+    {
+      internal: true
+    },
+    async (_request, reply) => {
+      reply.code(200).send({ hidden: true });
+    }
+  );
+  router.get("/public-route", async (_request, reply) => {
+    reply.code(200).send({ ok: true });
+  });
+
+  app.instance("jskit.fastify", fastify);
+  app.instance("jskit.http.router", router);
+
+  const registration = registerHttpRuntime(app);
+  assert.equal(registration.routeCount, 1);
+  assert.equal(fastify.routes.length, 1);
+  assert.equal(fastify.routes[0].url, "/public-route");
+});
+
+test("registerHttpRuntime skips internal routes generated through router apiResource helpers", () => {
+  const app = createApplication();
+  const fastify = createFastifyStub();
+  const router = createRouter();
+
+  router.apiResource(
+    "widgets",
+    {
+      index: async (_request, reply) => reply.code(200).send({ ok: true }),
+      store: async (_request, reply) => reply.code(201).send({ ok: true }),
+      show: async (_request, reply) => reply.code(200).send({ ok: true }),
+      update: async (_request, reply) => reply.code(200).send({ ok: true }),
+      destroy: async (_request, reply) => reply.code(204).send()
+    },
+    {
+      internal: true
+    }
+  );
+
+  app.instance("jskit.fastify", fastify);
+  app.instance("jskit.http.router", router);
+
+  const registration = registerHttpRuntime(app);
+  assert.equal(registration.routeCount, 0);
+  assert.equal(fastify.routes.length, 0);
+});
+
 test("registerHttpRuntime installs API error handling once by default", () => {
   const app = createApplication();
   const fastify = createFastifyStub();

--- a/packages/kernel/server/http/lib/routeRegistration.js
+++ b/packages/kernel/server/http/lib/routeRegistration.js
@@ -310,15 +310,16 @@ function registerRoutes(
   }
 
   const normalizedRoutes = normalizeArray(routes);
+  const publicRoutes = normalizedRoutes.filter((route) => route?.internal !== true);
   const policyApplier = typeof applyRoutePolicy === "function" ? applyRoutePolicy : defaultApplyRoutePolicy;
   const fallbackHandler = typeof missingHandler === "function" ? missingHandler : defaultMissingHandler;
   const runtimeMiddlewareConfig = normalizeRuntimeMiddlewareConfig(middleware);
 
-  if (normalizedRoutes.some((route) => routeRequiresJsonApiContentTypeParser(route))) {
+  if (publicRoutes.some((route) => routeRequiresJsonApiContentTypeParser(route))) {
     registerJsonApiContentTypeParser(fastify);
   }
 
-  for (const route of normalizedRoutes) {
+  for (const route of publicRoutes) {
     const routeTransport = normalizeRouteTransport(route?.transport, {
       context: `Route ${String(route?.method || "<unknown>")} ${String(route?.path || "<unknown>")} transport`,
       ErrorType: RouteRegistrationError
@@ -407,7 +408,7 @@ function registerRoutes(
   }
 
   return {
-    routeCount: normalizedRoutes.length
+    routeCount: publicRoutes.length
   };
 }
 

--- a/packages/kernel/server/http/lib/router.js
+++ b/packages/kernel/server/http/lib/router.js
@@ -35,6 +35,18 @@ function normalizeRouterMiddlewareStack(value, { context = "middleware" } = {}) 
   });
 }
 
+function normalizeRouteInternal(value, { method = "", path = "" } = {}) {
+  if (value == null) {
+    return false;
+  }
+  if (typeof value !== "boolean") {
+    throw new RouteDefinitionError(
+      `Route ${String(method || "<unknown>")} ${String(path || "<unknown>")} internal must be a boolean.`
+    );
+  }
+  return value;
+}
+
 function normalizeRouteInput(method, path, optionsOrHandler, maybeHandler) {
   const options =
     typeof optionsOrHandler === "function"
@@ -108,6 +120,10 @@ class HttpRouter {
       auth: resolvedOptions.auth,
       contextPolicy: resolvedOptions.contextPolicy,
       surface: resolvedOptions.surface,
+      internal: normalizeRouteInternal(resolvedOptions.internal, {
+        method: input.method,
+        path: input.path
+      }),
       visibility: resolvedOptions.visibility,
       permission: resolvedOptions.permission,
       ownerParam: resolvedOptions.ownerParam,
@@ -186,9 +202,11 @@ class HttpRouter {
     const itemPath = `/${resourceName}/:${idParam}`;
 
     const methods = normalizeObject(controller);
-    const middleware = normalizeRouterMiddlewareStack(options.middleware, {
-      context: `resource ${resourceName} middleware`
-    });
+    const routeOptions = {
+      ...normalizeObject(options)
+    };
+    delete routeOptions.idParam;
+    delete routeOptions.apiOnly;
 
     const requireMethod = (methodName) => {
       const handler = methods[methodName];
@@ -198,15 +216,15 @@ class HttpRouter {
       return handler;
     };
 
-    this.get(basePath, { middleware }, requireMethod("index"));
+    this.get(basePath, routeOptions, requireMethod("index"));
     if (!options.apiOnly) {
-      this.get(`${basePath}/create`, { middleware }, requireMethod("create"));
-      this.get(`${itemPath}/edit`, { middleware }, requireMethod("edit"));
+      this.get(`${basePath}/create`, routeOptions, requireMethod("create"));
+      this.get(`${itemPath}/edit`, routeOptions, requireMethod("edit"));
     }
-    this.post(basePath, { middleware }, requireMethod("store"));
-    this.get(itemPath, { middleware }, requireMethod("show"));
-    this.put(itemPath, { middleware }, requireMethod("update"));
-    this.delete(itemPath, { middleware }, requireMethod("destroy"));
+    this.post(basePath, routeOptions, requireMethod("store"));
+    this.get(itemPath, routeOptions, requireMethod("show"));
+    this.put(itemPath, routeOptions, requireMethod("update"));
+    this.delete(itemPath, routeOptions, requireMethod("destroy"));
   }
 
   list() {


### PR DESCRIPTION
## Summary
- add a real route-level `internal` contract in kernel HTTP and skip those routes from public registration
- add `--internal` support to `crud-server-generator` and stamp generated CRUD routes accordingly
- document internal CRUD exposure in the human and agent docs

## Testing
- node --test packages/kernel/server/http/lib/kernel.test.js packages/crud-server-generator/test/packageDescriptor.test.js packages/crud-server-generator/test/buildTemplateContext.test.js packages/crud-server-generator/test/routeInputContracts.test.js
- npm run agent-docs:build
- npm run docs:build

## Not run
- npm run verify