### PR TITLE
Refresh JSKIT package metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6617,28 +6617,28 @@
     },
     "packages/agent-docs": {
       "name": "@jskit-ai/agent-docs",
-      "version": "0.1.30",
+      "version": "0.1.31",
       "engines": {
-        "node": "20.x"
+        "node": ">=20 <23"
       }
     },
     "packages/assistant": {
       "name": "@jskit-ai/assistant",
-      "version": "0.1.78",
+      "version": "0.1.79",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.69"
+        "@jskit-ai/kernel": "0.1.70"
       }
     },
     "packages/assistant-core": {
       "name": "@jskit-ai/assistant-core",
-      "version": "0.1.45",
+      "version": "0.1.46",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.69",
-        "@jskit-ai/http-runtime": "0.1.68",
-        "@jskit-ai/kernel": "0.1.69",
-        "@jskit-ai/resource-core": "0.1.14",
-        "@jskit-ai/resource-crud-core": "0.1.14",
-        "@jskit-ai/users-core": "0.1.79",
+        "@jskit-ai/database-runtime": "0.1.70",
+        "@jskit-ai/http-runtime": "0.1.69",
+        "@jskit-ai/kernel": "0.1.70",
+        "@jskit-ai/resource-core": "0.1.15",
+        "@jskit-ai/resource-crud-core": "0.1.15",
+        "@jskit-ai/users-core": "0.1.80",
         "dompurify": "^3.3.3",
         "json-rest-schema": "1.x.x",
         "marked": "^17.0.4",
@@ -6651,15 +6651,15 @@
     },
     "packages/assistant-runtime": {
       "name": "@jskit-ai/assistant-runtime",
-      "version": "0.1.40",
+      "version": "0.1.41",
       "dependencies": {
-        "@jskit-ai/assistant-core": "0.1.45",
-        "@jskit-ai/database-runtime": "0.1.69",
-        "@jskit-ai/http-runtime": "0.1.68",
-        "@jskit-ai/kernel": "0.1.69",
-        "@jskit-ai/shell-web": "0.1.68",
-        "@jskit-ai/users-core": "0.1.79",
-        "@jskit-ai/users-web": "0.1.84",
+        "@jskit-ai/assistant-core": "0.1.46",
+        "@jskit-ai/database-runtime": "0.1.70",
+        "@jskit-ai/http-runtime": "0.1.69",
+        "@jskit-ai/kernel": "0.1.70",
+        "@jskit-ai/shell-web": "0.1.69",
+        "@jskit-ai/users-core": "0.1.80",
+        "@jskit-ai/users-web": "0.1.85",
         "json-rest-schema": "1.x.x"
       },
       "peerDependencies": {
@@ -6670,21 +6670,21 @@
     },
     "packages/auth-core": {
       "name": "@jskit-ai/auth-core",
-      "version": "0.1.68",
+      "version": "0.1.69",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0",
-        "@jskit-ai/kernel": "0.1.69",
+        "@jskit-ai/kernel": "0.1.70",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/auth-provider-supabase-core": {
       "name": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.68",
+      "version": "0.1.69",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.68",
-        "@jskit-ai/kernel": "0.1.69",
+        "@jskit-ai/auth-core": "0.1.69",
+        "@jskit-ai/kernel": "0.1.70",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0",
         "json-rest-schema": "1.x.x",
@@ -6693,12 +6693,12 @@
     },
     "packages/auth-web": {
       "name": "@jskit-ai/auth-web",
-      "version": "0.1.70",
+      "version": "0.1.71",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.68",
-        "@jskit-ai/http-runtime": "0.1.68",
-        "@jskit-ai/kernel": "0.1.69",
-        "@jskit-ai/shell-web": "0.1.68",
+        "@jskit-ai/auth-core": "0.1.69",
+        "@jskit-ai/http-runtime": "0.1.69",
+        "@jskit-ai/kernel": "0.1.70",
+        "@jskit-ai/shell-web": "0.1.69",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -6711,38 +6711,38 @@
     },
     "packages/console-core": {
       "name": "@jskit-ai/console-core",
-      "version": "0.1.32",
+      "version": "0.1.33",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.68",
-        "@jskit-ai/database-runtime": "0.1.69",
-        "@jskit-ai/http-runtime": "0.1.68",
-        "@jskit-ai/kernel": "0.1.69",
-        "@jskit-ai/resource-crud-core": "0.1.14",
-        "@jskit-ai/users-core": "0.1.79",
+        "@jskit-ai/auth-core": "0.1.69",
+        "@jskit-ai/database-runtime": "0.1.70",
+        "@jskit-ai/http-runtime": "0.1.69",
+        "@jskit-ai/kernel": "0.1.70",
+        "@jskit-ai/resource-crud-core": "0.1.15",
+        "@jskit-ai/users-core": "0.1.80",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/console-web": {
       "name": "@jskit-ai/console-web",
-      "version": "0.1.37",
+      "version": "0.1.38",
       "dependencies": {
-        "@jskit-ai/auth-web": "0.1.70",
-        "@jskit-ai/console-core": "0.1.32",
-        "@jskit-ai/shell-web": "0.1.68"
+        "@jskit-ai/auth-web": "0.1.71",
+        "@jskit-ai/console-core": "0.1.33",
+        "@jskit-ai/shell-web": "0.1.69"
       }
     },
     "packages/crud-core": {
       "name": "@jskit-ai/crud-core",
-      "version": "0.1.77",
+      "version": "0.1.78",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.69",
-        "@jskit-ai/http-runtime": "0.1.68",
-        "@jskit-ai/kernel": "0.1.69",
-        "@jskit-ai/realtime": "0.1.68",
-        "@jskit-ai/resource-crud-core": "0.1.14",
-        "@jskit-ai/shell-web": "0.1.68",
-        "@jskit-ai/users-core": "0.1.79",
-        "@jskit-ai/users-web": "0.1.84",
+        "@jskit-ai/database-runtime": "0.1.70",
+        "@jskit-ai/http-runtime": "0.1.69",
+        "@jskit-ai/kernel": "0.1.70",
+        "@jskit-ai/realtime": "0.1.69",
+        "@jskit-ai/resource-crud-core": "0.1.15",
+        "@jskit-ai/shell-web": "0.1.69",
+        "@jskit-ai/users-core": "0.1.80",
+        "@jskit-ai/users-web": "0.1.85",
         "json-rest-schema": "1.x.x"
       },
       "peerDependencies": {
@@ -6753,98 +6753,98 @@
     },
     "packages/crud-server-generator": {
       "name": "@jskit-ai/crud-server-generator",
-      "version": "0.1.77",
+      "version": "0.1.78",
       "dependencies": {
         "@babel/parser": "^7.29.2",
-        "@jskit-ai/crud-core": "0.1.77",
-        "@jskit-ai/database-runtime": "0.1.69",
-        "@jskit-ai/http-runtime": "0.1.68",
-        "@jskit-ai/json-rest-api-core": "0.1.14",
-        "@jskit-ai/kernel": "0.1.69",
-        "@jskit-ai/resource-crud-core": "0.1.14",
+        "@jskit-ai/crud-core": "0.1.78",
+        "@jskit-ai/database-runtime": "0.1.70",
+        "@jskit-ai/http-runtime": "0.1.69",
+        "@jskit-ai/json-rest-api-core": "0.1.15",
+        "@jskit-ai/kernel": "0.1.70",
+        "@jskit-ai/resource-crud-core": "0.1.15",
         "recast": "^0.23.11"
       }
     },
     "packages/crud-ui-generator": {
       "name": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.52",
+      "version": "0.1.53",
       "dependencies": {
-        "@jskit-ai/crud-core": "0.1.77",
-        "@jskit-ai/kernel": "0.1.69",
-        "@jskit-ai/resource-crud-core": "0.1.14"
+        "@jskit-ai/crud-core": "0.1.78",
+        "@jskit-ai/kernel": "0.1.70",
+        "@jskit-ai/resource-crud-core": "0.1.15"
       }
     },
     "packages/database-runtime": {
       "name": "@jskit-ai/database-runtime",
-      "version": "0.1.69",
+      "version": "0.1.70",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.69"
+        "@jskit-ai/kernel": "0.1.70"
       }
     },
     "packages/database-runtime-mysql": {
       "name": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.68",
+      "version": "0.1.69",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.69",
-        "@jskit-ai/kernel": "0.1.69"
+        "@jskit-ai/database-runtime": "0.1.70",
+        "@jskit-ai/kernel": "0.1.70"
       }
     },
     "packages/database-runtime-postgres": {
       "name": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.68",
+      "version": "0.1.69",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.69"
+        "@jskit-ai/database-runtime": "0.1.70"
       }
     },
     "packages/feature-server-generator": {
       "name": "@jskit-ai/feature-server-generator",
-      "version": "0.1.11"
+      "version": "0.1.12"
     },
     "packages/google-rewarded-core": {
       "name": "@jskit-ai/google-rewarded-core",
-      "version": "0.1.6"
+      "version": "0.1.7"
     },
     "packages/google-rewarded-web": {
       "name": "@jskit-ai/google-rewarded-web",
-      "version": "0.1.6"
+      "version": "0.1.7"
     },
     "packages/http-runtime": {
       "name": "@jskit-ai/http-runtime",
-      "version": "0.1.68",
+      "version": "0.1.69",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.69",
+        "@jskit-ai/kernel": "0.1.70",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/json-rest-api-core": {
       "name": "@jskit-ai/json-rest-api-core",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.69",
+        "@jskit-ai/kernel": "0.1.70",
         "hooked-api": "1.x.x",
         "json-rest-api": "1.x.x"
       }
     },
     "packages/kernel": {
       "name": "@jskit-ai/kernel",
-      "version": "0.1.69",
+      "version": "0.1.70",
       "dependencies": {
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/mobile-capacitor": {
       "name": "@jskit-ai/mobile-capacitor",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "@capacitor/browser": "^7.0.1",
-        "@jskit-ai/kernel": "0.1.69"
+        "@jskit-ai/kernel": "0.1.70"
       }
     },
     "packages/realtime": {
       "name": "@jskit-ai/realtime",
-      "version": "0.1.68",
+      "version": "0.1.69",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.69",
+        "@jskit-ai/kernel": "0.1.70",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",
@@ -6856,24 +6856,24 @@
     },
     "packages/resource-core": {
       "name": "@jskit-ai/resource-core",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.69"
+        "@jskit-ai/kernel": "0.1.70"
       }
     },
     "packages/resource-crud-core": {
       "name": "@jskit-ai/resource-crud-core",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.69",
-        "@jskit-ai/resource-core": "0.1.14"
+        "@jskit-ai/kernel": "0.1.70",
+        "@jskit-ai/resource-core": "0.1.15"
       }
     },
     "packages/shell-web": {
       "name": "@jskit-ai/shell-web",
-      "version": "0.1.68",
+      "version": "0.1.69",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.69",
+        "@jskit-ai/kernel": "0.1.70",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -6885,25 +6885,25 @@
     },
     "packages/storage-runtime": {
       "name": "@jskit-ai/storage-runtime",
-      "version": "0.1.68",
+      "version": "0.1.69",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.69",
+        "@jskit-ai/kernel": "0.1.70",
         "unstorage": "^1.17.3"
       }
     },
     "packages/ui-generator": {
       "name": "@jskit-ai/ui-generator",
-      "version": "0.1.52",
+      "version": "0.1.53",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.69",
-        "@jskit-ai/shell-web": "0.1.68"
+        "@jskit-ai/kernel": "0.1.70",
+        "@jskit-ai/shell-web": "0.1.69"
       }
     },
     "packages/uploads-image-web": {
       "name": "@jskit-ai/uploads-image-web",
-      "version": "0.1.47",
+      "version": "0.1.48",
       "dependencies": {
-        "@jskit-ai/uploads-runtime": "0.1.47",
+        "@jskit-ai/uploads-runtime": "0.1.48",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",
@@ -6916,37 +6916,37 @@
     },
     "packages/uploads-runtime": {
       "name": "@jskit-ai/uploads-runtime",
-      "version": "0.1.47",
+      "version": "0.1.48",
       "dependencies": {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.69"
+        "@jskit-ai/kernel": "0.1.70"
       }
     },
     "packages/users-core": {
       "name": "@jskit-ai/users-core",
-      "version": "0.1.79",
+      "version": "0.1.80",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.68",
-        "@jskit-ai/database-runtime": "0.1.69",
-        "@jskit-ai/http-runtime": "0.1.68",
-        "@jskit-ai/json-rest-api-core": "0.1.14",
-        "@jskit-ai/kernel": "0.1.69",
-        "@jskit-ai/resource-core": "0.1.14",
-        "@jskit-ai/resource-crud-core": "0.1.14",
-        "@jskit-ai/uploads-runtime": "0.1.47",
+        "@jskit-ai/auth-core": "0.1.69",
+        "@jskit-ai/database-runtime": "0.1.70",
+        "@jskit-ai/http-runtime": "0.1.69",
+        "@jskit-ai/json-rest-api-core": "0.1.15",
+        "@jskit-ai/kernel": "0.1.70",
+        "@jskit-ai/resource-core": "0.1.15",
+        "@jskit-ai/resource-crud-core": "0.1.15",
+        "@jskit-ai/uploads-runtime": "0.1.48",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/users-web": {
       "name": "@jskit-ai/users-web",
-      "version": "0.1.84",
+      "version": "0.1.85",
       "dependencies": {
-        "@jskit-ai/http-runtime": "0.1.68",
-        "@jskit-ai/kernel": "0.1.69",
-        "@jskit-ai/realtime": "0.1.68",
-        "@jskit-ai/shell-web": "0.1.68",
-        "@jskit-ai/uploads-image-web": "0.1.47",
-        "@jskit-ai/users-core": "0.1.79",
+        "@jskit-ai/http-runtime": "0.1.69",
+        "@jskit-ai/kernel": "0.1.70",
+        "@jskit-ai/realtime": "0.1.69",
+        "@jskit-ai/shell-web": "0.1.69",
+        "@jskit-ai/uploads-image-web": "0.1.48",
+        "@jskit-ai/users-core": "0.1.80",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -6958,29 +6958,29 @@
     },
     "packages/workspaces-core": {
       "name": "@jskit-ai/workspaces-core",
-      "version": "0.1.45",
+      "version": "0.1.46",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.68",
-        "@jskit-ai/database-runtime": "0.1.69",
-        "@jskit-ai/http-runtime": "0.1.68",
-        "@jskit-ai/json-rest-api-core": "0.1.14",
-        "@jskit-ai/kernel": "0.1.69",
-        "@jskit-ai/resource-core": "0.1.14",
-        "@jskit-ai/resource-crud-core": "0.1.14",
-        "@jskit-ai/users-core": "0.1.79",
+        "@jskit-ai/auth-core": "0.1.69",
+        "@jskit-ai/database-runtime": "0.1.70",
+        "@jskit-ai/http-runtime": "0.1.69",
+        "@jskit-ai/json-rest-api-core": "0.1.15",
+        "@jskit-ai/kernel": "0.1.70",
+        "@jskit-ai/resource-core": "0.1.15",
+        "@jskit-ai/resource-crud-core": "0.1.15",
+        "@jskit-ai/users-core": "0.1.80",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/workspaces-web": {
       "name": "@jskit-ai/workspaces-web",
-      "version": "0.1.45",
+      "version": "0.1.46",
       "dependencies": {
-        "@jskit-ai/http-runtime": "0.1.68",
-        "@jskit-ai/kernel": "0.1.69",
-        "@jskit-ai/shell-web": "0.1.68",
-        "@jskit-ai/users-core": "0.1.79",
-        "@jskit-ai/users-web": "0.1.84",
-        "@jskit-ai/workspaces-core": "0.1.45",
+        "@jskit-ai/http-runtime": "0.1.69",
+        "@jskit-ai/kernel": "0.1.70",
+        "@jskit-ai/shell-web": "0.1.69",
+        "@jskit-ai/users-core": "0.1.80",
+        "@jskit-ai/users-web": "0.1.85",
+        "@jskit-ai/workspaces-core": "0.1.46",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -6992,7 +6992,7 @@
     },
     "tooling/config-eslint": {
       "name": "@jskit-ai/config-eslint",
-      "version": "0.1.68",
+      "version": "0.1.69",
       "dependencies": {
         "@eslint/js": "^9.39.1",
         "eslint-plugin-vue": "^10.5.1",
@@ -7002,7 +7002,7 @@
         "eslint": "^9.39.1"
       },
       "engines": {
-        "node": "20.x"
+        "node": ">=20 <23"
       },
       "peerDependencies": {
         "eslint": "^9.39.1"
@@ -7010,34 +7010,34 @@
     },
     "tooling/create-app": {
       "name": "@jskit-ai/create-app",
-      "version": "0.1.77",
+      "version": "0.1.78",
       "bin": {
         "jskit-create-app": "bin/jskit-create-app.js"
       },
       "engines": {
-        "node": "20.x"
+        "node": ">=20 <23"
       }
     },
     "tooling/jskit-catalog": {
       "name": "@jskit-ai/jskit-catalog",
-      "version": "0.1.77",
+      "version": "0.1.78",
       "engines": {
-        "node": "20.x"
+        "node": ">=20 <23"
       }
     },
     "tooling/jskit-cli": {
       "name": "@jskit-ai/jskit-cli",
-      "version": "0.2.78",
+      "version": "0.2.79",
       "dependencies": {
-        "@jskit-ai/jskit-catalog": "0.1.77",
-        "@jskit-ai/kernel": "0.1.69",
-        "@jskit-ai/shell-web": "0.1.68"
+        "@jskit-ai/jskit-catalog": "0.1.78",
+        "@jskit-ai/kernel": "0.1.70",
+        "@jskit-ai/shell-web": "0.1.69"
       },
       "bin": {
         "jskit": "bin/jskit.js"
       },
       "engines": {
-        "node": "20.x"
+        "node": ">=20 <23"
       }
     },
     "tooling/testUtils": {}

--- a/packages/agent-docs/package.json
+++ b/packages/agent-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/agent-docs",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "description": "Distributed JSKIT agent workflows, guides, and generated reference maps.",
   "type": "module",
   "files": [
@@ -16,7 +16,7 @@
     "test": "node --test"
   },
   "engines": {
-    "node": "20.x"
+    "node": ">=20 <23"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/agent-docs/reference/autogen/packages/users-web.md
+++ b/packages/agent-docs/reference/autogen/packages/users-web.md
@@ -223,7 +223,7 @@ Local functions
 
 ### `src/client/composables/records/useCrudList.js`
 Exports
-- `useCrudList({ resource = null, requestQueryParams = null, parentBinding = null, recordIdParam = "recordId", route = null, ...listOptions } = {})`
+- `useCrudList({ resource = null, requestQueryParams = null, parentBinding = null, recordIdParam = "recordId", route = null, realtime = undefined, ...listOptions } = {})`
 Local functions
 - `resolveRequestQueryParamsInput(requestQueryParams, context = {})`
 - `resolveCrudParentRequestQueryParams({ resource = {}, route = null, recordIdParam = "recordId" } = {})`
@@ -238,7 +238,7 @@ Exports
 
 ### `src/client/composables/records/useView.js`
 Exports
-- `useView({ ownershipFilter = ROUTE_VISIBILITY_WORKSPACE, surfaceId = "", access = "auto", apiSuffix = "", queryKeyFactory = null, viewPermissions = [], readMethod = "GET", readEnabled = true, transport = null, placementSource = "users-web.view", fallbackLoadError = "Unable to load resource.", notFoundStatuses = [404], notFoundMessage = "Record not found.", model, mapLoadedToModel, requestQueryParams = null, recordIdParam = "recordId", routeParams = null, routeRecordId = null, apiUrlTemplate = "", listUrlTemplate = "", editUrlTemplate = "", includeRecordIdInQueryKey = false, realtime = null, adapter = null } = {})`
+- `useView({ ownershipFilter = ROUTE_VISIBILITY_WORKSPACE, surfaceId = "", access = "auto", apiSuffix = "", queryKeyFactory = null, viewPermissions = [], readMethod = "GET", readEnabled = true, transport = null, placementSource = "users-web.view", fallbackLoadError = "Unable to load resource.", notFoundStatuses = [404], notFoundMessage = "Record not found.", model, mapLoadedToModel, requestQueryParams = null, recordIdParam = "recordId", routeParams = null, routeRecordId = null, apiUrlTemplate = "", listUrlTemplate = "", editUrlTemplate = "", includeRecordIdInQueryKey = false, realtime = undefined, adapter = null } = {})`
 
 ### `src/client/composables/runtime/addEditUiRuntime.js`
 Exports
@@ -290,7 +290,7 @@ Exports
 Exports
 - `buildEndpointReadRequestOptions({ method = "GET", query = null, transport = null } = {})`
 - `buildEndpointWriteRequestOptions({ method = "PATCH", body = undefined, options = null, transport = null } = {})`
-- `useEndpointResource({ queryKey, path = "", enabled = true, client = usersWebHttpClient, readMethod = "GET", writeMethod = "PATCH", readQuery = null, transport = null, refreshOnPull = false, queryOptions = null, mutationOptions = null, fallbackLoadError = "Unable to load resource.", fallbackSaveError = "Unable to save resource." } = {})`
+- `useEndpointResource({ queryKey, path = "", enabled = true, client = usersWebHttpClient, readMethod = "GET", writeMethod = "PATCH", readQuery = null, transport = null, refreshOnPull = false, realtime = null, queryOptions = null, mutationOptions = null, fallbackLoadError = "Unable to load resource.", fallbackSaveError = "Unable to save resource." } = {})`
 Local functions
 - `resolveRequestQuery(value = null)`
 
@@ -501,10 +501,12 @@ Local functions
 
 ### `src/client/composables/useRealtimeQueryInvalidation.js`
 Exports
+- `resolveOperationRealtimeOptions({ realtime = undefined, fallbackRealtime = null } = {})`
 - `useRealtimeQueryInvalidation({ event = "", enabled = true, matches = null, queryKey = null, onEvent = null } = {})`
 - `useOperationRealtime({ realtime = null, queryKey = null, enabled = true } = {})`
 Local functions
 - `normalizeRealtimeOptions(value = {})`
+- `hasRealtimeEventConfig(value = {})`
 - `resolveEnabled(value)`
 - `toQueryKeyList(value)`
 

--- a/packages/agent-docs/reference/autogen/tooling/jskit-cli.md
+++ b/packages/agent-docs/reference/autogen/tooling/jskit-cli.md
@@ -209,6 +209,7 @@ Local functions
 Exports
 - `normalizeMutationExtension(value)`
 - `normalizeTemplateContextRecord(value)`
+- `normalizeDependencyMutationRecord(value)`
 - `normalizeFileMutationRecord(value)`
 - `normalizeMutationWhen(value)`
 - `readObjectPath(source, rawPath)`
@@ -234,6 +235,7 @@ Local functions
 - `isWorkspaceCapableTenancyMode(value = "")`
 - `collectInstallWarnings({ packageEntry, appRoot, appPackageJson })`
 - `resolveManagedSourceRecord(packageEntry, existingInstall = {})`
+- `dependencyMutationUsesWhen(entries = [])`
 
 ### `src/server/cliRuntime/packageIntrospection.js`
 Exports
@@ -678,6 +680,7 @@ Exports
 Local functions
 - `resolveGeneratorSubcommandRows(payload = {})`
 - `resolveOwnershipGuidance(payload = {})`
+- `renderDependencyMutationSpec(versionSpec)`
 
 ### `src/server/core/argParser.js`
 Exports

--- a/packages/assistant-core/package.descriptor.mjs
+++ b/packages/assistant-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-core",
-  version: "0.1.45",
+  version: "0.1.46",
   kind: "runtime",
   description: "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
   dependsOn: [
@@ -47,11 +47,11 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/http-runtime": "0.1.68",
-        "@jskit-ai/kernel": "0.1.69",
-        "@jskit-ai/resource-core": "0.1.14",
-        "@jskit-ai/resource-crud-core": "0.1.14",
-        "@jskit-ai/users-core": "0.1.79",
+        "@jskit-ai/http-runtime": "0.1.69",
+        "@jskit-ai/kernel": "0.1.70",
+        "@jskit-ai/resource-core": "0.1.15",
+        "@jskit-ai/resource-crud-core": "0.1.15",
+        "@jskit-ai/users-core": "0.1.80",
         "dompurify": "^3.3.3",
         "json-rest-schema": "1.x.x",
         "marked": "^17.0.4",

--- a/packages/assistant-core/package.json
+++ b/packages/assistant-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-core",
-  "version": "0.1.45",
+  "version": "0.1.46",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,12 +11,12 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.69",
-    "@jskit-ai/http-runtime": "0.1.68",
-    "@jskit-ai/kernel": "0.1.69",
-    "@jskit-ai/resource-crud-core": "0.1.14",
-    "@jskit-ai/resource-core": "0.1.14",
-    "@jskit-ai/users-core": "0.1.79",
+    "@jskit-ai/database-runtime": "0.1.70",
+    "@jskit-ai/http-runtime": "0.1.69",
+    "@jskit-ai/kernel": "0.1.70",
+    "@jskit-ai/resource-crud-core": "0.1.15",
+    "@jskit-ai/resource-core": "0.1.15",
+    "@jskit-ai/users-core": "0.1.80",
     "dompurify": "^3.3.3",
     "json-rest-schema": "1.x.x",
     "marked": "^17.0.4",

--- a/packages/assistant-runtime/package.descriptor.mjs
+++ b/packages/assistant-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-runtime",
-  version: "0.1.40",
+  version: "0.1.41",
   kind: "runtime",
   description: "Shared assistant runtime with per-surface assistant registration.",
   dependsOn: [
@@ -95,13 +95,13 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/assistant-core": "0.1.45",
-        "@jskit-ai/database-runtime": "0.1.69",
-        "@jskit-ai/http-runtime": "0.1.68",
-        "@jskit-ai/kernel": "0.1.69",
-        "@jskit-ai/shell-web": "0.1.68",
-        "@jskit-ai/users-core": "0.1.79",
-        "@jskit-ai/users-web": "0.1.84"
+        "@jskit-ai/assistant-core": "0.1.46",
+        "@jskit-ai/database-runtime": "0.1.70",
+        "@jskit-ai/http-runtime": "0.1.69",
+        "@jskit-ai/kernel": "0.1.70",
+        "@jskit-ai/shell-web": "0.1.69",
+        "@jskit-ai/users-core": "0.1.80",
+        "@jskit-ai/users-web": "0.1.85"
       },
       dev: {}
     },

--- a/packages/assistant-runtime/package.json
+++ b/packages/assistant-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-runtime",
-  "version": "0.1.40",
+  "version": "0.1.41",
   "type": "module",
   "exports": {
     "./client": "./src/client/index.js",
@@ -8,13 +8,13 @@
     "./server/actionIds": "./src/server/actionIds.js"
   },
   "dependencies": {
-    "@jskit-ai/assistant-core": "0.1.45",
-    "@jskit-ai/database-runtime": "0.1.69",
-    "@jskit-ai/http-runtime": "0.1.68",
-    "@jskit-ai/kernel": "0.1.69",
-    "@jskit-ai/shell-web": "0.1.68",
-    "@jskit-ai/users-core": "0.1.79",
-    "@jskit-ai/users-web": "0.1.84",
+    "@jskit-ai/assistant-core": "0.1.46",
+    "@jskit-ai/database-runtime": "0.1.70",
+    "@jskit-ai/http-runtime": "0.1.69",
+    "@jskit-ai/kernel": "0.1.70",
+    "@jskit-ai/shell-web": "0.1.69",
+    "@jskit-ai/users-core": "0.1.80",
+    "@jskit-ai/users-web": "0.1.85",
     "json-rest-schema": "1.x.x"
   },
   "peerDependencies": {

--- a/packages/assistant/package.descriptor.mjs
+++ b/packages/assistant/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant",
-  version: "0.1.78",
+  version: "0.1.79",
   kind: "generator",
   description: "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
   options: {

--- a/packages/assistant/package.json
+++ b/packages/assistant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant",
-  "version": "0.1.78",
+  "version": "0.1.79",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.69"
+    "@jskit-ai/kernel": "0.1.70"
   }
 }

--- a/packages/auth-core/package.descriptor.mjs
+++ b/packages/auth-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-core",
-  "version": "0.1.68",
+  "version": "0.1.69",
   "kind": "runtime",
   "dependsOn": [
     "@jskit-ai/value-app-config-shared"
@@ -69,7 +69,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.69",
+        "@jskit-ai/kernel": "0.1.70",
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0"

--- a/packages/auth-core/package.json
+++ b/packages/auth-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-core",
-  "version": "0.1.68",
+  "version": "0.1.69",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -46,7 +46,7 @@
     "./shared/commands/authSessionReadCommand": "./src/shared/commands/authSessionReadCommand.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.69",
+    "@jskit-ai/kernel": "0.1.70",
     "@fastify/cookie": "^11.0.2",
     "@fastify/csrf-protection": "^7.1.0",
     "@fastify/rate-limit": "^10.3.0",

--- a/packages/auth-provider-supabase-core/package.descriptor.mjs
+++ b/packages/auth-provider-supabase-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.68",
+  "version": "0.1.69",
   "kind": "runtime",
   "options": {
     "auth-supabase-url": {
@@ -83,8 +83,8 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/auth-core": "0.1.68",
-        "@jskit-ai/kernel": "0.1.69",
+        "@jskit-ai/auth-core": "0.1.69",
+        "@jskit-ai/kernel": "0.1.70",
         "dotenv": "^16.4.5",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0"

--- a/packages/auth-provider-supabase-core/package.json
+++ b/packages/auth-provider-supabase-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.68",
+  "version": "0.1.69",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,8 +12,8 @@
     "./client": "./src/client/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.68",
-    "@jskit-ai/kernel": "0.1.69",
+    "@jskit-ai/auth-core": "0.1.69",
+    "@jskit-ai/kernel": "0.1.70",
     "json-rest-schema": "1.x.x",
     "jose": "^6.1.0",
     "@supabase/supabase-js": "^2.57.4",

--- a/packages/auth-web/package.descriptor.mjs
+++ b/packages/auth-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-web",
-  "version": "0.1.70",
+  "version": "0.1.71",
   "kind": "runtime",
   "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
   "dependsOn": [
@@ -247,10 +247,10 @@ export default Object.freeze({
     "dependencies": {
       "runtime": {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/auth-core": "0.1.68",
-        "@jskit-ai/http-runtime": "0.1.68",
-        "@jskit-ai/kernel": "0.1.69",
-        "@jskit-ai/shell-web": "0.1.68"
+        "@jskit-ai/auth-core": "0.1.69",
+        "@jskit-ai/http-runtime": "0.1.69",
+        "@jskit-ai/kernel": "0.1.70",
+        "@jskit-ai/shell-web": "0.1.69"
       },
       "dev": {}
     },

--- a/packages/auth-web/package.json
+++ b/packages/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-web",
-  "version": "0.1.70",
+  "version": "0.1.71",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -18,11 +18,11 @@
     "./client/runtime/useSignOut": "./src/client/runtime/useSignOut.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.68",
+    "@jskit-ai/auth-core": "0.1.69",
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/kernel": "0.1.69",
-    "@jskit-ai/shell-web": "0.1.68",
-    "@jskit-ai/http-runtime": "0.1.68"
+    "@jskit-ai/kernel": "0.1.70",
+    "@jskit-ai/shell-web": "0.1.69",
+    "@jskit-ai/http-runtime": "0.1.69"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/console-core/package.descriptor.mjs
+++ b/packages/console-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-core",
-  version: "0.1.32",
+  version: "0.1.33",
   kind: "runtime",
   description: "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
   dependsOn: [
@@ -85,12 +85,12 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.68",
-        "@jskit-ai/database-runtime": "0.1.69",
-        "@jskit-ai/http-runtime": "0.1.68",
-        "@jskit-ai/kernel": "0.1.69",
-        "@jskit-ai/resource-crud-core": "0.1.14",
-        "@jskit-ai/users-core": "0.1.79"
+        "@jskit-ai/auth-core": "0.1.69",
+        "@jskit-ai/database-runtime": "0.1.70",
+        "@jskit-ai/http-runtime": "0.1.69",
+        "@jskit-ai/kernel": "0.1.70",
+        "@jskit-ai/resource-crud-core": "0.1.15",
+        "@jskit-ai/users-core": "0.1.80"
       },
       dev: {}
     },

--- a/packages/console-core/package.json
+++ b/packages/console-core/package.json
@@ -1,17 +1,17 @@
 {
   "name": "@jskit-ai/console-core",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.68",
-    "@jskit-ai/database-runtime": "0.1.69",
-    "@jskit-ai/http-runtime": "0.1.68",
-    "@jskit-ai/kernel": "0.1.69",
-    "@jskit-ai/resource-crud-core": "0.1.14",
-    "@jskit-ai/users-core": "0.1.79",
+    "@jskit-ai/auth-core": "0.1.69",
+    "@jskit-ai/database-runtime": "0.1.70",
+    "@jskit-ai/http-runtime": "0.1.69",
+    "@jskit-ai/kernel": "0.1.70",
+    "@jskit-ai/resource-crud-core": "0.1.15",
+    "@jskit-ai/users-core": "0.1.80",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/console-web/package.descriptor.mjs
+++ b/packages/console-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-web",
-  version: "0.1.37",
+  version: "0.1.38",
   kind: "runtime",
   description: "Authenticated console surface scaffold and surface policy wiring.",
   dependsOn: [
@@ -103,9 +103,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-web": "0.1.70",
-        "@jskit-ai/console-core": "0.1.32",
-        "@jskit-ai/shell-web": "0.1.68",
+        "@jskit-ai/auth-web": "0.1.71",
+        "@jskit-ai/console-core": "0.1.33",
+        "@jskit-ai/shell-web": "0.1.69",
       },
       dev: {}
     },

--- a/packages/console-web/package.json
+++ b/packages/console-web/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/console-web",
-  "version": "0.1.37",
+  "version": "0.1.38",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-web": "0.1.70",
-    "@jskit-ai/console-core": "0.1.32",
-    "@jskit-ai/shell-web": "0.1.68"
+    "@jskit-ai/auth-web": "0.1.71",
+    "@jskit-ai/console-core": "0.1.33",
+    "@jskit-ai/shell-web": "0.1.69"
   }
 }

--- a/packages/crud-core/package.descriptor.mjs
+++ b/packages/crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-core",
-  version: "0.1.77",
+  version: "0.1.78",
   kind: "runtime",
   description: "Shared CRUD helpers used by CRUD modules.",
   dependsOn: [
@@ -28,7 +28,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/crud-core": "0.1.77"
+        "@jskit-ai/crud-core": "0.1.78"
       },
       dev: {}
     },

--- a/packages/crud-core/package.json
+++ b/packages/crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-core",
-  "version": "0.1.77",
+  "version": "0.1.78",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -27,15 +27,15 @@
     "./server/routeContracts": "./src/server/routeContracts.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.69",
-    "@jskit-ai/http-runtime": "0.1.68",
-    "@jskit-ai/kernel": "0.1.69",
+    "@jskit-ai/database-runtime": "0.1.70",
+    "@jskit-ai/http-runtime": "0.1.69",
+    "@jskit-ai/kernel": "0.1.70",
     "json-rest-schema": "1.x.x",
-    "@jskit-ai/realtime": "0.1.68",
-    "@jskit-ai/resource-crud-core": "0.1.14",
-    "@jskit-ai/shell-web": "0.1.68",
-    "@jskit-ai/users-core": "0.1.79",
-    "@jskit-ai/users-web": "0.1.84"
+    "@jskit-ai/realtime": "0.1.69",
+    "@jskit-ai/resource-crud-core": "0.1.15",
+    "@jskit-ai/shell-web": "0.1.69",
+    "@jskit-ai/users-core": "0.1.80",
+    "@jskit-ai/users-web": "0.1.85"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/crud-server-generator/package.descriptor.mjs
+++ b/packages/crud-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-server-generator",
-  version: "0.1.77",
+  version: "0.1.78",
   kind: "generator",
   description: "CRUD server generator with routes, actions, and persistence scaffolding.",
   options: {
@@ -160,14 +160,14 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.68",
-        "@jskit-ai/crud-core": "0.1.77",
-        "@jskit-ai/database-runtime": "0.1.69",
-        "@jskit-ai/http-runtime": "0.1.68",
-        "@jskit-ai/json-rest-api-core": "0.1.14",
-        "@jskit-ai/kernel": "0.1.69",
-        "@jskit-ai/realtime": "0.1.68",
-        "@jskit-ai/resource-crud-core": "0.1.14",
+        "@jskit-ai/auth-core": "0.1.69",
+        "@jskit-ai/crud-core": "0.1.78",
+        "@jskit-ai/database-runtime": "0.1.70",
+        "@jskit-ai/http-runtime": "0.1.69",
+        "@jskit-ai/json-rest-api-core": "0.1.15",
+        "@jskit-ai/kernel": "0.1.70",
+        "@jskit-ai/realtime": "0.1.69",
+        "@jskit-ai/resource-crud-core": "0.1.15",
         "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}"
       },
       dev: {}

--- a/packages/crud-server-generator/package.json
+++ b/packages/crud-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-server-generator",
-  "version": "0.1.77",
+  "version": "0.1.78",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,12 +13,12 @@
   },
   "dependencies": {
     "@babel/parser": "^7.29.2",
-    "@jskit-ai/crud-core": "0.1.77",
-    "@jskit-ai/database-runtime": "0.1.69",
-    "@jskit-ai/http-runtime": "0.1.68",
-    "@jskit-ai/json-rest-api-core": "0.1.14",
-    "@jskit-ai/kernel": "0.1.69",
-    "@jskit-ai/resource-crud-core": "0.1.14",
+    "@jskit-ai/crud-core": "0.1.78",
+    "@jskit-ai/database-runtime": "0.1.70",
+    "@jskit-ai/http-runtime": "0.1.69",
+    "@jskit-ai/json-rest-api-core": "0.1.15",
+    "@jskit-ai/kernel": "0.1.70",
+    "@jskit-ai/resource-crud-core": "0.1.15",
     "recast": "^0.23.11"
   }
 }

--- a/packages/crud-ui-generator/package.descriptor.mjs
+++ b/packages/crud-ui-generator/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { GENERATED_UI_NAVIGATION_ROLE_OPTION } from "@jskit-ai/kernel/shared/sup
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-ui-generator",
-  version: "0.1.52",
+  version: "0.1.53",
   kind: "generator",
   description: "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
   options: {
@@ -175,7 +175,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.84"
+        "@jskit-ai/users-web": "0.1.85"
       },
       dev: {}
     },

--- a/packages/crud-ui-generator/package.json
+++ b/packages/crud-ui-generator/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@jskit-ai/crud-ui-generator",
-  "version": "0.1.52",
+  "version": "0.1.53",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/crud-core": "0.1.77",
-    "@jskit-ai/kernel": "0.1.69",
-    "@jskit-ai/resource-crud-core": "0.1.14"
+    "@jskit-ai/crud-core": "0.1.78",
+    "@jskit-ai/kernel": "0.1.70",
+    "@jskit-ai/resource-crud-core": "0.1.15"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/database-runtime-mysql/package.descriptor.mjs
+++ b/packages/database-runtime-mysql/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-mysql",
-  version: "0.1.68",
+  version: "0.1.69",
   kind: "runtime",
   options: {
     "db-host": {
@@ -91,7 +91,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.69",
+        "@jskit-ai/database-runtime": "0.1.70",
         "mysql2": "^3.11.2"
       },
       dev: {}

--- a/packages/database-runtime-mysql/package.json
+++ b/packages/database-runtime-mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-mysql",
-  "version": "0.1.68",
+  "version": "0.1.69",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,7 +12,7 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.69",
-    "@jskit-ai/kernel": "0.1.69"
+    "@jskit-ai/database-runtime": "0.1.70",
+    "@jskit-ai/kernel": "0.1.70"
   }
 }

--- a/packages/database-runtime-postgres/package.descriptor.mjs
+++ b/packages/database-runtime-postgres/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-postgres",
-  version: "0.1.68",
+  version: "0.1.69",
   kind: "runtime",
   options: {
     "db-host": {
@@ -91,7 +91,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.69",
+        "@jskit-ai/database-runtime": "0.1.70",
         "pg": "^8.13.1"
       },
       dev: {}

--- a/packages/database-runtime-postgres/package.json
+++ b/packages/database-runtime-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-postgres",
-  "version": "0.1.68",
+  "version": "0.1.69",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,6 +12,6 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.69"
+    "@jskit-ai/database-runtime": "0.1.70"
   }
 }

--- a/packages/database-runtime/package.descriptor.mjs
+++ b/packages/database-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime",
-  version: "0.1.69",
+  version: "0.1.70",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -58,7 +58,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.69",
+        "@jskit-ai/kernel": "0.1.70",
         "dotenv": "^16.4.5",
         "knex": "^3.1.0"
       },

--- a/packages/database-runtime/package.json
+++ b/packages/database-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime",
-  "version": "0.1.69",
+  "version": "0.1.70",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -25,6 +25,6 @@
     "./shared/transactions": "./src/shared/transactions.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.69"
+    "@jskit-ai/kernel": "0.1.70"
   }
 }

