### PR TITLE
Centralize generated UI contract support

### DIFF
--- a/packages/agent-docs/patterns/generated-ui-contract-tracking.md
+++ b/packages/agent-docs/patterns/generated-ui-contract-tracking.md
@@ -8,38 +8,42 @@ Generated JSKIT apps should feel like real adaptive apps by default, not framewo
 
 ## Current Scope
 
-- [ ] Centralize navigation role behavior beyond per-generator helpers.
-- [ ] Improve product-aware navigation inference and CLI prompting.
-- [ ] Audit generated/package UI templates for placeholder or instructional live-page copy.
-- [ ] Formalize surface density rules for app, admin, console, and settings screens.
-- [ ] Add shared typography/density primitives or generator support helpers where they reduce duplication.
-- [ ] Enforce "no cards inside cards" for generated page architecture while preserving intentional tool/dialog cards.
+- [x] Centralize navigation role behavior beyond per-generator helpers.
+- [x] Improve product-aware navigation inference and CLI prompting.
+- [x] Audit generated/package UI templates for placeholder or instructional live-page copy.
+- [x] Formalize surface density rules for app, admin, console, and settings screens.
+- [x] Add shared typography/density primitives or generator support helpers where they reduce duplication.
+- [x] Enforce "no cards inside cards" for generated page architecture while preserving intentional tool/dialog cards.
 - [ ] Expand UI verification from shell smoke coverage to generator-pattern smoke coverage.
-- [ ] Centralize the JSKIT design contract and make tests consume it.
+- [x] Centralize the JSKIT design contract and make tests consume it.
 
 ## Work Slices
 
-- [ ] Slice 1: create the central contract/support seam and move navigation-role constants into it.
-- [ ] Slice 2: wire `ui-generator` and `crud-ui-generator` to the shared contract.
-- [ ] Slice 3: add template/content contract scans for placeholder copy, card-shell misuse, and missing responsive hooks.
-- [ ] Slice 4: audit package templates that ship live UI and classify intentional cards.
-- [ ] Slice 5: add generator-level Playwright smoke templates for page and CRUD patterns.
-- [ ] Slice 6: update distributed agent docs and regenerated references/catalog outputs.
+- [x] Slice 1: create the central contract/support seam and move navigation-role constants into it.
+- [x] Slice 2: wire `ui-generator` and `crud-ui-generator` to the shared contract.
+- [x] Slice 3: add template/content contract scans for placeholder copy, card-shell misuse, and missing responsive hooks.
+- [x] Slice 4: audit package templates that ship live UI and classify intentional cards.
+- [x] Slice 5a: extend generated app Playwright smoke coverage to assert the generated screen contract.
+- [ ] Slice 5b: add full generator-level Playwright fixtures for page and CRUD patterns.
+- [x] Slice 6: update distributed agent docs and regenerated references/catalog outputs.
 
 ## Verification Checklist
 
-- [ ] `npm run lint`
-- [ ] `npm run check:runtime-deps`
-- [ ] `npm run jskit -- lint-descriptors`
-- [ ] `npm run catalog:build`
-- [ ] `npm run agent-docs:build`
-- [ ] `npm test --workspace @jskit-ai/ui-generator`
-- [ ] `npm test --workspace @jskit-ai/crud-ui-generator`
-- [ ] `npm test --workspace @jskit-ai/shell-web`
-- [ ] `npm test --workspace @jskit-ai/jskit-cli`
-- [ ] `npm test --workspace @jskit-ai/create-app`
-- [ ] `npm test --workspace @jskit-ai/agent-docs`
-- [ ] `git diff --check`
+- [x] `npm run lint`
+- [x] `npm run check:runtime-deps`
+- [x] `npm run jskit -- lint-descriptors`
+- [x] `npm run catalog:build`
+- [x] `npm run agent-docs:build`
+- [x] `npm test --workspace @jskit-ai/kernel`
+- [x] `npm test --workspace @jskit-ai/ui-generator`
+- [x] `npm test --workspace @jskit-ai/crud-ui-generator`
+- [x] `npm test --workspace @jskit-ai/shell-web`
+- [x] `npm test --workspace @jskit-ai/users-web`
+- [x] `npm test --workspace @jskit-ai/workspaces-web`
+- [x] `npm test --workspace @jskit-ai/jskit-cli`
+- [x] `npm test --workspace @jskit-ai/create-app`
+- [x] `npm test --workspace @jskit-ai/agent-docs`
+- [x] `git diff --check`
 
 ## Notes
 
@@ -47,3 +51,4 @@ Generated JSKIT apps should feel like real adaptive apps by default, not framewo
 - Do not turn the contract into runtime business logic; it is generator and template policy.
 - Do not remove intentional cards from specialist UI components just to satisfy a broad scan.
 - Keep generated files deterministic and update catalog/agent-doc outputs when descriptors or exported symbols change.
+- Kernel shared UI contract must stay surface-id agnostic. Concrete mappings like admin/console to operator profile belong in generators or package templates.

--- a/packages/agent-docs/reference/autogen/KERNEL_MAP.md
+++ b/packages/agent-docs/reference/autogen/KERNEL_MAP.md
@@ -124,6 +124,35 @@ Exports
 Exports
 - `formatDateTime(value, { fallback = "unknown" } = {})`
 
+### `support/generatedUiContract.js`
+Exports
+- `GENERATED_UI_FORBIDDEN_CARD_SHELL_PATTERNS`
+- `GENERATED_UI_FORBIDDEN_LIVE_COPY_PATTERNS`
+- `GENERATED_UI_NAVIGATION_ROLE_DEFAULT`
+- `GENERATED_UI_NAVIGATION_ROLE_LINK_PLACEMENTS`
+- `GENERATED_UI_NAVIGATION_ROLE_OPTION`
+- `GENERATED_UI_NAVIGATION_ROLE_VALUES`
+- `GENERATED_UI_NO_LINK_NAVIGATION_ROLES`
+- `GENERATED_UI_SOURCE_CONTRACT_PROFILES`
+- `GENERATED_UI_SURFACE_PROFILES`
+- `assertGeneratedUiSourceContract(source = "", options = {})`
+- `buildGeneratedUiScreenClassName(baseClassName = "", { surfaceProfile = "" } = {})`
+- `collectGeneratedUiSourceContractIssues(source = "", { profile = "", forbidLiveCopy = undefined, forbidCardShell = undefined, forbiddenPatterns = [], requiredPatterns = [] } = {})`
+- `inferGeneratedUiNavigationRole(options = {}, { dynamicRoutePolicy = "leaf", routePath = "" } = {})`
+- `isGeneratedUiNoLinkNavigationRole(value = "")`
+- `normalizeGeneratedUiNavigationRole(value = "")`
+- `resolveGeneratedUiSurfaceProfile(surfaceProfile = "")`
+- `resolveGeneratedUiNavigationRoleLinkPlacement(options = {}, inferenceContext = {})`
+- `shouldCreateGeneratedUiNavigationLink(options = {}, { allowLinkTo = false, dynamicRoutePolicy = "leaf", routePath = "" } = {})`
+Local functions
+- `matchesGeneratedUiContractPattern(source = "", pattern)`
+- `normalizeGeneratedUiContractPattern(patternEntry = {}, fallbackMessage = "")`
+- `normalizeGeneratedUiContractPatternList(patternEntries = [], fallbackMessage = "")`
+- `resolveGeneratedUiSourceContractProfile(profile = "")`
+- `hasExplicitGeneratedUiNavigationRole(options = {})`
+- `normalizeGeneratedUiRouteSegments(routePath = "")`
+- `isGeneratedUiDynamicRouteSegment(routeSegment = "")`
+
 ### `support/index.js`
 Exports
 - `isRecord`

--- a/packages/agent-docs/reference/autogen/packages/crud-ui-generator.md
+++ b/packages/agent-docs/reference/autogen/packages/crud-ui-generator.md
@@ -32,9 +32,8 @@ Local functions
 - `parseOperationsOption(options)`
 - `parseDisplayFieldsOption(options)`
 - `parseParentTitleOption(options)`
-- `normalizeNavigationRole(value = "")`
-- `shouldCreateNavigationLink(options = {})`
-- `resolveNavigationRoleLinkPlacement(options = {})`
+- `shouldCreateNavigationLink(options = {}, inferenceContext = {})`
+- `resolveNavigationRoleLinkPlacement(options = {}, inferenceContext = {})`
 - `validateDisplayFieldsForOperation(selectedFieldKeys, fields, operationName)`
 - `filterDisplayFields(selectedFieldKeys, fields)`
 - `rewriteGeneratedBlockIndent(source = "", { trimPrefix = "", addPrefix = "" } = {})`
@@ -49,6 +48,7 @@ Local functions
 - `resolveResourceNamespace(resource = {}, pageTarget = {}, options = {})`
 - `resolveResourceLabels(namespace = "", pageTarget = {})`
 - `resolveTargetRootRelativeRoutePath(pageTarget = {})`
+- `resolveNavigationInferenceRoutePath(pageTarget = {})`
 - `resolveMenuToPropLine(linkTo = "")`
 - `resolveMenuOwnerLine(owner = "")`
 - `resolveCrudRelativePath(namespace = "")`

--- a/packages/agent-docs/reference/autogen/packages/kernel.md
+++ b/packages/agent-docs/reference/autogen/packages/kernel.md
@@ -288,6 +288,35 @@ Exports
 Exports
 - `formatDateTime(value, { fallback = "unknown" } = {})`
 
+### `shared/support/generatedUiContract.js`
+Exports
+- `GENERATED_UI_FORBIDDEN_CARD_SHELL_PATTERNS`
+- `GENERATED_UI_FORBIDDEN_LIVE_COPY_PATTERNS`
+- `GENERATED_UI_NAVIGATION_ROLE_DEFAULT`
+- `GENERATED_UI_NAVIGATION_ROLE_LINK_PLACEMENTS`
+- `GENERATED_UI_NAVIGATION_ROLE_OPTION`
+- `GENERATED_UI_NAVIGATION_ROLE_VALUES`
+- `GENERATED_UI_NO_LINK_NAVIGATION_ROLES`
+- `GENERATED_UI_SOURCE_CONTRACT_PROFILES`
+- `GENERATED_UI_SURFACE_PROFILES`
+- `assertGeneratedUiSourceContract(source = "", options = {})`
+- `buildGeneratedUiScreenClassName(baseClassName = "", { surfaceProfile = "" } = {})`
+- `collectGeneratedUiSourceContractIssues(source = "", { profile = "", forbidLiveCopy = undefined, forbidCardShell = undefined, forbiddenPatterns = [], requiredPatterns = [] } = {})`
+- `inferGeneratedUiNavigationRole(options = {}, { dynamicRoutePolicy = "leaf", routePath = "" } = {})`
+- `isGeneratedUiNoLinkNavigationRole(value = "")`
+- `normalizeGeneratedUiNavigationRole(value = "")`
+- `resolveGeneratedUiSurfaceProfile(surfaceProfile = "")`
+- `resolveGeneratedUiNavigationRoleLinkPlacement(options = {}, inferenceContext = {})`
+- `shouldCreateGeneratedUiNavigationLink(options = {}, { allowLinkTo = false, dynamicRoutePolicy = "leaf", routePath = "" } = {})`
+Local functions
+- `matchesGeneratedUiContractPattern(source = "", pattern)`
+- `normalizeGeneratedUiContractPattern(patternEntry = {}, fallbackMessage = "")`
+- `normalizeGeneratedUiContractPatternList(patternEntries = [], fallbackMessage = "")`
+- `resolveGeneratedUiSourceContractProfile(profile = "")`
+- `hasExplicitGeneratedUiNavigationRole(options = {})`
+- `normalizeGeneratedUiRouteSegments(routePath = "")`
+- `isGeneratedUiDynamicRouteSegment(routeSegment = "")`
+
 ### `shared/support/index.js`
 Exports
 - `isRecord`

--- a/packages/agent-docs/reference/autogen/packages/ui-generator.md
+++ b/packages/agent-docs/reference/autogen/packages/ui-generator.md
@@ -17,9 +17,10 @@ Use this on demand; do not load the full index at startup.
 ### `src/server/buildTemplateContext.js`
 Exports
 - `buildUiPageTemplateContext({ appRoot, targetFile = "", options = {} } = {})`
-- `normalizeNavigationRole(value = "")`
-- `resolveNavigationRoleLinkPlacement(options = {})`
-- `shouldCreateNavigationLink(options = {})`
+- `normalizeNavigationRole`
+- `resolveNavigationInferenceRoutePath(pageTarget = {})`
+- `resolveNavigationRoleLinkPlacement(options = {}, inferenceContext = {})`
+- `shouldCreateNavigationLink(options = {}, inferenceContext = {})`
 Local functions
 - `resolveLinkToPropLine(linkTo = "")`
 - `resolveOwnerLine(owner = "")`
@@ -81,11 +82,12 @@ Exports
 - `resolvePageTargetDetails`
 - `resolveNearestParentSubpagesHost`
 - `deriveDefaultSubpagesHost`
