### PR TITLE
Separate mobile sync from package install

### DIFF
--- a/packages/agent-docs/guide/agent/app-extras/mobile-capacitor.md
+++ b/packages/agent-docs/guide/agent/app-extras/mobile-capacitor.md
@@ -36,6 +36,9 @@ npx jskit mobile android doctor
 ```
 
 If doctor passes, the app is ready for the normal mobile workflow.
+The `jskit mobile android ...` commands expect the mobile runtime package to be
+installed in `package.json` and recorded in `.jskit/lock.json`; they do not
+install `@jskit-ai/mobile-capacitor` for you.
 
 ## What you need on your machine
 
@@ -126,6 +129,10 @@ This:
 - builds the JSKIT web app into `dist/`
 - runs `cap sync android`
 
+The refresh step requires the managed files from the package install to exist.
+If `capacitor.config.json` or `.jskit/mobile-capacitor.md` is missing, install
+the package again with `npx jskit add package @jskit-ai/mobile-capacitor`.
+
 ### Create the local tunnel
 
 ```bash
@@ -177,7 +184,7 @@ Use it when you want a clean signed-out state.
 
 ## The command set
 
-These are the mobile commands the package adds:
+These are the CLI mobile commands used by the package workflow:
 
 - `jskit mobile android devices`
   - list visible Android devices
@@ -288,8 +295,8 @@ The package manages:
   - `MainActivity.java` or `MainActivity.kt`
 - the managed deep-link block in `AndroidManifest.xml`
 
-`jskit mobile android sync` is expected to refresh those files from
-`config.mobile`.
+After the package is installed, `jskit mobile android sync` refreshes those
+managed files from `config.mobile`.
 
 ### Why the tunnel exists
 

--- a/packages/agent-docs/guide/agent/app-setup/console.md
+++ b/packages/agent-docs/guide/agent/app-setup/console.md
@@ -25,7 +25,7 @@ npm run db:migrate
 - `console-core` owns the console schema, owner check, bootstrap flag, and API routes
 - `console-web` owns the console surface scaffold, settings shell, and menu placement
 
-So the console is a real vertical slice now. The users packages no longer know about it.
+The console is a real vertical slice. The users packages do not own it.
 
 ## What the console is for
 
@@ -70,7 +70,7 @@ Then sign in.
 
 Once you are authenticated, two things matter:
 
-- the app now knows who you are as a persistent JSKIT user
+- the app knows who you are as a persistent JSKIT user
 - the console bootstrap logic can determine whether you are the console owner
 
 Open:

--- a/packages/agent-docs/guide/agent/app-setup/database-layer.md
+++ b/packages/agent-docs/guide/agent/app-setup/database-layer.md
@@ -73,7 +73,7 @@ If you run the status command immediately after this chapter:
 npm run db:migrate:status
 ```
 
-you should still see that there are no completed migrations and no pending migration files yet. The runtime and the Knex wiring exist now, but no package has added real schema files until the next chapter.
+you should still see that there are no completed migrations and no pending migration files yet. The runtime and the Knex wiring exist at this point, but no package has added real schema files until the next chapter.
 
 ### A place for future schema files
 
@@ -88,7 +88,7 @@ That is the key idea of this chapter:
 
 This chapter is the right place to make one distinction very explicit.
 
-There are now two different migration-related layers in the app:
+The app has two different migration-related layers:
 
 - JSKIT-managed migration files on disk
 - Knex actually applying those files to the database
@@ -171,7 +171,7 @@ import {
 } from "@jskit-ai/database-runtime/shared";
 ```
 
-This is worth calling out now because the database layer is not only "Knex plus migrations".
+This is worth calling out here because the database layer is not only "Knex plus migrations".
 
 It also gives your later repositories and services a standard persistence toolbox so every package does not have to solve the same problems differently. The main point is consistency:
 
@@ -628,7 +628,7 @@ It is not the main runtime API that your app code imports during a request. It i
 npm run db:migrate
 ```
 
-So there are really two separate database entry points now:
+So there are really two separate database entry points:
 
 - `knexfile.js` for migration commands
 - the JSKIT server provider runtime for application code
@@ -695,7 +695,7 @@ At first glance it can feel strange that the database layer is installed but the
 
 The reason is simple:
 
-- the runtime is now available
+- the runtime is available
 - but almost no installed package is using it yet
 
 Right now:
@@ -739,7 +739,7 @@ So the auth layer keeps behaving the same way it did before:
 - JSKIT still mirrors just enough profile data locally
 - that JSKIT-side mirror is still not persistent yet
 
-The database runtime is now ready, but the users layer that will actually use it has not been installed yet.
+The database runtime is ready, but the users layer that will actually use it has not been installed yet.
 
 ### Why the empty `migrations/` directory is important
 
@@ -771,5 +771,5 @@ But just as importantly, this chapter also defined what has **not** changed yet:
 So the right mental model at the end of this chapter is:
 
 - Supabase already handles real authentication
-- MySQL is now wired up and ready
+- MySQL is wired up and ready
 - the persistent JSKIT-side user model arrives in the next chapter

--- a/packages/agent-docs/guide/agent/app-setup/initial-scaffolding.md
+++ b/packages/agent-docs/guide/agent/app-setup/initial-scaffolding.md
@@ -14,7 +14,7 @@ npm install
 
 The first command creates a new folder called `exampleapp` and fills it with JSKIT's base shell template. The `exampleapp` name is used in a few template replacements, such as the package name and the browser title. The `--tenancy-mode none` flag tells JSKIT to start with the smallest routing model. In this mode, the app is not workspace-aware (more of this later in the guide, when multihoming is introduced). That keeps the first scaffold easier to read because there is no workspace slug handling yet.
 
-If you are working with an AI agent and want the agent to drive the initial JSKIT setup conversation, there is now a dedicated seed path:
+If you are working with an AI agent and want the agent to drive the initial JSKIT setup conversation, use the dedicated seed path:
 
 ```bash
 npx @jskit-ai/create-app exampleapp --template ai-seed