--- a/packages/feature-server-generator/package.descriptor.mjs
+++ b/packages/feature-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/feature-server-generator",
-  version: "0.1.11",
+  version: "0.1.12",
   kind: "generator",
   description: "Scaffold substantial non-CRUD server feature packages with provider, actions, service, and optional persistence seams.",
   options: {
@@ -153,10 +153,28 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.69",
-        "@jskit-ai/database-runtime-mysql": "0.1.68",
-        "@jskit-ai/json-rest-api-core": "0.1.14",
-        "@jskit-ai/kernel": "0.1.69",
+        "@jskit-ai/database-runtime": {
+          version: "0.1.69",
+          when: {
+            option: "mode",
+            notEquals: "orchestrator"
+          }
+        },
+        "@jskit-ai/database-runtime-mysql": {
+          version: "0.1.68",
+          when: {
+            option: "mode",
+            notEquals: "orchestrator"
+          }
+        },
+        "@jskit-ai/json-rest-api-core": {
+          version: "0.1.14",
+          when: {
+            option: "mode",
+            equals: "json-rest"
+          }
+        },
+        "@jskit-ai/kernel": "0.1.70",
         "json-rest-schema": "1.x.x",
         "@local/${option:feature-name|kebab}": "file:packages/${option:feature-name|kebab}"
       },