-- `renderPlainPageSource(pageTitle = "")`
+- `renderPlainPageSource(pageTitle = "", { surfaceId = "", routePath = "" } = {})`
 - `ensureSubpagesSupportScaffold({ appRoot, componentDirectory = DEFAULT_COMPONENT_DIRECTORY, dryRun = false } = {})`
 - `applySubpagesUpgradeToPageSource(source = "", { target = "", title = "", subtitle = "", sectionContainerComponentImportPath = "/src/components/SectionContainerShell.vue", preserveExistingContent = true } = {})`
 - `upgradePageFileToSubpages({ appRoot, targetFile, target = "", title = "", subtitle = "", componentDirectory = DEFAULT_COMPONENT_DIRECTORY, preserveExistingContent = true, dryRun = false } = {})`
 Local functions
+- `resolveGeneratedPageSurfaceProfile({ surfaceId = "", routePath = "" } = {})`
 - `trimEdgeBlankLines(source = "")`
 - `renderSectionContainerShellSource()`
 - `findTemplateBlock(source = "")`

--- a/packages/crud-ui-generator/package.descriptor.mjs
+++ b/packages/crud-ui-generator/package.descriptor.mjs
@@ -1,3 +1,5 @@
+import { GENERATED_UI_NAVIGATION_ROLE_OPTION } from "@jskit-ai/kernel/shared/support/generatedUiContract";
+
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-ui-generator",
@@ -66,15 +68,7 @@ export default Object.freeze({
       promptLabel: "Link placement",
       promptHint: "Optional semantic target override for the generated list-page link placement (format: area.slot)."
     },
-    "navigation-role": {
-      required: false,
-      inputType: "text",
-      validationType: "enum",
-      allowedValues: ["primary", "secondary", "utility", "detail", "workflow", "none"],
-      defaultValue: "primary",
-      promptLabel: "Navigation role",
-      promptHint: "Product navigation role for the generated CRUD list link. primary uses normal inference, secondary maps to shell.secondary-nav, utility maps to shell.global-actions, and detail/workflow/none create no nav link."
-    },
+    "navigation-role": GENERATED_UI_NAVIGATION_ROLE_OPTION,
     namespace: {
       required: false,
       inputType: "text",

--- a/packages/crud-ui-generator/src/server/buildTemplateContext.js
+++ b/packages/crud-ui-generator/src/server/buildTemplateContext.js
@@ -8,6 +8,10 @@ import {
 } from "@jskit-ai/kernel/server/support";
 import { normalizeText } from "@jskit-ai/kernel/shared/support/normalize";
 import {
+  resolveGeneratedUiNavigationRoleLinkPlacement,
+  shouldCreateGeneratedUiNavigationLink
+} from "@jskit-ai/kernel/shared/support/generatedUiContract";
+import {
   loadResourceDefinition,
   requireOperation,
   resolveOperationRealtimeEvents,
@@ -70,12 +74,6 @@ const DEFAULT_LIST_HIDDEN_FIELD_KEYS = new Set(["createdAt", "updatedAt"]);
 const DEFAULT_FORM_COMPONENT_FILE = "CrudAddEditForm.vue";
 const DEFAULT_FORM_FIELDS_FILE = "CrudAddEditFormFields.js";
 const DEFAULT_GENERATED_LINK_ICON = "mdi-view-list-outline";
-const NAVIGATION_ROLE_VALUES = Object.freeze(["primary", "secondary", "utility", "detail", "workflow", "none"]);
-const NAVIGATION_ROLE_LINK_PLACEMENTS = Object.freeze({
-  secondary: "shell.secondary-nav",
-  utility: "shell.global-actions"
-});
-const NO_LINK_NAVIGATION_ROLES = new Set(["detail", "workflow", "none"]);
 
 function splitTextIntoWords(value = "") {
   const normalized = String(value || "")
@@ -261,36 +259,18 @@ function parseParentTitleOption(options) {
   return parentTitleMode;
 }
 
-function normalizeNavigationRole(value = "") {
-  const normalizedRole = normalizeText(value).toLowerCase();
-  if (!normalizedRole) {
-    return "primary";
-  }
-  if (!NAVIGATION_ROLE_VALUES.includes(normalizedRole)) {
-    throw new Error(`navigation-role must be one of: ${NAVIGATION_ROLE_VALUES.join(", ")}.`);
-  }
-  return normalizedRole;
+function shouldCreateNavigationLink(options = {}, inferenceContext = {}) {
+  return shouldCreateGeneratedUiNavigationLink(options, {
+    dynamicRoutePolicy: "any",
+    routePath: inferenceContext?.routePath
+  });
 }
 
-function shouldCreateNavigationLink(options = {}) {
-  const role = normalizeNavigationRole(options?.["navigation-role"]);
-  const linkPlacement = normalizeText(options?.["link-placement"]);
-  if (NO_LINK_NAVIGATION_ROLES.has(role)) {
-    if (linkPlacement) {
-      throw new Error(`navigation-role "${role}" cannot be combined with --link-placement.`);
-    }
-    return false;
-  }
-  return true;
-}
-
-function resolveNavigationRoleLinkPlacement(options = {}) {
-  const explicitPlacement = normalizeText(options?.["link-placement"]);
-  if (explicitPlacement) {
-    return explicitPlacement;
-  }
-  const role = normalizeNavigationRole(options?.["navigation-role"]);
-  return NAVIGATION_ROLE_LINK_PLACEMENTS[role] || "";
+function resolveNavigationRoleLinkPlacement(options = {}, inferenceContext = {}) {
+  return resolveGeneratedUiNavigationRoleLinkPlacement(options, {
+    dynamicRoutePolicy: "any",
+    routePath: inferenceContext?.routePath
+  });
 }
 
 function validateDisplayFieldsForOperation(selectedFieldKeys, fields, operationName) {
@@ -519,6 +499,16 @@ function resolveTargetRootRelativeRoutePath(pageTarget = {}) {
   return visibleRouteSegments.length > 0 ? `/${visibleRouteSegments.join("/")}` : "/";
 }
 
+function resolveNavigationInferenceRoutePath(pageTarget = {}) {
+  const visibleRouteSegments = Array.isArray(pageTarget?.visibleRouteSegments)
+    ? pageTarget.visibleRouteSegments.map((entry) => normalizeText(entry)).filter(Boolean)
+    : [];
+  if (visibleRouteSegments.length > 0) {
+    return `/${visibleRouteSegments.join("/")}`;
+  }
+  return String(pageTarget?.routeUrlSuffix || "");
+}
+
 function resolveMenuToPropLine(linkTo = "") {
   if (!linkTo) {
     return "";
@@ -706,12 +696,16 @@ async function buildUiTemplateContext({ appRoot, options } = {}) {
     ? resolveViewTitleFallbackFieldKey(listFieldsAll, { recordIdFieldKey: listRecordIdFieldKey })
     : "";
 
-  const pageLinkTarget = hasListOperation && shouldCreateNavigationLink(options)
+  const pageLinkTarget = hasListOperation && shouldCreateNavigationLink(options, {
+    routePath: resolveNavigationInferenceRoutePath(pageTarget)
+  })
     ? await resolvePageLinkTargetDetails({
       appRoot,
       pageTarget,
       targetFile: listTargetFile,
-      placement: resolveNavigationRoleLinkPlacement(options),
+      placement: resolveNavigationRoleLinkPlacement(options, {
+        routePath: resolveNavigationInferenceRoutePath(pageTarget)
+      }),
       context: "crud-ui-generator"
     })
     : null;

--- a/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/AddEditForm.vue
+++ b/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/AddEditForm.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="ui-generator-add-edit-form d-flex flex-column ga-4">
+  <section class="generated-ui-screen generated-ui-screen--operator ui-generator-add-edit-form d-flex flex-column ga-4">
     <header class="ui-generator-add-edit-form__header">
       <div class="ui-generator-add-edit-form__copy">
         <h1 class="ui-generator-add-edit-form__title">{{ title }}</h1>
@@ -99,6 +99,15 @@ function resolveCancelTo(target) {
 </script>
 
 <style scoped>
+.generated-ui-screen {
+  --generated-ui-screen-title-size: clamp(1.35rem, 2vw, 1.85rem);
+  --generated-ui-screen-state-padding: 2.5rem 1.25rem;
+}
+
+.generated-ui-screen--operator {
+  --generated-ui-screen-state-padding: 2rem 1rem;
+}
+
 .ui-generator-add-edit-form__header {
   align-items: flex-start;
   display: flex;
@@ -111,7 +120,7 @@ function resolveCancelTo(target) {
 }
 
 .ui-generator-add-edit-form__title {
-  font-size: clamp(1.35rem, 2vw, 1.85rem);
+  font-size: var(--generated-ui-screen-title-size);
   font-weight: 650;
   letter-spacing: -0.02em;
   line-height: 1.15;
@@ -132,7 +141,7 @@ function resolveCancelTo(target) {
 .ui-generator-add-edit-form__state {
   margin-inline: auto;
   max-width: 30rem;
-  padding: 3rem 1.25rem;
+  padding: var(--generated-ui-screen-state-padding);
   text-align: center;
 }
 

--- a/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/EditElement.vue
+++ b/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/EditElement.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="ui-generator-edit-element d-flex flex-column ga-4">
+  <section class="generated-ui-screen generated-ui-screen--operator ui-generator-edit-element d-flex flex-column ga-4">
     <header class="ui-generator-form-header">
       <div class="ui-generator-form-header__copy">
         <p class="text-overline text-medium-emphasis mb-1">Edit record</p>
@@ -129,6 +129,15 @@ function resolveFieldErrors(fieldKey) {
 </script>
 
 <style scoped>
+.generated-ui-screen {
+  --generated-ui-screen-title-size: clamp(1.35rem, 2vw, 1.85rem);
+  --generated-ui-screen-state-padding: 2.5rem 1.25rem;
+}
+
+.generated-ui-screen--operator {
+  --generated-ui-screen-state-padding: 2rem 1rem;
+}
+
 .ui-generator-form-header {
   align-items: flex-start;
   display: flex;
@@ -141,7 +150,7 @@ function resolveFieldErrors(fieldKey) {
 }
 
 .ui-generator-form-header__title {
-  font-size: clamp(1.35rem, 2vw, 1.85rem);
+  font-size: var(--generated-ui-screen-title-size);
   font-weight: 650;
   letter-spacing: -0.02em;
   line-height: 1.15;
@@ -162,7 +171,7 @@ function resolveFieldErrors(fieldKey) {
 .ui-generator-form-state {
   margin-inline: auto;
   max-width: 30rem;
-  padding: 3rem 1.25rem;
+  padding: var(--generated-ui-screen-state-padding);
   text-align: center;
 }
 

--- a/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/ListElement.vue
+++ b/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/ListElement.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="ui-generator-list-element d-flex flex-column ga-4">
+  <section class="generated-ui-screen generated-ui-screen--operator ui-generator-list-element d-flex flex-column ga-4">
     <header class="ui-generator-list-header">
       <div class="ui-generator-list-header__copy">
         <p class="text-overline text-medium-emphasis mb-1">__JSKIT_UI_RESOURCE_PLURAL_TITLE__</p>
@@ -242,6 +242,15 @@ function formatListCardValue(value) {
 </script>
 
 <style scoped>
+.generated-ui-screen {
+  --generated-ui-screen-title-size: clamp(1.35rem, 2vw, 1.85rem);
+  --generated-ui-screen-state-padding: 2.5rem 1.25rem;
+}
+
+.generated-ui-screen--operator {
+  --generated-ui-screen-state-padding: 2rem 1rem;
+}
+
 .ui-generator-list-header {
   align-items: flex-start;
   display: flex;
@@ -254,7 +263,7 @@ function formatListCardValue(value) {
 }
 
 .ui-generator-list-header__title {
-  font-size: clamp(1.35rem, 2vw, 1.85rem);
+  font-size: var(--generated-ui-screen-title-size);
   font-weight: 650;
   letter-spacing: -0.02em;
   line-height: 1.15;
@@ -283,7 +292,7 @@ function formatListCardValue(value) {
 .ui-generator-list-state {
   margin-inline: auto;
   max-width: 30rem;
-  padding: 3rem 1.25rem;
+  padding: var(--generated-ui-screen-state-padding);
   text-align: center;
 }
 

--- a/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/NewElement.vue
+++ b/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/NewElement.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="ui-generator-new-element d-flex flex-column ga-4">
+  <section class="generated-ui-screen generated-ui-screen--operator ui-generator-new-element d-flex flex-column ga-4">
     <header class="ui-generator-form-header">
       <div class="ui-generator-form-header__copy">
         <p class="text-overline text-medium-emphasis mb-1">New record</p>
@@ -101,6 +101,15 @@ function resolveFieldErrors(fieldKey) {
 </script>
 
 <style scoped>
+.generated-ui-screen {
+  --generated-ui-screen-title-size: clamp(1.35rem, 2vw, 1.85rem);
+  --generated-ui-screen-state-padding: 2.5rem 1.25rem;
+}
+
+.generated-ui-screen--operator {
+  --generated-ui-screen-state-padding: 2rem 1rem;
+}
+
 .ui-generator-form-header {
   align-items: flex-start;
   display: flex;
@@ -113,7 +122,7 @@ function resolveFieldErrors(fieldKey) {
 }
 
 .ui-generator-form-header__title {
-  font-size: clamp(1.35rem, 2vw, 1.85rem);
+  font-size: var(--generated-ui-screen-title-size);
   font-weight: 650;
   letter-spacing: -0.02em;
   line-height: 1.15;
@@ -134,7 +143,7 @@ function resolveFieldErrors(fieldKey) {
 .ui-generator-form-state {
   margin-inline: auto;
   max-width: 30rem;
-  padding: 3rem 1.25rem;
+  padding: var(--generated-ui-screen-state-padding);
   text-align: center;
 }
 

--- a/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/ViewElement.vue
+++ b/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/ViewElement.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="ui-generator-view-element d-flex flex-column ga-4">
+  <section class="generated-ui-screen generated-ui-screen--operator ui-generator-view-element d-flex flex-column ga-4">
     <header class="ui-generator-view-header">
       <div class="ui-generator-view-header__copy">
         <p class="text-overline text-medium-emphasis mb-1">__JSKIT_UI_RESOURCE_SINGULAR_TITLE__</p>
@@ -101,6 +101,15 @@ const view = useCrudView({
 </script>
 
 <style scoped>
+.generated-ui-screen {
+  --generated-ui-screen-title-size: clamp(1.35rem, 2vw, 1.85rem);
+  --generated-ui-screen-state-padding: 2.5rem 1.25rem;
+}
+
+.generated-ui-screen--operator {
+  --generated-ui-screen-state-padding: 2rem 1rem;
+}
+
 .ui-generator-view-header {
   align-items: flex-start;
   display: flex;
@@ -113,7 +122,7 @@ const view = useCrudView({
 }
 
 .ui-generator-view-header__title {
-  font-size: clamp(1.35rem, 2vw, 1.85rem);
+  font-size: var(--generated-ui-screen-title-size);
   font-weight: 650;
   letter-spacing: -0.02em;
   line-height: 1.15;
@@ -135,7 +144,7 @@ const view = useCrudView({
 .ui-generator-view-state {
   margin-inline: auto;
   max-width: 30rem;
-  padding: 3rem 1.25rem;
+  padding: var(--generated-ui-screen-state-padding);
   text-align: center;
 }
 

--- a/packages/crud-ui-generator/test/buildTemplateContext.test.js
+++ b/packages/crud-ui-generator/test/buildTemplateContext.test.js
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
+import { assertGeneratedUiSourceContract } from "@jskit-ai/kernel/shared/support/generatedUiContract";
 import { buildUiTemplateContext } from "../src/server/buildTemplateContext.js";
 
 const JSON_REST_SCHEMA_PACKAGE_DIR = path.dirname(
@@ -818,6 +819,23 @@ test("buildUiTemplateContext supports no-link navigation roles for detail or wor
   });
 });
 
+test("buildUiTemplateContext infers no-link navigation for dynamic nested list routes", async () => {
+  await withTempApp(async (appRoot) => {
+    await writeResource(appRoot, RESOURCE_FILE, FULL_RESOURCE_SOURCE);
+
+    const context = await buildUiTemplateContext({
+      appRoot,
+      options: createOptions({
+        "target-root": "admin/customers/[customerId]/orders"
+      })
+    });
+
+    assert.equal(context.__JSKIT_UI_MENU_PLACEMENT_ID__, "");
+    assert.equal(context.__JSKIT_UI_MENU_PLACEMENT_TARGET__, "");
+    assert.equal(context.__JSKIT_UI_MENU_MARKER__, "jskit:crud-ui-generator.page.link:admin:/customers/[customerId]/orders");
+  });
+});
+
 test("buildUiTemplateContext rejects no-link navigation roles with explicit link-placement", async () => {
   await withTempApp(async (appRoot) => {
     await writeResource(appRoot, RESOURCE_FILE, FULL_RESOURCE_SOURCE);
@@ -893,10 +911,28 @@ test("crud ui templates derive JSON:API transport from the shared CRUD resource"
   const viewTemplateSource = await readFile(path.join(templateRoot, "ViewElement.vue"), "utf8");
   const newTemplateSource = await readFile(path.join(templateRoot, "NewElement.vue"), "utf8");
   const editTemplateSource = await readFile(path.join(templateRoot, "EditElement.vue"), "utf8");
+  const addEditFormTemplateSource = await readFile(path.join(templateRoot, "AddEditForm.vue"), "utf8");
   const newWrapperTemplateSource = await readFile(path.join(templateRoot, "NewWrapperElement.vue"), "utf8");
   const editWrapperTemplateSource = await readFile(path.join(templateRoot, "EditWrapperElement.vue"), "utf8");
 
+  assertGeneratedUiSourceContract(listTemplateSource, {
+    profile: "crud-list",
+    sourceName: "ListElement.vue"
+  });
+  for (const [sourceName, source] of [
+    ["ViewElement.vue", viewTemplateSource],
+    ["NewElement.vue", newTemplateSource],
+    ["EditElement.vue", editTemplateSource]
+  ]) {
+    assertGeneratedUiSourceContract(source, {
+      profile: "crud-detail",
+      sourceName
+    });
+  }
+
   assert.match(listTemplateSource, /resource: uiResource,/);
+  assert.match(listTemplateSource, /generated-ui-screen generated-ui-screen--operator ui-generator-list-element/);
+  assert.match(listTemplateSource, /--generated-ui-screen-title-size/);
   assert.match(listTemplateSource, /ui-generator-list-cards d-md-none/);
   assert.match(listTemplateSource, /ui-generator-list-table d-none d-md-block/);
   assert.match(listTemplateSource, /class="ui-generator-list-fab d-md-none"/);
@@ -915,6 +951,7 @@ test("crud ui templates derive JSON:API transport from the shared CRUD resource"
 
   assert.match(viewTemplateSource, /import \{ resource as uiResource \} from/);
   assert.match(viewTemplateSource, /resource: uiResource,/);
+  assert.match(viewTemplateSource, /generated-ui-screen generated-ui-screen--operator ui-generator-view-element/);
   assert.match(viewTemplateSource, /ui-generator-view-header/);
   assert.match(viewTemplateSource, /ui-generator-view-panel/);
   assert.match(viewTemplateSource, /Record unavailable/);
@@ -923,6 +960,7 @@ test("crud ui templates derive JSON:API transport from the shared CRUD resource"
   assert.doesNotMatch(viewTemplateSource, /transport:\s*UI_VIEW_TRANSPORT,/);
 
   assert.match(newTemplateSource, /resource: uiResource,/);
+  assert.match(newTemplateSource, /generated-ui-screen generated-ui-screen--operator ui-generator-new-element/);
   assert.match(newTemplateSource, /ui-generator-form-header/);
   assert.match(newTemplateSource, /ui-generator-form-panel/);
   assert.match(newTemplateSource, /Unable to prepare __JSKIT_UI_RESOURCE_SINGULAR_TITLE__/);
@@ -931,12 +969,16 @@ test("crud ui templates derive JSON:API transport from the shared CRUD resource"
   assert.doesNotMatch(newTemplateSource, /transport:\s*UI_CREATE_TRANSPORT,/);
 
   assert.match(editTemplateSource, /resource: uiResource,/);
+  assert.match(editTemplateSource, /generated-ui-screen generated-ui-screen--operator ui-generator-edit-element/);
   assert.match(editTemplateSource, /ui-generator-form-header/);
   assert.match(editTemplateSource, /ui-generator-form-panel/);
   assert.match(editTemplateSource, /Unable to load __JSKIT_UI_RESOURCE_SINGULAR_TITLE__/);
   assert.doesNotMatch(editTemplateSource, /<v-card\b|<v-card-title/);
   assert.doesNotMatch(editTemplateSource, /const UI_EDIT_TRANSPORT = Object\.freeze\(\{/);
   assert.doesNotMatch(editTemplateSource, /transport:\s*UI_EDIT_TRANSPORT,/);
+
+  assert.match(addEditFormTemplateSource, /generated-ui-screen generated-ui-screen--operator ui-generator-add-edit-form/);
+  assert.match(addEditFormTemplateSource, /--generated-ui-screen-title-size/);
 
   assert.match(newWrapperTemplateSource, /resource: uiResource,/);
   assert.doesNotMatch(newWrapperTemplateSource, /<v-card\b/);

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -42,6 +42,7 @@
     "./shared/support/crudListFilters": "./shared/support/crudListFilters.js",
     "./shared/support/crudFieldContract": "./shared/support/crudFieldContract.js",
     "./shared/support/crudLookup": "./shared/support/crudLookup.js",
+    "./shared/support/generatedUiContract": "./shared/support/generatedUiContract.js",
     "./shared/support/deepFreeze": "./shared/support/deepFreeze.js",
     "./shared/support/listenerSet": "./shared/support/listenerSet.js",
     "./shared/support/shellLayoutTargets": "./shared/support/shellLayoutTargets.js",

--- a/packages/kernel/shared/support/generatedUiContract.js
+++ b/packages/kernel/shared/support/generatedUiContract.js
@@ -1,0 +1,517 @@
+import { normalizeText } from "./normalize.js";
+
+const GENERATED_UI_NAVIGATION_ROLE_VALUES = Object.freeze([
+  "primary",
+  "secondary",
+  "utility",
+  "detail",
+  "workflow",
+  "none"
+]);
+const GENERATED_UI_NAVIGATION_ROLE_DEFAULT = "primary";
+const GENERATED_UI_NAVIGATION_ROLE_LINK_PLACEMENTS = Object.freeze({
+  secondary: "shell.secondary-nav",
+  utility: "shell.global-actions"
+});
+const GENERATED_UI_NO_LINK_NAVIGATION_ROLES = Object.freeze(["detail", "workflow", "none"]);
+const GENERATED_UI_NO_LINK_NAVIGATION_ROLE_SET = new Set(GENERATED_UI_NO_LINK_NAVIGATION_ROLES);
+const GENERATED_UI_SURFACE_PROFILES = Object.freeze({
+  task: Object.freeze({
+    id: "task",
+    className: "generated-ui-screen--app",
+    density: "comfortable",
+    titleLabel: "Screen",
+    emptyStateBody: "Activity and actions for this screen will appear here."
+  }),
+  operator: Object.freeze({
+    id: "operator",
+    className: "generated-ui-screen--operator",
+    density: "compact",
+    titleLabel: "Workspace tool",
+    emptyStateBody: "Operational activity and actions for this screen will appear here."
+  }),
+  settings: Object.freeze({
+    id: "settings",
+    className: "generated-ui-screen--settings",
+    density: "comfortable",
+    titleLabel: "Settings",
+    emptyStateBody: "Saved settings, controls, and activity for this section will appear here."
+  })
+});
+const GENERATED_UI_NAVIGATION_ROLE_OPTION = Object.freeze({
+  required: false,
+  inputType: "text",
+  validationType: "enum",
+  allowedValues: GENERATED_UI_NAVIGATION_ROLE_VALUES,
+  defaultValue: GENERATED_UI_NAVIGATION_ROLE_DEFAULT,
+  promptLabel: "Navigation role",
+  promptHint: "Product navigation role for generated links. When omitted, dynamic detail and workflow routes create no nav link; primary uses normal inference, secondary maps to shell.secondary-nav, utility maps to shell.global-actions, and detail/workflow/none force no nav link."
+});
+const GENERATED_UI_FORBIDDEN_LIVE_COPY_PATTERNS = Object.freeze([
+  Object.freeze({
+    id: "replace-this-copy",
+    pattern: /replace\s+this/i,
+    message: "Generated live UI must not tell users to replace scaffold content."
+  }),
+  Object.freeze({
+    id: "use-this-area-copy",
+    pattern: /use\s+this\s+area/i,
+    message: "Generated live UI must be a usable screen, not an implementation instruction."
+  }),
+  Object.freeze({
+    id: "this-is-your-page-copy",
+    pattern: /this\s+is\s+your\s+page/i,
+    message: "Generated live UI must not describe itself as a scaffold page."
+  }),
+  Object.freeze({
+    id: "ready-for-implementation-copy",
+    pattern: /ready\s+for\s+your\s+implementation/i,
+    message: "Generated live UI must not ask the app author to implement the screen."
+  }),
+  Object.freeze({
+    id: "main-public-surface-copy",
+    pattern: /main\s+public\s+surface/i,
+    message: "Generated live UI must not expose framework/surface scaffolding language."
+  }),
+  Object.freeze({
+    id: "generate-route-copy",
+    pattern: /generate\s+(?:a|your\s+first)\s+(?:page|route)/i,
+    message: "Starter UI should present a product-shaped empty state, not CLI instructions."
+  }),
+  Object.freeze({
+    id: "install-package-copy",
+    pattern: /install\s+(?:a\s+)?package/i,
+    message: "Starter UI should avoid package-installation instructions in live screens."
+  }),
+  Object.freeze({
+    id: "add-product-packages-copy",
+    pattern: /add\s+product\s+packages/i,
+    message: "Starter UI should avoid package-installation instructions in live screens."
+  })
+]);
+const GENERATED_UI_FORBIDDEN_CARD_SHELL_PATTERNS = Object.freeze([
+  Object.freeze({
+    id: "vuetify-card-shell",
+    pattern: /<v-card\b/i,
+    message: "Generated page architecture should not use a generic v-card shell."
+  }),
+  Object.freeze({
+    id: "vuetify-card-title-shell",
+    pattern: /<v-card-title\b/i,
+    message: "Generated pages should not repeat page titles inside card title chrome."
+  })
+]);
+const GENERATED_UI_SOURCE_CONTRACT_PROFILES = Object.freeze({
+  page: Object.freeze({
+    forbidCardShell: true,
+    requiredPatterns: Object.freeze([
+      Object.freeze({
+        id: "shared-screen-class",
+        pattern: /generated-ui-screen\s+generated-ui-screen--/,
+        message: "Generated pages must opt into the shared screen density contract."
+      }),
+      Object.freeze({
+        id: "page-screen-title",
+        pattern: /generated-page-screen__title/,
+        message: "Generated pages need an explicit responsive page title class."
+      }),
+      Object.freeze({
+        id: "page-empty-state-sheet",
+        pattern: /<v-sheet\b[\s\S]*generated-page-screen__empty-state/,
+        message: "Generated pages need a direct sheet-based empty/work region."
+      }),
+      Object.freeze({
+        id: "page-responsive-title-type",
+        pattern: /--generated-ui-screen-title-size/,
+        message: "Generated pages need shared responsive title typography."
+      })
+    ])
+  }),
+  "placed-element": Object.freeze({
+    requiredPatterns: Object.freeze([
+      Object.freeze({
+        id: "placed-element-min-target",
+        pattern: /min-height:\s*48px/,
+        message: "Placed generated elements need a 48px minimum interactive target."
+      })
+    ])
+  }),
+  "crud-list": Object.freeze({
+    forbidCardShell: true,
+    forbiddenPatterns: Object.freeze([
+      Object.freeze({
+        id: "desktop-only-data-table",
+        pattern: /<v-data-table\b/i,
+        message: "Generated CRUD lists must not rely on a desktop-only data table."
+      })
+    ]),
+    requiredPatterns: Object.freeze([
+      Object.freeze({
+        id: "operator-surface-profile",
+        pattern: /generated-ui-screen--operator/,
+        message: "Generated CRUD lists must use the operator surface density profile."
+      }),
+      Object.freeze({
+        id: "shared-title-density",
+        pattern: /--generated-ui-screen-title-size/,
+        message: "Generated CRUD lists must use shared title density variables."
+      }),
+      Object.freeze({
+        id: "compact-list-cards",
+        pattern: /d-md-none/,
+        message: "Generated CRUD lists need compact card/list presentation."
+      }),
+      Object.freeze({
+        id: "expanded-list-table",
+        pattern: /d-none\s+d-md-block/,
+        message: "Generated CRUD lists need a separate medium/expanded table presentation."
+      }),
+      Object.freeze({
+        id: "compact-row-actions",
+        pattern: /<v-menu\b[\s\S]*Actions/,
+        message: "Generated CRUD row actions should collapse into an overflow menu on compact layouts."
+      }),
+      Object.freeze({
+        id: "crud-list-empty-state",
+        pattern: /__JSKIT_UI_LIST_EMPTY_TITLE__/,
+        message: "Generated CRUD lists need resource-shaped empty state copy."
+      }),
+      Object.freeze({
+        id: "crud-list-error-state",
+        pattern: /__JSKIT_UI_LIST_LOAD_ERROR_TITLE__/,
+        message: "Generated CRUD lists need resource-shaped load error copy."
+      }),
+      Object.freeze({
+        id: "crud-list-tap-targets",
+        pattern: /min-height:\s*48px/,
+        message: "Generated CRUD lists need 48px tap targets."
+      })
+    ])
+  }),
+  "crud-detail": Object.freeze({
+    forbidCardShell: true,
+    requiredPatterns: Object.freeze([
+      Object.freeze({
+        id: "operator-surface-profile",
+        pattern: /generated-ui-screen--operator/,
+        message: "Generated CRUD detail screens must use the operator surface density profile."
+      }),
+      Object.freeze({
+        id: "shared-title-density",
+        pattern: /--generated-ui-screen-title-size/,
+        message: "Generated CRUD detail screens must use shared title density variables."
+      }),
+      Object.freeze({
+        id: "crud-detail-panel",
+        pattern: /ui-generator-(?:view|form)-panel/,
+        message: "Generated CRUD detail screens need a direct sheet panel."
+      }),
+      Object.freeze({
+        id: "crud-detail-header",
+        pattern: /ui-generator-(?:view|form)-header/,
+        message: "Generated CRUD detail screens need a direct page header."
+      })
+    ])
+  }),
+  "responsive-smoke": Object.freeze({
+    forbidLiveCopy: false,
+    requiredPatterns: Object.freeze([
+      Object.freeze({
+        id: "compact-viewport",
+        pattern: /\b390\b/,
+        message: "Generated UI smoke tests must include compact phone width."
+      }),
+      Object.freeze({
+        id: "medium-viewport",
+        pattern: /\b768\b/,
+        message: "Generated UI smoke tests must include tablet-ish medium width."
+      }),
+      Object.freeze({
+        id: "expanded-viewport",
+        pattern: /\b1280\b/,
+        message: "Generated UI smoke tests must include expanded desktop width."
+      }),
+      Object.freeze({
+        id: "overflow-check",
+        pattern: /scrollWidth/,
+        message: "Generated UI smoke tests must check horizontal overflow."
+      })
+    ])
+  }),
+  "starter-home": Object.freeze({
+    requiredPatterns: Object.freeze([
+      Object.freeze({
+        id: "app-surface-profile",
+        pattern: /generated-ui-screen--app/,
+        message: "Base generated apps must use the app surface density profile."
+      }),
+      Object.freeze({
+        id: "starter-home-screen",
+        pattern: /home-start-screen/,
+        message: "Base generated apps need a stable starter home screen."
+      }),
+      Object.freeze({
+        id: "starter-home-panel",
+        pattern: /<v-sheet\b[\s\S]*home-start-screen__panel/,
+        message: "Base generated apps need a real sheet-based starter panel."
+      }),
+      Object.freeze({
+        id: "starter-home-responsive-title",
+        pattern: /--generated-ui-screen-title-size/,
+        message: "Base generated apps need shared responsive starter typography."
+      })
+    ])
+  }),
+  "shell-home": Object.freeze({
+    requiredPatterns: Object.freeze([
+      Object.freeze({
+        id: "app-surface-profile",
+        pattern: /generated-ui-screen--app/,
+        message: "Shell starter home must use the app surface density profile."
+      }),
+      Object.freeze({
+        id: "shell-home-health",
+        pattern: /Service health/,
+        message: "Shell starter home should expose real runtime health state."
+      }),
+      Object.freeze({
+        id: "shell-home-responsive-action",
+        pattern: /min-height:\s*48px/,
+        message: "Shell starter home actions need compact tap targets."
+      })
+    ])
+  })
+});
+const GENERATED_UI_WORKFLOW_ROUTE_SEGMENTS = new Set(["create", "edit", "new", "setup"]);
+
+function matchesGeneratedUiContractPattern(source = "", pattern) {
+  const sourceText = String(source || "");
+  if (pattern instanceof RegExp) {
+    pattern.lastIndex = 0;
+    return pattern.test(sourceText);
+  }
+  const literalPattern = String(pattern || "");
+  return literalPattern ? sourceText.includes(literalPattern) : false;
+}
+
+function normalizeGeneratedUiContractPattern(patternEntry = {}, fallbackMessage = "") {
+  if (patternEntry instanceof RegExp || typeof patternEntry === "string") {
+    return Object.freeze({
+      id: String(patternEntry),
+      pattern: patternEntry,
+      message: fallbackMessage
+    });
+  }
+  return Object.freeze({
+    id: normalizeText(patternEntry?.id) || String(patternEntry?.pattern || ""),
+    pattern: patternEntry?.pattern || "",
+    message: normalizeText(patternEntry?.message) || fallbackMessage
+  });
+}
+
+function normalizeGeneratedUiContractPatternList(patternEntries = [], fallbackMessage = "") {
+  return (Array.isArray(patternEntries) ? patternEntries : [])
+    .map((entry) => normalizeGeneratedUiContractPattern(entry, fallbackMessage))
+    .filter((entry) => entry.id && entry.pattern);
+}
+
+function resolveGeneratedUiSourceContractProfile(profile = "") {
+  const normalizedProfile = normalizeText(profile).toLowerCase();
+  return GENERATED_UI_SOURCE_CONTRACT_PROFILES[normalizedProfile] || Object.freeze({});
+}
+
+function collectGeneratedUiSourceContractIssues(source = "", {
+  profile = "",
+  forbidLiveCopy = undefined,
+  forbidCardShell = undefined,
+  forbiddenPatterns = [],
+  requiredPatterns = []
+} = {}) {
+  const profileContract = resolveGeneratedUiSourceContractProfile(profile);
+  const shouldForbidLiveCopy = forbidLiveCopy ?? profileContract.forbidLiveCopy ?? true;
+  const shouldForbidCardShell = forbidCardShell ?? profileContract.forbidCardShell ?? false;
+  const resolvedForbiddenPatterns = [
+    ...(shouldForbidLiveCopy ? GENERATED_UI_FORBIDDEN_LIVE_COPY_PATTERNS : []),
+    ...(shouldForbidCardShell ? GENERATED_UI_FORBIDDEN_CARD_SHELL_PATTERNS : []),
+    ...normalizeGeneratedUiContractPatternList(profileContract.forbiddenPatterns, "Generated UI contains forbidden source."),
+    ...normalizeGeneratedUiContractPatternList(forbiddenPatterns, "Generated UI contains forbidden source.")
+  ];
+  const resolvedRequiredPatterns = [
+    ...normalizeGeneratedUiContractPatternList(profileContract.requiredPatterns, "Generated UI is missing required source."),
+    ...normalizeGeneratedUiContractPatternList(requiredPatterns, "Generated UI is missing required source.")
+  ];
+  const issues = [];
+
+  for (const patternEntry of resolvedForbiddenPatterns) {
+    if (!matchesGeneratedUiContractPattern(source, patternEntry.pattern)) {
+      continue;
+    }
+    issues.push(Object.freeze({
+      kind: "forbidden",
+      id: patternEntry.id,
+      message: patternEntry.message
+    }));
+  }
+
+  for (const patternEntry of resolvedRequiredPatterns) {
+    if (matchesGeneratedUiContractPattern(source, patternEntry.pattern)) {
+      continue;
+    }
+    issues.push(Object.freeze({
+      kind: "missing",
+      id: patternEntry.id,
+      message: patternEntry.message
+    }));
+  }
+
+  return Object.freeze(issues);
+}
+
+function assertGeneratedUiSourceContract(source = "", options = {}) {
+  const issues = collectGeneratedUiSourceContractIssues(source, options);
+  if (issues.length < 1) {
+    return;
+  }
+  const sourceName = normalizeText(options?.sourceName);
+  const sourceLabel = sourceName ? ` for ${sourceName}` : "";
+  throw new Error(
+    `Generated UI source contract failed${sourceLabel}: ` +
+    issues.map((issue) => `${issue.kind}:${issue.id} - ${issue.message}`).join("; ")
+  );
+}
+
+function normalizeGeneratedUiNavigationRole(value = "") {
+  const normalizedRole = normalizeText(value).toLowerCase();
+  if (!normalizedRole) {
+    return GENERATED_UI_NAVIGATION_ROLE_DEFAULT;
+  }
+  if (!GENERATED_UI_NAVIGATION_ROLE_VALUES.includes(normalizedRole)) {
+    throw new Error(`navigation-role must be one of: ${GENERATED_UI_NAVIGATION_ROLE_VALUES.join(", ")}.`);
+  }
+  return normalizedRole;
+}
+
+function hasExplicitGeneratedUiNavigationRole(options = {}) {
+  if (!options || typeof options !== "object") {
+    return false;
+  }
+  return Object.prototype.hasOwnProperty.call(options, "navigation-role") &&
+    Boolean(normalizeText(options?.["navigation-role"]));
+}
+
+function normalizeGeneratedUiRouteSegments(routePath = "") {
+  return normalizeText(routePath)
+    .replaceAll("\\", "/")
+    .split("/")
+    .map((entry) => normalizeText(entry))
+    .filter(Boolean);
+}
+
+function isGeneratedUiDynamicRouteSegment(routeSegment = "") {
+  const normalizedSegment = normalizeText(routeSegment);
+  return normalizedSegment.startsWith("[") && normalizedSegment.endsWith("]");
+}
+
+function resolveGeneratedUiSurfaceProfile(surfaceProfile = "") {
+  const surfaceProfileId = normalizeText(surfaceProfile).toLowerCase();
+  return GENERATED_UI_SURFACE_PROFILES[surfaceProfileId] || GENERATED_UI_SURFACE_PROFILES.task;
+}
+
+function buildGeneratedUiScreenClassName(baseClassName = "", {
+  surfaceProfile = ""
+} = {}) {
+  const profile = resolveGeneratedUiSurfaceProfile(surfaceProfile);
+  return [
+    "generated-ui-screen",
+    profile.className,
+    normalizeText(baseClassName)
+  ]
+    .filter(Boolean)
+    .join(" ");
+}
+
+function inferGeneratedUiNavigationRole(options = {}, {
+  dynamicRoutePolicy = "leaf",
+  routePath = ""
+} = {}) {
+  if (hasExplicitGeneratedUiNavigationRole(options)) {
+    return normalizeGeneratedUiNavigationRole(options?.["navigation-role"]);
+  }
+
+  const routeSegments = normalizeGeneratedUiRouteSegments(routePath);
+  const dynamicRouteSegments = routeSegments.filter((routeSegment) => isGeneratedUiDynamicRouteSegment(routeSegment));
+  const lastRouteSegment = routeSegments.at(-1) || "";
+  if (
+    dynamicRouteSegments.length > 0 &&
+    (
+      normalizeText(dynamicRoutePolicy).toLowerCase() === "any" ||
+      isGeneratedUiDynamicRouteSegment(lastRouteSegment)
+    )
+  ) {
+    return "detail";
+  }
+  if (GENERATED_UI_WORKFLOW_ROUTE_SEGMENTS.has(lastRouteSegment)) {
+    return "workflow";
+  }
+  return GENERATED_UI_NAVIGATION_ROLE_DEFAULT;
+}
+
+function isGeneratedUiNoLinkNavigationRole(value = "") {
+  return GENERATED_UI_NO_LINK_NAVIGATION_ROLE_SET.has(normalizeGeneratedUiNavigationRole(value));
+}
+
+function resolveGeneratedUiNavigationRoleLinkPlacement(options = {}, inferenceContext = {}) {
+  const explicitPlacement = normalizeText(options?.["link-placement"]);
+  if (explicitPlacement) {
+    return explicitPlacement;
+  }
+  const role = inferGeneratedUiNavigationRole(options, inferenceContext);
+  return GENERATED_UI_NAVIGATION_ROLE_LINK_PLACEMENTS[role] || "";
+}
+
+function shouldCreateGeneratedUiNavigationLink(options = {}, {
+  allowLinkTo = false,
+  dynamicRoutePolicy = "leaf",
+  routePath = ""
+} = {}) {
+  const hasExplicitNoLinkRole = hasExplicitGeneratedUiNavigationRole(options) &&
+    GENERATED_UI_NO_LINK_NAVIGATION_ROLE_SET.has(normalizeGeneratedUiNavigationRole(options?.["navigation-role"]));
+  const role = inferGeneratedUiNavigationRole(options, {
+    dynamicRoutePolicy,
+    routePath
+  });
+  const linkPlacement = normalizeText(options?.["link-placement"]);
+  const linkTo = allowLinkTo ? normalizeText(options?.["link-to"]) : "";
+  if (!GENERATED_UI_NO_LINK_NAVIGATION_ROLE_SET.has(role)) {
+    return true;
+  }
+  if (linkPlacement || linkTo) {
+    if (!hasExplicitNoLinkRole) {
+      return true;
+    }
+    const disallowedOptions = allowLinkTo ? "--link-placement or --link-to" : "--link-placement";
+    throw new Error(`navigation-role "${role}" cannot be combined with ${disallowedOptions}.`);
+  }
+  return false;
+}
+
+export {
+  GENERATED_UI_FORBIDDEN_CARD_SHELL_PATTERNS,
+  GENERATED_UI_FORBIDDEN_LIVE_COPY_PATTERNS,
+  GENERATED_UI_NAVIGATION_ROLE_DEFAULT,
+  GENERATED_UI_NAVIGATION_ROLE_LINK_PLACEMENTS,
+  GENERATED_UI_NAVIGATION_ROLE_OPTION,
+  GENERATED_UI_NAVIGATION_ROLE_VALUES,
+  GENERATED_UI_NO_LINK_NAVIGATION_ROLES,
+  GENERATED_UI_SOURCE_CONTRACT_PROFILES,
+  GENERATED_UI_SURFACE_PROFILES,
+  assertGeneratedUiSourceContract,
+  buildGeneratedUiScreenClassName,
+  collectGeneratedUiSourceContractIssues,
+  inferGeneratedUiNavigationRole,
+  isGeneratedUiNoLinkNavigationRole,
+  normalizeGeneratedUiNavigationRole,
+  resolveGeneratedUiSurfaceProfile,
+  resolveGeneratedUiNavigationRoleLinkPlacement,
+  shouldCreateGeneratedUiNavigationLink
+};

--- a/packages/kernel/shared/support/generatedUiContract.test.js
+++ b/packages/kernel/shared/support/generatedUiContract.test.js
@@ -1,0 +1,187 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  GENERATED_UI_NAVIGATION_ROLE_OPTION,
+  GENERATED_UI_NAVIGATION_ROLE_VALUES,
+  GENERATED_UI_SURFACE_PROFILES,
+  assertGeneratedUiSourceContract,
+  buildGeneratedUiScreenClassName,
+  collectGeneratedUiSourceContractIssues,
+  inferGeneratedUiNavigationRole,
+  isGeneratedUiNoLinkNavigationRole,
+  normalizeGeneratedUiNavigationRole,
+  resolveGeneratedUiSurfaceProfile,
+  resolveGeneratedUiNavigationRoleLinkPlacement,
+  shouldCreateGeneratedUiNavigationLink
+} from "./generatedUiContract.js";
+
+test("generated UI navigation role metadata is descriptor-ready", () => {
+  assert.deepEqual(
+    GENERATED_UI_NAVIGATION_ROLE_VALUES,
+    ["primary", "secondary", "utility", "detail", "workflow", "none"]
+  );
+  assert.equal(GENERATED_UI_NAVIGATION_ROLE_OPTION.validationType, "enum");
+  assert.deepEqual(GENERATED_UI_NAVIGATION_ROLE_OPTION.allowedValues, GENERATED_UI_NAVIGATION_ROLE_VALUES);
+  assert.equal(GENERATED_UI_NAVIGATION_ROLE_OPTION.defaultValue, "primary");
+});
+
+test("generated UI surface profiles map app, operator, and settings density", () => {
+  assert.deepEqual(Object.keys(GENERATED_UI_SURFACE_PROFILES), ["task", "operator", "settings"]);
+  assert.equal(resolveGeneratedUiSurfaceProfile("").id, "task");
+  assert.equal(resolveGeneratedUiSurfaceProfile("operator").id, "operator");
+  assert.equal(resolveGeneratedUiSurfaceProfile("operator").density, "compact");
+  assert.equal(resolveGeneratedUiSurfaceProfile("settings").id, "settings");
+  assert.equal(
+    buildGeneratedUiScreenClassName("generated-page-screen d-flex", {
+      surfaceProfile: "operator"
+    }),
+    "generated-ui-screen generated-ui-screen--operator generated-page-screen d-flex"
+  );
+});
+
+test("normalizeGeneratedUiNavigationRole defaults and validates roles", () => {
+  assert.equal(normalizeGeneratedUiNavigationRole(""), "primary");
+  assert.equal(normalizeGeneratedUiNavigationRole(" Secondary "), "secondary");
+  assert.throws(
+    () => normalizeGeneratedUiNavigationRole("drawer"),
+    /navigation-role must be one of: primary, secondary, utility, detail, workflow, none/
+  );
+});
+
+test("generated UI navigation roles resolve semantic link placements", () => {
+  assert.equal(resolveGeneratedUiNavigationRoleLinkPlacement({}), "");
+  assert.equal(resolveGeneratedUiNavigationRoleLinkPlacement({ "navigation-role": "secondary" }), "shell.secondary-nav");
+  assert.equal(resolveGeneratedUiNavigationRoleLinkPlacement({ "navigation-role": "utility" }), "shell.global-actions");
+  assert.equal(
+    resolveGeneratedUiNavigationRoleLinkPlacement({
+      "navigation-role": "secondary",
+      "link-placement": "settings.sections"
+    }),
+    "settings.sections"
+  );
+});
+
+test("generated UI navigation role inference keeps detail and workflow routes out of primary nav", () => {
+  assert.equal(inferGeneratedUiNavigationRole({}, { routePath: "/reports" }), "primary");
+  assert.equal(inferGeneratedUiNavigationRole({}, { routePath: "/reports/[reportId]" }), "detail");
+  assert.equal(inferGeneratedUiNavigationRole({}, { routePath: "/reports/[reportId]/activity" }), "primary");
+  assert.equal(
+    inferGeneratedUiNavigationRole({}, {
+      dynamicRoutePolicy: "any",
+      routePath: "/reports/[reportId]/activity"
+    }),
+    "detail"
+  );
+  assert.equal(inferGeneratedUiNavigationRole({}, { routePath: "/reports/new" }), "workflow");
+  assert.equal(
+    inferGeneratedUiNavigationRole({ "navigation-role": "primary" }, { routePath: "/reports/[reportId]" }),
+    "primary"
+  );
+  assert.equal(
+    shouldCreateGeneratedUiNavigationLink({}, {
+      allowLinkTo: true,
+      routePath: "/reports/[reportId]"
+    }),
+    false
+  );
+  assert.equal(
+    shouldCreateGeneratedUiNavigationLink({ "navigation-role": "primary" }, {
+      allowLinkTo: true,
+      routePath: "/reports/[reportId]"
+    }),
+    true
+  );
+  assert.equal(
+    shouldCreateGeneratedUiNavigationLink({ "link-placement": "shell.secondary-nav" }, {
+      allowLinkTo: true,
+      routePath: "/reports/[reportId]"
+    }),
+    true
+  );
+});
+
+test("generated UI no-link roles reject conflicting link options", () => {
+  assert.equal(isGeneratedUiNoLinkNavigationRole("detail"), true);
+  assert.equal(shouldCreateGeneratedUiNavigationLink({ "navigation-role": "workflow" }), false);
+  assert.equal(shouldCreateGeneratedUiNavigationLink({ "navigation-role": "primary" }), true);
+  assert.throws(
+    () => shouldCreateGeneratedUiNavigationLink({
+      "navigation-role": "detail",
+      "link-placement": "shell.primary-nav"
+    }),
+    /navigation-role "detail" cannot be combined with --link-placement/
+  );
+  assert.throws(
+    () => shouldCreateGeneratedUiNavigationLink({
+      "navigation-role": "none",
+      "link-to": "./details"
+    }, {
+      allowLinkTo: true
+    }),
+    /navigation-role "none" cannot be combined with --link-placement or --link-to/
+  );
+});
+
+test("generated UI source contract flags placeholder copy and missing profile hooks", () => {
+  const issues = collectGeneratedUiSourceContractIssues(
+    `<template>
+  <section>
+    <v-card>Replace this content</v-card>
+  </section>
+</template>`,
+    {
+      profile: "page"
+    }
+  );
+
+  assert.deepEqual(
+    issues.map((issue) => issue.id),
+    [
+      "replace-this-copy",
+      "vuetify-card-shell",
+      "shared-screen-class",
+      "page-screen-title",
+      "page-empty-state-sheet",
+      "page-responsive-title-type"
+    ]
+  );
+});
+
+test("generated UI source contract accepts compact-first CRUD list structure", () => {
+  assert.doesNotThrow(() => assertGeneratedUiSourceContract(
+    `<template>
+  <section class="generated-ui-screen generated-ui-screen--operator">
+    <div class="ui-generator-list-cards d-md-none">
+      <v-menu>Actions</v-menu>
+    </div>
+    <div class="ui-generator-list-table d-none d-md-block"></div>
+    <h2>__JSKIT_UI_LIST_EMPTY_TITLE__</h2>
+    <h2>__JSKIT_UI_LIST_LOAD_ERROR_TITLE__</h2>
+  </section>
+</template>
+
+<style scoped>
+.generated-ui-screen {
+  --generated-ui-screen-title-size: clamp(1.35rem, 2vw, 1.85rem);
+}
+
+.ui-generator-list-header__actions :deep(.v-btn) {
+  min-height: 48px;
+}
+</style>`,
+    {
+      profile: "crud-list",
+      sourceName: "ListElement.vue"
+    }
+  ));
+});
+
+test("generated UI responsive smoke profile requires compact medium expanded checks", () => {
+  assert.throws(
+    () => assertGeneratedUiSourceContract("const width = 390;", {
+      profile: "responsive-smoke",
+      sourceName: "tests/e2e/example.spec.ts"
+    }),
+    /missing:medium-viewport/
+  );
+});

--- a/packages/shell-web/templates/expected-existing/src/pages/home/index.vue
+++ b/packages/shell-web/templates/expected-existing/src/pages/home/index.vue
@@ -1,30 +1,35 @@
 <template>
-  <section class="home-start-screen d-flex flex-column ga-4">
+  <section class="generated-ui-screen generated-ui-screen--app home-start-screen d-flex flex-column ga-4">
     <header>
       <p class="text-overline text-medium-emphasis mb-1">Home</p>
-      <h1 class="home-start-screen__title">Starter app</h1>
+      <h1 class="home-start-screen__title">Home base</h1>
       <p class="text-body-2 text-medium-emphasis mb-0">
-        Core app runtime is ready. Add product packages or generate your first route when the surface plan is clear.
+        The app runtime is online and ready for the first real workflow.
       </p>
     </header>
 
     <v-sheet rounded="lg" border class="home-start-screen__panel">
-      <h2 class="text-h6 mb-2">Next useful screen</h2>
+      <h2 class="text-h6 mb-2">No activity yet</h2>
       <p class="text-body-2 text-medium-emphasis mb-0">
-        Generate a page or install a package to turn this starter into a real app surface.
+        Recent work, saved records, and next actions will appear here once this app has data.
       </p>
     </v-sheet>
   </section>
 </template>
 
 <style scoped>
+.generated-ui-screen {
+  --generated-ui-screen-title-size: clamp(1.5rem, 3vw, 2.5rem);
+  --generated-ui-screen-panel-padding: 1rem;
+}
+
 .home-start-screen {
   margin-inline: auto;
   max-width: 48rem;
 }
 
 .home-start-screen__title {
-  font-size: clamp(1.5rem, 3vw, 2.5rem);
+  font-size: var(--generated-ui-screen-title-size);
   font-weight: 700;
   letter-spacing: -0.03em;
   line-height: 1.08;
@@ -32,6 +37,6 @@
 }
 
 .home-start-screen__panel {
-  padding: 1rem;
+  padding: var(--generated-ui-screen-panel-padding);
 }
 </style>

--- a/packages/shell-web/templates/src/pages/home/index.vue
+++ b/packages/shell-web/templates/src/pages/home/index.vue
@@ -28,7 +28,7 @@ const health = computed(() => {
 </script>
 
 <template>
-  <section class="home-surface-screen d-flex flex-column ga-4">
+  <section class="generated-ui-screen generated-ui-screen--app home-surface-screen d-flex flex-column ga-4">
     <header class="home-surface-screen__header">
       <div>
         <p class="text-overline text-medium-emphasis mb-1">Home</p>
@@ -55,6 +55,11 @@ const health = computed(() => {
 </template>
 
 <style scoped>
+.generated-ui-screen {
+  --generated-ui-screen-title-size: clamp(1.5rem, 2.5vw, 2.25rem);
+  --generated-ui-screen-panel-padding: 1rem;
+}
+
 .home-surface-screen__header {
   align-items: flex-start;
   display: flex;
@@ -63,7 +68,7 @@ const health = computed(() => {
 }
 
 .home-surface-screen__title {
-  font-size: clamp(1.5rem, 2.5vw, 2.25rem);
+  font-size: var(--generated-ui-screen-title-size);
   font-weight: 700;
   letter-spacing: -0.03em;
   line-height: 1.1;
@@ -75,7 +80,7 @@ const health = computed(() => {
   display: flex;
   flex-wrap: wrap;
   gap: 1rem;
-  padding: 1rem;
+  padding: var(--generated-ui-screen-panel-padding);
 }
 
 .home-surface-screen__status {

--- a/packages/shell-web/templates/src/pages/home/settings.vue
+++ b/packages/shell-web/templates/src/pages/home/settings.vue
@@ -4,7 +4,7 @@ import { RouterView } from "vue-router";
 </script>
 
 <template>
-  <section class="settings-shell d-flex flex-column ga-4">
+  <section class="generated-ui-screen generated-ui-screen--settings settings-shell d-flex flex-column ga-4">
     <header>
       <p class="text-overline text-medium-emphasis mb-1">Settings</p>
       <h1 class="settings-shell__title">Home settings</h1>
@@ -28,8 +28,13 @@ import { RouterView } from "vue-router";
 </template>
 
 <style scoped>
+.generated-ui-screen {
+  --generated-ui-screen-title-size: clamp(1.35rem, 2vw, 1.85rem);
+  --generated-ui-screen-panel-padding: 1rem;
+}
+
 .settings-shell__title {
-  font-size: clamp(1.35rem, 2vw, 1.85rem);
+  font-size: var(--generated-ui-screen-title-size);
   font-weight: 650;
   letter-spacing: -0.02em;
   line-height: 1.15;
@@ -44,7 +49,7 @@ import { RouterView } from "vue-router";
   display: grid;
   gap: 1rem;
   grid-template-columns: minmax(12rem, 16rem) minmax(0, 1fr);
-  padding: 1rem;
+  padding: var(--generated-ui-screen-panel-padding);
 }
 
 .settings-shell__content {

--- a/packages/shell-web/templates/src/pages/home/settings/general/index.vue
+++ b/packages/shell-web/templates/src/pages/home/settings/general/index.vue
@@ -15,7 +15,7 @@ const drawerDefaultOpenModel = computed({
 </script>
 
 <template>
-  <section class="d-flex flex-column ga-4">
+  <section class="generated-ui-screen generated-ui-screen--settings settings-general-screen d-flex flex-column ga-4">
     <div>
       <h2 class="text-h6 mb-2">Navigation</h2>
       <p class="text-body-2 text-medium-emphasis mb-0">
@@ -32,3 +32,9 @@ const drawerDefaultOpenModel = computed({
     />
   </section>
 </template>
+
+<style scoped>
+.settings-general-screen :deep(.v-switch) {
+  min-height: 48px;
+}
+</style>

--- a/packages/shell-web/test/settingsPlacementContract.test.js
+++ b/packages/shell-web/test/settingsPlacementContract.test.js
@@ -3,6 +3,7 @@ import path from "node:path";
 import test from "node:test";
 import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
+import { assertGeneratedUiSourceContract } from "@jskit-ai/kernel/shared/support/generatedUiContract";
 import descriptor from "../package.descriptor.mjs";
 
 const TEST_DIRECTORY = path.dirname(fileURLToPath(import.meta.url));
@@ -47,6 +48,8 @@ test("shell-web home settings template exposes surface-derived settings outlets"
   const source = await readFile(path.join(PACKAGE_DIR, "templates", "src", "pages", "home", "settings.vue"), "utf8");
 
   assert.match(source, /target="home-settings:primary-menu"/);
+  assert.match(source, /generated-ui-screen generated-ui-screen--settings settings-shell/);
+  assert.match(source, /--generated-ui-screen-title-size/);
   assert.doesNotMatch(source, /default-link-component-token/);
   assert.match(source, /<RouterView \/>/);
 });
@@ -73,6 +76,10 @@ test("shell-web shell layout registers navigation at the app layout level", asyn
 test("shell-web installs generated adaptive shell Playwright smoke coverage", async () => {
   const source = await readFile(path.join(PACKAGE_DIR, "templates", "tests", "e2e", "adaptive-shell.spec.ts"), "utf8");
 
+  assertGeneratedUiSourceContract(source, {
+    profile: "responsive-smoke",
+    sourceName: "adaptive-shell.spec.ts"
+  });
   assert.match(source, /generated adaptive shell smoke/);
   assert.match(source, /390/);
   assert.match(source, /768/);
@@ -119,10 +126,12 @@ test("shell-web settings general child page exposes an adaptive drawer preferenc
   );
 
   assert.match(source, /useShellLayoutState/);
+  assert.match(source, /generated-ui-screen generated-ui-screen--settings settings-general-screen/);
   assert.match(source, /drawerDefaultOpen/);
   assert.match(source, /setDrawerDefaultOpen/);
   assert.match(source, /Phone layouts keep primary navigation in the bottom bar/);
   assert.match(source, /Open drawer by default on wider screens/);
+  assert.match(source, /min-height:\s*48px/);
   assert.doesNotMatch(source, /live in this browser only|tiny example|starter settings/);
 });
 
@@ -258,6 +267,12 @@ test("shell-web descriptor metadata advertises adaptive shell outlets, default l
 test("shell-web home starter page relies on adaptive shell navigation instead of dead feature buttons", async () => {
   const source = await readFile(path.join(PACKAGE_DIR, "templates", "src", "pages", "home", "index.vue"), "utf8");
 
+  assertGeneratedUiSourceContract(source, {
+    profile: "shell-home",
+    sourceName: "shell-web home/index.vue"
+  });
+  assert.match(source, /generated-ui-screen generated-ui-screen--app home-surface-screen/);
+  assert.match(source, /--generated-ui-screen-title-size/);
   assert.match(source, /Core services are available\./);
   assert.match(source, /to="\/home\/settings\/general"/);
   assert.doesNotMatch(source, /Use bottom navigation|Replace this content|Main public surface/);

--- a/packages/ui-generator/package.descriptor.mjs
+++ b/packages/ui-generator/package.descriptor.mjs
@@ -1,3 +1,5 @@
+import { GENERATED_UI_NAVIGATION_ROLE_OPTION } from "@jskit-ai/kernel/shared/support/generatedUiContract";
+
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/ui-generator",
@@ -79,15 +81,7 @@ export default Object.freeze({
       promptLabel: "Link placement",
       promptHint: "Optional semantic target for the generated page link placement (format: area.slot)."
     },
-    "navigation-role": {
-      required: false,
-      inputType: "text",
-      validationType: "enum",
-      allowedValues: ["primary", "secondary", "utility", "detail", "workflow", "none"],
-      defaultValue: "primary",
-      promptLabel: "Navigation role",
-      promptHint: "Product navigation role for generated page links. primary uses normal inference, secondary maps to shell.secondary-nav, utility maps to shell.global-actions, and detail/workflow/none create no nav link."
-    },
+    "navigation-role": GENERATED_UI_NAVIGATION_ROLE_OPTION,
     "link-to": {
       required: false,
       inputType: "text",

--- a/packages/ui-generator/src/server/buildTemplateContext.js
+++ b/packages/ui-generator/src/server/buildTemplateContext.js
@@ -2,15 +2,13 @@ import {
   resolvePageLinkTargetDetails,
   resolvePageTargetDetails
 } from "@jskit-ai/kernel/server/support";
-import { normalizeText } from "@jskit-ai/kernel/shared/support/normalize";
+import {
+  normalizeGeneratedUiNavigationRole,
+  resolveGeneratedUiNavigationRoleLinkPlacement,
+  shouldCreateGeneratedUiNavigationLink
+} from "@jskit-ai/kernel/shared/support/generatedUiContract";
 
 const DEFAULT_GENERATED_LINK_ICON = "mdi-view-list-outline";
-const NAVIGATION_ROLE_VALUES = Object.freeze(["primary", "secondary", "utility", "detail", "workflow", "none"]);
-const NAVIGATION_ROLE_LINK_PLACEMENTS = Object.freeze({
-  secondary: "shell.secondary-nav",
-  utility: "shell.global-actions"
-});
-const NO_LINK_NAVIGATION_ROLES = new Set(["detail", "workflow", "none"]);
 
 function resolveLinkToPropLine(linkTo = "") {
   if (!linkTo) {
@@ -26,37 +24,25 @@ function resolveOwnerLine(owner = "") {
   return `    owner: ${JSON.stringify(owner)},\n`;
 }
 
-function normalizeNavigationRole(value = "") {
-  const normalizedRole = normalizeText(value).toLowerCase();
-  if (!normalizedRole) {
-    return "primary";
+function resolveNavigationInferenceRoutePath(pageTarget = {}) {
+  const routeSegments = Array.isArray(pageTarget?.visibleRouteSegments)
+    ? pageTarget.visibleRouteSegments.map((entry) => String(entry || "").trim()).filter(Boolean)
+    : [];
+  if (routeSegments.length > 0) {
+    return `/${routeSegments.join("/")}`;
   }
-  if (!NAVIGATION_ROLE_VALUES.includes(normalizedRole)) {
-    throw new Error(`navigation-role must be one of: ${NAVIGATION_ROLE_VALUES.join(", ")}.`);
-  }
-  return normalizedRole;
+  return String(pageTarget?.routeUrlSuffix || "");
 }
 
-function shouldCreateNavigationLink(options = {}) {
-  const role = normalizeNavigationRole(options?.["navigation-role"]);
-  const linkPlacement = String(options?.["link-placement"] || "").trim();
-  const linkTo = String(options?.["link-to"] || "").trim();
-  if (NO_LINK_NAVIGATION_ROLES.has(role)) {
-    if (linkPlacement || linkTo) {
-      throw new Error(`navigation-role "${role}" cannot be combined with --link-placement or --link-to.`);
-    }
-    return false;
-  }
-  return true;
+function shouldCreateNavigationLink(options = {}, inferenceContext = {}) {
+  return shouldCreateGeneratedUiNavigationLink(options, {
+    allowLinkTo: true,
+    routePath: inferenceContext?.routePath
+  });
 }
 
-function resolveNavigationRoleLinkPlacement(options = {}) {
-  const explicitPlacement = String(options?.["link-placement"] || "").trim();
-  if (explicitPlacement) {
-    return explicitPlacement;
-  }
-  const role = normalizeNavigationRole(options?.["navigation-role"]);
-  return NAVIGATION_ROLE_LINK_PLACEMENTS[role] || "";
+function resolveNavigationRoleLinkPlacement(options = {}, inferenceContext = {}) {
+  return resolveGeneratedUiNavigationRoleLinkPlacement(options, inferenceContext);
 }
 
 async function buildUiPageTemplateContext({
@@ -74,7 +60,9 @@ async function buildUiPageTemplateContext({
     pageTarget,
     targetFile,
     context: "ui-generator page",
-    placement: resolveNavigationRoleLinkPlacement(options),
+    placement: resolveNavigationRoleLinkPlacement(options, {
+      routePath: resolveNavigationInferenceRoutePath(pageTarget)
+    }),
     linkTo: options?.["link-to"]
   });
 
@@ -93,7 +81,8 @@ async function buildUiPageTemplateContext({
 
 export {
   buildUiPageTemplateContext,
-  normalizeNavigationRole,
+  normalizeGeneratedUiNavigationRole as normalizeNavigationRole,
+  resolveNavigationInferenceRoutePath,
   resolveNavigationRoleLinkPlacement,
   shouldCreateNavigationLink
 };

--- a/packages/ui-generator/src/server/subcommands/page.js
+++ b/packages/ui-generator/src/server/subcommands/page.js
@@ -3,6 +3,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { normalizeBoolean, normalizeText } from "@jskit-ai/kernel/shared/support/normalize";
 import {
   buildUiPageTemplateContext,
+  resolveNavigationInferenceRoutePath,
   shouldCreateNavigationLink
 } from "../buildTemplateContext.js";
 import {
@@ -79,6 +80,7 @@ async function runGeneratorSubcommand({
     : false;
   const pageFilePath = pageTarget.targetFilePath.absolutePath;
   const pageRelativePath = pageTarget.targetFilePath.relativePath;
+  const navigationInferenceRoutePath = resolveNavigationInferenceRoutePath(pageTarget);
 
   const touchedFiles = new Set();
   let pageAlreadyExisted = true;
@@ -94,7 +96,9 @@ async function runGeneratorSubcommand({
     );
   }
 
-  const shouldCreateLink = shouldCreateNavigationLink(options);
+  const shouldCreateLink = shouldCreateNavigationLink(options, {
+    routePath: navigationInferenceRoutePath
+  });
   const placementContext = shouldCreateLink
     ? await buildUiPageTemplateContext({
       appRoot: pageTarget.appRoot,
@@ -125,7 +129,14 @@ async function runGeneratorSubcommand({
   if (!pageAlreadyExisted || forceOverwrite) {
     if (dryRun !== true) {
       await mkdir(path.dirname(pageFilePath), { recursive: true });
-      await writeFile(pageFilePath, renderPlainPageSource(pageLabel), "utf8");
+      await writeFile(
+        pageFilePath,
+        renderPlainPageSource(pageLabel, {
+          surfaceId: pageTarget.surfaceId,
+          routePath: navigationInferenceRoutePath
+        }),
+        "utf8"
+      );
     }
     touchedFiles.add(pageRelativePath);
   }

--- a/packages/ui-generator/src/server/subcommands/pageSupport.js
+++ b/packages/ui-generator/src/server/subcommands/pageSupport.js
@@ -14,6 +14,10 @@ import {
 } from "@jskit-ai/shell-web/server/support/localLinkItemScaffolds";
 import { normalizeText } from "@jskit-ai/kernel/shared/support/normalize";
 import {
+  buildGeneratedUiScreenClassName,
+  resolveGeneratedUiSurfaceProfile
+} from "@jskit-ai/kernel/shared/support/generatedUiContract";
+import {
   DEFAULT_COMPONENT_DIRECTORY,
   MAIN_CLIENT_PROVIDER_FILE,
   resolvePathWithinApp,
@@ -29,6 +33,7 @@ const SECTION_CONTAINER_SHELL_COMPONENT = "SectionContainerShell";
 const SUBPAGES_LINK_COMPONENT_TOKEN = "local.main.ui.tab-link-item";
 const DEFAULT_MENU_COMPONENT_DIRECTORY = path.join(DEFAULT_COMPONENT_DIRECTORY, "menus");
 const SUBPAGES_LINK_COMPONENT_DEFINITION = findLocalLinkItemDefinition(SUBPAGES_LINK_COMPONENT_TOKEN);
+const OPERATOR_SURFACE_IDS = new Set(["admin", "console"]);
 
 if (!SUBPAGES_LINK_COMPONENT_DEFINITION) {
   throw new Error(`ui-generator add-subpages could not resolve ${SUBPAGES_LINK_COMPONENT_TOKEN} scaffold definition.`);
@@ -41,32 +46,72 @@ const SHELL_OUTLET_TAG_PATTERN = /<ShellOutlet\b[^>]*\/?>\s*/gi;
 const ROUTER_VIEW_TAG_PATTERN = /<RouterView\b/i;
 const ROUTER_VIEW_LINE_PATTERN = /^\s*<RouterView(?:\s[^>]*)?\s*\/>\s*$/gm;
 
+function resolveGeneratedPageSurfaceProfile({
+  surfaceId = "",
+  routePath = ""
+} = {}) {
+  const routeSegments = normalizeText(routePath)
+    .replaceAll("\\", "/")
+    .split("/")
+    .map((entry) => normalizeText(entry).toLowerCase())
+    .filter(Boolean);
+  if (routeSegments.includes("settings")) {
+    return "settings";
+  }
+  if (OPERATOR_SURFACE_IDS.has(normalizeText(surfaceId).toLowerCase())) {
+    return "operator";
+  }
+  return "task";
+}
+
 function trimEdgeBlankLines(source = "") {
   return String(source || "")
     .replace(/^\s*\n/, "")
     .replace(/\n\s*$/, "");
 }
 
-function renderPlainPageSource(pageTitle = "") {
+function renderPlainPageSource(pageTitle = "", {
+  surfaceId = "",
+  routePath = ""
+} = {}) {
+  const surfaceProfileId = resolveGeneratedPageSurfaceProfile({ surfaceId, routePath });
+  const surfaceProfile = resolveGeneratedUiSurfaceProfile(surfaceProfileId);
+  const screenClass = buildGeneratedUiScreenClassName("generated-page-screen d-flex flex-column ga-4", {
+    surfaceProfile: surfaceProfileId
+  });
   return `<template>
-  <section class="generated-page-screen d-flex flex-column ga-4">
+  <section class="${screenClass}">
     <header>
-      <p class="text-overline text-medium-emphasis mb-1">Screen</p>
+      <p class="text-overline text-medium-emphasis mb-1">${surfaceProfile.titleLabel}</p>
       <h1 class="generated-page-screen__title">${pageTitle}</h1>
     </header>
 
     <v-sheet rounded="lg" border class="generated-page-screen__empty-state">
       <h2 class="text-h6 mb-2">No ${pageTitle} activity yet</h2>
       <p class="text-body-2 text-medium-emphasis mb-0">
-        Activity and actions for this screen will appear here.
+        ${surfaceProfile.emptyStateBody}
       </p>
     </v-sheet>
   </section>
 </template>
 
 <style scoped>
+.generated-ui-screen {
+  --generated-ui-screen-title-size: clamp(1.35rem, 2vw, 1.85rem);
+  --generated-ui-screen-panel-padding: 2rem 1.25rem;
+  --generated-ui-screen-panel-align: center;
+}
+
+.generated-ui-screen--operator {
+  --generated-ui-screen-panel-padding: 1.5rem 1rem;
+}
+
+.generated-ui-screen--settings {
+  --generated-ui-screen-panel-padding: 1.5rem 1rem;
+}
+
 .generated-page-screen__title {
-  font-size: clamp(1.35rem, 2vw, 1.85rem);
+  font-size: var(--generated-ui-screen-title-size);
   font-weight: 650;
   letter-spacing: -0.02em;
   line-height: 1.15;
@@ -76,8 +121,8 @@ function renderPlainPageSource(pageTitle = "") {
 .generated-page-screen__empty-state {
   margin-inline: auto;
   max-width: 34rem;
-  padding: 2rem 1.25rem;
-  text-align: center;
+  padding: var(--generated-ui-screen-panel-padding);
+  text-align: var(--generated-ui-screen-panel-align);
   width: 100%;
 }
 </style>

--- a/packages/ui-generator/test/elementSubcommand.test.js
+++ b/packages/ui-generator/test/elementSubcommand.test.js
@@ -3,6 +3,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { tmpdir } from "node:os";
 import test from "node:test";
+import { assertGeneratedUiSourceContract } from "@jskit-ai/kernel/shared/support/generatedUiContract";
 import { runGeneratorSubcommand } from "../src/server/subcommands/element.js";
 
 async function withTempApp(run) {
@@ -176,6 +177,10 @@ test("ui-generator placed-element subcommand creates component and outlet placem
     assert.match(providerSource, /registerMainClientComponent\("local\.main\.ui\.element\.ops-panel", \(\) => OpsPanelElement\);/);
 
     const componentSource = await readFile(path.join(appRoot, "src", "components", "OpsPanelElement.vue"), "utf8");
+    assertGeneratedUiSourceContract(componentSource, {
+      profile: "placed-element",
+      sourceName: "OpsPanelElement.vue"
+    });
     assert.match(componentSource, /class="generated-element-panel"/);
     assert.match(componentSource, /<h2 class="text-subtitle-1 font-weight-medium mb-0">Ops Panel<\/h2>/);
     assert.match(componentSource, /<v-chip color="primary" variant="tonal" size="small">Ready<\/v-chip>/);

--- a/packages/ui-generator/test/pageSubcommand.test.js
+++ b/packages/ui-generator/test/pageSubcommand.test.js
@@ -3,6 +3,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { tmpdir } from "node:os";
 import test from "node:test";
+import { assertGeneratedUiSourceContract } from "@jskit-ai/kernel/shared/support/generatedUiContract";
 import { runGeneratorSubcommand } from "../src/server/subcommands/page.js";
 
 async function withTempApp(run) {
@@ -148,6 +149,12 @@ test("ui-generator page subcommand creates an index page from an explicit target
     assert.equal(result.summary, 'Generated UI page "/practice" at src/pages/w/[workspaceSlug]/admin/practice/index.vue.');
 
     const pageSource = await readFile(path.join(appRoot, toPagePath(targetFile)), "utf8");
+    assertGeneratedUiSourceContract(pageSource, {
+      profile: "page",
+      sourceName: targetFile
+    });
+    assert.match(pageSource, /generated-ui-screen generated-ui-screen--operator generated-page-screen/);
+    assert.match(pageSource, /<p class="text-overline text-medium-emphasis mb-1">Workspace tool<\/p>/);
     assert.match(pageSource, /<h1 class="generated-page-screen__title">Practice<\/h1>/);
     assert.match(pageSource, /<v-sheet rounded="lg" border class="generated-page-screen__empty-state">/);
     assert.match(pageSource, /No Practice activity yet/);
@@ -222,7 +229,7 @@ test("ui-generator page subcommand rejects no-link navigation roles with link pl
   });
 });
 
-test("ui-generator page subcommand creates a file route and derives label from the file path", async () => {
+test("ui-generator page subcommand treats dynamic file routes as detail pages by default", async () => {
   await withTempApp(async (appRoot) => {
     await writeAppFixture(appRoot);
 
@@ -234,11 +241,33 @@ test("ui-generator page subcommand creates a file route and derives label from t
       options: {}
     });
 
-    assert.deepEqual(result.touchedFiles, [toPagePath(targetFile), "src/placement.js"]);
+    assert.deepEqual(result.touchedFiles, [toPagePath(targetFile)]);
 
     const pageSource = await readFile(path.join(appRoot, toPagePath(targetFile)), "utf8");
+    assert.match(pageSource, /generated-ui-screen generated-ui-screen--operator generated-page-screen/);
     assert.match(pageSource, /<h1 class="generated-page-screen__title">Contact Id<\/h1>/);
     assert.match(pageSource, /No Contact Id activity yet/);
+
+    const placementSource = await readFile(path.join(appRoot, "src", "placement.js"), "utf8");
+    assert.doesNotMatch(placementSource, /ui-generator\.page\.admin\.contacts\.contact-id\.link/);
+  });
+});
+
+test("ui-generator page subcommand allows explicit primary navigation for dynamic routes", async () => {
+  await withTempApp(async (appRoot) => {
+    await writeAppFixture(appRoot);
+
+    const targetFile = "w/[workspaceSlug]/admin/contacts/[contactId].vue";
+    const result = await runGeneratorSubcommand({
+      appRoot,
+      subcommand: "page",
+      args: [targetFile],
+      options: {
+        "navigation-role": "primary"
+      }
+    });
+
+    assert.deepEqual(result.touchedFiles, [toPagePath(targetFile), "src/placement.js"]);
 
     const placementSource = await readFile(path.join(appRoot, "src", "placement.js"), "utf8");
     assert.match(placementSource, /scopedSuffix: "\/contacts\/\[contactId\]"/);

--- a/packages/users-web/test/settingsPlacementContract.test.js
+++ b/packages/users-web/test/settingsPlacementContract.test.js
@@ -3,6 +3,7 @@ import path from "node:path";
 import test from "node:test";
 import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
+import { assertGeneratedUiSourceContract } from "@jskit-ai/kernel/shared/support/generatedUiContract";
 import descriptor from "../package.descriptor.mjs";
 
 const TEST_DIRECTORY = path.dirname(fileURLToPath(import.meta.url));
@@ -110,6 +111,22 @@ test("users-web package-owned account settings host is fully placement-backed", 
     "utf8"
   );
 
+  assertGeneratedUiSourceContract(source, {
+    forbidCardShell: true,
+    sourceName: "AccountSettingsClientElement.vue",
+    requiredPatterns: [
+      {
+        id: "account-settings-header",
+        pattern: /settings-panel__header/,
+        message: "Account settings host needs a direct settings panel header."
+      },
+      {
+        id: "account-settings-sections",
+        pattern: /useAccountSettingsSections/,
+        message: "Account settings host must remain placement-backed."
+      }
+    ]
+  });
   assert.match(source, /useAccountSettingsSections/);
   assert.match(source, /settings-panel__header/);
   assert.doesNotMatch(source, /<v-card\b|v-card-title|v-card-subtitle/);
@@ -121,6 +138,17 @@ test("users-web package-owned account settings host is fully placement-backed", 
 test("users-web profile form element uses a direct panel instead of card scaffolding", async () => {
   const source = await readFile(path.join(PACKAGE_DIR, "src", "client", "components", "ProfileClientElement.vue"), "utf8");
 
+  assertGeneratedUiSourceContract(source, {
+    forbidCardShell: true,
+    sourceName: "ProfileClientElement.vue",
+    requiredPatterns: [
+      {
+        id: "profile-panel-body",
+        pattern: /profile-client-panel__body/,
+        message: "Profile editor needs a direct panel body."
+      }
+    ]
+  });
   assert.match(source, /profile-client-panel__body/);
   assert.doesNotMatch(source, /<v-card\b|v-card-title|v-card-subtitle|v-card-text|v-card-item/);
 });
@@ -133,6 +161,17 @@ test("users-web account settings section templates use direct settings panels", 
   ]) {
     const source = await readFile(path.join(PACKAGE_DIR, relativePath), "utf8");
 
+    assertGeneratedUiSourceContract(source, {
+      forbidCardShell: true,
+      sourceName: relativePath,
+      requiredPatterns: [
+        {
+          id: "account-settings-section",
+          pattern: /account-settings-section/,
+          message: "Account settings sections need the direct section panel primitive."
+        }
+      ]
+    });
     assert.match(source, /account-settings-section/);
     assert.doesNotMatch(source, /<v-card\b|v-card-title|v-card-subtitle/);
   }

--- a/packages/workspaces-web/test/settingsPlacementContract.test.js
+++ b/packages/workspaces-web/test/settingsPlacementContract.test.js
@@ -3,6 +3,7 @@ import path from "node:path";
 import test from "node:test";
 import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
+import { assertGeneratedUiSourceContract } from "@jskit-ai/kernel/shared/support/generatedUiContract";
 import descriptor from "../package.descriptor.mjs";
 
 const TEST_DIRECTORY = path.dirname(fileURLToPath(import.meta.url));
@@ -56,6 +57,22 @@ test("workspaces-web admin settings template exposes surface-derived settings ou
     "utf8"
   );
 
+  assertGeneratedUiSourceContract(source, {
+    forbidCardShell: true,
+    sourceName: "admin/workspace/settings.vue",
+    requiredPatterns: [
+      {
+        id: "admin-settings-outlet",
+        pattern: /target="admin-settings:primary-menu"/,
+        message: "Admin settings shell needs the semantic settings outlet host."
+      },
+      {
+        id: "admin-settings-router-view",
+        pattern: /<RouterView \/>/,
+        message: "Admin settings shell needs to host child settings routes."
+      }
+    ]
+  });
   assert.match(source, /target="admin-settings:primary-menu"/);
   assert.doesNotMatch(source, /default-link-component-token/);
   assert.doesNotMatch(source, /<v-card\b/);
@@ -91,6 +108,10 @@ test("workspaces-web settings components use direct panels instead of card scaff
   ]) {
     const source = await readFile(path.join(PACKAGE_DIR, relativePath), "utf8");
 
+    assertGeneratedUiSourceContract(source, {
+      forbidCardShell: true,
+      sourceName: relativePath
+    });
     assert.doesNotMatch(source, /<v-card\b|v-card-title|v-card-subtitle/);
   }
 });
@@ -135,6 +156,33 @@ test("workspaces-web starter surfaces avoid instructional placeholder copy", asy
     "utf8"
   );
 
+  assertGeneratedUiSourceContract(appSource, {
+    forbidCardShell: true,
+    sourceName: "workspaces app surface",
+    requiredPatterns: [
+      {
+        id: "workspace-app-empty-state",
+        pattern: /No workspace activity yet/,
+        message: "Workspace app surface needs a product-shaped empty state."
+      }
+    ]
+  });
+  assertGeneratedUiSourceContract(adminSource, {
+    forbidCardShell: true,
+    sourceName: "workspaces admin surface",
+    requiredPatterns: [
+      {
+        id: "workspace-admin-member-link",
+        pattern: /to="\.\/members"/,
+        message: "Workspace admin surface needs a direct members action."
+      },
+      {
+        id: "workspace-admin-settings-link",
+        pattern: /to="\.\/workspace\/settings"/,
+        message: "Workspace admin surface needs a direct settings action."
+      }
+    ]
+  });
   assert.match(appSource, /No workspace activity yet/);
   assert.match(adminSource, /Manage members and workspace settings/);
   assert.match(adminSource, /to="\.\/members"/);

--- a/tooling/create-app/templates/base-shell/src/pages/home/index.vue
+++ b/tooling/create-app/templates/base-shell/src/pages/home/index.vue
@@ -1,30 +1,35 @@
 <template>
-  <section class="home-start-screen d-flex flex-column ga-4">
+  <section class="generated-ui-screen generated-ui-screen--app home-start-screen d-flex flex-column ga-4">
     <header>
       <p class="text-overline text-medium-emphasis mb-1">Home</p>
-      <h1 class="home-start-screen__title">Starter app</h1>
+      <h1 class="home-start-screen__title">Home base</h1>
       <p class="text-body-2 text-medium-emphasis mb-0">
-        Core app runtime is ready. Add product packages or generate your first route when the surface plan is clear.
+        The app runtime is online and ready for the first real workflow.
       </p>
     </header>
 
     <v-sheet rounded="lg" border class="home-start-screen__panel">
-      <h2 class="text-h6 mb-2">Next useful screen</h2>
+      <h2 class="text-h6 mb-2">No activity yet</h2>
       <p class="text-body-2 text-medium-emphasis mb-0">
-        Generate a page or install a package to turn this starter into a real app surface.
+        Recent work, saved records, and next actions will appear here once this app has data.
       </p>
     </v-sheet>
   </section>
 </template>
 
 <style scoped>
+.generated-ui-screen {
+  --generated-ui-screen-title-size: clamp(1.5rem, 3vw, 2.5rem);
+  --generated-ui-screen-panel-padding: 1rem;
+}
+
 .home-start-screen {
   margin-inline: auto;
   max-width: 48rem;
 }
 
 .home-start-screen__title {
-  font-size: clamp(1.5rem, 3vw, 2.5rem);
+  font-size: var(--generated-ui-screen-title-size);
   font-weight: 700;
   letter-spacing: -0.03em;
   line-height: 1.08;
@@ -32,6 +37,6 @@
 }
 
 .home-start-screen__panel {
-  padding: 1rem;
+  padding: var(--generated-ui-screen-panel-padding);
 }
 </style>

--- a/tooling/create-app/templates/base-shell/tests/e2e/base-shell.spec.ts
+++ b/tooling/create-app/templates/base-shell/tests/e2e/base-shell.spec.ts
@@ -18,13 +18,22 @@ async function expectNoHorizontalOverflow(page) {
   expect(metrics.scrollWidth).toBeLessThanOrEqual(metrics.clientWidth + 1);
 }
 
+async function expectGeneratedScreenContract(page) {
+  const screen = page.locator(".generated-ui-screen").first();
+
+  await expect(screen).toBeVisible();
+  await expect(screen).toHaveClass(/generated-ui-screen--app/u);
+  await expect(screen.locator("h1").first()).toBeVisible();
+}
+
 test.describe("generated base app responsive smoke", () => {
   for (const viewport of viewports) {
     test(`${viewport.name} home route renders without horizontal overflow`, async ({ page }) => {
       await page.setViewportSize({ width: viewport.width, height: viewport.height });
       await page.goto(`${BASE_URL}${SMOKE_PATH}`);
       await expect(page.locator("body")).toBeVisible();
-      await expect(page.getByText("Starter app")).toBeVisible();
+      await expect(page.getByText("Home base")).toBeVisible();
+      await expectGeneratedScreenContract(page);
       await expectNoHorizontalOverflow(page);
     });
   }

--- a/tooling/create-app/test/createApp.test.js
+++ b/tooling/create-app/test/createApp.test.js
@@ -201,6 +201,8 @@ test("create-app scaffolds the base shell with placeholder replacements", async 
     assert.match(e2eSmoke, /768/);
     assert.match(e2eSmoke, /1280/);
     assert.match(e2eSmoke, /scrollWidth/);
+    assert.match(e2eSmoke, /expectGeneratedScreenContract/);
+    assert.match(e2eSmoke, /\.generated-ui-screen/);
 
     const mainJs = await readFile(path.join(appRoot, "src/main.js"), "utf8");
     assert.match(mainJs, /import App from "\.\/App\.vue";/);
@@ -337,9 +339,12 @@ test("create-app scaffolds the base shell with placeholder replacements", async 
     await assert.rejects(access(path.join(appRoot, "src/pages/index.vue")), /ENOENT/);
     const homeView = await readFile(path.join(appRoot, "src/pages/home/index.vue"), "utf8");
     assert.doesNotMatch(homeView, /@jskit-ai\/shell-web/);
+    assert.match(homeView, /generated-ui-screen generated-ui-screen--app home-start-screen/);
+    assert.match(homeView, /--generated-ui-screen-title-size/);
     assert.match(homeView, /home-start-screen/);
-    assert.match(homeView, /Core app runtime is ready/);
-    assert.doesNotMatch(homeView, /<v-card\b|Start by adding packages/);
+    assert.match(homeView, /Home base/);
+    assert.match(homeView, /No activity yet/);
+    assert.doesNotMatch(homeView, /<v-card\b|Start by adding packages|Generate a page|install a package|Add product packages/);
     assert.doesNotMatch(homeView, /const appTitle =/);
     await assert.rejects(access(path.join(appRoot, "src/pages/console.vue")), /ENOENT/);
     await assert.rejects(access(path.join(appRoot, "src/pages/console/index.vue")), /ENOENT/);
@@ -574,8 +579,11 @@ test("create-app applies explicit app title when --title is provided", async () 
     await assert.rejects(access(path.join(appRoot, "src/pages/index.vue")), /ENOENT/);
     const homeView = await readFile(path.join(appRoot, "src/pages/home/index.vue"), "utf8");
     assert.doesNotMatch(homeView, /@jskit-ai\/shell-web/);
+    assert.match(homeView, /generated-ui-screen generated-ui-screen--app home-start-screen/);
+    assert.match(homeView, /--generated-ui-screen-title-size/);
     assert.match(homeView, /home-start-screen/);
-    assert.doesNotMatch(homeView, /<v-card\b|Start by adding packages/);
+    assert.match(homeView, /No activity yet/);
+    assert.doesNotMatch(homeView, /<v-card\b|Start by adding packages|Generate a page|install a package|Add product packages/);
   });
 });
 

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -1956,7 +1956,7 @@
             ],
             "defaultValue": "primary",
             "promptLabel": "Navigation role",
-            "promptHint": "Product navigation role for the generated CRUD list link. primary uses normal inference, secondary maps to shell.secondary-nav, utility maps to shell.global-actions, and detail/workflow/none create no nav link."
+            "promptHint": "Product navigation role for generated links. When omitted, dynamic detail and workflow routes create no nav link; primary uses normal inference, secondary maps to shell.secondary-nav, utility maps to shell.global-actions, and detail/workflow/none force no nav link."
           },
           "namespace": {
             "required": false,
@@ -4421,7 +4421,7 @@
             ],
             "defaultValue": "primary",
             "promptLabel": "Navigation role",
-            "promptHint": "Product navigation role for generated page links. primary uses normal inference, secondary maps to shell.secondary-nav, utility maps to shell.global-actions, and detail/workflow/none create no nav link."
+            "promptHint": "Product navigation role for generated links. When omitted, dynamic detail and workflow routes create no nav link; primary uses normal inference, secondary maps to shell.secondary-nav, utility maps to shell.global-actions, and detail/workflow/none force no nav link."
           },
           "link-to": {
             "required": false,

--- a/tooling/jskit-cli/test/uiElementGeneratorPackage.test.js
+++ b/tooling/jskit-cli/test/uiElementGeneratorPackage.test.js
@@ -340,7 +340,7 @@ test("generate @jskit-ai/ui-generator with no subcommand shows generator help wi
   });
 });
 
-test("generate @jskit-ai/ui-generator page creates an explicit file-route target", async () => {
+test("generate @jskit-ai/ui-generator page creates an explicit detail file-route target without nav by default", async () => {
   await withTempDir(async (cwd) => {
     const appRoot = path.join(cwd, "ui-element-generator-file-page");
     await createMinimalApp(appRoot, { name: "ui-element-generator-file-page" });
@@ -368,8 +368,7 @@ test("generate @jskit-ai/ui-generator page creates an explicit file-route target
     assert.match(pageSource, /Contact/);
 
     const placementSource = await readFile(placementPath, "utf8");
-    assert.match(placementSource, /scopedSuffix: "\/contacts\/\[contactId\]"/);
-    assert.match(placementSource, /id: "ui-generator\.page\.admin\.contacts\.contact-id\.link"/);
+    assert.doesNotMatch(placementSource, /ui-generator\.page\.admin\.contacts\.contact-id\.link/);
   });
 });
 


### PR DESCRIPTION
## Summary
- add shared generated UI contract support in kernel
- route UI and CRUD generator template context through the shared contract support
- update templates, docs, catalog, and tests for generated UI/e2e contract expectations

## Verification
- Not run per instruction: npm run verify