--- a/packages/agent-docs/guide/agent/app-setup/working-with-the-jskit-cli.md
+++ b/packages/agent-docs/guide/agent/app-setup/working-with-the-jskit-cli.md
@@ -506,7 +506,7 @@ npx jskit add package shell-web
 npm install
 ```
 
-`jskit add` changes the app. `npm install` downloads the dependencies that the changed app now requires.
+`jskit add` changes the app. `npm install` downloads the dependencies that the changed app requires.
 
 If the app is being tested against a local JSKIT checkout with linked packages, run the local-link wrapper again after every `npm install`:
 
@@ -707,7 +707,7 @@ That is a different job from:
 
 Those commands can all pass while JSKIT-managed state is still inconsistent. `doctor` is the command that checks that JSKIT's own view of the app still makes sense.
 
-That is exactly why the starter scaffold now routes `npm run verify` through `jskit app verify`.
+That is exactly why the starter scaffold routes `npm run verify` through `jskit app verify`.
 
 It belongs there because JSKIT apps are not only source trees. They also have:
 
@@ -739,7 +739,7 @@ Good times to run it manually include:
 
 One important nuance: `doctor` is checking for broken JSKIT ownership and visibility, not trying to stop you from editing app-owned files. For example, a managed file that still exists but whose contents changed is normally fine. The problem is when JSKIT expects a managed file to exist and it is gone, or when the installed package state no longer resolves cleanly.
 
-There is one intentional exception now for user-facing UI work.
+There is one intentional exception for user-facing UI work.
 
 If the current git working tree has changed UI files under the app's normal UI paths, `doctor` expects a matching `.jskit/verification/ui.json` receipt. The intended way to create that receipt is:
 
@@ -969,7 +969,7 @@ Good fits include:
 - a custom integration package that talks to one external API
 - app-specific auth or policy behavior
 - a local runtime package that owns both client and server behavior for one feature area
-- a package that starts small now but may later grow providers, shared helpers, and routes
+- a package that starts small but may later grow providers, shared helpers, and routes
 
 Use a generator when the problem is already understood well enough that JSKIT can scaffold the feature shape for you.
 

--- a/packages/agent-docs/guide/agent/generators/crud-generators.md
+++ b/packages/agent-docs/guide/agent/generators/crud-generators.md
@@ -262,7 +262,7 @@ npx jskit generate crud-server-generator scaffold \
 
 This creates an app-local package under `packages/contacts/`.
 
-If the table should be CRUD-owned now but should **not** expose public HTTP CRUD routes yet, add:
+If the table should already be CRUD-owned but should **not** expose public HTTP CRUD routes yet, add:
 
 ```bash
 --internal
@@ -322,7 +322,7 @@ npm run devlinks
 
 The same rule applies after later server scaffolds such as `addresses` and `comments`. The UI generator can still read the generated resource file directly, but the app runtime needs the local package install boundary to be completed before the CRUD can boot normally.
 
-For standard CRUDs, that file is now intentionally compact. It uses `defineCrudResource(...)` from `@jskit-ai/resource-crud-core`, authors the canonical `schema` / `searchSchema` / `defaultSort` / `autofilter` shape once, and lets JSKIT derive the standard CRUD operation contracts from it.
+For standard CRUDs, that file is intentionally compact. It uses `defineCrudResource(...)` from `@jskit-ai/resource-crud-core`, authors the canonical `schema` / `searchSchema` / `defaultSort` / `autofilter` shape once, and lets JSKIT derive the standard CRUD operation contracts from it.
 
 ### Step 3: scaffold the UI
 
@@ -498,7 +498,7 @@ It will be the block added for the `w/[workspaceSlug]/admin/contacts/[contactId]
 
 Depending on what outlets already exist in the app, that block may try to place `Addresses` in the shell menu or in the contact subpages outlet. For this example, remove it either way and keep navigation manual from the contact view.
 
-This is an intentional manual cleanup for now:
+This workflow has one intentional manual cleanup:
 
 - keep the routed pages
 - remove the auto menu link
@@ -772,4 +772,4 @@ They become one workflow:
 2. scaffold the server/resource package
 3. scaffold only the UI shape that the feature actually needs
 
-The next chapter is [Advanced CRUDs](/guide/generators/advanced-cruds). Read it as the structural follow-on to this one: this chapter teaches how to generate the CRUD, and the next one teaches how to reason about the files you now own.
+The next chapter is [Advanced CRUDs](/guide/generators/advanced-cruds). Read it as the structural follow-on to this one: this chapter teaches how to generate the CRUD, and the next one teaches how to reason about the generated files the app owns.

--- a/packages/agent-docs/guide/agent/generators/ui-generators.md
+++ b/packages/agent-docs/guide/agent/generators/ui-generators.md
@@ -80,7 +80,7 @@ The important default is this:
 - if JSKIT sees no nearer routed host, the new page gets a normal shell/menu placement
 - if JSKIT does see a nearer routed host, the new page gets linked into that host instead
 
-Open the app and you now have a real `/reports` page plus a real shell link for it.
+Open the app to see a real `/reports` page plus a real shell link for it.
 
 ### Customizing the generated menu link
 
@@ -217,7 +217,7 @@ After the command, the page gains three important pieces:
 - a `ShellOutlet` for the child-page tabs
 - `RouterView`
 
-That means the page can now keep rendering shared content while child routes render underneath it.
+That lets the page keep rendering shared content while child routes render underneath it.
 
 This is the first big distinction in this chapter:
 

--- a/packages/agent-docs/patterns/crud-scaffolding.md
+++ b/packages/agent-docs/patterns/crud-scaffolding.md
@@ -19,7 +19,7 @@ Rules:
 - For a CRUD-backed entity, start with `jskit generate crud-server-generator scaffold ...`.
 - Unless the table is already owned by a JSKIT baseline package or is an explicit narrow exception recorded in `.jskit/table-ownership.json`, every persisted app-owned table must go through that server CRUD step first.
 - That server scaffold is the crucial first step even if no CRUD UI will be created yet.
-- If the table should be CRUD-owned now but should not expose public CRUD HTTP routes yet, scaffold it with `jskit generate crud-server-generator scaffold ... --internal` instead of dropping to direct knex or a hand-built pseudo-repository.
+- If the table should already be CRUD-owned but should not expose public CRUD HTTP routes yet, scaffold it with `jskit generate crud-server-generator scaffold ... --internal` instead of dropping to direct knex or a hand-built pseudo-repository.
 - Create the real table directly in the database before scaffolding. `crud-server-generator` reads the live table shape.
 - If `crud-server-generator` is going to own the CRUD, do not hand-write a separate CRUD migration for that table. The generator installs and manages the CRUD migration scaffold itself.
 - Do not scaffold CRUD UI, hand-build CRUD routes, or hand-build CRUD endpoints before the server CRUD package and shared resource file exist.

--- a/packages/agent-docs/reference/autogen/tooling/jskit-cli.md
+++ b/packages/agent-docs/reference/autogen/tooling/jskit-cli.md
@@ -460,10 +460,9 @@ Local functions
 
 ### `src/server/commandHandlers/mobile.js`
 Exports
-- `createMobileCommands(ctx = {}, { commandAdd } = {})`
+- `createMobileCommands(ctx = {})`
 Local functions
 - `collectManagedMobileFileDriftIssues({ ctx, appRoot, issues = [] } = {})`
-- `collectMissingInstalledDependencyNames(ctx, appRoot = "", packageJson = {})`
 - `renderAndroidMobileCommandList(lines, color)`
 - `renderMobileHelp(stream, definition = null, platform = "")`
 - `isValidHttpOrHttpsUrl(value = "")`
@@ -476,17 +475,19 @@ Local functions
 - `resolveAndroidDeviceTarget({ ctx, appRoot, explicitTarget = "", commandLabel = "this mobile command" } = {})`
 - `resolveInstalledMobileConfigForCommand({ appRoot, createCliError } = {})`
 - `runLocalBinary(binaryName, args = [], { appRoot, cwd = appRoot, env = {}, stderr, stdout, pathModule, createCliError, dryRun = false } = {})`
-- `runMobileAppInstall({ ctx, appRoot, stdout, stderr, dryRun = false, devlinks = false } = {})`
-- `refreshManagedMobileFiles({ ctx, commandAdd, appRoot, options = {}, stdout, stderr } = {})`
-- `runMobileSyncAndroidCommand({ ctx, commandAdd, appRoot, options = {}, stdout, stderr })`
-- `runMobileRunAndroidCommand({ ctx, commandAdd, appRoot, options = {}, stdout, stderr })`
+- `hasPackageDependency(packageJson = {}, packageId = "")`
+- `readJsonFileForMobileCommand(filePath = "", label = "", createCliError)`
+- `assertMobileRuntimePackageInstalled({ ctx, appRoot } = {})`
+- `refreshManagedMobileFiles({ ctx, appRoot, options = {}, stdout } = {})`
+- `runMobileSyncAndroidCommand({ ctx, appRoot, options = {}, stdout, stderr })`
+- `runMobileRunAndroidCommand({ ctx, appRoot, options = {}, stdout, stderr })`
 - `runCapRunAndroidCommand({ ctx, appRoot, pathModule, target = "", stdout, stderr, dryRun = false } = {})`
-- `runMobileBuildAndroidCommand({ ctx, commandAdd, appRoot, options = {}, stdout, stderr })`
+- `runMobileBuildAndroidCommand({ ctx, appRoot, options = {}, stdout, stderr })`
 - `runMobileDoctorCommand({ ctx, appRoot, stdout })`
 - `runMobileDevicesAndroidCommand({ ctx, appRoot, stdout })`
 - `runMobileTunnelAndroidCommand({ ctx, appRoot, options = {}, stdout })`
 - `runMobileRestartAndroidCommand({ ctx, appRoot, options = {}, stdout })`
-- `runMobileDevAndroidCommand({ ctx, commandAdd, appRoot, options = {}, stdout, stderr })`
+- `runMobileDevAndroidCommand({ ctx, appRoot, options = {}, stdout, stderr })`
 
 ### `src/server/commandHandlers/mobileCommandCatalog.js`
 Exports

--- a/packages/agent-docs/site/guide/app-extras/mobile-capacitor.md
+++ b/packages/agent-docs/site/guide/app-extras/mobile-capacitor.md
@@ -34,6 +34,9 @@ npx jskit mobile android doctor
 ```
 
 If doctor passes, the app is ready for the normal mobile workflow.