--- a/packages/feature-server-generator/package.json
+++ b/packages/feature-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/feature-server-generator",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "type": "module",
   "scripts": {
     "test": "node --test"

--- a/packages/feature-server-generator/test/packageDescriptor.test.js
+++ b/packages/feature-server-generator/test/packageDescriptor.test.js
@@ -51,3 +51,31 @@ test("feature-server-generator routes mode-specific files through mutation when 
 
   assert.equal(actionIdsTemplate, undefined);
 });
+
+test("feature-server-generator scopes persistence dependencies to persistent modes", () => {
+  const runtimeDependencies = descriptor.mutations?.dependencies?.runtime || {};
+
+  assert.deepEqual(runtimeDependencies["@jskit-ai/json-rest-api-core"], {
+    version: "0.1.14",
+    when: {
+      option: "mode",
+      equals: "json-rest"
+    }
+  });
+  assert.deepEqual(runtimeDependencies["@jskit-ai/database-runtime"], {
+    version: "0.1.69",
+    when: {
+      option: "mode",
+      notEquals: "orchestrator"
+    }
+  });
+  assert.deepEqual(runtimeDependencies["@jskit-ai/database-runtime-mysql"], {
+    version: "0.1.68",
+    when: {
+      option: "mode",
+      notEquals: "orchestrator"
+    }
+  });
+  assert.equal(runtimeDependencies["@jskit-ai/kernel"], "0.1.69");
+  assert.equal(runtimeDependencies["json-rest-schema"], "1.x.x");
+});

