### PR TITLE
Fix local CRUD descriptor template context

### DIFF
--- a/packages/crud-server-generator/package.descriptor.mjs
+++ b/packages/crud-server-generator/package.descriptor.mjs
@@ -202,7 +202,11 @@ export default Object.freeze({
         to: "packages/${option:namespace|kebab}/package.descriptor.mjs",
         reason: "Install app-local CRUD package descriptor.",
         category: "crud",
-        id: "crud-local-package-descriptor-${option:namespace|snake}"
+        id: "crud-local-package-descriptor-${option:namespace|snake}",
+        templateContext: {
+          entrypoint: "src/server/buildTemplateContext.js",
+          export: "buildTemplateContext"
+        }
       },
       {
         from: "templates/src/local-package/server/CrudProvider.js",

--- a/packages/crud-server-generator/src/server/buildTemplateContext.js
+++ b/packages/crud-server-generator/src/server/buildTemplateContext.js
@@ -83,6 +83,12 @@ function resolveInternalRouteOption(options = {}) {
   if (!Object.prototype.hasOwnProperty.call(options, "internal")) {
     return false;
   }
+  if (options.internal === "" || options.internal === true) {
+    return true;
+  }
+  if (options.internal === false) {
+    return false;
+  }
   return normalizeBoolean(options.internal);
 }
 

--- a/packages/crud-server-generator/test/buildTemplateContext.test.js
+++ b/packages/crud-server-generator/test/buildTemplateContext.test.js
@@ -266,6 +266,12 @@ test("resolveInternalRouteOption rejects invalid internal flag values instead of
   );
 });
 
+test("resolveInternalRouteOption treats an empty-string flag presence as true", () => {
+  assert.equal(__testables.resolveInternalRouteOption({ internal: "" }), true);
+  assert.equal(__testables.resolveInternalRouteOption({ internal: "true" }), true);
+  assert.equal(__testables.resolveInternalRouteOption({ internal: "false" }), false);
+});
+
 test("resolveCrudGenerationTableName defaults table-name from namespace", () => {
   assert.equal(
     __testables.resolveCrudGenerationTableName({

--- a/packages/crud-server-generator/test/packageDescriptor.test.js
+++ b/packages/crud-server-generator/test/packageDescriptor.test.js
@@ -32,9 +32,16 @@ test("crud-server-generator no longer installs a separate jsonRestResource serve
 
 test("crud-server-generator wires action and role mutations through template context", () => {
   const files = descriptor.mutations?.files || [];
+  const descriptorTemplate = files.find((entry) => entry.from === "templates/src/local-package/package.descriptor.mjs");
   const actionsTemplate = files.find((entry) => entry.from === "templates/src/local-package/server/actions.js");
   const routesTemplate = files.find((entry) => entry.from === "templates/src/local-package/server/registerRoutes.js");
   const roleGrantMutation = (descriptor.mutations?.text || []).find((entry) => entry.file === "config/roles.js");
+
+  assert.ok(descriptorTemplate);
+  assert.deepEqual(descriptorTemplate.templateContext, {
+    entrypoint: "src/server/buildTemplateContext.js",
+    export: "buildTemplateContext"
+  });
 
   assert.ok(actionsTemplate);
   assert.deepEqual(actionsTemplate.templateContext, {


### PR DESCRIPTION
## Summary
- attach template context to the local CRUD package descriptor mutation
- treat a present empty internal flag as true when building template context
- cover both behaviors in generator tests

## Testing
- not run, per request