+The `jskit mobile android ...` commands expect the mobile runtime package to be
+installed in `package.json` and recorded in `.jskit/lock.json`; they do not
+install `@jskit-ai/mobile-capacitor` for you.
 
 ## What you need on your machine
 
@@ -124,6 +127,10 @@ This:
 - builds the JSKIT web app into `dist/`
 - runs `cap sync android`
 
+The refresh step requires the managed files from the package install to exist.
+If `capacitor.config.json` or `.jskit/mobile-capacitor.md` is missing, install
+the package again with `npx jskit add package @jskit-ai/mobile-capacitor`.
+
 ### Create the local tunnel
 
 ```bash
@@ -175,7 +182,7 @@ Use it when you want a clean signed-out state.
 
 ## The command set
 
-These are the mobile commands the package adds:
+These are the CLI mobile commands used by the package workflow:
 
 - `jskit mobile android devices`
   - list visible Android devices
@@ -286,8 +293,8 @@ The package manages:
   - `MainActivity.java` or `MainActivity.kt`
 - the managed deep-link block in `AndroidManifest.xml`
 
-`jskit mobile android sync` is expected to refresh those files from
-`config.mobile`.
+After the package is installed, `jskit mobile android sync` refreshes those
+managed files from `config.mobile`.
 
 ### Why the tunnel exists
 

--- a/packages/agent-docs/site/guide/app-setup/console.md
+++ b/packages/agent-docs/site/guide/app-setup/console.md
@@ -59,7 +59,7 @@ npm run db:migrate
 - `console-core` owns the console schema, owner check, bootstrap flag, and API routes
 - `console-web` owns the console surface scaffold, settings shell, and menu placement
 
-So the console is a real vertical slice now. The users packages no longer know about it.
+The console is a real vertical slice. The users packages do not own it.
 
 ## What the console is for
 
@@ -104,7 +104,7 @@ Then sign in.
 
 Once you are authenticated, two things matter:
 
-- the app now knows who you are as a persistent JSKIT user
+- the app knows who you are as a persistent JSKIT user
 - the console bootstrap logic can determine whether you are the console owner
 
 Open:

--- a/packages/agent-docs/site/guide/app-setup/database-layer.md
+++ b/packages/agent-docs/site/guide/app-setup/database-layer.md
@@ -130,7 +130,7 @@ If you run the status command immediately after this chapter:
 npm run db:migrate:status
 ```
 
-you should still see that there are no completed migrations and no pending migration files yet. The runtime and the Knex wiring exist now, but no package has added real schema files until the next chapter.
+you should still see that there are no completed migrations and no pending migration files yet. The runtime and the Knex wiring exist at this point, but no package has added real schema files until the next chapter.
 
 ### A place for future schema files
 
@@ -145,7 +145,7 @@ That is the key idea of this chapter:
 
 This chapter is the right place to make one distinction very explicit.
 
-There are now two different migration-related layers in the app:
+The app has two different migration-related layers:
 
 - JSKIT-managed migration files on disk
 - Knex actually applying those files to the database