--- a/packages/google-rewarded-core/package.descriptor.mjs
+++ b/packages/google-rewarded-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/google-rewarded-core",
-  version: "0.1.6",
+  version: "0.1.7",
   kind: "runtime",
   description: "Google rewarded workflow runtime plus internal CRUD providers for rules, provider configs, watch sessions, and unlock receipts.",
   dependsOn: [
@@ -128,14 +128,14 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.68",
-        "@jskit-ai/crud-core": "0.1.77",
-        "@jskit-ai/database-runtime": "0.1.69",
-        "@jskit-ai/http-runtime": "0.1.68",
-        "@jskit-ai/json-rest-api-core": "0.1.14",
-        "@jskit-ai/kernel": "0.1.69",
-        "@jskit-ai/resource-crud-core": "0.1.14",
-        "@jskit-ai/workspaces-core": "0.1.45"
+        "@jskit-ai/auth-core": "0.1.69",
+        "@jskit-ai/crud-core": "0.1.78",
+        "@jskit-ai/database-runtime": "0.1.70",
+        "@jskit-ai/http-runtime": "0.1.69",
+        "@jskit-ai/json-rest-api-core": "0.1.15",
+        "@jskit-ai/kernel": "0.1.70",
+        "@jskit-ai/resource-crud-core": "0.1.15",
+        "@jskit-ai/workspaces-core": "0.1.46"
       },
       dev: {}
     },

--- a/packages/google-rewarded-core/package.json
+++ b/packages/google-rewarded-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/google-rewarded-core",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/google-rewarded-web/package.descriptor.mjs
+++ b/packages/google-rewarded-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/google-rewarded-web",
-  version: "0.1.6",
+  version: "0.1.7",
   kind: "runtime",
   description: "Google rewarded client runtime with a fullscreen gate host and GPT orchestration.",
   dependsOn: [
@@ -46,10 +46,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/google-rewarded-core": "0.1.6",
-        "@jskit-ai/http-runtime": "0.1.68",
-        "@jskit-ai/kernel": "0.1.69",
-        "@jskit-ai/shell-web": "0.1.68"
+        "@jskit-ai/google-rewarded-core": "0.1.7",
+        "@jskit-ai/http-runtime": "0.1.69",
+        "@jskit-ai/kernel": "0.1.70",
+        "@jskit-ai/shell-web": "0.1.69"
       },
       dev: {}
     },

--- a/packages/google-rewarded-web/package.json
+++ b/packages/google-rewarded-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/google-rewarded-web",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/http-runtime/package.descriptor.mjs
+++ b/packages/http-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/http-runtime",
-  "version": "0.1.68",
+  "version": "0.1.69",
   "kind": "runtime",
   "dependsOn": [],
   "capabilities": {
@@ -67,7 +67,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.69"
+        "@jskit-ai/kernel": "0.1.70"
       },
       "dev": {}
     },

--- a/packages/http-runtime/package.json
+++ b/packages/http-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/http-runtime",
-  "version": "0.1.68",
+  "version": "0.1.69",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -18,7 +18,7 @@
     "./shared/validators/operationValidation": "./src/shared/validators/operationValidation.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.69",
+    "@jskit-ai/kernel": "0.1.70",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/json-rest-api-core/package.descriptor.mjs
+++ b/packages/json-rest-api-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/json-rest-api-core",
-  version: "0.1.14",
+  version: "0.1.15",
   kind: "runtime",
   description: "Shared internal json-rest-api host runtime for JSKIT server packages.",
   dependsOn: [

--- a/packages/json-rest-api-core/package.json
+++ b/packages/json-rest-api-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/json-rest-api-core",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,6 +11,6 @@
   "dependencies": {
     "hooked-api": "1.x.x",
     "json-rest-api": "1.x.x",
-    "@jskit-ai/kernel": "0.1.69"
+    "@jskit-ai/kernel": "0.1.70"
   }
 }

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/kernel",
-  "version": "0.1.69",
+  "version": "0.1.70",
   "type": "module",
   "dependencies": {
     "json-rest-schema": "1.x.x"

--- a/packages/mobile-capacitor/package.descriptor.mjs
+++ b/packages/mobile-capacitor/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/mobile-capacitor",
-  version: "0.1.6",
+  version: "0.1.7",
   kind: "runtime",
   description: "Thin Capacitor client integration for JSKIT mobile-shell launch routing and auth callback completion.",
   dependsOn: [
@@ -62,8 +62,8 @@ export default Object.freeze({
         "@capacitor/app": "^7.1.0",
         "@capacitor/browser": "^7.0.1",
         "@capacitor/core": "^7.4.3",
-        "@jskit-ai/kernel": "0.1.69",
-        "@jskit-ai/shell-web": "0.1.68"
+        "@jskit-ai/kernel": "0.1.70",
+        "@jskit-ai/shell-web": "0.1.69"
       },
       dev: {
         "@capacitor/cli": "^7.4.3"

--- a/packages/mobile-capacitor/package.json
+++ b/packages/mobile-capacitor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/mobile-capacitor",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,6 +12,6 @@
   },
   "dependencies": {
     "@capacitor/browser": "^7.0.1",
-    "@jskit-ai/kernel": "0.1.69"
+    "@jskit-ai/kernel": "0.1.70"
   }
 }

--- a/packages/realtime/package.descriptor.mjs
+++ b/packages/realtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/realtime",
-  version: "0.1.68",
+  version: "0.1.69",
   kind: "runtime",
   description: "Thin, generic realtime runtime wrappers for socket.io server and client.",
   options: {
@@ -95,7 +95,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.69",
+        "@jskit-ai/kernel": "0.1.70",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/realtime",
-  "version": "0.1.68",
+  "version": "0.1.69",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@socket.io/redis-adapter": "^8.3.0",
-    "@jskit-ai/kernel": "0.1.69",
+    "@jskit-ai/kernel": "0.1.70",
     "redis": "^5.8.2",
     "socket.io": "^4.8.3",
     "socket.io-client": "^4.8.3"

--- a/packages/resource-core/package.descriptor.mjs
+++ b/packages/resource-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/resource-core",
-  version: "0.1.14",
+  version: "0.1.15",
   kind: "runtime",
   description: "Generic resource-definition helpers and schema-definition normalization.",
   dependsOn: [
@@ -22,7 +22,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/resource-core": "0.1.14"
+        "@jskit-ai/resource-core": "0.1.15"
       },
       dev: {}
     },

--- a/packages/resource-core/package.json
+++ b/packages/resource-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/resource-core",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./shared/resource": "./src/shared/resource.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.69"
+    "@jskit-ai/kernel": "0.1.70"
   }
 }

