### PR TITLE
Rework placements and client singleton ownership

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,10 +28,14 @@
         "vuetify": "^4.0.0"
       },
       "devDependencies": {
+        "@tanstack/vue-query": "^5.90.5",
         "cloc": "^2.6.0-cloc",
         "jscpd": "^4.0.8",
         "knex": "^3.1.0",
-        "vitepress": "^1.6.4"
+        "pinia": "^3.0.4",
+        "vitepress": "^1.6.4",
+        "vue": "^3.5.13",
+        "vue-router": "^5.0.4"
       }
     },
     "node_modules/@algolia/abtesting": {
@@ -2023,11 +2027,71 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.90.20",
+      "version": "5.100.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.9.tgz",
+      "integrity": "sha512-SJSFw1S8+kQ0+knv/XGfrbocWoAlT7vDKsSImtLx3ZPQmEcR46hkDjLSvynSy25N8Ms4tIEini1FuBd5k7IscQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/vue-query": {
+      "version": "5.100.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/vue-query/-/vue-query-5.100.9.tgz",
+      "integrity": "sha512-wGiv/AirRuITlTDl87zdBRaZIZTejMItUswKgMzzcX/1gfn95iKw2EaCuz7qlX9ceB0DwBj9FqaroLnDoJCecg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@tanstack/match-sorter-utils": "^8.19.4",
+        "@tanstack/query-core": "5.100.9",
+        "@vue/devtools-api": "^6.6.3",
+        "vue-demi": "^0.14.10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.1.2",
+        "vue": "^2.6.0 || ^3.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@tanstack/vue-query/node_modules/@vue/devtools-api": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+      "license": "MIT"
+    },
+    "node_modules/@tanstack/vue-query/node_modules/vue-demi": {
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
       }
     },
     "node_modules/@transloadit/prettier-bytes": {
@@ -5004,6 +5068,7 @@
     "node_modules/pinia": {
       "version": "3.0.4",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/devtools-api": "^7.7.7"
       },
@@ -6411,6 +6476,7 @@
     "node_modules/vuetify": {
       "version": "4.0.0",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/johnleider"
@@ -6573,74 +6639,14 @@
         "@jskit-ai/resource-core": "0.1.11",
         "@jskit-ai/resource-crud-core": "0.1.11",
         "@jskit-ai/users-core": "0.1.76",
-        "@tanstack/vue-query": "^5.90.5",
         "dompurify": "^3.3.3",
         "json-rest-schema": "1.x.x",
         "marked": "^17.0.4",
-        "openai": "^6.22.0",
+        "openai": "^6.22.0"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.13",
         "vuetify": "^4.0.0"
-      },
-      "peerDependencies": {
-        "vue": "^3.5.13"
-      }
-    },
-    "packages/assistant-core/node_modules/@tanstack/query-core": {
-      "version": "5.96.2",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      }
-    },
-    "packages/assistant-core/node_modules/@tanstack/vue-query": {
-      "version": "5.96.2",
-      "license": "MIT",
-      "dependencies": {
-        "@tanstack/match-sorter-utils": "^8.19.4",
-        "@tanstack/query-core": "5.96.2",
-        "@vue/devtools-api": "^6.6.3",
-        "vue-demi": "^0.14.10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "@vue/composition-api": "^1.1.2",
-        "vue": "^2.6.0 || ^3.3.0"
-      },
-      "peerDependenciesMeta": {
-        "@vue/composition-api": {
-          "optional": true
-        }
-      }
-    },
-    "packages/assistant-core/node_modules/@vue/devtools-api": {
-      "version": "6.6.4",
-      "license": "MIT"
-    },
-    "packages/assistant-core/node_modules/vue-demi": {
-      "version": "0.14.10",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "vue-demi-fix": "bin/vue-demi-fix.js",
-        "vue-demi-switch": "bin/vue-demi-switch.js"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      },
-      "peerDependencies": {
-        "@vue/composition-api": "^1.0.0-rc.1",
-        "vue": "^3.0.0-0 || ^2.6.0"
-      },
-      "peerDependenciesMeta": {
-        "@vue/composition-api": {
-          "optional": true
-        }
       }
     },
     "packages/assistant-runtime": {
@@ -6654,71 +6660,12 @@
         "@jskit-ai/shell-web": "0.1.65",
         "@jskit-ai/users-core": "0.1.76",
         "@jskit-ai/users-web": "0.1.81",
+        "json-rest-schema": "1.x.x"
+      },
+      "peerDependencies": {
         "@tanstack/vue-query": "^5.90.5",
-        "json-rest-schema": "1.x.x",
+        "vue": "^3.5.13",
         "vuetify": "^4.0.0"
-      },
-      "peerDependencies": {
-        "vue": "^3.5.13"
-      }
-    },
-    "packages/assistant-runtime/node_modules/@tanstack/query-core": {
-      "version": "5.96.2",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      }
-    },
-    "packages/assistant-runtime/node_modules/@tanstack/vue-query": {
-      "version": "5.96.2",
-      "license": "MIT",
-      "dependencies": {
-        "@tanstack/match-sorter-utils": "^8.19.4",
-        "@tanstack/query-core": "5.96.2",
-        "@vue/devtools-api": "^6.6.3",
-        "vue-demi": "^0.14.10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "@vue/composition-api": "^1.1.2",
-        "vue": "^2.6.0 || ^3.3.0"
-      },
-      "peerDependenciesMeta": {
-        "@vue/composition-api": {
-          "optional": true
-        }
-      }
-    },
-    "packages/assistant-runtime/node_modules/@vue/devtools-api": {
-      "version": "6.6.4",
-      "license": "MIT"
-    },
-    "packages/assistant-runtime/node_modules/vue-demi": {
-      "version": "0.14.10",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "vue-demi-fix": "bin/vue-demi-fix.js",
-        "vue-demi-switch": "bin/vue-demi-switch.js"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      },
-      "peerDependencies": {
-        "@vue/composition-api": "^1.0.0-rc.1",
-        "vue": "^3.0.0-0 || ^2.6.0"
-      },
-      "peerDependenciesMeta": {
-        "@vue/composition-api": {
-          "optional": true
-        }
       }
     },
     "packages/auth-core": {
@@ -6752,65 +6699,14 @@
         "@jskit-ai/http-runtime": "0.1.65",
         "@jskit-ai/kernel": "0.1.66",
         "@jskit-ai/shell-web": "0.1.65",
-        "@mdi/js": "^7.4.47",
+        "@mdi/js": "^7.4.47"
+      },
+      "peerDependencies": {
         "@tanstack/vue-query": "^5.90.5",
         "pinia": "^3.0.4",
-        "vuetify": "^4.0.0"
-      },
-      "peerDependencies": {
         "vue": "^3.5.13",
-        "vue-router": "^5.0.4"
-      }
-    },
-    "packages/auth-web/node_modules/@tanstack/vue-query": {
-      "version": "5.92.9",
-      "license": "MIT",
-      "dependencies": {
-        "@tanstack/match-sorter-utils": "^8.19.4",
-        "@tanstack/query-core": "5.90.20",
-        "@vue/devtools-api": "^6.6.3",
-        "vue-demi": "^0.14.10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "@vue/composition-api": "^1.1.2",
-        "vue": "^2.6.0 || ^3.3.0"
-      },
-      "peerDependenciesMeta": {
-        "@vue/composition-api": {
-          "optional": true
-        }
-      }
-    },
-    "packages/auth-web/node_modules/@vue/devtools-api": {
-      "version": "6.6.4",
-      "license": "MIT"
-    },
-    "packages/auth-web/node_modules/vue-demi": {
-      "version": "0.14.10",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "vue-demi-fix": "bin/vue-demi-fix.js",
-        "vue-demi-switch": "bin/vue-demi-switch.js"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      },
-      "peerDependencies": {
-        "@vue/composition-api": "^1.0.0-rc.1",
-        "vue": "^3.0.0-0 || ^2.6.0"
-      },
-      "peerDependenciesMeta": {
-        "@vue/composition-api": {
-          "optional": true
-        }
+        "vue-router": "^5.0.4",
+        "vuetify": "^4.0.0"
       }
     },
     "packages/console-core": {
@@ -6847,71 +6743,12 @@
         "@jskit-ai/shell-web": "0.1.65",
         "@jskit-ai/users-core": "0.1.76",
         "@jskit-ai/users-web": "0.1.81",
-        "@tanstack/vue-query": "^5.90.5",
         "json-rest-schema": "1.x.x"
       },
       "peerDependencies": {
+        "@tanstack/vue-query": "^5.90.5",
         "vue": "^3.5.13",
         "vue-router": "^5.0.4"
-      }
-    },
-    "packages/crud-core/node_modules/@tanstack/query-core": {
-      "version": "5.91.2",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      }
-    },
-    "packages/crud-core/node_modules/@tanstack/vue-query": {
-      "version": "5.92.12",
-      "license": "MIT",
-      "dependencies": {
-        "@tanstack/match-sorter-utils": "^8.19.4",
-        "@tanstack/query-core": "5.91.2",
-        "@vue/devtools-api": "^6.6.3",
-        "vue-demi": "^0.14.10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "@vue/composition-api": "^1.1.2",
-        "vue": "^2.6.0 || ^3.3.0"
-      },
-      "peerDependenciesMeta": {
-        "@vue/composition-api": {
-          "optional": true
-        }
-      }
-    },
-    "packages/crud-core/node_modules/@vue/devtools-api": {
-      "version": "6.6.4",
-      "license": "MIT"
-    },
-    "packages/crud-core/node_modules/vue-demi": {
-      "version": "0.14.10",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "vue-demi-fix": "bin/vue-demi-fix.js",
-        "vue-demi-switch": "bin/vue-demi-switch.js"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      },
-      "peerDependencies": {
-        "@vue/composition-api": "^1.0.0-rc.1",
-        "vue": "^3.0.0-0 || ^2.6.0"
-      },
-      "peerDependenciesMeta": {
-        "@vue/composition-api": {
-          "optional": true
-        }
       }
     },
     "packages/crud-server-generator": {
@@ -7037,65 +6874,13 @@
       "version": "0.1.65",
       "dependencies": {
         "@jskit-ai/kernel": "0.1.66",
-        "@mdi/js": "^7.4.47",
-        "@tanstack/vue-query": "^5.90.5",
+        "@mdi/js": "^7.4.47"
+      },
+      "peerDependencies": {
         "pinia": "^3.0.4",
-        "vuetify": "^4.0.0"
-      },
-      "peerDependencies": {
         "vue": "^3.5.13",
-        "vue-router": "^5.0.4"
-      }
-    },
-    "packages/shell-web/node_modules/@tanstack/vue-query": {
-      "version": "5.92.9",
-      "license": "MIT",
-      "dependencies": {
-        "@tanstack/match-sorter-utils": "^8.19.4",
-        "@tanstack/query-core": "5.90.20",
-        "@vue/devtools-api": "^6.6.3",
-        "vue-demi": "^0.14.10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "@vue/composition-api": "^1.1.2",
-        "vue": "^2.6.0 || ^3.3.0"
-      },
-      "peerDependenciesMeta": {
-        "@vue/composition-api": {
-          "optional": true
-        }
-      }
-    },
-    "packages/shell-web/node_modules/@vue/devtools-api": {
-      "version": "6.6.4",
-      "license": "MIT"
-    },
-    "packages/shell-web/node_modules/vue-demi": {
-      "version": "0.14.10",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "vue-demi-fix": "bin/vue-demi-fix.js",
-        "vue-demi-switch": "bin/vue-demi-switch.js"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      },
-      "peerDependencies": {
-        "@vue/composition-api": "^1.0.0-rc.1",
-        "vue": "^3.0.0-0 || ^2.6.0"
-      },
-      "peerDependenciesMeta": {
-        "@vue/composition-api": {
-          "optional": true
-        }
+        "vue-router": "^5.0.4",
+        "vuetify": "^4.0.0"
       }
     },
     "packages/storage-runtime": {
@@ -7162,72 +6947,13 @@
         "@jskit-ai/shell-web": "0.1.65",
         "@jskit-ai/uploads-image-web": "0.1.44",
         "@jskit-ai/users-core": "0.1.76",
-        "@mdi/js": "^7.4.47",
-        "@tanstack/vue-query": "5.92.12",
-        "vuetify": "^4.0.0"
+        "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
+        "@tanstack/vue-query": "^5.90.5",
         "vue": "^3.5.13",
-        "vue-router": "^5.0.4"
-      }
-    },
-    "packages/users-web/node_modules/@tanstack/query-core": {
-      "version": "5.91.2",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      }
-    },
-    "packages/users-web/node_modules/@tanstack/vue-query": {
-      "version": "5.92.12",
-      "license": "MIT",
-      "dependencies": {
-        "@tanstack/match-sorter-utils": "^8.19.4",
-        "@tanstack/query-core": "5.91.2",
-        "@vue/devtools-api": "^6.6.3",
-        "vue-demi": "^0.14.10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "@vue/composition-api": "^1.1.2",
-        "vue": "^2.6.0 || ^3.3.0"
-      },
-      "peerDependenciesMeta": {
-        "@vue/composition-api": {
-          "optional": true
-        }
-      }
-    },
-    "packages/users-web/node_modules/@vue/devtools-api": {
-      "version": "6.6.4",
-      "license": "MIT"
-    },
-    "packages/users-web/node_modules/vue-demi": {
-      "version": "0.14.10",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "vue-demi-fix": "bin/vue-demi-fix.js",
-        "vue-demi-switch": "bin/vue-demi-switch.js"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      },
-      "peerDependencies": {
-        "@vue/composition-api": "^1.0.0-rc.1",
-        "vue": "^3.0.0-0 || ^2.6.0"
-      },
-      "peerDependenciesMeta": {
-        "@vue/composition-api": {
-          "optional": true
-        }
+        "vue-router": "^5.0.4",
+        "vuetify": "^4.0.0"
       }
     },
     "packages/workspaces-core": {
@@ -7255,72 +6981,13 @@
         "@jskit-ai/users-core": "0.1.76",
         "@jskit-ai/users-web": "0.1.81",
         "@jskit-ai/workspaces-core": "0.1.42",
-        "@mdi/js": "^7.4.47",
-        "@tanstack/vue-query": "5.92.12",
-        "vuetify": "^4.0.0"
+        "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
+        "@tanstack/vue-query": "^5.90.5",
         "vue": "^3.5.13",
-        "vue-router": "^5.0.4"
-      }
-    },
-    "packages/workspaces-web/node_modules/@tanstack/query-core": {
-      "version": "5.91.2",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      }
-    },
-    "packages/workspaces-web/node_modules/@tanstack/vue-query": {
-      "version": "5.92.12",
-      "license": "MIT",
-      "dependencies": {
-        "@tanstack/match-sorter-utils": "^8.19.4",
-        "@tanstack/query-core": "5.91.2",
-        "@vue/devtools-api": "^6.6.3",
-        "vue-demi": "^0.14.10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "@vue/composition-api": "^1.1.2",
-        "vue": "^2.6.0 || ^3.3.0"
-      },
-      "peerDependenciesMeta": {
-        "@vue/composition-api": {
-          "optional": true
-        }
-      }
-    },
-    "packages/workspaces-web/node_modules/@vue/devtools-api": {
-      "version": "6.6.4",
-      "license": "MIT"
-    },
-    "packages/workspaces-web/node_modules/vue-demi": {
-      "version": "0.14.10",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "vue-demi-fix": "bin/vue-demi-fix.js",
-        "vue-demi-switch": "bin/vue-demi-switch.js"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      },
-      "peerDependencies": {
-        "@vue/composition-api": "^1.0.0-rc.1",
-        "vue": "^3.0.0-0 || ^2.6.0"
-      },
-      "peerDependenciesMeta": {
-        "@vue/composition-api": {
-          "optional": true
-        }
+        "vue-router": "^5.0.4",
+        "vuetify": "^4.0.0"
       }
     },
     "tooling/config-eslint": {

--- a/package.json
+++ b/package.json
@@ -31,9 +31,13 @@
     "tooling/*"
   ],
   "devDependencies": {
+    "@tanstack/vue-query": "^5.90.5",
     "cloc": "^2.6.0-cloc",
     "jscpd": "^4.0.8",
     "knex": "^3.1.0",
+    "pinia": "^3.0.4",
+    "vue": "^3.5.13",
+    "vue-router": "^5.0.4",
     "vitepress": "^1.6.4"
   },
   "dependencies": {

--- a/packages/agent-docs/reference/autogen/packages/kernel.md
+++ b/packages/agent-docs/reference/autogen/packages/kernel.md
@@ -667,7 +667,7 @@ Local functions
 
 ### `client/moduleBootstrap.js`
 Exports
-- `bootClientModules({ clientModules = [], app, pinia = null, router, surfaceRuntime, surfaceMode, env, logger = console } = {})`
+- `bootClientModules({ clientModules = [], app, pinia = null, queryClient = null, router, surfaceRuntime, surfaceMode, env, logger = console } = {})`
 Local functions
 - `normalizePackageId(value)`
 - `toRouteSnapshot(route)`
@@ -684,7 +684,7 @@ Local functions
 - `assertRoutesDeclaredInDescriptor({ packageId, source, normalizedRoutes = [], descriptorRouteDeclarations = null } = {})`
 - `resolveDescriptorClientRoutes({ packageId, descriptorUiRoutes = [], routeComponents = {}, logger = null } = {})`
 - `normalizeClientModuleEntries(clientModules)`
-- `createClientRuntimeApp({ profile = "client", app, pinia = null, router, env, logger, surfaceRuntime, surfaceMode } = {})`
+- `createClientRuntimeApp({ profile = "client", app, pinia = null, queryClient = null, router, env, logger, surfaceRuntime, surfaceMode } = {})`
 
 ### `client/pageRedirects.js`
 Exports
@@ -697,7 +697,7 @@ Exports
 - `resolveClientBootstrapDebugEnabled({ env = {}, debugEnabled = undefined, debugEnvKey = "VITE_JSKIT_CLIENT_DEBUG" } = {})`
 - `createClientBootstrapLogger({ env = {}, logger = console, debugEnabled = undefined, debugEnvKey = "VITE_JSKIT_CLIENT_DEBUG" } = {})`
 - `createSurfaceShellRouter({ createRouter, history, routes = [], surfaceRuntime, surfaceMode, fallbackRoute = null, notFoundComponent = null, guard = false } = {})`
-- `bootstrapClientShellApp({ createApp, rootComponent, appConfig = {}, appPlugins = [], pinia = null, router, bootClientModules, surfaceRuntime, surfaceMode, env = {}, fallbackRoute = null, logger = console, createBootstrapLogger = null, debugEnabled = undefined, debugEnvKey = "VITE_JSKIT_CLIENT_DEBUG", debugMessage = "Client modules bootstrapped before router install.", onAfterModulesBootstrapped = null, onAfterRouterReady = null, mountSelector = "#app" } = {})`
+- `bootstrapClientShellApp({ createApp, rootComponent, appConfig = {}, appPlugins = [], pinia = null, queryClient = null, router, bootClientModules, surfaceRuntime, surfaceMode, env = {}, fallbackRoute = null, logger = console, createBootstrapLogger = null, debugEnabled = undefined, debugEnvKey = "VITE_JSKIT_CLIENT_DEBUG", debugMessage = "Client modules bootstrapped before router install.", onAfterModulesBootstrapped = null, onAfterRouterReady = null, mountSelector = "#app" } = {})`
 Local functions
 - `installAppPlugins(app, appPlugins = [])`
 

--- a/packages/agent-docs/reference/autogen/packages/shell-web.md
+++ b/packages/agent-docs/reference/autogen/packages/shell-web.md
@@ -269,7 +269,6 @@ Exports
 - `ShellWebClientProvider`
 - `resolveAppPlacementTopologyExport(exported, logger)`
 Local functions
-- `createShellWebQueryClient()`
 - `isMissingDynamicModule(error, moduleSpecifier)`
 - `loadAppPlacementDefinitions(logger)`
 - `loadAppPlacementTopology(logger)`

--- a/packages/agent-docs/reference/autogen/packages/users-core.md
+++ b/packages/agent-docs/reference/autogen/packages/users-core.md
@@ -289,6 +289,8 @@ Exports
 ### `templates/packages/users-workspace/src/server/actions.js`
 Exports
 - `createActions({ surface } = {})`
+Local functions
+- `buildListQuery(input = {})`
 
 ### `templates/packages/users-workspace/src/server/registerRoutes.js`
 Exports

--- a/packages/agent-docs/reference/autogen/tooling/jskit-cli.md
+++ b/packages/agent-docs/reference/autogen/tooling/jskit-cli.md
@@ -440,6 +440,16 @@ Local functions
 - `resolveGeneratorDescription(packageEntry = {})`
 - `resolveGeneratorQuickStartRows(packageEntry = {}, { limit = 3 } = {})`
 - `isLinkItemToken(token = "")`
+- `collectPlacementRendererKinds(placementTarget = {})`
+- `collectPlacementConcreteOutlets(placementTarget = {})`
+- `classifyPlacementTarget(placementTarget = {})`
+- `createConcreteTargetSourcePathMap(concreteTargets = [])`
+- `resolveChildPagePatternFromHostSourcePath(sourcePath = "")`
+- `resolveOwnerScopedChildPagePattern(placementTarget = {}, concreteSourcePathByTarget = new Map())`
+- `createPlacementTargetSummary(placementTarget = {}, color, { concreteSourcePathByTarget = new Map() } = {})`
+- `appendPlacementLayoutDetails(lines, placementTarget = {}, color)`
+- `appendPlacementGroup(lines, { color, title = "", description = "", guidance = [], targets = [], concreteSourcePathByTarget = new Map(), showLayoutDetails = false } = {})`
+- `appendSemanticPlacementGroups(lines, { color, semanticPlacements = [], concreteTargets = [], hostPathLookupError = null, showLayoutDetails = false } = {})`
 - `readFileIfExists(filePath = "")`
 - `resolveDescriptorFromLockEntry({ appRoot = "", packageId = "", installedPackageEntry = {} } = {})`
 - `collectProviderSourceFiles(rootPath = "")`

--- a/packages/assistant-core/package.descriptor.mjs
+++ b/packages/assistant-core/package.descriptor.mjs
@@ -52,12 +52,10 @@ export default Object.freeze({
         "@jskit-ai/resource-core": "0.1.11",
         "@jskit-ai/resource-crud-core": "0.1.11",
         "@jskit-ai/users-core": "0.1.76",
-        "@tanstack/vue-query": "^5.90.5",
         "dompurify": "^3.3.3",
         "json-rest-schema": "1.x.x",
         "marked": "^17.0.4",
-        "openai": "^6.22.0",
-        "vuetify": "^4.0.0"
+        "openai": "^6.22.0"
       },
       dev: {}
     },

--- a/packages/assistant-core/package.json
+++ b/packages/assistant-core/package.json
@@ -17,14 +17,13 @@
     "@jskit-ai/resource-crud-core": "0.1.11",
     "@jskit-ai/resource-core": "0.1.11",
     "@jskit-ai/users-core": "0.1.76",
-    "@tanstack/vue-query": "^5.90.5",
     "dompurify": "^3.3.3",
     "json-rest-schema": "1.x.x",
     "marked": "^17.0.4",
-    "openai": "^6.22.0",
-    "vuetify": "^4.0.0"
+    "openai": "^6.22.0"
   },
   "peerDependencies": {
-    "vue": "^3.5.13"
+    "vue": "^3.5.13",
+    "vuetify": "^4.0.0"
   }
 }

