### PR TITLE
Continue placement rollout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6551,28 +6551,28 @@
     },
     "packages/agent-docs": {
       "name": "@jskit-ai/agent-docs",
-      "version": "0.1.26",
+      "version": "0.1.27",
       "engines": {
         "node": "20.x"
       }
     },
     "packages/assistant": {
       "name": "@jskit-ai/assistant",
-      "version": "0.1.74",
+      "version": "0.1.75",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.65"
+        "@jskit-ai/kernel": "0.1.66"
       }
     },
     "packages/assistant-core": {
       "name": "@jskit-ai/assistant-core",
-      "version": "0.1.41",
+      "version": "0.1.42",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.65",
-        "@jskit-ai/http-runtime": "0.1.64",
-        "@jskit-ai/kernel": "0.1.65",
-        "@jskit-ai/resource-core": "0.1.10",
-        "@jskit-ai/resource-crud-core": "0.1.10",
-        "@jskit-ai/users-core": "0.1.75",
+        "@jskit-ai/database-runtime": "0.1.66",
+        "@jskit-ai/http-runtime": "0.1.65",
+        "@jskit-ai/kernel": "0.1.66",
+        "@jskit-ai/resource-core": "0.1.11",
+        "@jskit-ai/resource-crud-core": "0.1.11",
+        "@jskit-ai/users-core": "0.1.76",
         "@tanstack/vue-query": "^5.90.5",
         "dompurify": "^3.3.3",
         "json-rest-schema": "1.x.x",
@@ -6645,15 +6645,15 @@
     },
     "packages/assistant-runtime": {
       "name": "@jskit-ai/assistant-runtime",
-      "version": "0.1.36",
+      "version": "0.1.37",
       "dependencies": {
-        "@jskit-ai/assistant-core": "0.1.41",
-        "@jskit-ai/database-runtime": "0.1.65",
-        "@jskit-ai/http-runtime": "0.1.64",
-        "@jskit-ai/kernel": "0.1.65",
-        "@jskit-ai/shell-web": "0.1.64",
-        "@jskit-ai/users-core": "0.1.75",
-        "@jskit-ai/users-web": "0.1.80",
+        "@jskit-ai/assistant-core": "0.1.42",
+        "@jskit-ai/database-runtime": "0.1.66",
+        "@jskit-ai/http-runtime": "0.1.65",
+        "@jskit-ai/kernel": "0.1.66",
+        "@jskit-ai/shell-web": "0.1.65",
+        "@jskit-ai/users-core": "0.1.76",
+        "@jskit-ai/users-web": "0.1.81",
         "@tanstack/vue-query": "^5.90.5",
         "json-rest-schema": "1.x.x",
         "vuetify": "^4.0.0"
@@ -6723,21 +6723,21 @@
     },
     "packages/auth-core": {
       "name": "@jskit-ai/auth-core",
-      "version": "0.1.64",
+      "version": "0.1.65",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0",
-        "@jskit-ai/kernel": "0.1.65",
+        "@jskit-ai/kernel": "0.1.66",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/auth-provider-supabase-core": {
       "name": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.64",
+      "version": "0.1.65",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.64",
-        "@jskit-ai/kernel": "0.1.65",
+        "@jskit-ai/auth-core": "0.1.65",
+        "@jskit-ai/kernel": "0.1.66",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0",
         "json-rest-schema": "1.x.x",
@@ -6746,12 +6746,12 @@
     },
     "packages/auth-web": {
       "name": "@jskit-ai/auth-web",
-      "version": "0.1.66",
+      "version": "0.1.67",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.64",
-        "@jskit-ai/http-runtime": "0.1.64",
-        "@jskit-ai/kernel": "0.1.65",
-        "@jskit-ai/shell-web": "0.1.64",
+        "@jskit-ai/auth-core": "0.1.65",
+        "@jskit-ai/http-runtime": "0.1.65",
+        "@jskit-ai/kernel": "0.1.66",
+        "@jskit-ai/shell-web": "0.1.65",
         "@mdi/js": "^7.4.47",
         "@tanstack/vue-query": "^5.90.5",
         "pinia": "^3.0.4",
@@ -6815,38 +6815,38 @@
     },
     "packages/console-core": {
       "name": "@jskit-ai/console-core",
-      "version": "0.1.28",
+      "version": "0.1.29",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.64",
-        "@jskit-ai/database-runtime": "0.1.65",
-        "@jskit-ai/http-runtime": "0.1.64",
-        "@jskit-ai/kernel": "0.1.65",
-        "@jskit-ai/resource-crud-core": "0.1.10",
-        "@jskit-ai/users-core": "0.1.75",
+        "@jskit-ai/auth-core": "0.1.65",
+        "@jskit-ai/database-runtime": "0.1.66",
+        "@jskit-ai/http-runtime": "0.1.65",
+        "@jskit-ai/kernel": "0.1.66",
+        "@jskit-ai/resource-crud-core": "0.1.11",
+        "@jskit-ai/users-core": "0.1.76",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/console-web": {
       "name": "@jskit-ai/console-web",
-      "version": "0.1.33",
+      "version": "0.1.34",
       "dependencies": {
-        "@jskit-ai/auth-web": "0.1.66",
-        "@jskit-ai/console-core": "0.1.28",
-        "@jskit-ai/shell-web": "0.1.64"
+        "@jskit-ai/auth-web": "0.1.67",
+        "@jskit-ai/console-core": "0.1.29",
+        "@jskit-ai/shell-web": "0.1.65"
       }
     },
     "packages/crud-core": {
       "name": "@jskit-ai/crud-core",
-      "version": "0.1.73",
+      "version": "0.1.74",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.65",
-        "@jskit-ai/http-runtime": "0.1.64",
-        "@jskit-ai/kernel": "0.1.65",
-        "@jskit-ai/realtime": "0.1.64",
-        "@jskit-ai/resource-crud-core": "0.1.10",
-        "@jskit-ai/shell-web": "0.1.64",
-        "@jskit-ai/users-core": "0.1.75",
-        "@jskit-ai/users-web": "0.1.80",
+        "@jskit-ai/database-runtime": "0.1.66",
+        "@jskit-ai/http-runtime": "0.1.65",
+        "@jskit-ai/kernel": "0.1.66",
+        "@jskit-ai/realtime": "0.1.65",
+        "@jskit-ai/resource-crud-core": "0.1.11",
+        "@jskit-ai/shell-web": "0.1.65",
+        "@jskit-ai/users-core": "0.1.76",
+        "@jskit-ai/users-web": "0.1.81",
         "@tanstack/vue-query": "^5.90.5",
         "json-rest-schema": "1.x.x"
       },
@@ -6916,98 +6916,98 @@
     },
     "packages/crud-server-generator": {
       "name": "@jskit-ai/crud-server-generator",
-      "version": "0.1.73",
+      "version": "0.1.74",
       "dependencies": {
         "@babel/parser": "^7.29.2",
-        "@jskit-ai/crud-core": "0.1.73",
-        "@jskit-ai/database-runtime": "0.1.65",
-        "@jskit-ai/http-runtime": "0.1.64",
-        "@jskit-ai/json-rest-api-core": "0.1.10",
-        "@jskit-ai/kernel": "0.1.65",
-        "@jskit-ai/resource-crud-core": "0.1.10",
+        "@jskit-ai/crud-core": "0.1.74",
+        "@jskit-ai/database-runtime": "0.1.66",
+        "@jskit-ai/http-runtime": "0.1.65",
+        "@jskit-ai/json-rest-api-core": "0.1.11",
+        "@jskit-ai/kernel": "0.1.66",
+        "@jskit-ai/resource-crud-core": "0.1.11",
         "recast": "^0.23.11"
       }
     },
     "packages/crud-ui-generator": {
       "name": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.48",
+      "version": "0.1.49",
       "dependencies": {
-        "@jskit-ai/crud-core": "0.1.73",
-        "@jskit-ai/kernel": "0.1.65",
-        "@jskit-ai/resource-crud-core": "0.1.10"
+        "@jskit-ai/crud-core": "0.1.74",
+        "@jskit-ai/kernel": "0.1.66",
+        "@jskit-ai/resource-crud-core": "0.1.11"
       }
     },
     "packages/database-runtime": {
       "name": "@jskit-ai/database-runtime",
-      "version": "0.1.65",
+      "version": "0.1.66",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.65"
+        "@jskit-ai/kernel": "0.1.66"
       }
     },
     "packages/database-runtime-mysql": {
       "name": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.64",
+      "version": "0.1.65",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.65",
-        "@jskit-ai/kernel": "0.1.65"
+        "@jskit-ai/database-runtime": "0.1.66",
+        "@jskit-ai/kernel": "0.1.66"
       }
     },
     "packages/database-runtime-postgres": {
       "name": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.64",
+      "version": "0.1.65",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.65"
+        "@jskit-ai/database-runtime": "0.1.66"
       }
     },
     "packages/feature-server-generator": {
       "name": "@jskit-ai/feature-server-generator",
-      "version": "0.1.7"
+      "version": "0.1.8"
     },
     "packages/google-rewarded-core": {
       "name": "@jskit-ai/google-rewarded-core",
-      "version": "0.1.2"
+      "version": "0.1.3"
     },
     "packages/google-rewarded-web": {
       "name": "@jskit-ai/google-rewarded-web",
-      "version": "0.1.2"
+      "version": "0.1.3"
     },
     "packages/http-runtime": {
       "name": "@jskit-ai/http-runtime",
-      "version": "0.1.64",
+      "version": "0.1.65",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.65",
+        "@jskit-ai/kernel": "0.1.66",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/json-rest-api-core": {
       "name": "@jskit-ai/json-rest-api-core",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.65",
+        "@jskit-ai/kernel": "0.1.66",
         "hooked-api": "1.x.x",
         "json-rest-api": "1.x.x"
       }
     },
     "packages/kernel": {
       "name": "@jskit-ai/kernel",
-      "version": "0.1.65",
+      "version": "0.1.66",
       "dependencies": {
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/mobile-capacitor": {
       "name": "@jskit-ai/mobile-capacitor",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "dependencies": {
         "@capacitor/browser": "^7.0.1",
-        "@jskit-ai/kernel": "0.1.65"
+        "@jskit-ai/kernel": "0.1.66"
       }
     },
     "packages/realtime": {
       "name": "@jskit-ai/realtime",
-      "version": "0.1.64",
+      "version": "0.1.65",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.65",
+        "@jskit-ai/kernel": "0.1.66",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",
@@ -7019,24 +7019,24 @@
     },
     "packages/resource-core": {
       "name": "@jskit-ai/resource-core",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.65"
+        "@jskit-ai/kernel": "0.1.66"
       }
     },
     "packages/resource-crud-core": {
       "name": "@jskit-ai/resource-crud-core",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.65",
-        "@jskit-ai/resource-core": "0.1.10"
+        "@jskit-ai/kernel": "0.1.66",
+        "@jskit-ai/resource-core": "0.1.11"
       }
     },
     "packages/shell-web": {
       "name": "@jskit-ai/shell-web",
-      "version": "0.1.64",
+      "version": "0.1.65",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.65",
+        "@jskit-ai/kernel": "0.1.66",
         "@mdi/js": "^7.4.47",
         "@tanstack/vue-query": "^5.90.5",
         "pinia": "^3.0.4",
@@ -7100,25 +7100,25 @@
     },
     "packages/storage-runtime": {
       "name": "@jskit-ai/storage-runtime",
-      "version": "0.1.64",
+      "version": "0.1.65",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.65",
+        "@jskit-ai/kernel": "0.1.66",
         "unstorage": "^1.17.3"
       }
     },
     "packages/ui-generator": {
       "name": "@jskit-ai/ui-generator",
-      "version": "0.1.48",
+      "version": "0.1.49",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.65",
-        "@jskit-ai/shell-web": "0.1.64"
+        "@jskit-ai/kernel": "0.1.66",
+        "@jskit-ai/shell-web": "0.1.65"
       }
     },
     "packages/uploads-image-web": {
       "name": "@jskit-ai/uploads-image-web",
-      "version": "0.1.43",
+      "version": "0.1.44",
       "dependencies": {
-        "@jskit-ai/uploads-runtime": "0.1.43",
+        "@jskit-ai/uploads-runtime": "0.1.44",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",
@@ -7131,37 +7131,37 @@
     },
     "packages/uploads-runtime": {
       "name": "@jskit-ai/uploads-runtime",
-      "version": "0.1.43",
+      "version": "0.1.44",
       "dependencies": {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.65"
+        "@jskit-ai/kernel": "0.1.66"
       }
     },
     "packages/users-core": {
       "name": "@jskit-ai/users-core",
-      "version": "0.1.75",
+      "version": "0.1.76",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.64",
-        "@jskit-ai/database-runtime": "0.1.65",
-        "@jskit-ai/http-runtime": "0.1.64",
-        "@jskit-ai/json-rest-api-core": "0.1.10",
-        "@jskit-ai/kernel": "0.1.65",
-        "@jskit-ai/resource-core": "0.1.10",
-        "@jskit-ai/resource-crud-core": "0.1.10",
-        "@jskit-ai/uploads-runtime": "0.1.43",
+        "@jskit-ai/auth-core": "0.1.65",
+        "@jskit-ai/database-runtime": "0.1.66",
+        "@jskit-ai/http-runtime": "0.1.65",
+        "@jskit-ai/json-rest-api-core": "0.1.11",
+        "@jskit-ai/kernel": "0.1.66",
+        "@jskit-ai/resource-core": "0.1.11",
+        "@jskit-ai/resource-crud-core": "0.1.11",
+        "@jskit-ai/uploads-runtime": "0.1.44",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/users-web": {
       "name": "@jskit-ai/users-web",
-      "version": "0.1.80",
+      "version": "0.1.81",
       "dependencies": {
-        "@jskit-ai/http-runtime": "0.1.64",
-        "@jskit-ai/kernel": "0.1.65",
-        "@jskit-ai/realtime": "0.1.64",
-        "@jskit-ai/shell-web": "0.1.64",
-        "@jskit-ai/uploads-image-web": "0.1.43",
-        "@jskit-ai/users-core": "0.1.75",
+        "@jskit-ai/http-runtime": "0.1.65",
+        "@jskit-ai/kernel": "0.1.66",
+        "@jskit-ai/realtime": "0.1.65",
+        "@jskit-ai/shell-web": "0.1.65",
+        "@jskit-ai/uploads-image-web": "0.1.44",
+        "@jskit-ai/users-core": "0.1.76",
         "@mdi/js": "^7.4.47",
         "@tanstack/vue-query": "5.92.12",
         "vuetify": "^4.0.0"
@@ -7232,29 +7232,29 @@
     },
     "packages/workspaces-core": {
       "name": "@jskit-ai/workspaces-core",
-      "version": "0.1.41",
+      "version": "0.1.42",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.64",
-        "@jskit-ai/database-runtime": "0.1.65",
-        "@jskit-ai/http-runtime": "0.1.64",
-        "@jskit-ai/json-rest-api-core": "0.1.10",
-        "@jskit-ai/kernel": "0.1.65",
-        "@jskit-ai/resource-core": "0.1.10",
-        "@jskit-ai/resource-crud-core": "0.1.10",
-        "@jskit-ai/users-core": "0.1.75",
+        "@jskit-ai/auth-core": "0.1.65",
+        "@jskit-ai/database-runtime": "0.1.66",
+        "@jskit-ai/http-runtime": "0.1.65",
+        "@jskit-ai/json-rest-api-core": "0.1.11",
+        "@jskit-ai/kernel": "0.1.66",
+        "@jskit-ai/resource-core": "0.1.11",
+        "@jskit-ai/resource-crud-core": "0.1.11",
+        "@jskit-ai/users-core": "0.1.76",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/workspaces-web": {
       "name": "@jskit-ai/workspaces-web",
-      "version": "0.1.41",
+      "version": "0.1.42",
       "dependencies": {
-        "@jskit-ai/http-runtime": "0.1.64",
-        "@jskit-ai/kernel": "0.1.65",
-        "@jskit-ai/shell-web": "0.1.64",
-        "@jskit-ai/users-core": "0.1.75",
-        "@jskit-ai/users-web": "0.1.80",
-        "@jskit-ai/workspaces-core": "0.1.41",
+        "@jskit-ai/http-runtime": "0.1.65",
+        "@jskit-ai/kernel": "0.1.66",
+        "@jskit-ai/shell-web": "0.1.65",
+        "@jskit-ai/users-core": "0.1.76",
+        "@jskit-ai/users-web": "0.1.81",
+        "@jskit-ai/workspaces-core": "0.1.42",
         "@mdi/js": "^7.4.47",
         "@tanstack/vue-query": "5.92.12",
         "vuetify": "^4.0.0"
@@ -7325,7 +7325,7 @@
     },
     "tooling/config-eslint": {
       "name": "@jskit-ai/config-eslint",
-      "version": "0.1.64",
+      "version": "0.1.65",
       "dependencies": {
         "@eslint/js": "^9.39.1",
         "eslint-plugin-vue": "^10.5.1",
@@ -7343,7 +7343,7 @@
     },
     "tooling/create-app": {
       "name": "@jskit-ai/create-app",
-      "version": "0.1.73",
+      "version": "0.1.74",
       "bin": {
         "jskit-create-app": "bin/jskit-create-app.js"
       },
@@ -7353,18 +7353,18 @@
     },
     "tooling/jskit-catalog": {
       "name": "@jskit-ai/jskit-catalog",
-      "version": "0.1.73",
+      "version": "0.1.74",
       "engines": {
         "node": "20.x"
       }
     },
     "tooling/jskit-cli": {
       "name": "@jskit-ai/jskit-cli",
-      "version": "0.2.74",
+      "version": "0.2.75",
       "dependencies": {
-        "@jskit-ai/jskit-catalog": "0.1.73",
-        "@jskit-ai/kernel": "0.1.65",
-        "@jskit-ai/shell-web": "0.1.64"
+        "@jskit-ai/jskit-catalog": "0.1.74",
+        "@jskit-ai/kernel": "0.1.66",
+        "@jskit-ai/shell-web": "0.1.65"
       },
       "bin": {
         "jskit": "bin/jskit.js"

--- a/packages/agent-docs/guide/agent/app-extras/assistant.md
+++ b/packages/agent-docs/guide/agent/app-extras/assistant.md
@@ -389,7 +389,7 @@ In the `page` subcommand:
 
 - the target file path decides the route location
 - `--name` changes the generated menu label
-- `--link-placement`, `--link-component-token`, and `--link-to` are optional overrides if you want to place the route link somewhere other than the generator's normal inferred target
+- `--link-placement` and `--link-to` are optional overrides if you want to place the route link somewhere other than the generator's normal inferred semantic target
 
 ## Generating the assistant settings pages
 
@@ -398,23 +398,17 @@ Now create the three settings pages:
 ```bash
 npx jskit generate assistant settings-page \
   console/settings/assistant/index.vue \
-  --surface console \
-  --link-placement console-settings:primary-menu \
-  --link-component-token local.main.ui.surface-aware-menu-link-item
+  --surface console
 
 npx jskit generate assistant settings-page \
   console/settings/admin-assistant/index.vue \
   --surface admin \
-  --name "Admin Assistant" \
-  --link-placement console-settings:primary-menu \
-  --link-component-token local.main.ui.surface-aware-menu-link-item
+  --name "Admin Assistant"
 
 npx jskit generate assistant settings-page \
   w/[workspaceSlug]/admin/workspace/settings/app-assistant/index.vue \
   --surface app \
-  --name "App Assistant" \
-  --link-placement admin-settings:primary-menu \
-  --link-component-token local.main.ui.surface-aware-menu-link-item
+  --name "App Assistant"
 ```
 
 This is the part that often trips people up, so read the rule carefully:
@@ -443,19 +437,14 @@ import { AssistantSettingsClientElement } from "@jskit-ai/assistant-runtime/clie
 
 The file path decides where the settings screen is opened. `target-surface-id` decides which assistant it edits.
 
-The extra link options matter here too:
+The inferred placement matters here too:
 
-- `--link-placement`
-  - which settings menu outlet should receive the generated link
-- `--link-component-token`
-  - which link component token should render that menu entry
 - `--name`
   - the label shown for the settings entry
 
-That is why the chapter uses:
+The console settings pages live under the console settings host, so JSKIT infers `page.section-nav` with owner `console-settings`. The workspace settings page lives under the admin workspace settings host, so JSKIT infers `page.section-nav` with owner `admin-settings`.
 
-- `console-settings:primary-menu` for the two console-owned settings screens
-- `admin-settings:primary-menu` for the workspace-admin-owned settings screen
+The concrete outlet and link renderer come from topology. Those settings hosts map `page.section-nav` to their concrete menus in `src/placementTopology.js`, so the commands do not need renderer flags.
 
 ## What to look at in the browser
 

--- a/packages/agent-docs/guide/agent/app-extras/realtime.md
+++ b/packages/agent-docs/guide/agent/app-extras/realtime.md
@@ -166,7 +166,8 @@ The package appends this placement:
 ```js
 addPlacement({
   id: "realtime.connection.indicator",
-  target: "shell-layout:top-right",
+  target: "shell.status",
+  kind: "component",
   surfaces: ["*"],
   order: 950,
   componentToken: "realtime.web.connection.indicator"

--- a/packages/agent-docs/guide/agent/app-setup/a-more-interesting-shell.md
+++ b/packages/agent-docs/guide/agent/app-setup/a-more-interesting-shell.md
@@ -53,7 +53,7 @@ Open `http://localhost:5173/home/settings` in the browser to see that nested set
 
 The most important new idea in `shell-web` is that the app now has _specific, named places_ where UI can be inserted later. JSKIT calls those places _placements_. In practice, this means later packages or generators do not have to rewrite the whole shell every time they want to add a menu entry, a widget, or a settings section.
 
-Start by asking JSKIT what placement targets already exist:
+Start by asking JSKIT what public placement targets already exist:
 
 ```bash
 npx jskit list-placements
@@ -63,16 +63,25 @@ In a fresh `shell-web` app, the result looks like this:
 
 ```text
 Available placements:
-- home-settings:primary-menu [src/pages/home/settings.vue]
-- shell-layout:primary-menu (default) [src/components/ShellLayout.vue]
-- shell-layout:secondary-menu [src/components/ShellLayout.vue]
-- shell-layout:top-left [src/components/ShellLayout.vue]
-- shell-layout:top-right [src/components/ShellLayout.vue]
+- shell.primary-nav (default): Primary top-level navigation for the current surface.
+  - compact -> shell-layout:primary-menu
+  - medium -> shell-layout:primary-menu
+  - expanded -> shell-layout:primary-menu
+- page.section-nav [owner:home-settings]: Navigation between child pages in the home settings section.
+  - compact -> home-settings:primary-menu
+  - medium -> home-settings:primary-menu
+  - expanded -> home-settings:primary-menu
 ```
 
-This command lists placement targets, not the content inside them. That is why the output is about target names and source files. Later, when you place things into the shell, this list stays the same unless you add or remove a `ShellOutlet` in source.
+This command lists semantic placements, not the content inside them. Later, when you place things into the shell, this list stays stable unless the public placement topology changes.
 
-Those target names come from real `ShellOutlet` elements in the app. See `src/components/ShellLayout.vue`:
+The concrete outlets still exist, but they are implementation details. If you need to inspect them directly, use:
+
+```bash
+npx jskit list-placements --concrete
+```
+
+Those concrete target names come from real `ShellOutlet` elements in the app. See `src/components/ShellLayout.vue`:
 
 ```html
 ...
@@ -83,27 +92,20 @@ Those target names come from real `ShellOutlet` elements in the app. See `src/co
 <ShellOutlet
   target="shell-layout:primary-menu"
   default
-  default-link-component-token="local.main.ui.surface-aware-menu-link-item"
 />
 ...
-<ShellOutlet
-  target="shell-layout:secondary-menu"
-  default-link-component-token="local.main.ui.surface-aware-menu-link-item"
-/>
+<ShellOutlet target="shell-layout:secondary-menu" />
 ```
 
 And the settings page introduces its own nested outlet in `src/pages/home/settings.vue`:
 
 ```html
-<ShellOutlet
-  target="home-settings:primary-menu"
-  default-link-component-token="local.main.ui.surface-aware-menu-link-item"
-/>
+<ShellOutlet target="home-settings:primary-menu" />
 ```
 
 That nested example matters. It shows that the shell is not the only place that can host placements. A page inside the shell can define its own insertion point too. That is how JSKIT can later build menus inside sections such as settings without rewriting the whole shell.
 
-Just as importantly, `shell-web` already uses that placement system itself. The starter app is not only exposing placement targets; it is also seeding real placement entries into them. The drawer gets `Home` and `Settings`, and the nested settings menu gets `General`. That is why the shell already feels real before you generate anything of your own.
+Just as importantly, `shell-web` already uses that placement system itself. The starter app is not only exposing semantic placement targets; it is also seeding real placement entries into them. The drawer gets `Home` and `Settings`, and the nested settings menu gets `General`. That is why the shell already feels real before you generate anything of your own.
 
 The shell also ships with a few app-owned component tokens that it can use as default link renderers. You can inspect those too:
 
@@ -133,7 +135,7 @@ To add a small UI element to the shell itself:
 npx jskit generate ui-generator placed-element --name "Alerts Widget"
 ```
 
-That command creates a Vue component under `src/components/` (in this case `src/components/AlertsWidgetElement.vue`), registers a new local token for it, and adds a placement entry targeting `shell-layout:top-right`. After running it, refresh the home page in the browser. The shell now has a real app-owned widget living inside one of its named placement targets.
+That command creates a Vue component under `src/components/` (in this case `src/components/AlertsWidgetElement.vue`), registers a new local token for it, and adds a placement entry targeting `shell.status`. After running it, refresh the home page in the browser. The shell now has a real app-owned widget living inside one of its named placement targets.
 
 In this app, there is no need to pass `--surface`: since the app only has one enabled surface, JSKIT can infer it automatically.
 
@@ -141,13 +143,13 @@ In this app, there is no need to pass `--surface`: since the app only has one en
 
 The settings host uses the same placement machinery, but the normal way to grow it is not by dropping a free-standing widget there. The more interesting case is adding a child page and letting JSKIT wire the menu entry for you.
 
-The source path in the `list-placements` output helps you reason about where child pages belong. When you see:
+The owner in the `list-placements` output helps you reason about where child pages belong. When you see:
 
 ```text
-- home-settings:primary-menu [src/pages/home/settings.vue]
+- page.section-nav [owner:home-settings]
 ```
 
-you know that the outlet lives in the settings host page. So if you want a child page to appear in that menu, you should create it under that part of the route tree instead of treating the menu like a generic widget area. For example, `src/pages/home/settings/profile/index.vue` belongs to that settings section, so JSKIT can wire its preferred menu entry into `home-settings:primary-menu` automatically.
+you know that the semantic placement is owned by the settings host page. So if you want a child page to appear in that menu, you should create it under that part of the route tree instead of treating the menu like a generic widget area. For example, `src/pages/home/settings/profile/index.vue` belongs to that settings section, so JSKIT can wire its preferred menu entry into `page.section-nav` with owner `home-settings` automatically.
 
 Now use the settings host the way it is normally meant to be used: add a real child page under it.
 
@@ -155,7 +157,7 @@ Now use the settings host the way it is normally meant to be used: add a real ch
 npx jskit generate ui-generator page home/settings/profile/index.vue --name "Profile"
 ```
 
-This is a more interesting example than the widget case. JSKIT creates the page file, notices that `src/pages/home/settings.vue` owns the `home-settings:primary-menu` outlet, and adds the preferred menu entry there automatically. You do not have to write that placement entry by hand.
+This is a more interesting example than the widget case. JSKIT creates the page file, notices that `src/pages/home/settings.vue` owns the settings section navigation, and adds the preferred semantic menu entry there automatically. You do not have to write that placement entry by hand.
 
 Open `/home/settings/profile` in the browser. The settings shell now shows a second real child page and a second real menu entry created by the same page-generation command. `General` was already there from `shell-web`; `Profile` is the first additional settings page you add yourself. This is the important part of the chapter: the exact same placement system works both at the top shell level and inside a page-owned nested outlet.
 
@@ -165,7 +167,7 @@ Now add a second sibling page:
 npx jskit generate ui-generator page home/settings/notifications/index.vue --name "Notifications"
 ```
 
-Open `/home/settings/notifications` in the browser. You now get a third settings menu entry without touching `settings.vue`, without writing a second menu component, and without hand-editing `src/placement.js`. JSKIT appends another placement entry targeting the same `home-settings:primary-menu` outlet, so the links simply stack in the menu for free.
+Open `/home/settings/notifications` in the browser. You now get a third settings menu entry without touching `settings.vue`, without writing a second menu component, and without hand-editing `src/placement.js`. JSKIT appends another placement entry targeting the same `page.section-nav` owner, so the links simply stack in the menu for free.
 
 The order is also easy to reason about:
 
@@ -191,7 +193,7 @@ definePage({
 });
 ```
 
-This is why the `home-settings:primary-menu` outlet from `list-placements` is such a useful clue: it tells you which page is acting as the host.
+This is why the `page.section-nav` owner from `list-placements` is such a useful clue: it tells you which page is acting as the host.
 
 Even an `index.vue` page can have children. If you want an index page to stay visible while child routes render underneath it, put those children under an `index/` directory such as `src/pages/home/settings/profile/index/details.vue`.
 
@@ -209,8 +211,10 @@ In placement metadata, raw `mdi-*` strings are acceptable because the shell menu
 ```js
 addPlacement({
   id: "home.settings.profile.link",
-  target: "home-settings:primary-menu",
-  componentToken: "local.main.ui.surface-aware-menu-link-item",
+  target: "page.section-nav",
+  owner: "home-settings",
+  kind: "link",
+  surfaces: ["home"],
   props: {
     label: "Profile",
     to: "./profile",
@@ -382,10 +386,10 @@ After the `shell-web` install plus the `placed-element` and `page` commands from
 ```js
 addPlacement({
   id: "shell-web.home.menu.home",
-  target: "shell-layout:primary-menu",
-  surfaces: ["*"],
+  target: "shell.primary-nav",
+  kind: "link",
+  surfaces: ["home"],
   order: 50,
-  componentToken: "local.main.ui.surface-aware-menu-link-item",
   props: {
     label: "Home",
     surface: "home",
@@ -397,10 +401,10 @@ addPlacement({
 
 addPlacement({
   id: "shell-web.home.menu.settings",
-  target: "shell-layout:primary-menu",
+  target: "shell.primary-nav",
+  kind: "link",
   surfaces: ["home"],
   order: 100,
-  componentToken: "local.main.ui.surface-aware-menu-link-item",
   props: {
     label: "Settings",
     surface: "home",
@@ -411,10 +415,11 @@ addPlacement({
 
 addPlacement({
   id: "shell-web.home.settings.general",
-  target: "home-settings:primary-menu",
+  target: "page.section-nav",
+  owner: "home-settings",
+  kind: "link",
   surfaces: ["home"],
   order: 100,
-  componentToken: "local.main.ui.surface-aware-menu-link-item",
   props: {
     label: "General",
     surface: "home",
@@ -426,7 +431,8 @@ addPlacement({
 
 addPlacement({
   id: "ui-generator.element.alerts-widget",
-  target: "shell-layout:top-right",
+  target: "shell.status",
+  kind: "component",
   surfaces: ["home"],
   order: 155,
   componentToken: "local.main.ui.element.alerts-widget"
@@ -434,10 +440,11 @@ addPlacement({
 
 addPlacement({
   id: "ui-generator.page.home.settings.profile.link",
-  target: "home-settings:primary-menu",
+  target: "page.section-nav",
+  owner: "home-settings",
+  kind: "link",
   surfaces: ["home"],
   order: 155,
-  componentToken: "local.main.ui.surface-aware-menu-link-item",
   props: {
     label: "Profile",
     surface: "home",
@@ -449,10 +456,11 @@ addPlacement({
 
 addPlacement({
   id: "ui-generator.page.home.settings.notifications.link",
-  target: "home-settings:primary-menu",
+  target: "page.section-nav",
+  owner: "home-settings",
+  kind: "link",
   surfaces: ["home"],
   order: 155,
-  componentToken: "local.main.ui.surface-aware-menu-link-item",
   props: {
     label: "Notifications",
     surface: "home",
@@ -465,13 +473,15 @@ addPlacement({
 
 That snippet shows the full placement contract clearly:
 
-- the target says where the UI should go
-- the component token says what should render that entry
+- the target says which semantic placement should receive the entry
+- the owner disambiguates page-owned semantic placements such as `page.section-nav`
+- `kind: "link"` lets topology choose the concrete link renderer for the current layout
+- component placements still provide their own `componentToken`
 - `props.to` tells the generated menu link which child route to open
 - `props.icon`, when you add one, belongs to menu metadata rather than direct Vuetify icon rendering
 - the surface list says where it is active
 - lower `order` values come first
-- when multiple entries target the same outlet with the same order, the shell keeps their source order
+- when multiple entries target the same semantic placement with the same order, the shell keeps their source order
 
 That is why the settings menu now shows `General` first, followed by `Profile` and `Notifications`: `General` is seeded by `shell-web` with a lower order, while the two generated pages share the same later order and keep their source order.
 
@@ -616,10 +626,7 @@ The important host file is still `src/pages/home/settings.vue`:
 
 ```vue
 <v-list nav density="comfortable" rounded="lg" border>
-  <ShellOutlet
-    target="home-settings:primary-menu"
-    default-link-component-token="local.main.ui.surface-aware-menu-link-item"
-  />
+  <ShellOutlet target="home-settings:primary-menu" />
 </v-list>
 
 <RouterView />
@@ -631,7 +638,7 @@ The starter shell now uses a real child-page structure right away:
 
 - `src/pages/home/settings/index.vue` is only a redirect into the first child page
 - `src/pages/home/settings/general/index.vue` is the first real settings page
-- `src/placement.js` already seeds a `General` link into `home-settings:primary-menu`
+- `src/placement.js` already seeds a `General` link into `page.section-nav` with owner `home-settings`
 
 When you need that landing redirect yourself, use the same helper pattern:
 

--- a/packages/agent-docs/guide/agent/app-setup/authentication.md
+++ b/packages/agent-docs/guide/agent/app-setup/authentication.md
@@ -319,10 +319,10 @@ The placement entry is just a normal shell link:
 ```js
 addPlacement({
   id: "ui-generator.page.home.reports.link",
-  target: "shell-layout:primary-menu",
+  target: "shell.primary-nav",
+  kind: "link",
   surfaces: ["home"],
   order: 155,
-  componentToken: "local.main.ui.surface-aware-menu-link-item",
   props: {
     label: "Reports",
     surface: "home",
@@ -390,10 +390,10 @@ To hide the `Reports` menu entry until the user is logged in, update the placeme
 ```js
 addPlacement({
   id: "ui-generator.page.home.reports.link",
-  target: "shell-layout:primary-menu",
+  target: "shell.primary-nav",
+  kind: "link",
   surfaces: ["home"],
   order: 155,
-  componentToken: "local.main.ui.surface-aware-menu-link-item",
   props: {
     label: "Reports",
     surface: "home",
@@ -606,7 +606,8 @@ Authentication also becomes visible in the shell through `src/placement.js`:
 ```js
 addPlacement({
   id: "auth.profile.widget",
-  target: "shell-layout:top-right",
+  target: "shell.status",
+  kind: "component",
   surfaces: ["*"],
   order: 1000,
   componentToken: "auth.web.profile.widget"
@@ -614,10 +615,10 @@ addPlacement({
 
 addPlacement({
   id: "auth.profile.menu.sign-in",
-  target: "auth-profile-menu:primary-menu",
+  target: "auth.profile-menu",
+  kind: "link",
   surfaces: ["*"],
   order: 200,
-  componentToken: "auth.web.profile.menu.link-item",
   props: {
     label: "Sign in",
     to: "/auth/login"
@@ -627,10 +628,10 @@ addPlacement({
 
 addPlacement({
   id: "auth.profile.menu.sign-out",
-  target: "auth-profile-menu:primary-menu",
+  target: "auth.profile-menu",
+  kind: "link",
   surfaces: ["*"],
   order: 1000,
-  componentToken: "auth.web.profile.menu.link-item",
   props: {
     label: "Sign out",
     to: "/auth/signout"

--- a/packages/agent-docs/guide/agent/app-setup/console.md
+++ b/packages/agent-docs/guide/agent/app-setup/console.md
@@ -179,7 +179,7 @@ This follows the same route-owner pattern the guide has already shown on `home` 
 - `src/pages/console/settings.vue` is the nested settings shell
 - `src/pages/console/settings/index.vue` is the initial developer-owned stub
 
-That last file is intentionally empty, because later modules are expected to add real console settings sections into the `console-settings:primary-menu` outlet.
+That last file is intentionally empty, because later modules are expected to add real console settings sections through `page.section-nav` with owner `console-settings`.
 
 ### `src/placement.js` wires the first console menu entry
 
@@ -188,10 +188,10 @@ The starter placement block is:
 ```js
 addPlacement({
   id: "console.web.menu.settings",
-  target: "shell-layout:primary-menu",
+  target: "shell.primary-nav",
+  kind: "link",
   surfaces: ["console"],
   order: 100,
-  componentToken: "local.main.ui.menu-link-item",
   props: {
     label: "Settings",
     to: "/console/settings",

--- a/packages/agent-docs/guide/agent/app-setup/multi-homing.md
+++ b/packages/agent-docs/guide/agent/app-setup/multi-homing.md
@@ -325,16 +325,13 @@ That command does two things:
 - it creates `src/pages/w/[workspaceSlug]/admin/workspace/settings/billing/index.vue`
 - it also appends the matching workspace settings menu entry into `src/placement.js`
 
-The reason JSKIT can wire that link automatically is that the workspace settings shell already exposes a named placement outlet with a default link renderer:
+The reason JSKIT can wire that link automatically is that the workspace settings shell already exposes a concrete outlet and topology maps it to semantic section navigation:
 
 ```vue
-<ShellOutlet
-  target="admin-settings:primary-menu"
-  default-link-component-token="local.main.ui.surface-aware-menu-link-item"
-/>
+<ShellOutlet target="admin-settings:primary-menu" />
 ```
 
-`target="admin-settings:primary-menu"` tells the generator which settings menu host owns those child links. `default-link-component-token="local.main.ui.surface-aware-menu-link-item"` tells it which local menu-link component to use unless you override it. So a page generated under `w/[workspaceSlug]/admin/workspace/settings/...` automatically lands in the left-side workspace settings menu without you hand-writing the placement entry.
+The route host lets the generator infer `page.section-nav` with owner `admin-settings`. `src/placementTopology.js` then maps that semantic placement to `admin-settings:primary-menu` and supplies the link renderer for compact, medium, and expanded layouts. So a page generated under `w/[workspaceSlug]/admin/workspace/settings/...` automatically lands in the left-side workspace settings menu without you hand-writing the placement entry.
 
 ### Workspace pages are prepared for missing-workspace states
 
@@ -524,7 +521,8 @@ The workspace packages append a new block of placements:
 ```js
 addPlacement({
   id: "workspaces.profile.menu.surface-switch",
-  target: "auth-profile-menu:primary-menu",
+  target: "auth.profile-menu",
+  kind: "component",
   surfaces: ["*"],
   order: 100,
   componentToken: "workspaces.web.profile.menu.surface-switch-item",
@@ -533,7 +531,8 @@ addPlacement({
 
 addPlacement({
   id: "workspaces.workspace.selector",
-  target: "shell-layout:top-left",
+  target: "shell.identity",
+  kind: "component",
   surfaces: ["*"],
   order: 200,
   componentToken: "workspaces.web.workspace.selector",
@@ -548,7 +547,8 @@ addPlacement({
 
 addPlacement({
   id: "workspaces.account.invites.cue",
-  target: "shell-layout:top-right",
+  target: "shell.status",
+  kind: "component",
   surfaces: ["*"],
   order: 850,
   componentToken: "local.main.account.pending-invites.cue",
@@ -557,7 +557,8 @@ addPlacement({
 
 addPlacement({
   id: "workspaces.workspace.tools.widget",
-  target: "shell-layout:top-right",
+  target: "shell.status",
+  kind: "component",
   surfaces: ["admin"],
   order: 900,
   componentToken: "workspaces.web.workspace.tools.widget"
@@ -565,7 +566,8 @@ addPlacement({
 
 addPlacement({
   id: "workspaces.workspace.menu.workspace-settings",
-  target: "admin-cog:primary-menu",
+  target: "admin.tools-menu",
+  kind: "component",
   surfaces: ["admin"],
   order: 100,
   componentToken: "workspaces.web.workspace-settings.menu-item"
@@ -573,7 +575,8 @@ addPlacement({
 
 addPlacement({
   id: "workspaces.workspace.menu.members",
-  target: "admin-cog:primary-menu",
+  target: "admin.tools-menu",
+  kind: "component",
   surfaces: ["admin"],
   order: 200,
   componentToken: "workspaces.web.workspace-members.menu-item"
@@ -588,7 +591,7 @@ That one block explains a lot of the new shell behavior.
 - the admin surface gets workspace tools in the top-right area
 - the admin workspace settings menu is now another nested placement host with both `Settings` and `Members`
 
-If you want to add your own app-owned page into that top cog menu, first ask JSKIT which placement targets exist:
+If you want to add your own app-owned page into that top cog menu, first ask JSKIT which semantic placements exist:
 
 ```bash
 npx jskit list-placements
@@ -597,25 +600,25 @@ npx jskit list-placements
 In a workspace-enabled app, that list now includes:
 
 ```text
-- admin-cog:primary-menu [package:@jskit-ai/workspaces-web:src/client/components/UsersWorkspaceToolsWidget.vue]
+- admin.tools-menu: Admin surface tools menu actions.
 ```
 
-If you want more context than the raw target list, `npx jskit show @jskit-ai/workspaces-web --details` also shows that same outlet plus the default `Settings` and `Members` entries already targeting it.
+If you want the underlying outlet inventory, use `npx jskit list-placements --concrete`. If you want more package context, `npx jskit show @jskit-ai/workspaces-web --details` also shows the topology plus the default `Settings` and `Members` entries already targeting it.
 
-Once you know the outlet id, generate the page like this:
+Once you know the semantic placement id, generate the page like this:
 
 ```bash
 npx jskit generate ui-generator page \
   w/[workspaceSlug]/admin/catalogue/index.vue \
   --name "Catalogue" \
-  --link-placement admin-cog:primary-menu
+  --link-placement admin.tools-menu
 ```
 
 That command creates `src/pages/w/[workspaceSlug]/admin/catalogue/index.vue` and appends the matching link entry into `src/placement.js`.
 
-`--link-placement` is necessary here because this route is just a normal `admin` page. It is **not** a child page under a local host like `w/[workspaceSlug]/admin/workspace/settings.vue`, so the generator has no nested settings outlet to infer automatically. If you omit `--link-placement`, the new page link falls back to the app's default shell menu outlet instead of the cog menu.
+`--link-placement` is necessary here because this route is just a normal `admin` page. It is **not** a child page under a local host like `w/[workspaceSlug]/admin/workspace/settings.vue`, so the generator has no nested settings placement to infer automatically. If you omit `--link-placement`, the new page link falls back to the app's default `shell.primary-nav` placement instead of the cog menu.
 
-You also do **not** need `--link-component-token` here. `admin-cog:primary-menu` already declares `local.main.ui.surface-aware-menu-link-item` as its default link renderer, so JSKIT reuses that automatically when it writes the placement entry.
+You also do **not** need a renderer flag here. `admin.tools-menu` defines its link renderer in topology, so JSKIT resolves that when it renders the placement entry.
 
 So the placement system from the shell chapter is still doing the same job as before. The app just has a richer routing and tenancy context now.
 

--- a/packages/agent-docs/guide/agent/app-setup/quickstart.md
+++ b/packages/agent-docs/guide/agent/app-setup/quickstart.md
@@ -85,9 +85,7 @@ npx jskit generate assistant page \
 npx jskit generate assistant settings-page \
   console/settings/admin-assistant/index.vue \
   --surface admin \
-  --name "Admin Assistant" \
-  --link-placement console-settings:primary-menu \
-  --link-component-token local.main.ui.surface-aware-menu-link-item
+  --name "Admin Assistant"
 
 npm install
 npm run db:migrate
@@ -154,7 +152,7 @@ First list the available placement destinations:
 npx jskit list-placements
 ```
 
-In a workspace-enabled app, that output includes `admin-cog:primary-menu`.
+In a workspace-enabled app, that output includes the semantic `admin.tools-menu` placement.
 
 Then generate the page:
 
@@ -162,7 +160,7 @@ Then generate the page:
 npx jskit generate ui-generator page \
   w/[workspaceSlug]/admin/catalogue/index.vue \
   --name "Catalogue" \
-  --link-placement admin-cog:primary-menu
+  --link-placement admin.tools-menu
 ```
 
 `--link-placement` is necessary here because this is just a normal `admin` page. It is not a child page under a local route host that already owns a nested outlet.
@@ -183,13 +181,10 @@ Because this page is not under a more specific local host, JSKIT falls back to t
 
 The workspace settings pages in Step 2 auto-linked into the settings menu for two reasons:
 
-1. The parent host already exposes a named outlet:
+1. The parent host already exposes a concrete outlet:
 
 ```vue
-<ShellOutlet
-  target="admin-settings:primary-menu"
-  default-link-component-token="local.main.ui.surface-aware-menu-link-item"
-/>
+<ShellOutlet target="admin-settings:primary-menu" />
 ```
 
 2. Your generated pages live under that host route:
@@ -200,12 +195,14 @@ w/[workspaceSlug]/admin/workspace/settings/...
 
 So JSKIT can infer both:
 
-- the placement target: `admin-settings:primary-menu`
-- the default link renderer: `local.main.ui.surface-aware-menu-link-item`
+- the semantic placement target: `page.section-nav`
+- the placement owner: `admin-settings`
 
-That is why the simple settings-page commands do not need `--link-placement` or `--link-component-token`.
+The renderer comes from `src/placementTopology.js`, where `page.section-nav` maps to the concrete `admin-settings:primary-menu` outlet for each layout class.
 
-The admin cog example is different. `w/[workspaceSlug]/admin/catalogue/index.vue` is just a normal admin page, so there is no local nested outlet to infer. That is why you must pass `--link-placement admin-cog:primary-menu` there.
+That is why the simple settings-page commands do not need `--link-placement`.
+
+The admin cog example is different. `w/[workspaceSlug]/admin/catalogue/index.vue` is just a normal admin page, so there is no local nested host to infer. That is why you must pass `--link-placement admin.tools-menu` there.
 
 If you want a little more context than the raw destination list, this is also useful:
 

--- a/packages/agent-docs/guide/agent/app-setup/users.md
+++ b/packages/agent-docs/guide/agent/app-setup/users.md
@@ -180,10 +180,10 @@ The placement registry also becomes more interesting:
 ```js
 addPlacement({
   id: "users.profile.menu.settings",
-  target: "auth-profile-menu:primary-menu",
+  target: "auth.profile-menu",
+  kind: "link",
   surfaces: ["*"],
   order: 500,
-  componentToken: "auth.web.profile.menu.link-item",
   props: {
     label: "Settings",
     to: "/account"
@@ -239,7 +239,7 @@ src/components/account/settings/
 
 Those three section components stay app-owned so you can reshape the actual UI freely.
 
-The host itself now lives in `users-web` and resolves every account section through the `account-settings:sections` placement target, including the default `profile`, `preferences`, and `notifications` entries.
+The host itself now lives in `users-web` and resolves every account section through the semantic `settings.sections` placement with owner `account-settings`, including the default `profile`, `preferences`, and `notifications` entries.
 
 So the screen follows the same rule as the rest of JSKIT UI: sections are added by placement rather than being hardcoded into an app-owned host component.
 

--- a/packages/agent-docs/guide/agent/app-setup/working-with-the-jskit-cli.md
+++ b/packages/agent-docs/guide/agent/app-setup/working-with-the-jskit-cli.md
@@ -332,8 +332,8 @@ The placement sections are often the most useful part of `show --details`.
 
 For `@jskit-ai/workspaces-web`, the detailed output shows placement contributions such as:
 
-- the workspace selector in `shell-layout:top-left`
-- the pending invites cue in `shell-layout:top-right`
+- the workspace selector in `shell.identity`
+- the pending invites cue in `shell.status`
 - the workspace tools widget on the `admin` surface
 - the `Members` and workspace settings menu entries
 
@@ -341,9 +341,10 @@ That lets you answer a very concrete question before installing anything:
 
 - *what will change in the shell if I add this package?*
 
-It also shows placement outlets, such as:
+It also shows semantic placement topology, such as:
 
-- `admin-settings:primary-menu`
+- `page.section-nav` with owner `admin-settings`
+- `admin.tools-menu`
 
 which helps you understand where later app-owned pages or settings links can attach.
 

--- a/packages/agent-docs/guide/agent/generators/ui-generators.md
+++ b/packages/agent-docs/guide/agent/generators/ui-generators.md
@@ -93,7 +93,8 @@ That is where things such as:
 - `label`
 - `order`
 - `icon`
-- a custom `componentToken`
+- `owner`
+- `surfaces`
 
 normally get adjusted.
 
@@ -145,21 +146,12 @@ Use this when the generated page link should go somewhere other than the generat
 Typical reasons:
 
 - you want the page in a different shell menu
-- you want the page link inside a specific existing outlet
+- you want the page link inside a specific existing semantic placement
 - you do not want the link to land in the normal top-level menu
 
 For example, if a page should appear in a settings menu rather than the shell drawer, `--link-placement` is the override that says so.
 
-#### `--link-component-token`
-
-Use this when the page link should render with a different link component than the default inferred one.
-
-In practice, this often means:
-
-- using a tab-style link instead of a normal menu link
-- using a local custom link token for a special shell section
-
-This matters most once you start targeting non-default outlets. A settings or tab host may want a different link renderer than the main shell drawer.
+The value should normally be semantic, such as `shell.primary-nav`, `page.section-nav`, or another `area.slot` placement from `jskit list-placements`. Concrete `host:position` outlets remain an escape hatch, not the default authoring path.
 
 #### `--link-to`
 
@@ -330,12 +322,13 @@ But the placement it wrote was **not** another top-level shell link.
 Instead, it targeted the host outlet:
 
 ```text
-reports:sub-pages
+page.section-nav
 ```
 
-and used the tab-link renderer with:
+with the host owner and relative route:
 
 ```js
+owner: "reports",
 to: "./exports"
 ```
 
@@ -345,7 +338,7 @@ That is exactly the behavior you want:
 - `Exports` becomes a child tab under it
 - the child route renders under the parent instead of becoming another top-level menu entry
 
-This is also why `--link-placement`, `--link-component-token`, and `--link-to` are often unnecessary in the default nested case. Once the host exists, JSKIT already knows the likely child placement target, link renderer, and relative `to` value.
+This is also why `--link-placement` and `--link-to` are often unnecessary in the default nested case. Once the host exists, JSKIT already knows the likely semantic placement, owner, and relative `to` value. The link renderer comes from `src/placementTopology.js`.
 
 ## Nested pages under a file-route host
 
@@ -532,13 +525,15 @@ In the verified throwaway app, after generating `Alerts Widget`, I ran:
 ```bash
 npx jskit generate ui-generator outlet \
   src/components/AlertsWidgetElement.vue \
-  --target alerts-widget:actions
+  --target alerts-widget:actions \
+  --placement page.actions
 ```
 
-That command touched only one file:
+That command touched the Vue file and the topology file:
 
 ```text
 src/components/AlertsWidgetElement.vue
+src/placementTopology.js
 ```
 
 and injected:
@@ -561,13 +556,16 @@ Use `outlet` when you want:
 - later content to be targetable there
 - no routed child-page behavior
 
-After adding the outlet, `npx jskit list-placements` showed the new target immediately:
+After adding the outlet, `npx jskit list-placements` showed the new semantic placement immediately:
 
 ```text
-- alerts-widget:actions [src/components/AlertsWidgetElement.vue]
+- page.actions: ...
+- compact -> alerts-widget:actions
+- medium -> alerts-widget:actions
+- expanded -> alerts-widget:actions
 ```
 
-So `outlet` is the smallest possible way to make a Vue file part of the placement topology.
+So `outlet` is the smallest possible way to add a concrete recipient and expose it through the public placement topology in the same change.
 
 ### When `outlet` is the smaller correct tool
 
@@ -588,7 +586,7 @@ That is why `outlet` is often the better choice for:
 
 If you do **not** need `RouterView` and you do **not** need child routes, `outlet` is usually the cleaner tool.
 
-### Choosing a good custom `--target`
+### Choosing a good custom `--target` and `--placement`
 
 `--target` should be meaningful to humans, not just syntactically valid.
 
@@ -611,11 +609,19 @@ custom-area:slot1
 
 because the meaningful target name will later show up in:
 
-- `jskit list-placements`
-- placement entries
+- `jskit list-placements --concrete`
+- topology mappings
 - future generator commands
 
 So the target should describe the UI seam you are creating, not just satisfy the `host:position` format.
+
+`--placement` is the public authoring target that other entries should use. It should be semantic, such as:
+
+```text
+page.actions
+```
+
+Adding an outlet without adding a semantic mapping would leave a low-level recipient that normal generators and humans will not discover by default.
 
 ## `add-subpages` versus `outlet`
 

--- a/packages/agent-docs/package.json
+++ b/packages/agent-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/agent-docs",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "description": "Distributed JSKIT agent workflows, guides, and generated reference maps.",
   "type": "module",
   "files": [

--- a/packages/agent-docs/patterns/page-scaffolding.md
+++ b/packages/agent-docs/patterns/page-scaffolding.md
@@ -18,8 +18,9 @@ Rules:
 
 - Default to `jskit generate ui-generator page ...` for a new app-owned non-CRUD route page.
 - Let the generator create both the page file and the matching `src/placement.js` entry, then adapt the generated output if needed.
-- If the page link belongs in a non-default outlet, discover the outlet first with `jskit list-placements` and pass `--link-placement`.
-- If the page sits under an existing routed host, check whether `ui-generator page` can infer the correct child placement before writing a custom link by hand.
+- If the page link belongs in a non-default semantic slot, discover the public placement first with `jskit list-placements` and pass `--link-placement`.
+- If you need the concrete outlet inventory, use `jskit list-placements --concrete`; do not target concrete outlets by default.
+- If the page sits under an existing routed host, check whether `ui-generator page` can infer the correct `page.section-nav` owner before writing a custom link by hand.
 - If you do not use `ui-generator page`, state exactly why the generator does not fit before editing code.
 - For a small placeholder route inside an existing route family, update the workboard rather than rewriting the blueprint unless the durable route or surface plan changed.
 

--- a/packages/agent-docs/patterns/placements.md
+++ b/packages/agent-docs/patterns/placements.md
@@ -16,6 +16,62 @@ Check first:
 - package placement topology
 - linked component token props
 
+Mental model:
+
+- `src/placement.js` answers "what is being placed?"
+- `src/placementTopology.js` answers "where does this semantic placement render for compact, medium, and expanded layouts?"
+- `<ShellOutlet target="host:position" />` is the concrete recipient rendered by Vue.
+- Semantic ids use dot notation, for example `shell.primary-nav`, `shell.status`, `page.section-nav`, `settings.sections`.
+- Concrete outlet ids use colon notation, for example `shell-layout:primary-menu`, `shell-layout:top-right`, `home-settings:primary-menu`.
+- Authoring should target semantic placements by default. Concrete outlets are an advanced escape hatch.
+
+Placement entries:
+
+- Add entries with `addPlacement(...)` in `src/placement.js`.
+- Use `target: "area.slot"` for normal entries.
+- Use `owner` when the semantic placement is scoped to a specific host, for example `target: "page.section-nav", owner: "home-settings"`.
+- Use `kind: "link"` for navigation/menu/tab links. Do not add a link renderer token to the entry unless there is a deliberate override.
+- Use `kind: "component"` for widgets/sections/elements. These entries require `componentToken`.
+- Use `surfaces` to say where the entry is eligible. Missing or `["*"]` means any surface.
+- Use `order` for ordering. Equal order preserves source order.
+- Use `props` for the rendered component props, including labels, icons, `surface`, `scopedSuffix`, `unscopedSuffix`, or explicit `to`.
+- Use `when(context)` only for auth, permissions, feature flags, and runtime state. Do not use `when()` for layout adaptation.
+- Direct concrete placement must use `target: "host:position"` plus `internal: true`. Treat this as low-level infrastructure, not normal app authoring.
+
+Placement topology:
+
+- `src/placementTopology.js` should be append-friendly: keep a `placements` array, export `addPlacementTopology(value)`, and append `addPlacementTopology(...)` blocks at the bottom.
+- Every semantic placement topology entry needs `id`, optional `owner`, optional `description`, `surfaces`, and all three variants: `compact`, `medium`, and `expanded`.
+- Every variant needs an `outlet: "host:position"`.
+- Variant `renderers` maps semantic `kind` values to component tokens, for example `renderers: { link: "local.main.ui.surface-aware-menu-link-item" }`.
+- Renderer choice for semantic `kind: "link"` placements belongs in topology, not in each placement entry.
+- `default: true` marks the fallback semantic placement that page generators use when no nearer host applies.
+- Package topology is discovered too, but app topology with the same `id` and `owner` overrides package topology in CLI discovery.
+
+Runtime behavior:
+
+- The shell runtime loads `/src/placementTopology.js` and `/src/placement.js`.
+- Each `ShellOutlet` asks for placements by concrete `target`, current `surface`, and current layout class.
+- Layout classes are `compact`, `medium`, and `expanded`.
+- For semantic entries, runtime matches topology by `target`, `owner`, and `surface`, then chooses the current layout variant.
+- A semantic entry renders only when the selected variant's `outlet` equals the concrete `ShellOutlet target`.
+- Runtime resolves the component token as `entry.componentToken || variant.renderers[entry.kind]`.
+- Entries without a resolvable component token do not render.
+- `when()` receives placement context including `app`, `surface`, `target`, `layoutClass`, runtime context, local outlet context, and context contributors.
+
+CLI and generators:
+
+- `jskit list-placements` shows semantic placements by default.
+- `jskit list-placements --concrete` shows concrete `ShellOutlet` recipients.
+- `jskit list-placements --all` shows both.
+- `jskit list-placements --json` returns structured semantic and concrete placement data.
+- `ui-generator page`, CRUD UI list generation, and assistant page generation target semantic placements.
+- `--link-placement` for generated pages is a semantic placement id, not a concrete outlet id.
+- If a generated page is under a parent host with a mapped `ShellOutlet`, the generator infers the semantic placement and owner from topology.
+- `ui-generator add-subpages` upgrades a page into a routed child-page host and appends a `page.section-nav` topology entry for the generated concrete outlet.
+- `ui-generator outlet` injects a plain concrete `ShellOutlet` and appends the semantic topology mapping in the same command.
+- When adding a public concrete outlet by hand, add its semantic topology mapping in the same change.
+
 Rules:
 
 - In JSKIT, tab-like links and shell/menu entries are often placement-owned, not page-owned.

--- a/packages/agent-docs/patterns/placements.md
+++ b/packages/agent-docs/patterns/placements.md
@@ -11,7 +11,9 @@ Use when:
 Check first:
 
 - app `src/placement.js`
+- app `src/placementTopology.js`
 - package placement contributions
+- package placement topology
 - linked component token props
 
 Rules:
@@ -20,9 +22,13 @@ Rules:
 - When asked to change a tab or menu icon, inspect placement metadata before editing page components.
 - Look at placement `props`, especially fields such as `icon`, `prependIcon`, `appendIcon`, or props passed into the linked component token.
 - If the visible entry is contributed by a package, update the owning package placement contribution instead of patching a local page component.
-- If the request is really about where a link appears, check the placement `target`, `surfaces`, `order`, and `when` fields before changing UI markup.
+- If the request is really about where a link appears, check the placement `target`, `owner`, `surfaces`, `order`, and `when` fields before changing UI markup.
+- Placement targets should be semantic by default, such as `shell.primary-nav` or `page.section-nav`; concrete `host:position` outlets are the advanced escape hatch.
+- Renderer choice for semantic `kind: "link"` placements belongs in topology, not in each placement entry.
+- Adding a public concrete `ShellOutlet` should happen with a matching semantic topology entry in the same change.
 
 Avoid:
 
 - editing the routed page just to change a shell/tab/menu icon that is actually placement-owned
 - assuming a rendered tab label/icon lives in the page component
+- adding a public `ShellOutlet` without also exposing a semantic placement that maps to it

--- a/packages/agent-docs/reference/autogen/KERNEL_MAP.md
+++ b/packages/agent-docs/reference/autogen/KERNEL_MAP.md
@@ -233,14 +233,26 @@ Local functions
 
 ### `support/shellLayoutTargets.js`
 Exports
+- `PLACEMENT_LAYOUT_CLASSES`
 - `describeShellOutletTargets(targets = [])`
 - `discoverShellOutletTargetsFromVueSource(source = "", { context = "shell layout" } = {})`
 - `findShellOutletTargetById(targets = [], targetId = "")`
+- `normalizePlacementKind(value = "")`
+- `normalizePlacementLayoutClass(value = "")`
+- `normalizePlacementOwnerId(value = "")`
+- `normalizePlacementSurfaceId(value = "")`
+- `normalizePlacementSurfaces(value)`
+- `normalizePlacementTopologyDefinition(value = {}, { context = "placement topology" } = {})`
+- `normalizePlacementTopologyEntry(value = {}, { context = "placement topology" } = {})`
+- `normalizePlacementTopologyVariant(value = {}, { context = "placement topology variant" } = {})`
+- `normalizeSemanticPlacementId(value = "")`
 - `normalizeShellOutletTargetId(value = "")`
 - `normalizeShellOutletTargetRecord(value = {}, { context = "shell layout" } = {})`
+- `resolvePlacementTargetReference(value = "")`
 - `resolveShellOutletTargetParts({ target = "" } = {})`
 Local functions
 - `parseTagAttributes(attributesSource = "")`
+- `normalizePlacementRenderers(value = {})`
 - `isDefaultAttributeEnabled(value)`
 
 ### `support/sorting.js`

--- a/packages/agent-docs/reference/autogen/packages/assistant.md
+++ b/packages/agent-docs/reference/autogen/packages/assistant.md
@@ -54,7 +54,7 @@ Exports
 - `normalizeConfigScope(value = "")`
 - `loadAppConfig(appRoot = "")`
 - `resolveSurfaceDefinition(appConfig = {}, surfaceId = "", optionName = "surface")`
-- `assertAssistantSurfaceIsAvailable(appConfig = {}, surfaceId = "")`
+- `assertAssistantSurfaceIsAvailable(appConfig = {}, surfaceId = "", expected = {})`
 - `resolveAiConfigPrefix(surfaceId = "", explicitPrefix = "")`
 
 ### templates

--- a/packages/agent-docs/reference/autogen/packages/assistant.md
+++ b/packages/agent-docs/reference/autogen/packages/assistant.md
@@ -27,6 +27,7 @@ Exports
 - `renderAssistantPageSummary(pageTarget = {}, { pageAlreadyExisted = false, pageOverwritten = false } = {})`
 Local functions
 - `resolveLinkToPropLine(linkTo = "")`
+- `resolveOwnerLine(owner = "")`
 - `resolveTemplateFilePath(relativePath = "")`
 
 ### `src/server/subcommands/page.js`

--- a/packages/agent-docs/reference/autogen/packages/crud-ui-generator.md
+++ b/packages/agent-docs/reference/autogen/packages/crud-ui-generator.md
@@ -46,6 +46,7 @@ Local functions
 - `resolveResourceLabels(namespace = "", pageTarget = {})`
 - `resolveTargetRootRelativeRoutePath(pageTarget = {})`
 - `resolveMenuToPropLine(linkTo = "")`
+- `resolveMenuOwnerLine(owner = "")`
 - `resolveCrudRelativePath(namespace = "")`
 - `buildListParentTitleImportLine(parentTitleMode = "contextual")`
 - `buildListHeadingTitleSetup({ parentTitleMode = "contextual", resourceNamespace = "", routeTitle = "Records" } = {})`

--- a/packages/agent-docs/reference/autogen/packages/kernel.md
+++ b/packages/agent-docs/reference/autogen/packages/kernel.md
@@ -397,14 +397,26 @@ Local functions
 
 ### `shared/support/shellLayoutTargets.js`
 Exports
+- `PLACEMENT_LAYOUT_CLASSES`
 - `describeShellOutletTargets(targets = [])`
 - `discoverShellOutletTargetsFromVueSource(source = "", { context = "shell layout" } = {})`
 - `findShellOutletTargetById(targets = [], targetId = "")`
+- `normalizePlacementKind(value = "")`
+- `normalizePlacementLayoutClass(value = "")`
+- `normalizePlacementOwnerId(value = "")`
+- `normalizePlacementSurfaceId(value = "")`
+- `normalizePlacementSurfaces(value)`
+- `normalizePlacementTopologyDefinition(value = {}, { context = "placement topology" } = {})`
+- `normalizePlacementTopologyEntry(value = {}, { context = "placement topology" } = {})`
+- `normalizePlacementTopologyVariant(value = {}, { context = "placement topology variant" } = {})`
+- `normalizeSemanticPlacementId(value = "")`
 - `normalizeShellOutletTargetId(value = "")`
 - `normalizeShellOutletTargetRecord(value = {}, { context = "shell layout" } = {})`
+- `resolvePlacementTargetReference(value = "")`
 - `resolveShellOutletTargetParts({ target = "" } = {})`
 Local functions
 - `parseTagAttributes(attributesSource = "")`
+- `normalizePlacementRenderers(value = {})`
 - `isDefaultAttributeEnabled(value)`
 
 ### `shared/support/sorting.js`
@@ -1344,7 +1356,9 @@ Exports
 - `deriveDefaultSubpagesHost`
 - `resolveNearestParentSubpagesHost`
 - `resolvePageLinkTargetDetails`
+- `discoverPlacementTopologyFromApp`
 - `discoverShellOutletTargetsFromApp`
+- `resolveSemanticPlacementTargetFromApp`
 - `resolveShellOutletPlacementTargetFromApp`
 
 ### `server/support/pageTargets.js`
@@ -1358,7 +1372,7 @@ Exports
 - `resolvePageTargetDetails({ appRoot, targetFile = "", context = "page target" } = {})`
 - `deriveDefaultSubpagesHost(pageTarget = {})`
 - `resolveNearestParentSubpagesHost({ appRoot, pageTarget = {}, context = "page target" } = {})`
-- `resolvePageLinkTargetDetails({ appRoot, targetFile = "", pageTarget = null, placement = "", componentToken = "", linkTo = "", defaultComponentToken = DEFAULT_PAGE_LINK_COMPONENT_TOKEN, subpageComponentToken = DEFAULT_SUBPAGE_LINK_COMPONENT_TOKEN, context = "page target" } = {})`
+- `resolvePageLinkTargetDetails({ appRoot, targetFile = "", pageTarget = null, placement = "", componentToken = "", linkTo = "", context = "page target" } = {})`
 Local functions
 - `normalizeRelativeFilePath(value = "")`
 - `validateVueTargetFile(relativePath = "", { context = "page target" } = {})`
@@ -1383,10 +1397,12 @@ Local functions
 - `buildParentPageFileCandidates(pageTarget = {}, ancestorRoute = {})`
 - `resolveSubpagesHostTargetFromPageSource(source = "")`
 - `normalizePlacementTargetId(target = {})`
+- `resolveConcreteTargetOwner(target = "")`
+- `topologyPlacementTargetsConcreteOutlet(placement = {}, target = "")`
+- `resolveSemanticPlacementTargetForConcreteOutlet({ appRoot, concreteTarget = "", surface = "" } = {})`
 - `resolveRelativeLinkToFromParent(pageTarget = {}, parentHost = null)`
 - `resolveRelativeLinkToFromNearestIndexOwner(pageTarget = {})`
-- `resolveInferredPageLinkTo({ explicitLinkTo = "", pageTarget = {}, parentHost = null, placementTarget = null, suppressImplicitRelativeLinks = false } = {})`
-- `resolveInferredPageLinkComponentToken({ explicitComponentToken = "", parentHost = null, placementTarget = null, defaultComponentToken = DEFAULT_PAGE_LINK_COMPONENT_TOKEN, subpageComponentToken = DEFAULT_SUBPAGE_LINK_COMPONENT_TOKEN } = {})`
+- `resolveInferredPageLinkTo({ explicitLinkTo = "", pageTarget = {}, parentHost = null, preservesRelativeSubpageLinks = false, suppressImplicitRelativeLinks = false } = {})`
 - `renderPageLinkWhenLine(pageTarget = {})`
 
 ### `server/support/path.js`
@@ -1401,7 +1417,9 @@ Exports
 
 ### `server/support/shellOutlets.js`
 Exports
+- `discoverPlacementTopologyFromApp({ appRoot } = {})`
 - `discoverShellOutletTargetsFromApp({ appRoot, sourceRoot = "src" } = {})`
+- `resolveSemanticPlacementTargetFromApp({ appRoot, placement = "", owner = "", surface = "", context = "ui-generator" } = {})`
 - `resolveShellOutletPlacementTargetFromApp({ appRoot, placement = "", context = "ui-generator" } = {})`
 Local functions
 - `parseTagAttributes(attributesSource = "")`
@@ -1411,9 +1429,11 @@ Local functions
 - `collectVueFilePaths(rootDirectoryPath)`
 - `readInstalledPackageStates(appRoot)`
 - `normalizePackageOutletTarget({ packageId = "", outlet = {}, descriptorPath = "" } = {})`
-- `loadOutletDefaultOverrides(appRoot = "")`
-- `applyOutletDefaultOverrides(target = {}, outletDefaultOverrides = {})`
 - `collectInstalledPackageOutletTargets(appRoot)`
+- `withTopologySource(placement = {}, sourcePath = "")`
+- `loadAppPlacementTopology(appRoot)`
+- `collectInstalledPackagePlacementTopology(appRoot)`
+- `findSemanticPlacementById(placements = [], { id = "", owner = "", surface = "" } = {})`
 
 ### `server/support/SupportCoreServiceProvider.js`
 Exports

--- a/packages/agent-docs/reference/autogen/packages/realtime.md
+++ b/packages/agent-docs/reference/autogen/packages/realtime.md
@@ -42,6 +42,7 @@ Local functions
 Exports
 - `RealtimeClientProvider`
 Local functions
+- `isCapacitorRuntimeAvailable(app)`
 - `resolveRealtimeClientConfig(app)`
 
 ### `src/client/runtime.js`

--- a/packages/agent-docs/reference/autogen/packages/shell-web.md
+++ b/packages/agent-docs/reference/autogen/packages/shell-web.md
@@ -184,6 +184,8 @@ Local functions
 ### `src/client/placement/index.js`
 Exports
 - `createPlacementRegistry`
+- `definePlacement`
+- `definePlacementTopology`
 - `useWebPlacementContext`
 - `resolveRuntimePathname`
 - `readPlacementSurfaceConfig`
@@ -220,7 +222,10 @@ Local functions
 - `debugLog(message, payload = null)`
 - `createRuntimeLogger(logger)`
 - `normalizePlacementList(placements, context = {})`
+- `normalizeTopologyList(topology, context = {})`
 - `matchesSurface(placementSurfaces, requestedSurface)`
+- `resolveTopologyPlacement(topologyEntries = [], placement = {}, requestedSurface = WEB_PLACEMENT_SURFACE_ANY)`
+- `resolveRenderablePlacement({ placement = {}, topologyEntries = [], requestedSurface = WEB_PLACEMENT_SURFACE_ANY, requestedTarget = "", requestedLayoutClass = "compact" } = {})`
 - `resolveContextContributors(app, baseContext = {}, logger)`
 - `resolvePlacementComponent(app, placement, logger, missingTokens, invalidComponentTokens, failedTokens)`
 - `shouldIncludePlacement(placement, placementContext, logger)`
@@ -253,6 +258,8 @@ Exports
 - `normalizePlacementSurfaces(value, { strict = false, source = "placement" } = {})`
 - `normalizePlacementDefinition(value, { strict = false, source = "placement" } = {})`
 - `definePlacement(value = {})`
+- `definePlacementTopology(value = {})`
+- `normalizeSemanticPlacementId`
 Local functions
 - `isValidSurfaceIdToken(value = "")`
 - `toInteger(value, fallback = 1000)`
@@ -264,6 +271,7 @@ Local functions
 - `createShellWebQueryClient()`
 - `isMissingDynamicModule(error, moduleSpecifier)`
 - `loadAppPlacementDefinitions(logger)`
+- `loadAppPlacementTopology(logger)`
 - `createErrorConfigToolkit(errorRuntime)`
 - `loadAppErrorConfig(logger, errorRuntime)`
 - `applyAppErrorConfig(errorRuntime, errorConfig = {})`
@@ -372,6 +380,11 @@ Exports
 Exports
 - `addPlacement`
 - `getPlacements()`
+
+### `templates/src/placementTopology.js`
+Exports
+- `addPlacementTopology(value = {})`
+- `default`
 
 ### root
 

--- a/packages/agent-docs/reference/autogen/packages/shell-web.md
+++ b/packages/agent-docs/reference/autogen/packages/shell-web.md
@@ -267,6 +267,7 @@ Local functions
 ### `src/client/providers/ShellWebClientProvider.js`
 Exports
 - `ShellWebClientProvider`
+- `resolveAppPlacementTopologyExport(exported, logger)`
 Local functions
 - `createShellWebQueryClient()`
 - `isMissingDynamicModule(error, moduleSpecifier)`

--- a/packages/agent-docs/reference/autogen/packages/ui-generator.md
+++ b/packages/agent-docs/reference/autogen/packages/ui-generator.md
@@ -19,11 +19,14 @@ Exports
 - `buildUiPageTemplateContext({ appRoot, targetFile = "", options = {} } = {})`
 Local functions
 - `resolveLinkToPropLine(linkTo = "")`
+- `resolveOwnerLine(owner = "")`
 
 ### `src/server/subcommands/addSubpages.js`
 Exports
 - `runGeneratorSubcommand({ appRoot, subcommand = "", args = [], options = {}, dryRun = false } = {})`
 Local functions
+- `resolveOutletOwner(target = "")`
+- `renderSectionNavTopologyBlock({ marker = "", owner = "", surface = "", target = "" } = {})`
 - `resolveSubpagesOutletTarget(options = {}, pageTarget = {})`
 
 ### `src/server/subcommands/element.js`
@@ -40,6 +43,13 @@ Local functions
 - `hasShellOutletTarget(source = "", { target = "" } = {})`
 - `applyScriptImports(source = "")`
 - `createOutletBlock({ target = "" } = {})`
+- `resolveOutletOwner(target = "")`
+- `resolveSemanticPlacementOption(options = {})`
+- `resolveSemanticPlacementOwner({ placementId = "", targetId = "", owner = "" } = {})`
+- `resolveTopologySurfaces(options = {})`
+- `renderTopologyOwnerLine(owner = "")`
+- `renderLinkRendererBlock(rendererToken = "")`
+- `renderOutletTopologyBlock({ marker = "", placementId = "", owner = "", surfaces = ["*"], description = "", target = "", rendererToken = "" } = {})`
 - `findLastTemplateCloseTag(source = "")`
 - `applyOutletTemplateBlock(source = "", { target = "" } = {})`
 
@@ -79,6 +89,7 @@ Exports
 - `DEFAULT_COMPONENT_DIRECTORY`
 - `MAIN_CLIENT_PROVIDER_FILE`
 - `PLACEMENT_FILE`
+- `PLACEMENT_TOPOLOGY_FILE`
 - `toKebabCase(value = "")`
 - `toPascalCase(value = "")`
 - `requireOption(options = {}, optionName = "", { context = "ui-generator" } = {})`

--- a/packages/agent-docs/reference/autogen/packages/users-web.md
+++ b/packages/agent-docs/reference/autogen/packages/users-web.md
@@ -502,7 +502,6 @@ Exports
 
 ### `src/shared/toolsOutletContracts.js`
 Exports
-- `DEFAULT_COG_LINK_COMPONENT_TOKEN`
 - `HOME_COG_OUTLET`
 
 ### templates

--- a/packages/agent-docs/reference/autogen/packages/workspaces-web.md
+++ b/packages/agent-docs/reference/autogen/packages/workspaces-web.md
@@ -321,7 +321,6 @@ Exports
 
 ### `src/shared/toolsOutletContracts.js`
 Exports
-- `DEFAULT_COG_LINK_COMPONENT_TOKEN`
 - `ADMIN_COG_OUTLET`
 
 ### templates

--- a/packages/agent-docs/reference/autogen/tooling/jskit-cli.md
+++ b/packages/agent-docs/reference/autogen/tooling/jskit-cli.md
@@ -487,6 +487,7 @@ Exports
 - `ANDROID_DIRECTORY_NAME`
 - `ANDROID_MANIFEST_RELATIVE_PATH`
 - `buildManagedMobileConfigStub({ packageJson = {} } = {})`
+- `isEmptyDisabledMobileConfigPlaceholder(mobileConfig = {})`
 - `resolveInstalledMobileConfig(appRoot = "")`
 - `resolveAndroidSdkDetails({ appRoot = "" } = {})`
 - `collectAndroidSdkComponentIssues({ appRoot = "", sdkRoot = "" } = {})`

--- a/packages/agent-docs/reference/autogen/tooling/jskit-cli.md
+++ b/packages/agent-docs/reference/autogen/tooling/jskit-cli.md
@@ -82,6 +82,8 @@ Local functions
 - `discoverGenerators(appRoot)`
 - `discoverRuntimePackages(appRoot)`
 - `extractMatches(source = "", patterns = [])`
+- `discoverSemanticPlacementTargets(appRoot)`
+- `discoverConcretePlacementTargets(appRoot)`
 - `discoverComponentTokens(appRoot)`
 - `isRouteLikeRelativePath(relativePath = "")`
 - `discoverPagesRelativeDirectories(appRoot)`
@@ -264,6 +266,7 @@ Local functions
 Exports
 - `normalizePlacementContributions(value)`
 - `normalizePlacementOutlets(value)`
+- `normalizePlacementTopology(value, { context = "package placement topology" } = {})`
 
 ### `src/server/cliRuntime/packageIntrospection/providerBindingIntrospection.js`
 Exports

--- a/packages/agent-docs/site/guide/app-extras/assistant.md
+++ b/packages/agent-docs/site/guide/app-extras/assistant.md
@@ -446,7 +446,7 @@ In the `page` subcommand:
 
 - the target file path decides the route location
 - `--name` changes the generated menu label
-- `--link-placement`, `--link-component-token`, and `--link-to` are optional overrides if you want to place the route link somewhere other than the generator's normal inferred target
+- `--link-placement` and `--link-to` are optional overrides if you want to place the route link somewhere other than the generator's normal inferred semantic target
 
 ## Generating the assistant settings pages
 
@@ -455,23 +455,17 @@ Now create the three settings pages:
 ```bash
 npx jskit generate assistant settings-page \
   console/settings/assistant/index.vue \
-  --surface console \
-  --link-placement console-settings:primary-menu \
-  --link-component-token local.main.ui.surface-aware-menu-link-item
+  --surface console
 
 npx jskit generate assistant settings-page \
   console/settings/admin-assistant/index.vue \
   --surface admin \
-  --name "Admin Assistant" \
-  --link-placement console-settings:primary-menu \
-  --link-component-token local.main.ui.surface-aware-menu-link-item
+  --name "Admin Assistant"
 
 npx jskit generate assistant settings-page \
   w/[workspaceSlug]/admin/workspace/settings/app-assistant/index.vue \
   --surface app \
-  --name "App Assistant" \
-  --link-placement admin-settings:primary-menu \
-  --link-component-token local.main.ui.surface-aware-menu-link-item
+  --name "App Assistant"
 ```
 
 This is the part that often trips people up, so read the rule carefully:
@@ -500,19 +494,14 @@ import { AssistantSettingsClientElement } from "@jskit-ai/assistant-runtime/clie
 
 The file path decides where the settings screen is opened. `target-surface-id` decides which assistant it edits.
 
-The extra link options matter here too:
+The inferred placement matters here too:
 
-- `--link-placement`
-  - which settings menu outlet should receive the generated link
-- `--link-component-token`
-  - which link component token should render that menu entry
 - `--name`
   - the label shown for the settings entry
 
-That is why the chapter uses:
+The console settings pages live under the console settings host, so JSKIT infers `page.section-nav` with owner `console-settings`. The workspace settings page lives under the admin workspace settings host, so JSKIT infers `page.section-nav` with owner `admin-settings`.
 
-- `console-settings:primary-menu` for the two console-owned settings screens
-- `admin-settings:primary-menu` for the workspace-admin-owned settings screen
+The concrete outlet and link renderer come from topology. Those settings hosts map `page.section-nav` to their concrete menus in `src/placementTopology.js`, so the commands do not need renderer flags.
 
 ## What to look at in the browser
 

--- a/packages/agent-docs/site/guide/app-extras/realtime.md
+++ b/packages/agent-docs/site/guide/app-extras/realtime.md
@@ -211,7 +211,8 @@ The package appends this placement:
 ```js
 addPlacement({
   id: "realtime.connection.indicator",
-  target: "shell-layout:top-right",
+  target: "shell.status",
+  kind: "component",
   surfaces: ["*"],
   order: 950,
   componentToken: "realtime.web.connection.indicator"

--- a/packages/agent-docs/site/guide/app-setup/a-more-interesting-shell.md
+++ b/packages/agent-docs/site/guide/app-setup/a-more-interesting-shell.md
@@ -94,7 +94,7 @@ Open `http://localhost:5173/home/settings` in the browser to see that nested set
 
 The most important new idea in `shell-web` is that the app now has _specific, named places_ where UI can be inserted later. JSKIT calls those places _placements_. In practice, this means later packages or generators do not have to rewrite the whole shell every time they want to add a menu entry, a widget, or a settings section.
 
-Start by asking JSKIT what placement targets already exist:
+Start by asking JSKIT what public placement targets already exist:
 
 ```bash
 npx jskit list-placements
@@ -104,16 +104,25 @@ In a fresh `shell-web` app, the result looks like this:
 
 ```text
 Available placements:
-- home-settings:primary-menu [src/pages/home/settings.vue]
-- shell-layout:primary-menu (default) [src/components/ShellLayout.vue]
-- shell-layout:secondary-menu [src/components/ShellLayout.vue]
-- shell-layout:top-left [src/components/ShellLayout.vue]
-- shell-layout:top-right [src/components/ShellLayout.vue]
+- shell.primary-nav (default): Primary top-level navigation for the current surface.
+  - compact -> shell-layout:primary-menu
+  - medium -> shell-layout:primary-menu
+  - expanded -> shell-layout:primary-menu
+- page.section-nav [owner:home-settings]: Navigation between child pages in the home settings section.
+  - compact -> home-settings:primary-menu
+  - medium -> home-settings:primary-menu
+  - expanded -> home-settings:primary-menu
 ```
 
-This command lists placement targets, not the content inside them. That is why the output is about target names and source files. Later, when you place things into the shell, this list stays the same unless you add or remove a `ShellOutlet` in source.
+This command lists semantic placements, not the content inside them. Later, when you place things into the shell, this list stays stable unless the public placement topology changes.
 
-Those target names come from real `ShellOutlet` elements in the app. See `src/components/ShellLayout.vue`:
+The concrete outlets still exist, but they are implementation details. If you need to inspect them directly, use:
+
+```bash
+npx jskit list-placements --concrete
+```
+
+Those concrete target names come from real `ShellOutlet` elements in the app. See `src/components/ShellLayout.vue`:
 
 ```html
 ...
@@ -124,27 +133,20 @@ Those target names come from real `ShellOutlet` elements in the app. See `src/co
 <ShellOutlet
   target="shell-layout:primary-menu"
   default
-  default-link-component-token="local.main.ui.surface-aware-menu-link-item"
 />
 ...
-<ShellOutlet
-  target="shell-layout:secondary-menu"
-  default-link-component-token="local.main.ui.surface-aware-menu-link-item"
-/>
+<ShellOutlet target="shell-layout:secondary-menu" />
 ```
 
 And the settings page introduces its own nested outlet in `src/pages/home/settings.vue`:
 
 ```html
-<ShellOutlet
-  target="home-settings:primary-menu"
-  default-link-component-token="local.main.ui.surface-aware-menu-link-item"
-/>
+<ShellOutlet target="home-settings:primary-menu" />
 ```
 
 That nested example matters. It shows that the shell is not the only place that can host placements. A page inside the shell can define its own insertion point too. That is how JSKIT can later build menus inside sections such as settings without rewriting the whole shell.
 
-Just as importantly, `shell-web` already uses that placement system itself. The starter app is not only exposing placement targets; it is also seeding real placement entries into them. The drawer gets `Home` and `Settings`, and the nested settings menu gets `General`. That is why the shell already feels real before you generate anything of your own.
+Just as importantly, `shell-web` already uses that placement system itself. The starter app is not only exposing semantic placement targets; it is also seeding real placement entries into them. The drawer gets `Home` and `Settings`, and the nested settings menu gets `General`. That is why the shell already feels real before you generate anything of your own.
 
 The shell also ships with a few app-owned component tokens that it can use as default link renderers. You can inspect those too:
 
@@ -175,7 +177,7 @@ To add a small UI element to the shell itself:
 npx jskit generate ui-generator placed-element --name "Alerts Widget"
 ```
 
-That command creates a Vue component under `src/components/` (in this case `src/components/AlertsWidgetElement.vue`), registers a new local token for it, and adds a placement entry targeting `shell-layout:top-right`. After running it, refresh the home page in the browser. The shell now has a real app-owned widget living inside one of its named placement targets.
+That command creates a Vue component under `src/components/` (in this case `src/components/AlertsWidgetElement.vue`), registers a new local token for it, and adds a placement entry targeting `shell.status`. After running it, refresh the home page in the browser. The shell now has a real app-owned widget living inside one of its named placement targets.
 
 <figure class="docs-browser-shot">
   <div class="docs-browser-shot__bar">
@@ -198,13 +200,13 @@ In this app, there is no need to pass `--surface`: since the app only has one en
 
 The settings host uses the same placement machinery, but the normal way to grow it is not by dropping a free-standing widget there. The more interesting case is adding a child page and letting JSKIT wire the menu entry for you.
 
-The source path in the `list-placements` output helps you reason about where child pages belong. When you see:
+The owner in the `list-placements` output helps you reason about where child pages belong. When you see:
 
 ```text
-- home-settings:primary-menu [src/pages/home/settings.vue]
+- page.section-nav [owner:home-settings]
 ```
 
-you know that the outlet lives in the settings host page. So if you want a child page to appear in that menu, you should create it under that part of the route tree instead of treating the menu like a generic widget area. For example, `src/pages/home/settings/profile/index.vue` belongs to that settings section, so JSKIT can wire its preferred menu entry into `home-settings:primary-menu` automatically.
+you know that the semantic placement is owned by the settings host page. So if you want a child page to appear in that menu, you should create it under that part of the route tree instead of treating the menu like a generic widget area. For example, `src/pages/home/settings/profile/index.vue` belongs to that settings section, so JSKIT can wire its preferred menu entry into `page.section-nav` with owner `home-settings` automatically.
 
 
 Now use the settings host the way it is normally meant to be used: add a real child page under it.
@@ -213,7 +215,7 @@ Now use the settings host the way it is normally meant to be used: add a real ch
 npx jskit generate ui-generator page home/settings/profile/index.vue --name "Profile"
 ```
 
-This is a more interesting example than the widget case. JSKIT creates the page file, notices that `src/pages/home/settings.vue` owns the `home-settings:primary-menu` outlet, and adds the preferred menu entry there automatically. You do not have to write that placement entry by hand.
+This is a more interesting example than the widget case. JSKIT creates the page file, notices that `src/pages/home/settings.vue` owns the settings section navigation, and adds the preferred semantic menu entry there automatically. You do not have to write that placement entry by hand.
 
 Open `/home/settings/profile` in the browser. The settings shell now shows a second real child page and a second real menu entry created by the same page-generation command. `General` was already there from `shell-web`; `Profile` is the first additional settings page you add yourself. This is the important part of the chapter: the exact same placement system works both at the top shell level and inside a page-owned nested outlet.
 
@@ -238,7 +240,7 @@ Now add a second sibling page:
 npx jskit generate ui-generator page home/settings/notifications/index.vue --name "Notifications"
 ```
 
-Open `/home/settings/notifications` in the browser. You now get a third settings menu entry without touching `settings.vue`, without writing a second menu component, and without hand-editing `src/placement.js`. JSKIT appends another placement entry targeting the same `home-settings:primary-menu` outlet, so the links simply stack in the menu for free.
+Open `/home/settings/notifications` in the browser. You now get a third settings menu entry without touching `settings.vue`, without writing a second menu component, and without hand-editing `src/placement.js`. JSKIT appends another placement entry targeting the same `page.section-nav` owner, so the links simply stack in the menu for free.
 
 The order is also easy to reason about:
 
@@ -278,7 +280,7 @@ definePage({
 });
 ```
 
-This is why the `home-settings:primary-menu` outlet from `list-placements` is such a useful clue: it tells you which page is acting as the host.
+This is why the `page.section-nav` owner from `list-placements` is such a useful clue: it tells you which page is acting as the host.
 
 Even an `index.vue` page can have children. If you want an index page to stay visible while child routes render underneath it, put those children under an `index/` directory such as `src/pages/home/settings/profile/index/details.vue`.
 </DocsTerminalTip>
@@ -296,8 +298,10 @@ In placement metadata, raw `mdi-*` strings are acceptable because the shell menu
 ```js
 addPlacement({
   id: "home.settings.profile.link",
-  target: "home-settings:primary-menu",
-  componentToken: "local.main.ui.surface-aware-menu-link-item",
+  target: "page.section-nav",
+  owner: "home-settings",
+  kind: "link",
+  surfaces: ["home"],
   props: {
     label: "Profile",
     to: "./profile",
@@ -471,10 +475,10 @@ After the `shell-web` install plus the `placed-element` and `page` commands from
 ```js
 addPlacement({
   id: "shell-web.home.menu.home",
-  target: "shell-layout:primary-menu",
-  surfaces: ["*"],
+  target: "shell.primary-nav",
+  kind: "link",
+  surfaces: ["home"],
   order: 50,
-  componentToken: "local.main.ui.surface-aware-menu-link-item",
   props: {
     label: "Home",
     surface: "home",
@@ -486,10 +490,10 @@ addPlacement({
 
 addPlacement({
   id: "shell-web.home.menu.settings",
-  target: "shell-layout:primary-menu",
+  target: "shell.primary-nav",
+  kind: "link",
   surfaces: ["home"],
   order: 100,
-  componentToken: "local.main.ui.surface-aware-menu-link-item",
   props: {
     label: "Settings",
     surface: "home",
@@ -500,10 +504,11 @@ addPlacement({
 
 addPlacement({
   id: "shell-web.home.settings.general",
-  target: "home-settings:primary-menu",
+  target: "page.section-nav",
+  owner: "home-settings",
+  kind: "link",
   surfaces: ["home"],
   order: 100,
-  componentToken: "local.main.ui.surface-aware-menu-link-item",
   props: {
     label: "General",
     surface: "home",
@@ -515,7 +520,8 @@ addPlacement({
 
 addPlacement({
   id: "ui-generator.element.alerts-widget",
-  target: "shell-layout:top-right",
+  target: "shell.status",
+  kind: "component",
   surfaces: ["home"],
   order: 155,
   componentToken: "local.main.ui.element.alerts-widget"
@@ -523,10 +529,11 @@ addPlacement({
 
 addPlacement({
   id: "ui-generator.page.home.settings.profile.link",
-  target: "home-settings:primary-menu",
+  target: "page.section-nav",
+  owner: "home-settings",
+  kind: "link",
   surfaces: ["home"],
   order: 155,
-  componentToken: "local.main.ui.surface-aware-menu-link-item",
   props: {
     label: "Profile",
     surface: "home",
@@ -538,10 +545,11 @@ addPlacement({
 
 addPlacement({
   id: "ui-generator.page.home.settings.notifications.link",
-  target: "home-settings:primary-menu",
+  target: "page.section-nav",
+  owner: "home-settings",
+  kind: "link",
   surfaces: ["home"],
   order: 155,
-  componentToken: "local.main.ui.surface-aware-menu-link-item",
   props: {
     label: "Notifications",
     surface: "home",
@@ -554,13 +562,15 @@ addPlacement({
 
 That snippet shows the full placement contract clearly:
 
-- the target says where the UI should go
-- the component token says what should render that entry
+- the target says which semantic placement should receive the entry
+- the owner disambiguates page-owned semantic placements such as `page.section-nav`
+- `kind: "link"` lets topology choose the concrete link renderer for the current layout
+- component placements still provide their own `componentToken`
 - `props.to` tells the generated menu link which child route to open
 - `props.icon`, when you add one, belongs to menu metadata rather than direct Vuetify icon rendering
 - the surface list says where it is active
 - lower `order` values come first
-- when multiple entries target the same outlet with the same order, the shell keeps their source order
+- when multiple entries target the same semantic placement with the same order, the shell keeps their source order
 
 That is why the settings menu now shows `General` first, followed by `Profile` and `Notifications`: `General` is seeded by `shell-web` with a lower order, while the two generated pages share the same later order and keep their source order.
 
@@ -705,10 +715,7 @@ The important host file is still `src/pages/home/settings.vue`:
 
 ```vue
 <v-list nav density="comfortable" rounded="lg" border>
-  <ShellOutlet
-    target="home-settings:primary-menu"
-    default-link-component-token="local.main.ui.surface-aware-menu-link-item"
-  />
+  <ShellOutlet target="home-settings:primary-menu" />
 </v-list>
 
 <RouterView />
@@ -720,7 +727,7 @@ The starter shell now uses a real child-page structure right away:
 
 - `src/pages/home/settings/index.vue` is only a redirect into the first child page
 - `src/pages/home/settings/general/index.vue` is the first real settings page
-- `src/placement.js` already seeds a `General` link into `home-settings:primary-menu`
+- `src/placement.js` already seeds a `General` link into `page.section-nav` with owner `home-settings`
 
 When you need that landing redirect yourself, use the same helper pattern:
 

--- a/packages/agent-docs/site/guide/app-setup/authentication.md
+++ b/packages/agent-docs/site/guide/app-setup/authentication.md
@@ -332,10 +332,10 @@ The placement entry is just a normal shell link:
 ```js
 addPlacement({
   id: "ui-generator.page.home.reports.link",
-  target: "shell-layout:primary-menu",
+  target: "shell.primary-nav",
+  kind: "link",
   surfaces: ["home"],
   order: 155,
-  componentToken: "local.main.ui.surface-aware-menu-link-item",
   props: {
     label: "Reports",
     surface: "home",
@@ -403,10 +403,10 @@ To hide the `Reports` menu entry until the user is logged in, update the placeme
 ```js
 addPlacement({
   id: "ui-generator.page.home.reports.link",
-  target: "shell-layout:primary-menu",
+  target: "shell.primary-nav",
+  kind: "link",
   surfaces: ["home"],
   order: 155,
-  componentToken: "local.main.ui.surface-aware-menu-link-item",
   props: {
     label: "Reports",
     surface: "home",
@@ -619,7 +619,8 @@ Authentication also becomes visible in the shell through `src/placement.js`:
 ```js
 addPlacement({
   id: "auth.profile.widget",
-  target: "shell-layout:top-right",
+  target: "shell.status",
+  kind: "component",
   surfaces: ["*"],
   order: 1000,
   componentToken: "auth.web.profile.widget"
@@ -627,10 +628,10 @@ addPlacement({
 
 addPlacement({
   id: "auth.profile.menu.sign-in",
-  target: "auth-profile-menu:primary-menu",
+  target: "auth.profile-menu",
+  kind: "link",
   surfaces: ["*"],
   order: 200,
-  componentToken: "auth.web.profile.menu.link-item",
   props: {
     label: "Sign in",
     to: "/auth/login"
@@ -640,10 +641,10 @@ addPlacement({
 
 addPlacement({
   id: "auth.profile.menu.sign-out",
-  target: "auth-profile-menu:primary-menu",
+  target: "auth.profile-menu",
+  kind: "link",
   surfaces: ["*"],
   order: 1000,
-  componentToken: "auth.web.profile.menu.link-item",
   props: {
     label: "Sign out",
     to: "/auth/signout"

--- a/packages/agent-docs/site/guide/app-setup/console.md
+++ b/packages/agent-docs/site/guide/app-setup/console.md
@@ -213,7 +213,7 @@ This follows the same route-owner pattern the guide has already shown on `home` 
 - `src/pages/console/settings.vue` is the nested settings shell
 - `src/pages/console/settings/index.vue` is the initial developer-owned stub
 
-That last file is intentionally empty, because later modules are expected to add real console settings sections into the `console-settings:primary-menu` outlet.
+That last file is intentionally empty, because later modules are expected to add real console settings sections through `page.section-nav` with owner `console-settings`.
 
 ### `src/placement.js` wires the first console menu entry
 
@@ -222,10 +222,10 @@ The starter placement block is:
 ```js
 addPlacement({
   id: "console.web.menu.settings",
-  target: "shell-layout:primary-menu",
+  target: "shell.primary-nav",
+  kind: "link",
   surfaces: ["console"],
   order: 100,
-  componentToken: "local.main.ui.menu-link-item",
   props: {
     label: "Settings",
     to: "/console/settings",

--- a/packages/agent-docs/site/guide/app-setup/multi-homing.md
+++ b/packages/agent-docs/site/guide/app-setup/multi-homing.md
@@ -478,16 +478,13 @@ That command does two things:
 - it creates `src/pages/w/[workspaceSlug]/admin/workspace/settings/billing/index.vue`
 - it also appends the matching workspace settings menu entry into `src/placement.js`
 
-The reason JSKIT can wire that link automatically is that the workspace settings shell already exposes a named placement outlet with a default link renderer:
+The reason JSKIT can wire that link automatically is that the workspace settings shell already exposes a concrete outlet and topology maps it to semantic section navigation:
 
 ```vue
-<ShellOutlet
-  target="admin-settings:primary-menu"
-  default-link-component-token="local.main.ui.surface-aware-menu-link-item"
-/>
+<ShellOutlet target="admin-settings:primary-menu" />
 ```
 
-`target="admin-settings:primary-menu"` tells the generator which settings menu host owns those child links. `default-link-component-token="local.main.ui.surface-aware-menu-link-item"` tells it which local menu-link component to use unless you override it. So a page generated under `w/[workspaceSlug]/admin/workspace/settings/...` automatically lands in the left-side workspace settings menu without you hand-writing the placement entry.
+The route host lets the generator infer `page.section-nav` with owner `admin-settings`. `src/placementTopology.js` then maps that semantic placement to `admin-settings:primary-menu` and supplies the link renderer for compact, medium, and expanded layouts. So a page generated under `w/[workspaceSlug]/admin/workspace/settings/...` automatically lands in the left-side workspace settings menu without you hand-writing the placement entry.
 
 ### Workspace pages are prepared for missing-workspace states
 
@@ -677,7 +674,8 @@ The workspace packages append a new block of placements:
 ```js
 addPlacement({
   id: "workspaces.profile.menu.surface-switch",
-  target: "auth-profile-menu:primary-menu",
+  target: "auth.profile-menu",
+  kind: "component",
   surfaces: ["*"],
   order: 100,
   componentToken: "workspaces.web.profile.menu.surface-switch-item",
@@ -686,7 +684,8 @@ addPlacement({
 
 addPlacement({
   id: "workspaces.workspace.selector",
-  target: "shell-layout:top-left",
+  target: "shell.identity",
+  kind: "component",
   surfaces: ["*"],
   order: 200,
   componentToken: "workspaces.web.workspace.selector",
@@ -701,7 +700,8 @@ addPlacement({
 
 addPlacement({
   id: "workspaces.account.invites.cue",
-  target: "shell-layout:top-right",
+  target: "shell.status",
+  kind: "component",
   surfaces: ["*"],
   order: 850,
   componentToken: "local.main.account.pending-invites.cue",
@@ -710,7 +710,8 @@ addPlacement({
 
 addPlacement({
   id: "workspaces.workspace.tools.widget",
-  target: "shell-layout:top-right",
+  target: "shell.status",
+  kind: "component",
   surfaces: ["admin"],
   order: 900,
   componentToken: "workspaces.web.workspace.tools.widget"
@@ -718,7 +719,8 @@ addPlacement({
 
 addPlacement({
   id: "workspaces.workspace.menu.workspace-settings",
-  target: "admin-cog:primary-menu",
+  target: "admin.tools-menu",
+  kind: "component",
   surfaces: ["admin"],
   order: 100,
   componentToken: "workspaces.web.workspace-settings.menu-item"
@@ -726,7 +728,8 @@ addPlacement({
 
 addPlacement({
   id: "workspaces.workspace.menu.members",
-  target: "admin-cog:primary-menu",
+  target: "admin.tools-menu",
+  kind: "component",
   surfaces: ["admin"],
   order: 200,
   componentToken: "workspaces.web.workspace-members.menu-item"
@@ -741,7 +744,7 @@ That one block explains a lot of the new shell behavior.
 - the admin surface gets workspace tools in the top-right area
 - the admin workspace settings menu is now another nested placement host with both `Settings` and `Members`
 
-If you want to add your own app-owned page into that top cog menu, first ask JSKIT which placement targets exist:
+If you want to add your own app-owned page into that top cog menu, first ask JSKIT which semantic placements exist:
 
 ```bash
 npx jskit list-placements
@@ -750,25 +753,25 @@ npx jskit list-placements
 In a workspace-enabled app, that list now includes:
 
 ```text
-- admin-cog:primary-menu [package:@jskit-ai/workspaces-web:src/client/components/UsersWorkspaceToolsWidget.vue]
+- admin.tools-menu: Admin surface tools menu actions.
 ```
 
-If you want more context than the raw target list, `npx jskit show @jskit-ai/workspaces-web --details` also shows that same outlet plus the default `Settings` and `Members` entries already targeting it.
+If you want the underlying outlet inventory, use `npx jskit list-placements --concrete`. If you want more package context, `npx jskit show @jskit-ai/workspaces-web --details` also shows the topology plus the default `Settings` and `Members` entries already targeting it.
 
-Once you know the outlet id, generate the page like this:
+Once you know the semantic placement id, generate the page like this:
 
 ```bash
 npx jskit generate ui-generator page \
   w/[workspaceSlug]/admin/catalogue/index.vue \
   --name "Catalogue" \
-  --link-placement admin-cog:primary-menu
+  --link-placement admin.tools-menu
 ```
 
 That command creates `src/pages/w/[workspaceSlug]/admin/catalogue/index.vue` and appends the matching link entry into `src/placement.js`.
 
-`--link-placement` is necessary here because this route is just a normal `admin` page. It is **not** a child page under a local host like `w/[workspaceSlug]/admin/workspace/settings.vue`, so the generator has no nested settings outlet to infer automatically. If you omit `--link-placement`, the new page link falls back to the app's default shell menu outlet instead of the cog menu.
+`--link-placement` is necessary here because this route is just a normal `admin` page. It is **not** a child page under a local host like `w/[workspaceSlug]/admin/workspace/settings.vue`, so the generator has no nested settings placement to infer automatically. If you omit `--link-placement`, the new page link falls back to the app's default `shell.primary-nav` placement instead of the cog menu.
 
-You also do **not** need `--link-component-token` here. `admin-cog:primary-menu` already declares `local.main.ui.surface-aware-menu-link-item` as its default link renderer, so JSKIT reuses that automatically when it writes the placement entry.
+You also do **not** need a renderer flag here. `admin.tools-menu` defines its link renderer in topology, so JSKIT resolves that when it renders the placement entry.
 
 So the placement system from the shell chapter is still doing the same job as before. The app just has a richer routing and tenancy context now.
 

--- a/packages/agent-docs/site/guide/app-setup/quickstart.md
+++ b/packages/agent-docs/site/guide/app-setup/quickstart.md
@@ -83,9 +83,7 @@ npx jskit generate assistant page \
 npx jskit generate assistant settings-page \
   console/settings/admin-assistant/index.vue \
   --surface admin \
-  --name "Admin Assistant" \
-  --link-placement console-settings:primary-menu \
-  --link-component-token local.main.ui.surface-aware-menu-link-item
+  --name "Admin Assistant"
 
 npm install
 npm run db:migrate
@@ -152,7 +150,7 @@ First list the available placement destinations:
 npx jskit list-placements
 ```
 
-In a workspace-enabled app, that output includes `admin-cog:primary-menu`.
+In a workspace-enabled app, that output includes the semantic `admin.tools-menu` placement.
 
 Then generate the page:
 
@@ -160,7 +158,7 @@ Then generate the page:
 npx jskit generate ui-generator page \
   w/[workspaceSlug]/admin/catalogue/index.vue \
   --name "Catalogue" \
-  --link-placement admin-cog:primary-menu
+  --link-placement admin.tools-menu
 ```
 
 `--link-placement` is necessary here because this is just a normal `admin` page. It is not a child page under a local route host that already owns a nested outlet.
@@ -181,13 +179,10 @@ Because this page is not under a more specific local host, JSKIT falls back to t
 
 The workspace settings pages in Step 2 auto-linked into the settings menu for two reasons:
 
-1. The parent host already exposes a named outlet:
+1. The parent host already exposes a concrete outlet:
 
 ```vue
-<ShellOutlet
-  target="admin-settings:primary-menu"
-  default-link-component-token="local.main.ui.surface-aware-menu-link-item"
-/>
+<ShellOutlet target="admin-settings:primary-menu" />
 ```
 
 2. Your generated pages live under that host route:
@@ -198,12 +193,14 @@ w/[workspaceSlug]/admin/workspace/settings/...
 
 So JSKIT can infer both:
 
-- the placement target: `admin-settings:primary-menu`
-- the default link renderer: `local.main.ui.surface-aware-menu-link-item`
+- the semantic placement target: `page.section-nav`
+- the placement owner: `admin-settings`
 
-That is why the simple settings-page commands do not need `--link-placement` or `--link-component-token`.
+The renderer comes from `src/placementTopology.js`, where `page.section-nav` maps to the concrete `admin-settings:primary-menu` outlet for each layout class.
 
-The admin cog example is different. `w/[workspaceSlug]/admin/catalogue/index.vue` is just a normal admin page, so there is no local nested outlet to infer. That is why you must pass `--link-placement admin-cog:primary-menu` there.
+That is why the simple settings-page commands do not need `--link-placement`.
+
+The admin cog example is different. `w/[workspaceSlug]/admin/catalogue/index.vue` is just a normal admin page, so there is no local nested host to infer. That is why you must pass `--link-placement admin.tools-menu` there.
 
 If you want a little more context than the raw destination list, this is also useful:
 

--- a/packages/agent-docs/site/guide/app-setup/users.md
+++ b/packages/agent-docs/site/guide/app-setup/users.md
@@ -227,10 +227,10 @@ The placement registry also becomes more interesting:
 ```js
 addPlacement({
   id: "users.profile.menu.settings",
-  target: "auth-profile-menu:primary-menu",
+  target: "auth.profile-menu",
+  kind: "link",
   surfaces: ["*"],
   order: 500,
-  componentToken: "auth.web.profile.menu.link-item",
   props: {
     label: "Settings",
     to: "/account"
@@ -286,7 +286,7 @@ src/components/account/settings/
 
 Those three section components stay app-owned so you can reshape the actual UI freely.
 
-The host itself now lives in `users-web` and resolves every account section through the `account-settings:sections` placement target, including the default `profile`, `preferences`, and `notifications` entries.
+The host itself now lives in `users-web` and resolves every account section through the semantic `settings.sections` placement with owner `account-settings`, including the default `profile`, `preferences`, and `notifications` entries.
 
 So the screen follows the same rule as the rest of JSKIT UI: sections are added by placement rather than being hardcoded into an app-owned host component.
 

--- a/packages/agent-docs/site/guide/app-setup/working-with-the-jskit-cli.md
+++ b/packages/agent-docs/site/guide/app-setup/working-with-the-jskit-cli.md
@@ -344,8 +344,8 @@ The placement sections are often the most useful part of `show --details`.
 
 For `@jskit-ai/workspaces-web`, the detailed output shows placement contributions such as:
 
-- the workspace selector in `shell-layout:top-left`
-- the pending invites cue in `shell-layout:top-right`
+- the workspace selector in `shell.identity`
+- the pending invites cue in `shell.status`
 - the workspace tools widget on the `admin` surface
 - the `Members` and workspace settings menu entries
 
@@ -353,9 +353,10 @@ That lets you answer a very concrete question before installing anything:
 
 - *what will change in the shell if I add this package?*
 
-It also shows placement outlets, such as:
+It also shows semantic placement topology, such as:
 
-- `admin-settings:primary-menu`
+- `page.section-nav` with owner `admin-settings`
+- `admin.tools-menu`
 
 which helps you understand where later app-owned pages or settings links can attach.
 

--- a/packages/agent-docs/site/guide/generators/ui-generators.md
+++ b/packages/agent-docs/site/guide/generators/ui-generators.md
@@ -108,7 +108,8 @@ That is where things such as:
 - `label`
 - `order`
 - `icon`
-- a custom `componentToken`
+- `owner`
+- `surfaces`
 
 normally get adjusted.
 
@@ -160,21 +161,12 @@ Use this when the generated page link should go somewhere other than the generat
 Typical reasons:
 
 - you want the page in a different shell menu
-- you want the page link inside a specific existing outlet
+- you want the page link inside a specific existing semantic placement
 - you do not want the link to land in the normal top-level menu
 
 For example, if a page should appear in a settings menu rather than the shell drawer, `--link-placement` is the override that says so.
 
-#### `--link-component-token`
-
-Use this when the page link should render with a different link component than the default inferred one.
-
-In practice, this often means:
-
-- using a tab-style link instead of a normal menu link
-- using a local custom link token for a special shell section
-
-This matters most once you start targeting non-default outlets. A settings or tab host may want a different link renderer than the main shell drawer.
+The value should normally be semantic, such as `shell.primary-nav`, `page.section-nav`, or another `area.slot` placement from `jskit list-placements`. Concrete `host:position` outlets remain an escape hatch, not the default authoring path.
 
 #### `--link-to`
 
@@ -345,12 +337,13 @@ But the placement it wrote was **not** another top-level shell link.
 Instead, it targeted the host outlet:
 
 ```text
-reports:sub-pages
+page.section-nav
 ```
 
-and used the tab-link renderer with:
+with the host owner and relative route:
 
 ```js
+owner: "reports",
 to: "./exports"
 ```
 
@@ -360,7 +353,7 @@ That is exactly the behavior you want:
 - `Exports` becomes a child tab under it
 - the child route renders under the parent instead of becoming another top-level menu entry
 
-This is also why `--link-placement`, `--link-component-token`, and `--link-to` are often unnecessary in the default nested case. Once the host exists, JSKIT already knows the likely child placement target, link renderer, and relative `to` value.
+This is also why `--link-placement` and `--link-to` are often unnecessary in the default nested case. Once the host exists, JSKIT already knows the likely semantic placement, owner, and relative `to` value. The link renderer comes from `src/placementTopology.js`.
 
 ## Nested pages under a file-route host
 
@@ -547,13 +540,15 @@ In the verified throwaway app, after generating `Alerts Widget`, I ran:
 ```bash
 npx jskit generate ui-generator outlet \
   src/components/AlertsWidgetElement.vue \
-  --target alerts-widget:actions
+  --target alerts-widget:actions \
+  --placement page.actions
 ```
 
-That command touched only one file:
+That command touched the Vue file and the topology file:
 
 ```text
 src/components/AlertsWidgetElement.vue
+src/placementTopology.js
 ```
 
 and injected:
@@ -576,13 +571,16 @@ Use `outlet` when you want:
 - later content to be targetable there
 - no routed child-page behavior
 
-After adding the outlet, `npx jskit list-placements` showed the new target immediately:
+After adding the outlet, `npx jskit list-placements` showed the new semantic placement immediately:
 
 ```text
-- alerts-widget:actions [src/components/AlertsWidgetElement.vue]
+- page.actions: ...
+- compact -> alerts-widget:actions
+- medium -> alerts-widget:actions
+- expanded -> alerts-widget:actions
 ```
 
-So `outlet` is the smallest possible way to make a Vue file part of the placement topology.
+So `outlet` is the smallest possible way to add a concrete recipient and expose it through the public placement topology in the same change.
 
 ### When `outlet` is the smaller correct tool
 
@@ -603,7 +601,7 @@ That is why `outlet` is often the better choice for:
 
 If you do **not** need `RouterView` and you do **not** need child routes, `outlet` is usually the cleaner tool.
 
-### Choosing a good custom `--target`
+### Choosing a good custom `--target` and `--placement`
 
 `--target` should be meaningful to humans, not just syntactically valid.
 
@@ -626,11 +624,19 @@ custom-area:slot1
 
 because the meaningful target name will later show up in:
 
-- `jskit list-placements`
-- placement entries
+- `jskit list-placements --concrete`
+- topology mappings
 - future generator commands
 
 So the target should describe the UI seam you are creating, not just satisfy the `host:position` format.
+
+`--placement` is the public authoring target that other entries should use. It should be semantic, such as:
+
+```text
+page.actions
+```
+
+Adding an outlet without adding a semantic mapping would leave a low-level recipient that normal generators and humans will not discover by default.
 
 ## `add-subpages` versus `outlet`
 

--- a/packages/assistant-core/package.descriptor.mjs
+++ b/packages/assistant-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-core",
-  version: "0.1.41",
+  version: "0.1.42",
   kind: "runtime",
   description: "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
   dependsOn: [
@@ -47,11 +47,11 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/http-runtime": "0.1.64",
-        "@jskit-ai/kernel": "0.1.65",
-        "@jskit-ai/resource-core": "0.1.10",
-        "@jskit-ai/resource-crud-core": "0.1.10",
-        "@jskit-ai/users-core": "0.1.75",
+        "@jskit-ai/http-runtime": "0.1.65",
+        "@jskit-ai/kernel": "0.1.66",
+        "@jskit-ai/resource-core": "0.1.11",
+        "@jskit-ai/resource-crud-core": "0.1.11",
+        "@jskit-ai/users-core": "0.1.76",
         "@tanstack/vue-query": "^5.90.5",
         "dompurify": "^3.3.3",
         "json-rest-schema": "1.x.x",

--- a/packages/assistant-core/package.json
+++ b/packages/assistant-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-core",
-  "version": "0.1.41",
+  "version": "0.1.42",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,12 +11,12 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.65",
-    "@jskit-ai/http-runtime": "0.1.64",
-    "@jskit-ai/kernel": "0.1.65",
-    "@jskit-ai/resource-crud-core": "0.1.10",
-    "@jskit-ai/resource-core": "0.1.10",
-    "@jskit-ai/users-core": "0.1.75",
+    "@jskit-ai/database-runtime": "0.1.66",
+    "@jskit-ai/http-runtime": "0.1.65",
+    "@jskit-ai/kernel": "0.1.66",
+    "@jskit-ai/resource-crud-core": "0.1.11",
+    "@jskit-ai/resource-core": "0.1.11",
+    "@jskit-ai/users-core": "0.1.76",
     "@tanstack/vue-query": "^5.90.5",
     "dompurify": "^3.3.3",
     "json-rest-schema": "1.x.x",

--- a/packages/assistant-runtime/package.descriptor.mjs
+++ b/packages/assistant-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-runtime",
-  version: "0.1.36",
+  version: "0.1.37",
   kind: "runtime",
   description: "Shared assistant runtime with per-surface assistant registration.",
   dependsOn: [
@@ -95,13 +95,13 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/assistant-core": "0.1.41",
-        "@jskit-ai/database-runtime": "0.1.65",
-        "@jskit-ai/http-runtime": "0.1.64",
-        "@jskit-ai/kernel": "0.1.65",
-        "@jskit-ai/shell-web": "0.1.64",
-        "@jskit-ai/users-core": "0.1.75",
-        "@jskit-ai/users-web": "0.1.80",
+        "@jskit-ai/assistant-core": "0.1.42",
+        "@jskit-ai/database-runtime": "0.1.66",
+        "@jskit-ai/http-runtime": "0.1.65",
+        "@jskit-ai/kernel": "0.1.66",
+        "@jskit-ai/shell-web": "0.1.65",
+        "@jskit-ai/users-core": "0.1.76",
+        "@jskit-ai/users-web": "0.1.81",
         "@tanstack/vue-query": "^5.90.5",
         "vuetify": "^4.0.0"
       },

--- a/packages/assistant-runtime/package.json
+++ b/packages/assistant-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-runtime",
-  "version": "0.1.36",
+  "version": "0.1.37",
   "type": "module",
   "exports": {
     "./client": "./src/client/index.js",
@@ -8,13 +8,13 @@
     "./server/actionIds": "./src/server/actionIds.js"
   },
   "dependencies": {
-    "@jskit-ai/assistant-core": "0.1.41",
-    "@jskit-ai/database-runtime": "0.1.65",
-    "@jskit-ai/http-runtime": "0.1.64",
-    "@jskit-ai/kernel": "0.1.65",
-    "@jskit-ai/shell-web": "0.1.64",
-    "@jskit-ai/users-core": "0.1.75",
-    "@jskit-ai/users-web": "0.1.80",
+    "@jskit-ai/assistant-core": "0.1.42",
+    "@jskit-ai/database-runtime": "0.1.66",
+    "@jskit-ai/http-runtime": "0.1.65",
+    "@jskit-ai/kernel": "0.1.66",
+    "@jskit-ai/shell-web": "0.1.65",
+    "@jskit-ai/users-core": "0.1.76",
+    "@jskit-ai/users-web": "0.1.81",
     "json-rest-schema": "1.x.x",
     "@tanstack/vue-query": "^5.90.5",
     "vuetify": "^4.0.0"

--- a/packages/assistant/package.descriptor.mjs
+++ b/packages/assistant/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant",
-  version: "0.1.74",
+  version: "0.1.75",
   kind: "generator",
   description: "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
   options: {

--- a/packages/assistant/package.descriptor.mjs
+++ b/packages/assistant/package.descriptor.mjs
@@ -49,14 +49,7 @@ export default Object.freeze({
       inputType: "text",
       defaultValue: "",
       promptLabel: "Link placement",
-      promptHint: "Optional target for the generated page link placement (format: host:position)."
-    },
-    "link-component-token": {
-      required: false,
-      inputType: "text",
-      defaultValue: "",
-      promptLabel: "Link component token",
-      promptHint: "Optional component token override for the generated page link placement."
+      promptHint: "Optional semantic target for the generated page link placement (format: area.slot)."
     },
     "link-to": {
       required: false,
@@ -169,7 +162,7 @@ export default Object.freeze({
             descriptionKey: "page-target-file"
           }
         ],
-        optionNames: ["name", "link-placement", "link-component-token", "link-to", "force"],
+        optionNames: ["name", "link-placement", "link-to", "force"],
         notes: [
           "The target file decides where the page lives.",
           "Page-link placement follows the same inference rules as ui-generator page.",
@@ -189,7 +182,7 @@ export default Object.freeze({
               "npx jskit generate assistant page \\",
               "  admin/ops/copilot/index.vue \\",
               "  --name \"Copilot\" \\",
-              "  --link-placement shell-layout:top-right"
+              "  --link-placement shell.status"
             ]
           }
         ]
@@ -206,7 +199,7 @@ export default Object.freeze({
             descriptionKey: "page-target-file"
           }
         ],
-        optionNames: ["surface", "name", "link-placement", "link-component-token", "link-to", "force"],
+        optionNames: ["surface", "name", "link-placement", "link-to", "force"],
         requiredOptionNames: ["surface"],
         notes: [
           "The target file decides where the settings page lives.",

--- a/packages/assistant/package.json
+++ b/packages/assistant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant",
-  "version": "0.1.74",
+  "version": "0.1.75",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.65"
+    "@jskit-ai/kernel": "0.1.66"
   }
 }

--- a/packages/assistant/src/server/buildTemplateContext.js
+++ b/packages/assistant/src/server/buildTemplateContext.js
@@ -12,7 +12,10 @@ async function buildTemplateContext({ appRoot, options } = {}) {
   const settingsSurface = resolveSurfaceDefinition(appConfig, options?.["settings-surface"], "settings-surface");
   const configScope = normalizeConfigScope(options?.["config-scope"]);
 
-  assertAssistantSurfaceIsAvailable(appConfig, runtimeSurface.id);
+  assertAssistantSurfaceIsAvailable(appConfig, runtimeSurface.id, {
+    settingsSurfaceId: settingsSurface.id,
+    configScope
+  });
 
   if (configScope === "workspace" && runtimeSurface.requiresWorkspace !== true) {
     throw new Error(

--- a/packages/assistant/src/server/pageSupport.js
+++ b/packages/assistant/src/server/pageSupport.js
@@ -16,6 +16,14 @@ function resolveLinkToPropLine(linkTo = "") {
   return `      to: ${JSON.stringify(linkTo)},\n`;
 }
 
+function resolveOwnerLine(owner = "") {
+  const normalizedOwner = normalizeText(owner);
+  if (!normalizedOwner) {
+    return "";
+  }
+  return `    owner: ${JSON.stringify(normalizedOwner)},\n`;
+}
+
 function resolveTemplateFilePath(relativePath = "") {
   return fileURLToPath(new URL(relativePath, import.meta.url));
 }
@@ -49,7 +57,6 @@ async function resolveAssistantPageGenerationContext({
     targetFile,
     context,
     placement: options?.["link-placement"],
-    componentToken: options?.["link-component-token"],
     linkTo: options?.["link-to"]
   });
 
@@ -57,7 +64,7 @@ async function resolveAssistantPageGenerationContext({
     pageTarget,
     pageLabel: normalizeText(options?.name) || pageTarget.defaultName,
     linkPlacementTarget: String(linkTarget.placementTarget?.id || ""),
-    linkComponentToken: String(linkTarget.componentToken || ""),
+    linkOwnerLine: resolveOwnerLine(linkTarget.placementTarget?.owner || ""),
     linkWorkspaceSuffix: pageTarget.routeUrlSuffix,
     linkNonWorkspaceSuffix: pageTarget.routeUrlSuffix,
     linkWhenLine: String(linkTarget.whenLine || ""),
@@ -76,9 +83,10 @@ function renderAssistantPageLinkPlacementBlock({
     "  addPlacement({\n" +
     `    id: "${String(pageTarget?.placementId || "")}",\n` +
     `    target: "${String(generationContext?.linkPlacementTarget || "")}",\n` +
+    `${String(generationContext?.linkOwnerLine || "")}` +
+    "    kind: \"link\",\n" +
     `    surfaces: ["${String(pageTarget?.surfaceId || "")}"],\n` +
     "    order: 155,\n" +
-    `    componentToken: "${String(generationContext?.linkComponentToken || "")}",\n` +
     "    props: {\n" +
     `      label: "${String(generationContext?.pageLabel || "")}",\n` +
     `      surface: "${String(pageTarget?.surfaceId || "")}",\n` +

--- a/packages/assistant/src/server/subcommands/page.js
+++ b/packages/assistant/src/server/subcommands/page.js
@@ -30,7 +30,7 @@ async function runGeneratorSubcommand({
   }
 
   const targetFile = requireSinglePositionalTargetFile(args, { context: "assistant page" });
-  rejectUnexpectedOptions(options, ["name", "link-placement", "link-component-token", "link-to", "force"], {
+  rejectUnexpectedOptions(options, ["name", "link-placement", "link-to", "force"], {
     context: "assistant page"
   });
   const forceOverwrite = Object.prototype.hasOwnProperty.call(options, "force")

--- a/packages/assistant/src/server/subcommands/settingsPage.js
+++ b/packages/assistant/src/server/subcommands/settingsPage.js
@@ -31,7 +31,7 @@ async function runGeneratorSubcommand({
   }
 
   const targetFile = requireSinglePositionalTargetFile(args, { context: "assistant settings-page" });
-  rejectUnexpectedOptions(options, ["surface", "name", "link-placement", "link-component-token", "link-to", "force"], {
+  rejectUnexpectedOptions(options, ["surface", "name", "link-placement", "link-to", "force"], {
     context: "assistant settings-page"
   });
   const forceOverwrite = Object.prototype.hasOwnProperty.call(options, "force")

--- a/packages/assistant/src/server/support.js
+++ b/packages/assistant/src/server/support.js
@@ -49,11 +49,25 @@ function resolveSurfaceDefinition(appConfig = {}, surfaceId = "", optionName = "
   });
 }
 
-function assertAssistantSurfaceIsAvailable(appConfig = {}, surfaceId = "") {
+function assertAssistantSurfaceIsAvailable(appConfig = {}, surfaceId = "", expected = {}) {
   const assistantSurfaces =
     appConfig && typeof appConfig.assistantSurfaces === "object" && !Array.isArray(appConfig.assistantSurfaces)
       ? appConfig.assistantSurfaces
       : {};
+  const existingSurface = assistantSurfaces[surfaceId];
+  if (!existingSurface) {
+    return;
+  }
+
+  const expectedSettingsSurfaceId = normalizeSurfaceId(expected?.settingsSurfaceId);
+  const expectedConfigScope = normalizeConfigScope(expected?.configScope);
+  const existingSettingsSurfaceId = normalizeSurfaceId(existingSurface?.settingsSurfaceId);
+  const existingConfigScope = normalizeConfigScope(existingSurface?.configScope);
+
+  if (existingSettingsSurfaceId === expectedSettingsSurfaceId && existingConfigScope === expectedConfigScope) {
+    return;
+  }
+
   if (assistantSurfaces[surfaceId]) {
     throw new Error(`assistant generator surface "${surfaceId}" already has an assistant configured in config/public.js.`);
   }

--- a/packages/assistant/test/buildTemplateContext.test.js
+++ b/packages/assistant/test/buildTemplateContext.test.js
@@ -84,7 +84,7 @@ test("buildTemplateContext rejects workspace config scope for a non-workspace as
   });
 });
 
-test("buildTemplateContext rejects duplicate assistant surfaces already configured in public config", async () => {
+test("buildTemplateContext accepts an already-configured matching assistant surface", async () => {
   await withTempApp(async (appRoot) => {
     await writeFile(
       path.join(appRoot, "config", "public.js"),
@@ -104,13 +104,48 @@ test("buildTemplateContext rejects duplicate assistant surfaces already configur
       "utf8"
     );
 
+    const context = await buildTemplateContext({
+      appRoot,
+      options: {
+        surface: "app",
+        "settings-surface": "console",
+        "config-scope": "global"
+      }
+    });
+
+    assert.equal(context.__ASSISTANT_SETTINGS_SURFACE_ID__, "console");
+    assert.equal(context.__ASSISTANT_CONFIG_SCOPE__, "global");
+  });
+});
+
+test("buildTemplateContext rejects conflicting assistant surfaces already configured in public config", async () => {
+  await withTempApp(async (appRoot) => {
+    await writeFile(
+      path.join(appRoot, "config", "public.js"),
+      `export const config = {
+  surfaceDefinitions: {
+    app: { id: "app", enabled: true, requiresWorkspace: false, accessPolicyId: "authenticated" },
+    admin: { id: "admin", enabled: true, requiresWorkspace: true, accessPolicyId: "workspace_member" },
+    console: { id: "console", enabled: true, requiresWorkspace: false, accessPolicyId: "console_owner" }
+  },
+  assistantSurfaces: {
+    app: {
+      settingsSurfaceId: "console",
+      configScope: "global"
+    }
+  }
+};
+`,
+      "utf8"
+    );
+
     await assert.rejects(
       () =>
         buildTemplateContext({
           appRoot,
           options: {
             surface: "app",
-            "settings-surface": "console",
+            "settings-surface": "admin",
             "config-scope": "global"
           }
         }),

--- a/packages/assistant/test/subcommands.test.js
+++ b/packages/assistant/test/subcommands.test.js
@@ -25,6 +25,61 @@ function toPagePath(targetFile = "") {
   return path.join("src/pages", targetFile);
 }
 
+function renderTopologyVariant(outlet, { linkRenderer = "" } = {}) {
+  const rendererLines = linkRenderer
+    ? `,
+      renderers: {
+        link: "${linkRenderer}"
+      }`
+    : "";
+  return `{
+      outlet: "${outlet}"${rendererLines}
+    }`;
+}
+
+function renderTopologyEntry({
+  id = "",
+  owner = "",
+  surfaces = ["*"],
+  defaultPlacement = false,
+  outlet = "",
+  linkRenderer = ""
+} = {}) {
+  const ownerLine = owner ? `    owner: "${owner}",\n` : "";
+  const defaultLine = defaultPlacement ? "    default: true,\n" : "";
+  return `  {
+    id: "${id}",
+${ownerLine}    surfaces: ${JSON.stringify(surfaces)},
+${defaultLine}    variants: {
+      compact: ${renderTopologyVariant(outlet, { linkRenderer })},
+      medium: ${renderTopologyVariant(outlet, { linkRenderer })},
+      expanded: ${renderTopologyVariant(outlet, { linkRenderer })}
+    }
+  }`;
+}
+
+async function writePlacementTopology(appRoot, entries = []) {
+  const defaultEntries = [
+    renderTopologyEntry({
+      id: "shell.primary-nav",
+      surfaces: ["*"],
+      defaultPlacement: true,
+      outlet: "shell-layout:primary-menu",
+      linkRenderer: "local.main.ui.surface-aware-menu-link-item"
+    })
+  ];
+  await writeFileInApp(
+    appRoot,
+    "src/placementTopology.js",
+    `export default {
+  placements: [
+${[...defaultEntries, ...entries].join(",\n")}
+  ]
+};
+`
+  );
+}
+
 async function writeAppFixture(appRoot, { configSource = "" } = {}) {
   await writeFileInApp(
     appRoot,
@@ -73,6 +128,7 @@ export default function getPlacements() {
 }
 `
   );
+  await writePlacementTopology(appRoot);
 }
 
 test("assistant page subcommand creates a runtime page at an explicit target file", async () => {
@@ -96,7 +152,9 @@ test("assistant page subcommand creates a runtime page at an explicit target fil
     const placementSource = await readFile(path.join(appRoot, "src/placement.js"), "utf8");
     assert.match(placementSource, /jskit:assistant\.page\.link:admin:\/ops\/copilot/);
     assert.match(placementSource, /id: "ui-generator\.page\.admin\.ops\.copilot\.link"/);
-    assert.match(placementSource, /target: "shell-layout:primary-menu"/);
+    assert.match(placementSource, /target: "shell\.primary-nav"/);
+    assert.match(placementSource, /kind: "link"/);
+    assert.doesNotMatch(placementSource, /componentToken:/);
     assert.match(placementSource, /label: "Copilot"/);
     assert.match(placementSource, /scopedSuffix: "\/ops\/copilot"/);
   });
@@ -105,6 +163,15 @@ test("assistant page subcommand creates a runtime page at an explicit target fil
 test("assistant settings-page subcommand uses the target assistant surface and infers parent subpage placement", async () => {
   await withTempApp(async (appRoot) => {
     await writeAppFixture(appRoot);
+    await writePlacementTopology(appRoot, [
+      renderTopologyEntry({
+        id: "page.section-nav",
+        owner: "admin-settings",
+        surfaces: ["admin"],
+        outlet: "admin-settings:sub-pages",
+        linkRenderer: "local.main.ui.surface-aware-menu-link-item"
+      })
+    ]);
     await writeFileInApp(
       appRoot,
       "src/pages/w/[workspaceSlug]/admin/settings/index.vue",
@@ -137,8 +204,9 @@ test("assistant settings-page subcommand uses the target assistant surface and i
 
     const placementSource = await readFile(path.join(appRoot, "src/placement.js"), "utf8");
     assert.match(placementSource, /jskit:assistant\.settings-page\.link:admin:\/settings\/assistant:console/);
-    assert.match(placementSource, /target: "admin-settings:sub-pages"/);
-    assert.match(placementSource, /componentToken: "local\.main\.ui\.surface-aware-menu-link-item"/);
+    assert.match(placementSource, /target: "page\.section-nav"/);
+    assert.match(placementSource, /owner: "admin-settings"/);
+    assert.doesNotMatch(placementSource, /componentToken: "local\.main\.ui\.surface-aware-menu-link-item"/);
     assert.match(placementSource, /to: "\.\/assistant"/);
     assert.match(placementSource, /label: "Assistant"/);
   });
@@ -241,6 +309,15 @@ test("assistant page subcommand overwrites an existing page when --force is pass
 test("assistant settings-page subcommand overwrites an existing page when --force is passed", async () => {
   await withTempApp(async (appRoot) => {
     await writeAppFixture(appRoot);
+    await writePlacementTopology(appRoot, [
+      renderTopologyEntry({
+        id: "page.section-nav",
+        owner: "admin-settings",
+        surfaces: ["admin"],
+        outlet: "admin-settings:sub-pages",
+        linkRenderer: "local.main.ui.surface-aware-menu-link-item"
+      })
+    ]);
     await writeFileInApp(
       appRoot,
       "src/pages/w/[workspaceSlug]/admin/settings/index.vue",

--- a/packages/auth-core/package.descriptor.mjs
+++ b/packages/auth-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-core",
-  "version": "0.1.64",
+  "version": "0.1.65",
   "kind": "runtime",
   "dependsOn": [
     "@jskit-ai/value-app-config-shared"
@@ -69,7 +69,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.65",
+        "@jskit-ai/kernel": "0.1.66",
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0"

--- a/packages/auth-core/package.json
+++ b/packages/auth-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-core",
-  "version": "0.1.64",
+  "version": "0.1.65",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -46,7 +46,7 @@
     "./shared/commands/authSessionReadCommand": "./src/shared/commands/authSessionReadCommand.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.65",
+    "@jskit-ai/kernel": "0.1.66",
     "@fastify/cookie": "^11.0.2",
     "@fastify/csrf-protection": "^7.1.0",
     "@fastify/rate-limit": "^10.3.0",

--- a/packages/auth-provider-supabase-core/package.descriptor.mjs
+++ b/packages/auth-provider-supabase-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.64",
+  "version": "0.1.65",
   "kind": "runtime",
   "options": {
     "auth-supabase-url": {
@@ -83,8 +83,8 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/auth-core": "0.1.64",
-        "@jskit-ai/kernel": "0.1.65",
+        "@jskit-ai/auth-core": "0.1.65",
+        "@jskit-ai/kernel": "0.1.66",
         "dotenv": "^16.4.5",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0"

--- a/packages/auth-provider-supabase-core/package.json
+++ b/packages/auth-provider-supabase-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.64",
+  "version": "0.1.65",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,8 +12,8 @@
     "./client": "./src/client/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.64",
-    "@jskit-ai/kernel": "0.1.65",
+    "@jskit-ai/auth-core": "0.1.65",
+    "@jskit-ai/kernel": "0.1.66",
     "json-rest-schema": "1.x.x",
     "jose": "^6.1.0",
     "@supabase/supabase-js": "^2.57.4",

--- a/packages/auth-web/package.descriptor.mjs
+++ b/packages/auth-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-web",
-  "version": "0.1.66",
+  "version": "0.1.67",
   "kind": "runtime",
   "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
   "dependsOn": [
@@ -248,10 +248,10 @@ export default Object.freeze({
       "runtime": {
         "@tanstack/vue-query": "5.92.12",
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/auth-core": "0.1.64",
-        "@jskit-ai/http-runtime": "0.1.64",
-        "@jskit-ai/kernel": "0.1.65",
-        "@jskit-ai/shell-web": "0.1.64",
+        "@jskit-ai/auth-core": "0.1.65",
+        "@jskit-ai/http-runtime": "0.1.65",
+        "@jskit-ai/kernel": "0.1.66",
+        "@jskit-ai/shell-web": "0.1.65",
         "vuetify": "^4.0.0"
       },
       "dev": {}

--- a/packages/auth-web/package.descriptor.mjs
+++ b/packages/auth-web/package.descriptor.mjs
@@ -178,15 +178,44 @@ export default Object.freeze({
         "outlets": [
           {
             "target": "auth-profile-menu:primary-menu",
-            "defaultLinkComponentToken": "auth.web.profile.menu.link-item",
             "surfaces": ["*"],
             "source": "src/client/views/AuthProfileWidget.vue"
           }
         ],
+        "topology": {
+          "placements": [
+            {
+              "id": "auth.profile-menu",
+              "description": "Authenticated profile menu actions.",
+              "surfaces": ["*"],
+              "variants": {
+                "compact": {
+                  "outlet": "auth-profile-menu:primary-menu",
+                  "renderers": {
+                    "link": "auth.web.profile.menu.link-item"
+                  }
+                },
+                "medium": {
+                  "outlet": "auth-profile-menu:primary-menu",
+                  "renderers": {
+                    "link": "auth.web.profile.menu.link-item"
+                  }
+                },
+                "expanded": {
+                  "outlet": "auth-profile-menu:primary-menu",
+                  "renderers": {
+                    "link": "auth.web.profile.menu.link-item"
+                  }
+                }
+              }
+            }
+          ]
+        },
         "contributions": [
           {
             "id": "auth.profile.widget",
-            "target": "shell-layout:top-right",
+            "target": "shell.status",
+            "kind": "component",
             "surfaces": ["*"],
             "order": 1000,
             "componentToken": "auth.web.profile.widget",
@@ -194,19 +223,19 @@ export default Object.freeze({
           },
           {
             "id": "auth.profile.menu.sign-in",
-            "target": "auth-profile-menu:primary-menu",
+            "target": "auth.profile-menu",
+            "kind": "link",
             "surfaces": ["*"],
             "order": 200,
-            "componentToken": "auth.web.profile.menu.link-item",
             "when": "auth.authenticated !== true",
             "source": "mutations.text#auth-web-placement-block"
           },
           {
             "id": "auth.profile.menu.sign-out",
-            "target": "auth-profile-menu:primary-menu",
+            "target": "auth.profile-menu",
+            "kind": "link",
             "surfaces": ["*"],
             "order": 1000,
-            "componentToken": "auth.web.profile.menu.link-item",
             "when": "auth.authenticated === true",
             "source": "mutations.text#auth-web-placement-block"
           }
@@ -281,10 +310,20 @@ export default Object.freeze({
         "file": "src/placement.js",
         "position": "bottom",
         "skipIfContains": "id: \"auth.profile.widget\"",
-        "value": "\naddPlacement({\n  id: \"auth.profile.widget\",\n  target: \"shell-layout:top-right\",\n  surfaces: [\"*\"],\n  order: 1000,\n  componentToken: \"auth.web.profile.widget\"\n});\n\naddPlacement({\n  id: \"auth.profile.menu.sign-in\",\n  target: \"auth-profile-menu:primary-menu\",\n  surfaces: [\"*\"],\n  order: 200,\n  componentToken: \"auth.web.profile.menu.link-item\",\n  props: {\n    label: \"Sign in\",\n    to: \"/auth/login\"\n  },\n  when: ({ auth }) => auth?.authenticated !== true\n});\n\naddPlacement({\n  id: \"auth.profile.menu.sign-out\",\n  target: \"auth-profile-menu:primary-menu\",\n  surfaces: [\"*\"],\n  order: 1000,\n  componentToken: \"auth.web.profile.menu.link-item\",\n  props: {\n    label: \"Sign out\",\n    to: \"/auth/signout\"\n  },\n  when: ({ auth }) => auth?.authenticated === true\n});\n",
+        "value": "\naddPlacement({\n  id: \"auth.profile.widget\",\n  target: \"shell.status\",\n  kind: \"component\",\n  surfaces: [\"*\"],\n  order: 1000,\n  componentToken: \"auth.web.profile.widget\"\n});\n\naddPlacement({\n  id: \"auth.profile.menu.sign-in\",\n  target: \"auth.profile-menu\",\n  kind: \"link\",\n  surfaces: [\"*\"],\n  order: 200,\n  props: {\n    label: \"Sign in\",\n    to: \"/auth/login\"\n  },\n  when: ({ auth }) => auth?.authenticated !== true\n});\n\naddPlacement({\n  id: \"auth.profile.menu.sign-out\",\n  target: \"auth.profile-menu\",\n  kind: \"link\",\n  surfaces: [\"*\"],\n  order: 1000,\n  props: {\n    label: \"Sign out\",\n    to: \"/auth/signout\"\n  },\n  when: ({ auth }) => auth?.authenticated === true\n});\n",
         "reason": "Append auth profile placement entries into app-owned placement registry.",
         "category": "auth-web",
         "id": "auth-web-placement-block"
+      },
+      {
+        "op": "append-text",
+        "file": "src/placementTopology.js",
+        "position": "bottom",
+        "skipIfContains": "id: \"auth.profile-menu\"",
+        "value": "\naddPlacementTopology({\n  id: \"auth.profile-menu\",\n  description: \"Authenticated profile menu actions.\",\n  surfaces: [\"*\"],\n  variants: {\n    compact: {\n      outlet: \"auth-profile-menu:primary-menu\",\n      renderers: {\n        link: \"auth.web.profile.menu.link-item\"\n      }\n    },\n    medium: {\n      outlet: \"auth-profile-menu:primary-menu\",\n      renderers: {\n        link: \"auth.web.profile.menu.link-item\"\n      }\n    },\n    expanded: {\n      outlet: \"auth-profile-menu:primary-menu\",\n      renderers: {\n        link: \"auth.web.profile.menu.link-item\"\n      }\n    }\n  }\n});\n",
+        "reason": "Append auth profile menu topology into the app-owned placement topology.",
+        "category": "auth-web",
+        "id": "auth-web-profile-menu-topology"
       }
     ]
   }

--- a/packages/auth-web/package.json
+++ b/packages/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-web",
-  "version": "0.1.66",
+  "version": "0.1.67",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -19,13 +19,13 @@
   },
   "dependencies": {
     "@tanstack/vue-query": "^5.90.5",
-    "@jskit-ai/auth-core": "0.1.64",
+    "@jskit-ai/auth-core": "0.1.65",
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/kernel": "0.1.65",
-    "@jskit-ai/shell-web": "0.1.64",
+    "@jskit-ai/kernel": "0.1.66",
+    "@jskit-ai/shell-web": "0.1.65",
     "pinia": "^3.0.4",
     "vuetify": "^4.0.0",
-    "@jskit-ai/http-runtime": "0.1.64"
+    "@jskit-ai/http-runtime": "0.1.65"
   },
   "peerDependencies": {
     "vue": "^3.5.13",

--- a/packages/auth-web/src/client/views/AuthProfileWidget.vue
+++ b/packages/auth-web/src/client/views/AuthProfileWidget.vue
@@ -75,7 +75,6 @@ const placementContext = computed(() => {
     <v-list min-width="220" density="comfortable" class="py-1">
       <ShellOutlet
         target="auth-profile-menu:primary-menu"
-        default-link-component-token="auth.web.profile.menu.link-item"
         :context="placementContext"
       />
     </v-list>

--- a/packages/console-core/package.descriptor.mjs
+++ b/packages/console-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-core",
-  version: "0.1.28",
+  version: "0.1.29",
   kind: "runtime",
   description: "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
   dependsOn: [
@@ -85,12 +85,12 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.64",
-        "@jskit-ai/database-runtime": "0.1.65",
-        "@jskit-ai/http-runtime": "0.1.64",
-        "@jskit-ai/kernel": "0.1.65",
-        "@jskit-ai/resource-crud-core": "0.1.10",
-        "@jskit-ai/users-core": "0.1.75"
+        "@jskit-ai/auth-core": "0.1.65",
+        "@jskit-ai/database-runtime": "0.1.66",
+        "@jskit-ai/http-runtime": "0.1.65",
+        "@jskit-ai/kernel": "0.1.66",
+        "@jskit-ai/resource-crud-core": "0.1.11",
+        "@jskit-ai/users-core": "0.1.76"
       },
       dev: {}
     },

--- a/packages/console-core/package.json
+++ b/packages/console-core/package.json
@@ -1,17 +1,17 @@
 {
   "name": "@jskit-ai/console-core",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.64",
-    "@jskit-ai/database-runtime": "0.1.65",
-    "@jskit-ai/http-runtime": "0.1.64",
-    "@jskit-ai/kernel": "0.1.65",
-    "@jskit-ai/resource-crud-core": "0.1.10",
-    "@jskit-ai/users-core": "0.1.75",
+    "@jskit-ai/auth-core": "0.1.65",
+    "@jskit-ai/database-runtime": "0.1.66",
+    "@jskit-ai/http-runtime": "0.1.65",
+    "@jskit-ai/kernel": "0.1.66",
+    "@jskit-ai/resource-crud-core": "0.1.11",
+    "@jskit-ai/users-core": "0.1.76",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/console-web/package.descriptor.mjs
+++ b/packages/console-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-web",
-  version: "0.1.33",
+  version: "0.1.34",
   kind: "runtime",
   description: "Authenticated console surface scaffold and surface policy wiring.",
   dependsOn: [
@@ -103,9 +103,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-web": "0.1.66",
-        "@jskit-ai/console-core": "0.1.28",
-        "@jskit-ai/shell-web": "0.1.64",
+        "@jskit-ai/auth-web": "0.1.67",
+        "@jskit-ai/console-core": "0.1.29",
+        "@jskit-ai/shell-web": "0.1.65",
       },
       dev: {}
     },

--- a/packages/console-web/package.descriptor.mjs
+++ b/packages/console-web/package.descriptor.mjs
@@ -43,27 +43,56 @@ export default Object.freeze({
         outlets: [
           {
             target: "console-settings:primary-menu",
-            defaultLinkComponentToken: "local.main.ui.surface-aware-menu-link-item",
             surfaces: ["console"],
             source: "templates/src/pages/console/settings.vue"
           }
         ],
+        topology: {
+          placements: [
+            {
+              id: "page.section-nav",
+              owner: "console-settings",
+              description: "Navigation between console settings child pages.",
+              surfaces: ["console"],
+              variants: {
+                compact: {
+                  outlet: "console-settings:primary-menu",
+                  renderers: {
+                    link: "local.main.ui.surface-aware-menu-link-item"
+                  }
+                },
+                medium: {
+                  outlet: "console-settings:primary-menu",
+                  renderers: {
+                    link: "local.main.ui.surface-aware-menu-link-item"
+                  }
+                },
+                expanded: {
+                  outlet: "console-settings:primary-menu",
+                  renderers: {
+                    link: "local.main.ui.surface-aware-menu-link-item"
+                  }
+                }
+              }
+            }
+          ]
+        },
         contributions: [
           {
             id: "console.web.profile.menu.console",
-            target: "auth-profile-menu:primary-menu",
+            target: "auth.profile-menu",
+            kind: "link",
             surfaces: ["*"],
             order: 600,
-            componentToken: "auth.web.profile.menu.link-item",
             when: "auth.authenticated === true && surfaceAccess.consoleowner === true && surface !== \"console\"",
             source: "mutations.text#console-web-profile-menu-console-placement"
           },
           {
             id: "console.web.menu.settings",
-            target: "shell-layout:primary-menu",
+            target: "shell.primary-nav",
+            kind: "link",
             surfaces: ["console"],
             order: 100,
-            componentToken: "local.main.ui.menu-link-item",
             when: "auth.authenticated === true",
             source: "mutations.text#console-web-console-settings-placement"
           }
@@ -154,7 +183,7 @@ export default Object.freeze({
         position: "bottom",
         skipIfContains: "id: \"console.web.profile.menu.console\"",
         value:
-          "\naddPlacement({\n  id: \"console.web.profile.menu.console\",\n  target: \"auth-profile-menu:primary-menu\",\n  surfaces: [\"*\"],\n  order: 600,\n  componentToken: \"auth.web.profile.menu.link-item\",\n  props: {\n    label: \"Go to console\",\n    to: \"/console\",\n    icon: \"mdi-console-network-outline\"\n  },\n  when: ({ auth, surfaceAccess, surface }) => {\n    return auth?.authenticated === true && surfaceAccess?.consoleowner === true && surface !== \"console\";\n  }\n});\n",
+          "\naddPlacement({\n  id: \"console.web.profile.menu.console\",\n  target: \"auth.profile-menu\",\n  kind: \"link\",\n  surfaces: [\"*\"],\n  order: 600,\n  props: {\n    label: \"Go to console\",\n    to: \"/console\",\n    icon: \"mdi-console-network-outline\"\n  },\n  when: ({ auth, surfaceAccess, surface }) => {\n    return auth?.authenticated === true && surfaceAccess?.consoleowner === true && surface !== \"console\";\n  }\n});\n",
         reason: "Append owner-only console navigation entry into the authenticated profile menu outside the console surface.",
         category: "console-web",
         id: "console-web-profile-menu-console-placement"
@@ -165,10 +194,21 @@ export default Object.freeze({
         position: "bottom",
         skipIfContains: "id: \"console.web.menu.settings\"",
         value:
-          "\naddPlacement({\n  id: \"console.web.menu.settings\",\n  target: \"shell-layout:primary-menu\",\n  surfaces: [\"console\"],\n  order: 100,\n  componentToken: \"local.main.ui.menu-link-item\",\n  props: {\n    label: \"Settings\",\n    to: \"/console/settings\",\n    icon: \"mdi-cog-outline\"\n  },\n  when: ({ auth }) => auth?.authenticated === true\n});\n",
+          "\naddPlacement({\n  id: \"console.web.menu.settings\",\n  target: \"shell.primary-nav\",\n  kind: \"link\",\n  surfaces: [\"console\"],\n  order: 100,\n  props: {\n    label: \"Settings\",\n    to: \"/console/settings\",\n    icon: \"mdi-cog-outline\"\n  },\n  when: ({ auth }) => auth?.authenticated === true\n});\n",
         reason: "Append console-web settings menu placement into app-owned placement registry.",
         category: "console-web",
         id: "console-web-console-settings-placement"
+      },
+      {
+        op: "append-text",
+        file: "src/placementTopology.js",
+        position: "bottom",
+        skipIfContains: "owner: \"console-settings\"",
+        value:
+          "\naddPlacementTopology({\n  id: \"page.section-nav\",\n  owner: \"console-settings\",\n  description: \"Navigation between console settings child pages.\",\n  surfaces: [\"console\"],\n  variants: {\n    compact: {\n      outlet: \"console-settings:primary-menu\",\n      renderers: {\n        link: \"local.main.ui.surface-aware-menu-link-item\"\n      }\n    },\n    medium: {\n      outlet: \"console-settings:primary-menu\",\n      renderers: {\n        link: \"local.main.ui.surface-aware-menu-link-item\"\n      }\n    },\n    expanded: {\n      outlet: \"console-settings:primary-menu\",\n      renderers: {\n        link: \"local.main.ui.surface-aware-menu-link-item\"\n      }\n    }\n  }\n});\n",
+        reason: "Append console settings semantic topology into app-owned placement topology.",
+        category: "console-web",
+        id: "console-web-settings-placement-topology"
       }
     ]
   }

--- a/packages/console-web/package.json
+++ b/packages/console-web/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/console-web",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-web": "0.1.66",
-    "@jskit-ai/console-core": "0.1.28",
-    "@jskit-ai/shell-web": "0.1.64"
+    "@jskit-ai/auth-web": "0.1.67",
+    "@jskit-ai/console-core": "0.1.29",
+    "@jskit-ai/shell-web": "0.1.65"
   }
 }

--- a/packages/console-web/templates/src/pages/console/settings.vue
+++ b/packages/console-web/templates/src/pages/console/settings.vue
@@ -15,10 +15,7 @@ import { RouterView } from "vue-router";
         <v-row no-gutters>
           <v-col cols="12" md="3" lg="2" class="pr-md-4 mb-4 mb-md-0">
             <v-list nav density="comfortable" rounded="lg" border>
-              <ShellOutlet
-                target="console-settings:primary-menu"
-                default-link-component-token="local.main.ui.surface-aware-menu-link-item"
-              />
+              <ShellOutlet target="console-settings:primary-menu" />
             </v-list>
           </v-col>
 

--- a/packages/console-web/test/packageDescriptor.test.js
+++ b/packages/console-web/test/packageDescriptor.test.js
@@ -22,6 +22,34 @@ function findTextMutation(id) {
     : null;
 }
 
+function readOutlets(target = "") {
+  const outlets = descriptor?.metadata?.ui?.placements?.outlets;
+  const normalizedTarget = String(target || "").trim();
+  return Array.isArray(outlets)
+    ? outlets.filter((entry) => String(entry?.target || "").trim() === normalizedTarget)
+    : [];
+}
+
+function findTopology(id, owner = "") {
+  const placements = descriptor?.metadata?.ui?.placements?.topology?.placements;
+  const normalizedId = String(id || "").trim();
+  const normalizedOwner = String(owner || "").trim();
+  return Array.isArray(placements)
+    ? placements.find((entry) => {
+        const entryId = String(entry?.id || "").trim();
+        const entryOwner = String(entry?.owner || "").trim();
+        return entryId === normalizedId && entryOwner === normalizedOwner;
+      }) || null
+    : null;
+}
+
+function findContribution(id) {
+  const contributions = descriptor?.metadata?.ui?.placements?.contributions;
+  return Array.isArray(contributions)
+    ? contributions.find((entry) => String(entry?.id || "").trim() === id) || null
+    : null;
+}
+
 test("console-web installs console surface scripts and files", () => {
   assert.deepEqual(descriptor?.mutations?.packageJson?.scripts, {
     "server:console": "SERVER_SURFACE=console node ./bin/server.js",
@@ -82,6 +110,49 @@ test("console-web wires console surface policy into app config", () => {
     /surfaceAccess\?\.consoleowner === true && surface !== "console"/
   );
   assert.equal(findTextMutation("console-web-console-settings-placement")?.file, "src/placement.js");
+  assert.equal(findTextMutation("console-web-settings-placement-topology")?.file, "src/placementTopology.js");
+  assert.deepEqual(readOutlets("console-settings:primary-menu"), [
+    {
+      target: "console-settings:primary-menu",
+      surfaces: ["console"],
+      source: "templates/src/pages/console/settings.vue"
+    }
+  ]);
+  assert.deepEqual(findTopology("page.section-nav", "console-settings"), {
+    id: "page.section-nav",
+    owner: "console-settings",
+    description: "Navigation between console settings child pages.",
+    surfaces: ["console"],
+    variants: {
+      compact: {
+        outlet: "console-settings:primary-menu",
+        renderers: {
+          link: "local.main.ui.surface-aware-menu-link-item"
+        }
+      },
+      medium: {
+        outlet: "console-settings:primary-menu",
+        renderers: {
+          link: "local.main.ui.surface-aware-menu-link-item"
+        }
+      },
+      expanded: {
+        outlet: "console-settings:primary-menu",
+        renderers: {
+          link: "local.main.ui.surface-aware-menu-link-item"
+        }
+      }
+    }
+  });
+  assert.deepEqual(findContribution("console.web.menu.settings"), {
+    id: "console.web.menu.settings",
+    target: "shell.primary-nav",
+    kind: "link",
+    surfaces: ["console"],
+    order: 100,
+    when: "auth.authenticated === true",
+    source: "mutations.text#console-web-console-settings-placement"
+  });
 });
 
 test("console-web console templates stay shell-driven", async () => {
@@ -94,7 +165,7 @@ test("console-web console templates stay shell-driven", async () => {
   assert.match(wrapperSource, /"surface": "console"/);
   assert.match(indexSource, /Operations Console/);
   assert.match(settingsSource, /target="console-settings:primary-menu"/);
-  assert.match(settingsSource, /default-link-component-token="local\.main\.ui\.surface-aware-menu-link-item"/);
+  assert.doesNotMatch(settingsSource, /default-link-component-token/);
   assert.match(settingsSource, /<RouterView \/>/);
   assert.match(settingsIndexSource, /definePage/);
   assert.match(settingsIndexSource, /your_child_segment/);

--- a/packages/crud-core/package.descriptor.mjs
+++ b/packages/crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-core",
-  version: "0.1.73",
+  version: "0.1.74",
   kind: "runtime",
   description: "Shared CRUD helpers used by CRUD modules.",
   dependsOn: [
@@ -28,7 +28,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/crud-core": "0.1.73"
+        "@jskit-ai/crud-core": "0.1.74"
       },
       dev: {}
     },

--- a/packages/crud-core/package.json
+++ b/packages/crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-core",
-  "version": "0.1.73",
+  "version": "0.1.74",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -28,15 +28,15 @@
   },
   "dependencies": {
     "@tanstack/vue-query": "^5.90.5",
-    "@jskit-ai/database-runtime": "0.1.65",
-    "@jskit-ai/http-runtime": "0.1.64",
-    "@jskit-ai/kernel": "0.1.65",
+    "@jskit-ai/database-runtime": "0.1.66",
+    "@jskit-ai/http-runtime": "0.1.65",
+    "@jskit-ai/kernel": "0.1.66",
     "json-rest-schema": "1.x.x",
-    "@jskit-ai/realtime": "0.1.64",
-    "@jskit-ai/resource-crud-core": "0.1.10",
-    "@jskit-ai/shell-web": "0.1.64",
-    "@jskit-ai/users-core": "0.1.75",
-    "@jskit-ai/users-web": "0.1.80"
+    "@jskit-ai/realtime": "0.1.65",
+    "@jskit-ai/resource-crud-core": "0.1.11",
+    "@jskit-ai/shell-web": "0.1.65",
+    "@jskit-ai/users-core": "0.1.76",
+    "@jskit-ai/users-web": "0.1.81"
   },
   "peerDependencies": {
     "vue": "^3.5.13",

--- a/packages/crud-server-generator/package.descriptor.mjs
+++ b/packages/crud-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-server-generator",
-  version: "0.1.73",
+  version: "0.1.74",
   kind: "generator",
   description: "CRUD server generator with routes, actions, and persistence scaffolding.",
   options: {
@@ -160,14 +160,14 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.64",
-        "@jskit-ai/crud-core": "0.1.73",
-        "@jskit-ai/database-runtime": "0.1.65",
-        "@jskit-ai/http-runtime": "0.1.64",
-        "@jskit-ai/json-rest-api-core": "0.1.10",
-        "@jskit-ai/kernel": "0.1.65",
-        "@jskit-ai/realtime": "0.1.64",
-        "@jskit-ai/resource-crud-core": "0.1.10",
+        "@jskit-ai/auth-core": "0.1.65",
+        "@jskit-ai/crud-core": "0.1.74",
+        "@jskit-ai/database-runtime": "0.1.66",
+        "@jskit-ai/http-runtime": "0.1.65",
+        "@jskit-ai/json-rest-api-core": "0.1.11",
+        "@jskit-ai/kernel": "0.1.66",
+        "@jskit-ai/realtime": "0.1.65",
+        "@jskit-ai/resource-crud-core": "0.1.11",
         "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}"
       },
       dev: {}

--- a/packages/crud-server-generator/package.json
+++ b/packages/crud-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-server-generator",
-  "version": "0.1.73",
+  "version": "0.1.74",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,12 +13,12 @@
   },
   "dependencies": {
     "@babel/parser": "^7.29.2",
-    "@jskit-ai/crud-core": "0.1.73",
-    "@jskit-ai/database-runtime": "0.1.65",
-    "@jskit-ai/http-runtime": "0.1.64",
-    "@jskit-ai/json-rest-api-core": "0.1.10",
-    "@jskit-ai/kernel": "0.1.65",
-    "@jskit-ai/resource-crud-core": "0.1.10",
+    "@jskit-ai/crud-core": "0.1.74",
+    "@jskit-ai/database-runtime": "0.1.66",
+    "@jskit-ai/http-runtime": "0.1.65",
+    "@jskit-ai/json-rest-api-core": "0.1.11",
+    "@jskit-ai/kernel": "0.1.66",
+    "@jskit-ai/resource-crud-core": "0.1.11",
     "recast": "^0.23.11"
   }
 }

--- a/packages/crud-ui-generator/package.descriptor.mjs
+++ b/packages/crud-ui-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-ui-generator",
-  version: "0.1.48",
+  version: "0.1.49",
   kind: "generator",
   description: "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
   options: {
@@ -171,7 +171,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.80"
+        "@jskit-ai/users-web": "0.1.81"
       },
       dev: {}
     },

--- a/packages/crud-ui-generator/package.descriptor.mjs
+++ b/packages/crud-ui-generator/package.descriptor.mjs
@@ -64,15 +64,7 @@ export default Object.freeze({
       inputType: "text",
       defaultValue: "",
       promptLabel: "Link placement",
-      promptHint: "Optional target override for the generated list-page link placement (format: host:position)."
-    },
-    "link-component-token": {
-      required: false,
-      inputType: "text",
-      defaultValue: "",
-      promptLabel: "Link component token",
-      promptHint:
-        "Optional component token override for the generated list-page link placement (example: local.main.ui.tab-link-item)."
+      promptHint: "Optional semantic target override for the generated list-page link placement (format: area.slot)."
     },
     namespace: {
       required: false,
@@ -119,7 +111,6 @@ export default Object.freeze({
           "id-param",
           "parent-title",
           "link-placement",
-          "link-component-token",
           "namespace",
           "force"
         ],
@@ -365,7 +356,7 @@ export default Object.freeze({
         position: "bottom",
         skipIfContains: "__JSKIT_UI_MENU_MARKER__",
         value:
-          "\n// __JSKIT_UI_MENU_MARKER__\n{\n  addPlacement({\n    id: \"__JSKIT_UI_MENU_PLACEMENT_ID__\",\n    target: \"__JSKIT_UI_MENU_PLACEMENT_TARGET__\",\n    surfaces: [\"__JSKIT_UI_SURFACE_ID__\"],\n    order: 155,\n    componentToken: \"__JSKIT_UI_MENU_COMPONENT_TOKEN__\",\n    props: {\n      label: \"__JSKIT_UI_MENU_LABEL__\",\n      icon: \"__JSKIT_UI_MENU_ICON__\",\n      surface: \"__JSKIT_UI_SURFACE_ID__\",\n      scopedSuffix: \"__JSKIT_UI_MENU_WORKSPACE_SUFFIX__\",\n      unscopedSuffix: \"__JSKIT_UI_MENU_NON_WORKSPACE_SUFFIX__\",\n__JSKIT_UI_MENU_TO_PROP_LINE__    },\n__JSKIT_UI_MENU_WHEN_LINE__  });\n}\n",
+          "\n// __JSKIT_UI_MENU_MARKER__\n{\n  addPlacement({\n    id: \"__JSKIT_UI_MENU_PLACEMENT_ID__\",\n    target: \"__JSKIT_UI_MENU_PLACEMENT_TARGET__\",\n__JSKIT_UI_MENU_OWNER_LINE__    kind: \"link\",\n    surfaces: [\"__JSKIT_UI_SURFACE_ID__\"],\n    order: 155,\n    props: {\n      label: \"__JSKIT_UI_MENU_LABEL__\",\n      icon: \"__JSKIT_UI_MENU_ICON__\",\n      surface: \"__JSKIT_UI_SURFACE_ID__\",\n      scopedSuffix: \"__JSKIT_UI_MENU_WORKSPACE_SUFFIX__\",\n      unscopedSuffix: \"__JSKIT_UI_MENU_NON_WORKSPACE_SUFFIX__\",\n__JSKIT_UI_MENU_TO_PROP_LINE__    },\n__JSKIT_UI_MENU_WHEN_LINE__  });\n}\n",
         reason: "Append generated CRUD list-page placement.",
         category: "crud-ui-generator",
         id: "crud-ui-placement-menu",

--- a/packages/crud-ui-generator/package.json
+++ b/packages/crud-ui-generator/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@jskit-ai/crud-ui-generator",
-  "version": "0.1.48",
+  "version": "0.1.49",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/crud-core": "0.1.73",
-    "@jskit-ai/kernel": "0.1.65",
-    "@jskit-ai/resource-crud-core": "0.1.10"
+    "@jskit-ai/crud-core": "0.1.74",
+    "@jskit-ai/kernel": "0.1.66",
+    "@jskit-ai/resource-crud-core": "0.1.11"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/crud-ui-generator/src/server/buildTemplateContext.js
+++ b/packages/crud-ui-generator/src/server/buildTemplateContext.js
@@ -475,6 +475,14 @@ function resolveMenuToPropLine(linkTo = "") {
   return `      to: ${JSON.stringify(linkTo)},\n`;
 }
 
+function resolveMenuOwnerLine(owner = "") {
+  const normalizedOwner = normalizeText(owner);
+  if (!normalizedOwner) {
+    return "";
+  }
+  return `    owner: ${JSON.stringify(normalizedOwner)},\n`;
+}
+
 function resolveCrudRelativePath(namespace = "") {
   return `/${requireCrudNamespace(namespace, {
     context: "crud-ui-generator resource namespace"
@@ -650,7 +658,6 @@ async function buildUiTemplateContext({ appRoot, options } = {}) {
       pageTarget,
       targetFile: listTargetFile,
       placement: options?.["link-placement"],
-      componentToken: options?.["link-component-token"],
       context: "crud-ui-generator"
     })
     : null;
@@ -727,7 +734,7 @@ async function buildUiTemplateContext({ appRoot, options } = {}) {
     __JSKIT_UI_MENU_MARKER__: menuMarker,
     __JSKIT_UI_MENU_PLACEMENT_ID__: String(pageLinkTarget?.pageTarget?.placementId || ""),
     __JSKIT_UI_MENU_PLACEMENT_TARGET__: String(pageLinkTarget?.placementTarget?.id || ""),
-    __JSKIT_UI_MENU_COMPONENT_TOKEN__: String(pageLinkTarget?.componentToken || ""),
+    __JSKIT_UI_MENU_OWNER_LINE__: resolveMenuOwnerLine(pageLinkTarget?.placementTarget?.owner || ""),
     __JSKIT_UI_MENU_ICON__: DEFAULT_GENERATED_LINK_ICON,
     __JSKIT_UI_MENU_WORKSPACE_SUFFIX__: String(pageLinkTarget?.pageTarget?.routeUrlSuffix || ""),
     __JSKIT_UI_MENU_NON_WORKSPACE_SUFFIX__: String(pageLinkTarget?.pageTarget?.routeUrlSuffix || ""),

--- a/packages/crud-ui-generator/test/buildTemplateContext.test.js
+++ b/packages/crud-ui-generator/test/buildTemplateContext.test.js
@@ -27,6 +27,67 @@ async function linkTestPackage(appRoot, packageName, packageDir) {
   await symlink(packageDir, targetPath, "dir");
 }
 
+function renderTopologyVariant(outlet, { linkRenderer = "" } = {}) {
+  const rendererLines = linkRenderer
+    ? `,
+      renderers: {
+        link: "${linkRenderer}"
+      }`
+    : "";
+  return `{
+      outlet: "${outlet}"${rendererLines}
+    }`;
+}
+
+function renderTopologyEntry({
+  id = "",
+  owner = "",
+  surfaces = ["*"],
+  defaultPlacement = false,
+  outlet = "",
+  linkRenderer = ""
+} = {}) {
+  const ownerLine = owner ? `    owner: "${owner}",\n` : "";
+  const defaultLine = defaultPlacement ? "    default: true,\n" : "";
+  return `  {
+    id: "${id}",
+${ownerLine}    surfaces: ${JSON.stringify(surfaces)},
+${defaultLine}    variants: {
+      compact: ${renderTopologyVariant(outlet, { linkRenderer })},
+      medium: ${renderTopologyVariant(outlet, { linkRenderer })},
+      expanded: ${renderTopologyVariant(outlet, { linkRenderer })}
+    }
+  }`;
+}
+
+async function writePlacementTopology(appRoot, entries = []) {
+  const defaultEntries = [
+    renderTopologyEntry({
+      id: "shell.primary-nav",
+      surfaces: ["*"],
+      defaultPlacement: true,
+      outlet: "shell-layout:primary-menu",
+      linkRenderer: "local.main.ui.surface-aware-menu-link-item"
+    }),
+    renderTopologyEntry({
+      id: "shell.secondary-nav",
+      surfaces: ["*"],
+      outlet: "shell-layout:secondary-menu",
+      linkRenderer: "local.main.ui.surface-aware-menu-link-item"
+    })
+  ];
+  await writeFile(
+    path.join(appRoot, "src", "placementTopology.js"),
+    `export default {
+  placements: [
+${[...defaultEntries, ...entries].join(",\n")}
+  ]
+};
+`,
+    "utf8"
+  );
+}
+
 async function withTempApp(run) {
   const appRoot = await mkdtemp(path.join(tmpdir(), "crud-ui-generator-"));
   try {
@@ -54,17 +115,14 @@ async function withTempApp(run) {
     <ShellOutlet
       target="shell-layout:primary-menu"
       default
-      default-link-component-token="local.main.ui.surface-aware-menu-link-item"
     />
-    <ShellOutlet
-      target="shell-layout:secondary-menu"
-      default-link-component-token="local.main.ui.surface-aware-menu-link-item"
-    />
+    <ShellOutlet target="shell-layout:secondary-menu" />
   </div>
 </template>
 `,
       "utf8"
     );
+    await writePlacementTopology(appRoot);
     return await run(appRoot);
   } finally {
     await rm(appRoot, { recursive: true, force: true });
@@ -614,8 +672,8 @@ test("buildUiTemplateContext resolves list placement from the app default shell 
     });
 
     assert.equal(context.__JSKIT_UI_MENU_PLACEMENT_ID__, "ui-generator.page.admin.customers.link");
-    assert.equal(context.__JSKIT_UI_MENU_PLACEMENT_TARGET__, "shell-layout:primary-menu");
-    assert.equal(context.__JSKIT_UI_MENU_COMPONENT_TOKEN__, "local.main.ui.surface-aware-menu-link-item");
+    assert.equal(context.__JSKIT_UI_MENU_PLACEMENT_TARGET__, "shell.primary-nav");
+    assert.equal(context.__JSKIT_UI_MENU_OWNER_LINE__, "");
     assert.equal(context.__JSKIT_UI_MENU_WORKSPACE_SUFFIX__, "/customers");
     assert.equal(context.__JSKIT_UI_MENU_NON_WORKSPACE_SUFFIX__, "/customers");
     assert.equal(context.__JSKIT_UI_MENU_TO_PROP_LINE__, "");
@@ -627,6 +685,15 @@ test("buildUiTemplateContext resolves list placement from the app default shell 
 test("buildUiTemplateContext infers tab placement and relative link-to from the nearest parent subpages host", async () => {
   await withTempApp(async (appRoot) => {
     await writeResource(appRoot, RESOURCE_FILE, FULL_RESOURCE_SOURCE);
+    await writePlacementTopology(appRoot, [
+      renderTopologyEntry({
+        id: "page.section-nav",
+        owner: "catalog",
+        surfaces: ["admin"],
+        outlet: "catalog:sub-pages",
+        linkRenderer: "local.main.ui.surface-aware-menu-link-item"
+      })
+    ]);
     await writeFileInApp(
       appRoot,
       "src/pages/admin/catalog/index.vue",
@@ -648,8 +715,8 @@ test("buildUiTemplateContext infers tab placement and relative link-to from the 
       })
     });
 
-    assert.equal(context.__JSKIT_UI_MENU_PLACEMENT_TARGET__, "catalog:sub-pages");
-    assert.equal(context.__JSKIT_UI_MENU_COMPONENT_TOKEN__, "local.main.ui.surface-aware-menu-link-item");
+    assert.equal(context.__JSKIT_UI_MENU_PLACEMENT_TARGET__, "page.section-nav");
+    assert.equal(context.__JSKIT_UI_MENU_OWNER_LINE__, "    owner: \"catalog\",\n");
     assert.equal(context.__JSKIT_UI_MENU_ICON__, "mdi-view-list-outline");
     assert.equal(context.__JSKIT_UI_MENU_TO_PROP_LINE__, "      to: \"./products\",\n");
     assert.equal(context.__JSKIT_UI_MENU_WORKSPACE_SUFFIX__, "/catalog/products");
@@ -659,15 +726,21 @@ test("buildUiTemplateContext infers tab placement and relative link-to from the 
 test("buildUiTemplateContext prefers an outlet-declared default link token and omits fragile relative to output", async () => {
   await withTempApp(async (appRoot) => {
     await writeResource(appRoot, RESOURCE_FILE, FULL_RESOURCE_SOURCE);
+    await writePlacementTopology(appRoot, [
+      renderTopologyEntry({
+        id: "page.section-nav",
+        owner: "admin-settings",
+        surfaces: ["admin"],
+        outlet: "admin-settings:primary-menu",
+        linkRenderer: "local.main.ui.surface-aware-menu-link-item"
+      })
+    ]);
     await writeFileInApp(
       appRoot,
       "src/pages/admin/settings.vue",
       `<template>
   <section>
-    <ShellOutlet
-      target="admin-settings:primary-menu"
-      default-link-component-token="local.main.ui.surface-aware-menu-link-item"
-    />
+    <ShellOutlet target="admin-settings:primary-menu" />
     <RouterView />
   </section>
 </template>
@@ -681,8 +754,8 @@ test("buildUiTemplateContext prefers an outlet-declared default link token and o
       })
     });
 
-    assert.equal(context.__JSKIT_UI_MENU_PLACEMENT_TARGET__, "admin-settings:primary-menu");
-    assert.equal(context.__JSKIT_UI_MENU_COMPONENT_TOKEN__, "local.main.ui.surface-aware-menu-link-item");
+    assert.equal(context.__JSKIT_UI_MENU_PLACEMENT_TARGET__, "page.section-nav");
+    assert.equal(context.__JSKIT_UI_MENU_OWNER_LINE__, "    owner: \"admin-settings\",\n");
     assert.equal(context.__JSKIT_UI_MENU_TO_PROP_LINE__, "");
   });
 });
@@ -694,12 +767,12 @@ test("buildUiTemplateContext honors explicit link-placement override", async () 
     const context = await buildUiTemplateContext({
       appRoot,
       options: createOptions({
-        "link-placement": "shell-layout:secondary-menu"
+        "link-placement": "shell.secondary-nav"
       })
     });
 
-    assert.equal(context.__JSKIT_UI_MENU_PLACEMENT_TARGET__, "shell-layout:secondary-menu");
-    assert.equal(context.__JSKIT_UI_MENU_COMPONENT_TOKEN__, "local.main.ui.surface-aware-menu-link-item");
+    assert.equal(context.__JSKIT_UI_MENU_PLACEMENT_TARGET__, "shell.secondary-nav");
+    assert.equal(context.__JSKIT_UI_MENU_OWNER_LINE__, "");
   });
 });
 

--- a/packages/database-runtime-mysql/package.descriptor.mjs
+++ b/packages/database-runtime-mysql/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-mysql",
-  version: "0.1.64",
+  version: "0.1.65",
   kind: "runtime",
   options: {
     "db-host": {
@@ -91,7 +91,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.65",
+        "@jskit-ai/database-runtime": "0.1.66",
         "mysql2": "^3.11.2"
       },
       dev: {}

--- a/packages/database-runtime-mysql/package.json
+++ b/packages/database-runtime-mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-mysql",
-  "version": "0.1.64",
+  "version": "0.1.65",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,7 +12,7 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.65",
-    "@jskit-ai/kernel": "0.1.65"
+    "@jskit-ai/database-runtime": "0.1.66",
+    "@jskit-ai/kernel": "0.1.66"
   }
 }

--- a/packages/database-runtime-postgres/package.descriptor.mjs
+++ b/packages/database-runtime-postgres/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-postgres",
-  version: "0.1.64",
+  version: "0.1.65",
   kind: "runtime",
   options: {
     "db-host": {
@@ -91,7 +91,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.65",
+        "@jskit-ai/database-runtime": "0.1.66",
         "pg": "^8.13.1"
       },
       dev: {}

--- a/packages/database-runtime-postgres/package.json
+++ b/packages/database-runtime-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-postgres",
-  "version": "0.1.64",
+  "version": "0.1.65",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,6 +12,6 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.65"
+    "@jskit-ai/database-runtime": "0.1.66"
   }
 }

--- a/packages/database-runtime/package.descriptor.mjs
+++ b/packages/database-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime",
-  version: "0.1.65",
+  version: "0.1.66",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -58,7 +58,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.65",
+        "@jskit-ai/kernel": "0.1.66",
         "dotenv": "^16.4.5",
         "knex": "^3.1.0"
       },

--- a/packages/database-runtime/package.json
+++ b/packages/database-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime",
-  "version": "0.1.65",
+  "version": "0.1.66",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -25,6 +25,6 @@
     "./shared/transactions": "./src/shared/transactions.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.65"
+    "@jskit-ai/kernel": "0.1.66"
   }
 }

--- a/packages/feature-server-generator/package.descriptor.mjs
+++ b/packages/feature-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/feature-server-generator",
-  version: "0.1.7",
+  version: "0.1.8",
   kind: "generator",
   description: "Scaffold substantial non-CRUD server feature packages with provider, actions, service, and optional persistence seams.",
   options: {
@@ -153,10 +153,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.65",
-        "@jskit-ai/database-runtime-mysql": "0.1.64",
-        "@jskit-ai/json-rest-api-core": "0.1.10",
-        "@jskit-ai/kernel": "0.1.65",
+        "@jskit-ai/database-runtime": "0.1.66",
+        "@jskit-ai/database-runtime-mysql": "0.1.65",
+        "@jskit-ai/json-rest-api-core": "0.1.11",
+        "@jskit-ai/kernel": "0.1.66",
         "json-rest-schema": "1.x.x",
         "@local/${option:feature-name|kebab}": "file:packages/${option:feature-name|kebab}"
       },

--- a/packages/feature-server-generator/package.json
+++ b/packages/feature-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/feature-server-generator",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "type": "module",
   "scripts": {
     "test": "node --test"

--- a/packages/google-rewarded-core/package.descriptor.mjs
+++ b/packages/google-rewarded-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/google-rewarded-core",
-  version: "0.1.2",
+  version: "0.1.3",
   kind: "runtime",
   description: "Google rewarded workflow runtime plus internal CRUD providers for rules, provider configs, watch sessions, and unlock receipts.",
   dependsOn: [
@@ -128,14 +128,14 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.64",
-        "@jskit-ai/crud-core": "0.1.73",
-        "@jskit-ai/database-runtime": "0.1.65",
-        "@jskit-ai/http-runtime": "0.1.64",
-        "@jskit-ai/json-rest-api-core": "0.1.10",
-        "@jskit-ai/kernel": "0.1.65",
-        "@jskit-ai/resource-crud-core": "0.1.10",
-        "@jskit-ai/workspaces-core": "0.1.41"
+        "@jskit-ai/auth-core": "0.1.65",
+        "@jskit-ai/crud-core": "0.1.74",
+        "@jskit-ai/database-runtime": "0.1.66",
+        "@jskit-ai/http-runtime": "0.1.65",
+        "@jskit-ai/json-rest-api-core": "0.1.11",
+        "@jskit-ai/kernel": "0.1.66",
+        "@jskit-ai/resource-crud-core": "0.1.11",
+        "@jskit-ai/workspaces-core": "0.1.42"
       },
       dev: {}
     },

--- a/packages/google-rewarded-core/package.json
+++ b/packages/google-rewarded-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/google-rewarded-core",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/google-rewarded-web/package.descriptor.mjs
+++ b/packages/google-rewarded-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/google-rewarded-web",
-  version: "0.1.2",
+  version: "0.1.3",
   kind: "runtime",
   description: "Google rewarded client runtime with a fullscreen gate host and GPT orchestration.",
   dependsOn: [
@@ -46,10 +46,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/google-rewarded-core": "0.1.2",
-        "@jskit-ai/http-runtime": "0.1.64",
-        "@jskit-ai/kernel": "0.1.65",
-        "@jskit-ai/shell-web": "0.1.64"
+        "@jskit-ai/google-rewarded-core": "0.1.3",
+        "@jskit-ai/http-runtime": "0.1.65",
+        "@jskit-ai/kernel": "0.1.66",
+        "@jskit-ai/shell-web": "0.1.65"
       },
       dev: {}
     },

--- a/packages/google-rewarded-web/package.json
+++ b/packages/google-rewarded-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/google-rewarded-web",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/http-runtime/package.descriptor.mjs
+++ b/packages/http-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/http-runtime",
-  "version": "0.1.64",
+  "version": "0.1.65",
   "kind": "runtime",
   "dependsOn": [],
   "capabilities": {
@@ -67,7 +67,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.65"
+        "@jskit-ai/kernel": "0.1.66"
       },
       "dev": {}
     },

--- a/packages/http-runtime/package.json
+++ b/packages/http-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/http-runtime",
-  "version": "0.1.64",
+  "version": "0.1.65",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -18,7 +18,7 @@
     "./shared/validators/operationValidation": "./src/shared/validators/operationValidation.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.65",
+    "@jskit-ai/kernel": "0.1.66",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/json-rest-api-core/package.descriptor.mjs
+++ b/packages/json-rest-api-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/json-rest-api-core",
-  version: "0.1.10",
+  version: "0.1.11",
   kind: "runtime",
   description: "Shared internal json-rest-api host runtime for JSKIT server packages.",
   dependsOn: [

--- a/packages/json-rest-api-core/package.json
+++ b/packages/json-rest-api-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/json-rest-api-core",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,6 +11,6 @@
   "dependencies": {
     "hooked-api": "1.x.x",
     "json-rest-api": "1.x.x",
-    "@jskit-ai/kernel": "0.1.65"
+    "@jskit-ai/kernel": "0.1.66"
   }
 }

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/kernel",
-  "version": "0.1.65",
+  "version": "0.1.66",
   "type": "module",
   "dependencies": {
     "json-rest-schema": "1.x.x"

--- a/packages/kernel/server/support/appConfigFiles.js
+++ b/packages/kernel/server/support/appConfigFiles.js
@@ -1,6 +1,7 @@
 import path from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
 import { fileExists } from "../../internal/node/fileSystem.js";
+import { importFreshModuleFromAbsolutePath } from "./importFreshModuleFromAbsolutePath.js";
 
 const PUBLIC_CONFIG_RELATIVE_PATH = "config/public.js";
 const SERVER_CONFIG_RELATIVE_PATH = "config/server.js";
@@ -35,7 +36,7 @@ async function loadConfigModuleAtPath(absolutePath) {
     return {};
   }
 
-  const loadedModule = await import(pathToFileURL(absolutePath).href);
+  const loadedModule = await importFreshModuleFromAbsolutePath(absolutePath);
   return normalizeConfigObject(loadedModule?.config);
 }
 

--- a/packages/kernel/server/support/appConfigFiles.test.js
+++ b/packages/kernel/server/support/appConfigFiles.test.js
@@ -47,6 +47,21 @@ test("loadAppConfigFromAppRoot merges public and server config", async () => {
   assert.equal(Object.isFrozen(loaded), true);
 });
 
+test("loadAppConfigFromAppRoot re-reads config changes within the same process", async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "kernel-app-config-"));
+  const appRoot = path.join(tempRoot, "app");
+  const publicConfigPath = path.join(appRoot, "config", "public.js");
+  await mkdir(path.dirname(publicConfigPath), { recursive: true });
+  await writeFile(publicConfigPath, "export const config = { mobile: { enabled: false } };", "utf8");
+
+  const firstLoaded = await loadAppConfigFromAppRoot({ appRoot });
+  await writeFile(publicConfigPath, "export const config = { mobile: { enabled: true } };", "utf8");
+  const secondLoaded = await loadAppConfigFromAppRoot({ appRoot });
+
+  assert.equal(firstLoaded.mobile.enabled, false);
+  assert.equal(secondLoaded.mobile.enabled, true);
+});
+
 test("loadAppConfigFromAppRoot requires an explicit appRoot", async () => {
   await assert.rejects(
     loadAppConfigFromAppRoot({ appRoot: "" }),

--- a/packages/kernel/server/support/index.js
+++ b/packages/kernel/server/support/index.js
@@ -16,6 +16,8 @@ export {
   resolvePageLinkTargetDetails
 } from "./pageTargets.js";
 export {
+  discoverPlacementTopologyFromApp,
   discoverShellOutletTargetsFromApp,
+  resolveSemanticPlacementTargetFromApp,
   resolveShellOutletPlacementTargetFromApp
 } from "./shellOutlets.js";

--- a/packages/kernel/server/support/pageTargets.js
+++ b/packages/kernel/server/support/pageTargets.js
@@ -14,7 +14,10 @@ import {
   findShellOutletTargetById,
   normalizeShellOutletTargetId
 } from "../../shared/support/shellLayoutTargets.js";
-import { resolveShellOutletPlacementTargetFromApp } from "./shellOutlets.js";
+import {
+  discoverPlacementTopologyFromApp,
+  resolveSemanticPlacementTargetFromApp
+} from "./shellOutlets.js";
 import { resolveRequiredAppRoot, toPosixPath } from "./path.js";
 import { loadAppConfigFromModuleUrl } from "./appConfigFiles.js";
 
@@ -562,6 +565,48 @@ function normalizePlacementTargetId(target = {}) {
   return normalizeShellOutletTargetId(target?.id || target?.target || target);
 }
 
+function resolveConcreteTargetOwner(target = "") {
+  const normalizedTarget = normalizeShellOutletTargetId(target);
+  if (!normalizedTarget) {
+    return "";
+  }
+  return normalizedTarget.slice(0, normalizedTarget.indexOf(":"));
+}
+
+function topologyPlacementTargetsConcreteOutlet(placement = {}, target = "") {
+  const normalizedTarget = normalizeShellOutletTargetId(target);
+  if (!normalizedTarget) {
+    return false;
+  }
+  const variants = placement?.variants && typeof placement.variants === "object" ? placement.variants : {};
+  return Object.values(variants).some((variant) => normalizeShellOutletTargetId(variant?.outlet) === normalizedTarget);
+}
+
+async function resolveSemanticPlacementTargetForConcreteOutlet({
+  appRoot,
+  concreteTarget = "",
+  surface = ""
+} = {}) {
+  const normalizedConcreteTarget = normalizeShellOutletTargetId(concreteTarget);
+  if (!normalizedConcreteTarget) {
+    return null;
+  }
+
+  const topology = await discoverPlacementTopologyFromApp({ appRoot });
+  const owner = resolveConcreteTargetOwner(normalizedConcreteTarget);
+  const normalizedSurface = normalizeSurfaceId(surface);
+  return (Array.isArray(topology.placements) ? topology.placements : []).find((placement) => {
+    if (!topologyPlacementTargetsConcreteOutlet(placement, normalizedConcreteTarget)) {
+      return false;
+    }
+    if (placement.owner && placement.owner !== owner) {
+      return false;
+    }
+    const surfaces = Array.isArray(placement.surfaces) ? placement.surfaces : ["*"];
+    return !normalizedSurface || surfaces.includes("*") || surfaces.includes(normalizedSurface);
+  }) || null;
+}
+
 function resolveRelativeLinkToFromParent(pageTarget = {}, parentHost = null) {
   const childSegments = Array.isArray(pageTarget?.visibleRouteSegments) ? pageTarget.visibleRouteSegments : [];
   const parentSegments = Array.isArray(parentHost?.visibleRouteSegments) ? parentHost.visibleRouteSegments : [];
@@ -598,7 +643,7 @@ function resolveInferredPageLinkTo({
   explicitLinkTo = "",
   pageTarget = {},
   parentHost = null,
-  placementTarget = null,
+  preservesRelativeSubpageLinks = false,
   suppressImplicitRelativeLinks = false
 } = {}) {
   const normalizedExplicitLinkTo = normalizeText(explicitLinkTo);
@@ -609,14 +654,10 @@ function resolveInferredPageLinkTo({
     return "";
   }
 
-  const parentTargetId = normalizePlacementTargetId(parentHost);
-  const placementTargetId = normalizePlacementTargetId(placementTarget);
-  if (parentTargetId && parentTargetId === placementTargetId) {
-    if (parentHost?.isSectionSubpagesHost === true) {
-      const inferredLinkTo = resolveRelativeLinkToFromParent(pageTarget, parentHost);
-      if (inferredLinkTo) {
-        return inferredLinkTo;
-      }
+  if (preservesRelativeSubpageLinks === true && parentHost?.isSectionSubpagesHost === true) {
+    const inferredLinkTo = resolveRelativeLinkToFromParent(pageTarget, parentHost);
+    if (inferredLinkTo) {
+      return inferredLinkTo;
     }
   }
 
@@ -625,36 +666,6 @@ function resolveInferredPageLinkTo({
     return inferredLinkTo;
   }
   return "";
-}
-
-function resolveInferredPageLinkComponentToken({
-  explicitComponentToken = "",
-  parentHost = null,
-  placementTarget = null,
-  defaultComponentToken = DEFAULT_PAGE_LINK_COMPONENT_TOKEN,
-  subpageComponentToken = DEFAULT_SUBPAGE_LINK_COMPONENT_TOKEN
-} = {}) {
-  const normalizedExplicitToken = normalizeText(explicitComponentToken);
-  if (normalizedExplicitToken) {
-    return normalizedExplicitToken;
-  }
-
-  const normalizedPlacementTargetDefaultToken = normalizeText(placementTarget?.defaultLinkComponentToken);
-  if (normalizedPlacementTargetDefaultToken) {
-    return normalizedPlacementTargetDefaultToken;
-  }
-
-  const parentTargetId = normalizePlacementTargetId(parentHost);
-  const placementTargetId = normalizePlacementTargetId(placementTarget);
-  if (
-    parentHost?.isSectionSubpagesHost === true &&
-    parentTargetId &&
-    parentTargetId === placementTargetId
-  ) {
-    return normalizeText(subpageComponentToken) || DEFAULT_SUBPAGE_LINK_COMPONENT_TOKEN;
-  }
-
-  return normalizeText(defaultComponentToken) || DEFAULT_PAGE_LINK_COMPONENT_TOKEN;
 }
 
 function renderPageLinkWhenLine(pageTarget = {}) {
@@ -672,8 +683,6 @@ async function resolvePageLinkTargetDetails({
   placement = "",
   componentToken = "",
   linkTo = "",
-  defaultComponentToken = DEFAULT_PAGE_LINK_COMPONENT_TOKEN,
-  subpageComponentToken = DEFAULT_SUBPAGE_LINK_COMPONENT_TOKEN,
   context = "page target"
 } = {}) {
   const resolvedPageTarget = pageTarget || await resolvePageTargetDetails({
@@ -686,39 +695,49 @@ async function resolvePageLinkTargetDetails({
     pageTarget: resolvedPageTarget,
     context
   });
-  const placementTarget = await resolveShellOutletPlacementTargetFromApp({
-    appRoot: resolvedPageTarget.appRoot,
-    context,
-    placement: normalizeText(placement) || parentHost?.id || ""
-  });
-  const resolvedComponentToken = resolveInferredPageLinkComponentToken({
-    explicitComponentToken: componentToken,
-    parentHost,
-    placementTarget,
-    defaultComponentToken,
-    subpageComponentToken
-  });
   const parentTargetId = normalizePlacementTargetId(parentHost);
-  const placementTargetId = normalizePlacementTargetId(placementTarget);
+  let placementTarget = null;
+  const explicitPlacement = normalizeText(placement);
+  if (explicitPlacement) {
+    placementTarget = await resolveSemanticPlacementTargetFromApp({
+      appRoot: resolvedPageTarget.appRoot,
+      context,
+      placement: explicitPlacement,
+      owner: parentTargetId ? resolveConcreteTargetOwner(parentTargetId) : "",
+      surface: resolvedPageTarget.surfaceId
+    });
+  } else if (parentTargetId) {
+    placementTarget = await resolveSemanticPlacementTargetForConcreteOutlet({
+      appRoot: resolvedPageTarget.appRoot,
+      concreteTarget: parentTargetId,
+      surface: resolvedPageTarget.surfaceId,
+      context
+    });
+  }
+  if (!placementTarget) {
+    placementTarget = await resolveSemanticPlacementTargetFromApp({
+      appRoot: resolvedPageTarget.appRoot,
+      context,
+      surface: resolvedPageTarget.surfaceId
+    });
+  }
   const preservesRelativeSubpageLinks =
     parentHost?.isSectionSubpagesHost === true &&
     Boolean(parentTargetId) &&
-    parentTargetId === placementTargetId;
+    topologyPlacementTargetsConcreteOutlet(placementTarget, parentTargetId);
 
   return Object.freeze({
     pageTarget: resolvedPageTarget,
     parentHost,
     placementTarget,
-    componentToken: resolvedComponentToken,
+    componentToken: normalizeText(componentToken),
     whenLine: renderPageLinkWhenLine(resolvedPageTarget),
     linkTo: resolveInferredPageLinkTo({
       explicitLinkTo: linkTo,
       pageTarget: resolvedPageTarget,
       parentHost,
-      placementTarget,
-      suppressImplicitRelativeLinks:
-        resolvedComponentToken === (normalizeText(defaultComponentToken) || DEFAULT_PAGE_LINK_COMPONENT_TOKEN) &&
-        preservesRelativeSubpageLinks !== true
+      preservesRelativeSubpageLinks,
+      suppressImplicitRelativeLinks: preservesRelativeSubpageLinks !== true
     })
   });
 }

--- a/packages/kernel/server/support/pageTargets.test.js
+++ b/packages/kernel/server/support/pageTargets.test.js
@@ -40,10 +40,71 @@ async function writeShellLayout(appRoot, source = "") {
     <ShellOutlet
       target="shell-layout:primary-menu"
       default
-      default-link-component-token="local.main.ui.surface-aware-menu-link-item"
     />
   </div>
 </template>
+`
+  );
+  await writePlacementTopology(appRoot);
+}
+
+function renderTopologyVariant(outlet, { linkRenderer = "" } = {}) {
+  const rendererLines = linkRenderer
+    ? `,
+      renderers: {
+        link: "${linkRenderer}"
+      }`
+    : "";
+  return `{
+      outlet: "${outlet}"${rendererLines}
+    }`;
+}
+
+function renderTopologyEntry({
+  id = "",
+  owner = "",
+  surfaces = ["*"],
+  defaultPlacement = false,
+  outlet = "",
+  linkRenderer = ""
+} = {}) {
+  const ownerLine = owner ? `    owner: "${owner}",\n` : "";
+  const defaultLine = defaultPlacement ? "    default: true,\n" : "";
+  return `  {
+    id: "${id}",
+${ownerLine}    surfaces: ${JSON.stringify(surfaces)},
+${defaultLine}    variants: {
+      compact: ${renderTopologyVariant(outlet, { linkRenderer })},
+      medium: ${renderTopologyVariant(outlet, { linkRenderer })},
+      expanded: ${renderTopologyVariant(outlet, { linkRenderer })}
+    }
+  }`;
+}
+
+async function writePlacementTopology(appRoot, entries = []) {
+  const defaultEntries = [
+    renderTopologyEntry({
+      id: "shell.primary-nav",
+      surfaces: ["*"],
+      defaultPlacement: true,
+      outlet: "shell-layout:primary-menu",
+      linkRenderer: "local.main.ui.surface-aware-menu-link-item"
+    }),
+    renderTopologyEntry({
+      id: "shell.status",
+      surfaces: ["*"],
+      outlet: "shell-layout:top-right",
+      linkRenderer: "local.main.ui.surface-aware-menu-link-item"
+    })
+  ];
+  await writeFileInApp(
+    appRoot,
+    "src/placementTopology.js",
+    `export default {
+  placements: [
+${[...defaultEntries, ...entries].join(",\n")}
+  ]
+};
 `
   );
 }
@@ -246,8 +307,8 @@ test("resolvePageLinkTargetDetails falls back to the app default placement targe
     });
 
     assert.equal(details.pageTarget.surfaceId, "admin");
-    assert.equal(details.placementTarget.id, "shell-layout:primary-menu");
-    assert.equal(details.componentToken, "local.main.ui.surface-aware-menu-link-item");
+    assert.equal(details.placementTarget.id, "shell.primary-nav");
+    assert.equal(details.componentToken, "");
     assert.equal(details.linkTo, "");
     assert.equal(details.whenLine, "");
   });
@@ -292,15 +353,21 @@ test("resolvePageLinkTargetDetails prefers an outlet-declared default link token
 };
 `
     );
+    await writePlacementTopology(appRoot, [
+      renderTopologyEntry({
+        id: "page.section-nav",
+        owner: "home-settings",
+        surfaces: ["home"],
+        outlet: "home-settings:primary-menu",
+        linkRenderer: "local.main.ui.surface-aware-menu-link-item"
+      })
+    ]);
     await writeFileInApp(
       appRoot,
       "src/pages/home/settings.vue",
       `<template>
   <section>
-    <ShellOutlet
-      target="home-settings:primary-menu"
-      default-link-component-token="local.main.ui.surface-aware-menu-link-item"
-    />
+    <ShellOutlet target="home-settings:primary-menu" />
     <RouterView />
   </section>
 </template>
@@ -314,8 +381,9 @@ test("resolvePageLinkTargetDetails prefers an outlet-declared default link token
     });
 
     assert.equal(details.parentHost?.id, "home-settings:primary-menu");
-    assert.equal(details.placementTarget.id, "home-settings:primary-menu");
-    assert.equal(details.componentToken, "local.main.ui.surface-aware-menu-link-item");
+    assert.equal(details.placementTarget.id, "page.section-nav");
+    assert.equal(details.placementTarget.owner, "home-settings");
+    assert.equal(details.componentToken, "");
     assert.equal(details.linkTo, "");
   });
 });
@@ -332,6 +400,15 @@ test("resolvePageLinkTargetDetails inherits a file-route parent subpages host", 
 `
     );
     await writeShellLayout(appRoot);
+    await writePlacementTopology(appRoot, [
+      renderTopologyEntry({
+        id: "page.section-nav",
+        owner: "contact-view",
+        surfaces: ["admin"],
+        outlet: "contact-view:sub-pages",
+        linkRenderer: "local.main.ui.surface-aware-menu-link-item"
+      })
+    ]);
     await writeFileInApp(
       appRoot,
       "src/pages/admin/contacts/[contactId].vue",
@@ -353,8 +430,9 @@ test("resolvePageLinkTargetDetails inherits a file-route parent subpages host", 
     });
 
     assert.equal(details.parentHost?.id, "contact-view:sub-pages");
-    assert.equal(details.placementTarget.id, "contact-view:sub-pages");
-    assert.equal(details.componentToken, "local.main.ui.surface-aware-menu-link-item");
+    assert.equal(details.placementTarget.id, "page.section-nav");
+    assert.equal(details.placementTarget.owner, "contact-view");
+    assert.equal(details.componentToken, "");
     assert.equal(details.linkTo, "./notes");
   });
 });
@@ -375,13 +453,13 @@ test("resolvePageLinkTargetDetails honors explicit placement and link overrides"
     const details = await resolvePageLinkTargetDetails({
       appRoot,
       targetFile: "admin/contacts/[contactId]/index/notes/index.vue",
-      placement: "shell-layout:top-right",
+      placement: "shell.status",
       componentToken: "custom.link-item",
       linkTo: "./assistant-notes",
       context: "page target"
     });
 
-    assert.equal(details.placementTarget.id, "shell-layout:top-right");
+    assert.equal(details.placementTarget.id, "shell.status");
     assert.equal(details.componentToken, "custom.link-item");
     assert.equal(details.linkTo, "./assistant-notes");
   });
@@ -399,6 +477,15 @@ test("resolvePageLinkTargetDetails inherits an index-route parent subpages host 
 `
     );
     await writeShellLayout(appRoot);
+    await writePlacementTopology(appRoot, [
+      renderTopologyEntry({
+        id: "page.section-nav",
+        owner: "customer-view",
+        surfaces: ["admin"],
+        outlet: "customer-view:sub-pages",
+        linkRenderer: "local.main.ui.surface-aware-menu-link-item"
+      })
+    ]);
     await writeFileInApp(
       appRoot,
       "src/pages/admin/customers/[customerId]/index.vue",
@@ -421,8 +508,9 @@ test("resolvePageLinkTargetDetails inherits an index-route parent subpages host 
 
     assert.equal(details.parentHost?.id, "customer-view:sub-pages");
     assert.equal(details.parentHost?.pageFile, "src/pages/admin/customers/[customerId]/index.vue");
-    assert.equal(details.placementTarget.id, "customer-view:sub-pages");
-    assert.equal(details.componentToken, "local.main.ui.surface-aware-menu-link-item");
+    assert.equal(details.placementTarget.id, "page.section-nav");
+    assert.equal(details.placementTarget.owner, "customer-view");
+    assert.equal(details.componentToken, "");
     assert.equal(details.linkTo, "./pets");
   });
 });

--- a/packages/kernel/server/support/shellOutlets.js
+++ b/packages/kernel/server/support/shellOutlets.js
@@ -8,13 +8,15 @@ import {
   describeShellOutletTargets,
   discoverShellOutletTargetsFromVueSource,
   findShellOutletTargetById,
+  normalizePlacementTopologyDefinition,
+  normalizeSemanticPlacementId,
   normalizeShellOutletTargetId,
   normalizeShellOutletTargetRecord
 } from "../../shared/support/shellLayoutTargets.js";
-import { loadAppConfigFromModuleUrl } from "./appConfigFiles.js";
 
 const VUE_DISCOVERY_IGNORED_ERROR_CODES = new Set(["ENOENT", "ENOTDIR", "EACCES", "EPERM"]);
 const LOCK_FILE_RELATIVE_PATH = ".jskit/lock.json";
+const PLACEMENT_TOPOLOGY_RELATIVE_PATH = "src/placementTopology.js";
 const ROUTE_TAG_PATTERN = /<route\b([^>]*)>([\s\S]*?)<\/route>/g;
 const ATTRIBUTE_PATTERN = /([:@]?[A-Za-z_][A-Za-z0-9_-]*)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'))?/g;
 
@@ -218,46 +220,6 @@ function normalizePackageOutletTarget({
   });
 }
 
-async function loadOutletDefaultOverrides(appRoot = "") {
-  const resolvedAppRoot = resolveRequiredAppRoot(appRoot, {
-    context: "discoverShellOutletTargetsFromApp"
-  });
-  let appConfig = {};
-  try {
-    appConfig = normalizeObject(
-      await loadAppConfigFromModuleUrl({
-        moduleUrl: pathToFileURL(path.join(resolvedAppRoot, "config", "public.js")).href
-      })
-    );
-  } catch {
-    return {};
-  }
-  return normalizeObject(normalizeObject(appConfig.ui).outletDefaults);
-}
-
-function applyOutletDefaultOverrides(target = {}, outletDefaultOverrides = {}) {
-  const targetRecord = normalizeObject(target);
-  const outletTargetId = normalizeShellOutletTargetId(targetRecord.id);
-  if (!outletTargetId) {
-    return targetRecord;
-  }
-
-  const overrideRecord = outletDefaultOverrides?.[outletTargetId];
-  const normalizedOverrideToken =
-    typeof overrideRecord === "string"
-      ? normalizeText(overrideRecord)
-      : normalizeText(normalizeObject(overrideRecord).linkComponentToken) ||
-        normalizeText(normalizeObject(overrideRecord)["link-component-token"]);
-  if (!normalizedOverrideToken) {
-    return targetRecord;
-  }
-
-  return Object.freeze({
-    ...targetRecord,
-    defaultLinkComponentToken: normalizedOverrideToken
-  });
-}
-
 async function collectInstalledPackageOutletTargets(appRoot) {
   const installedPackageStates = await readInstalledPackageStates(appRoot);
   const packageIds = Object.keys(installedPackageStates).sort((left, right) => left.localeCompare(right));
@@ -290,11 +252,180 @@ async function collectInstalledPackageOutletTargets(appRoot) {
   return targets;
 }
 
+function withTopologySource(placement = {}, sourcePath = "") {
+  return Object.freeze({
+    ...placement,
+    sourcePath
+  });
+}
+
+async function loadAppPlacementTopology(appRoot) {
+  const topologyPath = path.resolve(appRoot, PLACEMENT_TOPOLOGY_RELATIVE_PATH);
+  try {
+    await readFile(topologyPath, "utf8");
+  } catch (error) {
+    const errorCode = normalizeText(error?.code).toUpperCase();
+    if (errorCode === "ENOENT" || errorCode === "ENOTDIR") {
+      return [];
+    }
+    throw error;
+  }
+
+  let moduleNamespace = null;
+  try {
+    moduleNamespace = await import(pathToFileURL(topologyPath).href);
+  } catch (error) {
+    throw new Error(
+      `Could not load ${PLACEMENT_TOPOLOGY_RELATIVE_PATH}: ${String(error?.message || error || "unknown error")}`
+    );
+  }
+
+  const exported = moduleNamespace?.default;
+  const resolved = typeof exported === "function" ? exported() : exported;
+  const normalized = normalizePlacementTopologyDefinition(resolved, {
+    context: PLACEMENT_TOPOLOGY_RELATIVE_PATH
+  });
+  return normalized.placements.map((placement) => withTopologySource(placement, PLACEMENT_TOPOLOGY_RELATIVE_PATH));
+}
+
+async function collectInstalledPackagePlacementTopology(appRoot) {
+  const installedPackageStates = await readInstalledPackageStates(appRoot);
+  const packageIds = Object.keys(installedPackageStates).sort((left, right) => left.localeCompare(right));
+  const placements = [];
+
+  for (const packageId of packageIds) {
+    const installedPackageState = normalizeObject(installedPackageStates[packageId]);
+    const descriptorRecord = await loadInstalledPackageDescriptor({
+      appRoot,
+      packageId,
+      installedPackageState
+    });
+    const descriptor = normalizeObject(descriptorRecord.descriptor);
+    const metadata = normalizeObject(descriptor.metadata);
+    const ui = normalizeObject(metadata.ui);
+    const placementsMeta = normalizeObject(ui.placements);
+    const topology = placementsMeta.topology;
+    if (!topology) {
+      continue;
+    }
+
+    const normalized = normalizePlacementTopologyDefinition(topology, {
+      context: `package:${packageId}:metadata.ui.placements.topology`
+    });
+    for (const placement of normalized.placements) {
+      placements.push(
+        withTopologySource(
+          placement,
+          `package:${packageId}${descriptorRecord.descriptorPath ? `:${toPosixPath(descriptorRecord.descriptorPath)}` : ""}`
+        )
+      );
+    }
+  }
+
+  return placements;
+}
+
+async function discoverPlacementTopologyFromApp({ appRoot } = {}) {
+  const resolvedAppRoot = resolveRequiredAppRoot(appRoot, {
+    context: "discoverPlacementTopologyFromApp"
+  });
+  const appPlacements = await loadAppPlacementTopology(resolvedAppRoot);
+  const packagePlacements = await collectInstalledPackagePlacementTopology(resolvedAppRoot);
+  const placementByKey = new Map();
+
+  for (const placement of [...packagePlacements, ...appPlacements]) {
+    const key = `${placement.id}::${placement.owner || ""}`;
+    placementByKey.set(key, placement);
+  }
+
+  return Object.freeze({
+    placements: Object.freeze(
+      [...placementByKey.values()].sort((left, right) => {
+        const idCompare = left.id.localeCompare(right.id);
+        if (idCompare !== 0) {
+          return idCompare;
+        }
+        return String(left.owner || "").localeCompare(String(right.owner || ""));
+      })
+    )
+  });
+}
+
+function findSemanticPlacementById(placements = [], { id = "", owner = "", surface = "" } = {}) {
+  const normalizedId = normalizeSemanticPlacementId(id);
+  const normalizedOwner = normalizeText(owner).toLowerCase();
+  const normalizedSurface = normalizeText(surface).toLowerCase();
+  if (!normalizedId) {
+    return null;
+  }
+
+  return (Array.isArray(placements) ? placements : []).find((placement) => {
+    if (placement.id !== normalizedId) {
+      return false;
+    }
+    if (normalizedOwner && placement.owner !== normalizedOwner) {
+      return false;
+    }
+    if (!normalizedOwner && placement.owner) {
+      return false;
+    }
+    const surfaces = Array.isArray(placement.surfaces) ? placement.surfaces : ["*"];
+    return !normalizedSurface || surfaces.includes("*") || surfaces.includes(normalizedSurface);
+  }) || null;
+}
+
+async function resolveSemanticPlacementTargetFromApp({
+  appRoot,
+  placement = "",
+  owner = "",
+  surface = "",
+  context = "ui-generator"
+} = {}) {
+  const resolvedContext = normalizeText(context) || "ui-generator";
+  const topology = await discoverPlacementTopologyFromApp({ appRoot });
+  const placements = Array.isArray(topology.placements) ? topology.placements : [];
+  if (placements.length < 1) {
+    throw new Error(`${resolvedContext} could not find semantic placement topology in ${PLACEMENT_TOPOLOGY_RELATIVE_PATH}.`);
+  }
+
+  const requestedPlacement = normalizeText(placement);
+  if (requestedPlacement) {
+    const requestedId = normalizeSemanticPlacementId(requestedPlacement);
+    if (!requestedId) {
+      throw new Error(`${resolvedContext} option "placement" must be a semantic target in "area.slot" format.`);
+    }
+    const match = findSemanticPlacementById(placements, {
+      id: requestedId,
+      owner,
+      surface
+    }) || (owner
+      ? findSemanticPlacementById(placements, {
+          id: requestedId,
+          owner: "",
+          surface
+        })
+      : null);
+    if (!match) {
+      throw new Error(`${resolvedContext} semantic placement "${requestedId}" is not declared in app placement topology.`);
+    }
+    return match;
+  }
+
+  const defaultPlacement =
+    placements.find((entry) => entry.default === true && (!surface || entry.surfaces.includes("*") || entry.surfaces.includes(surface))) ||
+    placements.find((entry) => !entry.owner && (!surface || entry.surfaces.includes("*") || entry.surfaces.includes(surface))) ||
+    null;
+  if (defaultPlacement) {
+    return defaultPlacement;
+  }
+
+  throw new Error(`${resolvedContext} could not resolve a default semantic placement target.`);
+}
+
 async function discoverShellOutletTargetsFromApp({ appRoot, sourceRoot = "src" } = {}) {
   const resolvedAppRoot = resolveRequiredAppRoot(appRoot, {
     context: "discoverShellOutletTargetsFromApp"
   });
-  const outletDefaultOverrides = await loadOutletDefaultOverrides(resolvedAppRoot);
 
   const sourceDirectory = path.resolve(resolvedAppRoot, String(sourceRoot || "src"));
   const targetById = new Map();
@@ -363,10 +494,10 @@ async function discoverShellOutletTargetsFromApp({ appRoot, sourceRoot = "src" }
 
   const targets = [...targetById.values()].sort((left, right) => left.id.localeCompare(right.id));
   const normalizedTargets = targets.map((target) =>
-    applyOutletDefaultOverrides({
+    Object.freeze({
       ...target,
       default: target.id === defaultTargetId
-    }, outletDefaultOverrides)
+    })
   );
 
   return Object.freeze({
@@ -418,6 +549,8 @@ async function resolveShellOutletPlacementTargetFromApp({ appRoot, placement = "
 }
 
 export {
+  discoverPlacementTopologyFromApp,
   discoverShellOutletTargetsFromApp,
+  resolveSemanticPlacementTargetFromApp,
   resolveShellOutletPlacementTargetFromApp
 };

--- a/packages/kernel/server/support/shellOutlets.test.js
+++ b/packages/kernel/server/support/shellOutlets.test.js
@@ -99,7 +99,6 @@ test("discoverShellOutletTargetsFromApp includes installed package placement out
         outlets: [
           {
             target: "admin-cog:primary-menu",
-            defaultLinkComponentToken: "local.main.ui.surface-aware-menu-link-item",
             source: "src/client/components/UsersWorkspaceToolsWidget.vue"
           }
         ]
@@ -118,7 +117,6 @@ test("discoverShellOutletTargetsFromApp includes installed package placement out
     assert.deepEqual(discovered.targets[0], {
       id: "admin-cog:primary-menu",
       default: false,
-      defaultLinkComponentToken: "local.main.ui.surface-aware-menu-link-item",
       sourcePath: "package:@example/users-web:src/client/components/UsersWorkspaceToolsWidget.vue",
       sourcePackageId: "@example/users-web"
     });
@@ -129,68 +127,6 @@ test("discoverShellOutletTargetsFromApp includes installed package placement out
       context: "ui-generator"
     });
     assert.equal(target.id, "admin-cog:primary-menu");
-  });
-});
-
-test("discoverShellOutletTargetsFromApp applies app config default-link overrides by target id", async () => {
-  await withTempApp(async (appRoot) => {
-    await writeFileInApp(
-      appRoot,
-      "config/public.js",
-      `export const config = {
-  ui: {
-    outletDefaults: {
-      "admin-cog:primary-menu": {
-        linkComponentToken: "local.main.ui.surface-aware-menu-link-item"
-      }
-    }
-  }
-};
-`
-    );
-    await writeFileInApp(
-      appRoot,
-      ".jskit/lock.json",
-      `${JSON.stringify(
-        {
-          lockVersion: 1,
-          installedPackages: {
-            "@example/users-web": {
-              packageId: "@example/users-web",
-              source: {
-                type: "npm-installed-package",
-                descriptorPath: "node_modules/@example/users-web/package.descriptor.mjs"
-              }
-            }
-          }
-        },
-        null,
-        2
-      )}\n`
-    );
-    await writeFileInApp(
-      appRoot,
-      "node_modules/@example/users-web/package.descriptor.mjs",
-      `export default {
-  packageId: "@example/users-web",
-  metadata: {
-    ui: {
-      placements: {
-        outlets: [
-          {
-            target: "admin-cog:primary-menu",
-            defaultLinkComponentToken: "local.main.ui.surface-aware-menu-link-item"
-          }
-        ]
-      }
-    }
-  }
-};
-`
-    );
-
-    const discovered = await discoverShellOutletTargetsFromApp({ appRoot });
-    assert.equal(discovered.targets[0].defaultLinkComponentToken, "local.main.ui.surface-aware-menu-link-item");
   });
 });
 
@@ -223,13 +159,11 @@ test("discoverShellOutletTargetsFromApp returns targets with sourcePath and defa
       {
         id: "admin-toolbox:widgets",
         default: true,
-        defaultLinkComponentToken: "",
         sourcePath: "src/pages/admin/toolbox/index.vue"
       },
       {
         id: "shell-layout:primary-menu",
         default: false,
-        defaultLinkComponentToken: "",
         sourcePath: "src/components/ShellLayout.vue"
       }
     ]);
@@ -266,7 +200,6 @@ test("discoverShellOutletTargetsFromApp discovers route meta placement outlets",
       {
         id: "contact-tools:sub-pages",
         default: false,
-        defaultLinkComponentToken: "",
         sourcePath: "src/pages/w/[workspaceSlug]/admin/contacts/[contactId]/contact-tools.vue"
       }
     ]);

--- a/packages/kernel/shared/support/shellLayoutTargets.js
+++ b/packages/kernel/shared/support/shellLayoutTargets.js
@@ -5,6 +5,8 @@ import {
 
 const SHELL_OUTLET_TAG_PATTERN = /<ShellOutlet\b([^>]*)\/?>/g;
 const ATTRIBUTE_PATTERN = /([:@]?[A-Za-z_][A-Za-z0-9_-]*)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'))?/g;
+const PLACEMENT_LAYOUT_CLASSES = Object.freeze(["compact", "medium", "expanded"]);
+const WEB_PLACEMENT_SURFACE_ANY = "*";
 
 function parseTagAttributes(attributesSource = "") {
   const attributes = {};
@@ -41,6 +43,211 @@ function normalizeShellOutletTargetId(value = "") {
   }
 
   return `${host}:${position}`;
+}
+
+function normalizeSemanticPlacementId(value = "") {
+  const normalizedValue = normalizeText(value).toLowerCase();
+  if (!normalizedValue || normalizedValue.includes(":") || !normalizedValue.includes(".")) {
+    return "";
+  }
+
+  const segments = normalizedValue.split(".");
+  if (segments.length < 2) {
+    return "";
+  }
+
+  const normalizedSegments = [];
+  for (const segment of segments) {
+    const normalizedSegment = normalizeText(segment);
+    if (!/^[a-z0-9]+(?:[_-][a-z0-9]+)*$/.test(normalizedSegment)) {
+      return "";
+    }
+    normalizedSegments.push(normalizedSegment);
+  }
+
+  return normalizedSegments.join(".");
+}
+
+function normalizePlacementOwnerId(value = "") {
+  const normalizedValue = normalizeText(value).toLowerCase();
+  if (!normalizedValue) {
+    return "";
+  }
+  if (!/^[a-z0-9]+(?:[._-][a-z0-9]+)*$/.test(normalizedValue)) {
+    return "";
+  }
+  return normalizedValue;
+}
+
+function normalizePlacementLayoutClass(value = "") {
+  const normalizedValue = normalizeText(value).toLowerCase();
+  if (PLACEMENT_LAYOUT_CLASSES.includes(normalizedValue)) {
+    return normalizedValue;
+  }
+  return "";
+}
+
+function normalizePlacementKind(value = "") {
+  const normalizedValue = normalizeText(value).toLowerCase();
+  if (normalizedValue === "link" || normalizedValue === "component") {
+    return normalizedValue;
+  }
+  return "";
+}
+
+function normalizePlacementSurfaceId(value = "") {
+  const normalizedValue = normalizeText(value).toLowerCase();
+  if (!normalizedValue) {
+    return "";
+  }
+  if (normalizedValue === WEB_PLACEMENT_SURFACE_ANY) {
+    return WEB_PLACEMENT_SURFACE_ANY;
+  }
+  if (/^[a-z0-9]+(?:[._-][a-z0-9]+)*$/.test(normalizedValue)) {
+    return normalizedValue;
+  }
+  return "";
+}
+
+function normalizePlacementSurfaces(value) {
+  const candidates = Array.isArray(value) ? value : value === undefined || value === null ? [] : [value];
+  if (candidates.length < 1) {
+    return Object.freeze([WEB_PLACEMENT_SURFACE_ANY]);
+  }
+
+  const normalized = [];
+  const seen = new Set();
+  for (const candidate of candidates) {
+    const surface = normalizePlacementSurfaceId(candidate);
+    if (!surface || seen.has(surface)) {
+      continue;
+    }
+    if (surface === WEB_PLACEMENT_SURFACE_ANY) {
+      return Object.freeze([WEB_PLACEMENT_SURFACE_ANY]);
+    }
+    seen.add(surface);
+    normalized.push(surface);
+  }
+
+  if (normalized.length < 1) {
+    return Object.freeze([WEB_PLACEMENT_SURFACE_ANY]);
+  }
+
+  return Object.freeze(normalized);
+}
+
+function resolvePlacementTargetReference(value = "") {
+  const semanticId = normalizeSemanticPlacementId(value);
+  if (semanticId) {
+    return Object.freeze({
+      id: semanticId,
+      type: "semantic"
+    });
+  }
+
+  const concreteId = normalizeShellOutletTargetId(value);
+  if (concreteId) {
+    return Object.freeze({
+      id: concreteId,
+      type: "concrete"
+    });
+  }
+
+  return null;
+}
+
+function normalizePlacementRenderers(value = {}) {
+  const record = normalizeObject(value);
+  const renderers = {};
+  for (const [key, rendererToken] of Object.entries(record)) {
+    const kind = normalizePlacementKind(key);
+    const token = normalizeText(rendererToken);
+    if (!kind || !token) {
+      continue;
+    }
+    renderers[kind] = token;
+  }
+  return Object.freeze(renderers);
+}
+
+function normalizePlacementTopologyVariant(
+  value = {},
+  {
+    context = "placement topology variant"
+  } = {}
+) {
+  const record = normalizeObject(value);
+  const outlet = normalizeShellOutletTargetId(record.outlet || record.target);
+  if (!outlet) {
+    throw new Error(`${normalizeText(context) || "placement topology variant"} requires outlet in "host:position" format.`);
+  }
+
+  return Object.freeze({
+    outlet,
+    renderers: normalizePlacementRenderers(record.renderers)
+  });
+}
+
+function normalizePlacementTopologyEntry(
+  value = {},
+  {
+    context = "placement topology"
+  } = {}
+) {
+  const record = normalizeObject(value);
+  const resolvedContext = normalizeText(context) || "placement topology";
+  const id = normalizeSemanticPlacementId(record.id || record.target);
+  if (!id) {
+    throw new Error(`${resolvedContext} requires semantic placement id in "area.slot" format.`);
+  }
+
+  const owner = normalizePlacementOwnerId(record.owner);
+  const surfaces = normalizePlacementSurfaces(record.surfaces);
+  const variantsRecord = normalizeObject(record.variants);
+  const variants = {};
+  for (const layoutClass of PLACEMENT_LAYOUT_CLASSES) {
+    const variant = variantsRecord[layoutClass];
+    if (!variant) {
+      throw new Error(`${resolvedContext} "${id}" requires ${layoutClass} topology variant.`);
+    }
+    variants[layoutClass] = normalizePlacementTopologyVariant(variant, {
+      context: `${resolvedContext} "${id}" ${layoutClass}`
+    });
+  }
+
+  return Object.freeze({
+    id,
+    owner,
+    description: normalizeText(record.description),
+    surfaces,
+    default: record.default === true,
+    variants: Object.freeze(variants)
+  });
+}
+
+function normalizePlacementTopologyDefinition(
+  value = {},
+  {
+    context = "placement topology"
+  } = {}
+) {
+  const record = normalizeObject(value);
+  const entries = Array.isArray(record.placements) ? record.placements : Array.isArray(value) ? value : [];
+  const normalized = [];
+  const seen = new Set();
+  for (const entry of entries) {
+    const placement = normalizePlacementTopologyEntry(entry, { context });
+    const key = `${placement.id}::${placement.owner || ""}`;
+    if (seen.has(key)) {
+      throw new Error(`${normalizeText(context) || "placement topology"} contains duplicate semantic placement "${placement.id}"${placement.owner ? ` for owner "${placement.owner}"` : ""}.`);
+    }
+    seen.add(key);
+    normalized.push(placement);
+  }
+
+  return Object.freeze({
+    placements: Object.freeze(normalized)
+  });
 }
 
 function resolveShellOutletTargetParts(
@@ -117,10 +324,7 @@ function normalizeShellOutletTargetRecord(
     ...targetParts,
     default:
       Object.hasOwn(record, "default") &&
-      isDefaultAttributeEnabled(record.default),
-    defaultLinkComponentToken:
-      normalizeText(record.defaultLinkComponentToken) ||
-      normalizeText(record["default-link-component-token"])
+      isDefaultAttributeEnabled(record.default)
   });
 }
 
@@ -161,10 +365,21 @@ function discoverShellOutletTargetsFromVueSource(source = "", { context = "shell
 }
 
 export {
+  PLACEMENT_LAYOUT_CLASSES,
   describeShellOutletTargets,
   discoverShellOutletTargetsFromVueSource,
   findShellOutletTargetById,
+  normalizePlacementKind,
+  normalizePlacementLayoutClass,
+  normalizePlacementOwnerId,
+  normalizePlacementSurfaceId,
+  normalizePlacementSurfaces,
+  normalizePlacementTopologyDefinition,
+  normalizePlacementTopologyEntry,
+  normalizePlacementTopologyVariant,
+  normalizeSemanticPlacementId,
   normalizeShellOutletTargetId,
   normalizeShellOutletTargetRecord,
+  resolvePlacementTargetReference,
   resolveShellOutletTargetParts
 };

--- a/packages/kernel/shared/support/shellLayoutTargets.test.js
+++ b/packages/kernel/shared/support/shellLayoutTargets.test.js
@@ -22,7 +22,6 @@ test("discoverShellOutletTargetsFromVueSource resolves legal targets and one def
       <ShellOutlet
         target="shell-layout:primary-menu"
         default
-        default-link-component-token="local.main.ui.surface-aware-menu-link-item"
       />
       <ShellOutlet target="shell-layout:secondary-menu" />
     </template>
@@ -37,7 +36,6 @@ test("discoverShellOutletTargetsFromVueSource resolves legal targets and one def
     discovered.targets.map((entry) => entry.id),
     ["shell-layout:top-left", "shell-layout:primary-menu", "shell-layout:secondary-menu"]
   );
-  assert.equal(discovered.targets[1].defaultLinkComponentToken, "local.main.ui.surface-aware-menu-link-item");
   assert.equal(
     describeShellOutletTargets(discovered.targets),
     "shell-layout:top-left, shell-layout:primary-menu, shell-layout:secondary-menu"

--- a/packages/mobile-capacitor/package.descriptor.mjs
+++ b/packages/mobile-capacitor/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/mobile-capacitor",
-  version: "0.1.2",
+  version: "0.1.3",
   kind: "runtime",
   description: "Thin Capacitor client integration for JSKIT mobile-shell launch routing and auth callback completion.",
   dependsOn: [
@@ -62,8 +62,8 @@ export default Object.freeze({
         "@capacitor/app": "^7.1.0",
         "@capacitor/browser": "^7.0.1",
         "@capacitor/core": "^7.4.3",
-        "@jskit-ai/kernel": "0.1.65",
-        "@jskit-ai/shell-web": "0.1.64"
+        "@jskit-ai/kernel": "0.1.66",
+        "@jskit-ai/shell-web": "0.1.65"
       },
       dev: {
         "@capacitor/cli": "^7.4.3"

--- a/packages/mobile-capacitor/package.json
+++ b/packages/mobile-capacitor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/mobile-capacitor",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,6 +12,6 @@
   },
   "dependencies": {
     "@capacitor/browser": "^7.0.1",
-    "@jskit-ai/kernel": "0.1.65"
+    "@jskit-ai/kernel": "0.1.66"
   }
 }

--- a/packages/realtime/package.descriptor.mjs
+++ b/packages/realtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/realtime",
-  version: "0.1.64",
+  version: "0.1.65",
   kind: "runtime",
   description: "Thin, generic realtime runtime wrappers for socket.io server and client.",
   options: {
@@ -95,7 +95,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.65",
+        "@jskit-ai/kernel": "0.1.66",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",

--- a/packages/realtime/package.descriptor.mjs
+++ b/packages/realtime/package.descriptor.mjs
@@ -81,7 +81,8 @@ export default Object.freeze({
         contributions: [
           {
             id: "realtime.connection.indicator",
-            target: "shell-layout:top-right",
+            target: "shell.status",
+            kind: "component",
             surfaces: ["*"],
             order: 950,
             componentToken: "realtime.web.connection.indicator",
@@ -133,7 +134,7 @@ export default Object.freeze({
         position: "bottom",
         skipIfContains: "id: \"realtime.connection.indicator\"",
         value:
-          "\naddPlacement({\n  id: \"realtime.connection.indicator\",\n  target: \"shell-layout:top-right\",\n  surfaces: [\"*\"],\n  order: 950,\n  componentToken: \"realtime.web.connection.indicator\"\n});\n",
+          "\naddPlacement({\n  id: \"realtime.connection.indicator\",\n  target: \"shell.status\",\n  kind: \"component\",\n  surfaces: [\"*\"],\n  order: 950,\n  componentToken: \"realtime.web.connection.indicator\"\n});\n",
         reason: "Append realtime connection indicator placement into app-owned placement registry.",
         category: "realtime-web",
         id: "realtime-placement-indicator"

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/realtime",
-  "version": "0.1.64",
+  "version": "0.1.65",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@socket.io/redis-adapter": "^8.3.0",
-    "@jskit-ai/kernel": "0.1.65",
+    "@jskit-ai/kernel": "0.1.66",
     "redis": "^5.8.2",
     "socket.io": "^4.8.3",
     "socket.io-client": "^4.8.3"

--- a/packages/realtime/src/client/RealtimeClientProvider.js
+++ b/packages/realtime/src/client/RealtimeClientProvider.js
@@ -10,6 +10,18 @@ const REALTIME_RUNTIME_CLIENT_API = Object.freeze({
   disconnectSocketIoClient
 });
 
+function isCapacitorRuntimeAvailable(app) {
+  if (!app || typeof app.has !== "function" || typeof app.make !== "function") {
+    return false;
+  }
+  if (app.has("mobile.capacitor.adapter.client") !== true) {
+    return false;
+  }
+
+  const adapter = app.make("mobile.capacitor.adapter.client");
+  return adapter?.available === true;
+}
+
 function resolveRealtimeClientConfig(app) {
   const appConfig = normalizeObject(getClientAppConfig());
   const env = app && typeof app.has === "function" && app.has("jskit.client.env") ? normalizeObject(app.make("jskit.client.env")) : {};
@@ -18,7 +30,9 @@ function resolveRealtimeClientConfig(app) {
   const mobileConfig = resolveMobileConfig({
     mobile: normalizeObject(appConfig.mobile)
   });
-  const url = normalizeText(realtimeClient.url || (mobileConfig.enabled === true ? mobileConfig.apiBaseUrl : ""));
+  const url = normalizeText(
+    realtimeClient.url || (mobileConfig.enabled === true && isCapacitorRuntimeAvailable(app) ? mobileConfig.apiBaseUrl : "")
+  );
   const options = normalizeObject(realtimeClient.options);
   const explicitDebugEnabled =
     typeof realtimeClient.debug === "boolean"

--- a/packages/realtime/test/providerRuntime.test.js
+++ b/packages/realtime/test/providerRuntime.test.js
@@ -248,7 +248,7 @@ test("RealtimeClientProvider registers runtime realtime client api", () => {
   assert.equal(typeof api.disconnectSocketIoClient, "function");
 });
 
-test("RealtimeClientProvider uses mobile.apiBaseUrl when realtimeClient.url is unset", () => {
+test("RealtimeClientProvider uses mobile.apiBaseUrl only inside the Capacitor runtime", () => {
   const previousAppConfig = globalThis[CLIENT_APP_CONFIG_GLOBAL_KEY];
   const calls = [];
   const socket = {
@@ -265,6 +265,9 @@ test("RealtimeClientProvider uses mobile.apiBaseUrl when realtimeClient.url is u
     });
 
     const app = createSingletonApp();
+    app.instance("mobile.capacitor.adapter.client", {
+      available: true
+    });
     app.instance("runtime.realtime.client", {
       createSocketIoClient(input = {}) {
         calls.push(input);
@@ -280,6 +283,53 @@ test("RealtimeClientProvider uses mobile.apiBaseUrl when realtimeClient.url is u
     assert.deepEqual(calls, [
       {
         url: "http://127.0.0.1:3000",
+        options: {}
+      }
+    ]);
+  } finally {
+    if (previousAppConfig === undefined) {
+      delete globalThis[CLIENT_APP_CONFIG_GLOBAL_KEY];
+    } else {
+      globalThis[CLIENT_APP_CONFIG_GLOBAL_KEY] = previousAppConfig;
+    }
+  }
+});
+
+test("RealtimeClientProvider keeps web socket connections URL-less when mobile is installed outside Capacitor", () => {
+  const previousAppConfig = globalThis[CLIENT_APP_CONFIG_GLOBAL_KEY];
+  const calls = [];
+  const socket = {
+    on() {},
+    off() {},
+    disconnect() {}
+  };
+  try {
+    setClientAppConfig({
+      mobile: {
+        enabled: true,
+        apiBaseUrl: "http://127.0.0.1:3000"
+      }
+    });
+
+    const app = createSingletonApp();
+    app.instance("mobile.capacitor.adapter.client", {
+      available: false
+    });
+    app.instance("runtime.realtime.client", {
+      createSocketIoClient(input = {}) {
+        calls.push(input);
+        return socket;
+      },
+      disconnectSocketIoClient() {}
+    });
+
+    const provider = new RealtimeClientProvider();
+    provider.register(app);
+
+    assert.equal(app.make("runtime.realtime.client.socket"), socket);
+    assert.deepEqual(calls, [
+      {
+        url: "",
         options: {}
       }
     ]);

--- a/packages/resource-core/package.descriptor.mjs
+++ b/packages/resource-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/resource-core",
-  version: "0.1.10",
+  version: "0.1.11",
   kind: "runtime",
   description: "Generic resource-definition helpers and schema-definition normalization.",
   dependsOn: [
@@ -22,7 +22,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/resource-core": "0.1.10"
+        "@jskit-ai/resource-core": "0.1.11"
       },
       dev: {}
     },

--- a/packages/resource-core/package.json
+++ b/packages/resource-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/resource-core",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./shared/resource": "./src/shared/resource.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.65"
+    "@jskit-ai/kernel": "0.1.66"
   }
 }

--- a/packages/resource-crud-core/package.descriptor.mjs
+++ b/packages/resource-crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/resource-crud-core",
-  version: "0.1.10",
+  version: "0.1.11",
   kind: "runtime",
   description: "CRUD-specific resource-definition helpers and namespace support.",
   dependsOn: [
@@ -23,7 +23,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/resource-crud-core": "0.1.10"
+        "@jskit-ai/resource-crud-core": "0.1.11"
       },
       dev: {}
     },

--- a/packages/resource-crud-core/package.json
+++ b/packages/resource-crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/resource-crud-core",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./shared/crudResource": "./src/shared/crudResource.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.65",
-    "@jskit-ai/resource-core": "0.1.10"
+    "@jskit-ai/kernel": "0.1.66",
+    "@jskit-ai/resource-core": "0.1.11"
   }
 }

--- a/packages/shell-web/package.descriptor.mjs
+++ b/packages/shell-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/shell-web",
-  version: "0.1.64",
+  version: "0.1.65",
   kind: "runtime",
   description: "Web shell layout runtime with outlet-based placement contributions.",
   dependsOn: [],
@@ -233,7 +233,7 @@ export default Object.freeze({
       runtime: {
         "@mdi/js": "^7.4.47",
         "@tanstack/vue-query": "^5.90.5",
-        "@jskit-ai/kernel": "0.1.65",
+        "@jskit-ai/kernel": "0.1.66",
         "vuetify": "^4.0.0"
       },
       dev: {}

--- a/packages/shell-web/package.descriptor.mjs
+++ b/packages/shell-web/package.descriptor.mjs
@@ -71,46 +71,157 @@ export default Object.freeze({
           },
           {
             target: "shell-layout:primary-menu",
-            defaultLinkComponentToken: "local.main.ui.surface-aware-menu-link-item",
             surfaces: ["*"],
             source: "src/client/components/ShellLayout.vue"
           },
           {
             target: "shell-layout:secondary-menu",
-            defaultLinkComponentToken: "local.main.ui.surface-aware-menu-link-item",
             surfaces: ["*"],
             source: "src/client/components/ShellLayout.vue"
           },
           {
             target: "home-settings:primary-menu",
-            defaultLinkComponentToken: "local.main.ui.surface-aware-menu-link-item",
             surfaces: ["home"],
             source: "templates/src/pages/home/settings.vue"
           }
         ],
+        topology: {
+          placements: [
+            {
+              id: "shell.primary-nav",
+              description: "Primary top-level navigation for the current surface.",
+              surfaces: ["*"],
+              default: true,
+              variants: {
+                compact: {
+                  outlet: "shell-layout:primary-menu",
+                  renderers: {
+                    link: "local.main.ui.surface-aware-menu-link-item"
+                  }
+                },
+                medium: {
+                  outlet: "shell-layout:primary-menu",
+                  renderers: {
+                    link: "local.main.ui.surface-aware-menu-link-item"
+                  }
+                },
+                expanded: {
+                  outlet: "shell-layout:primary-menu",
+                  renderers: {
+                    link: "local.main.ui.surface-aware-menu-link-item"
+                  }
+                }
+              }
+            },
+            {
+              id: "shell.status",
+              description: "Surface status, connection, and utility indicators.",
+              surfaces: ["*"],
+              variants: {
+                compact: {
+                  outlet: "shell-layout:top-right"
+                },
+                medium: {
+                  outlet: "shell-layout:top-right"
+                },
+                expanded: {
+                  outlet: "shell-layout:top-right"
+                }
+              }
+            },
+            {
+              id: "shell.secondary-nav",
+              description: "Secondary navigation for lower-priority shell links.",
+              surfaces: ["*"],
+              variants: {
+                compact: {
+                  outlet: "shell-layout:secondary-menu",
+                  renderers: {
+                    link: "local.main.ui.surface-aware-menu-link-item"
+                  }
+                },
+                medium: {
+                  outlet: "shell-layout:secondary-menu",
+                  renderers: {
+                    link: "local.main.ui.surface-aware-menu-link-item"
+                  }
+                },
+                expanded: {
+                  outlet: "shell-layout:secondary-menu",
+                  renderers: {
+                    link: "local.main.ui.surface-aware-menu-link-item"
+                  }
+                }
+              }
+            },
+            {
+              id: "shell.identity",
+              description: "Current user, workspace, and surface identity controls.",
+              surfaces: ["*"],
+              variants: {
+                compact: {
+                  outlet: "shell-layout:top-left"
+                },
+                medium: {
+                  outlet: "shell-layout:top-left"
+                },
+                expanded: {
+                  outlet: "shell-layout:top-left"
+                }
+              }
+            },
+            {
+              id: "page.section-nav",
+              owner: "home-settings",
+              description: "Navigation between child pages in the home settings section.",
+              surfaces: ["home"],
+              variants: {
+                compact: {
+                  outlet: "home-settings:primary-menu",
+                  renderers: {
+                    link: "local.main.ui.surface-aware-menu-link-item"
+                  }
+                },
+                medium: {
+                  outlet: "home-settings:primary-menu",
+                  renderers: {
+                    link: "local.main.ui.surface-aware-menu-link-item"
+                  }
+                },
+                expanded: {
+                  outlet: "home-settings:primary-menu",
+                  renderers: {
+                    link: "local.main.ui.surface-aware-menu-link-item"
+                  }
+                }
+              }
+            }
+          ]
+        },
         contributions: [
           {
             id: "shell-web.home.menu.home",
-            target: "shell-layout:primary-menu",
+            target: "shell.primary-nav",
+            kind: "link",
             surfaces: ["home"],
             order: 50,
-            componentToken: "local.main.ui.surface-aware-menu-link-item",
             source: "templates/src/placement.js"
           },
           {
             id: "shell-web.home.menu.settings",
-            target: "shell-layout:primary-menu",
+            target: "shell.primary-nav",
+            kind: "link",
             surfaces: ["home"],
             order: 100,
-            componentToken: "local.main.ui.surface-aware-menu-link-item",
             source: "templates/src/placement.js"
           },
           {
             id: "shell-web.home.settings.general",
-            target: "home-settings:primary-menu",
+            target: "page.section-nav",
+            owner: "home-settings",
+            kind: "link",
             surfaces: ["home"],
             order: 100,
-            componentToken: "local.main.ui.surface-aware-menu-link-item",
             source: "templates/src/placement.js"
           }
         ]
@@ -253,6 +364,14 @@ export default Object.freeze({
         reason: "Install app-owned placement registry scaffold used by shell-web placement runtime.",
         category: "shell-web",
         id: "shell-web-placement-registry"
+      },
+      {
+        from: "templates/src/placementTopology.js",
+        to: "src/placementTopology.js",
+        ownership: "app",
+        reason: "Install app-owned semantic placement topology used by shell-web placement runtime.",
+        category: "shell-web",
+        id: "shell-web-placement-topology"
       },
       {
         from: "templates/src/pages/home.vue",

--- a/packages/shell-web/package.json
+++ b/packages/shell-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/shell-web",
-  "version": "0.1.64",
+  "version": "0.1.65",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -25,7 +25,7 @@
   "dependencies": {
     "@mdi/js": "^7.4.47",
     "@tanstack/vue-query": "^5.90.5",
-    "@jskit-ai/kernel": "0.1.65",
+    "@jskit-ai/kernel": "0.1.66",
     "pinia": "^3.0.4",
     "vuetify": "^4.0.0"
   },

--- a/packages/shell-web/src/client/components/ShellLayout.vue
+++ b/packages/shell-web/src/client/components/ShellLayout.vue
@@ -52,13 +52,9 @@ const { drawerOpen, toggleDrawer, resolvedSurface, resolvedSurfaceLabel } = useS
           <ShellOutlet
             target="shell-layout:primary-menu"
             default
-            default-link-component-token="local.main.ui.surface-aware-menu-link-item"
           />
           <v-divider class="my-2" />
-          <ShellOutlet
-            target="shell-layout:secondary-menu"
-            default-link-component-token="local.main.ui.surface-aware-menu-link-item"
-          />
+          <ShellOutlet target="shell-layout:secondary-menu" />
         </v-list>
       </slot>
     </v-navigation-drawer>

--- a/packages/shell-web/src/client/components/ShellOutlet.vue
+++ b/packages/shell-web/src/client/components/ShellOutlet.vue
@@ -6,6 +6,7 @@ import {
   ref
 } from "vue";
 import { useRoute } from "vue-router";
+import { useDisplay } from "vuetify";
 import { useWebPlacementContext, useWebPlacementRuntime } from "../placement/inject.js";
 import { resolveRuntimePathname } from "../placement/pathname.js";
 import {
@@ -25,10 +26,6 @@ const props = defineProps({
   context: {
     type: Object,
     default: () => ({})
-  },
-  defaultLinkComponentToken: {
-    type: String,
-    default: ""
   }
 });
 
@@ -37,6 +34,13 @@ try {
   route = useRoute();
 } catch {
   route = null;
+}
+
+let display = null;
+try {
+  display = useDisplay();
+} catch {
+  display = null;
 }
 
 const placementRuntime = useWebPlacementRuntime();
@@ -82,11 +86,37 @@ const resolvedTargetId = computed(() => {
   return String(props.target || "").trim();
 });
 
+const resolvedLayoutClass = computed(() => {
+  const displayName = String(display?.name?.value || "").trim().toLowerCase();
+  if (displayName === "xs" || displayName === "sm") {
+    return "compact";
+  }
+  if (displayName === "md") {
+    return "medium";
+  }
+  if (displayName === "lg" || displayName === "xl" || displayName === "xxl") {
+    return "expanded";
+  }
+
+  const viewportWidth =
+    typeof window === "object" && window?.innerWidth
+      ? Number(window.innerWidth)
+      : 0;
+  if (viewportWidth > 0 && viewportWidth < 600) {
+    return "compact";
+  }
+  if (viewportWidth > 0 && viewportWidth < 1280) {
+    return "medium";
+  }
+  return "expanded";
+});
+
 const placements = computed(() => {
   void revision.value;
   return placementRuntime.getPlacements({
     surface: resolvedSurface.value,
     target: resolvedTargetId.value,
+    layoutClass: resolvedLayoutClass.value,
     context: props.context
   });
 });

--- a/packages/shell-web/src/client/components/ShellOutletMenuWidget.vue
+++ b/packages/shell-web/src/client/components/ShellOutletMenuWidget.vue
@@ -7,10 +7,6 @@ const props = defineProps({
     type: String,
     required: true
   },
-  defaultLinkComponentToken: {
-    type: String,
-    default: ""
-  },
   icon: {
     type: String,
     default: mdiCogOutline
@@ -48,10 +44,7 @@ const props = defineProps({
     </template>
 
     <v-list :min-width="props.minWidth" density="comfortable" class="py-1">
-      <ShellOutlet
-        :target="props.target"
-        :default-link-component-token="props.defaultLinkComponentToken"
-      />
+      <ShellOutlet :target="props.target" />
     </v-list>
   </v-menu>
 </template>

--- a/packages/shell-web/src/client/placement/index.js
+++ b/packages/shell-web/src/client/placement/index.js
@@ -3,6 +3,11 @@ export {
 } from "./registry.js";
 
 export {
+  definePlacement,
+  definePlacementTopology
+} from "./validators.js";
+
+export {
   useWebPlacementContext
 } from "./inject.js";
 

--- a/packages/shell-web/src/client/placement/runtime.js
+++ b/packages/shell-web/src/client/placement/runtime.js
@@ -2,6 +2,10 @@ import { DEFAULT_DEBUG_DEPTH, explodePayload } from "./debug.js";
 import { createListenerSubscription } from "@jskit-ai/kernel/shared/support/listenerSet";
 import { isRecord } from "@jskit-ai/kernel/shared/support/normalize";
 import {
+  normalizePlacementLayoutClass,
+  normalizePlacementTopologyDefinition
+} from "@jskit-ai/kernel/shared/support/shellLayoutTargets";
+import {
   isRenderableComponent,
   normalizePlacementDefinition,
   normalizePlacementTarget,
@@ -100,12 +104,107 @@ function normalizePlacementList(placements, context = {}) {
     .map((entry) => entry.placement);
 }
 
+function normalizeTopologyList(topology, context = {}) {
+  if (Array.isArray(topology)) {
+    const normalized = normalizePlacementTopologyDefinition(
+      { placements: topology },
+      {
+        context: context.source || "placement topology"
+      }
+    );
+    return normalizeTopologyList(normalized, context);
+  }
+
+  const candidates = ensureArray(topology);
+  const entries = [];
+  for (const candidate of candidates) {
+    const normalized = normalizePlacementTopologyDefinition(candidate, {
+      context: context.source || "placement topology"
+    });
+    entries.push(...normalized.placements);
+  }
+
+  const byKey = new Map();
+  for (const entry of entries) {
+    const key = `${entry.id}::${entry.owner || ""}`;
+    if (byKey.has(key)) {
+      throw new Error(
+        `Duplicate semantic placement "${entry.id}"${entry.owner ? ` for owner "${entry.owner}"` : ""} in ${context.source || "placement topology"}.`
+      );
+    }
+    byKey.set(key, entry);
+  }
+
+  return Object.freeze([...byKey.values()]);
+}
+
 function matchesSurface(placementSurfaces, requestedSurface) {
   if (requestedSurface === WEB_PLACEMENT_SURFACE_ANY) {
     return true;
   }
   const surfaces = Array.isArray(placementSurfaces) ? placementSurfaces : [WEB_PLACEMENT_SURFACE_ANY];
   return surfaces.includes(WEB_PLACEMENT_SURFACE_ANY) || surfaces.includes(requestedSurface);
+}
+
+function resolveTopologyPlacement(topologyEntries = [], placement = {}, requestedSurface = WEB_PLACEMENT_SURFACE_ANY) {
+  const semanticTarget = String(placement.target || "").trim();
+  const owner = String(placement.owner || "").trim();
+  const matches = topologyEntries.filter((entry) => {
+    if (entry.id !== semanticTarget) {
+      return false;
+    }
+    if (owner && entry.owner !== owner) {
+      return false;
+    }
+    if (!owner && entry.owner) {
+      return false;
+    }
+    return matchesSurface(entry.surfaces, requestedSurface);
+  });
+
+  if (matches.length === 1) {
+    return matches[0];
+  }
+  return null;
+}
+
+function resolveRenderablePlacement({
+  placement = {},
+  topologyEntries = [],
+  requestedSurface = WEB_PLACEMENT_SURFACE_ANY,
+  requestedTarget = "",
+  requestedLayoutClass = "compact"
+} = {}) {
+  if (placement.targetType === "concrete") {
+    if (placement.target !== requestedTarget) {
+      return null;
+    }
+    return placement;
+  }
+
+  const topologyPlacement = resolveTopologyPlacement(topologyEntries, placement, requestedSurface);
+  if (!topologyPlacement) {
+    return null;
+  }
+
+  const variant = topologyPlacement.variants?.[requestedLayoutClass] || null;
+  if (!variant || variant.outlet !== requestedTarget) {
+    return null;
+  }
+
+  const componentToken = String(placement.componentToken || variant.renderers?.[placement.kind] || "").trim();
+  if (!componentToken) {
+    return null;
+  }
+
+  return Object.freeze({
+    ...placement,
+    target: requestedTarget,
+    semanticTarget: placement.target,
+    topologyOwner: topologyPlacement.owner || "",
+    layoutClass: requestedLayoutClass,
+    componentToken
+  });
 }
 
 function resolveContextContributors(app, baseContext = {}, logger) {
@@ -232,6 +331,7 @@ function createWebPlacementRuntime({ app, logger = null } = {}) {
   const listeners = new Set();
   const subscribe = createListenerSubscription(listeners);
   let placementDefinitions = Object.freeze([]);
+  let placementTopology = Object.freeze([]);
   let sharedContext = Object.freeze({});
   let revision = 0;
 
@@ -276,6 +376,22 @@ function createWebPlacementRuntime({ app, logger = null } = {}) {
     });
   }
 
+  function replacePlacementTopology(topology = [], { source = "app placement topology" } = {}) {
+    missingTokens.clear();
+    invalidComponentTokens.clear();
+    failedTokens.clear();
+    placementTopology = normalizeTopologyList(topology, { source });
+    debugLog("replacePlacementTopology", {
+      source,
+      count: placementTopology.length,
+      ids: placementTopology.map((entry) => entry.owner ? `${entry.id}#${entry.owner}` : entry.id)
+    });
+    notify({
+      type: "placement-topology.replaced",
+      source
+    });
+  }
+
   function getContext() {
     return sharedContext;
   }
@@ -308,13 +424,17 @@ function createWebPlacementRuntime({ app, logger = null } = {}) {
     return revision;
   }
 
-  function getPlacements({ surface = WEB_PLACEMENT_SURFACE_ANY, target = "", context = {} } = {}) {
+  function getPlacements({ surface = WEB_PLACEMENT_SURFACE_ANY, target = "", layoutClass = "", context = {} } = {}) {
     const normalizedTarget = normalizePlacementTarget(target, { strict: false });
     if (!normalizedTarget) {
       return Object.freeze([]);
     }
 
     const normalizedSurface = normalizeSurface(surface);
+    const normalizedLayoutClass =
+      normalizePlacementLayoutClass(layoutClass) ||
+      normalizePlacementLayoutClass(sharedContext?.layoutClass) ||
+      "compact";
     const baseContext = isRecord(context) ? { ...context } : {};
     const contextFromRuntime = isRecord(sharedContext) ? sharedContext : {};
     const contextFromContributors = resolveContextContributors(
@@ -323,6 +443,7 @@ function createWebPlacementRuntime({ app, logger = null } = {}) {
         app,
         surface: normalizedSurface,
         target: normalizedTarget,
+        layoutClass: normalizedLayoutClass,
         context: {
           ...contextFromRuntime,
           ...baseContext
@@ -336,44 +457,54 @@ function createWebPlacementRuntime({ app, logger = null } = {}) {
       ...baseContext,
       app,
       surface: normalizedSurface,
-      target: normalizedTarget
+      target: normalizedTarget,
+      layoutClass: normalizedLayoutClass
     };
 
     debugLog("getPlacements:start", {
       surface: normalizedSurface,
       target: normalizedTarget,
+      layoutClass: normalizedLayoutClass,
       contextKeys: Object.keys(baseContext),
       sharedContextKeys: Object.keys(contextFromRuntime),
-      placementCount: placementDefinitions.length
+      placementCount: placementDefinitions.length,
+      topologyCount: placementTopology.length
     });
 
     const matches = [];
     for (const placement of placementDefinitions) {
-      if (placement.target !== normalizedTarget) {
+      const renderablePlacement = resolveRenderablePlacement({
+        placement,
+        topologyEntries: placementTopology,
+        requestedSurface: normalizedSurface,
+        requestedTarget: normalizedTarget,
+        requestedLayoutClass: normalizedLayoutClass
+      });
+      if (!renderablePlacement) {
         continue;
       }
-      const placementSurfaces = Array.isArray(placement.surfaces)
-        ? placement.surfaces
+      const placementSurfaces = Array.isArray(renderablePlacement.surfaces)
+        ? renderablePlacement.surfaces
         : [WEB_PLACEMENT_SURFACE_ANY];
 
       if (!matchesSurface(placementSurfaces, normalizedSurface)) {
         debugLog("getPlacements:skip-surfaces", {
-          placementId: placement.id,
+          placementId: renderablePlacement.id,
           placementSurfaces,
           requestedSurface: normalizedSurface
         });
         continue;
       }
-      if (!shouldIncludePlacement(placement, placementContext, runtimeLogger)) {
+      if (!shouldIncludePlacement(renderablePlacement, placementContext, runtimeLogger)) {
         debugLog("getPlacements:skip-when", {
-          placementId: placement.id
+          placementId: renderablePlacement.id
         });
         continue;
       }
 
       const component = resolvePlacementComponent(
         app,
-        placement,
+        renderablePlacement,
         runtimeLogger,
         missingTokens,
         invalidComponentTokens,
@@ -381,22 +512,22 @@ function createWebPlacementRuntime({ app, logger = null } = {}) {
       );
       if (!component) {
         debugLog("getPlacements:skip-component", {
-          placementId: placement.id,
-          componentToken: placement.componentToken
+          placementId: renderablePlacement.id,
+          componentToken: renderablePlacement.componentToken
         });
         continue;
       }
 
       debugLog("getPlacements:include", {
-        placementId: placement.id,
-        componentToken: placement.componentToken,
+        placementId: renderablePlacement.id,
+        componentToken: renderablePlacement.componentToken,
         placementSurfaces,
-        order: placement.order
+        order: renderablePlacement.order
       });
 
       matches.push(
         Object.freeze({
-          ...placement,
+          ...renderablePlacement,
           component
         })
       );
@@ -405,6 +536,7 @@ function createWebPlacementRuntime({ app, logger = null } = {}) {
     debugLog("getPlacements:done", {
       surface: normalizedSurface,
       target: normalizedTarget,
+      layoutClass: normalizedLayoutClass,
       resultIds: matches.map((entry) => entry.id)
     });
 
@@ -413,6 +545,7 @@ function createWebPlacementRuntime({ app, logger = null } = {}) {
 
   return Object.freeze({
     replacePlacements,
+    replacePlacementTopology,
     getPlacements,
     getContext,
     setContext,

--- a/packages/shell-web/src/client/placement/validators.js
+++ b/packages/shell-web/src/client/placement/validators.js
@@ -1,5 +1,10 @@
 import { isRecord, normalizeText } from "@jskit-ai/kernel/shared/support/normalize";
-import { normalizeShellOutletTargetId } from "@jskit-ai/kernel/shared/support/shellLayoutTargets";
+import {
+  normalizePlacementKind,
+  normalizePlacementTopologyDefinition,
+  normalizeSemanticPlacementId,
+  resolvePlacementTargetReference
+} from "@jskit-ai/kernel/shared/support/shellLayoutTargets";
 
 const WEB_PLACEMENT_SURFACE_ANY = "*";
 
@@ -57,13 +62,13 @@ function toInteger(value, fallback = 1000) {
 }
 
 function normalizePlacementTarget(value, { strict = false, source = "placement" } = {}) {
-  const normalized = normalizeShellOutletTargetId(String(value || "").toLowerCase());
-  if (normalized) {
-    return normalized;
+  const reference = resolvePlacementTargetReference(String(value || "").toLowerCase());
+  if (reference?.id) {
+    return reference.id;
   }
 
   if (strict) {
-    throw new TypeError(`${source} requires target in "host:position" format.`);
+    throw new TypeError(`${source} requires semantic target in "area.slot" format or internal concrete target in "host:position" format.`);
   }
   return "";
 }
@@ -132,8 +137,19 @@ function normalizePlacementDefinition(value, { strict = false, source = "placeme
     return null;
   }
 
+  const targetReference = resolvePlacementTargetReference(target);
+  const internal = value.internal === true;
+  if (targetReference?.type === "concrete" && internal !== true) {
+    if (strict) {
+      throw new TypeError(`${source} "${id}" targets concrete outlet "${target}" without internal: true.`);
+    }
+    return null;
+  }
+
+  const owner = normalizeText(value.owner).toLowerCase();
+  const kind = normalizePlacementKind(value.kind) || (normalizeText(value.componentToken) ? "component" : "link");
   const componentToken = normalizeText(value.componentToken);
-  if (!componentToken) {
+  if (kind === "component" && !componentToken) {
     if (strict) {
       throw new TypeError(`${source} "${id}" requires componentToken.`);
     }
@@ -150,12 +166,16 @@ function normalizePlacementDefinition(value, { strict = false, source = "placeme
   return Object.freeze({
     id,
     target,
+    targetType: targetReference?.type || "",
+    owner,
+    kind,
     surfaces,
     order: toInteger(value.order, 1000),
     componentToken,
     props,
     when,
-    enabled: value.enabled !== false
+    enabled: value.enabled !== false,
+    internal
   });
 }
 
@@ -163,6 +183,12 @@ function definePlacement(value = {}) {
   return normalizePlacementDefinition(value, {
     strict: true,
     source: "placement contribution"
+  });
+}
+
+function definePlacementTopology(value = {}) {
+  return normalizePlacementTopologyDefinition(value, {
+    context: "placement topology"
   });
 }
 
@@ -174,5 +200,7 @@ export {
   normalizePlacementTarget,
   normalizePlacementSurfaces,
   normalizePlacementDefinition,
-  definePlacement
+  definePlacement,
+  definePlacementTopology,
+  normalizeSemanticPlacementId
 };

--- a/packages/shell-web/src/client/providers/ShellWebClientProvider.js
+++ b/packages/shell-web/src/client/providers/ShellWebClientProvider.js
@@ -30,6 +30,7 @@ import { resolveBootstrapErrorStatusCode } from "../bootstrap/bootstrapErrorStat
 
 // Keep this constant for diagnostics, but keep import() below as a literal string so Vite can statically analyze it.
 const APP_PLACEMENT_MODULE_SPECIFIER = "/src/placement.js";
+const APP_PLACEMENT_TOPOLOGY_MODULE_SPECIFIER = "/src/placementTopology.js";
 const APP_ERROR_MODULE_SPECIFIER = "/src/error.js";
 
 function createShellWebQueryClient() {
@@ -82,6 +83,42 @@ async function loadAppPlacementDefinitions(logger) {
         error: String(error?.message || error || "unknown error")
       },
       "Failed to load app placement module; using empty list."
+    );
+  }
+
+  return [];
+}
+
+async function loadAppPlacementTopology(logger) {
+  try {
+    const moduleNamespace = await import("/src/placementTopology.js");
+    const exported = moduleNamespace?.default;
+    const resolved = typeof exported === "function" ? exported() : exported;
+    if (Array.isArray(resolved)) {
+      return resolved;
+    }
+    if (resolved && typeof resolved === "object") {
+      return [resolved];
+    }
+
+    logger.warn(
+      {
+        module: APP_PLACEMENT_TOPOLOGY_MODULE_SPECIFIER,
+        exportedType: typeof exported
+      },
+      "App placement topology module default export did not resolve to an object or array; using empty topology."
+    );
+  } catch (error) {
+    if (isMissingDynamicModule(error, APP_PLACEMENT_TOPOLOGY_MODULE_SPECIFIER)) {
+      return [];
+    }
+
+    logger.warn(
+      {
+        module: APP_PLACEMENT_TOPOLOGY_MODULE_SPECIFIER,
+        error: String(error?.message || error || "unknown error")
+      },
+      "Failed to load app placement topology module; using empty topology."
     );
   }
 
@@ -297,6 +334,10 @@ class ShellWebClientProvider {
     const logger = createSharedProviderLogger(isRecord(app) ? app : null);
     const placementRuntime = app.make("runtime.web-placement.client");
     if (placementRuntime && typeof placementRuntime.replacePlacements === "function") {
+      const placementTopology = await loadAppPlacementTopology(logger);
+      if (typeof placementRuntime.replacePlacementTopology === "function") {
+        placementRuntime.replacePlacementTopology(placementTopology, { source: APP_PLACEMENT_TOPOLOGY_MODULE_SPECIFIER });
+      }
       const placements = await loadAppPlacementDefinitions(logger);
       placementRuntime.replacePlacements(placements, { source: APP_PLACEMENT_MODULE_SPECIFIER });
       const appConfig = getClientAppConfig();

--- a/packages/shell-web/src/client/providers/ShellWebClientProvider.js
+++ b/packages/shell-web/src/client/providers/ShellWebClientProvider.js
@@ -93,21 +93,7 @@ async function loadAppPlacementTopology(logger) {
   try {
     const moduleNamespace = await import("/src/placementTopology.js");
     const exported = moduleNamespace?.default;
-    const resolved = typeof exported === "function" ? exported() : exported;
-    if (Array.isArray(resolved)) {
-      return resolved;
-    }
-    if (resolved && typeof resolved === "object") {
-      return [resolved];
-    }
-
-    logger.warn(
-      {
-        module: APP_PLACEMENT_TOPOLOGY_MODULE_SPECIFIER,
-        exportedType: typeof exported
-      },
-      "App placement topology module default export did not resolve to an object or array; using empty topology."
-    );
+    return resolveAppPlacementTopologyExport(exported, logger);
   } catch (error) {
     if (isMissingDynamicModule(error, APP_PLACEMENT_TOPOLOGY_MODULE_SPECIFIER)) {
       return [];
@@ -122,6 +108,25 @@ async function loadAppPlacementTopology(logger) {
     );
   }
 
+  return [];
+}
+
+function resolveAppPlacementTopologyExport(exported, logger) {
+  const resolved = typeof exported === "function" ? exported() : exported;
+  if (Array.isArray(resolved)) {
+    return resolved;
+  }
+  if (resolved && typeof resolved === "object") {
+    return resolved;
+  }
+
+  logger.warn(
+    {
+      module: APP_PLACEMENT_TOPOLOGY_MODULE_SPECIFIER,
+      exportedType: typeof exported
+    },
+    "App placement topology module default export did not resolve to an object or array; using empty topology."
+  );
   return [];
 }
 
@@ -402,5 +407,6 @@ class ShellWebClientProvider {
 }
 
 export {
-  ShellWebClientProvider
+  ShellWebClientProvider,
+  resolveAppPlacementTopologyExport
 };

--- a/packages/shell-web/templates/src/components/ShellLayout.vue
+++ b/packages/shell-web/templates/src/components/ShellLayout.vue
@@ -52,13 +52,9 @@ const { drawerOpen, toggleDrawer, resolvedSurface, resolvedSurfaceLabel } = useS
           <ShellOutlet
             target="shell-layout:primary-menu"
             default
-            default-link-component-token="local.main.ui.surface-aware-menu-link-item"
           />
           <v-divider class="my-2" />
-          <ShellOutlet
-            target="shell-layout:secondary-menu"
-            default-link-component-token="local.main.ui.surface-aware-menu-link-item"
-          />
+          <ShellOutlet target="shell-layout:secondary-menu" />
         </v-list>
       </slot>
     </v-navigation-drawer>

--- a/packages/shell-web/templates/src/pages/home/settings.vue
+++ b/packages/shell-web/templates/src/pages/home/settings.vue
@@ -15,10 +15,7 @@ import { RouterView } from "vue-router";
         <v-row no-gutters>
           <v-col cols="12" md="3" lg="2" class="pr-md-4 mb-4 mb-md-0">
             <v-list nav density="comfortable" rounded="lg" border>
-              <ShellOutlet
-                target="home-settings:primary-menu"
-                default-link-component-token="local.main.ui.surface-aware-menu-link-item"
-              />
+              <ShellOutlet target="home-settings:primary-menu" />
             </v-list>
           </v-col>
 

--- a/packages/shell-web/templates/src/placement.js
+++ b/packages/shell-web/templates/src/placement.js
@@ -13,10 +13,10 @@ export default function getPlacements() {
 
 addPlacement({
   id: "shell-web.home.menu.home",
-  target: "shell-layout:primary-menu",
+  target: "shell.primary-nav",
+  kind: "link",
   surfaces: ["home"],
   order: 50,
-  componentToken: "local.main.ui.surface-aware-menu-link-item",
   props: {
     label: "Home",
     surface: "home",
@@ -28,10 +28,10 @@ addPlacement({
 
 addPlacement({
   id: "shell-web.home.menu.settings",
-  target: "shell-layout:primary-menu",
+  target: "shell.primary-nav",
+  kind: "link",
   surfaces: ["home"],
   order: 100,
-  componentToken: "local.main.ui.surface-aware-menu-link-item",
   props: {
     label: "Settings",
     surface: "home",
@@ -42,10 +42,11 @@ addPlacement({
 
 addPlacement({
   id: "shell-web.home.settings.general",
-  target: "home-settings:primary-menu",
+  target: "page.section-nav",
+  owner: "home-settings",
+  kind: "link",
   surfaces: ["home"],
   order: 100,
-  componentToken: "local.main.ui.surface-aware-menu-link-item",
   props: {
     label: "General",
     surface: "home",

--- a/packages/shell-web/templates/src/placementTopology.js
+++ b/packages/shell-web/templates/src/placementTopology.js
@@ -1,0 +1,108 @@
+const placements = [];
+
+function addPlacementTopology(value = {}) {
+  placements.push(value);
+}
+
+export { addPlacementTopology };
+export default { placements };
+
+const menuLinkRenderers = Object.freeze({
+  link: "local.main.ui.surface-aware-menu-link-item"
+});
+
+addPlacementTopology({
+  id: "shell.primary-nav",
+  description: "Primary top-level navigation for the current surface.",
+  surfaces: ["*"],
+  default: true,
+  variants: {
+    compact: {
+      outlet: "shell-layout:primary-menu",
+      renderers: menuLinkRenderers
+    },
+    medium: {
+      outlet: "shell-layout:primary-menu",
+      renderers: menuLinkRenderers
+    },
+    expanded: {
+      outlet: "shell-layout:primary-menu",
+      renderers: menuLinkRenderers
+    }
+  }
+});
+
+addPlacementTopology({
+  id: "shell.secondary-nav",
+  description: "Secondary navigation for the current surface.",
+  surfaces: ["*"],
+  variants: {
+    compact: {
+      outlet: "shell-layout:secondary-menu",
+      renderers: menuLinkRenderers
+    },
+    medium: {
+      outlet: "shell-layout:secondary-menu",
+      renderers: menuLinkRenderers
+    },
+    expanded: {
+      outlet: "shell-layout:secondary-menu",
+      renderers: menuLinkRenderers
+    }
+  }
+});
+
+addPlacementTopology({
+  id: "shell.identity",
+  description: "Current surface identity and switcher controls.",
+  surfaces: ["*"],
+  variants: {
+    compact: {
+      outlet: "shell-layout:top-left"
+    },
+    medium: {
+      outlet: "shell-layout:top-left"
+    },
+    expanded: {
+      outlet: "shell-layout:top-left"
+    }
+  }
+});
+
+addPlacementTopology({
+  id: "shell.status",
+  description: "Surface status, connection, and utility indicators.",
+  surfaces: ["*"],
+  variants: {
+    compact: {
+      outlet: "shell-layout:top-right"
+    },
+    medium: {
+      outlet: "shell-layout:top-right"
+    },
+    expanded: {
+      outlet: "shell-layout:top-right"
+    }
+  }
+});
+
+addPlacementTopology({
+  id: "page.section-nav",
+  owner: "home-settings",
+  description: "Navigation between child pages in the home settings section.",
+  surfaces: ["home"],
+  variants: {
+    compact: {
+      outlet: "home-settings:primary-menu",
+      renderers: menuLinkRenderers
+    },
+    medium: {
+      outlet: "home-settings:primary-menu",
+      renderers: menuLinkRenderers
+    },
+    expanded: {
+      outlet: "home-settings:primary-menu",
+      renderers: menuLinkRenderers
+    }
+  }
+});

--- a/packages/shell-web/test/outletMenuWidgetContract.test.js
+++ b/packages/shell-web/test/outletMenuWidgetContract.test.js
@@ -14,9 +14,9 @@ test("shell-web outlet menu widget exposes a configurable nested outlet", async 
   );
 
   assert.match(source, /import \{ mdiCogOutline \} from "@mdi\/js";/);
-  assert.match(source, /defaultLinkComponentToken: \{/);
   assert.match(source, /:target="props\.target"/);
-  assert.match(source, /:default-link-component-token="props\.defaultLinkComponentToken"/);
+  assert.doesNotMatch(source, /defaultLinkComponentToken/);
+  assert.doesNotMatch(source, /default-link-component-token/);
   assert.match(source, /default: mdiCogOutline/);
   assert.doesNotMatch(source, /mdi-[a-z0-9-]+/);
 });

--- a/packages/shell-web/test/placementRegistry.test.js
+++ b/packages/shell-web/test/placementRegistry.test.js
@@ -7,13 +7,13 @@ test("placement registry stores unique entries and builds immutable array", () =
 
   const firstAdded = registry.addPlacement({
     id: "example.profile",
-    target: "shell-layout:top-right",
+    target: "shell.status",
     surfaces: ["*"],
     componentToken: "example.profile.component"
   });
   const duplicateAdded = registry.addPlacement({
     id: "example.profile",
-    target: "shell-layout:top-right",
+    target: "shell.status",
     surfaces: ["*"],
     componentToken: "example.profile.component.duplicate"
   });
@@ -33,7 +33,7 @@ test("placement registry accepts explicit non-global surface ids", () => {
 
   const added = registry.addPlacement({
     id: "example.admin",
-    target: "shell-layout:top-right",
+    target: "shell.status",
     surfaces: ["admin"],
     componentToken: "example.admin.component"
   });

--- a/packages/shell-web/test/placementRuntime.test.js
+++ b/packages/shell-web/test/placementRuntime.test.js
@@ -32,6 +32,82 @@ function createPlacementContext() {
   };
 }
 
+function semanticTopologyEntry({
+  id = "shell.primary-nav",
+  owner = "",
+  surfaces = ["*"],
+  compact = "shell-layout:primary-menu",
+  medium = "shell-layout:primary-menu",
+  expanded = "shell-layout:primary-menu",
+  compactRenderer = "component.menu",
+  mediumRenderer = "component.menu",
+  expandedRenderer = "component.menu"
+} = {}) {
+  const createVariant = (outlet, renderer) => ({
+    outlet,
+    renderers: renderer ? { link: renderer } : {}
+  });
+  return {
+    id,
+    owner,
+    surfaces,
+    variants: {
+      compact: createVariant(compact, compactRenderer),
+      medium: createVariant(medium, mediumRenderer),
+      expanded: createVariant(expanded, expandedRenderer)
+    }
+  };
+}
+
+test("web placement runtime resolves semantic targets through topology variants", () => {
+  const app = createAppStub({
+    tokens: {
+      "component.bottom": () => null,
+      "component.menu": () => null
+    }
+  });
+
+  const runtime = createWebPlacementRuntime({ app });
+  runtime.replacePlacementTopology([
+    semanticTopologyEntry({
+      id: "shell.primary-nav",
+      compact: "shell-layout:bottom-nav",
+      medium: "shell-layout:primary-menu",
+      expanded: "shell-layout:primary-menu",
+      compactRenderer: "component.bottom",
+      mediumRenderer: "component.menu",
+      expandedRenderer: "component.menu"
+    })
+  ]);
+  runtime.replacePlacements([
+    definePlacement({
+      id: "test.home",
+      target: "shell.primary-nav",
+      kind: "link",
+      surfaces: ["app"],
+      order: 10
+    })
+  ]);
+  runtime.setContext(createPlacementContext());
+
+  const compactEntries = runtime.getPlacements({
+    surface: "app",
+    target: "shell-layout:bottom-nav",
+    layoutClass: "compact"
+  });
+  assert.deepEqual(compactEntries.map((entry) => entry.id), ["test.home"]);
+  assert.equal(compactEntries[0].semanticTarget, "shell.primary-nav");
+  assert.equal(compactEntries[0].componentToken, "component.bottom");
+
+  const mediumEntries = runtime.getPlacements({
+    surface: "app",
+    target: "shell-layout:primary-menu",
+    layoutClass: "medium"
+  });
+  assert.deepEqual(mediumEntries.map((entry) => entry.id), ["test.home"]);
+  assert.equal(mediumEntries[0].componentToken, "component.menu");
+});
+
 test("web placement runtime filters by surface/host/position, resolves component tokens, and sorts by order", () => {
   const app = createAppStub({
     tokens: {
@@ -48,21 +124,24 @@ test("web placement runtime filters by surface/host/position, resolves component
       target: "shell-layout:primary-menu",
       surfaces: ["app"],
       order: 30,
-      componentToken: "component.menu"
+      componentToken: "component.menu",
+      internal: true
     }),
     definePlacement({
       id: "test.profile",
       target: "shell-layout:top-right",
       surfaces: ["*"],
       order: 20,
-      componentToken: "component.profile"
+      componentToken: "component.profile",
+      internal: true
     }),
     definePlacement({
       id: "test.alerts",
       target: "shell-layout:top-right",
       surfaces: ["app"],
       order: 10,
-      componentToken: "component.alerts"
+      componentToken: "component.alerts",
+      internal: true
     })
   ]);
   runtime.setContext(createPlacementContext());
@@ -93,14 +172,16 @@ test("web placement runtime preserves source order when placements share the sam
       target: "home-settings:primary-menu",
       surfaces: ["app"],
       order: 155,
-      componentToken: "component.beta"
+      componentToken: "component.beta",
+      internal: true
     }),
     definePlacement({
       id: "test.alpha",
       target: "home-settings:primary-menu",
       surfaces: ["app"],
       order: 155,
-      componentToken: "component.alpha"
+      componentToken: "component.alpha",
+      internal: true
     })
   ]);
   runtime.setContext(createPlacementContext());
@@ -129,6 +210,7 @@ test("web placement runtime applies context contributors and placement when() pr
       target: "auth-profile-menu:primary-menu",
       surfaces: ["*"],
       componentToken: "component.guest",
+      internal: true,
       when: ({ auth }) => !Boolean(auth?.authenticated)
     }),
     definePlacement({
@@ -136,6 +218,7 @@ test("web placement runtime applies context contributors and placement when() pr
       target: "auth-profile-menu:primary-menu",
       surfaces: ["*"],
       componentToken: "component.authenticated",
+      internal: true,
       when: ({ auth }) => Boolean(auth?.authenticated)
     })
   ]);
@@ -165,6 +248,7 @@ test("web placement runtime uses runtime context and local context overrides con
       target: "auth-profile-menu:primary-menu",
       surfaces: ["*"],
       componentToken: "component.allowed",
+      internal: true,
       when: ({ auth }) => Boolean(auth?.authenticated)
     })
   ]);
@@ -224,13 +308,15 @@ test("web placement runtime rejects duplicate placement ids", () => {
         id: "dup.entry",
         target: "shell-layout:top-right",
         surfaces: ["*"],
-        componentToken: "component.a"
+        componentToken: "component.a",
+        internal: true
       }),
       definePlacement({
         id: "dup.entry",
         target: "shell-layout:primary-menu",
         surfaces: ["*"],
-        componentToken: "component.b"
+        componentToken: "component.b",
+        internal: true
       })
     ]);
   }, /Duplicate placement id/);
@@ -271,13 +357,15 @@ test("web placement runtime skips throwing component tokens and logs resolution 
       id: "bad",
       target: "shell-layout:top-right",
       surfaces: ["*"],
-      componentToken: "component.bad"
+      componentToken: "component.bad",
+      internal: true
     }),
     definePlacement({
       id: "good",
       target: "shell-layout:top-right",
       surfaces: ["*"],
-      componentToken: "component.good"
+      componentToken: "component.good",
+      internal: true
     })
   ]);
 
@@ -323,7 +411,8 @@ test("web placement runtime clears failed token cache when placements are replac
       id: "toggle",
       target: "shell-layout:top-right",
       surfaces: ["*"],
-      componentToken: "component.toggle"
+      componentToken: "component.toggle",
+      internal: true
     })
   ]);
 
@@ -339,7 +428,8 @@ test("web placement runtime clears failed token cache when placements are replac
       id: "toggle",
       target: "shell-layout:top-right",
       surfaces: ["*"],
-      componentToken: "component.toggle"
+      componentToken: "component.toggle",
+      internal: true
     })
   ]);
 
@@ -362,21 +452,24 @@ test("web placement runtime follows explicit surface targeting without role indi
       target: "shell-layout:top-right",
       surfaces: ["*"],
       order: 10,
-      componentToken: "component.global"
+      componentToken: "component.global",
+      internal: true
     }),
     definePlacement({
       id: "app.link",
       target: "shell-layout:top-right",
       surfaces: ["app"],
       order: 20,
-      componentToken: "component.app"
+      componentToken: "component.app",
+      internal: true
     }),
     definePlacement({
       id: "admin.link",
       target: "shell-layout:top-right",
       surfaces: ["admin"],
       order: 30,
-      componentToken: "component.admin"
+      componentToken: "component.admin",
+      internal: true
     })
   ]);
   runtime.setContext(createPlacementContext());

--- a/packages/shell-web/test/placementRuntime.test.js
+++ b/packages/shell-web/test/placementRuntime.test.js
@@ -108,6 +108,43 @@ test("web placement runtime resolves semantic targets through topology variants"
   assert.equal(mediumEntries[0].componentToken, "component.menu");
 });
 
+test("web placement runtime accepts append-only topology objects", () => {
+  const app = createAppStub({
+    tokens: {
+      "component.menu": () => null
+    }
+  });
+
+  const runtime = createWebPlacementRuntime({ app });
+  runtime.replacePlacementTopology({
+    placements: [
+      semanticTopologyEntry({
+        id: "shell.primary-nav",
+        compactRenderer: "component.menu",
+        mediumRenderer: "component.menu",
+        expandedRenderer: "component.menu"
+      })
+    ]
+  });
+  runtime.replacePlacements([
+    definePlacement({
+      id: "test.home",
+      target: "shell.primary-nav",
+      kind: "link",
+      surfaces: ["app"],
+      order: 10
+    })
+  ]);
+  runtime.setContext(createPlacementContext());
+
+  const entries = runtime.getPlacements({
+    surface: "app",
+    target: "shell-layout:primary-menu",
+    layoutClass: "expanded"
+  });
+  assert.deepEqual(entries.map((entry) => entry.id), ["test.home"]);
+});
+
 test("web placement runtime filters by surface/host/position, resolves component tokens, and sorts by order", () => {
   const app = createAppStub({
     tokens: {

--- a/packages/shell-web/test/provider.test.js
+++ b/packages/shell-web/test/provider.test.js
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { createPinia } from "pinia";
-import { ShellWebClientProvider } from "../src/client/providers/ShellWebClientProvider.js";
+import {
+  ShellWebClientProvider,
+  resolveAppPlacementTopologyExport
+} from "../src/client/providers/ShellWebClientProvider.js";
 import { useShellErrorPresentationStore } from "../src/client/stores/useShellErrorPresentationStore.js";
 const CLIENT_APP_CONFIG_GLOBAL_KEY = "__JSKIT_CLIENT_APP_CONFIG__";
 
@@ -124,6 +127,32 @@ async function withFetchImplementation(fetchImplementation, callback) {
     }
   }
 }
+
+test("shell web client provider preserves append-only placement topology object exports", () => {
+  const warnings = [];
+  const topology = {
+    placements: [
+      {
+        id: "shell.primary-nav",
+        surfaces: ["*"],
+        variants: {
+          compact: { outlet: "shell-layout:primary-menu" },
+          medium: { outlet: "shell-layout:primary-menu" },
+          expanded: { outlet: "shell-layout:primary-menu" }
+        }
+      }
+    ]
+  };
+
+  const resolved = resolveAppPlacementTopologyExport(topology, {
+    warn(payload, message) {
+      warnings.push({ payload, message });
+    }
+  });
+
+  assert.equal(resolved, topology);
+  assert.deepEqual(warnings, []);
+});
 
 test("shell web client provider binds runtime and injects it into Vue app", async () => {
   await withFetchStub({ surfaceAccess: {} }, async () => {

--- a/packages/shell-web/test/settingsPlacementContract.test.js
+++ b/packages/shell-web/test/settingsPlacementContract.test.js
@@ -24,6 +24,18 @@ function readContributions(target = "") {
     : [];
 }
 
+function readTopology(id = "", owner = "") {
+  const placements = descriptor?.metadata?.ui?.placements?.topology?.placements;
+  const normalizedId = String(id || "").trim();
+  const normalizedOwner = String(owner || "").trim();
+  return Array.isArray(placements)
+    ? placements.filter((entry) =>
+        String(entry?.id || "").trim() === normalizedId &&
+        String(entry?.owner || "").trim() === normalizedOwner
+      )
+    : [];
+}
+
 function findFileMutation(id) {
   const files = descriptor?.mutations?.files;
   return Array.isArray(files)
@@ -35,7 +47,7 @@ test("shell-web home settings template exposes surface-derived settings outlets"
   const source = await readFile(path.join(PACKAGE_DIR, "templates", "src", "pages", "home", "settings.vue"), "utf8");
 
   assert.match(source, /target="home-settings:primary-menu"/);
-  assert.match(source, /default-link-component-token="local\.main\.ui\.surface-aware-menu-link-item"/);
+  assert.doesNotMatch(source, /default-link-component-token/);
   assert.match(source, /<RouterView \/>/);
 });
 
@@ -64,7 +76,8 @@ test("shell-web placement template seeds default Home and Settings drawer naviga
   const source = await readFile(path.join(PACKAGE_DIR, "templates", "src", "placement.js"), "utf8");
 
   assert.match(source, /id: "shell-web\.home\.menu\.home"/);
-  assert.match(source, /target: "shell-layout:primary-menu"/);
+  assert.match(source, /target: "shell\.primary-nav"/);
+  assert.match(source, /kind: "link"/);
   assert.match(source, /surfaces: \["home"\]/);
   assert.match(source, /label: "Home"/);
   assert.match(source, /unscopedSuffix: "\/"/);
@@ -72,7 +85,8 @@ test("shell-web placement template seeds default Home and Settings drawer naviga
   assert.match(source, /label: "Settings"/);
   assert.match(source, /unscopedSuffix: "\/settings"/);
   assert.match(source, /id: "shell-web\.home\.settings\.general"/);
-  assert.match(source, /target: "home-settings:primary-menu"/);
+  assert.match(source, /target: "page\.section-nav"/);
+  assert.match(source, /owner: "home-settings"/);
   assert.match(source, /label: "General"/);
   assert.match(source, /unscopedSuffix: "\/settings\/general"/);
   assert.doesNotMatch(source, /to: "\.\/general"/);
@@ -84,7 +98,6 @@ test("shell-web descriptor metadata advertises home settings outlets, default dr
     [
       {
         target: "home-settings:primary-menu",
-        defaultLinkComponentToken: "local.main.ui.surface-aware-menu-link-item",
         surfaces: ["home"],
         source: "templates/src/pages/home/settings.vue"
       }
@@ -92,40 +105,44 @@ test("shell-web descriptor metadata advertises home settings outlets, default dr
   );
 
   assert.deepEqual(
-    readContributions("shell-layout:primary-menu"),
+    readContributions("shell.primary-nav"),
     [
       {
         id: "shell-web.home.menu.home",
-        target: "shell-layout:primary-menu",
+        target: "shell.primary-nav",
+        kind: "link",
         surfaces: ["home"],
         order: 50,
-        componentToken: "local.main.ui.surface-aware-menu-link-item",
         source: "templates/src/placement.js"
       },
       {
         id: "shell-web.home.menu.settings",
-        target: "shell-layout:primary-menu",
+        target: "shell.primary-nav",
+        kind: "link",
         surfaces: ["home"],
         order: 100,
-        componentToken: "local.main.ui.surface-aware-menu-link-item",
         source: "templates/src/placement.js"
       }
     ]
   );
 
   assert.deepEqual(
-    readContributions("home-settings:primary-menu"),
+    readContributions("page.section-nav"),
     [
       {
         id: "shell-web.home.settings.general",
-        target: "home-settings:primary-menu",
+        target: "page.section-nav",
+        owner: "home-settings",
+        kind: "link",
         surfaces: ["home"],
         order: 100,
-        componentToken: "local.main.ui.surface-aware-menu-link-item",
         source: "templates/src/placement.js"
       }
     ]
   );
+
+  assert.equal(readTopology("shell.primary-nav").length, 1);
+  assert.equal(readTopology("page.section-nav", "home-settings").length, 1);
 
   assert.deepEqual(findFileMutation("shell-web-page-home-settings-shell"), {
     from: "templates/src/pages/home/settings.vue",

--- a/packages/storage-runtime/package.descriptor.mjs
+++ b/packages/storage-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/storage-runtime",
-  version: "0.1.64",
+  version: "0.1.65",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -50,7 +50,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.65",
+        "@jskit-ai/kernel": "0.1.66",
         "unstorage": "^1.17.3"
       },
       dev: {}

--- a/packages/storage-runtime/package.json
+++ b/packages/storage-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/storage-runtime",
-  "version": "0.1.64",
+  "version": "0.1.65",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./server/providers/StorageRuntimeServiceProvider": "./src/server/providers/StorageRuntimeServiceProvider.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.65",
+    "@jskit-ai/kernel": "0.1.66",
     "unstorage": "^1.17.3"
   }
 }

--- a/packages/ui-generator/package.descriptor.mjs
+++ b/packages/ui-generator/package.descriptor.mjs
@@ -40,22 +40,35 @@ export default Object.freeze({
       inputType: "text",
       defaultValue: "",
       promptLabel: "Placement target",
-      promptHint: "Optional target for placed-element placement (format: host:position, default: shell-layout:top-right)."
+      promptHint: "Semantic placement target for placed-element and outlet mapping (format: area.slot, default for placed-element: shell.status)."
+    },
+    owner: {
+      required: false,
+      inputType: "text",
+      defaultValue: "",
+      promptLabel: "Placement owner",
+      promptHint: "Optional owner id for semantic topology mappings. Page/settings placements default to the outlet host."
+    },
+    description: {
+      required: false,
+      inputType: "text",
+      defaultValue: "",
+      promptLabel: "Description",
+      promptHint: "Optional description for generated semantic topology mappings."
+    },
+    "link-renderer": {
+      required: false,
+      inputType: "text",
+      defaultValue: "local.main.ui.surface-aware-menu-link-item",
+      promptLabel: "Link renderer",
+      promptHint: "Default link renderer token for generated topology variants."
     },
     "link-placement": {
       required: false,
       inputType: "text",
       defaultValue: "",
       promptLabel: "Link placement",
-      promptHint: "Optional target for the generated page link placement (format: host:position)."
-    },
-    "link-component-token": {
-      required: false,
-      inputType: "text",
-      defaultValue: "",
-      promptLabel: "Link component token",
-      promptHint:
-        "Optional component token override for the generated page link placement (example: local.main.ui.tab-link-item)."
+      promptHint: "Optional semantic target for the generated page link placement (format: area.slot)."
     },
     "link-to": {
       required: false,
@@ -120,9 +133,9 @@ export default Object.freeze({
             descriptionKey: "page-target-file"
           }
         ],
-        optionNames: ["name", "link-placement", "link-component-token", "link-to", "force"],
+        optionNames: ["name", "link-placement", "link-to", "force"],
         notes: [
-          "If a nearest parent subpages target is found, placement, link component token, and props.to are inferred automatically.",
+          "If a nearest parent subpages target is found, semantic placement and props.to are inferred automatically.",
           "If the parent target page is index.vue, child pages belong under index/...",
           "If the target page file already exists, rerun with --force to overwrite it."
         ],
@@ -151,10 +164,10 @@ export default Object.freeze({
         entrypoint: "src/server/subcommands/element.js",
         export: "runGeneratorSubcommand",
         description: "Create a Vue component file under the chosen component directory (default: src/components) and add a placement entry that renders it.",
-        optionNames: ["name", "surface", "path", "placement", "force"],
+        optionNames: ["name", "surface", "path", "placement", "owner", "force"],
         requiredOptionNames: ["name"],
         notes: [
-          "If --placement is omitted, the placed element is added at shell-layout:top-right.",
+          "If --placement is omitted, the placed element is added at shell.status.",
           "If the placement target belongs to a page-owned outlet, JSKIT infers the surface automatically.",
           "If the target is shared and the app has multiple enabled surfaces, pass --surface explicitly.",
           "If the component file already exists, rerun with --force to overwrite it."
@@ -174,7 +187,7 @@ export default Object.freeze({
               "  --name \"Ops Panel\" \\",
               "  --surface admin \\",
               "  --path src/widgets \\",
-              "  --placement shell-layout:top-right \\",
+              "  --placement shell.status \\",
               "  --force"
             ]
           }
@@ -226,9 +239,9 @@ export default Object.freeze({
         export: "runGeneratorSubcommand",
         description: "Inject a generic ShellOutlet block into an existing Vue page/component.",
         longDescription: [
-          "A ShellOutlet creates a named placement target inside a Vue file. That target is what other parts of JSKIT render into later.",
-          "After an outlet exists, `jskit list-placements` will discover it and show its `target`. That makes the outlet visible to humans and to generators that need a placement destination.",
-          "Commands that create placed UI, such as `ui-generator placed-element`, and commands that add page links can then target that outlet by writing placement entries that point at the same target."
+          "A ShellOutlet creates a concrete placement recipient inside a Vue file.",
+          "The command also appends the semantic topology mapping for that outlet, so `jskit list-placements` exposes the public `area.slot` placement instead of leaving the concrete recipient unused.",
+          "Generated topology includes compact, medium, and expanded variants. By default all three point at the inserted outlet; hand-edit `src/placementTopology.js` if the adaptive layout uses different concrete outlets."
         ],
         positionalArgs: [
           {
@@ -237,10 +250,11 @@ export default Object.freeze({
             descriptionKey: "existing-vue-sfc-target-file"
           }
         ],
-        optionNames: ["target"],
-        requiredOptionNames: ["target"],
+        optionNames: ["target", "placement", "owner", "surface", "description", "link-renderer"],
+        requiredOptionNames: ["target", "placement"],
         notes: [
-          "Use --target host:position."
+          "Use --target host:position for the concrete outlet and --placement area.slot for the public semantic placement.",
+          "The generated topology maps compact, medium, and expanded to the new concrete outlet."
         ],
         examples: [
           {
@@ -248,7 +262,8 @@ export default Object.freeze({
             lines: [
               "npx jskit generate ui-generator outlet \\",
               "  src/components/ContactSummaryCard.vue \\",
-              "  --target contact-view:sub-pages"
+              "  --target contact-view:sub-pages \\",
+              "  --placement page.section-nav"
             ]
           },
           {
@@ -256,7 +271,9 @@ export default Object.freeze({
             lines: [
               "npx jskit generate ui-generator outlet \\",
               "  src/pages/admin/customers/[customerId]/index.vue \\",
-              "  --target customer-view:summary-actions"
+              "  --target customer-view:summary-actions \\",
+              "  --placement page.actions \\",
+              "  --surface admin"
             ]
           }
         ]

--- a/packages/ui-generator/package.descriptor.mjs
+++ b/packages/ui-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/ui-generator",
-  version: "0.1.48",
+  version: "0.1.49",
   kind: "generator",
   description: "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
   options: {
@@ -295,7 +295,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.80"
+        "@jskit-ai/users-web": "0.1.81"
       },
       dev: {}
     },

--- a/packages/ui-generator/package.json
+++ b/packages/ui-generator/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/ui-generator",
-  "version": "0.1.48",
+  "version": "0.1.49",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.65",
-    "@jskit-ai/shell-web": "0.1.64"
+    "@jskit-ai/kernel": "0.1.66",
+    "@jskit-ai/shell-web": "0.1.65"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/ui-generator/src/server/buildTemplateContext.js
+++ b/packages/ui-generator/src/server/buildTemplateContext.js
@@ -12,6 +12,13 @@ function resolveLinkToPropLine(linkTo = "") {
   return `      to: ${JSON.stringify(linkTo)},\n`;
 }
 
+function resolveOwnerLine(owner = "") {
+  if (!owner) {
+    return "";
+  }
+  return `    owner: ${JSON.stringify(owner)},\n`;
+}
+
 async function buildUiPageTemplateContext({
   appRoot,
   targetFile = "",
@@ -28,13 +35,13 @@ async function buildUiPageTemplateContext({
     targetFile,
     context: "ui-generator page",
     placement: options?.["link-placement"],
-    componentToken: options?.["link-component-token"],
     linkTo: options?.["link-to"]
   });
 
   return {
     __JSKIT_UI_LINK_PLACEMENT_ID__: pageTarget.placementId,
     __JSKIT_UI_LINK_PLACEMENT_TARGET__: String(linkTarget.placementTarget?.id || ""),
+    __JSKIT_UI_LINK_OWNER_LINE__: resolveOwnerLine(linkTarget.placementTarget?.owner || ""),
     __JSKIT_UI_LINK_COMPONENT_TOKEN__: String(linkTarget.componentToken || ""),
     __JSKIT_UI_LINK_ICON__: DEFAULT_GENERATED_LINK_ICON,
     __JSKIT_UI_LINK_WORKSPACE_SUFFIX__: pageTarget.routeUrlSuffix,

--- a/packages/ui-generator/src/server/subcommands/addSubpages.js
+++ b/packages/ui-generator/src/server/subcommands/addSubpages.js
@@ -1,3 +1,4 @@
+import { readFile, writeFile } from "node:fs/promises";
 import { normalizeText } from "@jskit-ai/kernel/shared/support/normalize";
 import {
   DEFAULT_COMPONENT_DIRECTORY,
@@ -7,10 +8,59 @@ import {
   upgradePageFileToSubpages
 } from "./pageSupport.js";
 import {
+  PLACEMENT_TOPOLOGY_FILE,
+  appendBlockIfMarkerMissing,
   requireSinglePositionalTargetFile,
+  resolvePathWithinApp,
   resolveOutletTargetId,
   rejectUnexpectedOptions
 } from "./support.js";
+
+function resolveOutletOwner(target = "") {
+  const normalizedTarget = normalizeText(target);
+  const separatorIndex = normalizedTarget.indexOf(":");
+  if (separatorIndex <= 0) {
+    return "";
+  }
+  return normalizedTarget.slice(0, separatorIndex);
+}
+
+function renderSectionNavTopologyBlock({
+  marker = "",
+  owner = "",
+  surface = "",
+  target = ""
+} = {}) {
+  return (
+    `// ${marker}\n` +
+    "addPlacementTopology({\n" +
+    `  id: "page.section-nav",\n` +
+    `  owner: "${owner}",\n` +
+    `  description: "Navigation between child pages in this section.",\n` +
+    `  surfaces: ["${surface}"],\n` +
+    "  variants: {\n" +
+    "    compact: {\n" +
+    `      outlet: "${target}",\n` +
+    "      renderers: {\n" +
+    `        link: "local.main.ui.surface-aware-menu-link-item"\n` +
+    "      }\n" +
+    "    },\n" +
+    "    medium: {\n" +
+    `      outlet: "${target}",\n` +
+    "      renderers: {\n" +
+    `        link: "local.main.ui.surface-aware-menu-link-item"\n` +
+    "      }\n" +
+    "    },\n" +
+    "    expanded: {\n" +
+    `      outlet: "${target}",\n` +
+    "      renderers: {\n" +
+    `        link: "local.main.ui.surface-aware-menu-link-item"\n` +
+    "      }\n" +
+    "    }\n" +
+    "  }\n" +
+    "});\n"
+  );
+}
 
 function resolveSubpagesOutletTarget(options = {}, pageTarget = {}) {
   const rawTarget = normalizeText(options?.target);
@@ -60,10 +110,35 @@ async function runGeneratorSubcommand({
     dryRun
   });
 
+  const topologyPath = resolvePathWithinApp(appRoot, PLACEMENT_TOPOLOGY_FILE, {
+    context: "ui-generator add-subpages"
+  });
+  const owner = resolveOutletOwner(outletTarget.id);
+  const topologyMarker = `jskit:ui-generator.topology:page.section-nav:${owner}`;
+  const topologySource = await readFile(topologyPath.absolutePath, "utf8");
+  const topologyApplied = appendBlockIfMarkerMissing(
+    topologySource,
+    topologyMarker,
+    renderSectionNavTopologyBlock({
+      marker: topologyMarker,
+      owner,
+      surface: result.surfaceId,
+      target: outletTarget.id
+    })
+  );
+  const touchedFiles = new Set(result.touchedFiles);
+  if (topologyApplied.changed) {
+    if (dryRun !== true) {
+      await writeFile(topologyPath.absolutePath, topologyApplied.content, "utf8");
+    }
+    touchedFiles.add(topologyPath.relativePath);
+  }
+  const touchedFileList = [...touchedFiles].sort((left, right) => left.localeCompare(right));
+
   return {
-    touchedFiles: result.touchedFiles,
+    touchedFiles: touchedFileList,
     summary:
-      result.touchedFiles.length > 0
+      touchedFileList.length > 0
         ? `Enabled subpages in ${result.targetFile} for "${pageTarget.routeUrlSuffix}" using outlet target "${outletTarget.id}".`
         : `Subpages are already enabled in ${result.targetFile}.`
   };

--- a/packages/ui-generator/src/server/subcommands/element.js
+++ b/packages/ui-generator/src/server/subcommands/element.js
@@ -3,7 +3,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import {
   listSurfacePageRoots,
   resolveBestSurfaceMatchFromPageFile,
-  resolveShellOutletPlacementTargetFromApp,
+  resolveSemanticPlacementTargetFromApp,
   toPosixPath
 } from "@jskit-ai/kernel/server/support";
 import { normalizeSurfaceId } from "@jskit-ai/kernel/shared/surface";
@@ -22,7 +22,7 @@ import {
   insertBeforeClassDeclaration
 } from "./support.js";
 
-const DEFAULT_ELEMENT_PLACEMENT = "shell-layout:top-right";
+const DEFAULT_ELEMENT_PLACEMENT = "shell.status";
 
 function renderElementComponentSource(elementName = "") {
   return `<template>
@@ -41,14 +41,28 @@ async function resolvePlacedElementSurface({
   context = "ui-generator placed-element"
 } = {}) {
   const explicitSurface = normalizeSurfaceId(surface);
+  const placementSurfaces = Array.isArray(placementTarget?.surfaces)
+    ? placementTarget.surfaces.map((entry) => normalizeSurfaceId(entry)).filter(Boolean)
+    : [];
+  const isPlacementGlobal = placementSurfaces.length < 1 || placementSurfaces.includes("*");
+  const concreteSourcePath = normalizeText(placementTarget?.sourcePath).startsWith("src/")
+    ? normalizeText(placementTarget?.sourcePath)
+    : "";
   const inferredSurfaceMatch = await resolveBestSurfaceMatchFromPageFile(
-    String(placementTarget?.sourcePath || ""),
+    concreteSourcePath,
     await listSurfacePageRoots(appRoot, { context }),
     { context }
   );
-  const inferredSurface = normalizeSurfaceId(inferredSurfaceMatch?.surfaceId);
+  const inferredSurface =
+    normalizeSurfaceId(inferredSurfaceMatch?.surfaceId) ||
+    (placementSurfaces.length === 1 && !isPlacementGlobal ? placementSurfaces[0] : "");
 
   if (explicitSurface) {
+    if (!isPlacementGlobal && placementSurfaces.length > 0 && !placementSurfaces.includes(explicitSurface)) {
+      throw new Error(
+        `${context} target "${normalizeText(placementTarget?.id) || "<unknown>"}" is not available on surface "${explicitSurface}".`
+      );
+    }
     if (inferredSurface && explicitSurface !== inferredSurface) {
       throw new Error(
         `${context} target "${normalizeText(placementTarget?.id) || "<unknown>"}" belongs to surface "${inferredSurface}", ` +
@@ -89,7 +103,7 @@ async function runGeneratorSubcommand({
   if (Array.isArray(args) && args.length > 0) {
     throw new Error("ui-generator placed-element does not accept positional arguments.");
   }
-  rejectUnexpectedOptions(options, ["name", "surface", "path", "placement", "force"], {
+  rejectUnexpectedOptions(options, ["name", "surface", "path", "placement", "owner", "force"], {
     context: "ui-generator placed-element"
   });
 
@@ -115,10 +129,11 @@ async function runGeneratorSubcommand({
     context: "ui-generator placed-element"
   });
   const componentToken = `local.main.ui.element.${elementNameKebab}`;
-  const placementTarget = await resolveShellOutletPlacementTargetFromApp({
+  const placementTarget = await resolveSemanticPlacementTargetFromApp({
     appRoot,
     context: "ui-generator",
-    placement: options?.placement || DEFAULT_ELEMENT_PLACEMENT
+    placement: options?.placement || DEFAULT_ELEMENT_PLACEMENT,
+    owner: options?.owner
   });
   const surface = await resolvePlacedElementSurface({
     appRoot,
@@ -179,12 +194,15 @@ async function runGeneratorSubcommand({
 
   const placementSource = await readFile(placementPath.absolutePath, "utf8");
   const placementMarker = `jskit:ui-generator.element:${surface}:${elementNameKebab}`;
+  const ownerLine = placementTarget.owner ? `    owner: "${placementTarget.owner}",\n` : "";
   const placementBlock =
     `// ${placementMarker}\n` +
     "{\n" +
     "  addPlacement({\n" +
     `    id: "ui-generator.element.${elementNameKebab}",\n` +
     `    target: "${placementTarget.id}",\n` +
+    ownerLine +
+    `    kind: "component",\n` +
     `    surfaces: ["${surface}"],\n` +
     "    order: 155,\n" +
     `    componentToken: "${componentToken}"\n` +

--- a/packages/ui-generator/src/server/subcommands/outlet.js
+++ b/packages/ui-generator/src/server/subcommands/outlet.js
@@ -1,6 +1,13 @@
 import { readFile, writeFile } from "node:fs/promises";
 import { normalizeText } from "@jskit-ai/kernel/shared/support/normalize";
 import {
+  normalizePlacementOwnerId,
+  normalizePlacementSurfaceId,
+  normalizeSemanticPlacementId
+} from "@jskit-ai/kernel/shared/support/shellLayoutTargets";
+import {
+  PLACEMENT_TOPOLOGY_FILE,
+  appendBlockIfMarkerMissing,
   requireSinglePositionalTargetFile,
   rejectUnexpectedOptions,
   resolveOutletTargetId,
@@ -75,6 +82,96 @@ function createOutletBlock({ target = "" } = {}) {
   return `<ShellOutlet target="${target}" />`;
 }
 
+function resolveOutletOwner(target = "") {
+  const normalizedTarget = normalizeText(target);
+  const separatorIndex = normalizedTarget.indexOf(":");
+  if (separatorIndex <= 0) {
+    return "";
+  }
+  return normalizedTarget.slice(0, separatorIndex);
+}
+
+function resolveSemanticPlacementOption(options = {}) {
+  const placementId = normalizeSemanticPlacementId(options?.placement);
+  if (!placementId) {
+    throw new Error('ui-generator outlet requires --placement in semantic "area.slot" format.');
+  }
+  return placementId;
+}
+
+function resolveSemanticPlacementOwner({ placementId = "", targetId = "", owner = "" } = {}) {
+  const explicitOwner = normalizePlacementOwnerId(owner);
+  if (explicitOwner) {
+    return explicitOwner;
+  }
+  if (placementId.startsWith("page.") || placementId.startsWith("settings.")) {
+    return resolveOutletOwner(targetId);
+  }
+  return "";
+}
+
+function resolveTopologySurfaces(options = {}) {
+  const surface = normalizePlacementSurfaceId(options?.surface);
+  if (surface) {
+    return [surface];
+  }
+  return ["*"];
+}
+
+function renderTopologyOwnerLine(owner = "") {
+  if (!owner) {
+    return "";
+  }
+  return `  owner: "${owner}",\n`;
+}
+
+function renderLinkRendererBlock(rendererToken = "") {
+  const normalizedRendererToken = normalizeText(rendererToken) || "local.main.ui.surface-aware-menu-link-item";
+  return (
+    "      renderers: {\n" +
+    `        link: "${normalizedRendererToken}"\n` +
+    "      }\n"
+  );
+}
+
+function renderOutletTopologyBlock({
+  marker = "",
+  placementId = "",
+  owner = "",
+  surfaces = ["*"],
+  description = "",
+  target = "",
+  rendererToken = ""
+} = {}) {
+  const descriptionLine = normalizeText(description)
+    ? `  description: ${JSON.stringify(normalizeText(description))},\n`
+    : "";
+  const rendererBlock = renderLinkRendererBlock(rendererToken);
+  return (
+    `// ${marker}\n` +
+    "addPlacementTopology({\n" +
+    `  id: "${placementId}",\n` +
+    renderTopologyOwnerLine(owner) +
+    descriptionLine +
+    `  surfaces: ${JSON.stringify(surfaces)},\n` +
+    "  variants: {\n" +
+    "    compact: {\n" +
+    `      outlet: "${target}",\n` +
+    rendererBlock +
+    "    },\n" +
+    "    medium: {\n" +
+    `      outlet: "${target}",\n` +
+    rendererBlock +
+    "    },\n" +
+    "    expanded: {\n" +
+    `      outlet: "${target}",\n` +
+    rendererBlock +
+    "    }\n" +
+    "  }\n" +
+    "});\n"
+  );
+}
+
 function findLastTemplateCloseTag(source = "") {
   const sourceText = String(source || "");
   let lastMatch = null;
@@ -123,7 +220,7 @@ async function runGeneratorSubcommand({
     throw new Error(`Unsupported ui-generator subcommand: ${normalizedSubcommand || "<empty>"}.`);
   }
   const targetFile = requireSinglePositionalTargetFile(args, { context: "ui-generator outlet" });
-  rejectUnexpectedOptions(options, ["target"], {
+  rejectUnexpectedOptions(options, ["target", "placement", "owner", "surface", "description", "link-renderer"], {
     context: "ui-generator outlet"
   });
 
@@ -132,6 +229,13 @@ async function runGeneratorSubcommand({
     optionName: "target"
   });
   const targetId = outletTarget.id;
+  const placementId = resolveSemanticPlacementOption(options);
+  const owner = resolveSemanticPlacementOwner({
+    placementId,
+    targetId,
+    owner: options?.owner
+  });
+  const surfaces = resolveTopologySurfaces(options);
 
   const targetFilePath = resolvePathWithinApp(appRoot, targetFile, {
     context: "ui-generator outlet"
@@ -162,11 +266,41 @@ async function runGeneratorSubcommand({
     await writeFile(targetFilePath.absolutePath, scriptApplied.content, "utf8");
   }
 
+  const topologyPath = resolvePathWithinApp(appRoot, PLACEMENT_TOPOLOGY_FILE, {
+    context: "ui-generator outlet"
+  });
+  const topologyMarker = `jskit:ui-generator.topology:${placementId}:${owner || "global"}`;
+  const topologySource = await readFile(topologyPath.absolutePath, "utf8");
+  const topologyApplied = appendBlockIfMarkerMissing(
+    topologySource,
+    topologyMarker,
+    renderOutletTopologyBlock({
+      marker: topologyMarker,
+      placementId,
+      owner,
+      surfaces,
+      description: options?.description,
+      target: targetId,
+      rendererToken: options?.["link-renderer"]
+    })
+  );
+  if (topologyApplied.changed && dryRun !== true) {
+    await writeFile(topologyPath.absolutePath, topologyApplied.content, "utf8");
+  }
+
+  const touchedFiles = new Set();
+  if (changed) {
+    touchedFiles.add(targetFilePath.relativePath);
+  }
+  if (topologyApplied.changed) {
+    touchedFiles.add(topologyPath.relativePath);
+  }
+
   return {
-    touchedFiles: changed ? [targetFilePath.relativePath] : [],
-    summary: changed
-      ? `Injected outlet "${targetId}" into ${targetFilePath.relativePath}.`
-      : `Outlet "${targetId}" is already present in ${targetFilePath.relativePath}.`
+    touchedFiles: [...touchedFiles].sort((left, right) => left.localeCompare(right)),
+    summary: touchedFiles.size > 0
+      ? `Injected outlet "${targetId}" and mapped semantic placement "${placementId}"${owner ? ` for owner "${owner}"` : ""}.`
+      : `Outlet "${targetId}" and semantic placement "${placementId}" are already present.`
   };
 }
 

--- a/packages/ui-generator/src/server/subcommands/page.js
+++ b/packages/ui-generator/src/server/subcommands/page.js
@@ -20,15 +20,20 @@ function renderPageLinkPlacementBlock({
   label = "",
   surface = ""
 } = {}) {
+  const componentTokenLine = context.__JSKIT_UI_LINK_COMPONENT_TOKEN__
+    ? `    componentToken: "${context.__JSKIT_UI_LINK_COMPONENT_TOKEN__}",\n`
+    : "";
   return (
     `// ${marker}\n` +
     "{\n" +
     "  addPlacement({\n" +
     `    id: "${context.__JSKIT_UI_LINK_PLACEMENT_ID__}",\n` +
     `    target: "${context.__JSKIT_UI_LINK_PLACEMENT_TARGET__}",\n` +
+    `${context.__JSKIT_UI_LINK_OWNER_LINE__}` +
+    `    kind: "link",\n` +
     `    surfaces: ["${surface}"],\n` +
     "    order: 155,\n" +
-    `    componentToken: "${context.__JSKIT_UI_LINK_COMPONENT_TOKEN__}",\n` +
+    componentTokenLine +
     "    props: {\n" +
     `      label: "${label}",\n` +
     `      icon: "${context.__JSKIT_UI_LINK_ICON__}",\n` +
@@ -56,7 +61,7 @@ async function runGeneratorSubcommand({
   const targetFile = requireSinglePositionalTargetFile(args, { context: "ui-generator page" });
   rejectUnexpectedOptions(
     options,
-    ["name", "link-placement", "link-component-token", "link-to", "force"],
+    ["name", "link-placement", "link-to", "force"],
     { context: "ui-generator page" }
   );
 

--- a/packages/ui-generator/src/server/subcommands/pageSupport.js
+++ b/packages/ui-generator/src/server/subcommands/pageSupport.js
@@ -313,7 +313,7 @@ function renderSubpagesTemplate({
     "<template>",
     renderSectionContainerOpenTag({ title, subtitle }),
     "    <template #tabs>",
-    `      <ShellOutlet target="${normalizedTarget}" default-link-component-token="${SUBPAGES_LINK_COMPONENT_TOKEN}" />`,
+    `      <ShellOutlet target="${normalizedTarget}" />`,
     "    </template>"
   ];
 

--- a/packages/ui-generator/src/server/subcommands/support.js
+++ b/packages/ui-generator/src/server/subcommands/support.js
@@ -10,6 +10,7 @@ import { toCamelCase, toSnakeCase } from "@jskit-ai/kernel/shared/support/string
 const DEFAULT_COMPONENT_DIRECTORY = "src/components";
 const MAIN_CLIENT_PROVIDER_FILE = "packages/main/src/client/providers/MainClientProvider.js";
 const PLACEMENT_FILE = "src/placement.js";
+const PLACEMENT_TOPOLOGY_FILE = "src/placementTopology.js";
 const SCRIPT_TAG_PATTERN = /<script\b([^>]*)>([\s\S]*?)<\/script>/gi;
 const SCRIPT_SETUP_ATTRIBUTE_PATTERN = /\bsetup\b/i;
 const ATTRIBUTE_PATTERN = /([:@]?[A-Za-z_][A-Za-z0-9_-]*)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'))?/g;
@@ -266,6 +267,7 @@ export {
   DEFAULT_COMPONENT_DIRECTORY,
   MAIN_CLIENT_PROVIDER_FILE,
   PLACEMENT_FILE,
+  PLACEMENT_TOPOLOGY_FILE,
   toKebabCase,
   toPascalCase,
   requireOption,

--- a/packages/ui-generator/test/addSubpagesSubcommand.test.js
+++ b/packages/ui-generator/test/addSubpagesSubcommand.test.js
@@ -43,6 +43,22 @@ export default function getPlacements() {
     "utf8"
   );
   await writeFile(
+    path.join(appRoot, "src", "placementTopology.js"),
+    `const placements = [];
+
+function addPlacementTopology(value = {}) {
+  placements.push(value);
+}
+
+export { addPlacementTopology };
+
+export default function getPlacementTopology() {
+  return { placements };
+}
+`,
+    "utf8"
+  );
+  await writeFile(
     path.join(appRoot, "packages", "main", "src", "client", "providers", "MainClientProvider.js"),
     `const mainClientComponents = [];
 
@@ -99,14 +115,21 @@ test("ui-generator add-subpages derives the default target from an index-route p
       "packages/main/src/client/providers/MainClientProvider.js",
       "src/components/menus/SurfaceAwareMenuLinkItem.vue",
       "src/components/SectionContainerShell.vue",
-      `src/pages/${targetFile}`
+      `src/pages/${targetFile}`,
+      "src/placementTopology.js"
     ]);
 
     const pageSource = await readPageFile(appRoot, targetFile);
     assert.match(
       pageSource,
-      /<ShellOutlet target="practice:sub-pages" default-link-component-token="local\.main\.ui\.surface-aware-menu-link-item" \/>/
+      /<ShellOutlet target="practice:sub-pages" \/>/
     );
+    const topologySource = await readFile(path.join(appRoot, "src", "placementTopology.js"), "utf8");
+    assert.match(topologySource, /id: "page\.section-nav"/);
+    assert.match(topologySource, /owner: "practice"/);
+    assert.match(topologySource, /compact: \{/);
+    assert.match(topologySource, /medium: \{/);
+    assert.match(topologySource, /expanded: \{/);
     assert.match(pageSource, /<RouterView \/>/);
     assert.equal(
       await readFile(path.join(appRoot, "src", "components", "menus", "SurfaceAwareMenuLinkItem.vue"), "utf8"),
@@ -132,7 +155,7 @@ test("ui-generator add-subpages derives the default target from a dynamic file-r
     const pageSource = await readPageFile(appRoot, targetFile);
     assert.match(
       pageSource,
-      /<ShellOutlet target="contacts-contact-id:sub-pages" default-link-component-token="local\.main\.ui\.surface-aware-menu-link-item" \/>/
+      /<ShellOutlet target="contacts-contact-id:sub-pages" \/>/
     );
   });
 });
@@ -154,7 +177,7 @@ test("ui-generator add-subpages derives the default target from a nested route p
     const pageSource = await readPageFile(appRoot, targetFile);
     assert.match(
       pageSource,
-      /<ShellOutlet target="catalog-products:sub-pages" default-link-component-token="local\.main\.ui\.surface-aware-menu-link-item" \/>/
+      /<ShellOutlet target="catalog-products:sub-pages" \/>/
     );
   });
 });
@@ -199,7 +222,7 @@ test("ui-generator add-subpages supports explicit target host:position", async (
     const pageSource = await readPageFile(appRoot, targetFile);
     assert.match(
       pageSource,
-      /<ShellOutlet target="practice-hub:secondary-tabs" default-link-component-token="local\.main\.ui\.surface-aware-menu-link-item" \/>/
+      /<ShellOutlet target="practice-hub:secondary-tabs" \/>/
     );
   });
 });
@@ -235,7 +258,8 @@ test("ui-generator add-subpages does not rewrite existing scaffold support compo
 
     assert.deepEqual(result.touchedFiles, [
       "packages/main/src/client/providers/MainClientProvider.js",
-      `src/pages/${targetFile}`
+      `src/pages/${targetFile}`,
+      "src/placementTopology.js"
     ]);
     assert.equal(
       await readFile(path.join(appRoot, "src", "components", "SectionContainerShell.vue"), "utf8"),
@@ -332,7 +356,7 @@ test("ui-generator add-subpages accepts target files with a src/pages prefix", a
     const pageSource = await readFile(path.join(appRoot, targetFile), "utf8");
     assert.match(
       pageSource,
-      /<ShellOutlet target="practice:sub-pages" default-link-component-token="local\.main\.ui\.surface-aware-menu-link-item" \/>/
+      /<ShellOutlet target="practice:sub-pages" \/>/
     );
     assert.match(pageSource, /<RouterView \/>/);
   });

--- a/packages/ui-generator/test/buildTemplateContext.test.js
+++ b/packages/ui-generator/test/buildTemplateContext.test.js
@@ -35,10 +35,71 @@ async function writeShellLayout(appRoot, source = "") {
     <ShellOutlet
       target="shell-layout:primary-menu"
       default
-      default-link-component-token="local.main.ui.surface-aware-menu-link-item"
     />
   </div>
 </template>
+`
+  );
+  await writePlacementTopology(appRoot);
+}
+
+function renderTopologyVariant(outlet, { linkRenderer = "" } = {}) {
+  const rendererLines = linkRenderer
+    ? `,
+      renderers: {
+        link: "${linkRenderer}"
+      }`
+    : "";
+  return `{
+      outlet: "${outlet}"${rendererLines}
+    }`;
+}
+
+function renderTopologyEntry({
+  id = "",
+  owner = "",
+  surfaces = ["*"],
+  defaultPlacement = false,
+  outlet = "",
+  linkRenderer = ""
+} = {}) {
+  const ownerLine = owner ? `    owner: "${owner}",\n` : "";
+  const defaultLine = defaultPlacement ? "    default: true,\n" : "";
+  return `  {
+    id: "${id}",
+${ownerLine}    surfaces: ${JSON.stringify(surfaces)},
+${defaultLine}    variants: {
+      compact: ${renderTopologyVariant(outlet, { linkRenderer })},
+      medium: ${renderTopologyVariant(outlet, { linkRenderer })},
+      expanded: ${renderTopologyVariant(outlet, { linkRenderer })}
+    }
+  }`;
+}
+
+async function writePlacementTopology(appRoot, entries = []) {
+  const defaultEntries = [
+    renderTopologyEntry({
+      id: "shell.primary-nav",
+      surfaces: ["*"],
+      defaultPlacement: true,
+      outlet: "shell-layout:primary-menu",
+      linkRenderer: "local.main.ui.surface-aware-menu-link-item"
+    }),
+    renderTopologyEntry({
+      id: "shell.status",
+      surfaces: ["*"],
+      outlet: "shell-layout:top-right",
+      linkRenderer: "local.main.ui.surface-aware-menu-link-item"
+    })
+  ];
+  await writeFileInApp(
+    appRoot,
+    "src/placementTopology.js",
+    `export default {
+  placements: [
+${[...defaultEntries, ...entries].join(",\n")}
+  ]
+};
 `
   );
 }
@@ -61,8 +122,9 @@ test("buildUiPageTemplateContext resolves link placement from default app ShellO
       targetFile: "admin/reports/index.vue",
       options: {}
     });
-    assert.equal(context.__JSKIT_UI_LINK_PLACEMENT_TARGET__, "shell-layout:primary-menu");
-    assert.equal(context.__JSKIT_UI_LINK_COMPONENT_TOKEN__, "local.main.ui.surface-aware-menu-link-item");
+    assert.equal(context.__JSKIT_UI_LINK_PLACEMENT_TARGET__, "shell.primary-nav");
+    assert.equal(context.__JSKIT_UI_LINK_OWNER_LINE__, "");
+    assert.equal(context.__JSKIT_UI_LINK_COMPONENT_TOKEN__, "");
     assert.equal(context.__JSKIT_UI_LINK_WORKSPACE_SUFFIX__, "/reports");
     assert.equal(context.__JSKIT_UI_LINK_NON_WORKSPACE_SUFFIX__, "/reports");
     assert.equal(context.__JSKIT_UI_LINK_WHEN_LINE__, "");
@@ -116,15 +178,15 @@ test("buildUiPageTemplateContext supports explicit link placement override", asy
       appRoot,
       targetFile: "admin/reports/index.vue",
       options: {
-        "link-placement": "shell-layout:top-right"
+        "link-placement": "shell.status"
       }
     });
-    assert.equal(context.__JSKIT_UI_LINK_PLACEMENT_TARGET__, "shell-layout:top-right");
-    assert.equal(context.__JSKIT_UI_LINK_COMPONENT_TOKEN__, "local.main.ui.surface-aware-menu-link-item");
+    assert.equal(context.__JSKIT_UI_LINK_PLACEMENT_TARGET__, "shell.status");
+    assert.equal(context.__JSKIT_UI_LINK_COMPONENT_TOKEN__, "");
   });
 });
 
-test("buildUiPageTemplateContext supports explicit package outlet link placement", async () => {
+test("buildUiPageTemplateContext supports explicit package semantic link placement", async () => {
   await withTempApp(async (appRoot) => {
     await writeConfig(
       appRoot,
@@ -136,6 +198,22 @@ test("buildUiPageTemplateContext supports explicit package outlet link placement
 `
     );
     await writeShellLayout(appRoot);
+    await writePlacementTopology(appRoot, [
+      renderTopologyEntry({
+        id: "page.section-nav",
+        owner: "catalog",
+        surfaces: ["admin"],
+        outlet: "catalog:sub-pages",
+        linkRenderer: "local.main.ui.surface-aware-menu-link-item"
+      }),
+      renderTopologyEntry({
+        id: "page.section-nav",
+        owner: "catalog-products",
+        surfaces: ["admin"],
+        outlet: "catalog-products:sub-pages",
+        linkRenderer: "local.main.ui.surface-aware-menu-link-item"
+      })
+    ]);
     await writeFileInApp(
       appRoot,
       ".jskit/lock.json",
@@ -164,13 +242,34 @@ test("buildUiPageTemplateContext supports explicit package outlet link placement
   metadata: {
     ui: {
       placements: {
-        outlets: [
+        topology: {
+          placements: [
           {
-            target: "admin-cog:primary-menu",
-            defaultLinkComponentToken: "local.main.ui.surface-aware-menu-link-item",
-            source: "src/client/components/UsersWorkspaceToolsWidget.vue"
+            id: "admin.tools-menu",
+            surfaces: ["admin"],
+            variants: {
+              compact: {
+                outlet: "admin-cog:primary-menu",
+                renderers: {
+                  link: "local.main.ui.surface-aware-menu-link-item"
+                }
+              },
+              medium: {
+                outlet: "admin-cog:primary-menu",
+                renderers: {
+                  link: "local.main.ui.surface-aware-menu-link-item"
+                }
+              },
+              expanded: {
+                outlet: "admin-cog:primary-menu",
+                renderers: {
+                  link: "local.main.ui.surface-aware-menu-link-item"
+                }
+              }
+            }
           }
         ]
+        }
       }
     }
   }
@@ -182,10 +281,10 @@ test("buildUiPageTemplateContext supports explicit package outlet link placement
       appRoot,
       targetFile: "admin/reports/index.vue",
       options: {
-        "link-placement": "admin-cog:primary-menu"
+        "link-placement": "admin.tools-menu"
       }
     });
-    assert.equal(context.__JSKIT_UI_LINK_PLACEMENT_TARGET__, "admin-cog:primary-menu");
+    assert.equal(context.__JSKIT_UI_LINK_PLACEMENT_TARGET__, "admin.tools-menu");
   });
 });
 
@@ -200,15 +299,21 @@ test("buildUiPageTemplateContext suppresses inferred relative link-to for surfac
 };
 `
     );
+    await writePlacementTopology(appRoot, [
+      renderTopologyEntry({
+        id: "page.section-nav",
+        owner: "home-settings",
+        surfaces: ["home"],
+        outlet: "home-settings:primary-menu",
+        linkRenderer: "local.main.ui.surface-aware-menu-link-item"
+      })
+    ]);
     await writeFileInApp(
       appRoot,
       "src/pages/home/settings.vue",
       `<template>
   <section>
-    <ShellOutlet
-      target="home-settings:primary-menu"
-      default-link-component-token="local.main.ui.surface-aware-menu-link-item"
-    />
+    <ShellOutlet target="home-settings:primary-menu" />
     <RouterView />
   </section>
 </template>
@@ -221,13 +326,14 @@ test("buildUiPageTemplateContext suppresses inferred relative link-to for surfac
       options: {}
     });
 
-    assert.equal(context.__JSKIT_UI_LINK_PLACEMENT_TARGET__, "home-settings:primary-menu");
-    assert.equal(context.__JSKIT_UI_LINK_COMPONENT_TOKEN__, "local.main.ui.surface-aware-menu-link-item");
+    assert.equal(context.__JSKIT_UI_LINK_PLACEMENT_TARGET__, "page.section-nav");
+    assert.equal(context.__JSKIT_UI_LINK_OWNER_LINE__, "    owner: \"home-settings\",\n");
+    assert.equal(context.__JSKIT_UI_LINK_COMPONENT_TOKEN__, "");
     assert.equal(context.__JSKIT_UI_LINK_TO_PROP_LINE__, "");
   });
 });
 
-test("buildUiPageTemplateContext supports explicit link component token and link-to", async () => {
+test("buildUiPageTemplateContext supports explicit semantic placement and link-to", async () => {
   await withTempApp(async (appRoot) => {
     await writeConfig(
       appRoot,
@@ -244,12 +350,12 @@ test("buildUiPageTemplateContext supports explicit link component token and link
       appRoot,
       targetFile: "admin/contacts/[contactId]/index/notes/index.vue",
       options: {
-        "link-placement": "shell-layout:top-right",
-        "link-component-token": "local.main.ui.tab-link-item",
+        "link-placement": "shell.status",
         "link-to": "./notes"
       }
     });
-    assert.equal(context.__JSKIT_UI_LINK_COMPONENT_TOKEN__, "local.main.ui.tab-link-item");
+    assert.equal(context.__JSKIT_UI_LINK_PLACEMENT_TARGET__, "shell.status");
+    assert.equal(context.__JSKIT_UI_LINK_COMPONENT_TOKEN__, "");
     assert.equal(context.__JSKIT_UI_LINK_ICON__, "mdi-view-list-outline");
     assert.equal(context.__JSKIT_UI_LINK_WORKSPACE_SUFFIX__, "/contacts/[contactId]/notes");
     assert.equal(context.__JSKIT_UI_LINK_NON_WORKSPACE_SUFFIX__, "/contacts/[contactId]/notes");
@@ -294,6 +400,15 @@ test("buildUiPageTemplateContext infers subpage link placement, tab token, and l
 `
     );
     await writeShellLayout(appRoot);
+    await writePlacementTopology(appRoot, [
+      renderTopologyEntry({
+        id: "page.section-nav",
+        owner: "contact-view",
+        surfaces: ["admin"],
+        outlet: "contact-view:sub-pages",
+        linkRenderer: "local.main.ui.surface-aware-menu-link-item"
+      })
+    ]);
     await writeFileInApp(
       appRoot,
       "src/pages/admin/contacts/[contactId].vue",
@@ -314,8 +429,9 @@ test("buildUiPageTemplateContext infers subpage link placement, tab token, and l
       options: {}
     });
 
-    assert.equal(context.__JSKIT_UI_LINK_PLACEMENT_TARGET__, "contact-view:sub-pages");
-    assert.equal(context.__JSKIT_UI_LINK_COMPONENT_TOKEN__, "local.main.ui.surface-aware-menu-link-item");
+    assert.equal(context.__JSKIT_UI_LINK_PLACEMENT_TARGET__, "page.section-nav");
+    assert.equal(context.__JSKIT_UI_LINK_OWNER_LINE__, "    owner: \"contact-view\",\n");
+    assert.equal(context.__JSKIT_UI_LINK_COMPONENT_TOKEN__, "");
     assert.equal(context.__JSKIT_UI_LINK_ICON__, "mdi-view-list-outline");
     assert.equal(context.__JSKIT_UI_LINK_TO_PROP_LINE__, "      to: \"./notes\",\n");
   });
@@ -333,6 +449,15 @@ test("buildUiPageTemplateContext inherits a file-route parent host for deeper de
 `
     );
     await writeShellLayout(appRoot);
+    await writePlacementTopology(appRoot, [
+      renderTopologyEntry({
+        id: "page.section-nav",
+        owner: "contact-view",
+        surfaces: ["admin"],
+        outlet: "contact-view:sub-pages",
+        linkRenderer: "local.main.ui.surface-aware-menu-link-item"
+      })
+    ]);
     await writeFileInApp(
       appRoot,
       "src/pages/admin/contacts/[contactId].vue",
@@ -353,8 +478,8 @@ test("buildUiPageTemplateContext inherits a file-route parent host for deeper de
       options: {}
     });
 
-    assert.equal(context.__JSKIT_UI_LINK_PLACEMENT_TARGET__, "contact-view:sub-pages");
-    assert.equal(context.__JSKIT_UI_LINK_COMPONENT_TOKEN__, "local.main.ui.surface-aware-menu-link-item");
+    assert.equal(context.__JSKIT_UI_LINK_PLACEMENT_TARGET__, "page.section-nav");
+    assert.equal(context.__JSKIT_UI_LINK_COMPONENT_TOKEN__, "");
     assert.equal(context.__JSKIT_UI_LINK_TO_PROP_LINE__, "      to: \"./notes/history\",\n");
   });
 });
@@ -371,6 +496,15 @@ test("buildUiPageTemplateContext infers subpage link placement from an index-rou
 `
     );
     await writeShellLayout(appRoot);
+    await writePlacementTopology(appRoot, [
+      renderTopologyEntry({
+        id: "page.section-nav",
+        owner: "catalog",
+        surfaces: ["admin"],
+        outlet: "catalog:sub-pages",
+        linkRenderer: "local.main.ui.surface-aware-menu-link-item"
+      })
+    ]);
     await writeFileInApp(
       appRoot,
       "src/pages/admin/catalog/index.vue",
@@ -391,8 +525,9 @@ test("buildUiPageTemplateContext infers subpage link placement from an index-rou
       options: {}
     });
 
-    assert.equal(context.__JSKIT_UI_LINK_PLACEMENT_TARGET__, "catalog:sub-pages");
-    assert.equal(context.__JSKIT_UI_LINK_COMPONENT_TOKEN__, "local.main.ui.surface-aware-menu-link-item");
+    assert.equal(context.__JSKIT_UI_LINK_PLACEMENT_TARGET__, "page.section-nav");
+    assert.equal(context.__JSKIT_UI_LINK_OWNER_LINE__, "    owner: \"catalog\",\n");
+    assert.equal(context.__JSKIT_UI_LINK_COMPONENT_TOKEN__, "");
     assert.equal(context.__JSKIT_UI_LINK_ICON__, "mdi-view-list-outline");
     assert.equal(context.__JSKIT_UI_LINK_TO_PROP_LINE__, "      to: \"./products\",\n");
   });
@@ -410,6 +545,22 @@ test("buildUiPageTemplateContext finds the nearest index-route parent host", asy
 `
     );
     await writeShellLayout(appRoot);
+    await writePlacementTopology(appRoot, [
+      renderTopologyEntry({
+        id: "page.section-nav",
+        owner: "catalog",
+        surfaces: ["admin"],
+        outlet: "catalog:sub-pages",
+        linkRenderer: "local.main.ui.surface-aware-menu-link-item"
+      }),
+      renderTopologyEntry({
+        id: "page.section-nav",
+        owner: "catalog-products",
+        surfaces: ["admin"],
+        outlet: "catalog-products:sub-pages",
+        linkRenderer: "local.main.ui.surface-aware-menu-link-item"
+      })
+    ]);
     await writeFileInApp(
       appRoot,
       "src/pages/admin/catalog/index.vue",
@@ -443,8 +594,9 @@ test("buildUiPageTemplateContext finds the nearest index-route parent host", asy
       options: {}
     });
 
-    assert.equal(context.__JSKIT_UI_LINK_PLACEMENT_TARGET__, "catalog-products:sub-pages");
-    assert.equal(context.__JSKIT_UI_LINK_COMPONENT_TOKEN__, "local.main.ui.surface-aware-menu-link-item");
+    assert.equal(context.__JSKIT_UI_LINK_PLACEMENT_TARGET__, "page.section-nav");
+    assert.equal(context.__JSKIT_UI_LINK_OWNER_LINE__, "    owner: \"catalog-products\",\n");
+    assert.equal(context.__JSKIT_UI_LINK_COMPONENT_TOKEN__, "");
     assert.equal(context.__JSKIT_UI_LINK_TO_PROP_LINE__, "      to: \"./variants\",\n");
   });
 });
@@ -461,6 +613,15 @@ test("buildUiPageTemplateContext infers subpage link placement from an index rou
 `
     );
     await writeShellLayout(appRoot);
+    await writePlacementTopology(appRoot, [
+      renderTopologyEntry({
+        id: "page.section-nav",
+        owner: "customer-view",
+        surfaces: ["admin"],
+        outlet: "customer-view:sub-pages",
+        linkRenderer: "local.main.ui.surface-aware-menu-link-item"
+      })
+    ]);
     await writeFileInApp(
       appRoot,
       "src/pages/admin/customers/[customerId]/index.vue",
@@ -481,8 +642,9 @@ test("buildUiPageTemplateContext infers subpage link placement from an index rou
       options: {}
     });
 
-    assert.equal(context.__JSKIT_UI_LINK_PLACEMENT_TARGET__, "customer-view:sub-pages");
-    assert.equal(context.__JSKIT_UI_LINK_COMPONENT_TOKEN__, "local.main.ui.surface-aware-menu-link-item");
+    assert.equal(context.__JSKIT_UI_LINK_PLACEMENT_TARGET__, "page.section-nav");
+    assert.equal(context.__JSKIT_UI_LINK_OWNER_LINE__, "    owner: \"customer-view\",\n");
+    assert.equal(context.__JSKIT_UI_LINK_COMPONENT_TOKEN__, "");
     assert.equal(context.__JSKIT_UI_LINK_TO_PROP_LINE__, "      to: \"./pets\",\n");
     assert.equal(context.__JSKIT_UI_LINK_WORKSPACE_SUFFIX__, "/customers/[customerId]/pets");
   });
@@ -641,7 +803,7 @@ test("buildUiPageTemplateContext validates link placement format", async () => {
             "link-placement": "invalid-placement"
           }
         }),
-      /option "placement" must be a target in "host:position" format/
+      /option "placement" must be a semantic target in "area.slot" format/
     );
   });
 });

--- a/packages/ui-generator/test/elementSubcommand.test.js
+++ b/packages/ui-generator/test/elementSubcommand.test.js
@@ -14,6 +14,39 @@ async function withTempApp(run) {
   }
 }
 
+function renderTopologyEntry({
+  id = "",
+  owner = "",
+  surfaces = ["*"],
+  defaultPlacement = false,
+  outlet = "",
+  linkRenderer = ""
+} = {}) {
+  const ownerLine = owner ? `    owner: "${owner}",\n` : "";
+  const defaultLine = defaultPlacement ? "    default: true,\n" : "";
+  const rendererLines = linkRenderer
+    ? `,
+      renderers: {
+        link: "${linkRenderer}"
+      }`
+    : "";
+  return `  {
+    id: "${id}",
+${ownerLine}    surfaces: ${JSON.stringify(surfaces)},
+${defaultLine}    variants: {
+      compact: {
+        outlet: "${outlet}"${rendererLines}
+      },
+      medium: {
+        outlet: "${outlet}"${rendererLines}
+      },
+      expanded: {
+        outlet: "${outlet}"${rendererLines}
+      }
+    }
+  }`;
+}
+
 async function writeAppFixture(appRoot) {
   await mkdir(path.join(appRoot, "config"), { recursive: true });
   await mkdir(path.join(appRoot, "src", "components"), { recursive: true });
@@ -43,11 +76,39 @@ async function writeAppFixture(appRoot) {
     <ShellOutlet
       target="shell-layout:primary-menu"
       default
-      default-link-component-token="local.main.ui.surface-aware-menu-link-item"
     />
     <ShellOutlet target="shell-layout:top-right" />
   </div>
 </template>
+`,
+    "utf8"
+  );
+  await writeFile(
+    path.join(appRoot, "src", "placementTopology.js"),
+    `export default {
+  placements: [
+${[
+  renderTopologyEntry({
+    id: "shell.primary-nav",
+    surfaces: ["*"],
+    defaultPlacement: true,
+    outlet: "shell-layout:primary-menu",
+    linkRenderer: "local.main.ui.surface-aware-menu-link-item"
+  }),
+  renderTopologyEntry({
+    id: "shell.status",
+    surfaces: ["*"],
+    outlet: "shell-layout:top-right"
+  }),
+  renderTopologyEntry({
+    id: "settings.sections",
+    owner: "admin-settings",
+    surfaces: ["admin"],
+    outlet: "admin-settings:forms"
+  })
+].join(",\n")}
+  ]
+};
 `,
     "utf8"
   );
@@ -116,7 +177,8 @@ test("ui-generator placed-element subcommand creates component and outlet placem
 
     const placementSource = await readFile(path.join(appRoot, "src", "placement.js"), "utf8");
     assert.match(placementSource, /id: "ui-generator\.element\.ops-panel"/);
-    assert.match(placementSource, /target: "shell-layout:top-right"/);
+    assert.match(placementSource, /target: "shell\.status"/);
+    assert.match(placementSource, /kind: "component"/);
     assert.match(placementSource, /componentToken: "local\.main\.ui\.element\.ops-panel"/);
   });
 });
@@ -131,16 +193,16 @@ test("ui-generator placed-element subcommand supports explicit placement overrid
       options: {
         name: "Ops Panel",
         surface: "admin",
-        placement: "shell-layout:primary-menu"
+        placement: "shell.primary-nav"
       }
     });
 
     const placementSource = await readFile(path.join(appRoot, "src", "placement.js"), "utf8");
-    assert.match(placementSource, /target: "shell-layout:primary-menu"/);
+    assert.match(placementSource, /target: "shell\.primary-nav"/);
   });
 });
 
-test("ui-generator placed-element infers surface from a page-owned placement target", async () => {
+test("ui-generator placed-element infers surface from an owner-scoped semantic placement", async () => {
   await withTempApp(async (appRoot) => {
     await writeAppFixture(appRoot);
 
@@ -149,12 +211,14 @@ test("ui-generator placed-element infers surface from a page-owned placement tar
       subcommand: "placed-element",
       options: {
         name: "Ops Panel",
-        placement: "admin-settings:forms"
+        placement: "settings.sections",
+        owner: "admin-settings"
       }
     });
 
     const placementSource = await readFile(path.join(appRoot, "src", "placement.js"), "utf8");
-    assert.match(placementSource, /target: "admin-settings:forms"/);
+    assert.match(placementSource, /target: "settings\.sections"/);
+    assert.match(placementSource, /owner: "admin-settings"/);
     assert.match(placementSource, /surfaces: \["admin"\]/);
   });
 });
@@ -172,7 +236,7 @@ test("ui-generator placed-element infers the only enabled surface for shared she
     });
 
     const placementSource = await readFile(path.join(appRoot, "src", "placement.js"), "utf8");
-    assert.match(placementSource, /target: "shell-layout:top-right"/);
+    assert.match(placementSource, /target: "shell\.status"/);
     assert.match(placementSource, /surfaces: \["admin"\]/);
   });
 });
@@ -210,7 +274,7 @@ test("ui-generator placed-element requires explicit surface when a shared shell 
             name: "Ops Panel"
           }
         }),
-      /could not infer a surface for placement target "shell-layout:top-right". Pass --surface explicitly/
+      /could not infer a surface for placement target "shell.status". Pass --surface explicitly/
     );
   });
 });
@@ -226,11 +290,12 @@ test("ui-generator placed-element rejects explicit surfaces that conflict with p
           subcommand: "placed-element",
           options: {
             name: "Ops Panel",
-            placement: "admin-settings:forms",
+            placement: "settings.sections",
+            owner: "admin-settings",
             surface: "console"
           }
         }),
-      /target "admin-settings:forms" belongs to surface "admin", so --surface console is invalid/
+      /target "settings.sections" is not available on surface "console"/
     );
   });
 });

--- a/packages/ui-generator/test/outletSubcommand.test.js
+++ b/packages/ui-generator/test/outletSubcommand.test.js
@@ -8,6 +8,23 @@ import { runGeneratorSubcommand } from "../src/server/subcommands/outlet.js";
 async function withTempApp(run) {
   const appRoot = await mkdtemp(path.join(tmpdir(), "ui-generator-outlet-"));
   try {
+    await mkdir(path.join(appRoot, "src"), { recursive: true });
+    await writeFile(
+      path.join(appRoot, "src", "placementTopology.js"),
+      `const placements = [];
+
+function addPlacementTopology(value = {}) {
+  placements.push(value);
+}
+
+export { addPlacementTopology };
+
+export default function getPlacementTopology() {
+  return { placements };
+}
+`,
+      "utf8"
+    );
     return await run(appRoot);
   } finally {
     await rm(appRoot, { recursive: true, force: true });
@@ -40,24 +57,32 @@ import { computed } from "vue";
       subcommand: "outlet",
       args: [targetFile],
       options: {
-        target: "contact-view:sub-pages"
+        target: "contact-view:sub-pages",
+        placement: "page.section-nav"
       }
     });
 
-    assert.deepEqual(result.touchedFiles, [targetFile]);
+    assert.deepEqual(result.touchedFiles, [targetFile, "src/placementTopology.js"]);
 
     const output = await readFile(targetPath, "utf8");
     assert.match(output, /import ShellOutlet from "@jskit-ai\/shell-web\/client\/components\/ShellOutlet";/);
     assert.match(output, /<ShellOutlet target="contact-view:sub-pages" \/>/);
     assert.doesNotMatch(output, /RouterView/);
     assert.doesNotMatch(output, /jskit:ui-generator\.outlet:/);
+    const topologySource = await readFile(path.join(appRoot, "src", "placementTopology.js"), "utf8");
+    assert.match(topologySource, /id: "page\.section-nav"/);
+    assert.match(topologySource, /owner: "contact-view"/);
+    assert.match(topologySource, /compact: \{/);
+    assert.match(topologySource, /medium: \{/);
+    assert.match(topologySource, /expanded: \{/);
 
     const rerun = await runGeneratorSubcommand({
       appRoot,
       subcommand: "outlet",
       args: [targetFile],
       options: {
-        target: "contact-view:sub-pages"
+        target: "contact-view:sub-pages",
+        placement: "page.section-nav"
       }
     });
 
@@ -91,7 +116,8 @@ import ShellOutlet from "@jskit-ai/shell-web/client/components/ShellOutlet";
       subcommand: "outlet",
       args: [targetFile],
       options: {
-        target: "contact-view:sub-pages"
+        target: "contact-view:sub-pages",
+        placement: "page.section-nav"
       }
     });
 
@@ -124,7 +150,8 @@ test("ui-generator outlet creates script setup when missing", async () => {
       subcommand: "outlet",
       args: [targetFile],
       options: {
-        target: "contact-view:sub-pages"
+        target: "contact-view:sub-pages",
+        placement: "page.section-nav"
       }
     });
 
@@ -161,7 +188,8 @@ test("ui-generator outlet inserts generated script after existing route block", 
       subcommand: "outlet",
       args: [targetFile],
       options: {
-        target: "contact-view:sub-pages"
+        target: "contact-view:sub-pages",
+        placement: "page.section-nav"
       }
     });
 
@@ -203,7 +231,8 @@ test("ui-generator outlet keeps indentation when injected into nested template b
       subcommand: "outlet",
       args: [targetFile],
       options: {
-        target: "contact-view:sub-pages"
+        target: "contact-view:sub-pages",
+        placement: "page.section-nav"
       }
     });
 
@@ -229,6 +258,7 @@ test("ui-generator outlet rejects unsupported options", async () => {
       args: [targetFile],
       options: {
         target: "contact-view:sub-pages",
+        placement: "page.section-nav",
         bogus: "routed"
       }
       }),
@@ -250,7 +280,8 @@ test("ui-generator outlet supports explicit target host:position", async () => {
       subcommand: "outlet",
       args: [targetFile],
       options: {
-        target: "customer-view:summary-actions"
+        target: "customer-view:summary-actions",
+        placement: "page.actions"
       }
     });
 
@@ -272,9 +303,10 @@ test("ui-generator outlet rejects non-vue target files without changing them", a
       runGeneratorSubcommand({
         appRoot,
         subcommand: "outlet",
-        args: [targetFile],
-        options: {
-          target: "vet-view:sub-pages"
+      args: [targetFile],
+      options: {
+          target: "vet-view:sub-pages",
+          placement: "page.section-nav"
         }
       }),
       /ui-generator outlet target file must be an existing Vue SFC \(\.vue\): src\/pages\/w\/\[workspaceSlug\]\/admin\/practice\/vets\/_components\/VetAddEditFormFields\.js\./
@@ -297,9 +329,10 @@ test("ui-generator outlet validates target format", async () => {
       runGeneratorSubcommand({
         appRoot,
         subcommand: "outlet",
-        args: [targetFile],
-        options: {
-          target: "customer-view:"
+      args: [targetFile],
+      options: {
+          target: "customer-view:",
+          placement: "page.actions"
         }
       }),
       /ui-generator outlet option "target" must be a target in "host:position" format\./

--- a/packages/ui-generator/test/pageSubcommand.test.js
+++ b/packages/ui-generator/test/pageSubcommand.test.js
@@ -18,6 +18,67 @@ function toPagePath(targetFile = "") {
   return path.join("src/pages", targetFile);
 }
 
+function renderTopologyVariant(outlet, { linkRenderer = "" } = {}) {
+  const rendererLines = linkRenderer
+    ? `,
+      renderers: {
+        link: "${linkRenderer}"
+      }`
+    : "";
+  return `{
+      outlet: "${outlet}"${rendererLines}
+    }`;
+}
+
+function renderTopologyEntry({
+  id = "",
+  owner = "",
+  surfaces = ["*"],
+  defaultPlacement = false,
+  outlet = "",
+  linkRenderer = ""
+} = {}) {
+  const ownerLine = owner ? `    owner: "${owner}",\n` : "";
+  const defaultLine = defaultPlacement ? "    default: true,\n" : "";
+  return `  {
+    id: "${id}",
+${ownerLine}    surfaces: ${JSON.stringify(surfaces)},
+${defaultLine}    variants: {
+      compact: ${renderTopologyVariant(outlet, { linkRenderer })},
+      medium: ${renderTopologyVariant(outlet, { linkRenderer })},
+      expanded: ${renderTopologyVariant(outlet, { linkRenderer })}
+    }
+  }`;
+}
+
+async function writePlacementTopology(appRoot, entries = []) {
+  const defaultEntries = [
+    renderTopologyEntry({
+      id: "shell.primary-nav",
+      surfaces: ["*"],
+      defaultPlacement: true,
+      outlet: "shell-layout:primary-menu",
+      linkRenderer: "local.main.ui.surface-aware-menu-link-item"
+    }),
+    renderTopologyEntry({
+      id: "shell.status",
+      surfaces: ["*"],
+      outlet: "shell-layout:top-right",
+      linkRenderer: "local.main.ui.surface-aware-menu-link-item"
+    })
+  ];
+  await writeFile(
+    path.join(appRoot, "src", "placementTopology.js"),
+    `export default {
+  placements: [
+${[...defaultEntries, ...entries].join(",\n")}
+  ]
+};
+`,
+    "utf8"
+  );
+}
+
 async function writeAppFixture(appRoot, { configSource = "" } = {}) {
   await mkdir(path.join(appRoot, "config"), { recursive: true });
   await mkdir(path.join(appRoot, "src", "components"), { recursive: true });
@@ -41,7 +102,6 @@ async function writeAppFixture(appRoot, { configSource = "" } = {}) {
     <ShellOutlet
       target="shell-layout:primary-menu"
       default
-      default-link-component-token="local.main.ui.surface-aware-menu-link-item"
     />
     <ShellOutlet target="shell-layout:top-right" />
   </div>
@@ -60,6 +120,7 @@ export default function getPlacements() {
 `,
     "utf8"
   );
+  await writePlacementTopology(appRoot);
 }
 
 test("ui-generator page subcommand creates an index page from an explicit target file", async () => {
@@ -153,15 +214,15 @@ test("ui-generator page subcommand supports link placement options", async () =>
       subcommand: "page",
       args: [targetFile],
       options: {
-        "link-placement": "shell-layout:top-right",
-        "link-component-token": "local.main.ui.tab-link-item",
+        "link-placement": "shell.status",
         "link-to": "./notes"
       }
     });
 
     const placementSource = await readFile(path.join(appRoot, "src", "placement.js"), "utf8");
-    assert.match(placementSource, /target: "shell-layout:top-right"/);
-    assert.match(placementSource, /componentToken: "local\.main\.ui\.tab-link-item"/);
+    assert.match(placementSource, /target: "shell\.status"/);
+    assert.match(placementSource, /kind: "link"/);
+    assert.doesNotMatch(placementSource, /componentToken: "local\.main\.ui\.tab-link-item"/);
     assert.match(placementSource, /icon: "mdi-view-list-outline"/);
     assert.match(placementSource, /to: "\.\/notes"/);
   });
@@ -170,6 +231,15 @@ test("ui-generator page subcommand supports link placement options", async () =>
 test("ui-generator page subcommand infers subpage link placement, tab token, and link-to from the nearest parent host", async () => {
   await withTempApp(async (appRoot) => {
     await writeAppFixture(appRoot);
+    await writePlacementTopology(appRoot, [
+      renderTopologyEntry({
+        id: "page.section-nav",
+        owner: "contact-view",
+        surfaces: ["admin"],
+        outlet: "contact-view:sub-pages",
+        linkRenderer: "local.main.ui.surface-aware-menu-link-item"
+      })
+    ]);
 
     const parentFile = "w/[workspaceSlug]/admin/contacts/[contactId].vue";
     await mkdir(path.dirname(path.join(appRoot, toPagePath(parentFile))), { recursive: true });
@@ -196,8 +266,9 @@ test("ui-generator page subcommand infers subpage link placement, tab token, and
     });
 
     const placementSource = await readFile(path.join(appRoot, "src", "placement.js"), "utf8");
-    assert.match(placementSource, /target: "contact-view:sub-pages"/);
-    assert.match(placementSource, /componentToken: "local\.main\.ui\.surface-aware-menu-link-item"/);
+    assert.match(placementSource, /target: "page\.section-nav"/);
+    assert.match(placementSource, /owner: "contact-view"/);
+    assert.doesNotMatch(placementSource, /componentToken: "local\.main\.ui\.surface-aware-menu-link-item"/);
     assert.match(placementSource, /icon: "mdi-view-list-outline"/);
     assert.match(placementSource, /to: "\.\/notes"/);
   });
@@ -206,6 +277,22 @@ test("ui-generator page subcommand infers subpage link placement, tab token, and
 test("ui-generator page subcommand prefers the nearest index-route parent host", async () => {
   await withTempApp(async (appRoot) => {
     await writeAppFixture(appRoot);
+    await writePlacementTopology(appRoot, [
+      renderTopologyEntry({
+        id: "page.section-nav",
+        owner: "catalog",
+        surfaces: ["admin"],
+        outlet: "catalog:sub-pages",
+        linkRenderer: "local.main.ui.surface-aware-menu-link-item"
+      }),
+      renderTopologyEntry({
+        id: "page.section-nav",
+        owner: "catalog-products",
+        surfaces: ["admin"],
+        outlet: "catalog-products:sub-pages",
+        linkRenderer: "local.main.ui.surface-aware-menu-link-item"
+      })
+    ]);
 
     await mkdir(path.join(appRoot, "src/pages/w/[workspaceSlug]/admin/catalog/index/products"), {
       recursive: true
@@ -247,8 +334,9 @@ test("ui-generator page subcommand prefers the nearest index-route parent host",
     });
 
     const placementSource = await readFile(path.join(appRoot, "src", "placement.js"), "utf8");
-    assert.match(placementSource, /target: "catalog-products:sub-pages"/);
-    assert.match(placementSource, /componentToken: "local\.main\.ui\.surface-aware-menu-link-item"/);
+    assert.match(placementSource, /target: "page\.section-nav"/);
+    assert.match(placementSource, /owner: "catalog-products"/);
+    assert.doesNotMatch(placementSource, /componentToken: "local\.main\.ui\.surface-aware-menu-link-item"/);
     assert.match(placementSource, /to: "\.\/variants"/);
   });
 });
@@ -423,7 +511,7 @@ test("ui-generator page subcommand rejects invalid link placement before creatin
           "link-placement": "missing:target"
         }
       }),
-      /ui-generator page option "placement" target "missing:target" is not declared/
+      /ui-generator page option "placement" must be a semantic target in "area.slot" format/
     );
 
     await assert.rejects(readFile(path.join(appRoot, toPagePath(targetFile)), "utf8"), /ENOENT/);
@@ -455,10 +543,10 @@ test("ui-generator page subcommand rejects invalid link placement before overwri
         args: [targetFile],
         options: {
           force: "true",
-          "link-placement": "missing:target"
+          "link-placement": "missing.target"
         }
       }),
-      /ui-generator page option "placement" target "missing:target" is not declared/
+      /ui-generator page semantic placement "missing.target" is not declared/
     );
 
     const pageSource = await readFile(targetPath, "utf8");

--- a/packages/uploads-image-web/package.descriptor.mjs
+++ b/packages/uploads-image-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-image-web",
-  version: "0.1.43",
+  version: "0.1.44",
   kind: "runtime",
   description: "Reusable client-side image upload runtime with pre-upload image editing.",
   dependsOn: [
@@ -65,7 +65,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/uploads-runtime": "0.1.43",
+        "@jskit-ai/uploads-runtime": "0.1.44",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-image-web/package.json
+++ b/packages/uploads-image-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-image-web",
-  "version": "0.1.43",
+  "version": "0.1.44",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,7 +13,7 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/uploads-runtime": "0.1.43",
+    "@jskit-ai/uploads-runtime": "0.1.44",
     "@uppy/compressor": "^3.1.0",
     "@uppy/core": "^5.2.0",
     "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-runtime/package.descriptor.mjs
+++ b/packages/uploads-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-runtime",
-  version: "0.1.43",
+  version: "0.1.44",
   kind: "runtime",
   description: "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
   dependsOn: [
@@ -71,7 +71,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.65"
+        "@jskit-ai/kernel": "0.1.66"
       },
       dev: {}
     },

--- a/packages/uploads-runtime/package.json
+++ b/packages/uploads-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-runtime",
-  "version": "0.1.43",
+  "version": "0.1.44",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,6 +16,6 @@
   },
   "dependencies": {
     "@fastify/multipart": "^9.4.0",
-    "@jskit-ai/kernel": "0.1.65"
+    "@jskit-ai/kernel": "0.1.66"
   }
 }

--- a/packages/users-core/package.descriptor.mjs
+++ b/packages/users-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-core",
-  version: "0.1.75",
+  version: "0.1.76",
   kind: "runtime",
   description: "Users/account runtime plus HTTP routes for account features.",
   dependsOn: [
@@ -143,16 +143,16 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.64",
-        "@jskit-ai/crud-core": "0.1.73",
-        "@jskit-ai/database-runtime": "0.1.65",
-        "@jskit-ai/http-runtime": "0.1.64",
-        "@jskit-ai/json-rest-api-core": "0.1.10",
-        "@jskit-ai/kernel": "0.1.65",
-        "@jskit-ai/resource-core": "0.1.10",
-        "@jskit-ai/resource-crud-core": "0.1.10",
+        "@jskit-ai/auth-core": "0.1.65",
+        "@jskit-ai/crud-core": "0.1.74",
+        "@jskit-ai/database-runtime": "0.1.66",
+        "@jskit-ai/http-runtime": "0.1.65",
+        "@jskit-ai/json-rest-api-core": "0.1.11",
+        "@jskit-ai/kernel": "0.1.66",
+        "@jskit-ai/resource-core": "0.1.11",
+        "@jskit-ai/resource-crud-core": "0.1.11",
         "@local/users": "file:packages/users",
-        "@jskit-ai/uploads-runtime": "0.1.43"
+        "@jskit-ai/uploads-runtime": "0.1.44"
       },
       dev: {}
     },

--- a/packages/users-core/package.json
+++ b/packages/users-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-core",
-  "version": "0.1.75",
+  "version": "0.1.76",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,14 +11,14 @@
     "./shared/resources/userSettingsResource": "./src/shared/resources/userSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.64",
-    "@jskit-ai/database-runtime": "0.1.65",
-    "@jskit-ai/http-runtime": "0.1.64",
-    "@jskit-ai/json-rest-api-core": "0.1.10",
-    "@jskit-ai/kernel": "0.1.65",
-    "@jskit-ai/resource-crud-core": "0.1.10",
-    "@jskit-ai/resource-core": "0.1.10",
-    "@jskit-ai/uploads-runtime": "0.1.43",
+    "@jskit-ai/auth-core": "0.1.65",
+    "@jskit-ai/database-runtime": "0.1.66",
+    "@jskit-ai/http-runtime": "0.1.65",
+    "@jskit-ai/json-rest-api-core": "0.1.11",
+    "@jskit-ai/kernel": "0.1.66",
+    "@jskit-ai/resource-crud-core": "0.1.11",
+    "@jskit-ai/resource-core": "0.1.11",
+    "@jskit-ai/uploads-runtime": "0.1.44",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/users-web/package.descriptor.mjs
+++ b/packages/users-web/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { HOME_COG_OUTLET } from "./src/shared/toolsOutletContracts.js";
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-web",
-  version: "0.1.80",
+  version: "0.1.81",
   kind: "runtime",
   description: "Users web module: account/profile UI plus shared users web widgets.",
   dependsOn: [
@@ -235,12 +235,12 @@ export default Object.freeze({
       runtime: {
         "@tanstack/vue-query": "5.92.12",
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/http-runtime": "0.1.64",
-        "@jskit-ai/realtime": "0.1.64",
-        "@jskit-ai/kernel": "0.1.65",
-        "@jskit-ai/shell-web": "0.1.64",
-        "@jskit-ai/uploads-image-web": "0.1.43",
-        "@jskit-ai/users-core": "0.1.75",
+        "@jskit-ai/http-runtime": "0.1.65",
+        "@jskit-ai/realtime": "0.1.65",
+        "@jskit-ai/kernel": "0.1.66",
+        "@jskit-ai/shell-web": "0.1.65",
+        "@jskit-ai/uploads-image-web": "0.1.44",
+        "@jskit-ai/users-core": "0.1.76",
         vuetify: "^4.0.0"
       },
       dev: {}

--- a/packages/users-web/package.descriptor.mjs
+++ b/packages/users-web/package.descriptor.mjs
@@ -112,7 +112,6 @@ export default Object.freeze({
         outlets: [
           {
             target: HOME_COG_OUTLET.target,
-            defaultLinkComponentToken: HOME_COG_OUTLET.defaultLinkComponentToken,
             surfaces: ["home"],
             source: "src/client/components/UsersHomeToolsWidget.vue"
           },
@@ -122,19 +121,66 @@ export default Object.freeze({
             source: "src/client/components/AccountSettingsClientElement.vue"
           }
         ],
+        topology: {
+          placements: [
+            {
+              id: "home.tools-menu",
+              description: "Home surface tools menu actions.",
+              surfaces: ["home"],
+              variants: {
+                compact: {
+                  outlet: HOME_COG_OUTLET.target,
+                  renderers: {
+                    link: "local.main.ui.surface-aware-menu-link-item"
+                  }
+                },
+                medium: {
+                  outlet: HOME_COG_OUTLET.target,
+                  renderers: {
+                    link: "local.main.ui.surface-aware-menu-link-item"
+                  }
+                },
+                expanded: {
+                  outlet: HOME_COG_OUTLET.target,
+                  renderers: {
+                    link: "local.main.ui.surface-aware-menu-link-item"
+                  }
+                }
+              }
+            },
+            {
+              id: "settings.sections",
+              owner: "account-settings",
+              description: "Account settings content sections.",
+              surfaces: ["account"],
+              variants: {
+                compact: {
+                  outlet: "account-settings:sections"
+                },
+                medium: {
+                  outlet: "account-settings:sections"
+                },
+                expanded: {
+                  outlet: "account-settings:sections"
+                }
+              }
+            }
+          ]
+        },
         contributions: [
           {
             id: "users.profile.menu.settings",
-            target: "auth-profile-menu:primary-menu",
+            target: "auth.profile-menu",
+            kind: "link",
             surfaces: ["*"],
             order: 500,
-            componentToken: "auth.web.profile.menu.link-item",
             when: "auth.authenticated === true",
             source: "mutations.text#users-web-profile-settings-placement"
           },
           {
             id: "users.home.tools.widget",
-            target: "shell-layout:top-right",
+            target: "shell.status",
+            kind: "component",
             surfaces: ["home"],
             order: 900,
             componentToken: "users.web.home.tools.widget",
@@ -143,16 +189,18 @@ export default Object.freeze({
           },
           {
             id: "users.home.menu.settings",
-            target: "home-cog:primary-menu",
+            target: "home.tools-menu",
+            kind: "link",
             surfaces: ["home"],
             order: 100,
-            componentToken: "local.main.ui.surface-aware-menu-link-item",
             when: "auth.authenticated === true",
             source: "mutations.text#users-web-home-tools-placement"
           },
           {
             id: "users.account.settings.profile",
-            target: "account-settings:sections",
+            target: "settings.sections",
+            owner: "account-settings",
+            kind: "component",
             surfaces: ["account"],
             order: 100,
             componentToken: "local.main.account-settings.section.profile",
@@ -160,7 +208,9 @@ export default Object.freeze({
           },
           {
             id: "users.account.settings.preferences",
-            target: "account-settings:sections",
+            target: "settings.sections",
+            owner: "account-settings",
+            kind: "component",
             surfaces: ["account"],
             order: 200,
             componentToken: "local.main.account-settings.section.preferences",
@@ -168,7 +218,9 @@ export default Object.freeze({
           },
           {
             id: "users.account.settings.notifications",
-            target: "account-settings:sections",
+            target: "settings.sections",
+            owner: "account-settings",
+            kind: "component",
             surfaces: ["account"],
             order: 300,
             componentToken: "local.main.account-settings.section.notifications",
@@ -249,7 +301,7 @@ export default Object.freeze({
         position: "bottom",
         skipIfContains: "id: \"users.profile.menu.settings\"",
         value:
-          "\naddPlacement({\n  id: \"users.profile.menu.settings\",\n  target: \"auth-profile-menu:primary-menu\",\n  surfaces: [\"*\"],\n  order: 500,\n  componentToken: \"auth.web.profile.menu.link-item\",\n  props: {\n    label: \"Settings\",\n    to: \"/account\"\n  },\n  when: ({ auth }) => auth?.authenticated === true\n});\n",
+          "\naddPlacement({\n  id: \"users.profile.menu.settings\",\n  target: \"auth.profile-menu\",\n  kind: \"link\",\n  surfaces: [\"*\"],\n  order: 500,\n  props: {\n    label: \"Settings\",\n    to: \"/account\"\n  },\n  when: ({ auth }) => auth?.authenticated === true\n});\n",
         reason: "Append users-web profile settings menu placement into app-owned placement registry.",
         category: "users-web",
         id: "users-web-profile-settings-placement"
@@ -260,10 +312,21 @@ export default Object.freeze({
         position: "bottom",
         skipIfContains: "id: \"users.home.tools.widget\"",
         value:
-          "\naddPlacement({\n  id: \"users.home.tools.widget\",\n  target: \"shell-layout:top-right\",\n  surfaces: [\"home\"],\n  order: 900,\n  componentToken: \"users.web.home.tools.widget\",\n  when: ({ auth }) => auth?.authenticated === true\n});\n\naddPlacement({\n  id: \"users.home.menu.settings\",\n  target: \"home-cog:primary-menu\",\n  surfaces: [\"home\"],\n  order: 100,\n  componentToken: \"local.main.ui.surface-aware-menu-link-item\",\n  props: {\n    label: \"Settings\",\n    surface: \"home\",\n    scopedSuffix: \"/settings\",\n    unscopedSuffix: \"/settings\"\n  },\n  when: ({ auth }) => auth?.authenticated === true\n});\n",
+          "\naddPlacement({\n  id: \"users.home.tools.widget\",\n  target: \"shell.status\",\n  kind: \"component\",\n  surfaces: [\"home\"],\n  order: 900,\n  componentToken: \"users.web.home.tools.widget\",\n  when: ({ auth }) => auth?.authenticated === true\n});\n\naddPlacement({\n  id: \"users.home.menu.settings\",\n  target: \"home.tools-menu\",\n  kind: \"link\",\n  surfaces: [\"home\"],\n  order: 100,\n  props: {\n    label: \"Settings\",\n    surface: \"home\",\n    scopedSuffix: \"/settings\",\n    unscopedSuffix: \"/settings\"\n  },\n  when: ({ auth }) => auth?.authenticated === true\n});\n",
         reason: "Append users-web home tools widget and settings menu placements into app-owned placement registry.",
         category: "users-web",
         id: "users-web-home-tools-placement"
+      },
+      {
+        op: "append-text",
+        file: "src/placementTopology.js",
+        position: "bottom",
+        skipIfContains: "id: \"home.tools-menu\"",
+        value:
+          "\naddPlacementTopology({\n  id: \"home.tools-menu\",\n  description: \"Home surface tools menu actions.\",\n  surfaces: [\"home\"],\n  variants: {\n    compact: {\n      outlet: \"home-cog:primary-menu\",\n      renderers: {\n        link: \"local.main.ui.surface-aware-menu-link-item\"\n      }\n    },\n    medium: {\n      outlet: \"home-cog:primary-menu\",\n      renderers: {\n        link: \"local.main.ui.surface-aware-menu-link-item\"\n      }\n    },\n    expanded: {\n      outlet: \"home-cog:primary-menu\",\n      renderers: {\n        link: \"local.main.ui.surface-aware-menu-link-item\"\n      }\n    }\n  }\n});\n",
+        reason: "Append users-web home tools semantic topology into app-owned placement topology.",
+        category: "users-web",
+        id: "users-web-home-tools-topology"
       },
       {
         op: "append-text",
@@ -271,10 +334,21 @@ export default Object.freeze({
         position: "bottom",
         skipIfContains: "id: \"users.account.settings.profile\"",
         value:
-          "\naddPlacement({\n  id: \"users.account.settings.profile\",\n  target: \"account-settings:sections\",\n  surfaces: [\"account\"],\n  order: 100,\n  componentToken: \"local.main.account-settings.section.profile\",\n  props: {\n    title: \"Profile\",\n    value: \"profile\",\n    usesSharedRuntime: true\n  }\n});\n\naddPlacement({\n  id: \"users.account.settings.preferences\",\n  target: \"account-settings:sections\",\n  surfaces: [\"account\"],\n  order: 200,\n  componentToken: \"local.main.account-settings.section.preferences\",\n  props: {\n    title: \"Preferences\",\n    value: \"preferences\",\n    usesSharedRuntime: true\n  }\n});\n\naddPlacement({\n  id: \"users.account.settings.notifications\",\n  target: \"account-settings:sections\",\n  surfaces: [\"account\"],\n  order: 300,\n  componentToken: \"local.main.account-settings.section.notifications\",\n  props: {\n    title: \"Notifications\",\n    value: \"notifications\",\n    usesSharedRuntime: true\n  }\n});\n",
+          "\naddPlacement({\n  id: \"users.account.settings.profile\",\n  target: \"settings.sections\",\n  owner: \"account-settings\",\n  kind: \"component\",\n  surfaces: [\"account\"],\n  order: 100,\n  componentToken: \"local.main.account-settings.section.profile\",\n  props: {\n    title: \"Profile\",\n    value: \"profile\",\n    usesSharedRuntime: true\n  }\n});\n\naddPlacement({\n  id: \"users.account.settings.preferences\",\n  target: \"settings.sections\",\n  owner: \"account-settings\",\n  kind: \"component\",\n  surfaces: [\"account\"],\n  order: 200,\n  componentToken: \"local.main.account-settings.section.preferences\",\n  props: {\n    title: \"Preferences\",\n    value: \"preferences\",\n    usesSharedRuntime: true\n  }\n});\n\naddPlacement({\n  id: \"users.account.settings.notifications\",\n  target: \"settings.sections\",\n  owner: \"account-settings\",\n  kind: \"component\",\n  surfaces: [\"account\"],\n  order: 300,\n  componentToken: \"local.main.account-settings.section.notifications\",\n  props: {\n    title: \"Notifications\",\n    value: \"notifications\",\n    usesSharedRuntime: true\n  }\n});\n",
         reason: "Append users-web account settings section placements into the app-owned placement registry.",
         category: "users-web",
         id: "users-web-account-settings-sections-placement"
+      },
+      {
+        op: "append-text",
+        file: "src/placementTopology.js",
+        position: "bottom",
+        skipIfContains: "id: \"settings.sections\"",
+        value:
+          "\naddPlacementTopology({\n  id: \"settings.sections\",\n  owner: \"account-settings\",\n  description: \"Account settings content sections.\",\n  surfaces: [\"account\"],\n  variants: {\n    compact: {\n      outlet: \"account-settings:sections\"\n    },\n    medium: {\n      outlet: \"account-settings:sections\"\n    },\n    expanded: {\n      outlet: \"account-settings:sections\"\n    }\n  }\n});\n",
+        reason: "Append users-web account settings semantic topology into app-owned placement topology.",
+        category: "users-web",
+        id: "users-web-account-settings-topology"
       },
       {
         op: "append-text",

--- a/packages/users-web/package.json
+++ b/packages/users-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-web",
-  "version": "0.1.80",
+  "version": "0.1.81",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -34,12 +34,12 @@
   "dependencies": {
     "@tanstack/vue-query": "5.92.12",
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/http-runtime": "0.1.64",
-    "@jskit-ai/kernel": "0.1.65",
-    "@jskit-ai/realtime": "0.1.64",
-    "@jskit-ai/shell-web": "0.1.64",
-    "@jskit-ai/uploads-image-web": "0.1.43",
-    "@jskit-ai/users-core": "0.1.75",
+    "@jskit-ai/http-runtime": "0.1.65",
+    "@jskit-ai/kernel": "0.1.66",
+    "@jskit-ai/realtime": "0.1.65",
+    "@jskit-ai/shell-web": "0.1.65",
+    "@jskit-ai/uploads-image-web": "0.1.44",
+    "@jskit-ai/users-core": "0.1.76",
     "vuetify": "^4.0.0"
   },
   "peerDependencies": {

--- a/packages/users-web/src/client/components/UsersHomeToolsWidget.vue
+++ b/packages/users-web/src/client/components/UsersHomeToolsWidget.vue
@@ -6,7 +6,6 @@ import { HOME_COG_OUTLET } from "../../shared/toolsOutletContracts.js";
 <template>
   <ShellOutletMenuWidget
     :target="HOME_COG_OUTLET.target"
-    :default-link-component-token="HOME_COG_OUTLET.defaultLinkComponentToken"
     :aria-label="HOME_COG_OUTLET.ariaLabel"
   />
 </template>

--- a/packages/users-web/src/shared/toolsOutletContracts.js
+++ b/packages/users-web/src/shared/toolsOutletContracts.js
@@ -1,12 +1,8 @@
-const DEFAULT_COG_LINK_COMPONENT_TOKEN = "local.main.ui.surface-aware-menu-link-item";
-
 const HOME_COG_OUTLET = Object.freeze({
   target: "home-cog:primary-menu",
-  defaultLinkComponentToken: DEFAULT_COG_LINK_COMPONENT_TOKEN,
   ariaLabel: "Home cog"
 });
 
 export {
-  DEFAULT_COG_LINK_COMPONENT_TOKEN,
   HOME_COG_OUTLET
 };

--- a/packages/users-web/test/settingsPlacementContract.test.js
+++ b/packages/users-web/test/settingsPlacementContract.test.js
@@ -16,6 +16,19 @@ function readOutlets(host = "") {
     : [];
 }
 
+function findTopology(id, owner = "") {
+  const placements = descriptor?.metadata?.ui?.placements?.topology?.placements;
+  const normalizedId = String(id || "").trim();
+  const normalizedOwner = String(owner || "").trim();
+  return Array.isArray(placements)
+    ? placements.find((entry) => {
+        const entryId = String(entry?.id || "").trim();
+        const entryOwner = String(entry?.owner || "").trim();
+        return entryId === normalizedId && entryOwner === normalizedOwner;
+      }) || null
+    : null;
+}
+
 function findContribution(id) {
   const contributions = descriptor?.metadata?.ui?.placements?.contributions;
   return Array.isArray(contributions)
@@ -77,7 +90,8 @@ test("users-web home tools widget exposes home-cog outlet", async () => {
   assert.match(source, /import \{ HOME_COG_OUTLET \} from "\.\.\/\.\.\/shared\/toolsOutletContracts\.js";/);
   assert.match(source, /<ShellOutletMenuWidget/);
   assert.match(source, /:target="HOME_COG_OUTLET\.target"/);
-  assert.match(source, /:default-link-component-token="HOME_COG_OUTLET\.defaultLinkComponentToken"/);
+  assert.match(source, /:aria-label="HOME_COG_OUTLET\.ariaLabel"/);
+  assert.doesNotMatch(source, /default-link-component-token/);
 });
 
 test("users-web account page template uses the package-owned account settings host", async () => {
@@ -108,7 +122,6 @@ test("users-web descriptor metadata advertises home cog outlet and standard home
     [
       {
         target: "home-cog:primary-menu",
-        defaultLinkComponentToken: "local.main.ui.surface-aware-menu-link-item",
         surfaces: ["home"],
         source: "src/client/components/UsersHomeToolsWidget.vue"
       }
@@ -124,18 +137,61 @@ test("users-web descriptor metadata advertises home cog outlet and standard home
       }
     ]
   );
+  assert.deepEqual(findTopology("home.tools-menu"), {
+    id: "home.tools-menu",
+    description: "Home surface tools menu actions.",
+    surfaces: ["home"],
+    variants: {
+      compact: {
+        outlet: "home-cog:primary-menu",
+        renderers: {
+          link: "local.main.ui.surface-aware-menu-link-item"
+        }
+      },
+      medium: {
+        outlet: "home-cog:primary-menu",
+        renderers: {
+          link: "local.main.ui.surface-aware-menu-link-item"
+        }
+      },
+      expanded: {
+        outlet: "home-cog:primary-menu",
+        renderers: {
+          link: "local.main.ui.surface-aware-menu-link-item"
+        }
+      }
+    }
+  });
+  assert.deepEqual(findTopology("settings.sections", "account-settings"), {
+    id: "settings.sections",
+    owner: "account-settings",
+    description: "Account settings content sections.",
+    surfaces: ["account"],
+    variants: {
+      compact: {
+        outlet: "account-settings:sections"
+      },
+      medium: {
+        outlet: "account-settings:sections"
+      },
+      expanded: {
+        outlet: "account-settings:sections"
+      }
+    }
+  });
 
   expectContribution("users.profile.menu.settings", {
-    target: "auth-profile-menu:primary-menu",
+    target: "auth.profile-menu",
+    kind: "link",
     surfaces: ["*"],
     order: 500,
-    componentToken: "auth.web.profile.menu.link-item",
     when: "auth.authenticated === true",
     source: "mutations.text#users-web-profile-settings-placement"
   });
 
   expectContribution("users.home.tools.widget", {
-    target: "shell-layout:top-right",
+    target: "shell.status",
+    kind: "component",
     surfaces: ["home"],
     order: 900,
     componentToken: "users.web.home.tools.widget",
@@ -144,30 +200,36 @@ test("users-web descriptor metadata advertises home cog outlet and standard home
   });
 
   expectContribution("users.home.menu.settings", {
-    target: "home-cog:primary-menu",
+    target: "home.tools-menu",
+    kind: "link",
     surfaces: ["home"],
     order: 100,
-    componentToken: "local.main.ui.surface-aware-menu-link-item",
     when: "auth.authenticated === true",
     source: "mutations.text#users-web-home-tools-placement"
   });
   assert.equal(findContribution("users.home.settings.general"), null);
   expectContribution("users.account.settings.profile", {
-    target: "account-settings:sections",
+    target: "settings.sections",
+    owner: "account-settings",
+    kind: "component",
     surfaces: ["account"],
     order: 100,
     componentToken: "local.main.account-settings.section.profile",
     source: "mutations.text#users-web-account-settings-sections-placement"
   });
   expectContribution("users.account.settings.preferences", {
-    target: "account-settings:sections",
+    target: "settings.sections",
+    owner: "account-settings",
+    kind: "component",
     surfaces: ["account"],
     order: 200,
     componentToken: "local.main.account-settings.section.preferences",
     source: "mutations.text#users-web-account-settings-sections-placement"
   });
   expectContribution("users.account.settings.notifications", {
-    target: "account-settings:sections",
+    target: "settings.sections",
+    owner: "account-settings",
+    kind: "component",
     surfaces: ["account"],
     order: 300,
     componentToken: "local.main.account-settings.section.notifications",
@@ -182,18 +244,23 @@ test("users-web descriptor metadata advertises home cog outlet and standard home
       'id: "users.home.tools.widget"',
       'componentToken: "users.web.home.tools.widget"',
       'id: "users.home.menu.settings"',
-      'target: "home-cog:primary-menu"',
-      'componentToken: "local.main.ui.surface-aware-menu-link-item"',
+      'target: "home.tools-menu"',
+      'kind: "link"',
       'scopedSuffix: "/settings"',
       'unscopedSuffix: "/settings"'
     ]
   });
+  assert.equal(findTextMutation("users-web-home-tools-topology")?.file, "src/placementTopology.js");
+  assert.match(findTextMutation("users-web-home-tools-topology")?.value || "", /id: "home\.tools-menu"/);
+  assert.match(findTextMutation("users-web-home-tools-topology")?.value || "", /outlet: "home-cog:primary-menu"/);
   expectTextMutation("users-web-account-settings-sections-placement", {
     reason: "Append users-web account settings section placements into the app-owned placement registry.",
     category: "users-web",
     skipIfContains: 'id: "users.account.settings.profile"',
     snippets: [
       'id: "users.account.settings.profile"',
+      'target: "settings.sections"',
+      'owner: "account-settings"',
       'componentToken: "local.main.account-settings.section.profile"',
       'value: "profile"',
       'id: "users.account.settings.preferences"',
@@ -204,6 +271,10 @@ test("users-web descriptor metadata advertises home cog outlet and standard home
       'value: "notifications"'
     ]
   });
+  assert.equal(findTextMutation("users-web-account-settings-topology")?.file, "src/placementTopology.js");
+  assert.match(findTextMutation("users-web-account-settings-topology")?.value || "", /id: "settings\.sections"/);
+  assert.match(findTextMutation("users-web-account-settings-topology")?.value || "", /owner: "account-settings"/);
+  assert.match(findTextMutation("users-web-account-settings-topology")?.value || "", /outlet: "account-settings:sections"/);
 
   expectTextMutation("users-web-profile-settings-placement", {
     reason: "Append users-web profile settings menu placement into app-owned placement registry.",
@@ -211,8 +282,8 @@ test("users-web descriptor metadata advertises home cog outlet and standard home
     skipIfContains: 'id: "users.profile.menu.settings"',
     snippets: [
       'id: "users.profile.menu.settings"',
-      'target: "auth-profile-menu:primary-menu"',
-      'componentToken: "auth.web.profile.menu.link-item"',
+      'target: "auth.profile-menu"',
+      'kind: "link"',
       'label: "Settings"',
       'to: "/account"'
     ]

--- a/packages/workspaces-core/package.descriptor.mjs
+++ b/packages/workspaces-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-core",
-  version: "0.1.41",
+  version: "0.1.42",
   kind: "runtime",
   description: "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
   dependsOn: [
@@ -142,10 +142,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/json-rest-api-core": "0.1.10",
-        "@jskit-ai/resource-core": "0.1.10",
-        "@jskit-ai/resource-crud-core": "0.1.10",
-        "@jskit-ai/users-core": "0.1.75"
+        "@jskit-ai/json-rest-api-core": "0.1.11",
+        "@jskit-ai/resource-core": "0.1.11",
+        "@jskit-ai/resource-crud-core": "0.1.11",
+        "@jskit-ai/users-core": "0.1.76"
       },
       dev: {}
     },

--- a/packages/workspaces-core/package.json
+++ b/packages/workspaces-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-core",
-  "version": "0.1.41",
+  "version": "0.1.42",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -17,14 +17,14 @@
     "./shared/resources/workspaceSettingsResource": "./src/shared/resources/workspaceSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.64",
-    "@jskit-ai/database-runtime": "0.1.65",
-    "@jskit-ai/http-runtime": "0.1.64",
-    "@jskit-ai/json-rest-api-core": "0.1.10",
-    "@jskit-ai/kernel": "0.1.65",
-    "@jskit-ai/resource-crud-core": "0.1.10",
-    "@jskit-ai/resource-core": "0.1.10",
-    "@jskit-ai/users-core": "0.1.75",
+    "@jskit-ai/auth-core": "0.1.65",
+    "@jskit-ai/database-runtime": "0.1.66",
+    "@jskit-ai/http-runtime": "0.1.65",
+    "@jskit-ai/json-rest-api-core": "0.1.11",
+    "@jskit-ai/kernel": "0.1.66",
+    "@jskit-ai/resource-crud-core": "0.1.11",
+    "@jskit-ai/resource-core": "0.1.11",
+    "@jskit-ai/users-core": "0.1.76",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/workspaces-web/package.descriptor.mjs
+++ b/packages/workspaces-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-web",
-  version: "0.1.41",
+  version: "0.1.42",
   kind: "runtime",
   description: "Workspace web module: workspace selector, tools widget, workspace surfaces, and members/settings UI.",
   dependsOn: [
@@ -227,8 +227,8 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/workspaces-core": "0.1.41",
-        "@jskit-ai/users-web": "0.1.80",
+        "@jskit-ai/workspaces-core": "0.1.42",
+        "@jskit-ai/users-web": "0.1.81",
         "vuetify": "^4.0.0"
       },
       dev: {}

--- a/packages/workspaces-web/package.descriptor.mjs
+++ b/packages/workspaces-web/package.descriptor.mjs
@@ -69,39 +69,93 @@ export default Object.freeze({
         outlets: [
           {
             target: "admin-settings:primary-menu",
-            defaultLinkComponentToken: "local.main.ui.surface-aware-menu-link-item",
             surfaces: ["admin"],
             source: "templates/src/pages/admin/workspace/settings.vue"
           },
           {
             target: "admin-cog:primary-menu",
-            defaultLinkComponentToken: "local.main.ui.surface-aware-menu-link-item",
             surfaces: ["admin"],
             source: "src/client/components/UsersWorkspaceToolsWidget.vue"
           }
         ],
+        topology: {
+          placements: [
+            {
+              id: "page.section-nav",
+              owner: "admin-settings",
+              description: "Navigation between workspace admin settings child pages.",
+              surfaces: ["admin"],
+              variants: {
+                compact: {
+                  outlet: "admin-settings:primary-menu",
+                  renderers: {
+                    link: "local.main.ui.surface-aware-menu-link-item"
+                  }
+                },
+                medium: {
+                  outlet: "admin-settings:primary-menu",
+                  renderers: {
+                    link: "local.main.ui.surface-aware-menu-link-item"
+                  }
+                },
+                expanded: {
+                  outlet: "admin-settings:primary-menu",
+                  renderers: {
+                    link: "local.main.ui.surface-aware-menu-link-item"
+                  }
+                }
+              }
+            },
+            {
+              id: "admin.tools-menu",
+              description: "Admin surface tools menu actions.",
+              surfaces: ["admin"],
+              variants: {
+                compact: {
+                  outlet: "admin-cog:primary-menu",
+                  renderers: {
+                    link: "local.main.ui.surface-aware-menu-link-item"
+                  }
+                },
+                medium: {
+                  outlet: "admin-cog:primary-menu",
+                  renderers: {
+                    link: "local.main.ui.surface-aware-menu-link-item"
+                  }
+                },
+                expanded: {
+                  outlet: "admin-cog:primary-menu",
+                  renderers: {
+                    link: "local.main.ui.surface-aware-menu-link-item"
+                  }
+                }
+              }
+            }
+          ]
+        },
         contributions: [
           {
             id: "workspaces.workspace.menu.app",
-            target: "shell-layout:primary-menu",
+            target: "shell.primary-nav",
+            kind: "link",
             surfaces: ["app"],
             order: 50,
-            componentToken: "local.main.ui.surface-aware-menu-link-item",
             when: "auth.authenticated === true",
             source: "mutations.text#workspaces-web-placement-block"
           },
           {
             id: "workspaces.workspace.menu.admin",
-            target: "shell-layout:primary-menu",
+            target: "shell.primary-nav",
+            kind: "link",
             surfaces: ["admin"],
             order: 60,
-            componentToken: "local.main.ui.surface-aware-menu-link-item",
             when: "auth.authenticated === true",
             source: "mutations.text#workspaces-web-placement-block"
           },
           {
             id: "workspaces.profile.menu.surface-switch",
-            target: "auth-profile-menu:primary-menu",
+            target: "auth.profile-menu",
+            kind: "component",
             surfaces: ["*"],
             order: 100,
             componentToken: "workspaces.web.profile.menu.surface-switch-item",
@@ -110,7 +164,8 @@ export default Object.freeze({
           },
           {
             id: "workspaces.workspace.selector",
-            target: "shell-layout:top-left",
+            target: "shell.identity",
+            kind: "component",
             surfaces: ["*"],
             order: 200,
             componentToken: "workspaces.web.workspace.selector",
@@ -119,7 +174,8 @@ export default Object.freeze({
           },
           {
             id: "workspaces.account.invites.cue",
-            target: "shell-layout:top-right",
+            target: "shell.status",
+            kind: "component",
             surfaces: ["*"],
             order: 850,
             componentToken: "local.main.account.pending-invites.cue",
@@ -128,7 +184,9 @@ export default Object.freeze({
           },
           {
             id: "workspaces.account.settings.invites",
-            target: "account-settings:sections",
+            target: "settings.sections",
+            owner: "account-settings",
+            kind: "component",
             surfaces: ["account"],
             order: 400,
             componentToken: "local.main.account-settings.section.invites",
@@ -137,7 +195,8 @@ export default Object.freeze({
           },
           {
             id: "workspaces.workspace.tools.widget",
-            target: "shell-layout:top-right",
+            target: "shell.status",
+            kind: "component",
             surfaces: ["admin"],
             order: 900,
             componentToken: "workspaces.web.workspace.tools.widget",
@@ -145,7 +204,8 @@ export default Object.freeze({
           },
           {
             id: "workspaces.workspace.menu.workspace-settings",
-            target: "admin-cog:primary-menu",
+            target: "admin.tools-menu",
+            kind: "component",
             surfaces: ["admin"],
             order: 100,
             componentToken: "workspaces.web.workspace-settings.menu-item",
@@ -153,7 +213,8 @@ export default Object.freeze({
           },
           {
             id: "workspaces.workspace.menu.members",
-            target: "admin-cog:primary-menu",
+            target: "admin.tools-menu",
+            kind: "component",
             surfaces: ["admin"],
             order: 200,
             componentToken: "workspaces.web.workspace-members.menu-item",
@@ -310,7 +371,7 @@ export default Object.freeze({
         position: "bottom",
         skipIfContains: "id: \"workspaces.profile.menu.surface-switch\"",
         value:
-          "\naddPlacement({\n  id: \"workspaces.profile.menu.surface-switch\",\n  target: \"auth-profile-menu:primary-menu\",\n  surfaces: [\"*\"],\n  order: 100,\n  componentToken: \"workspaces.web.profile.menu.surface-switch-item\",\n  when: ({ auth }) => auth?.authenticated === true\n});\n",
+          "\naddPlacement({\n  id: \"workspaces.profile.menu.surface-switch\",\n  target: \"auth.profile-menu\",\n  kind: \"component\",\n  surfaces: [\"*\"],\n  order: 100,\n  componentToken: \"workspaces.web.profile.menu.surface-switch-item\",\n  when: ({ auth }) => auth?.authenticated === true\n});\n",
         reason: "Append workspaces-web profile surface switch placement into app-owned placement registry.",
         category: "workspaces-web",
         id: "workspaces-web-profile-surface-switch-placement",
@@ -324,10 +385,24 @@ export default Object.freeze({
         file: "src/placement.js",
         position: "bottom",
         skipIfContains: "id: \"workspaces.workspace.selector\"",
-        value: "\naddPlacement({\n  id: \"workspaces.workspace.menu.app\",\n  target: \"shell-layout:primary-menu\",\n  surfaces: [\"app\"],\n  order: 50,\n  componentToken: \"local.main.ui.surface-aware-menu-link-item\",\n  props: {\n    label: \"Home\",\n    surface: \"app\",\n    scopedSuffix: \"/\",\n    unscopedSuffix: \"/\",\n    exact: true\n  },\n  when: ({ auth }) => auth?.authenticated === true\n});\n\naddPlacement({\n  id: \"workspaces.workspace.menu.admin\",\n  target: \"shell-layout:primary-menu\",\n  surfaces: [\"admin\"],\n  order: 60,\n  componentToken: \"local.main.ui.surface-aware-menu-link-item\",\n  props: {\n    label: \"Home\",\n    surface: \"admin\",\n    scopedSuffix: \"/\",\n    unscopedSuffix: \"/\",\n    exact: true\n  },\n  when: ({ auth }) => auth?.authenticated === true\n});\n\naddPlacement({\n  id: \"workspaces.workspace.selector\",\n  target: \"shell-layout:top-left\",\n  surfaces: [\"*\"],\n  order: 200,\n  componentToken: \"workspaces.web.workspace.selector\",\n  props: {\n    allowOnNonWorkspaceSurface: true,\n    targetSurfaceId: \"app\"\n  },\n  when: ({ auth }) => auth?.authenticated === true\n});\n\naddPlacement({\n  id: \"workspaces.account.invites.cue\",\n  target: \"shell-layout:top-right\",\n  surfaces: [\"*\"],\n  order: 850,\n  componentToken: \"local.main.account.pending-invites.cue\",\n  when: ({ auth }) => auth?.authenticated === true\n});\n\naddPlacement({\n  id: \"workspaces.workspace.tools.widget\",\n  target: \"shell-layout:top-right\",\n  surfaces: [\"admin\"],\n  order: 900,\n  componentToken: \"workspaces.web.workspace.tools.widget\"\n});\n\naddPlacement({\n  id: \"workspaces.workspace.menu.workspace-settings\",\n  target: \"admin-cog:primary-menu\",\n  surfaces: [\"admin\"],\n  order: 100,\n  componentToken: \"workspaces.web.workspace-settings.menu-item\"\n});\n\naddPlacement({\n  id: \"workspaces.workspace.menu.members\",\n  target: \"admin-cog:primary-menu\",\n  surfaces: [\"admin\"],\n  order: 200,\n  componentToken: \"workspaces.web.workspace-members.menu-item\"\n});\n",
+        value: "\naddPlacement({\n  id: \"workspaces.workspace.menu.app\",\n  target: \"shell.primary-nav\",\n  kind: \"link\",\n  surfaces: [\"app\"],\n  order: 50,\n  props: {\n    label: \"Home\",\n    surface: \"app\",\n    scopedSuffix: \"/\",\n    unscopedSuffix: \"/\",\n    exact: true\n  },\n  when: ({ auth }) => auth?.authenticated === true\n});\n\naddPlacement({\n  id: \"workspaces.workspace.menu.admin\",\n  target: \"shell.primary-nav\",\n  kind: \"link\",\n  surfaces: [\"admin\"],\n  order: 60,\n  props: {\n    label: \"Home\",\n    surface: \"admin\",\n    scopedSuffix: \"/\",\n    unscopedSuffix: \"/\",\n    exact: true\n  },\n  when: ({ auth }) => auth?.authenticated === true\n});\n\naddPlacement({\n  id: \"workspaces.workspace.selector\",\n  target: \"shell.identity\",\n  kind: \"component\",\n  surfaces: [\"*\"],\n  order: 200,\n  componentToken: \"workspaces.web.workspace.selector\",\n  props: {\n    allowOnNonWorkspaceSurface: true,\n    targetSurfaceId: \"app\"\n  },\n  when: ({ auth }) => auth?.authenticated === true\n});\n\naddPlacement({\n  id: \"workspaces.account.invites.cue\",\n  target: \"shell.status\",\n  kind: \"component\",\n  surfaces: [\"*\"],\n  order: 850,\n  componentToken: \"local.main.account.pending-invites.cue\",\n  when: ({ auth }) => auth?.authenticated === true\n});\n\naddPlacement({\n  id: \"workspaces.workspace.tools.widget\",\n  target: \"shell.status\",\n  kind: \"component\",\n  surfaces: [\"admin\"],\n  order: 900,\n  componentToken: \"workspaces.web.workspace.tools.widget\"\n});\n\naddPlacement({\n  id: \"workspaces.workspace.menu.workspace-settings\",\n  target: \"admin.tools-menu\",\n  kind: \"component\",\n  surfaces: [\"admin\"],\n  order: 100,\n  componentToken: \"workspaces.web.workspace-settings.menu-item\"\n});\n\naddPlacement({\n  id: \"workspaces.workspace.menu.members\",\n  target: \"admin.tools-menu\",\n  kind: \"component\",\n  surfaces: [\"admin\"],\n  order: 200,\n  componentToken: \"workspaces.web.workspace-members.menu-item\"\n});\n",
         reason: "Append workspace placement entries into app-owned placement registry.",
         category: "workspaces-web",
         id: "workspaces-web-placement-block",
+        when: {
+          config: "tenancyMode",
+          in: ["personal", "workspaces"]
+        }
+      },
+      {
+        op: "append-text",
+        file: "src/placementTopology.js",
+        position: "bottom",
+        skipIfContains: "id: \"admin.tools-menu\"",
+        value: "\naddPlacementTopology({\n  id: \"page.section-nav\",\n  owner: \"admin-settings\",\n  description: \"Navigation between workspace admin settings child pages.\",\n  surfaces: [\"admin\"],\n  variants: {\n    compact: {\n      outlet: \"admin-settings:primary-menu\",\n      renderers: {\n        link: \"local.main.ui.surface-aware-menu-link-item\"\n      }\n    },\n    medium: {\n      outlet: \"admin-settings:primary-menu\",\n      renderers: {\n        link: \"local.main.ui.surface-aware-menu-link-item\"\n      }\n    },\n    expanded: {\n      outlet: \"admin-settings:primary-menu\",\n      renderers: {\n        link: \"local.main.ui.surface-aware-menu-link-item\"\n      }\n    }\n  }\n});\n\naddPlacementTopology({\n  id: \"admin.tools-menu\",\n  description: \"Admin surface tools menu actions.\",\n  surfaces: [\"admin\"],\n  variants: {\n    compact: {\n      outlet: \"admin-cog:primary-menu\",\n      renderers: {\n        link: \"local.main.ui.surface-aware-menu-link-item\"\n      }\n    },\n    medium: {\n      outlet: \"admin-cog:primary-menu\",\n      renderers: {\n        link: \"local.main.ui.surface-aware-menu-link-item\"\n      }\n    },\n    expanded: {\n      outlet: \"admin-cog:primary-menu\",\n      renderers: {\n        link: \"local.main.ui.surface-aware-menu-link-item\"\n      }\n    }\n  }\n});\n",
+        reason: "Append workspaces-web admin semantic topology into app-owned placement topology.",
+        category: "workspaces-web",
+        id: "workspaces-web-admin-placement-topology",
         when: {
           config: "tenancyMode",
           in: ["personal", "workspaces"]
@@ -339,7 +414,7 @@ export default Object.freeze({
         position: "bottom",
         skipIfContains: "id: \"workspaces.account.settings.invites\"",
         value:
-          "\naddPlacement({\n  id: \"workspaces.account.settings.invites\",\n  target: \"account-settings:sections\",\n  surfaces: [\"account\"],\n  order: 400,\n  componentToken: \"local.main.account-settings.section.invites\",\n  props: {\n    title: \"Invites\",\n    value: \"invites\",\n    usesSharedRuntime: false\n  },\n  when: ({ auth, workspaceInvitesEnabled }) => auth?.authenticated === true && workspaceInvitesEnabled === true\n});\n",
+          "\naddPlacement({\n  id: \"workspaces.account.settings.invites\",\n  target: \"settings.sections\",\n  owner: \"account-settings\",\n  kind: \"component\",\n  surfaces: [\"account\"],\n  order: 400,\n  componentToken: \"local.main.account-settings.section.invites\",\n  props: {\n    title: \"Invites\",\n    value: \"invites\",\n    usesSharedRuntime: false\n  },\n  when: ({ auth, workspaceInvitesEnabled }) => auth?.authenticated === true && workspaceInvitesEnabled === true\n});\n",
         reason: "Append workspaces-web account settings invites section placement into app-owned placement registry.",
         category: "workspaces-web",
         id: "workspaces-web-account-settings-placement",

--- a/packages/workspaces-web/package.json
+++ b/packages/workspaces-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-web",
-  "version": "0.1.41",
+  "version": "0.1.42",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -15,12 +15,12 @@
   "dependencies": {
     "@tanstack/vue-query": "5.92.12",
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/http-runtime": "0.1.64",
-    "@jskit-ai/kernel": "0.1.65",
-    "@jskit-ai/shell-web": "0.1.64",
-    "@jskit-ai/users-core": "0.1.75",
-    "@jskit-ai/users-web": "0.1.80",
-    "@jskit-ai/workspaces-core": "0.1.41",
+    "@jskit-ai/http-runtime": "0.1.65",
+    "@jskit-ai/kernel": "0.1.66",
+    "@jskit-ai/shell-web": "0.1.65",
+    "@jskit-ai/users-core": "0.1.76",
+    "@jskit-ai/users-web": "0.1.81",
+    "@jskit-ai/workspaces-core": "0.1.42",
     "vuetify": "^4.0.0"
   },
   "peerDependencies": {

--- a/packages/workspaces-web/src/client/components/UsersWorkspaceToolsWidget.vue
+++ b/packages/workspaces-web/src/client/components/UsersWorkspaceToolsWidget.vue
@@ -6,7 +6,6 @@ import { ADMIN_COG_OUTLET } from "../../shared/toolsOutletContracts.js";
 <template>
   <ShellOutletMenuWidget
     :target="ADMIN_COG_OUTLET.target"
-    :default-link-component-token="ADMIN_COG_OUTLET.defaultLinkComponentToken"
     :aria-label="ADMIN_COG_OUTLET.ariaLabel"
   />
 </template>

--- a/packages/workspaces-web/src/shared/toolsOutletContracts.js
+++ b/packages/workspaces-web/src/shared/toolsOutletContracts.js
@@ -1,9 +1,6 @@
-const DEFAULT_COG_LINK_COMPONENT_TOKEN = "local.main.ui.surface-aware-menu-link-item";
-
 const ADMIN_COG_OUTLET = Object.freeze({
   target: "admin-cog:primary-menu",
-  defaultLinkComponentToken: DEFAULT_COG_LINK_COMPONENT_TOKEN,
   ariaLabel: "Admin cog"
 });
 
-export { DEFAULT_COG_LINK_COMPONENT_TOKEN, ADMIN_COG_OUTLET };
+export { ADMIN_COG_OUTLET };

--- a/packages/workspaces-web/templates/src/pages/admin/workspace/settings.vue
+++ b/packages/workspaces-web/templates/src/pages/admin/workspace/settings.vue
@@ -15,10 +15,7 @@ import { RouterView } from "vue-router";
         <v-row no-gutters>
           <v-col cols="12" md="3" lg="2" class="pr-md-4 mb-4 mb-md-0">
             <v-list nav density="comfortable" rounded="lg" border>
-              <ShellOutlet
-                target="admin-settings:primary-menu"
-                default-link-component-token="local.main.ui.surface-aware-menu-link-item"
-              />
+              <ShellOutlet target="admin-settings:primary-menu" />
             </v-list>
           </v-col>
 

--- a/packages/workspaces-web/test/settingsPlacementContract.test.js
+++ b/packages/workspaces-web/test/settingsPlacementContract.test.js
@@ -16,6 +16,19 @@ function readOutlets(target = "") {
     : [];
 }
 
+function findTopology(id, owner = "") {
+  const placements = descriptor?.metadata?.ui?.placements?.topology?.placements;
+  const normalizedId = String(id || "").trim();
+  const normalizedOwner = String(owner || "").trim();
+  return Array.isArray(placements)
+    ? placements.find((entry) => {
+        const entryId = String(entry?.id || "").trim();
+        const entryOwner = String(entry?.owner || "").trim();
+        return entryId === normalizedId && entryOwner === normalizedOwner;
+      }) || null
+    : null;
+}
+
 function findContribution(id) {
   const contributions = descriptor?.metadata?.ui?.placements?.contributions;
   return Array.isArray(contributions)
@@ -44,7 +57,7 @@ test("workspaces-web admin settings template exposes surface-derived settings ou
   );
 
   assert.match(source, /target="admin-settings:primary-menu"/);
-  assert.match(source, /default-link-component-token="local\.main\.ui\.surface-aware-menu-link-item"/);
+  assert.doesNotMatch(source, /default-link-component-token/);
   assert.match(source, /<RouterView \/>/);
 });
 
@@ -102,7 +115,6 @@ test("workspaces-web descriptor metadata advertises admin settings outlets", () 
     [
       {
         target: "admin-settings:primary-menu",
-        defaultLinkComponentToken: "local.main.ui.surface-aware-menu-link-item",
         surfaces: ["admin"],
         source: "templates/src/pages/admin/workspace/settings.vue"
       }
@@ -113,28 +125,78 @@ test("workspaces-web descriptor metadata advertises admin settings outlets", () 
     [
       {
         target: "admin-cog:primary-menu",
-        defaultLinkComponentToken: "local.main.ui.surface-aware-menu-link-item",
         surfaces: ["admin"],
         source: "src/client/components/UsersWorkspaceToolsWidget.vue"
       }
     ]
   );
+  assert.deepEqual(findTopology("page.section-nav", "admin-settings"), {
+    id: "page.section-nav",
+    owner: "admin-settings",
+    description: "Navigation between workspace admin settings child pages.",
+    surfaces: ["admin"],
+    variants: {
+      compact: {
+        outlet: "admin-settings:primary-menu",
+        renderers: {
+          link: "local.main.ui.surface-aware-menu-link-item"
+        }
+      },
+      medium: {
+        outlet: "admin-settings:primary-menu",
+        renderers: {
+          link: "local.main.ui.surface-aware-menu-link-item"
+        }
+      },
+      expanded: {
+        outlet: "admin-settings:primary-menu",
+        renderers: {
+          link: "local.main.ui.surface-aware-menu-link-item"
+        }
+      }
+    }
+  });
+  assert.deepEqual(findTopology("admin.tools-menu"), {
+    id: "admin.tools-menu",
+    description: "Admin surface tools menu actions.",
+    surfaces: ["admin"],
+    variants: {
+      compact: {
+        outlet: "admin-cog:primary-menu",
+        renderers: {
+          link: "local.main.ui.surface-aware-menu-link-item"
+        }
+      },
+      medium: {
+        outlet: "admin-cog:primary-menu",
+        renderers: {
+          link: "local.main.ui.surface-aware-menu-link-item"
+        }
+      },
+      expanded: {
+        outlet: "admin-cog:primary-menu",
+        renderers: {
+          link: "local.main.ui.surface-aware-menu-link-item"
+        }
+      }
+    }
+  });
   assert.equal(findContribution("workspaces.workspace.settings.general"), null);
   assert.deepEqual(findContribution("workspaces.workspace.menu.app"), {
     id: "workspaces.workspace.menu.app",
-    target: "shell-layout:primary-menu",
+    target: "shell.primary-nav",
+    kind: "link",
     surfaces: ["app"],
     order: 50,
-    componentToken: "local.main.ui.surface-aware-menu-link-item",
     when: "auth.authenticated === true",
     source: "mutations.text#workspaces-web-placement-block"
   });
   assert.deepEqual(findContribution("workspaces.workspace.menu.admin"), {
     id: "workspaces.workspace.menu.admin",
-    target: "shell-layout:primary-menu",
+    target: "shell.primary-nav",
+    kind: "link",
     surfaces: ["admin"],
     order: 60,
-    componentToken: "local.main.ui.surface-aware-menu-link-item",
     when: "auth.authenticated === true",
     source: "mutations.text#workspaces-web-placement-block"
   });
@@ -142,7 +204,8 @@ test("workspaces-web descriptor metadata advertises admin settings outlets", () 
   assert.match(findTextMutation("workspaces-web-placement-block")?.value || "", /id: "workspaces\.workspace\.menu\.admin"[\s\S]*surfaces: \["admin"\][\s\S]*label: "Home"/);
   assert.deepEqual(findContribution("workspaces.profile.menu.surface-switch"), {
     id: "workspaces.profile.menu.surface-switch",
-    target: "auth-profile-menu:primary-menu",
+    target: "auth.profile-menu",
+    kind: "component",
     surfaces: ["*"],
     order: 100,
     componentToken: "workspaces.web.profile.menu.surface-switch-item",
@@ -151,7 +214,8 @@ test("workspaces-web descriptor metadata advertises admin settings outlets", () 
   });
   assert.deepEqual(findContribution("workspaces.workspace.selector"), {
     id: "workspaces.workspace.selector",
-    target: "shell-layout:top-left",
+    target: "shell.identity",
+    kind: "component",
     surfaces: ["*"],
     order: 200,
     componentToken: "workspaces.web.workspace.selector",
@@ -160,7 +224,9 @@ test("workspaces-web descriptor metadata advertises admin settings outlets", () 
   });
   assert.deepEqual(findContribution("workspaces.account.settings.invites"), {
     id: "workspaces.account.settings.invites",
-    target: "account-settings:sections",
+    target: "settings.sections",
+    owner: "account-settings",
+    kind: "component",
     surfaces: ["account"],
     order: 400,
     componentToken: "local.main.account-settings.section.invites",
@@ -168,8 +234,15 @@ test("workspaces-web descriptor metadata advertises admin settings outlets", () 
     source: "mutations.text#workspaces-web-account-settings-placement"
   });
   assert.match(findTextMutation("workspaces-web-account-settings-placement")?.value || "", /id: "workspaces\.account\.settings\.invites"/);
-  assert.match(findTextMutation("workspaces-web-account-settings-placement")?.value || "", /target: "account-settings:sections"/);
+  assert.match(findTextMutation("workspaces-web-account-settings-placement")?.value || "", /target: "settings\.sections"/);
+  assert.match(findTextMutation("workspaces-web-account-settings-placement")?.value || "", /owner: "account-settings"/);
   assert.match(findTextMutation("workspaces-web-account-settings-placement")?.value || "", /componentToken: "local\.main\.account-settings\.section\.invites"/);
+  assert.equal(findTextMutation("workspaces-web-admin-placement-topology")?.file, "src/placementTopology.js");
+  assert.match(findTextMutation("workspaces-web-admin-placement-topology")?.value || "", /id: "page\.section-nav"/);
+  assert.match(findTextMutation("workspaces-web-admin-placement-topology")?.value || "", /owner: "admin-settings"/);
+  assert.match(findTextMutation("workspaces-web-admin-placement-topology")?.value || "", /outlet: "admin-settings:primary-menu"/);
+  assert.match(findTextMutation("workspaces-web-admin-placement-topology")?.value || "", /id: "admin\.tools-menu"/);
+  assert.match(findTextMutation("workspaces-web-admin-placement-topology")?.value || "", /outlet: "admin-cog:primary-menu"/);
   assert.deepEqual(findFileMutation("users-web-page-admin-workspace-settings"), {
     from: "templates/src/pages/admin/workspace/settings/index.vue",
     toSurface: "admin",

--- a/tooling/config-eslint/package.json
+++ b/tooling/config-eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/config-eslint",
-  "version": "0.1.64",
+  "version": "0.1.65",
   "description": "Shared flat ESLint presets for JSKIT projects.",
   "type": "module",
   "files": [

--- a/tooling/create-app/package.descriptor.mjs
+++ b/tooling/create-app/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/create-app",
-  "version": "0.1.73",
+  "version": "0.1.74",
   "dependsOn": [],
   "capabilities": {
     "provides": [

--- a/tooling/create-app/package.json
+++ b/tooling/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/create-app",
-  "version": "0.1.73",
+  "version": "0.1.74",
   "description": "Scaffold minimal JSKIT app shells.",
   "type": "module",
   "files": [

--- a/tooling/create-app/test/createApp.test.js
+++ b/tooling/create-app/test/createApp.test.js
@@ -653,8 +653,10 @@ test("fresh app CRUD scaffolds encode explicit M3 action hierarchy and stable se
       "utf8"
     );
 
-    assert.match(placementSource, /target: "home-settings:primary-menu"/);
-    assert.match(placementSource, /componentToken: "local\.main\.ui\.surface-aware-menu-link-item"/);
+    assert.match(placementSource, /target: "page\.section-nav"/);
+    assert.match(placementSource, /owner: "home-settings"/);
+    assert.match(placementSource, /kind: "link"/);
+    assert.doesNotMatch(placementSource, /componentToken: "local\.main\.ui\.surface-aware-menu-link-item"/);
     assert.match(placementSource, /scopedSuffix: "\/settings\/customers"/);
     assert.doesNotMatch(placementSource, /to: "\.\/customers"/);
     assert.doesNotMatch(placementSource, /to: "\.\/general"/);
@@ -770,7 +772,8 @@ test("workspaces-web workspace tenancy mode installs workspace surfaces and wrap
     assert.match(placement, /id:\s*"workspaces\.account\.invites\.cue"/);
     assert.match(placement, /componentToken:\s*"local\.main\.account\.pending-invites\.cue"/);
     assert.match(placement, /id:\s*"workspaces\.account\.settings\.invites"/);
-    assert.match(placement, /target:\s*"account-settings:sections"/);
+    assert.match(placement, /target:\s*"settings\.sections"/);
+    assert.match(placement, /owner:\s*"account-settings"/);
     assert.match(placement, /componentToken:\s*"local\.main\.account-settings\.section\.invites"/);
     assert.match(mainClientProvider, /import AccountPendingInvitesCue from "\.\.\/components\/AccountPendingInvitesCue\.vue";/);
     assert.match(

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -58,14 +58,7 @@
             "inputType": "text",
             "defaultValue": "",
             "promptLabel": "Link placement",
-            "promptHint": "Optional target for the generated page link placement (format: host:position)."
-          },
-          "link-component-token": {
-            "required": false,
-            "inputType": "text",
-            "defaultValue": "",
-            "promptLabel": "Link component token",
-            "promptHint": "Optional component token override for the generated page link placement."
+            "promptHint": "Optional semantic target for the generated page link placement (format: area.slot)."
           },
           "link-to": {
             "required": false,
@@ -185,7 +178,6 @@
               "optionNames": [
                 "name",
                 "link-placement",
-                "link-component-token",
                 "link-to",
                 "force"
               ],
@@ -208,7 +200,7 @@
                     "npx jskit generate assistant page \\",
                     "  admin/ops/copilot/index.vue \\",
                     "  --name \"Copilot\" \\",
-                    "  --link-placement shell-layout:top-right"
+                    "  --link-placement shell.status"
                   ]
                 }
               ]
@@ -229,7 +221,6 @@
                 "surface",
                 "name",
                 "link-placement",
-                "link-component-token",
                 "link-to",
                 "force"
               ],
@@ -1019,17 +1010,48 @@
               "outlets": [
                 {
                   "target": "auth-profile-menu:primary-menu",
-                  "defaultLinkComponentToken": "auth.web.profile.menu.link-item",
                   "surfaces": [
                     "*"
                   ],
                   "source": "src/client/views/AuthProfileWidget.vue"
                 }
               ],
+              "topology": {
+                "placements": [
+                  {
+                    "id": "auth.profile-menu",
+                    "description": "Authenticated profile menu actions.",
+                    "surfaces": [
+                      "*"
+                    ],
+                    "variants": {
+                      "compact": {
+                        "outlet": "auth-profile-menu:primary-menu",
+                        "renderers": {
+                          "link": "auth.web.profile.menu.link-item"
+                        }
+                      },
+                      "medium": {
+                        "outlet": "auth-profile-menu:primary-menu",
+                        "renderers": {
+                          "link": "auth.web.profile.menu.link-item"
+                        }
+                      },
+                      "expanded": {
+                        "outlet": "auth-profile-menu:primary-menu",
+                        "renderers": {
+                          "link": "auth.web.profile.menu.link-item"
+                        }
+                      }
+                    }
+                  }
+                ]
+              },
               "contributions": [
                 {
                   "id": "auth.profile.widget",
-                  "target": "shell-layout:top-right",
+                  "target": "shell.status",
+                  "kind": "component",
                   "surfaces": [
                     "*"
                   ],
@@ -1039,23 +1061,23 @@
                 },
                 {
                   "id": "auth.profile.menu.sign-in",
-                  "target": "auth-profile-menu:primary-menu",
+                  "target": "auth.profile-menu",
+                  "kind": "link",
                   "surfaces": [
                     "*"
                   ],
                   "order": 200,
-                  "componentToken": "auth.web.profile.menu.link-item",
                   "when": "auth.authenticated !== true",
                   "source": "mutations.text#auth-web-placement-block"
                 },
                 {
                   "id": "auth.profile.menu.sign-out",
-                  "target": "auth-profile-menu:primary-menu",
+                  "target": "auth.profile-menu",
+                  "kind": "link",
                   "surfaces": [
                     "*"
                   ],
                   "order": 1000,
-                  "componentToken": "auth.web.profile.menu.link-item",
                   "when": "auth.authenticated === true",
                   "source": "mutations.text#auth-web-placement-block"
                 }
@@ -1130,10 +1152,20 @@
               "file": "src/placement.js",
               "position": "bottom",
               "skipIfContains": "id: \"auth.profile.widget\"",
-              "value": "\naddPlacement({\n  id: \"auth.profile.widget\",\n  target: \"shell-layout:top-right\",\n  surfaces: [\"*\"],\n  order: 1000,\n  componentToken: \"auth.web.profile.widget\"\n});\n\naddPlacement({\n  id: \"auth.profile.menu.sign-in\",\n  target: \"auth-profile-menu:primary-menu\",\n  surfaces: [\"*\"],\n  order: 200,\n  componentToken: \"auth.web.profile.menu.link-item\",\n  props: {\n    label: \"Sign in\",\n    to: \"/auth/login\"\n  },\n  when: ({ auth }) => auth?.authenticated !== true\n});\n\naddPlacement({\n  id: \"auth.profile.menu.sign-out\",\n  target: \"auth-profile-menu:primary-menu\",\n  surfaces: [\"*\"],\n  order: 1000,\n  componentToken: \"auth.web.profile.menu.link-item\",\n  props: {\n    label: \"Sign out\",\n    to: \"/auth/signout\"\n  },\n  when: ({ auth }) => auth?.authenticated === true\n});\n",
+              "value": "\naddPlacement({\n  id: \"auth.profile.widget\",\n  target: \"shell.status\",\n  kind: \"component\",\n  surfaces: [\"*\"],\n  order: 1000,\n  componentToken: \"auth.web.profile.widget\"\n});\n\naddPlacement({\n  id: \"auth.profile.menu.sign-in\",\n  target: \"auth.profile-menu\",\n  kind: \"link\",\n  surfaces: [\"*\"],\n  order: 200,\n  props: {\n    label: \"Sign in\",\n    to: \"/auth/login\"\n  },\n  when: ({ auth }) => auth?.authenticated !== true\n});\n\naddPlacement({\n  id: \"auth.profile.menu.sign-out\",\n  target: \"auth.profile-menu\",\n  kind: \"link\",\n  surfaces: [\"*\"],\n  order: 1000,\n  props: {\n    label: \"Sign out\",\n    to: \"/auth/signout\"\n  },\n  when: ({ auth }) => auth?.authenticated === true\n});\n",
               "reason": "Append auth profile placement entries into app-owned placement registry.",
               "category": "auth-web",
               "id": "auth-web-placement-block"
+            },
+            {
+              "op": "append-text",
+              "file": "src/placementTopology.js",
+              "position": "bottom",
+              "skipIfContains": "id: \"auth.profile-menu\"",
+              "value": "\naddPlacementTopology({\n  id: \"auth.profile-menu\",\n  description: \"Authenticated profile menu actions.\",\n  surfaces: [\"*\"],\n  variants: {\n    compact: {\n      outlet: \"auth-profile-menu:primary-menu\",\n      renderers: {\n        link: \"auth.web.profile.menu.link-item\"\n      }\n    },\n    medium: {\n      outlet: \"auth-profile-menu:primary-menu\",\n      renderers: {\n        link: \"auth.web.profile.menu.link-item\"\n      }\n    },\n    expanded: {\n      outlet: \"auth-profile-menu:primary-menu\",\n      renderers: {\n        link: \"auth.web.profile.menu.link-item\"\n      }\n    }\n  }\n});\n",
+              "reason": "Append auth profile menu topology into the app-owned placement topology.",
+              "category": "auth-web",
+              "id": "auth-web-profile-menu-topology"
             }
           ]
         }
@@ -1305,33 +1337,64 @@
               "outlets": [
                 {
                   "target": "console-settings:primary-menu",
-                  "defaultLinkComponentToken": "local.main.ui.surface-aware-menu-link-item",
                   "surfaces": [
                     "console"
                   ],
                   "source": "templates/src/pages/console/settings.vue"
                 }
               ],
+              "topology": {
+                "placements": [
+                  {
+                    "id": "page.section-nav",
+                    "owner": "console-settings",
+                    "description": "Navigation between console settings child pages.",
+                    "surfaces": [
+                      "console"
+                    ],
+                    "variants": {
+                      "compact": {
+                        "outlet": "console-settings:primary-menu",
+                        "renderers": {
+                          "link": "local.main.ui.surface-aware-menu-link-item"
+                        }
+                      },
+                      "medium": {
+                        "outlet": "console-settings:primary-menu",
+                        "renderers": {
+                          "link": "local.main.ui.surface-aware-menu-link-item"
+                        }
+                      },
+                      "expanded": {
+                        "outlet": "console-settings:primary-menu",
+                        "renderers": {
+                          "link": "local.main.ui.surface-aware-menu-link-item"
+                        }
+                      }
+                    }
+                  }
+                ]
+              },
               "contributions": [
                 {
                   "id": "console.web.profile.menu.console",
-                  "target": "auth-profile-menu:primary-menu",
+                  "target": "auth.profile-menu",
+                  "kind": "link",
                   "surfaces": [
                     "*"
                   ],
                   "order": 600,
-                  "componentToken": "auth.web.profile.menu.link-item",
                   "when": "auth.authenticated === true && surfaceAccess.consoleowner === true && surface !== \"console\"",
                   "source": "mutations.text#console-web-profile-menu-console-placement"
                 },
                 {
                   "id": "console.web.menu.settings",
-                  "target": "shell-layout:primary-menu",
+                  "target": "shell.primary-nav",
+                  "kind": "link",
                   "surfaces": [
                     "console"
                   ],
                   "order": 100,
-                  "componentToken": "local.main.ui.menu-link-item",
                   "when": "auth.authenticated === true",
                   "source": "mutations.text#console-web-console-settings-placement"
                 }
@@ -1420,7 +1483,7 @@
               "file": "src/placement.js",
               "position": "bottom",
               "skipIfContains": "id: \"console.web.profile.menu.console\"",
-              "value": "\naddPlacement({\n  id: \"console.web.profile.menu.console\",\n  target: \"auth-profile-menu:primary-menu\",\n  surfaces: [\"*\"],\n  order: 600,\n  componentToken: \"auth.web.profile.menu.link-item\",\n  props: {\n    label: \"Go to console\",\n    to: \"/console\",\n    icon: \"mdi-console-network-outline\"\n  },\n  when: ({ auth, surfaceAccess, surface }) => {\n    return auth?.authenticated === true && surfaceAccess?.consoleowner === true && surface !== \"console\";\n  }\n});\n",
+              "value": "\naddPlacement({\n  id: \"console.web.profile.menu.console\",\n  target: \"auth.profile-menu\",\n  kind: \"link\",\n  surfaces: [\"*\"],\n  order: 600,\n  props: {\n    label: \"Go to console\",\n    to: \"/console\",\n    icon: \"mdi-console-network-outline\"\n  },\n  when: ({ auth, surfaceAccess, surface }) => {\n    return auth?.authenticated === true && surfaceAccess?.consoleowner === true && surface !== \"console\";\n  }\n});\n",
               "reason": "Append owner-only console navigation entry into the authenticated profile menu outside the console surface.",
               "category": "console-web",
               "id": "console-web-profile-menu-console-placement"
@@ -1430,10 +1493,20 @@
               "file": "src/placement.js",
               "position": "bottom",
               "skipIfContains": "id: \"console.web.menu.settings\"",
-              "value": "\naddPlacement({\n  id: \"console.web.menu.settings\",\n  target: \"shell-layout:primary-menu\",\n  surfaces: [\"console\"],\n  order: 100,\n  componentToken: \"local.main.ui.menu-link-item\",\n  props: {\n    label: \"Settings\",\n    to: \"/console/settings\",\n    icon: \"mdi-cog-outline\"\n  },\n  when: ({ auth }) => auth?.authenticated === true\n});\n",
+              "value": "\naddPlacement({\n  id: \"console.web.menu.settings\",\n  target: \"shell.primary-nav\",\n  kind: \"link\",\n  surfaces: [\"console\"],\n  order: 100,\n  props: {\n    label: \"Settings\",\n    to: \"/console/settings\",\n    icon: \"mdi-cog-outline\"\n  },\n  when: ({ auth }) => auth?.authenticated === true\n});\n",
               "reason": "Append console-web settings menu placement into app-owned placement registry.",
               "category": "console-web",
               "id": "console-web-console-settings-placement"
+            },
+            {
+              "op": "append-text",
+              "file": "src/placementTopology.js",
+              "position": "bottom",
+              "skipIfContains": "owner: \"console-settings\"",
+              "value": "\naddPlacementTopology({\n  id: \"page.section-nav\",\n  owner: \"console-settings\",\n  description: \"Navigation between console settings child pages.\",\n  surfaces: [\"console\"],\n  variants: {\n    compact: {\n      outlet: \"console-settings:primary-menu\",\n      renderers: {\n        link: \"local.main.ui.surface-aware-menu-link-item\"\n      }\n    },\n    medium: {\n      outlet: \"console-settings:primary-menu\",\n      renderers: {\n        link: \"local.main.ui.surface-aware-menu-link-item\"\n      }\n    },\n    expanded: {\n      outlet: \"console-settings:primary-menu\",\n      renderers: {\n        link: \"local.main.ui.surface-aware-menu-link-item\"\n      }\n    }\n  }\n});\n",
+              "reason": "Append console settings semantic topology into app-owned placement topology.",
+              "category": "console-web",
+              "id": "console-web-settings-placement-topology"
             }
           ]
         }
@@ -1873,14 +1946,7 @@
             "inputType": "text",
             "defaultValue": "",
             "promptLabel": "Link placement",
-            "promptHint": "Optional target override for the generated list-page link placement (format: host:position)."
-          },
-          "link-component-token": {
-            "required": false,
-            "inputType": "text",
-            "defaultValue": "",
-            "promptLabel": "Link component token",
-            "promptHint": "Optional component token override for the generated list-page link placement (example: local.main.ui.tab-link-item)."
+            "promptHint": "Optional semantic target override for the generated list-page link placement (format: area.slot)."
           },
           "namespace": {
             "required": false,
@@ -1929,7 +1995,6 @@
                 "id-param",
                 "parent-title",
                 "link-placement",
-                "link-component-token",
                 "namespace",
                 "force"
               ],
@@ -2204,7 +2269,7 @@
               "file": "src/placement.js",
               "position": "bottom",
               "skipIfContains": "__JSKIT_UI_MENU_MARKER__",
-              "value": "\n// __JSKIT_UI_MENU_MARKER__\n{\n  addPlacement({\n    id: \"__JSKIT_UI_MENU_PLACEMENT_ID__\",\n    target: \"__JSKIT_UI_MENU_PLACEMENT_TARGET__\",\n    surfaces: [\"__JSKIT_UI_SURFACE_ID__\"],\n    order: 155,\n    componentToken: \"__JSKIT_UI_MENU_COMPONENT_TOKEN__\",\n    props: {\n      label: \"__JSKIT_UI_MENU_LABEL__\",\n      icon: \"__JSKIT_UI_MENU_ICON__\",\n      surface: \"__JSKIT_UI_SURFACE_ID__\",\n      scopedSuffix: \"__JSKIT_UI_MENU_WORKSPACE_SUFFIX__\",\n      unscopedSuffix: \"__JSKIT_UI_MENU_NON_WORKSPACE_SUFFIX__\",\n__JSKIT_UI_MENU_TO_PROP_LINE__    },\n__JSKIT_UI_MENU_WHEN_LINE__  });\n}\n",
+              "value": "\n// __JSKIT_UI_MENU_MARKER__\n{\n  addPlacement({\n    id: \"__JSKIT_UI_MENU_PLACEMENT_ID__\",\n    target: \"__JSKIT_UI_MENU_PLACEMENT_TARGET__\",\n__JSKIT_UI_MENU_OWNER_LINE__    kind: \"link\",\n    surfaces: [\"__JSKIT_UI_SURFACE_ID__\"],\n    order: 155,\n    props: {\n      label: \"__JSKIT_UI_MENU_LABEL__\",\n      icon: \"__JSKIT_UI_MENU_ICON__\",\n      surface: \"__JSKIT_UI_SURFACE_ID__\",\n      scopedSuffix: \"__JSKIT_UI_MENU_WORKSPACE_SUFFIX__\",\n      unscopedSuffix: \"__JSKIT_UI_MENU_NON_WORKSPACE_SUFFIX__\",\n__JSKIT_UI_MENU_TO_PROP_LINE__    },\n__JSKIT_UI_MENU_WHEN_LINE__  });\n}\n",
               "reason": "Append generated CRUD list-page placement.",
               "category": "crud-ui-generator",
               "id": "crud-ui-placement-menu",
@@ -3549,7 +3614,8 @@
               "contributions": [
                 {
                   "id": "realtime.connection.indicator",
-                  "target": "shell-layout:top-right",
+                  "target": "shell.status",
+                  "kind": "component",
                   "surfaces": [
                     "*"
                   ],
@@ -3602,7 +3668,7 @@
               "file": "src/placement.js",
               "position": "bottom",
               "skipIfContains": "id: \"realtime.connection.indicator\"",
-              "value": "\naddPlacement({\n  id: \"realtime.connection.indicator\",\n  target: \"shell-layout:top-right\",\n  surfaces: [\"*\"],\n  order: 950,\n  componentToken: \"realtime.web.connection.indicator\"\n});\n",
+              "value": "\naddPlacement({\n  id: \"realtime.connection.indicator\",\n  target: \"shell.status\",\n  kind: \"component\",\n  surfaces: [\"*\"],\n  order: 950,\n  componentToken: \"realtime.web.connection.indicator\"\n});\n",
               "reason": "Append realtime connection indicator placement into app-owned placement registry.",
               "category": "realtime-web",
               "id": "realtime-placement-indicator"
@@ -3776,7 +3842,6 @@
                 },
                 {
                   "target": "shell-layout:primary-menu",
-                  "defaultLinkComponentToken": "local.main.ui.surface-aware-menu-link-item",
                   "surfaces": [
                     "*"
                   ],
@@ -3784,7 +3849,6 @@
                 },
                 {
                   "target": "shell-layout:secondary-menu",
-                  "defaultLinkComponentToken": "local.main.ui.surface-aware-menu-link-item",
                   "surfaces": [
                     "*"
                   ],
@@ -3792,42 +3856,165 @@
                 },
                 {
                   "target": "home-settings:primary-menu",
-                  "defaultLinkComponentToken": "local.main.ui.surface-aware-menu-link-item",
                   "surfaces": [
                     "home"
                   ],
                   "source": "templates/src/pages/home/settings.vue"
                 }
               ],
+              "topology": {
+                "placements": [
+                  {
+                    "id": "shell.primary-nav",
+                    "description": "Primary top-level navigation for the current surface.",
+                    "surfaces": [
+                      "*"
+                    ],
+                    "default": true,
+                    "variants": {
+                      "compact": {
+                        "outlet": "shell-layout:primary-menu",
+                        "renderers": {
+                          "link": "local.main.ui.surface-aware-menu-link-item"
+                        }
+                      },
+                      "medium": {
+                        "outlet": "shell-layout:primary-menu",
+                        "renderers": {
+                          "link": "local.main.ui.surface-aware-menu-link-item"
+                        }
+                      },
+                      "expanded": {
+                        "outlet": "shell-layout:primary-menu",
+                        "renderers": {
+                          "link": "local.main.ui.surface-aware-menu-link-item"
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "id": "shell.status",
+                    "description": "Surface status, connection, and utility indicators.",
+                    "surfaces": [
+                      "*"
+                    ],
+                    "variants": {
+                      "compact": {
+                        "outlet": "shell-layout:top-right"
+                      },
+                      "medium": {
+                        "outlet": "shell-layout:top-right"
+                      },
+                      "expanded": {
+                        "outlet": "shell-layout:top-right"
+                      }
+                    }
+                  },
+                  {
+                    "id": "shell.secondary-nav",
+                    "description": "Secondary navigation for lower-priority shell links.",
+                    "surfaces": [
+                      "*"
+                    ],
+                    "variants": {
+                      "compact": {
+                        "outlet": "shell-layout:secondary-menu",
+                        "renderers": {
+                          "link": "local.main.ui.surface-aware-menu-link-item"
+                        }
+                      },
+                      "medium": {
+                        "outlet": "shell-layout:secondary-menu",
+                        "renderers": {
+                          "link": "local.main.ui.surface-aware-menu-link-item"
+                        }
+                      },
+                      "expanded": {
+                        "outlet": "shell-layout:secondary-menu",
+                        "renderers": {
+                          "link": "local.main.ui.surface-aware-menu-link-item"
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "id": "shell.identity",
+                    "description": "Current user, workspace, and surface identity controls.",
+                    "surfaces": [
+                      "*"
+                    ],
+                    "variants": {
+                      "compact": {
+                        "outlet": "shell-layout:top-left"
+                      },
+                      "medium": {
+                        "outlet": "shell-layout:top-left"
+                      },
+                      "expanded": {
+                        "outlet": "shell-layout:top-left"
+                      }
+                    }
+                  },
+                  {
+                    "id": "page.section-nav",
+                    "owner": "home-settings",
+                    "description": "Navigation between child pages in the home settings section.",
+                    "surfaces": [
+                      "home"
+                    ],
+                    "variants": {
+                      "compact": {
+                        "outlet": "home-settings:primary-menu",
+                        "renderers": {
+                          "link": "local.main.ui.surface-aware-menu-link-item"
+                        }
+                      },
+                      "medium": {
+                        "outlet": "home-settings:primary-menu",
+                        "renderers": {
+                          "link": "local.main.ui.surface-aware-menu-link-item"
+                        }
+                      },
+                      "expanded": {
+                        "outlet": "home-settings:primary-menu",
+                        "renderers": {
+                          "link": "local.main.ui.surface-aware-menu-link-item"
+                        }
+                      }
+                    }
+                  }
+                ]
+              },
               "contributions": [
                 {
                   "id": "shell-web.home.menu.home",
-                  "target": "shell-layout:primary-menu",
+                  "target": "shell.primary-nav",
+                  "kind": "link",
                   "surfaces": [
                     "home"
                   ],
                   "order": 50,
-                  "componentToken": "local.main.ui.surface-aware-menu-link-item",
                   "source": "templates/src/placement.js"
                 },
                 {
                   "id": "shell-web.home.menu.settings",
-                  "target": "shell-layout:primary-menu",
+                  "target": "shell.primary-nav",
+                  "kind": "link",
                   "surfaces": [
                     "home"
                   ],
                   "order": 100,
-                  "componentToken": "local.main.ui.surface-aware-menu-link-item",
                   "source": "templates/src/placement.js"
                 },
                 {
                   "id": "shell-web.home.settings.general",
-                  "target": "home-settings:primary-menu",
+                  "target": "page.section-nav",
+                  "owner": "home-settings",
+                  "kind": "link",
                   "surfaces": [
                     "home"
                   ],
                   "order": 100,
-                  "componentToken": "local.main.ui.surface-aware-menu-link-item",
                   "source": "templates/src/placement.js"
                 }
               ]
@@ -3970,6 +4157,14 @@
               "reason": "Install app-owned placement registry scaffold used by shell-web placement runtime.",
               "category": "shell-web",
               "id": "shell-web-placement-registry"
+            },
+            {
+              "from": "templates/src/placementTopology.js",
+              "to": "src/placementTopology.js",
+              "ownership": "app",
+              "reason": "Install app-owned semantic placement topology used by shell-web placement runtime.",
+              "category": "shell-web",
+              "id": "shell-web-placement-topology"
             },
             {
               "from": "templates/src/pages/home.vue",
@@ -4135,21 +4330,35 @@
             "inputType": "text",
             "defaultValue": "",
             "promptLabel": "Placement target",
-            "promptHint": "Optional target for placed-element placement (format: host:position, default: shell-layout:top-right)."
+            "promptHint": "Semantic placement target for placed-element and outlet mapping (format: area.slot, default for placed-element: shell.status)."
+          },
+          "owner": {
+            "required": false,
+            "inputType": "text",
+            "defaultValue": "",
+            "promptLabel": "Placement owner",
+            "promptHint": "Optional owner id for semantic topology mappings. Page/settings placements default to the outlet host."
+          },
+          "description": {
+            "required": false,
+            "inputType": "text",
+            "defaultValue": "",
+            "promptLabel": "Description",
+            "promptHint": "Optional description for generated semantic topology mappings."
+          },
+          "link-renderer": {
+            "required": false,
+            "inputType": "text",
+            "defaultValue": "local.main.ui.surface-aware-menu-link-item",
+            "promptLabel": "Link renderer",
+            "promptHint": "Default link renderer token for generated topology variants."
           },
           "link-placement": {
             "required": false,
             "inputType": "text",
             "defaultValue": "",
             "promptLabel": "Link placement",
-            "promptHint": "Optional target for the generated page link placement (format: host:position)."
-          },
-          "link-component-token": {
-            "required": false,
-            "inputType": "text",
-            "defaultValue": "",
-            "promptLabel": "Link component token",
-            "promptHint": "Optional component token override for the generated page link placement (example: local.main.ui.tab-link-item)."
+            "promptHint": "Optional semantic target for the generated page link placement (format: area.slot)."
           },
           "link-to": {
             "required": false,
@@ -4218,12 +4427,11 @@
               "optionNames": [
                 "name",
                 "link-placement",
-                "link-component-token",
                 "link-to",
                 "force"
               ],
               "notes": [
-                "If a nearest parent subpages target is found, placement, link component token, and props.to are inferred automatically.",
+                "If a nearest parent subpages target is found, semantic placement and props.to are inferred automatically.",
                 "If the parent target page is index.vue, child pages belong under index/...",
                 "If the target page file already exists, rerun with --force to overwrite it."
               ],
@@ -4257,13 +4465,14 @@
                 "surface",
                 "path",
                 "placement",
+                "owner",
                 "force"
               ],
               "requiredOptionNames": [
                 "name"
               ],
               "notes": [
-                "If --placement is omitted, the placed element is added at shell-layout:top-right.",
+                "If --placement is omitted, the placed element is added at shell.status.",
                 "If the placement target belongs to a page-owned outlet, JSKIT infers the surface automatically.",
                 "If the target is shared and the app has multiple enabled surfaces, pass --surface explicitly.",
                 "If the component file already exists, rerun with --force to overwrite it."
@@ -4283,7 +4492,7 @@
                     "  --name \"Ops Panel\" \\",
                     "  --surface admin \\",
                     "  --path src/widgets \\",
-                    "  --placement shell-layout:top-right \\",
+                    "  --placement shell.status \\",
                     "  --force"
                   ]
                 }
@@ -4340,9 +4549,9 @@
               "export": "runGeneratorSubcommand",
               "description": "Inject a generic ShellOutlet block into an existing Vue page/component.",
               "longDescription": [
-                "A ShellOutlet creates a named placement target inside a Vue file. That target is what other parts of JSKIT render into later.",
-                "After an outlet exists, `jskit list-placements` will discover it and show its `target`. That makes the outlet visible to humans and to generators that need a placement destination.",
-                "Commands that create placed UI, such as `ui-generator placed-element`, and commands that add page links can then target that outlet by writing placement entries that point at the same target."
+                "A ShellOutlet creates a concrete placement recipient inside a Vue file.",
+                "The command also appends the semantic topology mapping for that outlet, so `jskit list-placements` exposes the public `area.slot` placement instead of leaving the concrete recipient unused.",
+                "Generated topology includes compact, medium, and expanded variants. By default all three point at the inserted outlet; hand-edit `src/placementTopology.js` if the adaptive layout uses different concrete outlets."
               ],
               "positionalArgs": [
                 {
@@ -4352,13 +4561,20 @@
                 }
               ],
               "optionNames": [
-                "target"
+                "target",
+                "placement",
+                "owner",
+                "surface",
+                "description",
+                "link-renderer"
               ],
               "requiredOptionNames": [
-                "target"
+                "target",
+                "placement"
               ],
               "notes": [
-                "Use --target host:position."
+                "Use --target host:position for the concrete outlet and --placement area.slot for the public semantic placement.",
+                "The generated topology maps compact, medium, and expanded to the new concrete outlet."
               ],
               "examples": [
                 {
@@ -4366,7 +4582,8 @@
                   "lines": [
                     "npx jskit generate ui-generator outlet \\",
                     "  src/components/ContactSummaryCard.vue \\",
-                    "  --target contact-view:sub-pages"
+                    "  --target contact-view:sub-pages \\",
+                    "  --placement page.section-nav"
                   ]
                 },
                 {
@@ -4374,7 +4591,9 @@
                   "lines": [
                     "npx jskit generate ui-generator outlet \\",
                     "  src/pages/admin/customers/[customerId]/index.vue \\",
-                    "  --target customer-view:summary-actions"
+                    "  --target customer-view:summary-actions \\",
+                    "  --placement page.actions \\",
+                    "  --surface admin"
                   ]
                 }
               ]
@@ -5072,7 +5291,6 @@
               "outlets": [
                 {
                   "target": "home-cog:primary-menu",
-                  "defaultLinkComponentToken": "local.main.ui.surface-aware-menu-link-item",
                   "surfaces": [
                     "home"
                   ],
@@ -5086,21 +5304,72 @@
                   "source": "src/client/components/AccountSettingsClientElement.vue"
                 }
               ],
+              "topology": {
+                "placements": [
+                  {
+                    "id": "home.tools-menu",
+                    "description": "Home surface tools menu actions.",
+                    "surfaces": [
+                      "home"
+                    ],
+                    "variants": {
+                      "compact": {
+                        "outlet": "home-cog:primary-menu",
+                        "renderers": {
+                          "link": "local.main.ui.surface-aware-menu-link-item"
+                        }
+                      },
+                      "medium": {
+                        "outlet": "home-cog:primary-menu",
+                        "renderers": {
+                          "link": "local.main.ui.surface-aware-menu-link-item"
+                        }
+                      },
+                      "expanded": {
+                        "outlet": "home-cog:primary-menu",
+                        "renderers": {
+                          "link": "local.main.ui.surface-aware-menu-link-item"
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "id": "settings.sections",
+                    "owner": "account-settings",
+                    "description": "Account settings content sections.",
+                    "surfaces": [
+                      "account"
+                    ],
+                    "variants": {
+                      "compact": {
+                        "outlet": "account-settings:sections"
+                      },
+                      "medium": {
+                        "outlet": "account-settings:sections"
+                      },
+                      "expanded": {
+                        "outlet": "account-settings:sections"
+                      }
+                    }
+                  }
+                ]
+              },
               "contributions": [
                 {
                   "id": "users.profile.menu.settings",
-                  "target": "auth-profile-menu:primary-menu",
+                  "target": "auth.profile-menu",
+                  "kind": "link",
                   "surfaces": [
                     "*"
                   ],
                   "order": 500,
-                  "componentToken": "auth.web.profile.menu.link-item",
                   "when": "auth.authenticated === true",
                   "source": "mutations.text#users-web-profile-settings-placement"
                 },
                 {
                   "id": "users.home.tools.widget",
-                  "target": "shell-layout:top-right",
+                  "target": "shell.status",
+                  "kind": "component",
                   "surfaces": [
                     "home"
                   ],
@@ -5111,18 +5380,20 @@
                 },
                 {
                   "id": "users.home.menu.settings",
-                  "target": "home-cog:primary-menu",
+                  "target": "home.tools-menu",
+                  "kind": "link",
                   "surfaces": [
                     "home"
                   ],
                   "order": 100,
-                  "componentToken": "local.main.ui.surface-aware-menu-link-item",
                   "when": "auth.authenticated === true",
                   "source": "mutations.text#users-web-home-tools-placement"
                 },
                 {
                   "id": "users.account.settings.profile",
-                  "target": "account-settings:sections",
+                  "target": "settings.sections",
+                  "owner": "account-settings",
+                  "kind": "component",
                   "surfaces": [
                     "account"
                   ],
@@ -5132,7 +5403,9 @@
                 },
                 {
                   "id": "users.account.settings.preferences",
-                  "target": "account-settings:sections",
+                  "target": "settings.sections",
+                  "owner": "account-settings",
+                  "kind": "component",
                   "surfaces": [
                     "account"
                   ],
@@ -5142,7 +5415,9 @@
                 },
                 {
                   "id": "users.account.settings.notifications",
-                  "target": "account-settings:sections",
+                  "target": "settings.sections",
+                  "owner": "account-settings",
+                  "kind": "component",
                   "surfaces": [
                     "account"
                   ],
@@ -5223,7 +5498,7 @@
               "file": "src/placement.js",
               "position": "bottom",
               "skipIfContains": "id: \"users.profile.menu.settings\"",
-              "value": "\naddPlacement({\n  id: \"users.profile.menu.settings\",\n  target: \"auth-profile-menu:primary-menu\",\n  surfaces: [\"*\"],\n  order: 500,\n  componentToken: \"auth.web.profile.menu.link-item\",\n  props: {\n    label: \"Settings\",\n    to: \"/account\"\n  },\n  when: ({ auth }) => auth?.authenticated === true\n});\n",
+              "value": "\naddPlacement({\n  id: \"users.profile.menu.settings\",\n  target: \"auth.profile-menu\",\n  kind: \"link\",\n  surfaces: [\"*\"],\n  order: 500,\n  props: {\n    label: \"Settings\",\n    to: \"/account\"\n  },\n  when: ({ auth }) => auth?.authenticated === true\n});\n",
               "reason": "Append users-web profile settings menu placement into app-owned placement registry.",
               "category": "users-web",
               "id": "users-web-profile-settings-placement"
@@ -5233,20 +5508,40 @@
               "file": "src/placement.js",
               "position": "bottom",
               "skipIfContains": "id: \"users.home.tools.widget\"",
-              "value": "\naddPlacement({\n  id: \"users.home.tools.widget\",\n  target: \"shell-layout:top-right\",\n  surfaces: [\"home\"],\n  order: 900,\n  componentToken: \"users.web.home.tools.widget\",\n  when: ({ auth }) => auth?.authenticated === true\n});\n\naddPlacement({\n  id: \"users.home.menu.settings\",\n  target: \"home-cog:primary-menu\",\n  surfaces: [\"home\"],\n  order: 100,\n  componentToken: \"local.main.ui.surface-aware-menu-link-item\",\n  props: {\n    label: \"Settings\",\n    surface: \"home\",\n    scopedSuffix: \"/settings\",\n    unscopedSuffix: \"/settings\"\n  },\n  when: ({ auth }) => auth?.authenticated === true\n});\n",
+              "value": "\naddPlacement({\n  id: \"users.home.tools.widget\",\n  target: \"shell.status\",\n  kind: \"component\",\n  surfaces: [\"home\"],\n  order: 900,\n  componentToken: \"users.web.home.tools.widget\",\n  when: ({ auth }) => auth?.authenticated === true\n});\n\naddPlacement({\n  id: \"users.home.menu.settings\",\n  target: \"home.tools-menu\",\n  kind: \"link\",\n  surfaces: [\"home\"],\n  order: 100,\n  props: {\n    label: \"Settings\",\n    surface: \"home\",\n    scopedSuffix: \"/settings\",\n    unscopedSuffix: \"/settings\"\n  },\n  when: ({ auth }) => auth?.authenticated === true\n});\n",
               "reason": "Append users-web home tools widget and settings menu placements into app-owned placement registry.",
               "category": "users-web",
               "id": "users-web-home-tools-placement"
             },
             {
               "op": "append-text",
+              "file": "src/placementTopology.js",
+              "position": "bottom",
+              "skipIfContains": "id: \"home.tools-menu\"",
+              "value": "\naddPlacementTopology({\n  id: \"home.tools-menu\",\n  description: \"Home surface tools menu actions.\",\n  surfaces: [\"home\"],\n  variants: {\n    compact: {\n      outlet: \"home-cog:primary-menu\",\n      renderers: {\n        link: \"local.main.ui.surface-aware-menu-link-item\"\n      }\n    },\n    medium: {\n      outlet: \"home-cog:primary-menu\",\n      renderers: {\n        link: \"local.main.ui.surface-aware-menu-link-item\"\n      }\n    },\n    expanded: {\n      outlet: \"home-cog:primary-menu\",\n      renderers: {\n        link: \"local.main.ui.surface-aware-menu-link-item\"\n      }\n    }\n  }\n});\n",
+              "reason": "Append users-web home tools semantic topology into app-owned placement topology.",
+              "category": "users-web",
+              "id": "users-web-home-tools-topology"
+            },
+            {
+              "op": "append-text",
               "file": "src/placement.js",
               "position": "bottom",
               "skipIfContains": "id: \"users.account.settings.profile\"",
-              "value": "\naddPlacement({\n  id: \"users.account.settings.profile\",\n  target: \"account-settings:sections\",\n  surfaces: [\"account\"],\n  order: 100,\n  componentToken: \"local.main.account-settings.section.profile\",\n  props: {\n    title: \"Profile\",\n    value: \"profile\",\n    usesSharedRuntime: true\n  }\n});\n\naddPlacement({\n  id: \"users.account.settings.preferences\",\n  target: \"account-settings:sections\",\n  surfaces: [\"account\"],\n  order: 200,\n  componentToken: \"local.main.account-settings.section.preferences\",\n  props: {\n    title: \"Preferences\",\n    value: \"preferences\",\n    usesSharedRuntime: true\n  }\n});\n\naddPlacement({\n  id: \"users.account.settings.notifications\",\n  target: \"account-settings:sections\",\n  surfaces: [\"account\"],\n  order: 300,\n  componentToken: \"local.main.account-settings.section.notifications\",\n  props: {\n    title: \"Notifications\",\n    value: \"notifications\",\n    usesSharedRuntime: true\n  }\n});\n",
+              "value": "\naddPlacement({\n  id: \"users.account.settings.profile\",\n  target: \"settings.sections\",\n  owner: \"account-settings\",\n  kind: \"component\",\n  surfaces: [\"account\"],\n  order: 100,\n  componentToken: \"local.main.account-settings.section.profile\",\n  props: {\n    title: \"Profile\",\n    value: \"profile\",\n    usesSharedRuntime: true\n  }\n});\n\naddPlacement({\n  id: \"users.account.settings.preferences\",\n  target: \"settings.sections\",\n  owner: \"account-settings\",\n  kind: \"component\",\n  surfaces: [\"account\"],\n  order: 200,\n  componentToken: \"local.main.account-settings.section.preferences\",\n  props: {\n    title: \"Preferences\",\n    value: \"preferences\",\n    usesSharedRuntime: true\n  }\n});\n\naddPlacement({\n  id: \"users.account.settings.notifications\",\n  target: \"settings.sections\",\n  owner: \"account-settings\",\n  kind: \"component\",\n  surfaces: [\"account\"],\n  order: 300,\n  componentToken: \"local.main.account-settings.section.notifications\",\n  props: {\n    title: \"Notifications\",\n    value: \"notifications\",\n    usesSharedRuntime: true\n  }\n});\n",
               "reason": "Append users-web account settings section placements into the app-owned placement registry.",
               "category": "users-web",
               "id": "users-web-account-settings-sections-placement"
+            },
+            {
+              "op": "append-text",
+              "file": "src/placementTopology.js",
+              "position": "bottom",
+              "skipIfContains": "id: \"settings.sections\"",
+              "value": "\naddPlacementTopology({\n  id: \"settings.sections\",\n  owner: \"account-settings\",\n  description: \"Account settings content sections.\",\n  surfaces: [\"account\"],\n  variants: {\n    compact: {\n      outlet: \"account-settings:sections\"\n    },\n    medium: {\n      outlet: \"account-settings:sections\"\n    },\n    expanded: {\n      outlet: \"account-settings:sections\"\n    }\n  }\n});\n",
+              "reason": "Append users-web account settings semantic topology into app-owned placement topology.",
+              "category": "users-web",
+              "id": "users-web-account-settings-topology"
             },
             {
               "op": "append-text",
@@ -5706,7 +6001,6 @@
               "outlets": [
                 {
                   "target": "admin-settings:primary-menu",
-                  "defaultLinkComponentToken": "local.main.ui.surface-aware-menu-link-item",
                   "surfaces": [
                     "admin"
                   ],
@@ -5714,39 +6008,98 @@
                 },
                 {
                   "target": "admin-cog:primary-menu",
-                  "defaultLinkComponentToken": "local.main.ui.surface-aware-menu-link-item",
                   "surfaces": [
                     "admin"
                   ],
                   "source": "src/client/components/UsersWorkspaceToolsWidget.vue"
                 }
               ],
+              "topology": {
+                "placements": [
+                  {
+                    "id": "page.section-nav",
+                    "owner": "admin-settings",
+                    "description": "Navigation between workspace admin settings child pages.",
+                    "surfaces": [
+                      "admin"
+                    ],
+                    "variants": {
+                      "compact": {
+                        "outlet": "admin-settings:primary-menu",
+                        "renderers": {
+                          "link": "local.main.ui.surface-aware-menu-link-item"
+                        }
+                      },
+                      "medium": {
+                        "outlet": "admin-settings:primary-menu",
+                        "renderers": {
+                          "link": "local.main.ui.surface-aware-menu-link-item"
+                        }
+                      },
+                      "expanded": {
+                        "outlet": "admin-settings:primary-menu",
+                        "renderers": {
+                          "link": "local.main.ui.surface-aware-menu-link-item"
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "id": "admin.tools-menu",
+                    "description": "Admin surface tools menu actions.",
+                    "surfaces": [
+                      "admin"
+                    ],
+                    "variants": {
+                      "compact": {
+                        "outlet": "admin-cog:primary-menu",
+                        "renderers": {
+                          "link": "local.main.ui.surface-aware-menu-link-item"
+                        }
+                      },
+                      "medium": {
+                        "outlet": "admin-cog:primary-menu",
+                        "renderers": {
+                          "link": "local.main.ui.surface-aware-menu-link-item"
+                        }
+                      },
+                      "expanded": {
+                        "outlet": "admin-cog:primary-menu",
+                        "renderers": {
+                          "link": "local.main.ui.surface-aware-menu-link-item"
+                        }
+                      }
+                    }
+                  }
+                ]
+              },
               "contributions": [
                 {
                   "id": "workspaces.workspace.menu.app",
-                  "target": "shell-layout:primary-menu",
+                  "target": "shell.primary-nav",
+                  "kind": "link",
                   "surfaces": [
                     "app"
                   ],
                   "order": 50,
-                  "componentToken": "local.main.ui.surface-aware-menu-link-item",
                   "when": "auth.authenticated === true",
                   "source": "mutations.text#workspaces-web-placement-block"
                 },
                 {
                   "id": "workspaces.workspace.menu.admin",
-                  "target": "shell-layout:primary-menu",
+                  "target": "shell.primary-nav",
+                  "kind": "link",
                   "surfaces": [
                     "admin"
                   ],
                   "order": 60,
-                  "componentToken": "local.main.ui.surface-aware-menu-link-item",
                   "when": "auth.authenticated === true",
                   "source": "mutations.text#workspaces-web-placement-block"
                 },
                 {
                   "id": "workspaces.profile.menu.surface-switch",
-                  "target": "auth-profile-menu:primary-menu",
+                  "target": "auth.profile-menu",
+                  "kind": "component",
                   "surfaces": [
                     "*"
                   ],
@@ -5757,7 +6110,8 @@
                 },
                 {
                   "id": "workspaces.workspace.selector",
-                  "target": "shell-layout:top-left",
+                  "target": "shell.identity",
+                  "kind": "component",
                   "surfaces": [
                     "*"
                   ],
@@ -5768,7 +6122,8 @@
                 },
                 {
                   "id": "workspaces.account.invites.cue",
-                  "target": "shell-layout:top-right",
+                  "target": "shell.status",
+                  "kind": "component",
                   "surfaces": [
                     "*"
                   ],
@@ -5779,7 +6134,9 @@
                 },
                 {
                   "id": "workspaces.account.settings.invites",
-                  "target": "account-settings:sections",
+                  "target": "settings.sections",
+                  "owner": "account-settings",
+                  "kind": "component",
                   "surfaces": [
                     "account"
                   ],
@@ -5790,7 +6147,8 @@
                 },
                 {
                   "id": "workspaces.workspace.tools.widget",
-                  "target": "shell-layout:top-right",
+                  "target": "shell.status",
+                  "kind": "component",
                   "surfaces": [
                     "admin"
                   ],
@@ -5800,7 +6158,8 @@
                 },
                 {
                   "id": "workspaces.workspace.menu.workspace-settings",
-                  "target": "admin-cog:primary-menu",
+                  "target": "admin.tools-menu",
+                  "kind": "component",
                   "surfaces": [
                     "admin"
                   ],
@@ -5810,7 +6169,8 @@
                 },
                 {
                   "id": "workspaces.workspace.menu.members",
-                  "target": "admin-cog:primary-menu",
+                  "target": "admin.tools-menu",
+                  "kind": "component",
                   "surfaces": [
                     "admin"
                   ],
@@ -5995,7 +6355,7 @@
               "file": "src/placement.js",
               "position": "bottom",
               "skipIfContains": "id: \"workspaces.profile.menu.surface-switch\"",
-              "value": "\naddPlacement({\n  id: \"workspaces.profile.menu.surface-switch\",\n  target: \"auth-profile-menu:primary-menu\",\n  surfaces: [\"*\"],\n  order: 100,\n  componentToken: \"workspaces.web.profile.menu.surface-switch-item\",\n  when: ({ auth }) => auth?.authenticated === true\n});\n",
+              "value": "\naddPlacement({\n  id: \"workspaces.profile.menu.surface-switch\",\n  target: \"auth.profile-menu\",\n  kind: \"component\",\n  surfaces: [\"*\"],\n  order: 100,\n  componentToken: \"workspaces.web.profile.menu.surface-switch-item\",\n  when: ({ auth }) => auth?.authenticated === true\n});\n",
               "reason": "Append workspaces-web profile surface switch placement into app-owned placement registry.",
               "category": "workspaces-web",
               "id": "workspaces-web-profile-surface-switch-placement",
@@ -6012,7 +6372,7 @@
               "file": "src/placement.js",
               "position": "bottom",
               "skipIfContains": "id: \"workspaces.workspace.selector\"",
-              "value": "\naddPlacement({\n  id: \"workspaces.workspace.menu.app\",\n  target: \"shell-layout:primary-menu\",\n  surfaces: [\"app\"],\n  order: 50,\n  componentToken: \"local.main.ui.surface-aware-menu-link-item\",\n  props: {\n    label: \"Home\",\n    surface: \"app\",\n    scopedSuffix: \"/\",\n    unscopedSuffix: \"/\",\n    exact: true\n  },\n  when: ({ auth }) => auth?.authenticated === true\n});\n\naddPlacement({\n  id: \"workspaces.workspace.menu.admin\",\n  target: \"shell-layout:primary-menu\",\n  surfaces: [\"admin\"],\n  order: 60,\n  componentToken: \"local.main.ui.surface-aware-menu-link-item\",\n  props: {\n    label: \"Home\",\n    surface: \"admin\",\n    scopedSuffix: \"/\",\n    unscopedSuffix: \"/\",\n    exact: true\n  },\n  when: ({ auth }) => auth?.authenticated === true\n});\n\naddPlacement({\n  id: \"workspaces.workspace.selector\",\n  target: \"shell-layout:top-left\",\n  surfaces: [\"*\"],\n  order: 200,\n  componentToken: \"workspaces.web.workspace.selector\",\n  props: {\n    allowOnNonWorkspaceSurface: true,\n    targetSurfaceId: \"app\"\n  },\n  when: ({ auth }) => auth?.authenticated === true\n});\n\naddPlacement({\n  id: \"workspaces.account.invites.cue\",\n  target: \"shell-layout:top-right\",\n  surfaces: [\"*\"],\n  order: 850,\n  componentToken: \"local.main.account.pending-invites.cue\",\n  when: ({ auth }) => auth?.authenticated === true\n});\n\naddPlacement({\n  id: \"workspaces.workspace.tools.widget\",\n  target: \"shell-layout:top-right\",\n  surfaces: [\"admin\"],\n  order: 900,\n  componentToken: \"workspaces.web.workspace.tools.widget\"\n});\n\naddPlacement({\n  id: \"workspaces.workspace.menu.workspace-settings\",\n  target: \"admin-cog:primary-menu\",\n  surfaces: [\"admin\"],\n  order: 100,\n  componentToken: \"workspaces.web.workspace-settings.menu-item\"\n});\n\naddPlacement({\n  id: \"workspaces.workspace.menu.members\",\n  target: \"admin-cog:primary-menu\",\n  surfaces: [\"admin\"],\n  order: 200,\n  componentToken: \"workspaces.web.workspace-members.menu-item\"\n});\n",
+              "value": "\naddPlacement({\n  id: \"workspaces.workspace.menu.app\",\n  target: \"shell.primary-nav\",\n  kind: \"link\",\n  surfaces: [\"app\"],\n  order: 50,\n  props: {\n    label: \"Home\",\n    surface: \"app\",\n    scopedSuffix: \"/\",\n    unscopedSuffix: \"/\",\n    exact: true\n  },\n  when: ({ auth }) => auth?.authenticated === true\n});\n\naddPlacement({\n  id: \"workspaces.workspace.menu.admin\",\n  target: \"shell.primary-nav\",\n  kind: \"link\",\n  surfaces: [\"admin\"],\n  order: 60,\n  props: {\n    label: \"Home\",\n    surface: \"admin\",\n    scopedSuffix: \"/\",\n    unscopedSuffix: \"/\",\n    exact: true\n  },\n  when: ({ auth }) => auth?.authenticated === true\n});\n\naddPlacement({\n  id: \"workspaces.workspace.selector\",\n  target: \"shell.identity\",\n  kind: \"component\",\n  surfaces: [\"*\"],\n  order: 200,\n  componentToken: \"workspaces.web.workspace.selector\",\n  props: {\n    allowOnNonWorkspaceSurface: true,\n    targetSurfaceId: \"app\"\n  },\n  when: ({ auth }) => auth?.authenticated === true\n});\n\naddPlacement({\n  id: \"workspaces.account.invites.cue\",\n  target: \"shell.status\",\n  kind: \"component\",\n  surfaces: [\"*\"],\n  order: 850,\n  componentToken: \"local.main.account.pending-invites.cue\",\n  when: ({ auth }) => auth?.authenticated === true\n});\n\naddPlacement({\n  id: \"workspaces.workspace.tools.widget\",\n  target: \"shell.status\",\n  kind: \"component\",\n  surfaces: [\"admin\"],\n  order: 900,\n  componentToken: \"workspaces.web.workspace.tools.widget\"\n});\n\naddPlacement({\n  id: \"workspaces.workspace.menu.workspace-settings\",\n  target: \"admin.tools-menu\",\n  kind: \"component\",\n  surfaces: [\"admin\"],\n  order: 100,\n  componentToken: \"workspaces.web.workspace-settings.menu-item\"\n});\n\naddPlacement({\n  id: \"workspaces.workspace.menu.members\",\n  target: \"admin.tools-menu\",\n  kind: \"component\",\n  surfaces: [\"admin\"],\n  order: 200,\n  componentToken: \"workspaces.web.workspace-members.menu-item\"\n});\n",
               "reason": "Append workspace placement entries into app-owned placement registry.",
               "category": "workspaces-web",
               "id": "workspaces-web-placement-block",
@@ -6026,10 +6386,27 @@
             },
             {
               "op": "append-text",
+              "file": "src/placementTopology.js",
+              "position": "bottom",
+              "skipIfContains": "id: \"admin.tools-menu\"",
+              "value": "\naddPlacementTopology({\n  id: \"page.section-nav\",\n  owner: \"admin-settings\",\n  description: \"Navigation between workspace admin settings child pages.\",\n  surfaces: [\"admin\"],\n  variants: {\n    compact: {\n      outlet: \"admin-settings:primary-menu\",\n      renderers: {\n        link: \"local.main.ui.surface-aware-menu-link-item\"\n      }\n    },\n    medium: {\n      outlet: \"admin-settings:primary-menu\",\n      renderers: {\n        link: \"local.main.ui.surface-aware-menu-link-item\"\n      }\n    },\n    expanded: {\n      outlet: \"admin-settings:primary-menu\",\n      renderers: {\n        link: \"local.main.ui.surface-aware-menu-link-item\"\n      }\n    }\n  }\n});\n\naddPlacementTopology({\n  id: \"admin.tools-menu\",\n  description: \"Admin surface tools menu actions.\",\n  surfaces: [\"admin\"],\n  variants: {\n    compact: {\n      outlet: \"admin-cog:primary-menu\",\n      renderers: {\n        link: \"local.main.ui.surface-aware-menu-link-item\"\n      }\n    },\n    medium: {\n      outlet: \"admin-cog:primary-menu\",\n      renderers: {\n        link: \"local.main.ui.surface-aware-menu-link-item\"\n      }\n    },\n    expanded: {\n      outlet: \"admin-cog:primary-menu\",\n      renderers: {\n        link: \"local.main.ui.surface-aware-menu-link-item\"\n      }\n    }\n  }\n});\n",
+              "reason": "Append workspaces-web admin semantic topology into app-owned placement topology.",
+              "category": "workspaces-web",
+              "id": "workspaces-web-admin-placement-topology",
+              "when": {
+                "config": "tenancyMode",
+                "in": [
+                  "personal",
+                  "workspaces"
+                ]
+              }
+            },
+            {
+              "op": "append-text",
               "file": "src/placement.js",
               "position": "bottom",
               "skipIfContains": "id: \"workspaces.account.settings.invites\"",
-              "value": "\naddPlacement({\n  id: \"workspaces.account.settings.invites\",\n  target: \"account-settings:sections\",\n  surfaces: [\"account\"],\n  order: 400,\n  componentToken: \"local.main.account-settings.section.invites\",\n  props: {\n    title: \"Invites\",\n    value: \"invites\",\n    usesSharedRuntime: false\n  },\n  when: ({ auth, workspaceInvitesEnabled }) => auth?.authenticated === true && workspaceInvitesEnabled === true\n});\n",
+              "value": "\naddPlacement({\n  id: \"workspaces.account.settings.invites\",\n  target: \"settings.sections\",\n  owner: \"account-settings\",\n  kind: \"component\",\n  surfaces: [\"account\"],\n  order: 400,\n  componentToken: \"local.main.account-settings.section.invites\",\n  props: {\n    title: \"Invites\",\n    value: \"invites\",\n    usesSharedRuntime: false\n  },\n  when: ({ auth, workspaceInvitesEnabled }) => auth?.authenticated === true && workspaceInvitesEnabled === true\n});\n",
               "reason": "Append workspaces-web account settings invites section placement into app-owned placement registry.",
               "category": "workspaces-web",
               "id": "workspaces-web-account-settings-placement",

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -6,11 +6,11 @@
   "packages": [
     {
       "packageId": "@jskit-ai/assistant",
-      "version": "0.1.74",
+      "version": "0.1.75",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant",
-        "version": "0.1.74",
+        "version": "0.1.75",
         "kind": "generator",
         "description": "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
         "options": {
@@ -347,11 +347,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-core",
-      "version": "0.1.41",
+      "version": "0.1.42",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-core",
-        "version": "0.1.41",
+        "version": "0.1.42",
         "kind": "runtime",
         "description": "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
         "dependsOn": [
@@ -399,11 +399,11 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/http-runtime": "0.1.64",
-              "@jskit-ai/kernel": "0.1.65",
-              "@jskit-ai/resource-core": "0.1.10",
-              "@jskit-ai/resource-crud-core": "0.1.10",
-              "@jskit-ai/users-core": "0.1.75",
+              "@jskit-ai/http-runtime": "0.1.65",
+              "@jskit-ai/kernel": "0.1.66",
+              "@jskit-ai/resource-core": "0.1.11",
+              "@jskit-ai/resource-crud-core": "0.1.11",
+              "@jskit-ai/users-core": "0.1.76",
               "@tanstack/vue-query": "^5.90.5",
               "dompurify": "^3.3.3",
               "json-rest-schema": "1.x.x",
@@ -424,11 +424,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-runtime",
-      "version": "0.1.36",
+      "version": "0.1.37",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-runtime",
-        "version": "0.1.36",
+        "version": "0.1.37",
         "kind": "runtime",
         "description": "Shared assistant runtime with per-surface assistant registration.",
         "dependsOn": [
@@ -524,13 +524,13 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/assistant-core": "0.1.41",
-              "@jskit-ai/database-runtime": "0.1.65",
-              "@jskit-ai/http-runtime": "0.1.64",
-              "@jskit-ai/kernel": "0.1.65",
-              "@jskit-ai/shell-web": "0.1.64",
-              "@jskit-ai/users-core": "0.1.75",
-              "@jskit-ai/users-web": "0.1.80",
+              "@jskit-ai/assistant-core": "0.1.42",
+              "@jskit-ai/database-runtime": "0.1.66",
+              "@jskit-ai/http-runtime": "0.1.65",
+              "@jskit-ai/kernel": "0.1.66",
+              "@jskit-ai/shell-web": "0.1.65",
+              "@jskit-ai/users-core": "0.1.76",
+              "@jskit-ai/users-web": "0.1.81",
               "@tanstack/vue-query": "^5.90.5",
               "vuetify": "^4.0.0"
             },
@@ -587,11 +587,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-core",
-      "version": "0.1.64",
+      "version": "0.1.65",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-core",
-        "version": "0.1.64",
+        "version": "0.1.65",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/value-app-config-shared"
@@ -659,7 +659,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.65",
+              "@jskit-ai/kernel": "0.1.66",
               "@fastify/cookie": "^11.0.2",
               "@fastify/csrf-protection": "^7.1.0",
               "@fastify/rate-limit": "^10.3.0"
@@ -677,11 +677,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.64",
+      "version": "0.1.65",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-supabase-core",
-        "version": "0.1.64",
+        "version": "0.1.65",
         "kind": "runtime",
         "options": {
           "auth-supabase-url": {
@@ -763,8 +763,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.64",
-              "@jskit-ai/kernel": "0.1.65",
+              "@jskit-ai/auth-core": "0.1.65",
+              "@jskit-ai/kernel": "0.1.66",
               "dotenv": "^16.4.5",
               "@supabase/supabase-js": "^2.57.4",
               "jose": "^6.1.0"
@@ -829,11 +829,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-web",
-      "version": "0.1.66",
+      "version": "0.1.67",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-web",
-        "version": "0.1.66",
+        "version": "0.1.67",
         "kind": "runtime",
         "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
         "dependsOn": [
@@ -1090,10 +1090,10 @@
             "runtime": {
               "@tanstack/vue-query": "5.92.12",
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/auth-core": "0.1.64",
-              "@jskit-ai/http-runtime": "0.1.64",
-              "@jskit-ai/kernel": "0.1.65",
-              "@jskit-ai/shell-web": "0.1.64",
+              "@jskit-ai/auth-core": "0.1.65",
+              "@jskit-ai/http-runtime": "0.1.65",
+              "@jskit-ai/kernel": "0.1.66",
+              "@jskit-ai/shell-web": "0.1.65",
               "vuetify": "^4.0.0"
             },
             "dev": {}
@@ -1173,11 +1173,11 @@
     },
     {
       "packageId": "@jskit-ai/console-core",
-      "version": "0.1.28",
+      "version": "0.1.29",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-core",
-        "version": "0.1.28",
+        "version": "0.1.29",
         "kind": "runtime",
         "description": "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
         "dependsOn": [
@@ -1261,12 +1261,12 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.64",
-              "@jskit-ai/database-runtime": "0.1.65",
-              "@jskit-ai/http-runtime": "0.1.64",
-              "@jskit-ai/kernel": "0.1.65",
-              "@jskit-ai/resource-crud-core": "0.1.10",
-              "@jskit-ai/users-core": "0.1.75"
+              "@jskit-ai/auth-core": "0.1.65",
+              "@jskit-ai/database-runtime": "0.1.66",
+              "@jskit-ai/http-runtime": "0.1.65",
+              "@jskit-ai/kernel": "0.1.66",
+              "@jskit-ai/resource-crud-core": "0.1.11",
+              "@jskit-ai/users-core": "0.1.76"
             },
             "dev": {}
           },
@@ -1291,11 +1291,11 @@
     },
     {
       "packageId": "@jskit-ai/console-web",
-      "version": "0.1.33",
+      "version": "0.1.34",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-web",
-        "version": "0.1.33",
+        "version": "0.1.34",
         "kind": "runtime",
         "description": "Authenticated console surface scaffold and surface policy wiring.",
         "dependsOn": [
@@ -1405,9 +1405,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-web": "0.1.66",
-              "@jskit-ai/console-core": "0.1.28",
-              "@jskit-ai/shell-web": "0.1.64"
+              "@jskit-ai/auth-web": "0.1.67",
+              "@jskit-ai/console-core": "0.1.29",
+              "@jskit-ai/shell-web": "0.1.65"
             },
             "dev": {}
           },
@@ -1514,11 +1514,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-core",
-      "version": "0.1.73",
+      "version": "0.1.74",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-core",
-        "version": "0.1.73",
+        "version": "0.1.74",
         "kind": "runtime",
         "description": "Shared CRUD helpers used by CRUD modules.",
         "dependsOn": [
@@ -1547,7 +1547,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/crud-core": "0.1.73"
+              "@jskit-ai/crud-core": "0.1.74"
             },
             "dev": {}
           },
@@ -1561,11 +1561,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-server-generator",
-      "version": "0.1.73",
+      "version": "0.1.74",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-server-generator",
-        "version": "0.1.73",
+        "version": "0.1.74",
         "kind": "generator",
         "description": "CRUD server generator with routes, actions, and persistence scaffolding.",
         "options": {
@@ -1732,14 +1732,14 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.64",
-              "@jskit-ai/crud-core": "0.1.73",
-              "@jskit-ai/database-runtime": "0.1.65",
-              "@jskit-ai/http-runtime": "0.1.64",
-              "@jskit-ai/json-rest-api-core": "0.1.10",
-              "@jskit-ai/kernel": "0.1.65",
-              "@jskit-ai/realtime": "0.1.64",
-              "@jskit-ai/resource-crud-core": "0.1.10",
+              "@jskit-ai/auth-core": "0.1.65",
+              "@jskit-ai/crud-core": "0.1.74",
+              "@jskit-ai/database-runtime": "0.1.66",
+              "@jskit-ai/http-runtime": "0.1.65",
+              "@jskit-ai/json-rest-api-core": "0.1.11",
+              "@jskit-ai/kernel": "0.1.66",
+              "@jskit-ai/realtime": "0.1.65",
+              "@jskit-ai/resource-crud-core": "0.1.11",
               "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}"
             },
             "dev": {}
@@ -1871,11 +1871,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.48",
+      "version": "0.1.49",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-ui-generator",
-        "version": "0.1.48",
+        "version": "0.1.49",
         "kind": "generator",
         "description": "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
         "options": {
@@ -2057,7 +2057,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.80"
+              "@jskit-ai/users-web": "0.1.81"
             },
             "dev": {}
           },
@@ -2290,11 +2290,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime",
-      "version": "0.1.65",
+      "version": "0.1.66",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime",
-        "version": "0.1.65",
+        "version": "0.1.66",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -2351,7 +2351,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.65",
+              "@jskit-ai/kernel": "0.1.66",
               "dotenv": "^16.4.5",
               "knex": "^3.1.0"
             },
@@ -2386,11 +2386,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.64",
+      "version": "0.1.65",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-mysql",
-        "version": "0.1.64",
+        "version": "0.1.65",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -2480,7 +2480,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.65",
+              "@jskit-ai/database-runtime": "0.1.66",
               "mysql2": "^3.11.2"
             },
             "dev": {}
@@ -2551,11 +2551,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.64",
+      "version": "0.1.65",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-postgres",
-        "version": "0.1.64",
+        "version": "0.1.65",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -2645,7 +2645,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.65",
+              "@jskit-ai/database-runtime": "0.1.66",
               "pg": "^8.13.1"
             },
             "dev": {}
@@ -2716,11 +2716,11 @@
     },
     {
       "packageId": "@jskit-ai/feature-server-generator",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/feature-server-generator",
-        "version": "0.1.7",
+        "version": "0.1.8",
         "kind": "generator",
         "description": "Scaffold substantial non-CRUD server feature packages with provider, actions, service, and optional persistence seams.",
         "options": {
@@ -2884,10 +2884,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.65",
-              "@jskit-ai/database-runtime-mysql": "0.1.64",
-              "@jskit-ai/json-rest-api-core": "0.1.10",
-              "@jskit-ai/kernel": "0.1.65",
+              "@jskit-ai/database-runtime": "0.1.66",
+              "@jskit-ai/database-runtime-mysql": "0.1.65",
+              "@jskit-ai/json-rest-api-core": "0.1.11",
+              "@jskit-ai/kernel": "0.1.66",
               "json-rest-schema": "1.x.x",
               "@local/${option:feature-name|kebab}": "file:packages/${option:feature-name|kebab}"
             },
@@ -3000,11 +3000,11 @@
     },
     {
       "packageId": "@jskit-ai/google-rewarded-core",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/google-rewarded-core",
-        "version": "0.1.2",
+        "version": "0.1.3",
         "kind": "runtime",
         "description": "Google rewarded workflow runtime plus internal CRUD providers for rules, provider configs, watch sessions, and unlock receipts.",
         "dependsOn": [
@@ -3131,14 +3131,14 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.64",
-              "@jskit-ai/crud-core": "0.1.73",
-              "@jskit-ai/database-runtime": "0.1.65",
-              "@jskit-ai/http-runtime": "0.1.64",
-              "@jskit-ai/json-rest-api-core": "0.1.10",
-              "@jskit-ai/kernel": "0.1.65",
-              "@jskit-ai/resource-crud-core": "0.1.10",
-              "@jskit-ai/workspaces-core": "0.1.41"
+              "@jskit-ai/auth-core": "0.1.65",
+              "@jskit-ai/crud-core": "0.1.74",
+              "@jskit-ai/database-runtime": "0.1.66",
+              "@jskit-ai/http-runtime": "0.1.65",
+              "@jskit-ai/json-rest-api-core": "0.1.11",
+              "@jskit-ai/kernel": "0.1.66",
+              "@jskit-ai/resource-crud-core": "0.1.11",
+              "@jskit-ai/workspaces-core": "0.1.42"
             },
             "dev": {}
           },
@@ -3190,11 +3190,11 @@
     },
     {
       "packageId": "@jskit-ai/google-rewarded-web",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/google-rewarded-web",
-        "version": "0.1.2",
+        "version": "0.1.3",
         "kind": "runtime",
         "description": "Google rewarded client runtime with a fullscreen gate host and GPT orchestration.",
         "dependsOn": [
@@ -3241,10 +3241,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/google-rewarded-core": "0.1.2",
-              "@jskit-ai/http-runtime": "0.1.64",
-              "@jskit-ai/kernel": "0.1.65",
-              "@jskit-ai/shell-web": "0.1.64"
+              "@jskit-ai/google-rewarded-core": "0.1.3",
+              "@jskit-ai/http-runtime": "0.1.65",
+              "@jskit-ai/kernel": "0.1.66",
+              "@jskit-ai/shell-web": "0.1.65"
             },
             "dev": {}
           },
@@ -3262,11 +3262,11 @@
     },
     {
       "packageId": "@jskit-ai/http-runtime",
-      "version": "0.1.64",
+      "version": "0.1.65",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/http-runtime",
-        "version": "0.1.64",
+        "version": "0.1.65",
         "kind": "runtime",
         "dependsOn": [],
         "capabilities": {
@@ -3332,7 +3332,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.65"
+              "@jskit-ai/kernel": "0.1.66"
             },
             "dev": {}
           },
@@ -3346,11 +3346,11 @@
     },
     {
       "packageId": "@jskit-ai/json-rest-api-core",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/json-rest-api-core",
-        "version": "0.1.10",
+        "version": "0.1.11",
         "kind": "runtime",
         "description": "Shared internal json-rest-api host runtime for JSKIT server packages.",
         "dependsOn": [
@@ -3410,11 +3410,11 @@
     },
     {
       "packageId": "@jskit-ai/mobile-capacitor",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/mobile-capacitor",
-        "version": "0.1.2",
+        "version": "0.1.3",
         "kind": "runtime",
         "description": "Thin Capacitor client integration for JSKIT mobile-shell launch routing and auth callback completion.",
         "dependsOn": [
@@ -3477,8 +3477,8 @@
               "@capacitor/app": "^7.1.0",
               "@capacitor/browser": "^7.0.1",
               "@capacitor/core": "^7.4.3",
-              "@jskit-ai/kernel": "0.1.65",
-              "@jskit-ai/shell-web": "0.1.64"
+              "@jskit-ai/kernel": "0.1.66",
+              "@jskit-ai/shell-web": "0.1.65"
             },
             "dev": {
               "@capacitor/cli": "^7.4.3"
@@ -3530,11 +3530,11 @@
     },
     {
       "packageId": "@jskit-ai/realtime",
-      "version": "0.1.64",
+      "version": "0.1.65",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/realtime",
-        "version": "0.1.64",
+        "version": "0.1.65",
         "kind": "runtime",
         "description": "Thin, generic realtime runtime wrappers for socket.io server and client.",
         "options": {
@@ -3630,7 +3630,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.65",
+              "@jskit-ai/kernel": "0.1.66",
               "@socket.io/redis-adapter": "^8.3.0",
               "redis": "^5.8.2",
               "socket.io": "^4.8.3",
@@ -3679,11 +3679,11 @@
     },
     {
       "packageId": "@jskit-ai/resource-core",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/resource-core",
-        "version": "0.1.10",
+        "version": "0.1.11",
         "kind": "runtime",
         "description": "Generic resource-definition helpers and schema-definition normalization.",
         "dependsOn": [
@@ -3706,7 +3706,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/resource-core": "0.1.10"
+              "@jskit-ai/resource-core": "0.1.11"
             },
             "dev": {}
           },
@@ -3721,11 +3721,11 @@
     },
     {
       "packageId": "@jskit-ai/resource-crud-core",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/resource-crud-core",
-        "version": "0.1.10",
+        "version": "0.1.11",
         "kind": "runtime",
         "description": "CRUD-specific resource-definition helpers and namespace support.",
         "dependsOn": [
@@ -3749,7 +3749,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/resource-crud-core": "0.1.10"
+              "@jskit-ai/resource-crud-core": "0.1.11"
             },
             "dev": {}
           },
@@ -3764,11 +3764,11 @@
     },
     {
       "packageId": "@jskit-ai/shell-web",
-      "version": "0.1.64",
+      "version": "0.1.65",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/shell-web",
-        "version": "0.1.64",
+        "version": "0.1.65",
         "kind": "runtime",
         "description": "Web shell layout runtime with outlet-based placement contributions.",
         "dependsOn": [],
@@ -4026,7 +4026,7 @@
             "runtime": {
               "@mdi/js": "^7.4.47",
               "@tanstack/vue-query": "^5.90.5",
-              "@jskit-ai/kernel": "0.1.65",
+              "@jskit-ai/kernel": "0.1.66",
               "vuetify": "^4.0.0"
             },
             "dev": {}
@@ -4219,11 +4219,11 @@
     },
     {
       "packageId": "@jskit-ai/storage-runtime",
-      "version": "0.1.64",
+      "version": "0.1.65",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/storage-runtime",
-        "version": "0.1.64",
+        "version": "0.1.65",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -4272,7 +4272,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.65",
+              "@jskit-ai/kernel": "0.1.66",
               "unstorage": "^1.17.3"
             },
             "dev": {}
@@ -4288,11 +4288,11 @@
     },
     {
       "packageId": "@jskit-ai/ui-generator",
-      "version": "0.1.48",
+      "version": "0.1.49",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/ui-generator",
-        "version": "0.1.48",
+        "version": "0.1.49",
         "kind": "generator",
         "description": "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
         "options": {
@@ -4615,7 +4615,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.80"
+              "@jskit-ai/users-web": "0.1.81"
             },
             "dev": {}
           },
@@ -4630,11 +4630,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-image-web",
-      "version": "0.1.43",
+      "version": "0.1.44",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-image-web",
-        "version": "0.1.43",
+        "version": "0.1.44",
         "kind": "runtime",
         "description": "Reusable client-side image upload runtime with pre-upload image editing.",
         "dependsOn": [
@@ -4698,7 +4698,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/uploads-runtime": "0.1.43",
+              "@jskit-ai/uploads-runtime": "0.1.44",
               "@uppy/compressor": "^3.1.0",
               "@uppy/core": "^5.2.0",
               "@uppy/dashboard": "^5.1.1",
@@ -4718,11 +4718,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-runtime",
-      "version": "0.1.43",
+      "version": "0.1.44",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-runtime",
-        "version": "0.1.43",
+        "version": "0.1.44",
         "kind": "runtime",
         "description": "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
         "dependsOn": [
@@ -4792,7 +4792,7 @@
           "dependencies": {
             "runtime": {
               "@fastify/multipart": "^9.4.0",
-              "@jskit-ai/kernel": "0.1.65"
+              "@jskit-ai/kernel": "0.1.66"
             },
             "dev": {}
           },
@@ -4807,11 +4807,11 @@
     },
     {
       "packageId": "@jskit-ai/users-core",
-      "version": "0.1.75",
+      "version": "0.1.76",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-core",
-        "version": "0.1.75",
+        "version": "0.1.76",
         "kind": "runtime",
         "description": "Users/account runtime plus HTTP routes for account features.",
         "dependsOn": [
@@ -4952,16 +4952,16 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.64",
-              "@jskit-ai/crud-core": "0.1.73",
-              "@jskit-ai/database-runtime": "0.1.65",
-              "@jskit-ai/http-runtime": "0.1.64",
-              "@jskit-ai/json-rest-api-core": "0.1.10",
-              "@jskit-ai/kernel": "0.1.65",
-              "@jskit-ai/resource-core": "0.1.10",
-              "@jskit-ai/resource-crud-core": "0.1.10",
+              "@jskit-ai/auth-core": "0.1.65",
+              "@jskit-ai/crud-core": "0.1.74",
+              "@jskit-ai/database-runtime": "0.1.66",
+              "@jskit-ai/http-runtime": "0.1.65",
+              "@jskit-ai/json-rest-api-core": "0.1.11",
+              "@jskit-ai/kernel": "0.1.66",
+              "@jskit-ai/resource-core": "0.1.11",
+              "@jskit-ai/resource-crud-core": "0.1.11",
               "@local/users": "file:packages/users",
-              "@jskit-ai/uploads-runtime": "0.1.43"
+              "@jskit-ai/uploads-runtime": "0.1.44"
             },
             "dev": {}
           },
@@ -5178,11 +5178,11 @@
     },
     {
       "packageId": "@jskit-ai/users-web",
-      "version": "0.1.80",
+      "version": "0.1.81",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-web",
-        "version": "0.1.80",
+        "version": "0.1.81",
         "kind": "runtime",
         "description": "Users web module: account/profile UI plus shared users web widgets.",
         "dependsOn": [
@@ -5434,12 +5434,12 @@
             "runtime": {
               "@tanstack/vue-query": "5.92.12",
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/http-runtime": "0.1.64",
-              "@jskit-ai/realtime": "0.1.64",
-              "@jskit-ai/kernel": "0.1.65",
-              "@jskit-ai/shell-web": "0.1.64",
-              "@jskit-ai/uploads-image-web": "0.1.43",
-              "@jskit-ai/users-core": "0.1.75",
+              "@jskit-ai/http-runtime": "0.1.65",
+              "@jskit-ai/realtime": "0.1.65",
+              "@jskit-ai/kernel": "0.1.66",
+              "@jskit-ai/shell-web": "0.1.65",
+              "@jskit-ai/uploads-image-web": "0.1.44",
+              "@jskit-ai/users-core": "0.1.76",
               "vuetify": "^4.0.0"
             },
             "dev": {}
@@ -5609,11 +5609,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-core",
-      "version": "0.1.41",
+      "version": "0.1.42",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-core",
-        "version": "0.1.41",
+        "version": "0.1.42",
         "kind": "runtime",
         "description": "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
         "dependsOn": [
@@ -5754,10 +5754,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/json-rest-api-core": "0.1.10",
-              "@jskit-ai/resource-core": "0.1.10",
-              "@jskit-ai/resource-crud-core": "0.1.10",
-              "@jskit-ai/users-core": "0.1.75"
+              "@jskit-ai/json-rest-api-core": "0.1.11",
+              "@jskit-ai/resource-core": "0.1.11",
+              "@jskit-ai/resource-crud-core": "0.1.11",
+              "@jskit-ai/users-core": "0.1.76"
             },
             "dev": {}
           },
@@ -5929,11 +5929,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-web",
-      "version": "0.1.41",
+      "version": "0.1.42",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-web",
-        "version": "0.1.41",
+        "version": "0.1.42",
         "kind": "runtime",
         "description": "Workspace web module: workspace selector, tools widget, workspace surfaces, and members/settings UI.",
         "dependsOn": [
@@ -6185,8 +6185,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/workspaces-core": "0.1.41",
-              "@jskit-ai/users-web": "0.1.80",
+              "@jskit-ai/workspaces-core": "0.1.42",
+              "@jskit-ai/users-web": "0.1.81",
               "vuetify": "^4.0.0"
             },
             "dev": {}

--- a/tooling/jskit-catalog/package.json
+++ b/tooling/jskit-catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-catalog",
-  "version": "0.1.73",
+  "version": "0.1.74",
   "description": "Published metadata catalog for JSKIT package descriptors.",
   "type": "module",
   "files": [

--- a/tooling/jskit-cli/package.json
+++ b/tooling/jskit-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-cli",
-  "version": "0.2.74",
+  "version": "0.2.75",
   "description": "Bundle and package orchestration CLI for JSKIT apps.",
   "type": "module",
   "files": [
@@ -20,9 +20,9 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/jskit-catalog": "0.1.73",
-    "@jskit-ai/kernel": "0.1.65",
-    "@jskit-ai/shell-web": "0.1.64"
+    "@jskit-ai/jskit-catalog": "0.1.74",
+    "@jskit-ai/kernel": "0.1.66",
+    "@jskit-ai/shell-web": "0.1.65"
   },
   "engines": {
     "node": "20.x"

--- a/tooling/jskit-cli/src/server/cliRuntime/completion.js
+++ b/tooling/jskit-cli/src/server/cliRuntime/completion.js
@@ -3,6 +3,10 @@ import { pathToFileURL } from "node:url";
 import { access, readdir, readFile } from "node:fs/promises";
 import { buildCrudFieldContractMap } from "@jskit-ai/kernel/shared/support/crudFieldContract";
 import {
+  discoverPlacementTopologyFromApp,
+  discoverShellOutletTargetsFromApp
+} from "@jskit-ai/kernel/server/support";
+import {
   buildAppCommandOptionMeta,
   listAppCommandDefinitions
 } from "../commandHandlers/appCommandCatalog.js";
@@ -370,6 +374,37 @@ async function discoverPlacementTargets(appRoot) {
   return uniqueSorted(placementValues);
 }
 
+async function discoverSemanticPlacementTargets(appRoot) {
+  try {
+    const topology = await discoverPlacementTopologyFromApp({ appRoot });
+    return uniqueSorted(
+      (Array.isArray(topology?.placements) ? topology.placements : [])
+        .map((placement) => normalizeText(placement?.id))
+        .filter(Boolean)
+    );
+  } catch {
+    const topologyPath = path.join(appRoot, "src", "placementTopology.js");
+    if (!(await pathExists(topologyPath))) {
+      return [];
+    }
+    const source = await readFile(topologyPath, "utf8");
+    return uniqueSorted(extractMatches(source, [/\bid\s*:\s*["']([^"':]+(?:\.[^"':]+)+)["']/g]));
+  }
+}
+
+async function discoverConcretePlacementTargets(appRoot) {
+  try {
+    const discovered = await discoverShellOutletTargetsFromApp({ appRoot });
+    return uniqueSorted(
+      (Array.isArray(discovered?.targets) ? discovered.targets : [])
+        .map((target) => normalizeText(target?.id || target?.target))
+        .filter(Boolean)
+    );
+  } catch {
+    return discoverPlacementTargets(appRoot);
+  }
+}
+
 async function discoverComponentTokens(appRoot) {
   const tokens = [];
   for (const filePath of [
@@ -391,7 +426,6 @@ async function discoverComponentTokens(appRoot) {
     const source = await readFile(filePath, "utf8");
     tokens.push(...extractMatches(source, [
       /\bcomponentToken\s*:\s*["']([^"']+)["']/g,
-      /\bdefault-link-component-token\s*=\s*["']([^"']+)["']/g,
       /registerMainClientComponent\(\s*["']([^"']+)["']/g
     ]));
   }
@@ -590,9 +624,11 @@ async function completeOptionValue({
 
   if (normalizedOptionName === "resource-file") {
     suggestions = await discoverResourceFiles(appRoot);
-  } else if (["link-placement", "placement", "target"].includes(normalizedOptionName)) {
-    suggestions = await discoverPlacementTargets(appRoot);
-  } else if (normalizedOptionName === "link-component-token") {
+  } else if (["link-placement", "placement"].includes(normalizedOptionName)) {
+    suggestions = await discoverSemanticPlacementTargets(appRoot);
+  } else if (normalizedOptionName === "target") {
+    suggestions = await discoverConcretePlacementTargets(appRoot);
+  } else if (normalizedOptionName === "link-renderer") {
     suggestions = await discoverComponentTokens(appRoot);
   } else if (normalizedOptionName === "surface") {
     suggestions = await discoverSurfaces(appRoot);

--- a/tooling/jskit-cli/src/server/cliRuntime/mutations/textMutations.js
+++ b/tooling/jskit-cli/src/server/cliRuntime/mutations/textMutations.js
@@ -113,6 +113,13 @@ async function applyTextMutations(
       const previous = await readFileBufferIfExists(absoluteFile);
       const previousContent = previous.exists ? previous.buffer.toString("utf8") : "";
       const mutationId = String(mutation?.id || "").trim() || "append-text";
+      const interpolatedSkipChecks = normalizeSkipChecks(mutation?.skipIfContains)
+        .map((entry) => interpolateOptionValue(entry, options, packageEntry.packageId, `${mutationId}.skipIfContains`))
+        .filter((entry) => String(entry || "").trim().length > 0);
+      if (interpolatedSkipChecks.some((pattern) => previousContent.includes(String(pattern)))) {
+        continue;
+      }
+
       const resolvedSnippet = interpolateOptionValue(snippet, options, packageEntry.packageId, mutationId);
       const templateContextReplacements = await resolveTemplateContextReplacementsForMutation({
         packageEntry,
@@ -126,8 +133,7 @@ async function applyTextMutations(
       const renderedSnippet = templateContextReplacements
         ? applyTemplateContextReplacements(resolvedSnippet, templateContextReplacements)
         : resolvedSnippet;
-      const skipChecks = normalizeSkipChecks(mutation?.skipIfContains)
-        .map((entry) => interpolateOptionValue(entry, options, packageEntry.packageId, `${mutationId}.skipIfContains`))
+      const skipChecks = interpolatedSkipChecks
         .map((entry) => {
           if (!templateContextReplacements) {
             return entry;

--- a/tooling/jskit-cli/src/server/cliRuntime/packageIntrospection/placementNormalization.js
+++ b/tooling/jskit-cli/src/server/cliRuntime/packageIntrospection/placementNormalization.js
@@ -3,7 +3,11 @@ import {
   ensureObject
 } from "../../shared/collectionUtils.js";
 import {
-  normalizeShellOutletTargetId
+  normalizePlacementKind,
+  normalizePlacementOwnerId,
+  normalizePlacementTopologyDefinition,
+  normalizeShellOutletTargetId,
+  resolvePlacementTargetReference
 } from "@jskit-ai/kernel/shared/support/shellLayoutTargets";
 
 function normalizePlacementOutlets(value) {
@@ -41,22 +45,27 @@ function normalizePlacementContributions(value) {
   for (const entry of ensureArray(value)) {
     const record = ensureObject(entry);
     const id = String(record.id || "").trim();
-    const target = normalizeShellOutletTargetId(record.target);
-    if (!id || !target) {
+    const targetReference = resolvePlacementTargetReference(record.target);
+    if (!id || !targetReference?.id) {
       continue;
     }
 
     const surfaces = [...new Set(ensureArray(record.surfaces).map((item) => String(item || "").trim()).filter(Boolean))];
+    const kind = normalizePlacementKind(record.kind) || (String(record.componentToken || "").trim() ? "component" : "link");
     const componentToken = String(record.componentToken || "").trim();
     const when = String(record.when || "").trim();
     const description = String(record.description || "").trim();
     const source = String(record.source || "").trim();
+    const owner = normalizePlacementOwnerId(record.owner);
     const parsedOrder = Number(record.order);
     const order = Number.isFinite(parsedOrder) ? Math.trunc(parsedOrder) : null;
     contributions.push(
       Object.freeze({
         id,
-        target,
+        target: targetReference.id,
+        targetType: targetReference.type,
+        owner,
+        kind,
         surfaces: Object.freeze(surfaces),
         order,
         componentToken,
@@ -83,7 +92,12 @@ function normalizePlacementContributions(value) {
   );
 }
 
+function normalizePlacementTopology(value, { context = "package placement topology" } = {}) {
+  return normalizePlacementTopologyDefinition(value, { context }).placements;
+}
+
 export {
   normalizePlacementContributions,
-  normalizePlacementOutlets
+  normalizePlacementOutlets,
+  normalizePlacementTopology
 };

--- a/tooling/jskit-cli/src/server/commandHandlers/list.js
+++ b/tooling/jskit-cli/src/server/commandHandlers/list.js
@@ -177,6 +177,7 @@ function createListCommands(ctx = {}) {
     loadBundleRegistry,
     loadAppLocalPackageRegistry,
     resolveInstalledNodeModulePackageEntry,
+    discoverPlacementTopologyFromApp,
     discoverShellOutletTargetsFromApp,
     normalizePlacementContributions,
     resolvePackageKind
@@ -435,39 +436,99 @@ function createListCommands(ctx = {}) {
 
   async function commandListPlacements({ options, cwd, stdout }) {
     const appRoot = await resolveAppRootFromCwd(cwd);
-    const discoveredPlacements = await discoverShellOutletTargetsFromApp({
-      appRoot,
-      sourceRoot: "src"
-    });
-    const placementTargets = ensureArray(discoveredPlacements.targets)
+    const showConcreteOnly = options.concrete === true && options.all !== true;
+    const showConcrete = options.concrete === true || options.all === true;
+    const showSemantic = showConcreteOnly !== true;
+    const discoveredTopology = await discoverPlacementTopologyFromApp({ appRoot });
+    const semanticPlacements = ensureArray(discoveredTopology.placements)
+      .map((entry) => ensureObject(entry))
+      .filter((entry) => String(entry.id || "").trim())
+      .sort((left, right) => {
+        const idCompare = String(left.id || "").localeCompare(String(right.id || ""));
+        if (idCompare !== 0) {
+          return idCompare;
+        }
+        return String(left.owner || "").localeCompare(String(right.owner || ""));
+      });
+    const discoveredConcrete = showConcrete
+      ? await discoverShellOutletTargetsFromApp({
+        appRoot,
+        sourceRoot: "src"
+      })
+      : { targets: [] };
+    const concreteTargets = ensureArray(discoveredConcrete.targets)
       .map((entry) => ensureObject(entry))
       .filter((entry) => String(entry.id || "").trim())
       .sort((left, right) => String(left.id || "").localeCompare(String(right.id || "")));
 
     if (options.json) {
       const payload = {
-        placements: placementTargets.map((placementTarget) => ({
-          target: String(placementTarget.id || "").trim(),
-          default: placementTarget.default === true,
-          sourcePath: String(placementTarget.sourcePath || "").trim()
-        }))
+        placements: showSemantic
+          ? semanticPlacements.map((placementTarget) => ({
+            target: String(placementTarget.id || "").trim(),
+            owner: String(placementTarget.owner || "").trim(),
+            default: placementTarget.default === true,
+            description: String(placementTarget.description || "").trim(),
+            surfaces: ensureArray(placementTarget.surfaces).map((entry) => String(entry || "").trim()).filter(Boolean),
+            variants: ensureObject(placementTarget.variants),
+            sourcePath: String(placementTarget.sourcePath || "").trim()
+          }))
+          : [],
+        concretePlacements: showConcrete
+          ? concreteTargets.map((placementTarget) => ({
+            target: String(placementTarget.id || "").trim(),
+            default: placementTarget.default === true,
+            sourcePath: String(placementTarget.sourcePath || "").trim()
+          }))
+          : []
       };
       stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
       return 0;
     }
 
     const color = createColorFormatter(stdout);
-    const lines = [color.heading("Available placements:")];
-    if (placementTargets.length < 1) {
-      lines.push("- none");
-    } else {
-      for (const placementTarget of placementTargets) {
-        const placementId = String(placementTarget.id || "").trim();
-        const sourcePath = String(placementTarget.sourcePath || "").trim();
-        const isDefault = placementTarget.default === true;
-        const defaultLabel = isDefault ? color.installed(" (default)") : "";
-        const sourceLabel = sourcePath ? ` ${color.dim(`[${sourcePath}]`)}` : "";
-        lines.push(`- ${color.item(placementId)}${defaultLabel}${sourceLabel}`);
+    const lines = [];
+    if (showSemantic) {
+      lines.push(color.heading("Available placements:"));
+      if (semanticPlacements.length < 1) {
+        lines.push("- none");
+      } else {
+        for (const placementTarget of semanticPlacements) {
+          const placementId = String(placementTarget.id || "").trim();
+          const owner = String(placementTarget.owner || "").trim();
+          const ownerLabel = owner ? color.dim(` [owner:${owner}]`) : "";
+          const defaultLabel = placementTarget.default === true ? color.installed(" (default)") : "";
+          const description = String(placementTarget.description || "").trim();
+          const descriptionSuffix = description ? `: ${description}` : "";
+          lines.push(`- ${color.item(placementId)}${ownerLabel}${defaultLabel}${descriptionSuffix}`);
+          const variants = ensureObject(placementTarget.variants);
+          for (const layoutClass of ["compact", "medium", "expanded"]) {
+            const variant = ensureObject(variants[layoutClass]);
+            const outlet = String(variant.outlet || "").trim();
+            if (outlet) {
+              lines.push(`  ${layoutClass} -> ${color.dim(outlet)}`);
+            }
+          }
+        }
+      }
+    }
+
+    if (showConcrete) {
+      if (lines.length > 0) {
+        lines.push("");
+      }
+      lines.push(color.heading("Available concrete outlets:"));
+      if (concreteTargets.length < 1) {
+        lines.push("- none");
+      } else {
+        for (const placementTarget of concreteTargets) {
+          const placementId = String(placementTarget.id || "").trim();
+          const sourcePath = String(placementTarget.sourcePath || "").trim();
+          const isDefault = placementTarget.default === true;
+          const defaultLabel = isDefault ? color.installed(" (default)") : "";
+          const sourceLabel = sourcePath ? ` ${color.dim(`[${sourcePath}]`)}` : "";
+          lines.push(`- ${color.item(placementId)}${defaultLabel}${sourceLabel}`);
+        }
       }
     }
 

--- a/tooling/jskit-cli/src/server/commandHandlers/mobileShellSupport.js
+++ b/tooling/jskit-cli/src/server/commandHandlers/mobileShellSupport.js
@@ -158,6 +158,18 @@ function buildManagedMobileConfigStub({ packageJson = {} } = {}) {
   ].join("\n");
 }
 
+function isEmptyDisabledMobileConfigPlaceholder(mobileConfig = {}) {
+  return (
+    mobileConfig?.enabled !== true &&
+    !String(mobileConfig?.strategy || "").trim() &&
+    !String(mobileConfig?.appId || "").trim() &&
+    !String(mobileConfig?.appName || "").trim() &&
+    !String(mobileConfig?.apiBaseUrl || "").trim() &&
+    !String(mobileConfig?.auth?.customScheme || "").trim() &&
+    !String(mobileConfig?.android?.packageName || "").trim()
+  );
+}
+
 function parseAndroidSdkDirFromLocalProperties(source = "") {
   const lines = String(source || "").split(/\r?\n/u);
   for (const line of lines) {
@@ -489,8 +501,18 @@ async function ensureMobileConfigStub({
   } = ctx;
   const publicConfigPath = path.join(appRoot, PUBLIC_CONFIG_RELATIVE_PATH);
   const currentSource = await readFile(publicConfigPath, "utf8");
-  if (/\bconfig\.mobile\b|\bmobile\s*:/u.test(currentSource)) {
+  if (
+    currentSource.includes(MANAGED_MOBILE_CONFIG_START_MARKER) &&
+    currentSource.includes(MANAGED_MOBILE_CONFIG_END_MARKER)
+  ) {
     return false;
+  }
+  if (/\bconfig\.mobile\b|\bmobile\s*:/u.test(currentSource)) {
+    const mergedConfig = await loadAppConfigFromAppRoot({ appRoot });
+    const mobileConfig = resolveMobileConfig({ mobile: mergedConfig.mobile });
+    if (!isEmptyDisabledMobileConfigPlaceholder(mobileConfig)) {
+      return false;
+    }
   }
 
   const stubSource = buildManagedMobileConfigStub({
@@ -913,6 +935,7 @@ export {
   ANDROID_DIRECTORY_NAME,
   ANDROID_MANIFEST_RELATIVE_PATH,
   buildManagedMobileConfigStub,
+  isEmptyDisabledMobileConfigPlaceholder,
   resolveInstalledMobileConfig,
   resolveAndroidSdkDetails,
   collectAndroidSdkComponentIssues,

--- a/tooling/jskit-cli/src/server/core/argParser.js
+++ b/tooling/jskit-cli/src/server/core/argParser.js
@@ -23,6 +23,7 @@ function parseArgs(argv, { createCliError } = {}) {
         verbose: false,
         json: false,
         all: false,
+        concrete: false,
         help: true,
         inlineOptions: {}
       },
@@ -49,6 +50,7 @@ function parseArgs(argv, { createCliError } = {}) {
     verbose: false,
     json: false,
     all: false,
+    concrete: false,
     help: false,
     inlineOptions: {}
   };
@@ -105,6 +107,10 @@ function parseArgs(argv, { createCliError } = {}) {
     }
     if (token === "--all") {
       options.all = true;
+      continue;
+    }
+    if (token === "--concrete") {
+      options.concrete = true;
       continue;
     }
     if (token === "--help" || token === "-h") {

--- a/tooling/jskit-cli/src/server/core/buildCommandDeps.js
+++ b/tooling/jskit-cli/src/server/core/buildCommandDeps.js
@@ -54,7 +54,8 @@ function createCommandHandlerDeps(deps = {}) {
     removeManagedViteProxyEntries: deps.removeManagedViteProxyEntries,
     hashBuffer: deps.hashBuffer,
     rm: deps.rm,
-    discoverShellOutletTargetsFromApp: deps.discoverShellOutletTargetsFromApp
+    discoverShellOutletTargetsFromApp: deps.discoverShellOutletTargetsFromApp,
+    discoverPlacementTopologyFromApp: deps.discoverPlacementTopologyFromApp
   };
 }
 

--- a/tooling/jskit-cli/src/server/core/commandCatalog.js
+++ b/tooling/jskit-cli/src/server/core/commandCatalog.js
@@ -317,14 +317,14 @@ const COMMAND_DESCRIPTORS = Object.freeze({
     minimalUse: "jskit list-placements",
     parameters: Object.freeze([]),
     defaults: Object.freeze([
-      "Discovers placement outlets from app Vue ShellOutlet tags and route meta.",
-      "Includes placement outlets contributed by installed package metadata.",
-      "Shows plain text by default; use --json for structured output."
+      "Shows semantic placement targets from app placement topology by default.",
+      "Use --concrete to inspect low-level ShellOutlet recipients.",
+      "Use --all to show both semantic placements and concrete recipients."
     ]),
-    fullUse: "jskit list-placements [--json]",
+    fullUse: "jskit list-placements [--concrete] [--all] [--json]",
     showHelpOnBareInvocation: false,
     handlerName: "commandListPlacements",
-    allowedFlagKeys: Object.freeze(["json"]),
+    allowedFlagKeys: Object.freeze(["concrete", "all", "json"]),
     inlineOptionMode: "none",
     allowedValueOptionNames: Object.freeze([])
   }),

--- a/tooling/jskit-cli/src/server/core/createCliRunner.js
+++ b/tooling/jskit-cli/src/server/core/createCliRunner.js
@@ -5,7 +5,10 @@ import {
   writeFile
 } from "node:fs/promises";
 import path from "node:path";
-import { discoverShellOutletTargetsFromApp } from "@jskit-ai/kernel/server/support";
+import {
+  discoverPlacementTopologyFromApp,
+  discoverShellOutletTargetsFromApp
+} from "@jskit-ai/kernel/server/support";
 import { createCliError } from "../shared/cliError.js";
 import {
   createColorFormatter,
@@ -146,7 +149,8 @@ const commandHandlers = createCommandHandlers(
     removeManagedViteProxyEntries,
     hashBuffer,
     rm,
-    discoverShellOutletTargetsFromApp
+    discoverShellOutletTargetsFromApp,
+    discoverPlacementTopologyFromApp
   })
 );
 

--- a/tooling/jskit-cli/test/assistantPackage.test.js
+++ b/tooling/jskit-cli/test/assistantPackage.test.js
@@ -77,6 +77,74 @@ export default function getPlacements() {
   );
 
   await writeFile(
+    path.join(appRoot, "src", "placementTopology.js"),
+    `const placements = [];
+
+function addPlacementTopology(value = {}) {
+  placements.push(value);
+}
+
+addPlacementTopology({
+  id: "shell.primary-nav",
+  description: "Primary shell navigation.",
+  surfaces: ["*"],
+  default: true,
+  variants: {
+    compact: {
+      outlet: "shell-layout:primary-menu",
+      renderers: {
+        link: "local.main.ui.surface-aware-menu-link-item"
+      }
+    },
+    medium: {
+      outlet: "shell-layout:primary-menu",
+      renderers: {
+        link: "local.main.ui.surface-aware-menu-link-item"
+      }
+    },
+    expanded: {
+      outlet: "shell-layout:primary-menu",
+      renderers: {
+        link: "local.main.ui.surface-aware-menu-link-item"
+      }
+    }
+  }
+});
+
+addPlacementTopology({
+  id: "page.section-nav",
+  owner: "admin-settings",
+  description: "Admin settings section navigation.",
+  surfaces: ["admin"],
+  variants: {
+    compact: {
+      outlet: "admin-settings:sub-pages",
+      renderers: {
+        link: "local.main.ui.surface-aware-menu-link-item"
+      }
+    },
+    medium: {
+      outlet: "admin-settings:sub-pages",
+      renderers: {
+        link: "local.main.ui.surface-aware-menu-link-item"
+      }
+    },
+    expanded: {
+      outlet: "admin-settings:sub-pages",
+      renderers: {
+        link: "local.main.ui.surface-aware-menu-link-item"
+      }
+    }
+  }
+});
+
+export { addPlacementTopology };
+export default { placements };
+`,
+    "utf8"
+  );
+
+  await writeFile(
     path.join(appRoot, "src", "components", "ShellLayout.vue"),
     `<template>
   <div>
@@ -84,7 +152,6 @@ export default function getPlacements() {
     <ShellOutlet
       target="shell-layout:primary-menu"
       default
-      default-link-component-token="local.main.ui.surface-aware-menu-link-item"
     />
   </div>
 </template>
@@ -255,7 +322,8 @@ test("generate @jskit-ai/assistant settings-page scaffolds a settings page at an
 
     const placementSource = await readFile(path.join(appRoot, "src/placement.js"), "utf8");
     assert.match(placementSource, /jskit:assistant\.settings-page\.link:admin:\/settings\/assistant:console/);
-    assert.match(placementSource, /target: "admin-settings:sub-pages"/);
+    assert.match(placementSource, /target: "page\.section-nav"/);
+    assert.match(placementSource, /owner: "admin-settings"/);
     assert.match(placementSource, /to: "\.\/assistant"/);
   });
 });

--- a/tooling/jskit-cli/test/coreCommandOptionValidation.test.js
+++ b/tooling/jskit-cli/test/coreCommandOptionValidation.test.js
@@ -18,7 +18,7 @@ test("list-placements rejects unsupported value options and prints command help"
   const stderr = String(result.stderr || "");
   assert.match(stderr, /Unknown option for command list-placements: --prefix\./);
   assert.match(stderr, /Command: list-placements/);
-  assert.match(stderr, /jskit list-placements \[--json\]/);
+  assert.match(stderr, /jskit list-placements \[--concrete] \[--all] \[--json\]/);
 });
 
 test("show rejects unsupported flags and prints command help", () => {

--- a/tooling/jskit-cli/test/fileMutationTemplateContext.test.js
+++ b/tooling/jskit-cli/test/fileMutationTemplateContext.test.js
@@ -620,3 +620,93 @@ export { buildTemplateContext };
     assert.match(placementSource, /addPlacement\(\{ target: "shell-layout:primary-menu" \}\);/);
   });
 });
+
+test("add package skips append-text before resolving templateContext when skipIfContains already matches", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "template-context-append-skip-app");
+    await createMinimalApp(appRoot, { name: "template-context-append-skip-app" });
+    await mkdir(path.join(appRoot, "src"), { recursive: true });
+    await writeFile(path.join(appRoot, "src", "placement.js"), "// already-present target\n", "utf8");
+
+    const packageRoot = path.join(appRoot, "packages", "template-context-append-skip-feature");
+    await mkdir(path.join(packageRoot, "src", "server"), { recursive: true });
+
+    await writeFile(
+      path.join(packageRoot, "package.json"),
+      `${JSON.stringify(
+        {
+          name: "@demo/template-context-append-skip-feature",
+          version: "0.1.0",
+          type: "module"
+        },
+        null,
+        2
+      )}\n`,
+      "utf8"
+    );
+
+    await writeFile(
+      path.join(packageRoot, "src", "server", "Provider.js"),
+      "class Provider { static id = \"demo.template-context.append-skip\"; register() {} boot() {} }\nexport { Provider };\n",
+      "utf8"
+    );
+
+    await writeFile(
+      path.join(packageRoot, "src", "server", "templateContext.js"),
+      `function buildTemplateContext() {
+  throw new Error("templateContext should not run for skipped append-text mutations.");
+}
+
+export { buildTemplateContext };
+`,
+      "utf8"
+    );
+
+    await writeFile(
+      path.join(packageRoot, "package.descriptor.mjs"),
+      `export default Object.freeze({
+  packageId: "@demo/template-context-append-skip-feature",
+  version: "0.1.0",
+  kind: "runtime",
+  runtime: {
+    server: {
+      providers: [{ entrypoint: "src/server/Provider.js", export: "Provider" }]
+    },
+    client: {
+      providers: []
+    }
+  },
+  mutations: {
+    dependencies: {
+      runtime: {},
+      dev: {}
+    },
+    text: [
+      {
+        op: "append-text",
+        file: "src/placement.js",
+        id: "template-context-append-skip",
+        skipIfContains: "// already-present target",
+        value: "addPlacement({ target: \\"__TARGET__\\" });\\n",
+        templateContext: {
+          entrypoint: "src/server/templateContext.js",
+          export: "buildTemplateContext"
+        }
+      }
+    ]
+  }
+});
+`,
+      "utf8"
+    );
+
+    const addResult = runCli({
+      cwd: appRoot,
+      args: ["add", "package", "@demo/template-context-append-skip-feature"]
+    });
+    assert.equal(addResult.status, 0, String(addResult.stderr || ""));
+
+    const placementSource = await readFile(path.join(appRoot, "src", "placement.js"), "utf8");
+    assert.equal(placementSource, "// already-present target\n");
+  });
+});

--- a/tooling/jskit-cli/test/helpUsage.test.js
+++ b/tooling/jskit-cli/test/helpUsage.test.js
@@ -182,10 +182,9 @@ test("jskit generate ui-generator outlet help prints outlet-specific usage", () 
   const stdout = String(result.stdout || "");
   assert.match(stdout, /Generator subcommand help: @jskit-ai\/ui-generator outlet/);
   assert.match(stdout, /Long:/);
-  assert.match(stdout, /A ShellOutlet creates a named placement target inside a Vue file\./);
-  assert.match(stdout, /`jskit list-placements` will discover it and show its `target`\./);
-  assert.match(stdout, /`ui-generator placed-element`/);
-  assert.match(stdout, /Notes \(1\):/);
+  assert.match(stdout, /A ShellOutlet creates a concrete placement recipient inside a Vue file\./);
+  assert.match(stdout, /appends the semantic topology mapping for that outlet/);
+  assert.match(stdout, /Notes \(2\):/);
   assert.doesNotMatch(stdout, /RouterView or SectionContainerShell/);
   assert.match(stdout, /target-file/);
   assert.match(stdout, /--target/);
@@ -211,14 +210,14 @@ test("jskit generate ui-generator page help includes link options", () => {
   assert.match(stdout, /child pages\s+belong under `index\/\.\.\.`/);
   assert.match(stdout, /target-file \[required\]: Vue page file relative to src\/pages\/\. It must\s+resolve to a configured\s+surface\./);
   assert.match(stdout, /--link-placement/);
-  assert.match(stdout, /--link-component-token/);
+  assert.doesNotMatch(stdout, /--link-component-token/);
   assert.match(stdout, /--link-to/);
   assertHelpExamples(stdout, [
     /admin\/reports\/index\.vue/,
     /admin\/customers\/\[customerId\]\/index\/notes\/index\.vue/
   ]);
   assert.match(stdout, /Notes \(3\):/);
-  assert.match(stdout, /link component token, and props\.to are\s+inferred automatically/);
+  assert.match(stdout, /semantic placement and props\.to are\s+inferred\s+automatically/);
   assert.match(stdout, /target page file already exists, rerun with --force/);
 });
 
@@ -244,7 +243,7 @@ test("jskit generate ui-generator placed-element help includes common and advanc
   assert.equal(result.status, 0, String(result.stderr || ""));
   const stdout = String(result.stdout || "");
   assert.match(stdout, /Generator subcommand help: @jskit-ai\/ui-generator placed-element/);
-  assert.match(stdout, /If --placement is omitted, the placed element is added at shell-layout:top-right\./);
+  assert.match(stdout, /If --placement is omitted, the placed element is added at shell\.status\./);
   assert.match(stdout, /--name/);
   assert.match(stdout, /--surface/);
   assert.match(stdout, /--force/);

--- a/tooling/jskit-cli/test/listCommand.test.js
+++ b/tooling/jskit-cli/test/listCommand.test.js
@@ -45,6 +45,10 @@ async function writeVueFile(appRoot, relativePath, source) {
   await writeFile(absolutePath, source, "utf8");
 }
 
+async function writePlacementTopology(appRoot, source) {
+  await writeVueFile(appRoot, "src/placementTopology.js", source);
+}
+
 test("list packages shows installed local packages section for lock-only package ids", async () => {
   await withTempDir(async (cwd) => {
     const appRoot = path.join(cwd, "list-local-packages-app");
@@ -160,10 +164,80 @@ test("list packages does not include generator package ids", async () => {
   });
 });
 
-test("list-placements discovers shell outlets from app Vue files", async () => {
+test("list-placements shows semantic topology by default", async () => {
   await withTempDir(async (cwd) => {
     const appRoot = path.join(cwd, "list-placements-app");
     await createMinimalApp(appRoot, { name: "list-placements-app" });
+    await writeVueFile(
+      appRoot,
+      "src/components/ShellLayout.vue",
+      `<template>
+  <div>
+    <ShellOutlet target="shell-layout:primary-menu" default />
+    <ShellOutlet target="shell-layout:top-right" />
+  </div>
+</template>
+`
+    );
+    await writePlacementTopology(
+      appRoot,
+      `export default {
+  placements: [
+    {
+      id: "shell.primary-nav",
+      description: "Primary shell navigation.",
+      surfaces: ["*"],
+      default: true,
+      variants: {
+        compact: { outlet: "shell-layout:primary-menu" },
+        medium: { outlet: "shell-layout:primary-menu" },
+        expanded: { outlet: "shell-layout:primary-menu" }
+      }
+    },
+    {
+      id: "shell.status",
+      description: "Shell status widgets.",
+      surfaces: ["*"],
+      variants: {
+        compact: { outlet: "shell-layout:top-right" },
+        medium: { outlet: "shell-layout:top-right" },
+        expanded: { outlet: "shell-layout:top-right" }
+      }
+    }
+  ]
+};
+`
+    );
+    await writeVueFile(
+      appRoot,
+      "src/pages/admin/toolbox/index.vue",
+      `<template>
+  <section>
+    <ShellOutlet target="admin-toolbox:widgets" />
+  </section>
+</template>
+`
+    );
+
+    const result = runCli({
+      cwd: appRoot,
+      args: ["list-placements"]
+    });
+
+    assert.equal(result.status, 0, String(result.stderr || ""));
+    const stdout = String(result.stdout || "");
+    assert.match(stdout, /Available placements:/);
+    assert.match(stdout, /shell\.primary-nav \(default\): Primary shell navigation\./);
+    assert.match(stdout, /compact -> shell-layout:primary-menu/);
+    assert.match(stdout, /shell\.status: Shell status widgets\./);
+    assert.doesNotMatch(stdout, /admin-toolbox:widgets/);
+  });
+});
+
+test("list-placements --concrete discovers shell outlets from app Vue files", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "list-placements-concrete-app");
+    await createMinimalApp(appRoot, { name: "list-placements-concrete-app" });
     await writeVueFile(
       appRoot,
       "src/components/ShellLayout.vue",
@@ -188,19 +262,20 @@ test("list-placements discovers shell outlets from app Vue files", async () => {
 
     const result = runCli({
       cwd: appRoot,
-      args: ["list-placements"]
+      args: ["list-placements", "--concrete"]
     });
 
     assert.equal(result.status, 0, String(result.stderr || ""));
     const stdout = String(result.stdout || "");
-    assert.match(stdout, /Available placements:/);
+    assert.match(stdout, /Available concrete outlets:/);
     assert.match(stdout, /shell-layout:primary-menu \(default\) \[src\/components\/ShellLayout\.vue\]/);
     assert.match(stdout, /shell-layout:top-right \[src\/components\/ShellLayout\.vue\]/);
     assert.match(stdout, /admin-toolbox:widgets \[src\/pages\/admin\/toolbox\/index\.vue\]/);
+    assert.doesNotMatch(stdout, /Available placements:/);
   });
 });
 
-test("list-placements --json returns structured placement targets", async () => {
+test("list-placements --json returns structured semantic placement targets", async () => {
   await withTempDir(async (cwd) => {
     const appRoot = path.join(cwd, "list-placements-json-app");
     await createMinimalApp(appRoot, { name: "list-placements-json-app" });
@@ -214,6 +289,25 @@ test("list-placements --json returns structured placement targets", async () => 
 </template>
 `
     );
+    await writePlacementTopology(
+      appRoot,
+      `export default {
+  placements: [
+    {
+      id: "shell.primary-nav",
+      description: "Primary shell navigation.",
+      surfaces: ["*"],
+      default: true,
+      variants: {
+        compact: { outlet: "shell-layout:primary-menu" },
+        medium: { outlet: "shell-layout:primary-menu" },
+        expanded: { outlet: "shell-layout:primary-menu" }
+      }
+    }
+  ]
+};
+`
+    );
 
     const result = runCli({
       cwd: appRoot,
@@ -224,15 +318,24 @@ test("list-placements --json returns structured placement targets", async () => 
     const payload = JSON.parse(String(result.stdout || "{}"));
     assert.deepEqual(payload.placements, [
       {
-        target: "shell-layout:primary-menu",
+        target: "shell.primary-nav",
+        owner: "",
         default: true,
-        sourcePath: "src/components/ShellLayout.vue"
+        description: "Primary shell navigation.",
+        surfaces: ["*"],
+        variants: {
+          compact: { outlet: "shell-layout:primary-menu", renderers: {} },
+          medium: { outlet: "shell-layout:primary-menu", renderers: {} },
+          expanded: { outlet: "shell-layout:primary-menu", renderers: {} }
+        },
+        sourcePath: "src/placementTopology.js"
       }
     ]);
+    assert.deepEqual(payload.concretePlacements, []);
   });
 });
 
-test("list-placements includes installed package metadata outlets", async () => {
+test("list-placements includes installed package metadata topology", async () => {
   await withTempDir(async (cwd) => {
     const appRoot = path.join(cwd, "list-placements-package-outlets-app");
     await createMinimalApp(appRoot, {
@@ -267,7 +370,21 @@ test("list-placements includes installed package metadata outlets", async () => 
       placements: {
         outlets: [
           { target: "workspace-tools:primary-menu", source: "src/client/components/UsersWorkspaceToolsWidget.vue" }
-        ]
+        ],
+        topology: {
+          placements: [
+            {
+              id: "workspace.tools-menu",
+              description: "Workspace tools menu.",
+              surfaces: ["admin"],
+              variants: {
+                compact: { outlet: "workspace-tools:primary-menu" },
+                medium: { outlet: "workspace-tools:primary-menu" },
+                expanded: { outlet: "workspace-tools:primary-menu" }
+              }
+            }
+          ]
+        }
       }
     }
   }
@@ -284,12 +401,13 @@ test("list-placements includes installed package metadata outlets", async () => 
     const stdout = String(result.stdout || "");
     assert.match(
       stdout,
-      /workspace-tools:primary-menu \[package:@example\/users-web:src\/client\/components\/UsersWorkspaceToolsWidget\.vue\]/
+      /workspace\.tools-menu: Workspace tools menu\./
     );
+    assert.match(stdout, /compact -> workspace-tools:primary-menu/);
   });
 });
 
-test("list-placements discovers route meta placement outlets", async () => {
+test("list-placements --concrete discovers route meta placement outlets", async () => {
   await withTempDir(async (cwd) => {
     const appRoot = path.join(cwd, "list-placements-container-outlet-app");
     await createMinimalApp(appRoot, { name: "list-placements-container-outlet-app" });
@@ -318,7 +436,7 @@ test("list-placements discovers route meta placement outlets", async () => {
 
     const result = runCli({
       cwd: appRoot,
-      args: ["list-placements"]
+      args: ["list-placements", "--concrete"]
     });
 
     assert.equal(result.status, 0, String(result.stderr || ""));

--- a/tooling/jskit-cli/test/mobileCommand.test.js
+++ b/tooling/jskit-cli/test/mobileCommand.test.js
@@ -7,6 +7,7 @@ import { createCliRunner } from "../../testUtils/runCli.js";
 import { withTempDir } from "../../testUtils/tempDir.mjs";
 import {
   buildManagedDeepLinkIntentFilterBlock,
+  ensureMobileConfigStub,
   injectManagedDeepLinkBlock
 } from "../src/server/commandHandlers/mobileShellSupport.js";
 
@@ -464,6 +465,63 @@ if (process.argv[2] === "add" && process.argv[3] === "android") {
       "npm install",
       "cap add android"
     ]);
+  });
+});
+
+test("mobile config seeding replaces the fresh disabled create-app placeholder", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "app");
+    await createMobileReadyApp(appRoot, {
+      includeMobileConfig: false
+    });
+
+    const publicConfigPath = path.join(appRoot, "config", "public.js");
+    await writeFile(
+      publicConfigPath,
+      `${await readFile(publicConfigPath, "utf8")}
+config.mobile = {
+  enabled: false,
+  strategy: "",
+  appId: "",
+  appName: "",
+  assetMode: "bundled",
+  devServerUrl: "",
+  apiBaseUrl: "",
+  auth: {
+    callbackPath: "/auth/login",
+    customScheme: "",
+    appLinkDomains: []
+  },
+  android: {
+    packageName: "",
+    minSdk: 26,
+    targetSdk: 35,
+    versionCode: 1,
+    versionName: "1.0.0"
+  }
+};
+`,
+      "utf8"
+    );
+
+    const appended = await ensureMobileConfigStub({
+      ctx: {
+        normalizeRelativePath(root, filePath) {
+          return path.relative(root, filePath);
+        }
+      },
+      appRoot,
+      packageJson: {
+        name: "example-mobile-app",
+        version: "0.1.0"
+      }
+    });
+
+    assert.equal(appended, true);
+    const publicConfigSource = await readFile(publicConfigPath, "utf8");
+    assert.match(publicConfigSource, /jskit-mobile-capacitor:config:start/u);
+    assert.match(publicConfigSource, /enabled: true/u);
+    assert.match(publicConfigSource, /apiBaseUrl: "http:\/\/127\.0\.0\.1:3000"/u);
   });
 });
 

--- a/tooling/jskit-cli/test/uiElementGeneratorPackage.test.js
+++ b/tooling/jskit-cli/test/uiElementGeneratorPackage.test.js
@@ -72,6 +72,80 @@ export default function getPlacements() {
   );
 
   await writeFile(
+    path.join(appRoot, "src", "placementTopology.js"),
+    `const placements = [];
+
+function addPlacementTopology(value = {}) {
+  placements.push(value);
+}
+
+function shellPlacement(id, outlet) {
+  addPlacementTopology({
+    id,
+    description: \`\${id} test placement.\`,
+    surfaces: ["*"],
+    default: id === "shell.primary-nav",
+    variants: {
+      compact: {
+        outlet,
+        renderers: {
+          link: "local.main.ui.surface-aware-menu-link-item"
+        }
+      },
+      medium: {
+        outlet,
+        renderers: {
+          link: "local.main.ui.surface-aware-menu-link-item"
+        }
+      },
+      expanded: {
+        outlet,
+        renderers: {
+          link: "local.main.ui.surface-aware-menu-link-item"
+        }
+      }
+    }
+  });
+}
+
+shellPlacement("shell.primary-nav", "shell-layout:primary-menu");
+shellPlacement("shell.secondary-nav", "shell-layout:secondary-menu");
+shellPlacement("shell.status", "shell-layout:top-right");
+
+addPlacementTopology({
+  id: "page.section-nav",
+  owner: "admin-settings",
+  description: "Admin settings section navigation.",
+  surfaces: ["admin"],
+  variants: {
+    compact: {
+      outlet: "admin-settings:forms",
+      renderers: {
+        link: "local.main.ui.surface-aware-menu-link-item"
+      }
+    },
+    medium: {
+      outlet: "admin-settings:forms",
+      renderers: {
+        link: "local.main.ui.surface-aware-menu-link-item"
+      }
+    },
+    expanded: {
+      outlet: "admin-settings:forms",
+      renderers: {
+        link: "local.main.ui.surface-aware-menu-link-item"
+      }
+    }
+  }
+});
+
+export { addPlacementTopology };
+export default { placements };
+`,
+    "utf8"
+  );
+
+  await writeFile(
     path.join(appRoot, "src", "components", "ShellLayout.vue"),
     `<template>
   <div>
@@ -80,12 +154,8 @@ export default function getPlacements() {
     <ShellOutlet
       target="shell-layout:primary-menu"
       default
-      default-link-component-token="local.main.ui.surface-aware-menu-link-item"
     />
-    <ShellOutlet
-      target="shell-layout:secondary-menu"
-      default-link-component-token="local.main.ui.surface-aware-menu-link-item"
-    />
+    <ShellOutlet target="shell-layout:secondary-menu" />
   </div>
 </template>
 `,
@@ -160,6 +230,11 @@ async function fileExists(absolutePath) {
   }
 }
 
+async function appendPlacementTopology(appRoot, value = "") {
+  const topologyPath = path.join(appRoot, "src", "placementTopology.js");
+  await writeFile(topologyPath, `${await readFile(topologyPath, "utf8")}\n${value}\n`, "utf8");
+}
+
 test("generate @jskit-ai/ui-generator page scaffolds page and menu placement", async () => {
   await withTempDir(async (cwd) => {
     const appRoot = path.join(cwd, "ui-element-generator-default");
@@ -189,21 +264,11 @@ test("generate @jskit-ai/ui-generator page scaffolds page and menu placement", a
 
     const placementSource = await readFile(placementPath, "utf8");
     assert.match(placementSource, /id: "ui-generator\.page\.admin\.reports-dashboard\.link"/);
-    assert.match(placementSource, /target: "shell-layout:primary-menu"/);
-    assert.match(placementSource, /componentToken: "local\.main\.ui\.surface-aware-menu-link-item"/);
+    assert.match(placementSource, /target: "shell\.primary-nav"/);
+    assert.match(placementSource, /kind: "link"/);
+    assert.doesNotMatch(placementSource, /componentToken: "local\.main\.ui\.surface-aware-menu-link-item"/);
     assert.match(placementSource, /scopedSuffix: "\/reports-dashboard"/);
     assert.match(placementSource, /label: "Reports Dashboard"/);
-
-    const localLinkComponentPath = path.join(appRoot, "src", "components", "menus", "SurfaceAwareMenuLinkItem.vue");
-    const providerPath = path.join(appRoot, "packages", "main", "src", "client", "providers", "MainClientProvider.js");
-    assert.equal(await fileExists(localLinkComponentPath), true);
-
-    const providerSource = await readFile(providerPath, "utf8");
-    assert.match(providerSource, /import SurfaceAwareMenuLinkItem from "\/src\/components\/menus\/SurfaceAwareMenuLinkItem\.vue";/);
-    assert.match(
-      providerSource,
-      /registerMainClientComponent\("local\.main\.ui\.surface-aware-menu-link-item", \(\) => SurfaceAwareMenuLinkItem\);/
-    );
   });
 });
 
@@ -382,7 +447,7 @@ test("generate @jskit-ai/ui-generator page overwrites an existing page when --fo
   });
 });
 
-test("generate @jskit-ai/ui-generator page supports link-component-token for index-hosted child pages", async () => {
+test("generate @jskit-ai/ui-generator page supports semantic placement for index-hosted child pages", async () => {
   await withTempDir(async (cwd) => {
     const appRoot = path.join(cwd, "ui-element-generator-index-children");
     await createMinimalApp(appRoot, { name: "ui-element-generator-index-children" });
@@ -398,9 +463,7 @@ test("generate @jskit-ai/ui-generator page supports link-component-token for ind
         "--name",
         "Notes",
         "--link-placement",
-        "shell-layout:secondary-menu",
-        "--link-component-token",
-        "local.main.ui.tab-link-item"
+        "shell.secondary-nav"
       ]
     });
     assert.equal(result.status, 0, String(result.stderr || ""));
@@ -420,10 +483,11 @@ test("generate @jskit-ai/ui-generator page supports link-component-token for ind
     assert.equal(await fileExists(pagePath), true);
 
     const placementSource = await readFile(placementPath, "utf8");
-    assert.match(placementSource, /componentToken: "local\.main\.ui\.tab-link-item"/);
+    assert.match(placementSource, /target: "shell\.secondary-nav"/);
+    assert.match(placementSource, /kind: "link"/);
+    assert.doesNotMatch(placementSource, /componentToken:/);
     assert.match(placementSource, /scopedSuffix: "\/contacts\/\[contactId\]\/notes"/);
     assert.match(placementSource, /unscopedSuffix: "\/contacts\/\[contactId\]\/notes"/);
-    assert.match(placementSource, /to: "\.\/notes"/);
   });
 });
 
@@ -443,9 +507,7 @@ test("generate @jskit-ai/ui-generator page supports explicit link-to override", 
         "--name",
         "Notes",
         "--link-placement",
-        "shell-layout:secondary-menu",
-        "--link-component-token",
-        "local.main.ui.tab-link-item",
+        "shell.secondary-nav",
         "--link-to",
         "./custom-notes"
       ]
@@ -479,6 +541,32 @@ test("generate @jskit-ai/ui-generator page infers subpage link placement from th
 `,
       "utf8"
     );
+    await appendPlacementTopology(appRoot, `addPlacementTopology({
+  id: "page.section-nav",
+  owner: "contact-view",
+  description: "Contact section navigation.",
+  surfaces: ["admin"],
+  variants: {
+    compact: {
+      outlet: "contact-view:sub-pages",
+      renderers: {
+        link: "local.main.ui.surface-aware-menu-link-item"
+      }
+    },
+    medium: {
+      outlet: "contact-view:sub-pages",
+      renderers: {
+        link: "local.main.ui.surface-aware-menu-link-item"
+      }
+    },
+    expanded: {
+      outlet: "contact-view:sub-pages",
+      renderers: {
+        link: "local.main.ui.surface-aware-menu-link-item"
+      }
+    }
+  }
+});`);
 
     const result = runCli({
       cwd: appRoot,
@@ -495,8 +583,9 @@ test("generate @jskit-ai/ui-generator page infers subpage link placement from th
 
     const placementPath = path.join(appRoot, "src", "placement.js");
     const placementSource = await readFile(placementPath, "utf8");
-    assert.match(placementSource, /target: "contact-view:sub-pages"/);
-    assert.match(placementSource, /componentToken: "local\.main\.ui\.surface-aware-menu-link-item"/);
+    assert.match(placementSource, /target: "page\.section-nav"/);
+    assert.match(placementSource, /owner: "contact-view"/);
+    assert.doesNotMatch(placementSource, /componentToken: "local\.main\.ui\.surface-aware-menu-link-item"/);
     assert.match(placementSource, /to: "\.\/notes"/);
   });
 });
@@ -517,9 +606,7 @@ test("generate @jskit-ai/ui-generator page uses path-aware placement IDs for sam
         "--name",
         "One",
         "--link-placement",
-        "shell-layout:secondary-menu",
-        "--link-component-token",
-        "local.main.ui.tab-link-item"
+        "shell.secondary-nav"
       ]
     });
     assert.equal(alphaResult.status, 0, String(alphaResult.stderr || ""));
@@ -534,9 +621,7 @@ test("generate @jskit-ai/ui-generator page uses path-aware placement IDs for sam
         "--name",
         "One",
         "--link-placement",
-        "shell-layout:secondary-menu",
-        "--link-component-token",
-        "local.main.ui.tab-link-item"
+        "shell.secondary-nav"
       ]
     });
     assert.equal(betaResult.status, 0, String(betaResult.stderr || ""));
@@ -589,7 +674,7 @@ test("generate @jskit-ai/ui-generator placed-element scaffolds component token r
 
     const placementSource = await readFile(placementPath, "utf8");
     assert.match(placementSource, /id: "ui-generator\.element\.ops-panel"/);
-    assert.match(placementSource, /target: "shell-layout:top-right"/);
+    assert.match(placementSource, /target: "shell\.status"/);
     assert.match(placementSource, /componentToken: "local\.main\.ui\.element\.ops-panel"/);
   });
 });
@@ -609,14 +694,14 @@ test("generate @jskit-ai/ui-generator placed-element supports explicit placement
         "--name",
         "Ops Panel",
         "--placement",
-        "shell-layout:primary-menu"
+        "shell.secondary-nav"
       ]
     });
     assert.equal(result.status, 0, String(result.stderr || ""));
 
     const placementPath = path.join(appRoot, "src", "placement.js");
     const placementSource = await readFile(placementPath, "utf8");
-    assert.match(placementSource, /target: "shell-layout:primary-menu"/);
+    assert.match(placementSource, /target: "shell\.secondary-nav"/);
   });
 });
 
@@ -768,10 +853,7 @@ test("generate @jskit-ai/ui-generator add-subpages derives the default target fo
     const pageSource = await readFile(pagePath, "utf8");
     assert.match(pageSource, /<SectionContainerShell/);
     assert.match(pageSource, /<template #tabs>/);
-    assert.match(
-      pageSource,
-      /<ShellOutlet target="contacts-contact-id:sub-pages" default-link-component-token="local\.main\.ui\.surface-aware-menu-link-item" \/>/
-    );
+    assert.match(pageSource, /<ShellOutlet target="contacts-contact-id:sub-pages" \/>/);
     assert.match(pageSource, /<RouterView \/>/);
 
     const sectionShellSource = await readFile(sectionShellPath, "utf8");

--- a/tooling/jskit-cli/test/uiGeneratorPackage.test.js
+++ b/tooling/jskit-cli/test/uiGeneratorPackage.test.js
@@ -74,6 +74,53 @@ export default function getPlacements() {
   );
 
   await writeFile(
+    path.join(appRoot, "src", "placementTopology.js"),
+    `const placements = [];
+
+function addPlacementTopology(value = {}) {
+  placements.push(value);
+}
+
+function shellPlacement(id, outlet) {
+  addPlacementTopology({
+    id,
+    description: \`\${id} test placement.\`,
+    surfaces: ["*"],
+    default: id === "shell.primary-nav",
+    variants: {
+      compact: {
+        outlet,
+        renderers: {
+          link: "local.main.ui.surface-aware-menu-link-item"
+        }
+      },
+      medium: {
+        outlet,
+        renderers: {
+          link: "local.main.ui.surface-aware-menu-link-item"
+        }
+      },
+      expanded: {
+        outlet,
+        renderers: {
+          link: "local.main.ui.surface-aware-menu-link-item"
+        }
+      }
+    }
+  });
+}
+
+shellPlacement("shell.primary-nav", "shell-layout:primary-menu");
+shellPlacement("shell.secondary-nav", "shell-layout:secondary-menu");
+shellPlacement("shell.status", "shell-layout:top-right");
+
+export { addPlacementTopology };
+export default { placements };
+`,
+    "utf8"
+  );
+
+  await writeFile(
     path.join(appRoot, "src", "components", "ShellLayout.vue"),
     `<template>
   <div>
@@ -82,12 +129,8 @@ export default function getPlacements() {
     <ShellOutlet
       target="shell-layout:primary-menu"
       default
-      default-link-component-token="local.main.ui.surface-aware-menu-link-item"
     />
-    <ShellOutlet
-      target="shell-layout:secondary-menu"
-      default-link-component-token="local.main.ui.surface-aware-menu-link-item"
-    />
+    <ShellOutlet target="shell-layout:secondary-menu" />
   </div>
 </template>
 `,
@@ -301,20 +344,10 @@ test("generate @jskit-ai/crud-ui-generator crud scaffolds CRUD pages at an expli
     const placementSource = await readFile(path.join(appRoot, "src", "placement.js"), "utf8");
     assert.match(placementSource, /jskit:crud-ui-generator\.page\.link:admin:\/ops\/customers-ui/);
     assert.match(placementSource, /id: "ui-generator\.page\.admin\.ops\.customers-ui\.link"/);
-    assert.match(placementSource, /target: "shell-layout:primary-menu"/);
-    assert.match(placementSource, /componentToken: "local\.main\.ui\.surface-aware-menu-link-item"/);
+    assert.match(placementSource, /target: "shell\.primary-nav"/);
+    assert.match(placementSource, /kind: "link"/);
+    assert.doesNotMatch(placementSource, /componentToken: "local\.main\.ui\.surface-aware-menu-link-item"/);
     assert.match(placementSource, /scopedSuffix: "\/ops\/customers-ui"/);
-
-    const localLinkComponentPath = path.join(appRoot, "src", "components", "menus", "SurfaceAwareMenuLinkItem.vue");
-    const providerPath = path.join(appRoot, "packages", "main", "src", "client", "providers", "MainClientProvider.js");
-    assert.equal(await fileExists(localLinkComponentPath), true);
-
-    const providerSource = await readFile(providerPath, "utf8");
-    assert.match(providerSource, /import SurfaceAwareMenuLinkItem from "\/src\/components\/menus\/SurfaceAwareMenuLinkItem\.vue";/);
-    assert.match(
-      providerSource,
-      /registerMainClientComponent\("local\.main\.ui\.surface-aware-menu-link-item", \(\) => SurfaceAwareMenuLinkItem\);/
-    );
   });
 });
 
@@ -418,10 +451,7 @@ export { config };
       `<template>
   <section>
     <v-list>
-      <ShellOutlet
-        target="home-settings:primary-menu"
-        default-link-component-token="local.main.ui.surface-aware-menu-link-item"
-      />
+      <ShellOutlet target="home-settings:primary-menu" />
     </v-list>
     <RouterView />
   </section>
@@ -434,6 +464,40 @@ export { config };
       "<template>\n  <div>Settings</div>\n</template>\n",
       "utf8"
     );
+    const topologyPath = path.join(appRoot, "src", "placementTopology.js");
+    await writeFile(
+      topologyPath,
+      `${await readFile(topologyPath, "utf8")}
+
+addPlacementTopology({
+  id: "page.section-nav",
+  owner: "home-settings",
+  description: "Home settings section navigation.",
+  surfaces: ["home"],
+  variants: {
+    compact: {
+      outlet: "home-settings:primary-menu",
+      renderers: {
+        link: "local.main.ui.surface-aware-menu-link-item"
+      }
+    },
+    medium: {
+      outlet: "home-settings:primary-menu",
+      renderers: {
+        link: "local.main.ui.surface-aware-menu-link-item"
+      }
+    },
+    expanded: {
+      outlet: "home-settings:primary-menu",
+      renderers: {
+        link: "local.main.ui.surface-aware-menu-link-item"
+      }
+    }
+  }
+});
+`,
+      "utf8"
+    );
 
     await writeFile(
       path.join(appRoot, "src", "placement.js"),
@@ -443,10 +507,11 @@ export { config };
 {
   addPlacement({
     id: "ui-generator.page.home.settings.pollen-types.link",
-    target: "home-settings:primary-menu",
+    target: "page.section-nav",
+    owner: "home-settings",
+    kind: "link",
     surfaces: ["home"],
     order: 155,
-    componentToken: "local.main.ui.surface-aware-menu-link-item",
     props: {
       label: "Pollen Types",
       surface: "home",
@@ -469,16 +534,10 @@ export default function getPlacements() {
       targetRoot: "home/settings/pollen_types"
     });
 
-    const localLinkComponentPath = path.join(appRoot, "src", "components", "menus", "SurfaceAwareMenuLinkItem.vue");
-    const providerPath = path.join(appRoot, "packages", "main", "src", "client", "providers", "MainClientProvider.js");
-    assert.equal(await fileExists(localLinkComponentPath), true);
-
-    const providerSource = await readFile(providerPath, "utf8");
-    assert.match(providerSource, /import SurfaceAwareMenuLinkItem from "\/src\/components\/menus\/SurfaceAwareMenuLinkItem\.vue";/);
-    assert.match(
-      providerSource,
-      /registerMainClientComponent\("local\.main\.ui\.surface-aware-menu-link-item", \(\) => SurfaceAwareMenuLinkItem\);/
-    );
+    const placementSource = await readFile(path.join(appRoot, "src", "placement.js"), "utf8");
+    assert.equal((placementSource.match(/ui-generator\.page\.home\.settings\.pollen-types\.link/g) || []).length, 1);
+    assert.match(placementSource, /target: "page\.section-nav"/);
+    assert.match(placementSource, /owner: "home-settings"/);
   });
 });
 
@@ -501,14 +560,49 @@ test("generate @jskit-ai/crud-ui-generator infers tab placement and relative to 
 `,
       "utf8"
     );
+    const topologyPath = path.join(appRoot, "src", "placementTopology.js");
+    await writeFile(
+      topologyPath,
+      `${await readFile(topologyPath, "utf8")}
+
+addPlacementTopology({
+  id: "page.section-nav",
+  owner: "catalog",
+  description: "Catalog section navigation.",
+  surfaces: ["admin"],
+  variants: {
+    compact: {
+      outlet: "catalog:sub-pages",
+      renderers: {
+        link: "local.main.ui.surface-aware-menu-link-item"
+      }
+    },
+    medium: {
+      outlet: "catalog:sub-pages",
+      renderers: {
+        link: "local.main.ui.surface-aware-menu-link-item"
+      }
+    },
+    expanded: {
+      outlet: "catalog:sub-pages",
+      renderers: {
+        link: "local.main.ui.surface-aware-menu-link-item"
+      }
+    }
+  }
+});
+`,
+      "utf8"
+    );
 
     await generateCrudUiPackage(appRoot, {
       targetRoot: "admin/catalog/index/products"
     });
 
     const placementSource = await readFile(path.join(appRoot, "src", "placement.js"), "utf8");
-    assert.match(placementSource, /target: "catalog:sub-pages"/);
-    assert.match(placementSource, /componentToken: "local\.main\.ui\.surface-aware-menu-link-item"/);
+    assert.match(placementSource, /target: "page\.section-nav"/);
+    assert.match(placementSource, /owner: "catalog"/);
+    assert.doesNotMatch(placementSource, /componentToken: "local\.main\.ui\.surface-aware-menu-link-item"/);
     assert.match(placementSource, /to: "\.\/products"/);
   });
 });
@@ -520,11 +614,11 @@ test("generate @jskit-ai/crud-ui-generator honors explicit link-placement overri
     await writeCustomerResource(appRoot);
     await generateCrudUiPackage(appRoot, {
       operations: "list",
-      linkPlacement: "shell-layout:secondary-menu"
+      linkPlacement: "shell.secondary-nav"
     });
 
     const placementSource = await readFile(path.join(appRoot, "src", "placement.js"), "utf8");
-    assert.match(placementSource, /target: "shell-layout:secondary-menu"/);
+    assert.match(placementSource, /target: "shell\.secondary-nav"/);
   });
 });
 


### PR DESCRIPTION
## Summary
- continue the placement topology/runtime rollout across shell, assistant, realtime, and generator packages
- refresh package descriptors, package metadata, catalog output, and generated agent docs
- add/update tests for placement runtime behavior, template context, text mutations, mobile shell support, and related package contracts

## Verification
- not run `npm run verify` per request