--- a/packages/resource-crud-core/package.descriptor.mjs
+++ b/packages/resource-crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/resource-crud-core",
-  version: "0.1.14",
+  version: "0.1.15",
   kind: "runtime",
   description: "CRUD-specific resource-definition helpers and namespace support.",
   dependsOn: [
@@ -23,7 +23,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/resource-crud-core": "0.1.14"
+        "@jskit-ai/resource-crud-core": "0.1.15"
       },
       dev: {}
     },

--- a/packages/resource-crud-core/package.json
+++ b/packages/resource-crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/resource-crud-core",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./shared/crudResource": "./src/shared/crudResource.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.69",
-    "@jskit-ai/resource-core": "0.1.14"
+    "@jskit-ai/kernel": "0.1.70",
+    "@jskit-ai/resource-core": "0.1.15"
   }
 }

--- a/packages/shell-web/package.descriptor.mjs
+++ b/packages/shell-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/shell-web",
-  version: "0.1.68",
+  version: "0.1.69",
   kind: "runtime",
   description: "Web shell layout runtime with outlet-based placement contributions.",
   dependsOn: [],
@@ -291,7 +291,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/kernel": "0.1.69"
+        "@jskit-ai/kernel": "0.1.70"
       },
       dev: {}
     },

--- a/packages/shell-web/package.json
+++ b/packages/shell-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/shell-web",
-  "version": "0.1.68",
+  "version": "0.1.69",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/kernel": "0.1.69"
+    "@jskit-ai/kernel": "0.1.70"
   },
   "peerDependencies": {
     "pinia": "^3.0.4",

--- a/packages/storage-runtime/package.descriptor.mjs
+++ b/packages/storage-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/storage-runtime",
-  version: "0.1.68",
+  version: "0.1.69",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -50,7 +50,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.69",
+        "@jskit-ai/kernel": "0.1.70",
         "unstorage": "^1.17.3"
       },
       dev: {}

--- a/packages/storage-runtime/package.json
+++ b/packages/storage-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/storage-runtime",
-  "version": "0.1.68",
+  "version": "0.1.69",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./server/providers/StorageRuntimeServiceProvider": "./src/server/providers/StorageRuntimeServiceProvider.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.69",
+    "@jskit-ai/kernel": "0.1.70",
     "unstorage": "^1.17.3"
   }
 }

--- a/packages/ui-generator/package.descriptor.mjs
+++ b/packages/ui-generator/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { GENERATED_UI_NAVIGATION_ROLE_OPTION } from "@jskit-ai/kernel/shared/sup
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/ui-generator",
-  version: "0.1.52",
+  version: "0.1.53",
   kind: "generator",
   description: "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
   options: {
@@ -371,7 +371,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.84"
+        "@jskit-ai/users-web": "0.1.85"
       },
       dev: {}
     },

--- a/packages/ui-generator/package.json
+++ b/packages/ui-generator/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/ui-generator",
-  "version": "0.1.52",
+  "version": "0.1.53",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.69",
-    "@jskit-ai/shell-web": "0.1.68"
+    "@jskit-ai/kernel": "0.1.70",
+    "@jskit-ai/shell-web": "0.1.69"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/uploads-image-web/package.descriptor.mjs
+++ b/packages/uploads-image-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-image-web",
-  version: "0.1.47",
+  version: "0.1.48",
   kind: "runtime",
   description: "Reusable client-side image upload runtime with pre-upload image editing.",
   dependsOn: [
@@ -65,7 +65,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/uploads-runtime": "0.1.47",
+        "@jskit-ai/uploads-runtime": "0.1.48",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-image-web/package.json
+++ b/packages/uploads-image-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-image-web",
-  "version": "0.1.47",
+  "version": "0.1.48",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,7 +13,7 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/uploads-runtime": "0.1.47",
+    "@jskit-ai/uploads-runtime": "0.1.48",
     "@uppy/compressor": "^3.1.0",
     "@uppy/core": "^5.2.0",
     "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-runtime/package.descriptor.mjs
+++ b/packages/uploads-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-runtime",
-  version: "0.1.47",
+  version: "0.1.48",
   kind: "runtime",
   description: "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
   dependsOn: [
@@ -71,7 +71,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.69"
+        "@jskit-ai/kernel": "0.1.70"
       },
       dev: {}
     },

--- a/packages/uploads-runtime/package.json
+++ b/packages/uploads-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-runtime",
-  "version": "0.1.47",
+  "version": "0.1.48",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,6 +16,6 @@
   },
   "dependencies": {
     "@fastify/multipart": "^9.4.0",
-    "@jskit-ai/kernel": "0.1.69"
+    "@jskit-ai/kernel": "0.1.70"
   }
 }

--- a/packages/users-core/package.descriptor.mjs
+++ b/packages/users-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-core",
-  version: "0.1.79",
+  version: "0.1.80",
   kind: "runtime",
   description: "Users/account runtime plus HTTP routes for account features.",
   dependsOn: [
@@ -143,16 +143,16 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.68",
-        "@jskit-ai/crud-core": "0.1.77",
-        "@jskit-ai/database-runtime": "0.1.69",
-        "@jskit-ai/http-runtime": "0.1.68",
-        "@jskit-ai/json-rest-api-core": "0.1.14",
-        "@jskit-ai/kernel": "0.1.69",
-        "@jskit-ai/resource-core": "0.1.14",
-        "@jskit-ai/resource-crud-core": "0.1.14",
+        "@jskit-ai/auth-core": "0.1.69",
+        "@jskit-ai/crud-core": "0.1.78",
+        "@jskit-ai/database-runtime": "0.1.70",
+        "@jskit-ai/http-runtime": "0.1.69",
+        "@jskit-ai/json-rest-api-core": "0.1.15",
+        "@jskit-ai/kernel": "0.1.70",
+        "@jskit-ai/resource-core": "0.1.15",
+        "@jskit-ai/resource-crud-core": "0.1.15",
         "@local/users": "file:packages/users",
-        "@jskit-ai/uploads-runtime": "0.1.47"
+        "@jskit-ai/uploads-runtime": "0.1.48"
       },
       dev: {}
     },

--- a/packages/users-core/package.json
+++ b/packages/users-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-core",
-  "version": "0.1.79",
+  "version": "0.1.80",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,14 +11,14 @@
     "./shared/resources/userSettingsResource": "./src/shared/resources/userSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.68",
-    "@jskit-ai/database-runtime": "0.1.69",
-    "@jskit-ai/http-runtime": "0.1.68",
-    "@jskit-ai/json-rest-api-core": "0.1.14",
-    "@jskit-ai/kernel": "0.1.69",
-    "@jskit-ai/resource-crud-core": "0.1.14",
-    "@jskit-ai/resource-core": "0.1.14",
-    "@jskit-ai/uploads-runtime": "0.1.47",
+    "@jskit-ai/auth-core": "0.1.69",
+    "@jskit-ai/database-runtime": "0.1.70",
+    "@jskit-ai/http-runtime": "0.1.69",
+    "@jskit-ai/json-rest-api-core": "0.1.15",
+    "@jskit-ai/kernel": "0.1.70",
+    "@jskit-ai/resource-crud-core": "0.1.15",
+    "@jskit-ai/resource-core": "0.1.15",
+    "@jskit-ai/uploads-runtime": "0.1.48",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/users-web/package.descriptor.mjs
+++ b/packages/users-web/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { HOME_COG_OUTLET } from "./src/shared/toolsOutletContracts.js";
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-web",
-  version: "0.1.84",
+  version: "0.1.85",
   kind: "runtime",
   description: "Users web module: account/profile UI plus shared users web widgets.",
   dependsOn: [
@@ -278,12 +278,12 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/http-runtime": "0.1.68",
-        "@jskit-ai/realtime": "0.1.68",
-        "@jskit-ai/kernel": "0.1.69",
-        "@jskit-ai/shell-web": "0.1.68",
-        "@jskit-ai/uploads-image-web": "0.1.47",
-        "@jskit-ai/users-core": "0.1.79"
+        "@jskit-ai/http-runtime": "0.1.69",
+        "@jskit-ai/realtime": "0.1.69",
+        "@jskit-ai/kernel": "0.1.70",
+        "@jskit-ai/shell-web": "0.1.69",
+        "@jskit-ai/uploads-image-web": "0.1.48",
+        "@jskit-ai/users-core": "0.1.80"
       },
       dev: {}
     },

--- a/packages/users-web/package.json
+++ b/packages/users-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-web",
-  "version": "0.1.84",
+  "version": "0.1.85",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -44,12 +44,12 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/http-runtime": "0.1.68",
-    "@jskit-ai/kernel": "0.1.69",
-    "@jskit-ai/realtime": "0.1.68",
-    "@jskit-ai/shell-web": "0.1.68",
-    "@jskit-ai/uploads-image-web": "0.1.47",
-    "@jskit-ai/users-core": "0.1.79"
+    "@jskit-ai/http-runtime": "0.1.69",
+    "@jskit-ai/kernel": "0.1.70",
+    "@jskit-ai/realtime": "0.1.69",
+    "@jskit-ai/shell-web": "0.1.69",
+    "@jskit-ai/uploads-image-web": "0.1.48",
+    "@jskit-ai/users-core": "0.1.80"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/workspaces-core/package.descriptor.mjs
+++ b/packages/workspaces-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-core",
-  version: "0.1.45",
+  version: "0.1.46",
   kind: "runtime",
   description: "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
   dependsOn: [
@@ -142,10 +142,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/json-rest-api-core": "0.1.14",
-        "@jskit-ai/resource-core": "0.1.14",
-        "@jskit-ai/resource-crud-core": "0.1.14",
-        "@jskit-ai/users-core": "0.1.79"
+        "@jskit-ai/json-rest-api-core": "0.1.15",
+        "@jskit-ai/resource-core": "0.1.15",
+        "@jskit-ai/resource-crud-core": "0.1.15",
+        "@jskit-ai/users-core": "0.1.80"
       },
       dev: {}
     },

--- a/packages/workspaces-core/package.json
+++ b/packages/workspaces-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-core",
-  "version": "0.1.45",
+  "version": "0.1.46",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -17,14 +17,14 @@
     "./shared/resources/workspaceSettingsResource": "./src/shared/resources/workspaceSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.68",
-    "@jskit-ai/database-runtime": "0.1.69",
-    "@jskit-ai/http-runtime": "0.1.68",
-    "@jskit-ai/json-rest-api-core": "0.1.14",
-    "@jskit-ai/kernel": "0.1.69",
-    "@jskit-ai/resource-crud-core": "0.1.14",
-    "@jskit-ai/resource-core": "0.1.14",
-    "@jskit-ai/users-core": "0.1.79",
+    "@jskit-ai/auth-core": "0.1.69",
+    "@jskit-ai/database-runtime": "0.1.70",
+    "@jskit-ai/http-runtime": "0.1.69",
+    "@jskit-ai/json-rest-api-core": "0.1.15",
+    "@jskit-ai/kernel": "0.1.70",
+    "@jskit-ai/resource-crud-core": "0.1.15",
+    "@jskit-ai/resource-core": "0.1.15",
+    "@jskit-ai/users-core": "0.1.80",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/workspaces-web/package.descriptor.mjs
+++ b/packages/workspaces-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-web",
-  version: "0.1.45",
+  version: "0.1.46",
   kind: "runtime",
   description: "Workspace web module: workspace selector, tools widget, workspace surfaces, and members/settings UI.",
   dependsOn: [
@@ -231,8 +231,8 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/workspaces-core": "0.1.45",
-        "@jskit-ai/users-web": "0.1.84"
+        "@jskit-ai/workspaces-core": "0.1.46",
+        "@jskit-ai/users-web": "0.1.85"
       },
       dev: {}
     },