--- a/packages/assistant-runtime/package.descriptor.mjs
+++ b/packages/assistant-runtime/package.descriptor.mjs
@@ -101,9 +101,7 @@ export default Object.freeze({
         "@jskit-ai/kernel": "0.1.66",
         "@jskit-ai/shell-web": "0.1.65",
         "@jskit-ai/users-core": "0.1.76",
-        "@jskit-ai/users-web": "0.1.81",
-        "@tanstack/vue-query": "^5.90.5",
-        "vuetify": "^4.0.0"
+        "@jskit-ai/users-web": "0.1.81"
       },
       dev: {}
     },

--- a/packages/assistant-runtime/package.json
+++ b/packages/assistant-runtime/package.json
@@ -15,11 +15,11 @@
     "@jskit-ai/shell-web": "0.1.65",
     "@jskit-ai/users-core": "0.1.76",
     "@jskit-ai/users-web": "0.1.81",
-    "json-rest-schema": "1.x.x",
-    "@tanstack/vue-query": "^5.90.5",
-    "vuetify": "^4.0.0"
+    "json-rest-schema": "1.x.x"
   },
   "peerDependencies": {
-    "vue": "^3.5.13"
+    "@tanstack/vue-query": "^5.90.5",
+    "vue": "^3.5.13",
+    "vuetify": "^4.0.0"
   }
 }

