### PR TITLE
Add shell refresh and retry recovery

### DIFF
--- a/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/AddEditForm.vue
+++ b/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/AddEditForm.vue
@@ -22,9 +22,18 @@
     <v-sheet rounded="lg" border class="ui-generator-add-edit-form__panel">
       <div v-if="addEdit.loadError" class="ui-generator-add-edit-form__state">
         <h2 class="text-h6 mb-2">Unable to load form</h2>
-        <p class="text-body-2 text-medium-emphasis mb-0">
+        <p class="text-body-2 text-medium-emphasis mb-4">
           {{ addEdit.loadError }}
         </p>
+        <v-btn
+          v-if="addEdit.canRetryLoad"
+          color="primary"
+          variant="tonal"
+          :loading="addEdit.isFetching"
+          @click="addEdit.refresh"
+        >
+          Retry
+        </v-btn>
       </div>
       <template v-else-if="formRuntime.showFormSkeleton">
         <div class="pa-4">
@@ -161,6 +170,10 @@ function resolveCancelTo(target) {
   .ui-generator-add-edit-form__actions :deep(.v-btn) {
     min-height: 48px;
     flex: 1 1 10rem;
+  }
+
+  .ui-generator-add-edit-form__state :deep(.v-btn) {
+    min-height: 48px;
   }
 }
 </style>

--- a/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/EditElement.vue
+++ b/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/EditElement.vue
@@ -30,9 +30,18 @@
     <v-sheet rounded="lg" border class="ui-generator-form-panel">
       <div v-if="formRuntime.addEdit.loadError" class="ui-generator-form-state">
         <h2 class="text-h6 mb-2">Unable to load __JSKIT_UI_RESOURCE_SINGULAR_TITLE__</h2>
-        <p class="text-body-2 text-medium-emphasis mb-0">
+        <p class="text-body-2 text-medium-emphasis mb-4">
           {{ formRuntime.addEdit.loadError }}
         </p>
+        <v-btn
+          v-if="formRuntime.addEdit.canRetryLoad"
+          color="primary"
+          variant="tonal"
+          :loading="formRuntime.addEdit.isFetching"
+          @click="formRuntime.addEdit.refresh"
+        >
+          Retry
+        </v-btn>
       </div>
       <template v-else-if="formRuntime.showFormSkeleton">
         <div class="pa-4">
@@ -191,6 +200,10 @@ function resolveFieldErrors(fieldKey) {
   .ui-generator-form-header__actions :deep(.v-btn) {
     min-height: 48px;
     flex: 1 1 10rem;
+  }
+
+  .ui-generator-form-state :deep(.v-btn) {
+    min-height: 48px;
   }
 }
 </style>

--- a/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/NewElement.vue
+++ b/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/NewElement.vue
@@ -25,9 +25,18 @@
     <v-sheet rounded="lg" border class="ui-generator-form-panel">
       <div v-if="formRuntime.addEdit.loadError" class="ui-generator-form-state">
         <h2 class="text-h6 mb-2">Unable to prepare __JSKIT_UI_RESOURCE_SINGULAR_TITLE__</h2>
-        <p class="text-body-2 text-medium-emphasis mb-0">
+        <p class="text-body-2 text-medium-emphasis mb-4">
           {{ formRuntime.addEdit.loadError }}
         </p>
+        <v-btn
+          v-if="formRuntime.addEdit.canRetryLoad"
+          color="primary"
+          variant="tonal"
+          :loading="formRuntime.addEdit.isFetching"
+          @click="formRuntime.addEdit.refresh"
+        >
+          Retry
+        </v-btn>
       </div>
       <v-form v-else class="pa-4" @submit.prevent="formRuntime.addEdit.submit" novalidate>
         <v-row class="ui-generator-form-fields">
@@ -163,6 +172,10 @@ function resolveFieldErrors(fieldKey) {
   .ui-generator-form-header__actions :deep(.v-btn) {
     min-height: 48px;
     flex: 1 1 10rem;
+  }
+
+  .ui-generator-form-state :deep(.v-btn) {
+    min-height: 48px;
   }
 }
 </style>

--- a/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/ViewElement.vue
+++ b/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/ViewElement.vue
@@ -36,9 +36,28 @@
     <v-sheet rounded="lg" border class="ui-generator-view-panel">
       <div v-if="view.loadError || view.isNotFound" class="ui-generator-view-state">
         <h2 class="text-h6 mb-2">Record unavailable</h2>
-        <p class="text-body-2 text-medium-emphasis mb-0">
+        <p class="text-body-2 text-medium-emphasis mb-4">
           {{ view.loadError || "This __JSKIT_UI_RESOURCE_SINGULAR_TITLE__ could not be found." }}
         </p>
+        <div class="ui-generator-view-state__actions">
+          <v-btn
+            v-if="view.loadError"
+            color="primary"
+            variant="tonal"
+            :loading="view.isFetching"
+            @click="view.refresh"
+          >
+            Retry
+          </v-btn>
+          <v-btn
+            v-else-if="UI_LIST_URL"
+            color="primary"
+            variant="tonal"
+            :to="{ path: view.resolveParams(UI_LIST_URL), query: $route.query }"
+          >
+            Back to __JSKIT_UI_RESOURCE_PLURAL_TITLE__
+          </v-btn>
+        </div>
       </div>
 
       <template v-else-if="view.isLoading">
@@ -148,6 +167,13 @@ const view = useCrudView({
   text-align: center;
 }
 
+.ui-generator-view-state__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: center;
+}
+
 .ui-generator-view-fields :deep(.v-col) {
   min-width: 0;
 }