--- a/packages/workspaces-web/package.json
+++ b/packages/workspaces-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-web",
-  "version": "0.1.45",
+  "version": "0.1.46",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -15,12 +15,12 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/http-runtime": "0.1.68",
-    "@jskit-ai/kernel": "0.1.69",
-    "@jskit-ai/shell-web": "0.1.68",
-    "@jskit-ai/users-core": "0.1.79",
-    "@jskit-ai/users-web": "0.1.84",
-    "@jskit-ai/workspaces-core": "0.1.45"
+    "@jskit-ai/http-runtime": "0.1.69",
+    "@jskit-ai/kernel": "0.1.70",
+    "@jskit-ai/shell-web": "0.1.69",
+    "@jskit-ai/users-core": "0.1.80",
+    "@jskit-ai/users-web": "0.1.85",
+    "@jskit-ai/workspaces-core": "0.1.46"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/tooling/config-eslint/package.json
+++ b/tooling/config-eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/config-eslint",
-  "version": "0.1.68",
+  "version": "0.1.69",
   "description": "Shared flat ESLint presets for JSKIT projects.",
   "type": "module",
   "files": [
@@ -33,7 +33,7 @@
     "eslint": "^9.39.1"
   },
   "engines": {
-    "node": "20.x"
+    "node": ">=20 <23"
   },
   "publishConfig": {
     "access": "public"

--- a/tooling/create-app/package.descriptor.mjs
+++ b/tooling/create-app/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/create-app",
-  "version": "0.1.77",
+  "version": "0.1.78",
   "dependsOn": [],
   "capabilities": {
     "provides": [

--- a/tooling/create-app/package.json
+++ b/tooling/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/create-app",
-  "version": "0.1.77",
+  "version": "0.1.78",
   "description": "Scaffold minimal JSKIT app shells.",
   "type": "module",
   "files": [
@@ -21,7 +21,7 @@
   },
   "dependencies": {},
   "engines": {
-    "node": "20.x"
+    "node": ">=20 <23"
   },
   "publishConfig": {
     "access": "public"

--- a/tooling/create-app/templates/base-shell/package.json
+++ b/tooling/create-app/templates/base-shell/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "description": "Minimal JSKIT base app (Fastify + Vue)",
   "engines": {
-    "node": "20.x"
+    "node": ">=20 <23"
   },
   "scripts": {
     "server": "node ./bin/server.js",

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -6,11 +6,11 @@
   "packages": [
     {
       "packageId": "@jskit-ai/assistant",
-      "version": "0.1.78",
+      "version": "0.1.79",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant",
-        "version": "0.1.78",
+        "version": "0.1.79",
         "kind": "generator",
         "description": "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
         "options": {
@@ -347,11 +347,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-core",
-      "version": "0.1.45",
+      "version": "0.1.46",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-core",
-        "version": "0.1.45",
+        "version": "0.1.46",
         "kind": "runtime",
         "description": "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
         "dependsOn": [
@@ -399,11 +399,11 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/http-runtime": "0.1.68",
-              "@jskit-ai/kernel": "0.1.69",
-              "@jskit-ai/resource-core": "0.1.14",
-              "@jskit-ai/resource-crud-core": "0.1.14",
-              "@jskit-ai/users-core": "0.1.79",
+              "@jskit-ai/http-runtime": "0.1.69",
+              "@jskit-ai/kernel": "0.1.70",
+              "@jskit-ai/resource-core": "0.1.15",
+              "@jskit-ai/resource-crud-core": "0.1.15",
+              "@jskit-ai/users-core": "0.1.80",
               "dompurify": "^3.3.3",
               "json-rest-schema": "1.x.x",
               "marked": "^17.0.4",
@@ -422,11 +422,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-runtime",
-      "version": "0.1.40",
+      "version": "0.1.41",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-runtime",
-        "version": "0.1.40",
+        "version": "0.1.41",
         "kind": "runtime",
         "description": "Shared assistant runtime with per-surface assistant registration.",
         "dependsOn": [
@@ -522,13 +522,13 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/assistant-core": "0.1.45",
-              "@jskit-ai/database-runtime": "0.1.69",
-              "@jskit-ai/http-runtime": "0.1.68",
-              "@jskit-ai/kernel": "0.1.69",
-              "@jskit-ai/shell-web": "0.1.68",
-              "@jskit-ai/users-core": "0.1.79",
-              "@jskit-ai/users-web": "0.1.84"
+              "@jskit-ai/assistant-core": "0.1.46",
+              "@jskit-ai/database-runtime": "0.1.70",
+              "@jskit-ai/http-runtime": "0.1.69",
+              "@jskit-ai/kernel": "0.1.70",
+              "@jskit-ai/shell-web": "0.1.69",
+              "@jskit-ai/users-core": "0.1.80",
+              "@jskit-ai/users-web": "0.1.85"
             },
             "dev": {}
           },
@@ -583,11 +583,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-core",
-      "version": "0.1.68",
+      "version": "0.1.69",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-core",
-        "version": "0.1.68",
+        "version": "0.1.69",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/value-app-config-shared"
@@ -655,7 +655,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.69",
+              "@jskit-ai/kernel": "0.1.70",
               "@fastify/cookie": "^11.0.2",
               "@fastify/csrf-protection": "^7.1.0",
               "@fastify/rate-limit": "^10.3.0"
@@ -673,11 +673,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.68",
+      "version": "0.1.69",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-supabase-core",
-        "version": "0.1.68",
+        "version": "0.1.69",
         "kind": "runtime",
         "options": {
           "auth-supabase-url": {
@@ -759,8 +759,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.68",
-              "@jskit-ai/kernel": "0.1.69",
+              "@jskit-ai/auth-core": "0.1.69",
+              "@jskit-ai/kernel": "0.1.70",
               "dotenv": "^16.4.5",
               "@supabase/supabase-js": "^2.57.4",
               "jose": "^6.1.0"
@@ -825,11 +825,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-web",
-      "version": "0.1.70",
+      "version": "0.1.71",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-web",
-        "version": "0.1.70",
+        "version": "0.1.71",
         "kind": "runtime",
         "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
         "dependsOn": [
@@ -1085,10 +1085,10 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/auth-core": "0.1.68",
-              "@jskit-ai/http-runtime": "0.1.68",
-              "@jskit-ai/kernel": "0.1.69",
-              "@jskit-ai/shell-web": "0.1.68"
+              "@jskit-ai/auth-core": "0.1.69",
+              "@jskit-ai/http-runtime": "0.1.69",
+              "@jskit-ai/kernel": "0.1.70",
+              "@jskit-ai/shell-web": "0.1.69"
             },
             "dev": {}
           },
@@ -1167,11 +1167,11 @@
     },
     {
       "packageId": "@jskit-ai/console-core",
-      "version": "0.1.32",
+      "version": "0.1.33",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-core",
-        "version": "0.1.32",
+        "version": "0.1.33",
         "kind": "runtime",
         "description": "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
         "dependsOn": [
@@ -1255,12 +1255,12 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.68",
-              "@jskit-ai/database-runtime": "0.1.69",
-              "@jskit-ai/http-runtime": "0.1.68",
-              "@jskit-ai/kernel": "0.1.69",
-              "@jskit-ai/resource-crud-core": "0.1.14",
-              "@jskit-ai/users-core": "0.1.79"
+              "@jskit-ai/auth-core": "0.1.69",
+              "@jskit-ai/database-runtime": "0.1.70",
+              "@jskit-ai/http-runtime": "0.1.69",
+              "@jskit-ai/kernel": "0.1.70",
+              "@jskit-ai/resource-crud-core": "0.1.15",
+              "@jskit-ai/users-core": "0.1.80"
             },
             "dev": {}
           },
@@ -1285,11 +1285,11 @@
     },
     {
       "packageId": "@jskit-ai/console-web",
-      "version": "0.1.37",
+      "version": "0.1.38",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-web",
-        "version": "0.1.37",
+        "version": "0.1.38",
         "kind": "runtime",
         "description": "Authenticated console surface scaffold and surface policy wiring.",
         "dependsOn": [
@@ -1399,9 +1399,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-web": "0.1.70",
-              "@jskit-ai/console-core": "0.1.32",
-              "@jskit-ai/shell-web": "0.1.68"
+              "@jskit-ai/auth-web": "0.1.71",
+              "@jskit-ai/console-core": "0.1.33",
+              "@jskit-ai/shell-web": "0.1.69"
             },
             "dev": {}
           },
@@ -1508,11 +1508,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-core",
-      "version": "0.1.77",
+      "version": "0.1.78",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-core",
-        "version": "0.1.77",
+        "version": "0.1.78",
         "kind": "runtime",
         "description": "Shared CRUD helpers used by CRUD modules.",
         "dependsOn": [
@@ -1541,7 +1541,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/crud-core": "0.1.77"
+              "@jskit-ai/crud-core": "0.1.78"
             },
             "dev": {}
           },
@@ -1555,11 +1555,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-server-generator",
-      "version": "0.1.77",
+      "version": "0.1.78",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-server-generator",
-        "version": "0.1.77",
+        "version": "0.1.78",
         "kind": "generator",
         "description": "CRUD server generator with routes, actions, and persistence scaffolding.",
         "options": {
@@ -1726,14 +1726,14 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.68",
-              "@jskit-ai/crud-core": "0.1.77",
-              "@jskit-ai/database-runtime": "0.1.69",
-              "@jskit-ai/http-runtime": "0.1.68",
-              "@jskit-ai/json-rest-api-core": "0.1.14",
-              "@jskit-ai/kernel": "0.1.69",
-              "@jskit-ai/realtime": "0.1.68",
-              "@jskit-ai/resource-crud-core": "0.1.14",
+              "@jskit-ai/auth-core": "0.1.69",
+              "@jskit-ai/crud-core": "0.1.78",
+              "@jskit-ai/database-runtime": "0.1.70",
+              "@jskit-ai/http-runtime": "0.1.69",
+              "@jskit-ai/json-rest-api-core": "0.1.15",
+              "@jskit-ai/kernel": "0.1.70",
+              "@jskit-ai/realtime": "0.1.69",
+              "@jskit-ai/resource-crud-core": "0.1.15",
               "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}"
             },
             "dev": {}
@@ -1865,11 +1865,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.52",
+      "version": "0.1.53",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-ui-generator",
-        "version": "0.1.52",
+        "version": "0.1.53",
         "kind": "generator",
         "description": "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
         "options": {
@@ -2068,7 +2068,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.84"
+              "@jskit-ai/users-web": "0.1.85"
             },
             "dev": {}
           },
@@ -2327,11 +2327,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime",
-      "version": "0.1.69",
+      "version": "0.1.70",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime",
-        "version": "0.1.69",
+        "version": "0.1.70",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -2388,7 +2388,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.69",
+              "@jskit-ai/kernel": "0.1.70",
               "dotenv": "^16.4.5",
               "knex": "^3.1.0"
             },
@@ -2423,11 +2423,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.68",
+      "version": "0.1.69",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-mysql",
-        "version": "0.1.68",
+        "version": "0.1.69",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -2517,7 +2517,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.69",
+              "@jskit-ai/database-runtime": "0.1.70",
               "mysql2": "^3.11.2"
             },
             "dev": {}
@@ -2588,11 +2588,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.68",
+      "version": "0.1.69",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-postgres",
-        "version": "0.1.68",
+        "version": "0.1.69",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -2682,7 +2682,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.69",
+              "@jskit-ai/database-runtime": "0.1.70",
               "pg": "^8.13.1"
             },
             "dev": {}
@@ -2753,11 +2753,11 @@
     },
     {
       "packageId": "@jskit-ai/feature-server-generator",
-      "version": "0.1.11",
+      "version": "0.1.12",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/feature-server-generator",
-        "version": "0.1.11",
+        "version": "0.1.12",
         "kind": "generator",
         "description": "Scaffold substantial non-CRUD server feature packages with provider, actions, service, and optional persistence seams.",
         "options": {
@@ -2921,10 +2921,28 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.69",
-              "@jskit-ai/database-runtime-mysql": "0.1.68",
-              "@jskit-ai/json-rest-api-core": "0.1.14",
-              "@jskit-ai/kernel": "0.1.69",
+              "@jskit-ai/database-runtime": {
+                "version": "0.1.69",
+                "when": {
+                  "option": "mode",
+                  "notEquals": "orchestrator"
+                }
+              },
+              "@jskit-ai/database-runtime-mysql": {
+                "version": "0.1.68",
+                "when": {
+                  "option": "mode",
+                  "notEquals": "orchestrator"
+                }
+              },
+              "@jskit-ai/json-rest-api-core": {
+                "version": "0.1.14",
+                "when": {
+                  "option": "mode",
+                  "equals": "json-rest"
+                }
+              },
+              "@jskit-ai/kernel": "0.1.70",
               "json-rest-schema": "1.x.x",
               "@local/${option:feature-name|kebab}": "file:packages/${option:feature-name|kebab}"
             },
@@ -3037,11 +3055,11 @@
     },
     {
       "packageId": "@jskit-ai/google-rewarded-core",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/google-rewarded-core",
-        "version": "0.1.6",
+        "version": "0.1.7",
         "kind": "runtime",
         "description": "Google rewarded workflow runtime plus internal CRUD providers for rules, provider configs, watch sessions, and unlock receipts.",
         "dependsOn": [
@@ -3168,14 +3186,14 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.68",
-              "@jskit-ai/crud-core": "0.1.77",
-              "@jskit-ai/database-runtime": "0.1.69",
-              "@jskit-ai/http-runtime": "0.1.68",
-              "@jskit-ai/json-rest-api-core": "0.1.14",
-              "@jskit-ai/kernel": "0.1.69",
-              "@jskit-ai/resource-crud-core": "0.1.14",
-              "@jskit-ai/workspaces-core": "0.1.45"
+              "@jskit-ai/auth-core": "0.1.69",
+              "@jskit-ai/crud-core": "0.1.78",
+              "@jskit-ai/database-runtime": "0.1.70",
+              "@jskit-ai/http-runtime": "0.1.69",
+              "@jskit-ai/json-rest-api-core": "0.1.15",
+              "@jskit-ai/kernel": "0.1.70",
+              "@jskit-ai/resource-crud-core": "0.1.15",
+              "@jskit-ai/workspaces-core": "0.1.46"
             },
             "dev": {}
           },
@@ -3227,11 +3245,11 @@
     },
     {
       "packageId": "@jskit-ai/google-rewarded-web",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/google-rewarded-web",
-        "version": "0.1.6",
+        "version": "0.1.7",
         "kind": "runtime",
         "description": "Google rewarded client runtime with a fullscreen gate host and GPT orchestration.",
         "dependsOn": [
@@ -3278,10 +3296,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/google-rewarded-core": "0.1.6",
-              "@jskit-ai/http-runtime": "0.1.68",
-              "@jskit-ai/kernel": "0.1.69",
-              "@jskit-ai/shell-web": "0.1.68"
+              "@jskit-ai/google-rewarded-core": "0.1.7",
+              "@jskit-ai/http-runtime": "0.1.69",
+              "@jskit-ai/kernel": "0.1.70",
+              "@jskit-ai/shell-web": "0.1.69"
             },
             "dev": {}
           },