--- a/packages/auth-web/package.descriptor.mjs
+++ b/packages/auth-web/package.descriptor.mjs
@@ -246,13 +246,11 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@tanstack/vue-query": "5.92.12",
         "@mdi/js": "^7.4.47",
         "@jskit-ai/auth-core": "0.1.65",
         "@jskit-ai/http-runtime": "0.1.65",
         "@jskit-ai/kernel": "0.1.66",
-        "@jskit-ai/shell-web": "0.1.65",
-        "vuetify": "^4.0.0"
+        "@jskit-ai/shell-web": "0.1.65"
       },
       "dev": {}
     },

--- a/packages/auth-web/package.json
+++ b/packages/auth-web/package.json
@@ -18,17 +18,17 @@
     "./client/runtime/useSignOut": "./src/client/runtime/useSignOut.js"
   },
   "dependencies": {
-    "@tanstack/vue-query": "^5.90.5",
     "@jskit-ai/auth-core": "0.1.65",
     "@mdi/js": "^7.4.47",
     "@jskit-ai/kernel": "0.1.66",
     "@jskit-ai/shell-web": "0.1.65",
-    "pinia": "^3.0.4",
-    "vuetify": "^4.0.0",
     "@jskit-ai/http-runtime": "0.1.65"
   },
   "peerDependencies": {
+    "@tanstack/vue-query": "^5.90.5",
+    "pinia": "^3.0.4",
     "vue": "^3.5.13",
-    "vue-router": "^5.0.4"
+    "vue-router": "^5.0.4",
+    "vuetify": "^4.0.0"
   }
 }

--- a/packages/crud-core/package.json
+++ b/packages/crud-core/package.json
@@ -27,7 +27,6 @@
     "./server/routeContracts": "./src/server/routeContracts.js"
   },
   "dependencies": {
-    "@tanstack/vue-query": "^5.90.5",
     "@jskit-ai/database-runtime": "0.1.66",
     "@jskit-ai/http-runtime": "0.1.65",
     "@jskit-ai/kernel": "0.1.66",
@@ -39,6 +38,7 @@
     "@jskit-ai/users-web": "0.1.81"
   },
   "peerDependencies": {
+    "@tanstack/vue-query": "^5.90.5",
     "vue": "^3.5.13",
     "vue-router": "^5.0.4"
   }