@@ -228,7 +228,7 @@ import {
 } from "@jskit-ai/database-runtime/shared";
 ```
 
-This is worth calling out now because the database layer is not only "Knex plus migrations".
+This is worth calling out here because the database layer is not only "Knex plus migrations".
 
 It also gives your later repositories and services a standard persistence toolbox so every package does not have to solve the same problems differently. The main point is consistency:
 
@@ -685,7 +685,7 @@ It is not the main runtime API that your app code imports during a request. It i
 npm run db:migrate
 ```
 
-So there are really two separate database entry points now:
+So there are really two separate database entry points:
 
 - `knexfile.js` for migration commands
 - the JSKIT server provider runtime for application code
@@ -752,7 +752,7 @@ At first glance it can feel strange that the database layer is installed but the
 
 The reason is simple:
 
-- the runtime is now available
+- the runtime is available
 - but almost no installed package is using it yet
 
 Right now:
@@ -796,7 +796,7 @@ So the auth layer keeps behaving the same way it did before:
 - JSKIT still mirrors just enough profile data locally
 - that JSKIT-side mirror is still not persistent yet
 
-The database runtime is now ready, but the users layer that will actually use it has not been installed yet.
+The database runtime is ready, but the users layer that will actually use it has not been installed yet.
 
 ### Why the empty `migrations/` directory is important
 
@@ -828,5 +828,5 @@ But just as importantly, this chapter also defined what has **not** changed yet:
 So the right mental model at the end of this chapter is:
 
 - Supabase already handles real authentication
-- MySQL is now wired up and ready
+- MySQL is wired up and ready
 - the persistent JSKIT-side user model arrives in the next chapter

--- a/packages/agent-docs/site/guide/app-setup/initial-scaffolding.md
+++ b/packages/agent-docs/site/guide/app-setup/initial-scaffolding.md
@@ -12,7 +12,7 @@ npm install
 
 The first command creates a new folder called `exampleapp` and fills it with JSKIT's base shell template. The `exampleapp` name is used in a few template replacements, such as the package name and the browser title. The `--tenancy-mode none` flag tells JSKIT to start with the smallest routing model. In this mode, the app is not workspace-aware (more of this later in the guide, when multihoming is introduced). That keeps the first scaffold easier to read because there is no workspace slug handling yet.
 
-If you are working with an AI agent and want the agent to drive the initial JSKIT setup conversation, there is now a dedicated seed path:
+If you are working with an AI agent and want the agent to drive the initial JSKIT setup conversation, use the dedicated seed path:
 
 ```bash
 npx @jskit-ai/create-app exampleapp --template ai-seed

--- a/packages/agent-docs/site/guide/app-setup/working-with-the-jskit-cli.md
+++ b/packages/agent-docs/site/guide/app-setup/working-with-the-jskit-cli.md
@@ -518,7 +518,7 @@ npx jskit add package shell-web
 npm install
 ```
 
-`jskit add` changes the app. `npm install` downloads the dependencies that the changed app now requires.
+`jskit add` changes the app. `npm install` downloads the dependencies that the changed app requires.
 
 If the app is being tested against a local JSKIT checkout with linked packages, run the local-link wrapper again after every `npm install`:
 
@@ -719,7 +719,7 @@ That is a different job from:
 
 Those commands can all pass while JSKIT-managed state is still inconsistent. `doctor` is the command that checks that JSKIT's own view of the app still makes sense.
 
-That is exactly why the starter scaffold now routes `npm run verify` through `jskit app verify`.
+That is exactly why the starter scaffold routes `npm run verify` through `jskit app verify`.
 
 It belongs there because JSKIT apps are not only source trees. They also have:
 
@@ -751,7 +751,7 @@ Good times to run it manually include:
 
 One important nuance: `doctor` is checking for broken JSKIT ownership and visibility, not trying to stop you from editing app-owned files. For example, a managed file that still exists but whose contents changed is normally fine. The problem is when JSKIT expects a managed file to exist and it is gone, or when the installed package state no longer resolves cleanly.
 
-There is one intentional exception now for user-facing UI work.
+There is one intentional exception for user-facing UI work.
 
 If the current git working tree has changed UI files under the app's normal UI paths, `doctor` expects a matching `.jskit/verification/ui.json` receipt. The intended way to create that receipt is:
 
@@ -981,7 +981,7 @@ Good fits include:
 - a custom integration package that talks to one external API
 - app-specific auth or policy behavior
 - a local runtime package that owns both client and server behavior for one feature area
-- a package that starts small now but may later grow providers, shared helpers, and routes
+- a package that starts small but may later grow providers, shared helpers, and routes
 
 Use a generator when the problem is already understood well enough that JSKIT can scaffold the feature shape for you.
 

--- a/packages/agent-docs/site/guide/generators/crud-generators.md
+++ b/packages/agent-docs/site/guide/generators/crud-generators.md
@@ -260,7 +260,7 @@ npx jskit generate crud-server-generator scaffold \
 
 This creates an app-local package under `packages/contacts/`.
 
-If the table should be CRUD-owned now but should **not** expose public HTTP CRUD routes yet, add:
+If the table should already be CRUD-owned but should **not** expose public HTTP CRUD routes yet, add:
 
 ```bash
 --internal
@@ -320,7 +320,7 @@ npm run devlinks
 
 The same rule applies after later server scaffolds such as `addresses` and `comments`. The UI generator can still read the generated resource file directly, but the app runtime needs the local package install boundary to be completed before the CRUD can boot normally.
 
-For standard CRUDs, that file is now intentionally compact. It uses `defineCrudResource(...)` from `@jskit-ai/resource-crud-core`, authors the canonical `schema` / `searchSchema` / `defaultSort` / `autofilter` shape once, and lets JSKIT derive the standard CRUD operation contracts from it.
+For standard CRUDs, that file is intentionally compact. It uses `defineCrudResource(...)` from `@jskit-ai/resource-crud-core`, authors the canonical `schema` / `searchSchema` / `defaultSort` / `autofilter` shape once, and lets JSKIT derive the standard CRUD operation contracts from it.
 
 ### Step 3: scaffold the UI
 
@@ -496,7 +496,7 @@ It will be the block added for the `w/[workspaceSlug]/admin/contacts/[contactId]
 
 Depending on what outlets already exist in the app, that block may try to place `Addresses` in the shell menu or in the contact subpages outlet. For this example, remove it either way and keep navigation manual from the contact view.
 
-This is an intentional manual cleanup for now:
+This workflow has one intentional manual cleanup:
 
 - keep the routed pages
 - remove the auto menu link
@@ -770,4 +770,4 @@ They become one workflow:
 2. scaffold the server/resource package
 3. scaffold only the UI shape that the feature actually needs
 