@@ -3299,11 +3317,11 @@
     },
     {
       "packageId": "@jskit-ai/http-runtime",
-      "version": "0.1.68",
+      "version": "0.1.69",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/http-runtime",
-        "version": "0.1.68",
+        "version": "0.1.69",
         "kind": "runtime",
         "dependsOn": [],
         "capabilities": {
@@ -3369,7 +3387,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.69"
+              "@jskit-ai/kernel": "0.1.70"
             },
             "dev": {}
           },
@@ -3383,11 +3401,11 @@
     },
     {
       "packageId": "@jskit-ai/json-rest-api-core",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/json-rest-api-core",
-        "version": "0.1.14",
+        "version": "0.1.15",
         "kind": "runtime",
         "description": "Shared internal json-rest-api host runtime for JSKIT server packages.",
         "dependsOn": [
@@ -3447,11 +3465,11 @@
     },
     {
       "packageId": "@jskit-ai/mobile-capacitor",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/mobile-capacitor",
-        "version": "0.1.6",
+        "version": "0.1.7",
         "kind": "runtime",
         "description": "Thin Capacitor client integration for JSKIT mobile-shell launch routing and auth callback completion.",
         "dependsOn": [
@@ -3514,8 +3532,8 @@
               "@capacitor/app": "^7.1.0",
               "@capacitor/browser": "^7.0.1",
               "@capacitor/core": "^7.4.3",
-              "@jskit-ai/kernel": "0.1.69",
-              "@jskit-ai/shell-web": "0.1.68"
+              "@jskit-ai/kernel": "0.1.70",
+              "@jskit-ai/shell-web": "0.1.69"
             },
             "dev": {
               "@capacitor/cli": "^7.4.3"
@@ -3567,11 +3585,11 @@
     },
     {
       "packageId": "@jskit-ai/realtime",
-      "version": "0.1.68",
+      "version": "0.1.69",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/realtime",
-        "version": "0.1.68",
+        "version": "0.1.69",
         "kind": "runtime",
         "description": "Thin, generic realtime runtime wrappers for socket.io server and client.",
         "options": {
@@ -3667,7 +3685,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.69",
+              "@jskit-ai/kernel": "0.1.70",
               "@socket.io/redis-adapter": "^8.3.0",
               "redis": "^5.8.2",
               "socket.io": "^4.8.3",
@@ -3716,11 +3734,11 @@
     },
     {
       "packageId": "@jskit-ai/resource-core",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/resource-core",
-        "version": "0.1.14",
+        "version": "0.1.15",
         "kind": "runtime",
         "description": "Generic resource-definition helpers and schema-definition normalization.",
         "dependsOn": [
@@ -3743,7 +3761,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/resource-core": "0.1.14"
+              "@jskit-ai/resource-core": "0.1.15"
             },
             "dev": {}
           },
@@ -3758,11 +3776,11 @@
     },
     {
       "packageId": "@jskit-ai/resource-crud-core",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/resource-crud-core",
-        "version": "0.1.14",
+        "version": "0.1.15",
         "kind": "runtime",
         "description": "CRUD-specific resource-definition helpers and namespace support.",
         "dependsOn": [
@@ -3786,7 +3804,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/resource-crud-core": "0.1.14"
+              "@jskit-ai/resource-crud-core": "0.1.15"
             },
             "dev": {}
           },
@@ -3801,11 +3819,11 @@
     },
     {
       "packageId": "@jskit-ai/shell-web",
-      "version": "0.1.68",
+      "version": "0.1.69",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/shell-web",
-        "version": "0.1.68",
+        "version": "0.1.69",
         "kind": "runtime",
         "description": "Web shell layout runtime with outlet-based placement contributions.",
         "dependsOn": [],
@@ -4131,7 +4149,7 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/kernel": "0.1.69"
+              "@jskit-ai/kernel": "0.1.70"
             },
             "dev": {}
           },
@@ -4331,11 +4349,11 @@
     },
     {
       "packageId": "@jskit-ai/storage-runtime",
-      "version": "0.1.68",
+      "version": "0.1.69",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/storage-runtime",
-        "version": "0.1.68",
+        "version": "0.1.69",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -4384,7 +4402,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.69",
+              "@jskit-ai/kernel": "0.1.70",
               "unstorage": "^1.17.3"
             },
             "dev": {}
@@ -4400,11 +4418,11 @@
     },
     {
       "packageId": "@jskit-ai/ui-generator",
-      "version": "0.1.52",
+      "version": "0.1.53",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/ui-generator",
-        "version": "0.1.52",
+        "version": "0.1.53",
         "kind": "generator",
         "description": "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
         "options": {
@@ -4837,7 +4855,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.84"
+              "@jskit-ai/users-web": "0.1.85"
             },
             "dev": {}
           },
@@ -4852,11 +4870,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-image-web",
-      "version": "0.1.47",
+      "version": "0.1.48",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-image-web",
-        "version": "0.1.47",
+        "version": "0.1.48",
         "kind": "runtime",
         "description": "Reusable client-side image upload runtime with pre-upload image editing.",
         "dependsOn": [
@@ -4920,7 +4938,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/uploads-runtime": "0.1.47",
+              "@jskit-ai/uploads-runtime": "0.1.48",
               "@uppy/compressor": "^3.1.0",
               "@uppy/core": "^5.2.0",
               "@uppy/dashboard": "^5.1.1",
@@ -4940,11 +4958,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-runtime",
-      "version": "0.1.47",
+      "version": "0.1.48",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-runtime",
-        "version": "0.1.47",
+        "version": "0.1.48",
         "kind": "runtime",
         "description": "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
         "dependsOn": [
@@ -5014,7 +5032,7 @@
           "dependencies": {
             "runtime": {
               "@fastify/multipart": "^9.4.0",
-              "@jskit-ai/kernel": "0.1.69"
+              "@jskit-ai/kernel": "0.1.70"
             },
             "dev": {}
           },
@@ -5029,11 +5047,11 @@
     },
     {
       "packageId": "@jskit-ai/users-core",
-      "version": "0.1.79",
+      "version": "0.1.80",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-core",
-        "version": "0.1.79",
+        "version": "0.1.80",
         "kind": "runtime",
         "description": "Users/account runtime plus HTTP routes for account features.",
         "dependsOn": [
@@ -5174,16 +5192,16 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.68",
-              "@jskit-ai/crud-core": "0.1.77",
-              "@jskit-ai/database-runtime": "0.1.69",
-              "@jskit-ai/http-runtime": "0.1.68",
-              "@jskit-ai/json-rest-api-core": "0.1.14",
-              "@jskit-ai/kernel": "0.1.69",
-              "@jskit-ai/resource-core": "0.1.14",
-              "@jskit-ai/resource-crud-core": "0.1.14",
+              "@jskit-ai/auth-core": "0.1.69",
+              "@jskit-ai/crud-core": "0.1.78",
+              "@jskit-ai/database-runtime": "0.1.70",
+              "@jskit-ai/http-runtime": "0.1.69",
+              "@jskit-ai/json-rest-api-core": "0.1.15",
+              "@jskit-ai/kernel": "0.1.70",
+              "@jskit-ai/resource-core": "0.1.15",
+              "@jskit-ai/resource-crud-core": "0.1.15",
               "@local/users": "file:packages/users",
-              "@jskit-ai/uploads-runtime": "0.1.47"
+              "@jskit-ai/uploads-runtime": "0.1.48"
             },
             "dev": {}
           },
@@ -5400,11 +5418,11 @@
     },
     {
       "packageId": "@jskit-ai/users-web",
-      "version": "0.1.84",
+      "version": "0.1.85",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-web",
-        "version": "0.1.84",
+        "version": "0.1.85",
         "kind": "runtime",
         "description": "Users web module: account/profile UI plus shared users web widgets.",
         "dependsOn": [
@@ -5699,12 +5717,12 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/http-runtime": "0.1.68",
-              "@jskit-ai/realtime": "0.1.68",
-              "@jskit-ai/kernel": "0.1.69",
-              "@jskit-ai/shell-web": "0.1.68",
-              "@jskit-ai/uploads-image-web": "0.1.47",
-              "@jskit-ai/users-core": "0.1.79"
+              "@jskit-ai/http-runtime": "0.1.69",
+              "@jskit-ai/realtime": "0.1.69",
+              "@jskit-ai/kernel": "0.1.70",
+              "@jskit-ai/shell-web": "0.1.69",
+              "@jskit-ai/uploads-image-web": "0.1.48",
+              "@jskit-ai/users-core": "0.1.80"
             },
             "dev": {}
           },
@@ -5873,11 +5891,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-core",
-      "version": "0.1.45",
+      "version": "0.1.46",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-core",
-        "version": "0.1.45",
+        "version": "0.1.46",
         "kind": "runtime",
         "description": "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
         "dependsOn": [
@@ -6018,10 +6036,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/json-rest-api-core": "0.1.14",
-              "@jskit-ai/resource-core": "0.1.14",
-              "@jskit-ai/resource-crud-core": "0.1.14",
-              "@jskit-ai/users-core": "0.1.79"
+              "@jskit-ai/json-rest-api-core": "0.1.15",
+              "@jskit-ai/resource-core": "0.1.15",
+              "@jskit-ai/resource-crud-core": "0.1.15",
+              "@jskit-ai/users-core": "0.1.80"
             },
             "dev": {}
           },