--- a/packages/kernel/client/moduleBootstrap.js
+++ b/packages/kernel/client/moduleBootstrap.js
@@ -483,6 +483,7 @@ function createClientRuntimeApp({
   profile = "client",
   app,
   pinia = null,
+  queryClient = null,
   router,
   env,
   logger,
@@ -498,6 +499,7 @@ function createClientRuntimeApp({
   runtimeApp.instance("jskit.client.router", router || null);
   runtimeApp.instance("jskit.client.vue.app", app || null);
   runtimeApp.instance("jskit.client.pinia", pinia);
+  runtimeApp.instance("jskit.client.query-client", queryClient);
   runtimeApp.instance("jskit.client.env", isRecord(env) ? { ...env } : {});
   runtimeApp.instance("jskit.client.surface.runtime", surfaceRuntime || null);
   runtimeApp.instance("jskit.client.surface.mode", String(surfaceMode || "").trim());
@@ -510,6 +512,7 @@ async function bootClientModules({
   clientModules = [],
   app,
   pinia = null,
+  queryClient = null,
   router,
   surfaceRuntime,
   surfaceMode,
@@ -529,6 +532,7 @@ async function bootClientModules({
     profile: String(surfaceRuntime.normalizeSurfaceMode(surfaceMode) || "client"),
     app,
     pinia,
+    queryClient,
     router,
     env,
     logger: log,

--- a/packages/kernel/client/moduleBootstrap.test.js
+++ b/packages/kernel/client/moduleBootstrap.test.js
@@ -113,6 +113,7 @@ test("bootClientModules registers descriptor and clientRoutes with providers onl
   const events = [];
   const loginComponent = {};
   const pinia = { id: "pinia-instance" };
+  const queryClient = { id: "query-client-instance" };
   const implicitPinia = { id: "implicit-vue-global-pinia" };
   class ExampleClientProvider {
     static id = "example.client";
@@ -120,6 +121,7 @@ test("bootClientModules registers descriptor and clientRoutes with providers onl
       events.push("register");
       app.instance("example.value", 42);
       app.instance("example.pinia", app.make("jskit.client.pinia"));
+      app.instance("example.queryClient", app.make("jskit.client.query-client"));
     }
     boot() {
       events.push("boot");
@@ -190,6 +192,7 @@ test("bootClientModules registers descriptor and clientRoutes with providers onl
       }
     },
     pinia,
+    queryClient,
     router,
     surfaceRuntime,
     surfaceMode: "all",
@@ -206,6 +209,7 @@ test("bootClientModules registers descriptor and clientRoutes with providers onl
   assert.equal(router.routes[1].component, loginComponent);
   assert.equal(result.runtimeApp.make("example.value"), 42);
   assert.equal(result.runtimeApp.make("example.pinia"), pinia);
+  assert.equal(result.runtimeApp.make("example.queryClient"), queryClient);
   assert.notEqual(result.runtimeApp.make("example.pinia"), implicitPinia);
 });
 

--- a/packages/kernel/client/shellBootstrap.js
+++ b/packages/kernel/client/shellBootstrap.js
@@ -109,6 +109,7 @@ async function bootstrapClientShellApp({
   appConfig = {},
   appPlugins = [],
   pinia = null,
+  queryClient = null,
   router,
   bootClientModules,
   surfaceRuntime,
@@ -161,6 +162,7 @@ async function bootstrapClientShellApp({
   const clientBootstrap = await bootClientModules({
     app,
     pinia,
+    queryClient,
     router,
     surfaceRuntime,
     surfaceMode,

--- a/packages/kernel/client/shellBootstrap.test.js
+++ b/packages/kernel/client/shellBootstrap.test.js
@@ -86,6 +86,7 @@ test("bootstrapClientShellApp boots modules, reinstalls fallback route, and moun
   const surfaceRuntime = createSurfaceRuntimeFixture();
   const plugin = { name: "vuetify-like-plugin" };
   const pinia = { id: "pinia-instance" };
+  const queryClient = { id: "query-client-instance" };
   const fallbackRoute = {
     name: "not-found",
     path: "/:pathMatch(.*)*",
@@ -142,11 +143,13 @@ test("bootstrapClientShellApp boots modules, reinstalls fallback route, and moun
     },
     appPlugins: [plugin],
     pinia,
+    queryClient,
     router,
     bootClientModules: async (context) => {
       calls.push("bootClientModules");
       assert.equal(context.app, app);
       assert.equal(context.pinia, pinia);
+      assert.equal(context.queryClient, queryClient);
       assert.equal(context.router, router);
       assert.equal(typeof context.logger.debug, "function");
       return {

--- a/packages/kernel/client/vite/clientBootstrapPlugin.js
+++ b/packages/kernel/client/vite/clientBootstrapPlugin.js
@@ -14,6 +14,7 @@ const CLIENT_BOOTSTRAP_VIRTUAL_ID = "virtual:jskit-client-bootstrap";
 const CLIENT_BOOTSTRAP_RESOLVED_ID = `\0${CLIENT_BOOTSTRAP_VIRTUAL_ID}`;
 const CLIENT_RUNTIME_DEDUPE_SPECIFIERS = Object.freeze([
   "@tanstack/vue-query",
+  "pinia",
   "vue",
   "vue-router",
   "vuetify"

--- a/packages/kernel/client/vite/clientBootstrapPlugin.test.js
+++ b/packages/kernel/client/vite/clientBootstrapPlugin.test.js
@@ -404,7 +404,7 @@ test("createJskitClientBootstrapPlugin config excludes installed client package 
     assert.equal(Array.isArray(result?.optimizeDeps?.exclude), true);
     assert.deepEqual(result.optimizeDeps.exclude, ["already/excluded"]);
     assert.deepEqual(result.optimizeDeps.include, ["@example/has-client/client", "a"]);
-    assert.deepEqual(result.resolve.dedupe, ["@tanstack/vue-query", "vue", "vue-router", "vuetify"]);
+    assert.deepEqual(result.resolve.dedupe, ["@tanstack/vue-query", "pinia", "vue", "vue-router", "vuetify"]);
   } finally {
     process.chdir(previousCwd);
   }
@@ -469,7 +469,7 @@ test("createJskitClientBootstrapPlugin config excludes local package roots and c
       "@example/local-client/shared"
     ]);
     assert.deepEqual(result.optimizeDeps.include, ["@example/remote-client/client", "mime-match"]);
-    assert.deepEqual(result.resolve.dedupe, ["@tanstack/vue-query", "vue", "vue-router", "vuetify"]);
+    assert.deepEqual(result.resolve.dedupe, ["@tanstack/vue-query", "pinia", "vue", "vue-router", "vuetify"]);
   } finally {
     process.chdir(previousCwd);
   }
@@ -500,7 +500,7 @@ test("createJskitClientBootstrapPlugin config preserves user resolve fields and 
     assert.deepEqual(result.resolve.alias, {
       "@": "/tmp/app/src"
     });
-    assert.deepEqual(result.resolve.dedupe, ["@tanstack/vue-query", "custom-lib", "vue", "vue-router", "vuetify"]);
+    assert.deepEqual(result.resolve.dedupe, ["@tanstack/vue-query", "custom-lib", "pinia", "vue", "vue-router", "vuetify"]);
   } finally {
     process.chdir(previousCwd);
   }

--- a/packages/shell-web/package.descriptor.mjs
+++ b/packages/shell-web/package.descriptor.mjs
@@ -51,8 +51,7 @@ export default Object.freeze({
           "runtime.web-placement.client",
           "runtime.web-bootstrap.client",
           "runtime.web-error.client",
-          "runtime.web-error.presentation-store.client",
-          "shell.web.query-client"
+          "runtime.web-error.presentation-store.client"
         ]
       }
     },
@@ -232,9 +231,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@mdi/js": "^7.4.47",
-        "@tanstack/vue-query": "^5.90.5",
-        "@jskit-ai/kernel": "0.1.66",
-        "vuetify": "^4.0.0"
+        "@jskit-ai/kernel": "0.1.66"
       },
       dev: {}
     },

--- a/packages/shell-web/package.json
+++ b/packages/shell-web/package.json
@@ -24,13 +24,12 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@tanstack/vue-query": "^5.90.5",
-    "@jskit-ai/kernel": "0.1.66",
-    "pinia": "^3.0.4",
-    "vuetify": "^4.0.0"
+    "@jskit-ai/kernel": "0.1.66"
   },
   "peerDependencies": {
+    "pinia": "^3.0.4",
     "vue": "^3.5.13",
-    "vue-router": "^5.0.4"
+    "vue-router": "^5.0.4",
+    "vuetify": "^4.0.0"
   }
 }

--- a/packages/shell-web/src/client/providers/ShellWebClientProvider.js
+++ b/packages/shell-web/src/client/providers/ShellWebClientProvider.js
@@ -1,11 +1,8 @@
 import { getClientAppConfig } from "@jskit-ai/kernel/client";
 import {
-  isRecord,
-  shouldRetryTransientQueryFailure,
-  transientQueryRetryDelay
+  isRecord
 } from "@jskit-ai/kernel/shared/support";
 import { createProviderLogger as createSharedProviderLogger } from "@jskit-ai/kernel/shared/support/providerLogger";
-import { QueryClient, VueQueryPlugin } from "@tanstack/vue-query";
 import {
   createDefaultErrorPolicy
 } from "../error/policy.js";
@@ -32,19 +29,6 @@ import { resolveBootstrapErrorStatusCode } from "../bootstrap/bootstrapErrorStat
 const APP_PLACEMENT_MODULE_SPECIFIER = "/src/placement.js";
 const APP_PLACEMENT_TOPOLOGY_MODULE_SPECIFIER = "/src/placementTopology.js";
 const APP_ERROR_MODULE_SPECIFIER = "/src/error.js";
-
-function createShellWebQueryClient() {
-  return new QueryClient({
-    defaultOptions: {
-      queries: {
-        refetchOnWindowFocus: false,
-        refetchOnReconnect: true,
-        retry: shouldRetryTransientQueryFailure,
-        retryDelay: transientQueryRetryDelay
-      }
-    }
-  });
-}
 
 function isMissingDynamicModule(error, moduleSpecifier) {
   const message = String(error?.message || error || "");
@@ -317,7 +301,6 @@ class ShellWebClientProvider {
         logger
       })
     );
-    app.singleton("shell.web.query-client", () => createShellWebQueryClient());
     app.singleton("runtime.web-error.presentation-store.client", () => createErrorPresentationStore());
     app.singleton("runtime.web-error.client", (scope) =>
       createErrorRuntime({
@@ -391,9 +374,6 @@ class ShellWebClientProvider {
     const errorPresentationStore = app.make("runtime.web-error.presentation-store.client");
     useShellErrorPresentationStore(pinia).attachRuntimeStore(errorPresentationStore);
 
-    vueApp.use(VueQueryPlugin, {
-      queryClient: app.make("shell.web.query-client")
-    });
     vueApp.provide("jskit.shell-web.runtime.web-placement.client", placementRuntime);
     vueApp.provide("jskit.shell-web.runtime.web-error.client", errorRuntime);
     vueApp.provide(

--- a/packages/shell-web/test/provider.test.js
+++ b/packages/shell-web/test/provider.test.js
@@ -165,9 +165,7 @@ test("shell web client provider binds runtime and injects it into Vue app", asyn
     assert.equal(app.singletons.has("runtime.web-error.presentation-store.client"), true);
 
     await provider.boot(app);
-    assert.equal(app.plugins.length, 1);
-    assert.equal(typeof app.plugins[0].plugin.install, "function");
-    assert.equal(typeof app.plugins[0].options?.queryClient, "object");
+    assert.equal(app.plugins.length, 0);
 
     const providedByKey = new Map(app.provided.map((entry) => [entry.key, entry.value]));
 

--- a/packages/users-core/templates/packages/users-workspace/src/server/actions.js
+++ b/packages/users-core/templates/packages/users-workspace/src/server/actions.js
@@ -16,6 +16,12 @@ const authenticatedPermission = Object.freeze({
   require: "authenticated"
 });
 
+function buildListQuery(input = {}) {
+  const query = { ...(input || {}) };
+  delete query.workspaceSlug;
+  return query;
+}
+
 function createActions({ surface } = {}) {
   return Object.freeze([
     {
@@ -37,8 +43,7 @@ function createActions({ surface } = {}) {
       },
       observability: {},
       async execute(input, context, deps) {
-        const { workspaceSlug, ...query } = input || {};
-        return deps.usersService.queryDocuments(query, {
+        return deps.usersService.queryDocuments(buildListQuery(input), {
           context,
           visibilityContext: context?.visibilityContext
         });

--- a/packages/users-core/templates/packages/users/src/server/actions.js
+++ b/packages/users-core/templates/packages/users/src/server/actions.js
@@ -35,8 +35,7 @@ function createActions({ surface } = {}) {
       },
       observability: {},
       async execute(input, context, deps) {
-        const { workspaceSlug, ...query } = input || {};
-        return deps.usersService.queryDocuments(query, {
+        return deps.usersService.queryDocuments(input || {}, {
           context,
           visibilityContext: context?.visibilityContext
         });

--- a/packages/users-core/test/usersPackageScaffoldContract.test.js
+++ b/packages/users-core/test/usersPackageScaffoldContract.test.js
@@ -96,6 +96,7 @@ test("users-core base users package templates stay aligned with non-workspace ap
   assert.match(repositorySource, /async function getDocumentById\(recordId, options = \{\}\)/);
   assert.match(repositorySource, /returnNullWhenJsonRestResourceMissing/);
   assert.doesNotMatch(actionsSource, /workspaceSlugParamsValidator/);
+  assert.doesNotMatch(actionsSource, /delete query\.workspaceSlug/);
   assert.doesNotMatch(actionsSource, /requireActionSurface/);
   assert.match(actionsSource, /orderBy: resource\.defaultSort/);
   assert.match(actionsSource, /output: null/);
@@ -154,6 +155,7 @@ test("users-core workspace users package templates stay aligned with workspace a
   assert.match(providerSource, /createJsonRestResourceScopeOptions/);
   assert.match(providerSource, /addResourceIfMissing\(\s*api,\s*"users",\s*createJsonRestResourceScopeOptions\(resource,/s);
   assert.match(actionsSource, /workspaceSlugParamsValidator/);
+  assert.match(actionsSource, /delete query\.workspaceSlug/);
   assert.doesNotMatch(actionsSource, /requireActionSurface/);
   assert.match(actionsSource, /orderBy: resource\.defaultSort/);
   assert.match(actionsSource, /usersService\.queryDocuments/);

--- a/packages/users-web/package.descriptor.mjs
+++ b/packages/users-web/package.descriptor.mjs
@@ -233,15 +233,13 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@tanstack/vue-query": "5.92.12",
         "@mdi/js": "^7.4.47",
         "@jskit-ai/http-runtime": "0.1.65",
         "@jskit-ai/realtime": "0.1.65",
         "@jskit-ai/kernel": "0.1.66",
         "@jskit-ai/shell-web": "0.1.65",
         "@jskit-ai/uploads-image-web": "0.1.44",
-        "@jskit-ai/users-core": "0.1.76",
-        vuetify: "^4.0.0"
+        "@jskit-ai/users-core": "0.1.76"
       },
       dev: {}
     },

--- a/packages/users-web/package.json
+++ b/packages/users-web/package.json
@@ -32,18 +32,18 @@
     "./client/support/contractGuards": "./src/client/support/contractGuards.js"
   },
   "dependencies": {
-    "@tanstack/vue-query": "5.92.12",
     "@mdi/js": "^7.4.47",
     "@jskit-ai/http-runtime": "0.1.65",
     "@jskit-ai/kernel": "0.1.66",
     "@jskit-ai/realtime": "0.1.65",
     "@jskit-ai/shell-web": "0.1.65",
     "@jskit-ai/uploads-image-web": "0.1.44",
-    "@jskit-ai/users-core": "0.1.76",
-    "vuetify": "^4.0.0"
+    "@jskit-ai/users-core": "0.1.76"
   },
   "peerDependencies": {
+    "@tanstack/vue-query": "^5.90.5",
     "vue": "^3.5.13",
-    "vue-router": "^5.0.4"
+    "vue-router": "^5.0.4",
+    "vuetify": "^4.0.0"
   }
 }

--- a/packages/workspaces-web/package.descriptor.mjs
+++ b/packages/workspaces-web/package.descriptor.mjs
@@ -228,8 +228,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@jskit-ai/workspaces-core": "0.1.42",
-        "@jskit-ai/users-web": "0.1.81",
-        "vuetify": "^4.0.0"
+        "@jskit-ai/users-web": "0.1.81"
       },
       dev: {}
     },

--- a/packages/workspaces-web/package.json
+++ b/packages/workspaces-web/package.json
@@ -13,18 +13,18 @@
     "./client/composables/useWorkspaceRouteContext": "./src/client/composables/useWorkspaceRouteContext.js"
   },
   "dependencies": {
-    "@tanstack/vue-query": "5.92.12",
     "@mdi/js": "^7.4.47",
     "@jskit-ai/http-runtime": "0.1.65",
     "@jskit-ai/kernel": "0.1.66",
     "@jskit-ai/shell-web": "0.1.65",
     "@jskit-ai/users-core": "0.1.76",
     "@jskit-ai/users-web": "0.1.81",
-    "@jskit-ai/workspaces-core": "0.1.42",
-    "vuetify": "^4.0.0"
+    "@jskit-ai/workspaces-core": "0.1.42"
   },
   "peerDependencies": {
+    "@tanstack/vue-query": "^5.90.5",
     "vue": "^3.5.13",
-    "vue-router": "^5.0.4"
+    "vue-router": "^5.0.4",
+    "vuetify": "^4.0.0"
   }
 }

--- a/tooling/create-app/templates/base-shell/package.json
+++ b/tooling/create-app/templates/base-shell/package.json
@@ -31,6 +31,7 @@
     "@local/main": "file:packages/main",
     "@fastify/static": "^9.1.1",
     "@jskit-ai/kernel": "0.x",
+    "@tanstack/vue-query": "^5.90.5",
     "fastify": "^5.7.4",
     "json-rest-schema": "^1.0.13",
     "pinia": "^3.0.4",

--- a/tooling/create-app/templates/base-shell/src/main.js
+++ b/tooling/create-app/templates/base-shell/src/main.js
@@ -1,5 +1,6 @@
 import { createApp } from "vue";
 import { createPinia } from "pinia";
+import { QueryClient, VueQueryPlugin } from "@tanstack/vue-query";
 import { createRouter, createWebHistory } from "vue-router/auto";
 import { routes } from "vue-router/auto-routes";
 import "vuetify/styles";
@@ -11,6 +12,10 @@ import App from "./App.vue";
 import NotFoundView from "./views/NotFound.vue";
 import { bootInstalledClientModules } from "virtual:jskit-client-bootstrap";
 import { createSurfaceRuntime } from "@jskit-ai/kernel/shared/surface/runtime";
+import {
+  shouldRetryTransientQueryFailure,
+  transientQueryRetryDelay
+} from "@jskit-ai/kernel/shared/support";
 import {
   bootstrapClientShellApp,
   createShellRouter
@@ -51,13 +56,28 @@ const vuetify = createVuetify({
   }
 });
 const pinia = createPinia();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: true,
+      retry: shouldRetryTransientQueryFailure,
+      retryDelay: transientQueryRetryDelay
+    }
+  }
+});
 
 void bootstrapClientShellApp({
   createApp,
   rootComponent: App,
   appConfig: config,
-  appPlugins: [pinia, vuetify],
+  appPlugins: [
+    pinia,
+    [VueQueryPlugin, { queryClient }],
+    vuetify
+  ],
   pinia,
+  queryClient,
   router,
   bootClientModules: bootInstalledClientModules,
   surfaceRuntime,

--- a/tooling/create-app/test/createApp.test.js
+++ b/tooling/create-app/test/createApp.test.js
@@ -155,6 +155,7 @@ test("create-app scaffolds the base shell with placeholder replacements", async 
       false
     );
     assert.equal(packageJson.dependencies.pinia, "^3.0.4");
+    assert.equal(packageJson.dependencies["@tanstack/vue-query"], "^5.90.5");
     await assert.rejects(access(path.join(appRoot, "scripts/copy-local-packages.sh")), /ENOENT/);
     await assert.rejects(access(path.join(appRoot, "scripts/link-local-jskit-packages.sh")), /ENOENT/);
     await assert.rejects(access(path.join(appRoot, "scripts/release.sh")), /ENOENT/);
@@ -196,6 +197,7 @@ test("create-app scaffolds the base shell with placeholder replacements", async 
     const mainJs = await readFile(path.join(appRoot, "src/main.js"), "utf8");
     assert.match(mainJs, /import App from "\.\/App\.vue";/);
     assert.match(mainJs, /import \{ createPinia \} from "pinia";/);
+    assert.match(mainJs, /import \{ QueryClient, VueQueryPlugin \} from "@tanstack\/vue-query";/);
     assert.match(mainJs, /import NotFoundView from "\.\/views\/NotFound\.vue";/);
     assert.match(mainJs, /import \{ bootInstalledClientModules \} from "virtual:jskit-client-bootstrap";/);
     assert.doesNotMatch(mainJs, /@\/modules\/client-modules\.js/);
@@ -208,8 +210,10 @@ test("create-app scaffolds the base shell with placeholder replacements", async 
     assert.match(mainJs, /createRouter, createWebHistory/);
     assert.match(mainJs, /bootClientModules:\s*bootInstalledClientModules/);
     assert.match(mainJs, /const pinia = createPinia\(\);/);
-    assert.match(mainJs, /appPlugins:\s*\[pinia,\s*vuetify\]/);
-    assert.match(mainJs, /appPlugins:\s*\[pinia,\s*vuetify\],[\s\S]*?\bpinia,\s*router,/);
+    assert.match(mainJs, /const queryClient = new QueryClient\(/);
+    assert.match(mainJs, /\[VueQueryPlugin,\s*\{ queryClient \}\]/);
+    assert.match(mainJs, /appPlugins:[\s\S]*?pinia,[\s\S]*?\[VueQueryPlugin,\s*\{ queryClient \}\],[\s\S]*?vuetify/);
+    assert.match(mainJs, /\bpinia,[\s\S]*?\bqueryClient,[\s\S]*?\brouter,/);
     assert.match(mainJs, /fallbackRoute/);
 
     await assert.rejects(access(path.join(appRoot, "config/surfaces.js")), /ENOENT/);
@@ -336,6 +340,7 @@ test("create-app scaffolds the base shell with placeholder replacements", async 
     assert.doesNotMatch(viteConfig, /function reparentNestedChildrenToIndexOwners\(rootRoute\)/);
     assert.doesNotMatch(viteConfig, /^\s*beforeWriteFiles:\s*reparentNestedChildrenToIndexOwners/m);
     assert.match(viteConfig, /nestedChildren deprecated/);
+    assert.doesNotMatch(viteConfig, /dedupe:\s*\[/);
 
     assert.doesNotMatch(result.stdout, /Then add framework capabilities:/);
     assert.doesNotMatch(result.stdout, /npx jskit add package auth-provider-supabase-core/);

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -404,12 +404,10 @@
               "@jskit-ai/resource-core": "0.1.11",
               "@jskit-ai/resource-crud-core": "0.1.11",
               "@jskit-ai/users-core": "0.1.76",
-              "@tanstack/vue-query": "^5.90.5",
               "dompurify": "^3.3.3",
               "json-rest-schema": "1.x.x",
               "marked": "^17.0.4",
-              "openai": "^6.22.0",
-              "vuetify": "^4.0.0"
+              "openai": "^6.22.0"
             },
             "dev": {}
           },
@@ -530,9 +528,7 @@
               "@jskit-ai/kernel": "0.1.66",
               "@jskit-ai/shell-web": "0.1.65",
               "@jskit-ai/users-core": "0.1.76",
-              "@jskit-ai/users-web": "0.1.81",
-              "@tanstack/vue-query": "^5.90.5",
-              "vuetify": "^4.0.0"
+              "@jskit-ai/users-web": "0.1.81"
             },
             "dev": {}
           },
@@ -1088,13 +1084,11 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@tanstack/vue-query": "5.92.12",
               "@mdi/js": "^7.4.47",
               "@jskit-ai/auth-core": "0.1.65",
               "@jskit-ai/http-runtime": "0.1.65",
               "@jskit-ai/kernel": "0.1.66",
-              "@jskit-ai/shell-web": "0.1.65",
-              "vuetify": "^4.0.0"
+              "@jskit-ai/shell-web": "0.1.65"
             },
             "dev": {}
           },
@@ -3818,8 +3812,7 @@
                 "runtime.web-placement.client",
                 "runtime.web-bootstrap.client",
                 "runtime.web-error.client",
-                "runtime.web-error.presentation-store.client",
-                "shell.web.query-client"
+                "runtime.web-error.presentation-store.client"
               ]
             }
           },
@@ -4025,9 +4018,7 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@tanstack/vue-query": "^5.90.5",
-              "@jskit-ai/kernel": "0.1.66",
-              "vuetify": "^4.0.0"
+              "@jskit-ai/kernel": "0.1.66"
             },
             "dev": {}
           },
@@ -5432,15 +5423,13 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@tanstack/vue-query": "5.92.12",
               "@mdi/js": "^7.4.47",
               "@jskit-ai/http-runtime": "0.1.65",
               "@jskit-ai/realtime": "0.1.65",
               "@jskit-ai/kernel": "0.1.66",
               "@jskit-ai/shell-web": "0.1.65",
               "@jskit-ai/uploads-image-web": "0.1.44",
-              "@jskit-ai/users-core": "0.1.76",
-              "vuetify": "^4.0.0"
+              "@jskit-ai/users-core": "0.1.76"
             },
             "dev": {}
           },
@@ -6186,8 +6175,7 @@
           "dependencies": {
             "runtime": {
               "@jskit-ai/workspaces-core": "0.1.42",
-              "@jskit-ai/users-web": "0.1.81",
-              "vuetify": "^4.0.0"
+              "@jskit-ai/users-web": "0.1.81"
             },
             "dev": {}
           },

--- a/tooling/jskit-cli/src/server/commandHandlers/list.js
+++ b/tooling/jskit-cli/src/server/commandHandlers/list.js
@@ -14,6 +14,9 @@ const REGISTER_MAIN_CLIENT_COMPONENT_PATTERN = /registerMainClientComponent\(\s*
 const LINK_ITEM_TOKEN_SUFFIX = "link-item";
 const JSKIT_SCOPE_PREFIX = "@jskit-ai/";
 const FEATURE_SERVER_GENERATOR_PACKAGE_ID = "@jskit-ai/feature-server-generator";
+const PLACEMENT_LAYOUT_CLASSES = Object.freeze(["compact", "medium", "expanded"]);
+const PLACEMENT_KIND_COMPONENT = "component";
+const PLACEMENT_KIND_LINK = "link";
 const PROVIDER_SOURCE_EXTENSIONS = new Set([".js", ".mjs", ".cjs", ".ts", ".tsx"]);
 const READ_FILE_IGNORE_ERROR_CODES = new Set(["ENOENT", "ENOTDIR", "EISDIR", "EACCES", "EPERM"]);
 const READ_DIRECTORY_IGNORE_ERROR_CODES = new Set(["ENOENT", "ENOTDIR", "EACCES", "EPERM"]);
@@ -80,6 +83,271 @@ function resolveGeneratorQuickStartRows(packageEntry = {}, { limit = 3 } = {}) {
 
 function isLinkItemToken(token = "") {
   return String(token || "").trim().toLowerCase().endsWith(LINK_ITEM_TOKEN_SUFFIX);
+}
+
+function collectPlacementRendererKinds(placementTarget = {}) {
+  const kinds = new Set();
+  const variants = ensureObject(placementTarget.variants);
+  for (const layoutClass of PLACEMENT_LAYOUT_CLASSES) {
+    const variant = ensureObject(variants[layoutClass]);
+    const renderers = ensureObject(variant.renderers);
+    for (const kind of Object.keys(renderers)) {
+      const normalizedKind = String(kind || "").trim();
+      if (normalizedKind) {
+        kinds.add(normalizedKind);
+      }
+    }
+  }
+  if (kinds.size < 1) {
+    kinds.add(PLACEMENT_KIND_COMPONENT);
+  }
+  return sortStrings([...kinds]);
+}
+
+function collectPlacementConcreteOutlets(placementTarget = {}) {
+  const outlets = new Set();
+  const variants = ensureObject(placementTarget.variants);
+  for (const layoutClass of PLACEMENT_LAYOUT_CLASSES) {
+    const variant = ensureObject(variants[layoutClass]);
+    const outlet = String(variant.outlet || "").trim();
+    if (outlet) {
+      outlets.add(outlet);
+    }
+  }
+  return sortStrings([...outlets]);
+}
+
+function classifyPlacementTarget(placementTarget = {}) {
+  const owner = String(placementTarget.owner || "").trim();
+  const kinds = collectPlacementRendererKinds(placementTarget);
+  const acceptsLinks = kinds.includes(PLACEMENT_KIND_LINK);
+  const acceptsComponents = kinds.includes(PLACEMENT_KIND_COMPONENT);
+
+  if (acceptsLinks && acceptsComponents) {
+    return owner ? "ownerMixed" : "mixed";
+  }
+  if (acceptsLinks) {
+    return owner ? "ownerLinks" : "links";
+  }
+  return owner ? "ownerComponents" : "components";
+}
+
+function createConcreteTargetSourcePathMap(concreteTargets = []) {
+  const sourcePathByTarget = new Map();
+  for (const concreteTarget of ensureArray(concreteTargets)) {
+    const target = String(ensureObject(concreteTarget).id || "").trim();
+    const sourcePath = String(ensureObject(concreteTarget).sourcePath || "").trim();
+    if (target && sourcePath && !sourcePathByTarget.has(target)) {
+      sourcePathByTarget.set(target, sourcePath);
+    }
+  }
+  return sourcePathByTarget;
+}
+
+function resolveChildPagePatternFromHostSourcePath(sourcePath = "") {
+  const normalizedPath = String(sourcePath || "").replaceAll("\\", "/").trim();
+  if (!normalizedPath.startsWith("src/pages/")) {
+    return "";
+  }
+  const pagePath = normalizedPath.slice("src/pages/".length);
+  if (pagePath.endsWith("/index.vue")) {
+    const hostPath = pagePath.slice(0, -"/index.vue".length);
+    return hostPath ? `${hostPath}/<page>/index.vue` : "<page>/index.vue";
+  }
+  if (pagePath.endsWith(".vue")) {
+    const hostPath = pagePath.slice(0, -".vue".length);
+    return hostPath ? `${hostPath}/<page>/index.vue` : "<page>/index.vue";
+  }
+  return "";
+}
+
+function resolveOwnerScopedChildPagePattern(placementTarget = {}, concreteSourcePathByTarget = new Map()) {
+  const outlets = collectPlacementConcreteOutlets(placementTarget);
+  for (const outlet of outlets) {
+    const childPagePattern = resolveChildPagePatternFromHostSourcePath(
+      concreteSourcePathByTarget.get(outlet) || ""
+    );
+    if (childPagePattern) {
+      return childPagePattern;
+    }
+  }
+  return "";
+}
+
+function createPlacementTargetSummary(placementTarget = {}, color, { concreteSourcePathByTarget = new Map() } = {}) {
+  const placementId = String(placementTarget.id || "").trim();
+  const owner = String(placementTarget.owner || "").trim();
+  const ownerLabel = owner ? color.dim(` [owner:${owner}]`) : "";
+  const defaultLabel = placementTarget.default === true ? color.installed(" (default)") : "";
+  const description = String(placementTarget.description || "").trim();
+  const childPagePattern = owner
+    ? resolveOwnerScopedChildPagePattern(placementTarget, concreteSourcePathByTarget)
+    : "";
+  const childPagePatternLabel = childPagePattern ? ` -> ${color.dim(childPagePattern)}` : "";
+  const descriptionSuffix = description ? `: ${description}` : "";
+  return `- ${color.item(placementId)}${ownerLabel}${defaultLabel}${childPagePatternLabel}${descriptionSuffix}`;
+}
+
+function appendPlacementLayoutDetails(lines, placementTarget = {}, color) {
+  const variants = ensureObject(placementTarget.variants);
+  for (const layoutClass of PLACEMENT_LAYOUT_CLASSES) {
+    const variant = ensureObject(variants[layoutClass]);
+    const outlet = String(variant.outlet || "").trim();
+    if (outlet) {
+      lines.push(`  ${layoutClass} -> ${color.dim(outlet)}`);
+    }
+  }
+}
+
+function formatPlacementGuidanceLine(line = "", color) {
+  const guidanceLine = String(line || "").trim();
+  const labelMatch = /^([^:]+):\s*(.*)$/u.exec(guidanceLine);
+  if (!labelMatch) {
+    return `  ${color.dim(guidanceLine)}`;
+  }
+  const label = String(labelMatch[1] || "").trim();
+  const value = String(labelMatch[2] || "").trim();
+  const renderedLabel = color.installed(`${label}:`);
+  const renderedValue = value ? ` ${color.provider(value)}` : "";
+  return `  ${renderedLabel}${renderedValue}`;
+}
+
+function appendPlacementGroup(lines, {
+  color,
+  title = "",
+  description = "",
+  guidance = [],
+  targets = [],
+  concreteSourcePathByTarget = new Map(),
+  showLayoutDetails = false
+} = {}) {
+  const placementTargets = ensureArray(targets);
+  if (placementTargets.length < 1) {
+    return;
+  }
+  if (lines.length > 1) {
+    lines.push("");
+  }
+  lines.push(color.heading(title));
+  if (description) {
+    lines.push(description);
+  }
+  const guidanceLines = ensureArray(guidance).map((value) => String(value || "").trim()).filter(Boolean);
+  for (const guidanceLine of guidanceLines) {
+    lines.push(formatPlacementGuidanceLine(guidanceLine, color));
+  }
+  for (const placementTarget of placementTargets) {
+    lines.push(createPlacementTargetSummary(placementTarget, color, { concreteSourcePathByTarget }));
+    if (showLayoutDetails) {
+      appendPlacementLayoutDetails(lines, placementTarget, color);
+    }
+  }
+}
+
+function appendSemanticPlacementGroups(lines, {
+  color,
+  semanticPlacements = [],
+  concreteTargets = [],
+  hostPathLookupError = null,
+  showLayoutDetails = false
+} = {}) {
+  const concreteSourcePathByTarget = createConcreteTargetSourcePathMap(concreteTargets);
+  const groupedTargets = {
+    links: [],
+    ownerLinks: [],
+    components: [],
+    ownerComponents: [],
+    mixed: [],
+    ownerMixed: []
+  };
+
+  for (const placementTarget of ensureArray(semanticPlacements)) {
+    const groupKey = classifyPlacementTarget(placementTarget);
+    if (groupedTargets[groupKey]) {
+      groupedTargets[groupKey].push(placementTarget);
+    }
+  }
+
+  appendPlacementGroup(lines, {
+    color,
+    title: "Navigation link placements",
+    guidance: [
+      'Format: npx jskit generate ui-generator page <page-file> --name "Label" --link-placement <placement>',
+      'Example: npx jskit generate ui-generator page admin/reports/index.vue --name "Reports" --link-placement admin.tools-menu'
+    ],
+    targets: groupedTargets.links,
+    concreteSourcePathByTarget,
+    showLayoutDetails
+  });
+
+  appendPlacementGroup(lines, {
+    color,
+    title: "Owner-scoped navigation link placements",
+    guidance: [
+      'Format: npx jskit generate ui-generator page <host-path>/<page>/index.vue --name "Label"',
+      'Example: npx jskit generate ui-generator page home/settings/profile/index.vue --name "Profile"',
+      hostPathLookupError
+        ? `Host path lookup failed: ${String(hostPathLookupError?.message || hostPathLookupError).trim()}`
+        : ""
+    ],
+    targets: groupedTargets.ownerLinks,
+    concreteSourcePathByTarget,
+    showLayoutDetails
+  });
+
+  appendPlacementGroup(lines, {
+    color,
+    title: "Component, widget, and section placements",
+    guidance: [
+      'Format: npx jskit generate ui-generator placed-element --name "Widget Name" --placement <placement>',
+      'Example: npx jskit generate ui-generator placed-element --name "Connection Status" --placement shell.status'
+    ],
+    targets: groupedTargets.components,
+    concreteSourcePathByTarget,
+    showLayoutDetails
+  });
+
+  appendPlacementGroup(lines, {
+    color,
+    title: "Owner-scoped component and section placements",
+    guidance: [
+      'Format: npx jskit generate ui-generator placed-element --name "Section Name" --placement <placement> --owner <owner>',
+      'Example: npx jskit generate ui-generator placed-element --name "Security Section" --placement settings.sections --owner account-settings'
+    ],
+    targets: groupedTargets.ownerComponents,
+    concreteSourcePathByTarget,
+    showLayoutDetails
+  });
+
+  appendPlacementGroup(lines, {
+    color,
+    title: "Mixed-kind placements",
+    description: "These topology entries accept more than one semantic kind. Choose the generator by what you are adding.",
+    guidance: [
+      'Link format: npx jskit generate ui-generator page <page-file> --name "Label" --link-placement <placement>',
+      'Component format: npx jskit generate ui-generator placed-element --name "Widget Name" --placement <placement>',
+      'Link example: npx jskit generate ui-generator page admin/reports/index.vue --name "Reports" --link-placement <placement>',
+      'Component example: npx jskit generate ui-generator placed-element --name "Ops Panel" --placement <placement>'
+    ],
+    targets: groupedTargets.mixed,
+    concreteSourcePathByTarget,
+    showLayoutDetails
+  });
+
+  appendPlacementGroup(lines, {
+    color,
+    title: "Owner-scoped mixed-kind placements",
+    description: "These owner-scoped entries accept more than one semantic kind. Include the owner when adding manual placement entries.",
+    guidance: [
+      'Link format: npx jskit generate ui-generator page <host-path>/<page>/index.vue --name "Label"',
+      'Component format: npx jskit generate ui-generator placed-element --name "Widget Name" --placement <placement> --owner <owner>',
+      'Link example: npx jskit generate ui-generator page home/settings/profile/index.vue --name "Profile"',
+      'Component example: npx jskit generate ui-generator placed-element --name "Security Section" --placement <placement> --owner <owner>'
+    ],
+    targets: groupedTargets.ownerMixed,
+    concreteSourcePathByTarget,
+    showLayoutDetails
+  });
 }
 
 async function readFileIfExists(filePath = "") {
@@ -439,6 +707,8 @@ function createListCommands(ctx = {}) {
     const showConcreteOnly = options.concrete === true && options.all !== true;
     const showConcrete = options.concrete === true || options.all === true;
     const showSemantic = showConcreteOnly !== true;
+    const showLayoutDetails = options.details === true;
+    const shouldLookupHostPaths = showSemantic && options.json !== true;
     const discoveredTopology = await discoverPlacementTopologyFromApp({ appRoot });
     const semanticPlacements = ensureArray(discoveredTopology.placements)
       .map((entry) => ensureObject(entry))
@@ -450,12 +720,21 @@ function createListCommands(ctx = {}) {
         }
         return String(left.owner || "").localeCompare(String(right.owner || ""));
       });
-    const discoveredConcrete = showConcrete
-      ? await discoverShellOutletTargetsFromApp({
-        appRoot,
-        sourceRoot: "src"
-      })
-      : { targets: [] };
+    let hostPathLookupError = null;
+    let discoveredConcrete = { targets: [] };
+    if (showConcrete || shouldLookupHostPaths) {
+      try {
+        discoveredConcrete = await discoverShellOutletTargetsFromApp({
+          appRoot,
+          sourceRoot: "src"
+        });
+      } catch (error) {
+        if (showConcrete) {
+          throw error;
+        }
+        hostPathLookupError = error;
+      }
+    }
     const concreteTargets = ensureArray(discoveredConcrete.targets)
       .map((entry) => ensureObject(entry))
       .filter((entry) => String(entry.id || "").trim())
@@ -490,26 +769,17 @@ function createListCommands(ctx = {}) {
     const lines = [];
     if (showSemantic) {
       lines.push(color.heading("Available placements:"));
+      lines.push("Semantic placement targets are the stable IDs you should author against. Use --concrete only for low-level ShellOutlet recipients.");
       if (semanticPlacements.length < 1) {
         lines.push("- none");
       } else {
-        for (const placementTarget of semanticPlacements) {
-          const placementId = String(placementTarget.id || "").trim();
-          const owner = String(placementTarget.owner || "").trim();
-          const ownerLabel = owner ? color.dim(` [owner:${owner}]`) : "";
-          const defaultLabel = placementTarget.default === true ? color.installed(" (default)") : "";
-          const description = String(placementTarget.description || "").trim();
-          const descriptionSuffix = description ? `: ${description}` : "";
-          lines.push(`- ${color.item(placementId)}${ownerLabel}${defaultLabel}${descriptionSuffix}`);
-          const variants = ensureObject(placementTarget.variants);
-          for (const layoutClass of ["compact", "medium", "expanded"]) {
-            const variant = ensureObject(variants[layoutClass]);
-            const outlet = String(variant.outlet || "").trim();
-            if (outlet) {
-              lines.push(`  ${layoutClass} -> ${color.dim(outlet)}`);
-            }
-          }
-        }
+        appendSemanticPlacementGroups(lines, {
+          color,
+          semanticPlacements,
+          concreteTargets,
+          hostPathLookupError,
+          showLayoutDetails
+        });
       }
     }
 

--- a/tooling/jskit-cli/src/server/core/commandCatalog.js
+++ b/tooling/jskit-cli/src/server/core/commandCatalog.js
@@ -317,14 +317,16 @@ const COMMAND_DESCRIPTORS = Object.freeze({
     minimalUse: "jskit list-placements",
     parameters: Object.freeze([]),
     defaults: Object.freeze([
-      "Shows semantic placement targets from app placement topology by default.",
+      "Shows semantic placement targets from app placement topology grouped by authoring model.",
+      "Default output includes the generator command pattern for adding to each group.",
+      "Use --details to include compact, medium, and expanded layout outlet mappings.",
       "Use --concrete to inspect low-level ShellOutlet recipients.",
       "Use --all to show both semantic placements and concrete recipients."
     ]),
-    fullUse: "jskit list-placements [--concrete] [--all] [--json]",
+    fullUse: "jskit list-placements [--details] [--concrete] [--all] [--json]",
     showHelpOnBareInvocation: false,
     handlerName: "commandListPlacements",
-    allowedFlagKeys: Object.freeze(["concrete", "all", "json"]),
+    allowedFlagKeys: Object.freeze(["details", "concrete", "all", "json"]),
     inlineOptionMode: "none",
     allowedValueOptionNames: Object.freeze([])
   }),

--- a/tooling/jskit-cli/test/coreCommandOptionValidation.test.js
+++ b/tooling/jskit-cli/test/coreCommandOptionValidation.test.js
@@ -18,7 +18,7 @@ test("list-placements rejects unsupported value options and prints command help"
   const stderr = String(result.stderr || "");
   assert.match(stderr, /Unknown option for command list-placements: --prefix\./);
   assert.match(stderr, /Command: list-placements/);
-  assert.match(stderr, /jskit list-placements \[--concrete] \[--all] \[--json\]/);
+  assert.match(stderr, /jskit list-placements \[--details] \[--concrete] \[--all] \[--json\]/);
 });
 
 test("show rejects unsupported flags and prints command help", () => {

--- a/tooling/jskit-cli/test/listCommand.test.js
+++ b/tooling/jskit-cli/test/listCommand.test.js
@@ -179,6 +179,17 @@ test("list-placements shows semantic topology by default", async () => {
 </template>
 `
     );
+    await writeVueFile(
+      appRoot,
+      "src/pages/home/settings.vue",
+      `<template>
+  <section>
+    <ShellOutlet target="home-settings:primary-menu" />
+    <RouterView />
+  </section>
+</template>
+`
+    );
     await writePlacementTopology(
       appRoot,
       `export default {
@@ -189,9 +200,20 @@ test("list-placements shows semantic topology by default", async () => {
       surfaces: ["*"],
       default: true,
       variants: {
-        compact: { outlet: "shell-layout:primary-menu" },
-        medium: { outlet: "shell-layout:primary-menu" },
-        expanded: { outlet: "shell-layout:primary-menu" }
+        compact: { outlet: "shell-layout:primary-menu", renderers: { link: "local.main.ui.surface-aware-menu-link-item" } },
+        medium: { outlet: "shell-layout:primary-menu", renderers: { link: "local.main.ui.surface-aware-menu-link-item" } },
+        expanded: { outlet: "shell-layout:primary-menu", renderers: { link: "local.main.ui.surface-aware-menu-link-item" } }
+      }
+    },
+    {
+      id: "page.section-nav",
+      owner: "home-settings",
+      description: "Home settings child pages.",
+      surfaces: ["home"],
+      variants: {
+        compact: { outlet: "home-settings:primary-menu", renderers: { link: "local.main.ui.surface-aware-menu-link-item" } },
+        medium: { outlet: "home-settings:primary-menu", renderers: { link: "local.main.ui.surface-aware-menu-link-item" } },
+        expanded: { outlet: "home-settings:primary-menu", renderers: { link: "local.main.ui.surface-aware-menu-link-item" } }
       }
     },
     {
@@ -227,10 +249,115 @@ test("list-placements shows semantic topology by default", async () => {
     assert.equal(result.status, 0, String(result.stderr || ""));
     const stdout = String(result.stdout || "");
     assert.match(stdout, /Available placements:/);
+    assert.match(stdout, /Semantic placement targets are the stable IDs you should author against/);
+    assert.match(stdout, /Navigation link placements/);
+    assert.match(stdout, /Format: npx jskit generate ui-generator page <page-file> --name "Label" --link-placement <placement>/);
+    assert.match(stdout, /Example: npx jskit generate ui-generator page admin\/reports\/index\.vue --name "Reports" --link-placement admin\.tools-menu/);
+    assert.match(stdout, /shell\.primary-nav \(default\): Primary shell navigation\./);
+    assert.match(stdout, /Owner-scoped navigation link placements/);
+    assert.match(stdout, /Format: npx jskit generate ui-generator page <host-path>\/<page>\/index\.vue --name "Label"/);
+    assert.match(stdout, /Example: npx jskit generate ui-generator page home\/settings\/profile\/index\.vue --name "Profile"/);
+    assert.doesNotMatch(stdout, /--link-placement page\.section-nav/);
+    assert.match(stdout, /page\.section-nav \[owner:home-settings\] -> home\/settings\/<page>\/index\.vue: Home settings child pages\./);
+    assert.match(stdout, /Component, widget, and section placements/);
+    assert.match(stdout, /Format: npx jskit generate ui-generator placed-element --name "Widget Name" --placement <placement>/);
+    assert.match(stdout, /shell\.status: Shell status widgets\./);
+    assert.doesNotMatch(stdout, /Owner-scoped component and section placements/);
+    assert.doesNotMatch(stdout, /compact -> shell-layout:primary-menu/);
+    assert.doesNotMatch(stdout, /medium -> shell-layout:primary-menu/);
+    assert.doesNotMatch(stdout, /expanded -> shell-layout:primary-menu/);
+    assert.doesNotMatch(stdout, /admin-toolbox:widgets/);
+  });
+});
+
+test("list-placements --details shows semantic topology layout mappings", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "list-placements-details-app");
+    await createMinimalApp(appRoot, { name: "list-placements-details-app" });
+    await writePlacementTopology(
+      appRoot,
+      `export default {
+  placements: [
+    {
+      id: "shell.primary-nav",
+      description: "Primary shell navigation.",
+      surfaces: ["*"],
+      default: true,
+      variants: {
+        compact: { outlet: "shell-layout:primary-menu", renderers: { link: "local.main.ui.surface-aware-menu-link-item" } },
+        medium: { outlet: "shell-layout:primary-menu", renderers: { link: "local.main.ui.surface-aware-menu-link-item" } },
+        expanded: { outlet: "shell-layout:primary-menu", renderers: { link: "local.main.ui.surface-aware-menu-link-item" } }
+      }
+    }
+  ]
+};
+`
+    );
+
+    const result = runCli({
+      cwd: appRoot,
+      args: ["list-placements", "--details"]
+    });
+
+    assert.equal(result.status, 0, String(result.stderr || ""));
+    const stdout = String(result.stdout || "");
+    assert.match(stdout, /Available placements:/);
     assert.match(stdout, /shell\.primary-nav \(default\): Primary shell navigation\./);
     assert.match(stdout, /compact -> shell-layout:primary-menu/);
+    assert.match(stdout, /medium -> shell-layout:primary-menu/);
+    assert.match(stdout, /expanded -> shell-layout:primary-menu/);
+  });
+});
+
+test("list-placements separates owner-scoped component placements", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "list-placements-owner-components-app");
+    await createMinimalApp(appRoot, { name: "list-placements-owner-components-app" });
+    await writePlacementTopology(
+      appRoot,
+      `export default {
+  placements: [
+    {
+      id: "settings.sections",
+      owner: "account-settings",
+      description: "Account settings sections.",
+      surfaces: ["account"],
+      variants: {
+        compact: { outlet: "account-settings:sections" },
+        medium: { outlet: "account-settings:sections" },
+        expanded: { outlet: "account-settings:sections" }
+      }
+    },
+    {
+      id: "shell.status",
+      description: "Shell status widgets.",
+      surfaces: ["*"],
+      variants: {
+        compact: { outlet: "shell-layout:top-right" },
+        medium: { outlet: "shell-layout:top-right" },
+        expanded: { outlet: "shell-layout:top-right" }
+      }
+    }
+  ]
+};
+`
+    );
+
+    const result = runCli({
+      cwd: appRoot,
+      args: ["list-placements"]
+    });
+
+    assert.equal(result.status, 0, String(result.stderr || ""));
+    const stdout = String(result.stdout || "");
+    assert.match(stdout, /Component, widget, and section placements/);
     assert.match(stdout, /shell\.status: Shell status widgets\./);
-    assert.doesNotMatch(stdout, /admin-toolbox:widgets/);
+    assert.match(stdout, /Owner-scoped component and section placements/);
+    assert.match(
+      stdout,
+      /Example: npx jskit generate ui-generator placed-element --name "Security Section" --placement settings\.sections --owner account-settings/
+    );
+    assert.match(stdout, /settings\.sections \[owner:account-settings\]: Account settings sections\./);
   });
 });
 
@@ -378,9 +505,9 @@ test("list-placements includes installed package metadata topology", async () =>
               description: "Workspace tools menu.",
               surfaces: ["admin"],
               variants: {
-                compact: { outlet: "workspace-tools:primary-menu" },
-                medium: { outlet: "workspace-tools:primary-menu" },
-                expanded: { outlet: "workspace-tools:primary-menu" }
+                compact: { outlet: "workspace-tools:primary-menu", renderers: { link: "local.main.ui.surface-aware-menu-link-item" } },
+                medium: { outlet: "workspace-tools:primary-menu", renderers: { link: "local.main.ui.surface-aware-menu-link-item" } },
+                expanded: { outlet: "workspace-tools:primary-menu", renderers: { link: "local.main.ui.surface-aware-menu-link-item" } }
               }
             }
           ]
@@ -403,7 +530,7 @@ test("list-placements includes installed package metadata topology", async () =>
       stdout,
       /workspace\.tools-menu: Workspace tools menu\./
     );
-    assert.match(stdout, /compact -> workspace-tools:primary-menu/);
+    assert.doesNotMatch(stdout, /compact -> workspace-tools:primary-menu/);
   });
 });
 


### PR DESCRIPTION
## Summary
- make placement discovery semantic-first with topology-aware placement metadata
- move Vue Query ownership into the base client bootstrap and expose the app query client through client DI
- treat Vue app singleton libraries as host-provided peers across JSKIT web packages
- fix users-core scaffold action handling and refresh generated catalog/agent docs

## Verification
- Not run in this PR step per instruction: npm run verify
- Prior targeted checks were run before PR creation.