-The next chapter is [Advanced CRUDs](/guide/generators/advanced-cruds). Read it as the structural follow-on to this one: this chapter teaches how to generate the CRUD, and the next one teaches how to reason about the files you now own.
+The next chapter is [Advanced CRUDs](/guide/generators/advanced-cruds). Read it as the structural follow-on to this one: this chapter teaches how to generate the CRUD, and the next one teaches how to reason about the generated files the app owns.

--- a/packages/agent-docs/site/guide/generators/ui-generators.md
+++ b/packages/agent-docs/site/guide/generators/ui-generators.md
@@ -95,7 +95,7 @@ The important default is this:
 - if JSKIT sees no nearer routed host, the new page gets a normal shell/menu placement
 - if JSKIT does see a nearer routed host, the new page gets linked into that host instead
 
-Open the app and you now have a real `/reports` page plus a real shell link for it.
+Open the app to see a real `/reports` page plus a real shell link for it.
 
 ### Customizing the generated menu link
 
@@ -232,7 +232,7 @@ After the command, the page gains three important pieces:
 - a `ShellOutlet` for the child-page tabs
 - `RouterView`
 
-That means the page can now keep rendering shared content while child routes render underneath it.
+That lets the page keep rendering shared content while child routes render underneath it.
 
 This is the first big distinction in this chapter:
 

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -1954,7 +1954,7 @@
               "workflow",
               "none"
             ],
-            "defaultValue": "primary",
+            "defaultValue": "",
             "promptLabel": "Navigation role",
             "promptHint": "Product navigation role for generated links. When omitted, dynamic detail and workflow routes create no nav link; primary uses normal inference, secondary maps to shell.secondary-nav, utility maps to shell.global-actions, and detail/workflow/none force no nav link."
           },
@@ -2306,7 +2306,7 @@
               "file": "src/placement.js",
               "position": "bottom",
               "skipIfContains": "__JSKIT_UI_MENU_MARKER__",
-              "value": "\n// __JSKIT_UI_MENU_MARKER__\n{\n  addPlacement({\n    id: \"__JSKIT_UI_MENU_PLACEMENT_ID__\",\n    target: \"__JSKIT_UI_MENU_PLACEMENT_TARGET__\",\n__JSKIT_UI_MENU_OWNER_LINE__    kind: \"link\",\n    surfaces: [\"__JSKIT_UI_SURFACE_ID__\"],\n    order: 155,\n    props: {\n      label: \"__JSKIT_UI_MENU_LABEL__\",\n      icon: \"__JSKIT_UI_MENU_ICON__\",\n      surface: \"__JSKIT_UI_SURFACE_ID__\",\n      scopedSuffix: \"__JSKIT_UI_MENU_WORKSPACE_SUFFIX__\",\n      unscopedSuffix: \"__JSKIT_UI_MENU_NON_WORKSPACE_SUFFIX__\",\n__JSKIT_UI_MENU_TO_PROP_LINE__    },\n__JSKIT_UI_MENU_WHEN_LINE__  });\n}\n",
+              "value": "__JSKIT_UI_MENU_APPEND_BLOCK__",
               "reason": "Append generated CRUD list-page placement.",
               "category": "crud-ui-generator",
               "id": "crud-ui-placement-menu",
@@ -2315,21 +2315,9 @@
                 "export": "buildUiTemplateContext"
               },
               "when": {
-                "all": [
-                  {
-                    "option": "operations",
-                    "in": [
-                      "list"
-                    ]
-                  },
-                  {
-                    "option": "navigation-role",
-                    "notIn": [
-                      "detail",
-                      "workflow",
-                      "none"
-                    ]
-                  }
+                "option": "operations",
+                "in": [
+                  "list"
                 ]
               }
             }
@@ -4508,7 +4496,7 @@
               "workflow",
               "none"
             ],
-            "defaultValue": "primary",
+            "defaultValue": "",
             "promptLabel": "Navigation role",
             "promptHint": "Product navigation role for generated links. When omitted, dynamic detail and workflow routes create no nav link; primary uses normal inference, secondary maps to shell.secondary-nav, utility maps to shell.global-actions, and detail/workflow/none force no nav link."
           },