@@ -6193,11 +6211,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-web",
-      "version": "0.1.45",
+      "version": "0.1.46",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-web",
-        "version": "0.1.45",
+        "version": "0.1.46",
         "kind": "runtime",
         "description": "Workspace web module: workspace selector, tools widget, workspace surfaces, and members/settings UI.",
         "dependsOn": [
@@ -6453,8 +6471,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/workspaces-core": "0.1.45",
-              "@jskit-ai/users-web": "0.1.84"
+              "@jskit-ai/workspaces-core": "0.1.46",
+              "@jskit-ai/users-web": "0.1.85"
             },
             "dev": {}
           },

--- a/tooling/jskit-catalog/package.json
+++ b/tooling/jskit-catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-catalog",
-  "version": "0.1.77",
+  "version": "0.1.78",
   "description": "Published metadata catalog for JSKIT package descriptors.",
   "type": "module",
   "files": [
@@ -17,7 +17,7 @@
     "test": "node --test"
   },
   "engines": {
-    "node": "20.x"
+    "node": ">=20 <23"
   },
   "publishConfig": {
     "access": "public"

--- a/tooling/jskit-cli/package.json
+++ b/tooling/jskit-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-cli",
-  "version": "0.2.78",
+  "version": "0.2.79",
   "description": "Bundle and package orchestration CLI for JSKIT apps.",
   "type": "module",
   "files": [
@@ -20,12 +20,12 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/jskit-catalog": "0.1.77",
-    "@jskit-ai/kernel": "0.1.69",
-    "@jskit-ai/shell-web": "0.1.68"
+    "@jskit-ai/jskit-catalog": "0.1.78",
+    "@jskit-ai/kernel": "0.1.70",
+    "@jskit-ai/shell-web": "0.1.69"
   },
   "engines": {
-    "node": "20.x"
+    "node": ">=20 <23"
   },
   "publishConfig": {
     "access": "public"

--- a/tooling/jskit-cli/src/server/cliRuntime/mutationWhen.js
+++ b/tooling/jskit-cli/src/server/cliRuntime/mutationWhen.js
@@ -52,6 +52,21 @@ function normalizeFileMutationRecord(value) {
   };
 }
 
+function normalizeDependencyMutationRecord(value) {
+  const record = ensureObject(value);
+  if (Object.keys(record).length < 1) {
+    return {
+      version: String(value || ""),
+      when: null
+    };
+  }
+
+  return {
+    version: String(record.version || record.value || "").trim(),
+    when: normalizeMutationWhen(record.when)
+  };
+}
+
 function normalizeMutationWhen(value) {
   const source = ensureObject(value);
   const allConditions = ensureArray(source.all)
@@ -304,6 +319,7 @@ function shouldApplyMutationWhen(
 export {
   normalizeMutationExtension,
   normalizeTemplateContextRecord,
+  normalizeDependencyMutationRecord,
   normalizeFileMutationRecord,
   normalizeMutationWhen,
   readObjectPath,

--- a/tooling/jskit-cli/src/server/cliRuntime/packageInstallFlow.js
+++ b/tooling/jskit-cli/src/server/cliRuntime/packageInstallFlow.js
@@ -8,7 +8,9 @@ import {
   interpolateOptionValue
 } from "../shared/optionInterpolation.js";
 import {
-  normalizeFileMutationRecord
+  normalizeDependencyMutationRecord,
+  normalizeFileMutationRecord,
+  shouldApplyMutationWhen
 } from "./mutationWhen.js";
 import {
   applyViteMutations,
@@ -139,6 +141,13 @@ function resolveManagedSourceRecord(packageEntry, existingInstall = {}) {
     sourceRecord.descriptorPath = String(packageEntry.descriptorRelativePath).trim();
   }
   return sourceRecord;
+}
+
+function dependencyMutationUsesWhen(entries = []) {
+  return entries.some(([, rawDependencySpec]) => {
+    const dependencySpec = normalizeDependencyMutationRecord(rawDependencySpec);
+    return Boolean(dependencySpec.when);
+  });
 }
 
 async function applyPackagePositioning({
@@ -413,9 +422,28 @@ async function applyPackageInstall({
   const mutationDependencies = ensureObject(mutations.dependencies);
   const runtimeDependencies = ensureObject(mutationDependencies.runtime);
   const devDependencies = ensureObject(mutationDependencies.dev);
+  const runtimeDependencyEntries = Object.entries(runtimeDependencies);
+  const devDependencyEntries = Object.entries(devDependencies);
+  const needsDependencyWhenConfig = dependencyMutationUsesWhen([
+    ...runtimeDependencyEntries,
+    ...devDependencyEntries
+  ]);
+  const dependencyWhenConfigContext = needsDependencyWhenConfig
+    ? await loadMutationWhenConfigContext(appRoot)
+    : {};
   const mutationScripts = ensureObject(ensureObject(mutations.packageJson).scripts);
 
-  for (const [rawDependencyId, rawDependencyVersion] of Object.entries(runtimeDependencies)) {
+  for (const [rawDependencyId, rawDependencySpec] of runtimeDependencyEntries) {
+    const dependencySpec = normalizeDependencyMutationRecord(rawDependencySpec);
+    if (!shouldApplyMutationWhen(dependencySpec.when, {
+      options: packageOptions,
+      configContext: dependencyWhenConfigContext,
+      packageId: packageEntry.packageId,
+      mutationContext: `dependencies.runtime.${rawDependencyId}`
+    })) {
+      continue;
+    }
+
     const dependencyId = interpolateOptionValue(
       rawDependencyId,
       packageOptions,
@@ -423,7 +451,7 @@ async function applyPackageInstall({
       `dependencies.runtime.${rawDependencyId}.id`
     );
     const dependencyVersion = interpolateOptionValue(
-      String(rawDependencyVersion || ""),
+      dependencySpec.version,
       packageOptions,
       packageEntry.packageId,
       `dependencies.runtime.${rawDependencyId}.value`
@@ -447,7 +475,17 @@ async function applyPackageInstall({
     }
   }
 
-  for (const [rawDependencyId, rawDependencyVersion] of Object.entries(devDependencies)) {
+  for (const [rawDependencyId, rawDependencySpec] of devDependencyEntries) {
+    const dependencySpec = normalizeDependencyMutationRecord(rawDependencySpec);
+    if (!shouldApplyMutationWhen(dependencySpec.when, {
+      options: packageOptions,
+      configContext: dependencyWhenConfigContext,
+      packageId: packageEntry.packageId,
+      mutationContext: `dependencies.dev.${rawDependencyId}`
+    })) {
+      continue;
+    }
+
     const dependencyId = interpolateOptionValue(
       rawDependencyId,
       packageOptions,
@@ -455,7 +493,7 @@ async function applyPackageInstall({
       `dependencies.dev.${rawDependencyId}.id`
     );
     const dependencyVersion = interpolateOptionValue(
-      String(rawDependencyVersion || ""),
+      dependencySpec.version,
       packageOptions,
       packageEntry.packageId,
       `dependencies.dev.${rawDependencyId}.value`

--- a/tooling/jskit-cli/src/server/commandHandlers/show/renderPackageText.js
+++ b/tooling/jskit-cli/src/server/commandHandlers/show/renderPackageText.js
@@ -2,6 +2,9 @@ import {
   ensureArray,
   ensureObject
 } from "../../shared/collectionUtils.js";
+import {
+  normalizeDependencyMutationRecord
+} from "../../cliRuntime/mutationWhen.js";
 import { createShowRenderHelpers } from "./renderHelpers.js";
 import { writePackageExportsSection } from "./renderPackageExports.js";
 import { writeCapabilitiesSections } from "./renderPackageCapabilities.js";
@@ -33,6 +36,12 @@ function resolveGeneratorSubcommandRows(payload = {}) {
 
 function resolveOwnershipGuidance(payload = {}) {
   return ensureObject(ensureObject(ensureObject(payload.metadata).jskit).ownershipGuidance);
+}
+
+function renderDependencyMutationSpec(versionSpec) {
+  const dependencySpec = normalizeDependencyMutationRecord(versionSpec);
+  const whenSuffix = dependencySpec.when ? ` when ${JSON.stringify(dependencySpec.when)}` : "";
+  return `${dependencySpec.version}${whenSuffix}`.trim();
 }
 
 function renderPackagePayloadText({
@@ -255,7 +264,7 @@ function renderPackagePayloadText({
       wrapWidth,
       items: runtimeMutationEntries.map(([dependencyId, versionSpec]) => {
         const dependencyText = String(dependencyId);
-        const versionText = String(versionSpec);
+        const versionText = renderDependencyMutationSpec(versionSpec);
         return {
           text: `${dependencyText} ${versionText}`,
           rendered: `${color.item(dependencyText)} ${color.installed(versionText)}`
@@ -325,7 +334,7 @@ function renderPackagePayloadText({
       wrapWidth,
       items: devMutationEntries.map(([dependencyId, versionSpec]) => {
         const dependencyText = String(dependencyId);
-        const versionText = String(versionSpec);
+        const versionText = renderDependencyMutationSpec(versionSpec);
         return {
           text: `${dependencyText} ${versionText}`,
           rendered: `${color.item(dependencyText)} ${color.installed(versionText)}`

--- a/tooling/jskit-cli/test/featureServerGeneratorPackage.test.js
+++ b/tooling/jskit-cli/test/featureServerGeneratorPackage.test.js
@@ -136,6 +136,7 @@ test("generate feature-server-generator scaffold supports orchestrator mode with
     const serviceSource = await readFile(path.join(packageRoot, "src", "server", "service.js"), "utf8");
     const routesSource = await readFile(path.join(packageRoot, "src", "server", "registerRoutes.js"), "utf8");
     const descriptorSource = await readFile(path.join(packageRoot, "package.descriptor.mjs"), "utf8");
+    const appPackageJson = JSON.parse(await readFile(path.join(appRoot, "package.json"), "utf8"));
 
     assert.equal(await fileExists(path.join(packageRoot, "src", "server", "repository.js")), false);
     assert.equal(await fileExists(path.join(packageRoot, "src", "server", "registerRoutes.js")), true);
@@ -145,6 +146,12 @@ test("generate feature-server-generator scaffold supports orchestrator mode with
     assert.match(routesSource, /auth: "public"/);
     assert.match(descriptorSource, /scaffoldMode: "orchestrator"/);
     assert.match(descriptorSource, /lane: "default"/);
+    assert.equal(appPackageJson.dependencies["@local/availability-engine"], "file:packages/availability-engine");
+    assert.equal(typeof appPackageJson.dependencies["@jskit-ai/kernel"], "string");
+    assert.equal(appPackageJson.dependencies["json-rest-schema"], "1.x.x");
+    assert.equal(appPackageJson.dependencies["@jskit-ai/json-rest-api-core"], undefined);
+    assert.equal(appPackageJson.dependencies["@jskit-ai/database-runtime"], undefined);
+    assert.equal(appPackageJson.dependencies["@jskit-ai/database-runtime-mysql"], undefined);
   });
 });
 
@@ -171,12 +178,16 @@ test("generate feature-server-generator scaffold supports the explicit custom-kn
     const providerSource = await readFile(path.join(packageRoot, "src", "server", "InvoiceRollupProvider.js"), "utf8");
     const repositorySource = await readFile(path.join(packageRoot, "src", "server", "repository.js"), "utf8");
     const descriptorSource = await readFile(path.join(packageRoot, "package.descriptor.mjs"), "utf8");
+    const appPackageJson = JSON.parse(await readFile(path.join(appRoot, "package.json"), "utf8"));
 
     assert.match(providerSource, /jskit\.database\.knex/);
     assert.match(repositorySource, /createWithTransaction/);
     assert.match(repositorySource, /persistence: "custom-knex"/);
     assert.match(descriptorSource, /scaffoldMode: "custom-knex"/);
     assert.match(descriptorSource, /lane: "weird-custom"/);
+    assert.equal(typeof appPackageJson.dependencies["@jskit-ai/database-runtime"], "string");
+    assert.equal(typeof appPackageJson.dependencies["@jskit-ai/database-runtime-mysql"], "string");
+    assert.equal(appPackageJson.dependencies["@jskit-ai/json-rest-api-core"], undefined);
   });
 });
 


### PR DESCRIPTION
## Summary
- updates JSKIT package metadata and descriptors
- sets JSKIT Node engine compatibility to `>=20 <23` where engine metadata is declared
- keeps generated catalog/docs in sync

## Verification
- Not run, per request.