@@ -164,6 +190,10 @@ const view = useCrudView({
   .ui-generator-view-header__actions :deep(.v-btn) {
     min-height: 48px;
     flex: 1 1 10rem;
+  }
+
+  .ui-generator-view-state__actions :deep(.v-btn) {
+    min-height: 48px;
   }
 }
 </style>

--- a/packages/crud-ui-generator/test/buildTemplateContext.test.js
+++ b/packages/crud-ui-generator/test/buildTemplateContext.test.js
@@ -986,6 +986,7 @@ test("crud ui templates derive JSON:API transport from the shared CRUD resource"
   assert.match(viewTemplateSource, /ui-generator-view-header/);
   assert.match(viewTemplateSource, /ui-generator-view-panel/);
   assert.match(viewTemplateSource, /Record unavailable/);
+  assert.match(viewTemplateSource, /@click="view\.refresh"/);
   assert.doesNotMatch(viewTemplateSource, /<v-card\b|View and manage this/);
   assert.doesNotMatch(viewTemplateSource, /const UI_VIEW_TRANSPORT = Object\.freeze\(\{/);
   assert.doesNotMatch(viewTemplateSource, /transport:\s*UI_VIEW_TRANSPORT,/);
@@ -995,6 +996,8 @@ test("crud ui templates derive JSON:API transport from the shared CRUD resource"
   assert.match(newTemplateSource, /ui-generator-form-header/);
   assert.match(newTemplateSource, /ui-generator-form-panel/);
   assert.match(newTemplateSource, /Unable to prepare __JSKIT_UI_RESOURCE_SINGULAR_TITLE__/);
+  assert.match(newTemplateSource, /formRuntime\.addEdit\.canRetryLoad/);
+  assert.match(newTemplateSource, /@click="formRuntime\.addEdit\.refresh"/);
   assert.doesNotMatch(newTemplateSource, /<v-card\b|<v-card-title/);
   assert.doesNotMatch(newTemplateSource, /const UI_CREATE_TRANSPORT = Object\.freeze\(\{/);
   assert.doesNotMatch(newTemplateSource, /transport:\s*UI_CREATE_TRANSPORT,/);
@@ -1004,12 +1007,16 @@ test("crud ui templates derive JSON:API transport from the shared CRUD resource"
   assert.match(editTemplateSource, /ui-generator-form-header/);
   assert.match(editTemplateSource, /ui-generator-form-panel/);
   assert.match(editTemplateSource, /Unable to load __JSKIT_UI_RESOURCE_SINGULAR_TITLE__/);
+  assert.match(editTemplateSource, /formRuntime\.addEdit\.canRetryLoad/);
+  assert.match(editTemplateSource, /@click="formRuntime\.addEdit\.refresh"/);
   assert.doesNotMatch(editTemplateSource, /<v-card\b|<v-card-title/);
   assert.doesNotMatch(editTemplateSource, /const UI_EDIT_TRANSPORT = Object\.freeze\(\{/);
   assert.doesNotMatch(editTemplateSource, /transport:\s*UI_EDIT_TRANSPORT,/);
 
   assert.match(addEditFormTemplateSource, /generated-ui-screen generated-ui-screen--operator ui-generator-add-edit-form/);
   assert.match(addEditFormTemplateSource, /--generated-ui-screen-title-size/);
+  assert.match(addEditFormTemplateSource, /addEdit\.canRetryLoad/);
+  assert.match(addEditFormTemplateSource, /@click="addEdit\.refresh"/);
 
   assert.match(newWrapperTemplateSource, /resource: uiResource,/);
   assert.doesNotMatch(newWrapperTemplateSource, /<v-card\b/);

--- a/packages/kernel/shared/support/generatedUiContract.js
+++ b/packages/kernel/shared/support/generatedUiContract.js
@@ -235,6 +235,11 @@ const GENERATED_UI_SOURCE_CONTRACT_PROFILES = Object.freeze({
         id: "crud-detail-tap-targets",
         pattern: /min-height:\s*48px/,
         message: "Generated CRUD detail actions need 48px tap targets on compact layouts."
+      }),
+      Object.freeze({
+        id: "crud-detail-load-retry",
+        pattern: /loadError[\s\S]*(?:view|addEdit|formRuntime\.addEdit)\.refresh/,
+        message: "Generated CRUD detail load errors must expose an inline retry action."
       })
     ])
   }),

--- a/packages/kernel/shared/support/generatedUiContract.test.js
+++ b/packages/kernel/shared/support/generatedUiContract.test.js
@@ -154,6 +154,9 @@ test("generated UI source contract accepts compact-first CRUD detail structure",
   <section class="generated-ui-screen generated-ui-screen--operator">
     <header class="ui-generator-form-header"></header>
     <v-sheet class="ui-generator-form-panel">
+      <div v-if="addEdit.loadError">
+        <v-btn @click="addEdit.refresh">Retry</v-btn>
+      </div>
       <v-row class="ui-generator-form-fields"></v-row>
     </v-sheet>
   </section>

--- a/packages/shell-web/src/client/components/ShellErrorHost.vue
+++ b/packages/shell-web/src/client/components/ShellErrorHost.vue
@@ -26,6 +26,20 @@ function resolveSeverityColor(severity = "error") {
   return "error";
 }
 
+function resolveSeverityIcon(severity = "error") {
+  const normalized = String(severity || "error").trim().toLowerCase();
+  if (normalized === "info") {
+    return "mdi-information-outline";
+  }
+  if (normalized === "success") {
+    return "mdi-check-circle-outline";
+  }
+  if (normalized === "warning") {
+    return "mdi-alert-outline";
+  }
+  return "mdi-alert-outline";
+}
+
 function resolveTimeout(entry) {
   if (!entry) {
     return -1;
@@ -87,6 +101,7 @@ function onDialogModelValue(nextValue) {
           v-for="entry in bannerEntries"
           :key="entry.id"
           :type="resolveSeverityColor(entry.severity)"
+          :icon="resolveSeverityIcon(entry.severity)"
           variant="elevated"
           density="comfortable"
           rounded="lg"

--- a/packages/shell-web/src/client/components/ShellLayout.vue
+++ b/packages/shell-web/src/client/components/ShellLayout.vue
@@ -1,5 +1,12 @@
 <script setup>
-import { computed, watch } from "vue";
+import {
+  computed,
+  inject,
+  onBeforeUnmount,
+  onMounted,
+  ref,
+  watch
+} from "vue";
 import { useDisplay } from "vuetify";
 import { useShellLayoutState } from "../composables/useShellLayoutState.js";
 import ShellOutlet from "./ShellOutlet.vue";
@@ -33,6 +40,13 @@ const {
   resolvedSurfaceLabel
 } = useShellLayoutState(props);
 const display = useDisplay();
+const refreshRuntime = inject("jskit.shell-web.runtime.web-refresh.client", null);
+const pullDistance = ref(0);
+const pullRefreshing = ref(false);
+let activePull = null;
+
+const PULL_REFRESH_TRIGGER_DISTANCE = 72;
+const PULL_REFRESH_MAX_DISTANCE = 112;
 
 const layoutClass = computed(() => {
   const displayName = String(display?.name?.value || "").trim().toLowerCase();
@@ -45,6 +59,21 @@ const layoutClass = computed(() => {
   return "expanded";
 });
 const isCompactLayout = computed(() => layoutClass.value === "compact");
+const pullProgress = computed(() =>
+  Math.min(100, Math.round((pullDistance.value / PULL_REFRESH_TRIGGER_DISTANCE) * 100))
+);
+const pullIndicatorVisible = computed(() =>
+  Boolean(isCompactLayout.value && (pullDistance.value > 0 || pullRefreshing.value))
+);
+const pullRefreshLabel = computed(() => {
+  if (pullRefreshing.value) {
+    return "Refreshing";
+  }
+  return pullProgress.value >= 100 ? "Release to refresh" : "Pull to refresh";
+});
+const pullRefreshStyle = computed(() => ({
+  "--shell-pull-refresh-distance": `${Math.round(Math.min(pullDistance.value, PULL_REFRESH_MAX_DISTANCE))}px`
+}));
 
 watch(
   isCompactLayout,
@@ -53,6 +82,156 @@ watch(
   },
   { immediate: true }
 );
+
+onMounted(() => {
+  if (typeof window !== "object") {
+    return;
+  }
+
+  window.addEventListener("pointerdown", handlePullPointerDown, { capture: true, passive: true });
+  window.addEventListener("pointermove", handlePullPointerMove, { capture: true, passive: false });
+  window.addEventListener("pointerup", handlePullPointerEnd, { capture: true, passive: true });
+  window.addEventListener("pointercancel", handlePullPointerCancel, { capture: true, passive: true });
+});
+
+onBeforeUnmount(() => {
+  if (typeof window !== "object") {
+    return;
+  }
+
+  window.removeEventListener("pointerdown", handlePullPointerDown, { capture: true });
+  window.removeEventListener("pointermove", handlePullPointerMove, { capture: true });
+  window.removeEventListener("pointerup", handlePullPointerEnd, { capture: true });
+  window.removeEventListener("pointercancel", handlePullPointerCancel, { capture: true });
+});
+
+function handlePullPointerDown(event) {
+  if (!canStartPullRefresh(event)) {
+    activePull = null;
+    return;
+  }
+
+  activePull = {
+    pointerId: event.pointerId,
+    startX: event.clientX,
+    startY: event.clientY,
+    cancelled: false
+  };
+}
+
+function handlePullPointerMove(event) {
+  if (!activePull || event.pointerId !== activePull.pointerId) {
+    return;
+  }
+
+  const deltaX = event.clientX - activePull.startX;
+  const deltaY = event.clientY - activePull.startY;
+  const absX = Math.abs(deltaX);
+
+  if (deltaY < -4 || (absX > 24 && absX > deltaY * 1.15)) {
+    cancelPullRefresh();
+    return;
+  }
+
+  if (deltaY <= 6 || !isAtPageTop()) {
+    return;
+  }
+
+  event.preventDefault();
+  pullDistance.value = Math.min(PULL_REFRESH_MAX_DISTANCE, Math.round(deltaY * 0.55));
+}
+
+function handlePullPointerEnd(event) {
+  if (!activePull || event.pointerId !== activePull.pointerId) {
+    return;
+  }
+
+  const shouldRefresh = pullDistance.value >= PULL_REFRESH_TRIGGER_DISTANCE;
+  activePull = null;
+
+  if (!shouldRefresh) {
+    pullDistance.value = 0;
+    return;
+  }
+
+  void refreshFromPullGesture();
+}
+
+function handlePullPointerCancel(event) {
+  if (activePull && event.pointerId === activePull.pointerId) {
+    cancelPullRefresh();
+  }
+}
+
+function cancelPullRefresh() {
+  activePull = null;
+  if (!pullRefreshing.value) {
+    pullDistance.value = 0;
+  }
+}
+
+async function refreshFromPullGesture() {
+  if (!refreshRuntime || typeof refreshRuntime.refresh !== "function" || pullRefreshing.value) {
+    pullDistance.value = 0;
+    return;
+  }
+
+  pullRefreshing.value = true;
+  pullDistance.value = PULL_REFRESH_TRIGGER_DISTANCE;
+  try {
+    await refreshRuntime.refresh("pull-to-refresh");
+  } finally {
+    pullRefreshing.value = false;
+    pullDistance.value = 0;
+  }
+}
+
+function canStartPullRefresh(event) {
+  return Boolean(
+    isCompactLayout.value &&
+    refreshRuntime &&
+    typeof refreshRuntime.refresh === "function" &&
+    !pullRefreshing.value &&
+    isPrimaryTouchPointer(event) &&
+    isAtPageTop() &&
+    !isPullRefreshIgnoredTarget(event.target)
+  );
+}
+
+function isPrimaryTouchPointer(event) {
+  return event?.isPrimary !== false && event?.button === 0 && event?.pointerType !== "mouse";
+}
+
+function isAtPageTop() {
+  if (typeof window !== "object" || typeof document !== "object") {
+    return false;
+  }
+
+  const documentScrollTop = Number(document.documentElement?.scrollTop || 0);
+  const bodyScrollTop = Number(document.body?.scrollTop || 0);
+  return Math.max(Number(window.scrollY || 0), documentScrollTop, bodyScrollTop) <= 0;
+}
+
+function isPullRefreshIgnoredTarget(target) {
+  return Boolean(
+    target?.closest?.(
+      [
+        "a",
+        "button",
+        "input",
+        "select",
+        "textarea",
+        "summary",
+        "[role='button']",
+        "[role='link']",
+        "[role='slider']",
+        "[contenteditable='true']",
+        "[data-shell-pull-refresh-ignore]",
+        "[data-shell-swipe-ignore]"
+      ].join(",")
+    )
+  );
+}
 </script>
 
 <template>
@@ -86,6 +265,24 @@ watch(
       </div>
     </slot>
   </v-app-bar>
+
+  <div
+    v-if="pullIndicatorVisible"
+    class="shell-layout__pull-refresh"
+    :class="{ 'shell-layout__pull-refresh--refreshing': pullRefreshing }"
+    :style="pullRefreshStyle"
+    data-testid="jskit-shell-pull-refresh"
+    aria-live="polite"
+  >
+    <v-progress-circular
+      :model-value="pullProgress"
+      :indeterminate="pullRefreshing"
+      color="primary"
+      size="22"
+      width="3"
+    />
+    <span class="shell-layout__pull-refresh-label">{{ pullRefreshLabel }}</span>
+  </div>
 
   <v-navigation-drawer
     v-model="drawerOpen"
@@ -163,6 +360,37 @@ watch(
 .shell-layout__bottom-nav {
   border-top: 1px solid rgba(var(--v-border-color), var(--v-border-opacity));
   padding-bottom: env(safe-area-inset-bottom, 0px);
+}
+
+.shell-layout__pull-refresh {
+  align-items: center;
+  background: rgb(var(--v-theme-surface));
+  border: 1px solid rgba(var(--v-border-color), var(--v-border-opacity));
+  border-radius: 999px;
+  box-shadow: var(--v-shadow-3);
+  display: flex;
+  gap: 0.5rem;
+  left: 50%;
+  opacity: min(1, calc(var(--shell-pull-refresh-distance) / 56));
+  padding: 0.45rem 0.75rem;
+  pointer-events: none;
+  position: fixed;
+  top: calc(env(safe-area-inset-top, 0px) + 3.75rem);
+  transform: translate3d(-50%, calc((var(--shell-pull-refresh-distance) - 72px) * 0.35), 0);
+  transition:
+    opacity 160ms ease,
+    transform 160ms ease;
+  z-index: 2700;
+}
+
+.shell-layout__pull-refresh--refreshing {
+  opacity: 1;
+}
+
+.shell-layout__pull-refresh-label {
+  font-size: 0.78rem;
+  font-weight: 600;
+  white-space: nowrap;
 }
 
 @media (max-width: 640px) {

--- a/packages/shell-web/src/client/providers/ShellWebClientProvider.js
+++ b/packages/shell-web/src/client/providers/ShellWebClientProvider.js
@@ -186,6 +186,132 @@ function applyAppErrorConfig(errorRuntime, errorConfig = {}) {
   errorRuntime.assertBootReady();
 }
 
+function isPullRefreshQuery(query = null) {
+  const meta = isRecord(query?.meta) ? query.meta : {};
+  if (meta.jskitRefresh === "pull") {
+    return true;
+  }
+
+  return isRecord(meta.jskit) && meta.jskit.refreshOnPull === true;
+}
+
+function createShellRefreshRuntime({
+  app,
+  logger = null
+} = {}) {
+  if (!app || typeof app.has !== "function" || typeof app.make !== "function") {
+    throw new Error("createShellRefreshRuntime requires application has()/make().");
+  }
+
+  const runtimeLogger = logger || createSharedProviderLogger(app);
+  let refreshQueue = Promise.resolve(null);
+
+  async function refreshBootstrap(reason) {
+    if (!app.has("runtime.web-bootstrap.client")) {
+      return false;
+    }
+
+    const bootstrapRuntime = app.make("runtime.web-bootstrap.client");
+    if (!bootstrapRuntime || typeof bootstrapRuntime.refresh !== "function") {
+      return false;
+    }
+
+    await bootstrapRuntime.refresh(reason);
+    return true;
+  }
+
+  async function refetchPullQueries() {
+    if (!app.has("jskit.client.query-client")) {
+      return false;
+    }
+
+    const queryClient = app.make("jskit.client.query-client");
+    if (!queryClient || typeof queryClient.refetchQueries !== "function") {
+      return false;
+    }
+
+    await queryClient.refetchQueries(
+      {
+        type: "active",
+        predicate: isPullRefreshQuery
+      },
+      {
+        throwOnError: false
+      }
+    );
+    return true;
+  }
+
+  function reportRefreshFailure(error) {
+    runtimeLogger.warn(
+      {
+        error: String(error?.message || error || "unknown error")
+      },
+      "Shell refresh failed."
+    );
+
+    if (!app.has("runtime.web-error.client")) {
+      return;
+    }
+
+    const errorRuntime = app.make("runtime.web-error.client");
+    if (!errorRuntime || typeof errorRuntime.report !== "function") {
+      return;
+    }
+
+    errorRuntime.report({
+      source: "shell-web.refresh",
+      message: "Unable to refresh. Check the connection and try again.",
+      severity: "error",
+      channel: "banner",
+      dedupeKey: "shell-web.refresh.failed",
+      dedupeWindowMs: 2000,
+      action: {
+        label: "Retry",
+        dismissOnRun: true,
+        handler() {
+          void refresh("retry");
+        }
+      }
+    });
+  }
+
+  async function performRefresh(reason = "manual") {
+    const normalizedReason = String(reason || "manual").trim() || "manual";
+    try {
+      const [bootstrapRefreshed, queriesRefetched] = await Promise.all([
+        refreshBootstrap(normalizedReason),
+        refetchPullQueries()
+      ]);
+
+      return Object.freeze({
+        reason: normalizedReason,
+        bootstrapRefreshed,
+        queriesRefetched
+      });
+    } catch (error) {
+      reportRefreshFailure(error);
+      return Object.freeze({
+        reason: normalizedReason,
+        bootstrapRefreshed: false,
+        queriesRefetched: false,
+        error
+      });
+    }
+  }
+
+  function refresh(reason = "manual") {
+    refreshQueue = refreshQueue
+      .catch(() => null)
+      .then(() => performRefresh(reason));
+    return refreshQueue;
+  }
+
+  return Object.freeze({
+    refresh
+  });
+}
+
 function installVueErrorBridge(vueApp, errorRuntime, logger) {
   if (!vueApp || !isRecord(vueApp.config)) {
     return;
@@ -301,6 +427,12 @@ class ShellWebClientProvider {
         logger
       })
     );
+    app.singleton("runtime.web-refresh.client", (scope) =>
+      createShellRefreshRuntime({
+        app: scope,
+        logger
+      })
+    );
     app.singleton("runtime.web-error.presentation-store.client", () => createErrorPresentationStore());
     app.singleton("runtime.web-error.client", (scope) =>
       createErrorRuntime({
@@ -372,9 +504,11 @@ class ShellWebClientProvider {
       throw new Error("ShellWebClientProvider requires Pinia installed in the client app.");
     }
     const errorPresentationStore = app.make("runtime.web-error.presentation-store.client");
+    const refreshRuntime = app.make("runtime.web-refresh.client");
     useShellErrorPresentationStore(pinia).attachRuntimeStore(errorPresentationStore);
 
     vueApp.provide("jskit.shell-web.runtime.web-placement.client", placementRuntime);
+    vueApp.provide("jskit.shell-web.runtime.web-refresh.client", refreshRuntime);
     vueApp.provide("jskit.shell-web.runtime.web-error.client", errorRuntime);
     vueApp.provide(
       "jskit.shell-web.runtime.web-error.presentation-store.client",

--- a/packages/shell-web/templates/src/components/ShellLayout.vue
+++ b/packages/shell-web/templates/src/components/ShellLayout.vue
@@ -1,5 +1,12 @@
 <script setup>
-import { computed, watch } from "vue";
+import {
+  computed,
+  inject,
+  onBeforeUnmount,
+  onMounted,
+  ref,
+  watch
+} from "vue";
 import { useDisplay } from "vuetify";
 import { useShellLayoutState } from "@jskit-ai/shell-web/client/composables/useShellLayoutState";
 import ShellOutlet from "@jskit-ai/shell-web/client/components/ShellOutlet";
@@ -33,6 +40,13 @@ const {
   resolvedSurfaceLabel
 } = useShellLayoutState(props);
 const display = useDisplay();
+const refreshRuntime = inject("jskit.shell-web.runtime.web-refresh.client", null);
+const pullDistance = ref(0);
+const pullRefreshing = ref(false);
+let activePull = null;
+
+const PULL_REFRESH_TRIGGER_DISTANCE = 72;
+const PULL_REFRESH_MAX_DISTANCE = 112;
 
 const layoutClass = computed(() => {
   const displayName = String(display?.name?.value || "").trim().toLowerCase();
@@ -45,6 +59,21 @@ const layoutClass = computed(() => {
   return "expanded";
 });
 const isCompactLayout = computed(() => layoutClass.value === "compact");
+const pullProgress = computed(() =>
+  Math.min(100, Math.round((pullDistance.value / PULL_REFRESH_TRIGGER_DISTANCE) * 100))
+);
+const pullIndicatorVisible = computed(() =>
+  Boolean(isCompactLayout.value && (pullDistance.value > 0 || pullRefreshing.value))
+);
+const pullRefreshLabel = computed(() => {
+  if (pullRefreshing.value) {
+    return "Refreshing";
+  }
+  return pullProgress.value >= 100 ? "Release to refresh" : "Pull to refresh";
+});
+const pullRefreshStyle = computed(() => ({
+  "--shell-pull-refresh-distance": `${Math.round(Math.min(pullDistance.value, PULL_REFRESH_MAX_DISTANCE))}px`
+}));
 
 watch(
   isCompactLayout,
@@ -53,6 +82,156 @@ watch(
   },
   { immediate: true }
 );
+
+onMounted(() => {
+  if (typeof window !== "object") {
+    return;
+  }
+
+  window.addEventListener("pointerdown", handlePullPointerDown, { capture: true, passive: true });
+  window.addEventListener("pointermove", handlePullPointerMove, { capture: true, passive: false });
+  window.addEventListener("pointerup", handlePullPointerEnd, { capture: true, passive: true });
+  window.addEventListener("pointercancel", handlePullPointerCancel, { capture: true, passive: true });
+});
+
+onBeforeUnmount(() => {
+  if (typeof window !== "object") {
+    return;
+  }
+
+  window.removeEventListener("pointerdown", handlePullPointerDown, { capture: true });
+  window.removeEventListener("pointermove", handlePullPointerMove, { capture: true });
+  window.removeEventListener("pointerup", handlePullPointerEnd, { capture: true });
+  window.removeEventListener("pointercancel", handlePullPointerCancel, { capture: true });
+});
+
+function handlePullPointerDown(event) {
+  if (!canStartPullRefresh(event)) {
+    activePull = null;
+    return;
+  }
+
+  activePull = {
+    pointerId: event.pointerId,
+    startX: event.clientX,
+    startY: event.clientY,
+    cancelled: false
+  };
+}
+
+function handlePullPointerMove(event) {
+  if (!activePull || event.pointerId !== activePull.pointerId) {
+    return;
+  }
+
+  const deltaX = event.clientX - activePull.startX;
+  const deltaY = event.clientY - activePull.startY;
+  const absX = Math.abs(deltaX);
+
+  if (deltaY < -4 || (absX > 24 && absX > deltaY * 1.15)) {
+    cancelPullRefresh();
+    return;
+  }
+
+  if (deltaY <= 6 || !isAtPageTop()) {
+    return;
+  }
+
+  event.preventDefault();
+  pullDistance.value = Math.min(PULL_REFRESH_MAX_DISTANCE, Math.round(deltaY * 0.55));
+}
+
+function handlePullPointerEnd(event) {
+  if (!activePull || event.pointerId !== activePull.pointerId) {
+    return;
+  }
+
+  const shouldRefresh = pullDistance.value >= PULL_REFRESH_TRIGGER_DISTANCE;
+  activePull = null;
+
+  if (!shouldRefresh) {
+    pullDistance.value = 0;
+    return;
+  }
+
+  void refreshFromPullGesture();
+}
+
+function handlePullPointerCancel(event) {
+  if (activePull && event.pointerId === activePull.pointerId) {
+    cancelPullRefresh();
+  }
+}
+
+function cancelPullRefresh() {
+  activePull = null;
+  if (!pullRefreshing.value) {
+    pullDistance.value = 0;
+  }
+}
+
+async function refreshFromPullGesture() {
+  if (!refreshRuntime || typeof refreshRuntime.refresh !== "function" || pullRefreshing.value) {
+    pullDistance.value = 0;
+    return;
+  }
+
+  pullRefreshing.value = true;
+  pullDistance.value = PULL_REFRESH_TRIGGER_DISTANCE;
+  try {
+    await refreshRuntime.refresh("pull-to-refresh");
+  } finally {
+    pullRefreshing.value = false;
+    pullDistance.value = 0;
+  }
+}
+
+function canStartPullRefresh(event) {
+  return Boolean(
+    isCompactLayout.value &&
+    refreshRuntime &&
+    typeof refreshRuntime.refresh === "function" &&
+    !pullRefreshing.value &&
+    isPrimaryTouchPointer(event) &&
+    isAtPageTop() &&
+    !isPullRefreshIgnoredTarget(event.target)
+  );
+}
+
+function isPrimaryTouchPointer(event) {
+  return event?.isPrimary !== false && event?.button === 0 && event?.pointerType !== "mouse";
+}
+
+function isAtPageTop() {
+  if (typeof window !== "object" || typeof document !== "object") {
+    return false;
+  }
+
+  const documentScrollTop = Number(document.documentElement?.scrollTop || 0);
+  const bodyScrollTop = Number(document.body?.scrollTop || 0);
+  return Math.max(Number(window.scrollY || 0), documentScrollTop, bodyScrollTop) <= 0;
+}
+
+function isPullRefreshIgnoredTarget(target) {
+  return Boolean(
+    target?.closest?.(
+      [
+        "a",
+        "button",
+        "input",
+        "select",
+        "textarea",
+        "summary",
+        "[role='button']",
+        "[role='link']",
+        "[role='slider']",
+        "[contenteditable='true']",
+        "[data-shell-pull-refresh-ignore]",
+        "[data-shell-swipe-ignore]"
+      ].join(",")
+    )
+  );
+}
 </script>
 
 <template>
@@ -86,6 +265,24 @@ watch(
       </div>
     </slot>
   </v-app-bar>
+
+  <div
+    v-if="pullIndicatorVisible"
+    class="shell-layout__pull-refresh"
+    :class="{ 'shell-layout__pull-refresh--refreshing': pullRefreshing }"
+    :style="pullRefreshStyle"
+    data-testid="jskit-shell-pull-refresh"
+    aria-live="polite"
+  >
+    <v-progress-circular
+      :model-value="pullProgress"
+      :indeterminate="pullRefreshing"
+      color="primary"
+      size="22"
+      width="3"
+    />
+    <span class="shell-layout__pull-refresh-label">{{ pullRefreshLabel }}</span>
+  </div>
 
   <v-navigation-drawer
     v-model="drawerOpen"
@@ -163,6 +360,37 @@ watch(
 .shell-layout__bottom-nav {
   border-top: 1px solid rgba(var(--v-border-color), var(--v-border-opacity));
   padding-bottom: env(safe-area-inset-bottom, 0px);
+}
+
+.shell-layout__pull-refresh {
+  align-items: center;
+  background: rgb(var(--v-theme-surface));
+  border: 1px solid rgba(var(--v-border-color), var(--v-border-opacity));
+  border-radius: 999px;
+  box-shadow: var(--v-shadow-3);
+  display: flex;
+  gap: 0.5rem;
+  left: 50%;
+  opacity: min(1, calc(var(--shell-pull-refresh-distance) / 56));
+  padding: 0.45rem 0.75rem;
+  pointer-events: none;
+  position: fixed;
+  top: calc(env(safe-area-inset-top, 0px) + 3.75rem);
+  transform: translate3d(-50%, calc((var(--shell-pull-refresh-distance) - 72px) * 0.35), 0);
+  transition:
+    opacity 160ms ease,
+    transform 160ms ease;
+  z-index: 2700;
+}
+
+.shell-layout__pull-refresh--refreshing {
+  opacity: 1;
+}
+
+.shell-layout__pull-refresh-label {
+  font-size: 0.78rem;
+  font-weight: 600;
+  white-space: nowrap;
 }
 
 @media (max-width: 640px) {

--- a/packages/shell-web/templates/tests/e2e/adaptive-shell.spec.ts
+++ b/packages/shell-web/templates/tests/e2e/adaptive-shell.spec.ts
@@ -24,6 +24,37 @@ async function expectGeneratedScreenContract(page) {
   await expect(screen).toBeVisible();
 }
 
+async function pullToRefresh(page) {
+  await page.evaluate(() => {
+    window.scrollTo(0, 0);
+  });
+  await page.dispatchEvent("body", "pointerdown", {
+    pointerId: 41,
+    pointerType: "touch",
+    isPrimary: true,
+    button: 0,
+    clientX: 180,
+    clientY: 90
+  });
+  await page.dispatchEvent("body", "pointermove", {
+    pointerId: 41,
+    pointerType: "touch",
+    isPrimary: true,
+    button: 0,
+    clientX: 184,
+    clientY: 250
+  });
+  await expect(page.getByTestId("jskit-shell-pull-refresh")).toBeVisible();
+  await page.dispatchEvent("body", "pointerup", {
+    pointerId: 41,
+    pointerType: "touch",
+    isPrimary: true,
+    button: 0,
+    clientX: 184,
+    clientY: 250
+  });
+}
+
 async function isElementVisibleInViewport(page, testId: string) {
   return page.getByTestId(testId).evaluate((element) => {
     const rect = element.getBoundingClientRect();
@@ -51,6 +82,13 @@ test.describe("generated adaptive shell smoke", () => {
       await expectNoHorizontalOverflow(page);
 
       if (viewport.name === "compact") {
+        let bootstrapRequests = 0;
+        await page.route("**/api/bootstrap**", async (route) => {
+          bootstrapRequests += 1;
+          await route.continue();
+        });
+        const bootstrapRequestsBeforePull = bootstrapRequests;
+
         await expect(page.getByTestId("jskit-shell-bottom-nav")).toBeVisible();
         expect(await isElementVisibleInViewport(page, "jskit-shell-drawer")).toBe(false);
 
@@ -61,6 +99,9 @@ test.describe("generated adaptive shell smoke", () => {
         for (const height of navButtonHeights) {
           expect(height).toBeGreaterThanOrEqual(48);
         }
+
+        await pullToRefresh(page);
+        await expect.poll(() => bootstrapRequests).toBeGreaterThan(bootstrapRequestsBeforePull);
       } else {
         await expect(page.getByTestId("jskit-shell-drawer")).toBeVisible();
       }

--- a/packages/shell-web/test/provider.test.js
+++ b/packages/shell-web/test/provider.test.js
@@ -17,7 +17,7 @@ function setClientAppConfig(source = {}) {
   return normalized;
 }
 
-function createAppDouble({ surfaceRuntime = null } = {}) {
+function createAppDouble({ surfaceRuntime = null, queryClient = null } = {}) {
   const singletons = new Map();
   const singletonInstances = new Map();
   const provided = [];
@@ -64,6 +64,9 @@ function createAppDouble({ surfaceRuntime = null } = {}) {
       if (token === "jskit.client.surface.runtime") {
         return Boolean(surfaceRuntime);
       }
+      if (token === "jskit.client.query-client") {
+        return Boolean(queryClient);
+      }
       return singletons.has(token) || singletonInstances.has(token);
     },
     make(token) {
@@ -75,6 +78,9 @@ function createAppDouble({ surfaceRuntime = null } = {}) {
       }
       if (token === "jskit.client.surface.runtime" && surfaceRuntime) {
         return surfaceRuntime;
+      }
+      if (token === "jskit.client.query-client" && queryClient) {
+        return queryClient;
       }
       if (singletonInstances.has(token)) {
         return singletonInstances.get(token);
@@ -163,6 +169,7 @@ test("shell web client provider binds runtime and injects it into Vue app", asyn
     assert.equal(app.singletons.has("runtime.web-placement.client"), true);
     assert.equal(app.singletons.has("runtime.web-error.client"), true);
     assert.equal(app.singletons.has("runtime.web-error.presentation-store.client"), true);
+    assert.equal(app.singletons.has("runtime.web-refresh.client"), true);
 
     await provider.boot(app);
     assert.equal(app.plugins.length, 0);
@@ -170,6 +177,7 @@ test("shell web client provider binds runtime and injects it into Vue app", asyn
     const providedByKey = new Map(app.provided.map((entry) => [entry.key, entry.value]));
 
     assert.equal(providedByKey.has("jskit.shell-web.runtime.web-placement.client"), true);
+    assert.equal(providedByKey.has("jskit.shell-web.runtime.web-refresh.client"), true);
     assert.equal(providedByKey.has("jskit.shell-web.runtime.web-error.client"), true);
     assert.equal(providedByKey.has("jskit.shell-web.runtime.web-error.presentation-store.client"), true);
 
@@ -183,6 +191,9 @@ test("shell web client provider binds runtime and injects it into Vue app", asyn
     assert.equal(typeof errorRuntime.report, "function");
     assert.equal(typeof errorRuntime.configure, "function");
 
+    const refreshRuntime = providedByKey.get("jskit.shell-web.runtime.web-refresh.client");
+    assert.equal(typeof refreshRuntime.refresh, "function");
+
     const errorStore = providedByKey.get("jskit.shell-web.runtime.web-error.presentation-store.client");
     assert.equal(typeof errorStore.getState, "function");
     assert.equal(typeof errorStore.present, "function");
@@ -192,6 +203,33 @@ test("shell web client provider binds runtime and injects it into Vue app", asyn
     assert.equal(typeof errorPresentationStore.present, "function");
     errorStore.present("banner", { message: "Hello" });
     assert.equal(errorPresentationStore.channels.banner[0].message, "Hello");
+  });
+});
+
+test("shell refresh runtime refreshes bootstrap and active pull-refresh queries", async () => {
+  await withFetchStub({ surfaceAccess: { home: true } }, async () => {
+    const refetchCalls = [];
+    const queryClient = {
+      async refetchQueries(filters = {}, options = {}) {
+        refetchCalls.push({ filters, options });
+      }
+    };
+    const app = createAppDouble({ queryClient });
+    const provider = new ShellWebClientProvider();
+    provider.register(app);
+
+    const refreshRuntime = app.make("runtime.web-refresh.client");
+    const result = await refreshRuntime.refresh("test-refresh");
+
+    assert.equal(result.reason, "test-refresh");
+    assert.equal(result.bootstrapRefreshed, true);
+    assert.equal(result.queriesRefetched, true);
+    assert.equal(refetchCalls.length, 1);
+    assert.equal(refetchCalls[0].filters.type, "active");
+    assert.equal(refetchCalls[0].options.throwOnError, false);
+    assert.equal(refetchCalls[0].filters.predicate({ meta: { jskit: { refreshOnPull: true } } }), true);
+    assert.equal(refetchCalls[0].filters.predicate({ meta: { jskit: { refreshOnPull: false } } }), false);
+    assert.equal(refetchCalls[0].filters.predicate({ meta: {} }), false);
   });
 });
 

--- a/packages/shell-web/test/settingsPlacementContract.test.js
+++ b/packages/shell-web/test/settingsPlacementContract.test.js
@@ -70,12 +70,26 @@ test("shell-web shell layout registers navigation at the app layout level", asyn
     assert.match(source, /:density="isCompactLayout \? 'compact' : 'comfortable'"/);
     assert.match(source, /shell-layout__top-right[\s\S]*max-width:\s*min\(45vw, 18rem\)/);
     assert.match(source, /<v-bottom-navigation[\s\S]*target="shell-layout:primary-bottom-nav"/);
+    assert.match(source, /inject\("jskit\.shell-web\.runtime\.web-refresh\.client", null\)/);
+    assert.match(source, /window\.addEventListener\("pointerdown", handlePullPointerDown/);
+    assert.match(source, /refreshRuntime\.refresh\("pull-to-refresh"\)/);
+    assert.match(source, /data-testid="jskit-shell-pull-refresh"/);
     assert.match(source, /target="shell-layout:primary-menu"[\s\S]*default/);
     assert.doesNotMatch(source, /target="shell-layout:primary-bottom-nav"[\s\S]*default/);
     assert.match(source, /data-testid="jskit-shell-drawer"/);
     assert.match(source, /data-testid="jskit-shell-bottom-nav"/);
     assert.match(source, /padding:\s*0\.75rem 1rem calc\(1rem \+ env\(safe-area-inset-bottom, 0px\)\)/);
   }
+});
+
+test("shell-web error host uses one explicit close affordance for banner errors", async () => {
+  const source = await readFile(path.join(PACKAGE_DIR, "src", "client", "components", "ShellErrorHost.vue"), "utf8");
+
+  assert.match(source, /function resolveSeverityIcon/);
+  assert.match(source, /mdi-alert-outline/);
+  assert.match(source, /:icon="resolveSeverityIcon\(entry\.severity\)"/);
+  assert.match(source, /closable[\s\S]*@click:close="dismiss\(entry\)"/);
+  assert.doesNotMatch(source, /mdi-close/);
 });
 
 test("shell-web installs generated adaptive shell Playwright smoke coverage", async () => {

--- a/packages/users-web/src/client/composables/records/useAddEdit.js
+++ b/packages/users-web/src/client/composables/records/useAddEdit.js
@@ -163,9 +163,29 @@ function useAddEdit({
   );
   const loadError = operationScope.loadError(endpointResource.loadError);
   const isLoading = operationScope.isLoading(endpointResource.isLoading);
+  const canRetryLoad = computed(() => Boolean(readEnabled !== false && endpointResource?.reload));
+
+  async function refresh() {
+    if (!canRetryLoad.value) {
+      return null;
+    }
+
+    return endpointResource.reload();
+  }
+
   setupOperationErrorReporting({
     source: `${placementSource}.load`,
-    loadError
+    loadError,
+    dedupeWindowMs: 0,
+    loadActionFactory: () => canRetryLoad.value
+      ? {
+        label: "Retry",
+        dismissOnRun: true,
+        handler() {
+          void refresh();
+        }
+      }
+      : null
   });
 
   return proxyRefs({
@@ -177,13 +197,14 @@ function useAddEdit({
     isRefetching,
     isFieldLocked,
     isSubmitDisabled,
+    canRetryLoad,
     isLoading,
     isSaving: addEdit.saving,
     fieldErrors: addEdit.fieldErrors,
     message: addEdit.message,
     messageType: addEdit.messageType,
     submit: addEdit.submit,
-    refresh: endpointResource.reload,
+    refresh,
     resource: endpointResource,
     recordId: addEditUiRuntime.recordId,
     listUrl: addEditUiRuntime.listUrl,

--- a/packages/users-web/src/client/composables/records/useView.js
+++ b/packages/users-web/src/client/composables/records/useView.js
@@ -97,6 +97,7 @@ function useView({
     readMethod,
     readQuery: requestQueryRuntime.requestQuery,
     transport,
+    refreshOnPull: true,
     fallbackLoadError
   });
 

--- a/packages/users-web/src/client/composables/runtime/useEndpointResource.js
+++ b/packages/users-web/src/client/composables/runtime/useEndpointResource.js
@@ -4,7 +4,10 @@ import { usersWebHttpClient } from "../../lib/httpClient.js";
 import { asPlainObject } from "../support/scopeHelpers.js";
 import { resolveEnabledRef, resolveTextRef } from "../support/refValueHelpers.js";
 import { toQueryErrorMessage } from "../support/errorMessageHelpers.js";
-import { hasResolvedQueryData } from "../support/resourceLoadStateHelpers.js";
+import {
+  hasResolvedQueryData,
+  mergeQueryMeta
+} from "../support/resourceLoadStateHelpers.js";
 
 function buildEndpointReadRequestOptions({
   method = "GET",
@@ -67,6 +70,7 @@ function useEndpointResource({
   writeMethod = "PATCH",
   readQuery = null,
   transport = null,
+  refreshOnPull = false,
   queryOptions = null,
   mutationOptions = null,
   fallbackLoadError = "Unable to load resource.",
@@ -96,7 +100,13 @@ function useEndpointResource({
       });
     },
     enabled: queryEnabled,
-    ...(asPlainObject(queryOptions))
+    ...(refreshOnPull
+      ? mergeQueryMeta(asPlainObject(queryOptions), {
+        jskit: {
+          refreshOnPull: true
+        }
+      })
+      : asPlainObject(queryOptions))
   });
 
   const mutation = useMutation({

--- a/packages/users-web/src/client/composables/support/resourceLoadStateHelpers.js
+++ b/packages/users-web/src/client/composables/support/resourceLoadStateHelpers.js
@@ -7,4 +7,36 @@ function hasResolvedQueryData({ query = null, data = null } = {}) {
   return querySucceeded || hasDataPayload;
 }
 
-export { hasResolvedQueryData };
+function mergeQueryMeta(queryOptions = null, meta = {}) {
+  const sourceOptions =
+    queryOptions && typeof queryOptions === "object" && !Array.isArray(queryOptions) ? queryOptions : {};
+  const sourceMeta =
+    sourceOptions.meta && typeof sourceOptions.meta === "object" && !Array.isArray(sourceOptions.meta)
+      ? sourceOptions.meta
+      : {};
+  const sourceJskitMeta =
+    sourceMeta.jskit && typeof sourceMeta.jskit === "object" && !Array.isArray(sourceMeta.jskit)
+      ? sourceMeta.jskit
+      : {};
+  const nextJskitMeta =
+    meta.jskit && typeof meta.jskit === "object" && !Array.isArray(meta.jskit)
+      ? meta.jskit
+      : {};
+
+  return {
+    ...sourceOptions,
+    meta: {
+      ...sourceMeta,
+      ...meta,
+      jskit: {
+        ...sourceJskitMeta,
+        ...nextJskitMeta
+      }
+    }
+  };
+}
+
+export {
+  hasResolvedQueryData,
+  mergeQueryMeta
+};

--- a/packages/users-web/src/client/composables/usePagedCollection.js
+++ b/packages/users-web/src/client/composables/usePagedCollection.js
@@ -3,6 +3,7 @@ import { useInfiniteQuery, useQueryClient } from "@tanstack/vue-query";
 import { asPlainObject } from "./support/scopeHelpers.js";
 import { resolveEnabledRef } from "./support/refValueHelpers.js";
 import { toQueryErrorMessage } from "./support/errorMessageHelpers.js";
+import { mergeQueryMeta } from "./support/resourceLoadStateHelpers.js";
 
 function defaultSelectItems(page) {
   return Array.isArray(page?.items) ? page.items : [];
@@ -83,7 +84,11 @@ function usePagedCollection({
     queryFn,
     getNextPageParam: (lastPage, allPages, lastPageParam, allPageParams) =>
       getNextPageParam(lastPage, allPages, lastPageParam, allPageParams),
-    ...(asPlainObject(queryOptions))
+    ...mergeQueryMeta(asPlainObject(queryOptions), {
+      jskit: {
+        refreshOnPull: true
+      }
+    })
   });
 
   const pages = computed(() => {

--- a/packages/users-web/test/resourceLoadStateHelpers.test.js
+++ b/packages/users-web/test/resourceLoadStateHelpers.test.js
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { ref } from "vue";
-import { hasResolvedQueryData } from "../src/client/composables/support/resourceLoadStateHelpers.js";
+import {
+  hasResolvedQueryData,
+  mergeQueryMeta
+} from "../src/client/composables/support/resourceLoadStateHelpers.js";
 
 test("hasResolvedQueryData returns true when the query succeeded", () => {
   const query = {
@@ -36,4 +39,35 @@ test("hasResolvedQueryData returns false when query and payload are unresolved",
     query,
     data: ref(null)
   }), false);
+});
+
+test("mergeQueryMeta preserves caller metadata while adding JSKIT refresh policy", () => {
+  assert.deepEqual(
+    mergeQueryMeta(
+      {
+        staleTime: 1000,
+        meta: {
+          owner: "contacts",
+          jskit: {
+            feature: "list"
+          }
+        }
+      },
+      {
+        jskit: {
+          refreshOnPull: true
+        }
+      }
+    ),
+    {
+      staleTime: 1000,
+      meta: {
+        owner: "contacts",
+        jskit: {
+          feature: "list",
+          refreshOnPull: true
+        }
+      }
+    }
+  );
 });


### PR DESCRIPTION
## Summary
- add shell-level refresh runtime and compact pull-to-refresh gesture
- expose retry actions for generated CRUD load errors
- remove duplicate toast close affordance from shell error banners

## Verification
- Not run per request.