--- a/tooling/jskit-cli/src/server/commandHandlers/mobile.js
+++ b/tooling/jskit-cli/src/server/commandHandlers/mobile.js
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { spawn } from "node:child_process";
-import { readFile } from "node:fs/promises";
+import { readFile, writeFile } from "node:fs/promises";
 import {
   createColorFormatter,
   writeWrappedLines
@@ -23,6 +23,10 @@ import {
 } from "./mobileShellSupport.js";
 const CAPACITOR_RUNTIME_PACKAGE_ID = "@jskit-ai/mobile-capacitor";
 const MOBILE_NOTES_RELATIVE_PATH = path.join(".jskit", "mobile-capacitor.md");
+const MANAGED_MOBILE_FILE_RELATIVE_PATHS = Object.freeze([
+  "capacitor.config.json",
+  MOBILE_NOTES_RELATIVE_PATH
+]);
 
 async function collectManagedMobileFileDriftIssues({
   ctx,
@@ -34,12 +38,7 @@ async function collectManagedMobileFileDriftIssues({
     path: pathModule,
     normalizeRelativePath
   } = ctx;
-  const managedRelativePaths = [
-    "capacitor.config.json",
-    MOBILE_NOTES_RELATIVE_PATH
-  ];
-
-  for (const relativePath of managedRelativePaths) {
+  for (const relativePath of MANAGED_MOBILE_FILE_RELATIVE_PATHS) {
     const absolutePath = pathModule.join(appRoot, relativePath);
     if (!(await fileExists(absolutePath))) {
       continue;
@@ -64,46 +63,6 @@ async function collectManagedMobileFileDriftIssues({
       );
     }
   }
-}
-
-async function collectMissingInstalledDependencyNames(ctx, appRoot = "", packageJson = {}) {
-  const {
-    fileExists,
-    path: pathModule
-  } = ctx;
-  const sections = [
-    packageJson?.dependencies,
-    packageJson?.devDependencies,
-    packageJson?.optionalDependencies
-  ];
-  const missing = [];
-  const seen = new Set();
-
-  for (const section of sections) {
-    if (!section || typeof section !== "object" || Array.isArray(section)) {
-      continue;
-    }
-
-    for (const packageName of Object.keys(section).sort((left, right) => left.localeCompare(right))) {
-      const normalizedPackageName = String(packageName || "").trim();
-      if (!normalizedPackageName || seen.has(normalizedPackageName)) {
-        continue;
-      }
-      seen.add(normalizedPackageName);
-
-      const packageJsonPath = pathModule.join(
-        appRoot,
-        "node_modules",
-        ...normalizedPackageName.split("/"),
-        "package.json"
-      );
-      if (!(await fileExists(packageJsonPath))) {
-        missing.push(normalizedPackageName);
-      }
-    }
-  }
-
-  return missing;
 }
 
 function renderAndroidMobileCommandList(lines, color) {
@@ -429,9 +388,13 @@ async function runLocalBinary(binaryName, args = [], {
 
     child.on("error", (error) => {
       if (error?.code === "ENOENT") {
+        const installHint =
+          binaryName === "cap"
+            ? ` Run npm install after adding ${CAPACITOR_RUNTIME_PACKAGE_ID}, then rerun this command.`
+            : "";
         reject(
           createCliError(
-            `Could not find local "${binaryName}" in node_modules/.bin. Re-run jskit add package @jskit-ai/mobile-capacitor after npm install succeeds.`
+            `Could not find local "${binaryName}" in node_modules/.bin.${installHint}`
           )
         );
         return;
@@ -451,100 +414,93 @@ async function runLocalBinary(binaryName, args = [], {
   });
 }
 
-async function runMobileAppInstall({
+function hasPackageDependency(packageJson = {}, packageId = "") {
+  const sections = [
+    packageJson?.dependencies,
+    packageJson?.devDependencies,
+    packageJson?.optionalDependencies
+  ];
+  return sections.some((section) => (
+    section &&
+    typeof section === "object" &&
+    !Array.isArray(section) &&
+    Object.prototype.hasOwnProperty.call(section, packageId)
+  ));
+}
+
+async function readJsonFileForMobileCommand(filePath = "", label = "", createCliError) {
+  try {
+    return JSON.parse(await readFile(filePath, "utf8"));
+  } catch (error) {
+    const message = String(error?.message || error || "unknown error");
+    throw createCliError(`Could not read ${label}: ${message}`);
+  }
+}
+
+async function assertMobileRuntimePackageInstalled({
   ctx,
-  appRoot,
-  stdout,
-  stderr,
-  dryRun = false,
-  devlinks = false
+  appRoot
 } = {}) {
   const {
     path: pathModule,
-    loadAppPackageJson
+    createCliError
   } = ctx;
-  const { packageJson } = await loadAppPackageJson(appRoot);
-  const packageScripts = packageJson?.scripts && typeof packageJson.scripts === "object" ? packageJson.scripts : {};
+  const packageJsonPath = pathModule.join(appRoot, "package.json");
+  const lockPath = pathModule.join(appRoot, ".jskit", "lock.json");
+  const packageJson = await readJsonFileForMobileCommand(packageJsonPath, "package.json", createCliError);
+  const lock = await readJsonFileForMobileCommand(lockPath, ".jskit/lock.json", createCliError);
+  const hasDependency = hasPackageDependency(packageJson, CAPACITOR_RUNTIME_PACKAGE_ID);
+  const hasLockRecord = Boolean(lock?.installedPackages?.[CAPACITOR_RUNTIME_PACKAGE_ID]);
 
-  await runLocalBinary("npm", ["install"], {
-    appRoot,
-    stderr,
-    stdout,
-    pathModule,
-    createCliError: ctx.createCliError,
-    dryRun
-  });
-
-  if (devlinks === true && Object.prototype.hasOwnProperty.call(packageScripts, "devlinks")) {
-    await runLocalBinary("npm", ["run", "--if-present", "devlinks"], {
-      appRoot,
-      stderr,
-      stdout,
-      pathModule,
-      createCliError: ctx.createCliError,
-      dryRun
-    });
+  if (!hasDependency || !hasLockRecord) {
+    throw createCliError(
+      `Mobile Capacitor runtime package is not installed for this app. Run jskit add package ${CAPACITOR_RUNTIME_PACKAGE_ID} first.`
+    );
   }
 }
 
 async function refreshManagedMobileFiles({
   ctx,
-  commandAdd,
   appRoot,
   options = {},
-  stdout,
-  stderr
+  stdout
 } = {}) {
   const {
-    path: pathModule
+    fileExists,
+    path: pathModule,
+    normalizeRelativePath,
+    createCliError
   } = ctx;
-  const packageJsonPath = pathModule.join(appRoot, "package.json");
-  const packageJsonBefore = await readFile(packageJsonPath, "utf8");
-  let capturedStdout = "";
-  await commandAdd({
-    positional: ["package", CAPACITOR_RUNTIME_PACKAGE_ID],
-    options: {
-      ...options,
-      forceReapplyTarget: true,
-      runNpmInstall: false,
-      inlineOptions: {}
-    },
-    cwd: appRoot,
-    io: {
-      stdout: {
-        write(chunk) {
-          capturedStdout += String(chunk || "");
-        }
-      },
-      stderr
+
+  for (const relativePath of MANAGED_MOBILE_FILE_RELATIVE_PATHS) {
+    const absolutePath = pathModule.join(appRoot, relativePath);
+    if (!(await fileExists(absolutePath))) {
+      throw createCliError(
+        `Managed mobile file is missing: ${normalizeRelativePath(appRoot, absolutePath)}. Run jskit add package ${CAPACITOR_RUNTIME_PACKAGE_ID} first.`
+      );
     }
-  });
-  const packageJsonAfter = await readFile(packageJsonPath, "utf8");
-  const parsedPackageJsonAfter = JSON.parse(packageJsonAfter);
-  const missingInstalledDependencies = await collectMissingInstalledDependencyNames(ctx, appRoot, parsedPackageJsonAfter);
 
-  if (!/Touched files \(0\):/u.test(capturedStdout)) {
-    stdout.write(capturedStdout);
-  }
-
-  if (
-    options?.dryRun !== true &&
-    (packageJsonAfter !== packageJsonBefore || missingInstalledDependencies.length > 0)
-  ) {
-    await runMobileAppInstall({
-      ctx,
+    const currentSource = await readFile(absolutePath, "utf8");
+    const nextSource = await renderManagedMobileFile({
       appRoot,
-      stdout,
-      stderr,
-      dryRun: false,
-      devlinks: options?.devlinks === true
+      relativeTargetPath: relativePath
     });
+    if (nextSource === currentSource) {
+      continue;
+    }
+
+    if (options?.dryRun === true) {
+      stdout?.write(`[dry-run] refresh ${normalizeRelativePath(appRoot, absolutePath)}\n`);
+      continue;
+    }
+
+    await writeFile(absolutePath, nextSource, "utf8");
+    stdout?.write(`[mobile] Refreshed ${normalizeRelativePath(appRoot, absolutePath)}.\n`);
   }
 }
 
 async function runMobileSyncAndroidCommand({
   ctx,
-  commandAdd,
   appRoot,
   options = {},
   stdout,
@@ -554,18 +510,19 @@ async function runMobileSyncAndroidCommand({
     path: pathModule
   } = ctx;
 
-  await refreshManagedMobileFiles({
+  await assertMobileRuntimePackageInstalled({
     ctx,
-    commandAdd,
-    appRoot,
-    options,
-    stdout,
-    stderr
+    appRoot
   });
-
   await assertCapacitorShellInstalled({
     ctx,
     appRoot
+  });
+  await refreshManagedMobileFiles({
+    ctx,
+    appRoot,
+    options,
+    stdout
   });
   await ensureAndroidNativeShellIdentity({
     ctx,
@@ -607,7 +564,6 @@ async function runMobileSyncAndroidCommand({
 
 async function runMobileRunAndroidCommand({
   ctx,
-  commandAdd,
   appRoot,
   options = {},
   stdout,
@@ -632,25 +588,25 @@ async function runMobileRunAndroidCommand({
   if (mobileConfig.assetMode === "bundled") {
     await runMobileSyncAndroidCommand({
       ctx,
-      commandAdd,
       appRoot,
       options,
       stdout,
       stderr
     });
   } else {
-    await refreshManagedMobileFiles({
+    await assertMobileRuntimePackageInstalled({
       ctx,
-      commandAdd,
-      appRoot,
-      options,
-      stdout,
-      stderr
+      appRoot
     });
-
     await assertCapacitorShellInstalled({
       ctx,
       appRoot
+    });
+    await refreshManagedMobileFiles({
+      ctx,
+      appRoot,
+      options,
+      stdout
     });
     await ensureAndroidNativeShellIdentity({
       ctx,
@@ -722,7 +678,6 @@ async function runCapRunAndroidCommand({
 
 async function runMobileBuildAndroidCommand({
   ctx,
-  commandAdd,
   appRoot,
   options = {},
   stdout,
@@ -751,7 +706,6 @@ async function runMobileBuildAndroidCommand({
 
   await runMobileSyncAndroidCommand({
     ctx,
-    commandAdd,
     appRoot,
     options,
     stdout,
@@ -1005,7 +959,6 @@ async function runMobileRestartAndroidCommand({
 
 async function runMobileDevAndroidCommand({
   ctx,
-  commandAdd,
   appRoot,
   options = {},
   stdout,
@@ -1024,7 +977,6 @@ async function runMobileDevAndroidCommand({
   stdout.write("[mobile]   npx jskit mobile android sync\n");
   await runMobileSyncAndroidCommand({
     ctx,
-    commandAdd,
     appRoot,
     options,
     stdout,
@@ -1060,15 +1012,11 @@ async function runMobileDevAndroidCommand({
   return 0;
 }
 
-function createMobileCommands(ctx = {}, { commandAdd } = {}) {
+function createMobileCommands(ctx = {}) {
   const {
     createCliError,
     resolveAppRootFromCwd
   } = ctx;
-
-  if (typeof commandAdd !== "function") {
-    throw new TypeError("createMobileCommands requires commandAdd().");
-  }
 
   async function commandMobile({ positional = [], options = {}, cwd = "", stdout, stderr }) {
     const firstToken = String(positional[0] || "").trim();
@@ -1154,7 +1102,6 @@ function createMobileCommands(ctx = {}, { commandAdd } = {}) {
 
       return runMobileDevAndroidCommand({
         ctx,
-        commandAdd,
         appRoot,
         options,
         stdout,
@@ -1203,7 +1150,6 @@ function createMobileCommands(ctx = {}, { commandAdd } = {}) {
 
       return runMobileSyncAndroidCommand({
         ctx,
-        commandAdd,
         appRoot,
         options,
         stdout,
@@ -1220,7 +1166,6 @@ function createMobileCommands(ctx = {}, { commandAdd } = {}) {
 
       return runMobileRunAndroidCommand({
         ctx,
-        commandAdd,
         appRoot,
         options,
         stdout,
@@ -1237,7 +1182,6 @@ function createMobileCommands(ctx = {}, { commandAdd } = {}) {
 
       return runMobileBuildAndroidCommand({
         ctx,
-        commandAdd,
         appRoot,
         options,
         stdout,

--- a/tooling/jskit-cli/test/mobileCommand.test.js
+++ b/tooling/jskit-cli/test/mobileCommand.test.js
@@ -8,7 +8,8 @@ import { withTempDir } from "../../testUtils/tempDir.mjs";
 import {
   buildManagedDeepLinkIntentFilterBlock,
   ensureMobileConfigStub,
-  injectManagedDeepLinkBlock
+  injectManagedDeepLinkBlock,
+  renderManagedMobileFile
 } from "../src/server/commandHandlers/mobileShellSupport.js";
 
 const CLI_PATH = fileURLToPath(new URL("../bin/jskit.js", import.meta.url));
@@ -252,6 +253,7 @@ async function markPackageAsInstalled(appRoot, packageId, version = "0.1.0") {
 }
 
 async function seedInstalledCapacitorShell(appRoot, {
+  markPackage = true,
   appId = "com.example.mobile",
   appName = "Example Mobile",
   androidPackageName = appId,
@@ -266,6 +268,7 @@ async function seedInstalledCapacitorShell(appRoot, {
   const manifestPath = path.join(appRoot, "android", "app", "src", "main", "AndroidManifest.xml");
   const buildGradlePath = path.join(appRoot, "android", "app", "build.gradle");
   const stringsPath = path.join(appRoot, "android", "app", "src", "main", "res", "values", "strings.xml");
+  const notesPath = path.join(appRoot, ".jskit", "mobile-capacitor.md");
   const mainActivityPath = path.join(
     appRoot,
     "android",
@@ -277,6 +280,9 @@ async function seedInstalledCapacitorShell(appRoot, {
     "MainActivity.java"
   );
   const variablesGradlePath = path.join(appRoot, "android", "variables.gradle");
+  if (markPackage === true) {
+    await markPackageAsInstalled(appRoot, "@jskit-ai/mobile-capacitor");
+  }
   await mkdir(path.dirname(manifestPath), { recursive: true });
   const capacitorConfig = {
     appId,
@@ -300,6 +306,15 @@ async function seedInstalledCapacitorShell(appRoot, {
     )}\n`,
     "utf8"
   );
+  await mkdir(path.dirname(notesPath), { recursive: true });
+  let notesSource = "# Mobile Capacitor\n\nThis placeholder test fixture is used when config.mobile is intentionally invalid.\n";
+  try {
+    notesSource = await renderManagedMobileFile({
+      appRoot,
+      relativeTargetPath: ".jskit/mobile-capacitor.md"
+    });
+  } catch {}
+  await writeFile(notesPath, notesSource, "utf8");
   await mkdir(path.dirname(buildGradlePath), { recursive: true });
   await mkdir(path.dirname(stringsPath), { recursive: true });
   await mkdir(path.dirname(mainActivityPath), { recursive: true });
@@ -685,6 +700,7 @@ test("jskit mobile android sync builds the app and syncs the Android shell", asy
 
     await createMobileReadyApp(appRoot);
     await seedInstalledCapacitorShell(appRoot);
+    const packageJsonBefore = await readFile(path.join(appRoot, "package.json"), "utf8");
     await installFakeCommand(
       binDir,
       "npm",
@@ -726,12 +742,10 @@ if (process.argv[2] === "sync" && process.argv[3] === "android") {
       await readFile(path.join(appRoot, "dist", "index.html"), "utf8"),
       "<html></html>\n"
     );
-    const packageJson = JSON.parse(await readFile(path.join(appRoot, "package.json"), "utf8"));
-    assert.equal(packageJson.dependencies["@capacitor/browser"], "^7.0.1");
+    assert.equal(await readFile(path.join(appRoot, "package.json"), "utf8"), packageJsonBefore);
 
     const logLines = (await readFile(logPath, "utf8")).split(/\r?\n/u).filter(Boolean);
     assert.deepEqual(logLines, [
-      "npm install",
       "npm run build",
       "cap sync android"
     ]);
@@ -742,6 +756,47 @@ if (process.argv[2] === "sync" && process.argv[3] === "android") {
     );
     assert.match(manifestSource, /jskit-mobile-capacitor:deep-links:start/);
     assert.match(manifestSource, /android:scheme="examplemobile"/);
+  });
+});
+
+test("jskit mobile android sync fails before command execution when the mobile package was not added", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "app");
+    const binDir = path.join(cwd, "bin");
+    const logPath = path.join(cwd, "commands.log");
+
+    await createMobileReadyApp(appRoot);
+    await seedInstalledCapacitorShell(appRoot, {
+      markPackage: false
+    });
+    await installFakeCommand(
+      binDir,
+      "npm",
+      `#!/usr/bin/env node
+const fs = require("node:fs");
+fs.appendFileSync(process.env.TEST_LOG_PATH, ["npm", ...process.argv.slice(2)].join(" ") + "\\n");
+`
+    );
+    await writeExecutable(
+      path.join(appRoot, "node_modules", ".bin", "cap"),
+      `#!/usr/bin/env node
+const fs = require("node:fs");
+fs.appendFileSync(process.env.TEST_LOG_PATH, ["cap", ...process.argv.slice(2)].join(" ") + "\\n");
+`
+    );
+
+    const result = runCli({
+      cwd: appRoot,
+      args: ["mobile", "android", "sync"],
+      env: buildTestEnv(binDir, logPath)
+    });
+
+    assert.equal(result.status, 1);
+    assert.match(
+      String(result.stderr || ""),
+      /Run jskit add package @jskit-ai\/mobile-capacitor first/u
+    );
+    await assert.rejects(() => readFile(logPath, "utf8"));
   });
 });
 
@@ -1081,7 +1136,6 @@ if (process.argv[2] === "-s" && process.argv[4] === "reverse" && process.argv[5]
     const logLines = (await readFile(logPath, "utf8")).split(/\r?\n/u).filter(Boolean);
     assert.deepEqual(logLines, [
       "adb devices -l",
-      "npm install",
       "npm run build",
       "cap sync android",
       "adb devices -l",
@@ -1164,7 +1218,6 @@ if (process.argv[2] === "-s" && process.argv[4] === "reverse" && process.argv[5]
     const logLines = (await readFile(logPath, "utf8")).split(/\r?\n/u).filter(Boolean);
     assert.deepEqual(logLines, [
       "adb devices -l",
-      "npm install",
       "npm run build",
       "cap sync android",
       "adb devices -l",
@@ -1267,7 +1320,6 @@ if (process.argv[2] === "sync" && process.argv[3] === "android") {
     assert.equal(result.status, 0, String(result.stderr || ""));
     const logLines = (await readFile(logPath, "utf8")).split(/\r?\n/u).filter(Boolean);
     assert.deepEqual(logLines, [
-      "npm install",
       "npm run build",
       "cap sync android",
       "cap run android"
@@ -1320,7 +1372,6 @@ fs.appendFileSync(process.env.TEST_LOG_PATH, ["cap", ...process.argv.slice(2)].j
     assert.equal(result.status, 0, String(result.stderr || ""));
     const logLines = (await readFile(logPath, "utf8")).split(/\r?\n/u).filter(Boolean);
     assert.deepEqual(logLines, [
-      "npm install",
       "cap sync android",
       "cap run android"
     ]);
@@ -1378,7 +1429,6 @@ if (process.argv[2] === "sync" && process.argv[3] === "android") {
     assert.equal(result.status, 0, String(result.stderr || ""));
     const logLines = (await readFile(logPath, "utf8")).split(/\r?\n/u).filter(Boolean);
     assert.deepEqual(logLines, [
-      "npm install",
       "npm run build",
       "cap sync android",
       "cap run android --target 8ADX0QUH3"
@@ -1440,7 +1490,6 @@ fs.appendFileSync(process.env.TEST_LOG_PATH, ["cap", ...process.argv.slice(2)].j
     assert.equal(result.status, 0, String(result.stderr || ""));
     const logLines = (await readFile(logPath, "utf8")).split(/\r?\n/u).filter(Boolean);
     assert.deepEqual(logLines, [
-      "npm install",
       "npm run build",
       "cap sync android",
       "gradlew bundleRelease"


### PR DESCRIPTION
Summary:\n- stop mobile android sync/dev/run/build from re-entering package add/reapply\n- require the mobile-capacitor package to already be installed before operational mobile commands run\n- refresh only existing managed mobile/native files during sync and update tests/docs/catalog outputs accordingly\n\nVerification:\n- git diff --check\n- node --test tooling/jskit-cli/test/mobileCommand.test.js\n- npm test --workspace @jskit-ai/jskit-cli\n- npm run verify not run per instruction