### PR TITLE
Add session helper map workflow

### DIFF
--- a/FINAL_TODO.md
+++ b/FINAL_TODO.md
@@ -1,0 +1,785 @@
+# FINAL TODO: JSKIT Session Workflow Hardening
+
+This file is the implementation checklist for the next major JSKIT session workflow revision. Tick items as they are completed. Do not treat this as a loose workboard for an app session; this is the product-level implementation plan for JSKIT itself.
+
+## Ground Rules
+
+- [x] Create this `FINAL_TODO.md` as the shared implementation checklist.
+- [ ] Keep JSKIT as the source of truth for workflow state, steps, prompts, receipts, and session files.
+- [ ] Keep Studio thin: Studio renders JSKIT session JSON and does not own a parallel workflow state machine.
+- [ ] Do not resurrect the old giant `AGENTS.md` workflow.
+- [ ] Move useful old workflow discipline into JSKIT-owned session steps, prompt templates, preconditions, receipts, and JSON.
+- [ ] Keep all new session state filesystem-backed and inspectable under `.jskit/sessions/active/<session_id>/`.
+- [ ] Keep generated durable app memory under `.jskit/`, not in old free-form workboard files.
+- [ ] Add tests for every new session transition and every new JSON contract field.
+
+## Explicit Non-Goals
+
+- [ ] Do not make issue sessions reason about `empty`, `non_jskit_repo`, or `partial_jskit_app` as normal states.
+- [ ] Do not make Codex recover arbitrary non-JSKIT directories inside the issue workflow.
+- [ ] If a session is somehow started before app setup/app bootup readiness, JSKIT should block with a setup-required error rather than asking Codex to reason about recovery.
+- [ ] Do not add a project picker, app registry, or multi-project behavior.
+- [ ] Do not add a Studio-owned session workflow.
+- [ ] Do not reintroduce `.jskit/WORKBOARD.md`.
+- [ ] Do not make `AGENTS.md` long again.
+
+## Current Groundwork Already In Place
+
+- [x] `jskit session --json` exposes `stepDefinitions`, `currentStepAction`, Codex handoff metadata, receipts, issue text, PR URL, and session state.
+- [x] Studio can render the session timeline from JSKIT-owned step definitions.
+- [x] Session state lives in `.jskit/sessions/active/<session_id>/`.
+- [x] Completed and abandoned sessions are archived into separate filesystem directories.
+- [x] Worktrees live inside the owning session directory.
+- [x] `jskit helper-map update` exists as a JSKIT-owned helper map utility.
+- [x] The helper map is generated into `.jskit/helper-map.json` and `.jskit/helper-map.md`.
+- [x] Helper map generation uses parser-backed export discovery instead of regex-only parsing.
+- [x] Helper map update is integrated into the existing `Branch pushed, PR created` step.
+- [x] Existing prompts already mention `.jskit/helper-map.md` in planning/review contexts.
+
+## Desired High-Level Session Shape
+
+The final visible issue session should move through this broad sequence:
+
+- [ ] Session created.
+- [ ] Worktree created.
+- [ ] Dependencies installed.
+- [ ] Initial issue prompt rendered.
+- [ ] Issue drafted.
+- [ ] GitHub issue created.
+- [ ] Get issue details prompt rendered.
+- [ ] Plan details gathered.
+- [ ] Plan made.
+- [ ] Plan fine tuning.
+- [ ] Implementation changes accepted.
+- [ ] Implementation changes committed.
+- [ ] Pre-review checks run.
+- [ ] Deep UI check run or skipped.
+- [ ] Deslop/JSKIT review run.
+- [ ] Review changes accepted.
+- [ ] Review changes committed.
+- [ ] Post-review checks run.
+- [ ] Deep UI re-check run or skipped.
+- [ ] User check completed.
+- [ ] Blueprint updated.
+- [ ] Final verification run.
+- [ ] Final report created and commented.
+- [ ] Branch pushed and PR created.
+- [ ] PR merged, base updated, worktree removed.
+- [ ] Session finished and archived.
+
+## New And Revised Session Artifacts
+
+- [ ] Add `.jskit/sessions/active/<session_id>/plan_details.md`.
+- [ ] Add `.jskit/sessions/active/<session_id>/issue_metadata.json`.
+- [ ] Add `.jskit/sessions/active/<session_id>/agent_decisions.md`.
+- [ ] Add `.jskit/sessions/active/<session_id>/final_report.md`.
+- [ ] Add `.jskit/sessions/active/<session_id>/github_comments.json` for idempotent GitHub issue comments.
+- [ ] Add `.jskit/sessions/active/<session_id>/command_log.jsonl` if ordinary command execution needs durable command/output history beyond receipts.
+- [ ] Add `.jskit/sessions/active/<session_id>/checks/` for structured check receipts.
+- [ ] Add `.jskit/sessions/active/<session_id>/ui_checks/` for structured UI review/check receipts.
+- [ ] Add `.jskit/sessions/active/<session_id>/review_passes/` for repeated deslop/JSKIT review passes.
+- [ ] Keep `.jskit/APP_BLUEPRINT.md` as durable app memory.
+- [ ] Keep `.jskit/helper-map.md` as generated helper/export memory.
+- [ ] Make every artifact path appear in `jskit session <id> --json` when it exists.
+
+## Naming Decision: Plan Details
+
+- [ ] Use `plan_details.md` as the canonical accepted details file.
+- [ ] Treat `Get issue details` as the human-facing step label, because the developer is clarifying the issue with Codex.
+- [ ] Do not create a separate long-lived `issue_details.md` unless a compatibility alias is explicitly needed later.
+- [ ] The execution prompt must tell Codex to follow both `plan.md` and `plan_details.md`.
+- [ ] Any GitHub issue comment for the details step should post the accepted contents of `plan_details.md`.
+
+## JSON Contract Additions
+
+- [ ] Add `appReady` or equivalent setup-readiness status if JSKIT session must block before issue work.
+- [ ] Add `planDetails` as a string.
+- [ ] Add `planDetailsPath` as a string.
+- [ ] Add `issueCategory` with allowed values: `client`, `server`, `client_server`, `tooling`, `unknown`.
+- [ ] Add `uiImpact` with allowed values: `none`, `possible`, `definite`, `unknown`.
+- [ ] Add `agentDecisionsPath`.
+- [ ] Add `agentDecisionsSummary` or `agentDecisionsLatest`.
+- [ ] Add `blueprintPath`.
+- [ ] Add `blueprintExists`.
+- [ ] Add `helperMapPath`.
+- [ ] Add `helperMapExists`.
+- [ ] Add `finalReportPath`.
+- [ ] Add `finalReportText`.
+- [ ] Add `githubComments[]` or comment receipt metadata so Studio can show which issue comments have been posted.
+- [ ] Add `checks[]` with stable objects for automated checks.
+- [ ] Add `uiChecks[]` with stable objects for UI/deep UI checks.
+- [ ] Add `reviewPasses[]` with pass number, status, commit, changed files, and prompt path.
+- [ ] Add `currentStepAction.conditional` for steps that can skip.
+- [ ] Add `currentStepAction.skipReason` when JSKIT can determine why a conditional step is skipped.
+- [ ] Add `currentStepAction.retryable` for blocked check/review/UI steps that should rerun after repair.
+- [ ] Ensure `--json` writes only JSON to stdout.
+- [ ] Contract-test all new fields on active, completed, abandoned, and blocked sessions.
+
+## Step: Initial Issue Prompt
+
+Goal: create a first implementation-ready issue draft from the user's short request, without mutating the project.
+
+- [ ] Update `new_issue.md` to assume app setup already passed.
+- [ ] Remove normal reasoning around `empty`, `non_jskit_repo`, and `partial_jskit_app`.
+- [ ] Add instruction: if the filesystem contradicts a valid JSKIT app, report setup failure instead of inventing recovery work.
+- [ ] Instruct the agent to read `.jskit/APP_BLUEPRINT.md` when present.
+- [ ] Instruct the agent to read `.jskit/helper-map.md` when present.
+- [ ] Instruct the agent to inspect `package.json`, `.jskit/lock.json`, `config/public.js`, relevant `src/`, and relevant `packages/`.
+- [ ] Mention safe read-only commands: `pwd`, `ls`, `find`, `rg`, `cat`, `sed`, `git status`.
+- [ ] Mention safe JSKIT inspection commands only when available and non-mutating:
+  - [ ] `jskit list`
+  - [ ] `jskit show <package> --details`
+  - [ ] `jskit list-placements`
+- [ ] Keep mutation commands forbidden in issue drafting:
+  - [ ] no `jskit session step`
+  - [ ] no `gh`
+  - [ ] no `git add`
+  - [ ] no `git commit`
+  - [ ] no `git push`
+  - [ ] no `npm install`
+  - [ ] no generators
+  - [ ] no tests
+  - [ ] no doctor
+- [ ] Keep output tags:
+  - [ ] `[issue_title]...[/issue_title]`
+  - [ ] `[issue_text]...[/issue_text]`
+- [ ] Test that issue drafting remains read-only by prompt contract.
+- [ ] Test that generated issue prompt mentions blueprint/helper-map/app inspection.
+
+## New Step: Get Issue Details
+
+Goal: let the developer and Codex talk until no important implementation details are missing, before planning begins.
+
+### Step Shape
+
+- [ ] Add JSKIT session steps after `issue_created` and before `plan_made`.
+- [ ] Add internal step `plan_details_prompt_rendered`.
+- [ ] Use visible label `Get issue details` for `plan_details_prompt_rendered`.
+- [ ] Use button label `Start details conversation` for `plan_details_prompt_rendered`.
+- [ ] Add internal step `plan_details_gathered`.
+- [ ] Use visible label `Plan details gathered` for `plan_details_gathered`.
+- [ ] Use button label `Save plan details` for `plan_details_gathered`.
+- [ ] Keep both steps visible in CLI JSON; Studio may visually keep the form/conversation within the same details section using JSKIT-provided metadata, not hard-coded step IDs.
+- [ ] Preserve a clean manual CLI flow.
+- [ ] Preserve Studio's 1:1 rendering of JSKIT-owned steps.
+- [ ] Add prompt artifact path: `prompts/plan_details.md`.
+- [ ] Add accepted details file: `plan_details.md`.
+- [ ] Add metadata file: `issue_metadata.json`.
+- [ ] Append important decisions to `agent_decisions.md`.
+- [ ] Comment accepted plan details on the GitHub issue.
+
+### Prompt Behavior
+
+- [ ] Create `tooling/jskit-cli/src/server/sessionRuntime/prompts/plan_details.md`.
+- [ ] The prompt must tell Codex: "No stones unturned."
+- [ ] Codex must read:
+  - [ ] GitHub issue URL and issue text.
+  - [ ] `.jskit/APP_BLUEPRINT.md`.
+  - [ ] `.jskit/helper-map.md`.
+  - [ ] `package.json`.
+  - [ ] `.jskit/lock.json`.
+  - [ ] `config/public.js`.
+  - [ ] relevant `src/` and `packages/`.
+  - [ ] relevant JSKIT package docs or `jskit show ... --details`.
+- [ ] Codex must ask follow-up questions until implementation details are complete.
+- [ ] Codex must ask for final confirmation before emitting final details.
+- [ ] Codex must not edit files during this step.
+- [ ] Codex must not run mutation commands during this step.
+
+### Required Detail Areas
+
+- [ ] If CRUD or persisted data is involved, require:
+  - [ ] entity/table name.
+  - [ ] field names.
+  - [ ] field types.
+  - [ ] required/optional/nullability.
+  - [ ] defaults.
+  - [ ] uniqueness.
+  - [ ] indexes where relevant.
+  - [ ] relationships.
+  - [ ] ownership: `public`, `user`, `workspace`, `workspace_user`, or explicit exception.
+  - [ ] allowed operations: `list`, `view`, `new`, `edit`, `delete`, or narrower set.
+  - [ ] list fields.
+  - [ ] view form shape.
+  - [ ] edit/new form shape.
+  - [ ] validation rules.
+  - [ ] permissions and role boundaries.
+  - [ ] migration/generator lane.
+  - [ ] exact CRUD generator command or exact reason no CRUD generator applies.
+- [ ] If UI is involved, require:
+  - [ ] route path.
+  - [ ] placement/surface target.
+  - [ ] navigation entry expectations.
+  - [ ] responsive layout expectations.
+  - [ ] loading state.
+  - [ ] empty state.
+  - [ ] error state.
+  - [ ] disabled state.
+  - [ ] success state.
+  - [ ] Material/Vuetify quality expectations.
+  - [ ] Playwright verification path.
+  - [ ] auth/bootstrap strategy if login is needed.
+- [ ] If server-only work is involved, require:
+  - [ ] endpoint/command/job shape.
+  - [ ] request and response shape.
+  - [ ] validation behavior.
+  - [ ] auth/permission behavior.
+  - [ ] persistence ownership if any.
+  - [ ] error behavior.
+  - [ ] verification path.
+- [ ] If package/generator work is involved, require:
+  - [ ] exact `jskit add` or `jskit generate` command.
+  - [ ] reason the package/generator applies.
+  - [ ] expected generated files.
+  - [ ] follow-up custom code areas.
+- [ ] If the request is intentionally tiny, still require:
+  - [ ] exact file/path behavior.
+  - [ ] acceptance criteria.
+  - [ ] whether UI is impacted.
+  - [ ] whether tests/checks are needed.
+
+### Required Output Tags
+
+- [ ] Require Codex to output:
+
+```text
+[issue_category]
+client | server | client_server | tooling
+[/issue_category]
+
+[ui_impact]
+none | possible | definite
+[/ui_impact]
+
+[plan_details]
+<confirmed implementation details in Markdown>
+[/plan_details]
+
+[agent_decisions]
+<append-only decision entries with reasons>
+[/agent_decisions]
+```
+
+- [ ] Add parser helpers for these tags.
+- [ ] Validate allowed `issue_category` values.
+- [ ] Validate allowed `ui_impact` values.
+- [ ] Reject empty `plan_details`.
+- [ ] Save `agent_decisions` by appending to session `agent_decisions.md`.
+- [ ] Write a receipt when details are saved.
+- [ ] Add tests for valid output.
+- [ ] Add tests for missing tags.
+- [ ] Add tests for invalid category.
+- [ ] Add tests for invalid UI impact.
+- [ ] Add tests that plan details are commented on the GitHub issue.
+
+## Issue Classification
+
+- [ ] Store classification in `issue_metadata.json`.
+- [ ] Include `issueCategory` in session JSON.
+- [ ] Include `uiImpact` in session JSON.
+- [ ] Use `uiImpact` to decide whether Deep UI Check steps should run or skip.
+- [ ] Treat `uiImpact=none` as skip for Deep UI Check.
+- [ ] Treat `uiImpact=possible` as run unless the user explicitly marks UI not impacted.
+- [ ] Treat `uiImpact=definite` as mandatory Deep UI Check.
+- [ ] Add an explicit skip/override path for `uiImpact=possible`, requiring a short reason that is stored in `ui_checks/`.
+- [ ] Add repair/error behavior when classification is missing before UI/check steps.
+- [ ] Add Studio display for category and UI impact in the session info cards.
+
+## GitHub Comment Idempotency
+
+Goal: rerunning a step must not spam the GitHub issue with duplicate plan/details/final-report comments.
+
+- [ ] Store comment metadata in `github_comments.json`.
+- [ ] Track comment purpose keys such as `plan_details`, `plan`, `agent_decisions`, and `final_report`.
+- [ ] Store comment URL or id when `gh` exposes it.
+- [ ] If a comment already exists for a purpose, update it when supported or skip with a clear receipt.
+- [ ] If update is not feasible in V1, skip duplicate comments after the first successful comment and report the stored comment URL/id.
+- [ ] Add tests that rerunning plan-details comment does not duplicate the issue comment.
+- [ ] Add tests that rerunning plan comment does not duplicate the issue comment.
+- [ ] Add tests that rerunning final-report comment does not duplicate the issue comment.
+
+## Agent Decisions Log
+
+Goal: preserve the why behind important choices without resurrecting a workboard.
+
+- [ ] Add session-owned `agent_decisions.md`.
+- [ ] Initialize it with session id, issue URL, and timestamp.
+- [ ] Append decisions from Get Issue Details.
+- [ ] Append generator/package decisions from Plan Made.
+- [ ] Append implementation deviations from Plan Fine Tuning.
+- [ ] Append Deep UI Check decisions.
+- [ ] Append verification decisions.
+- [ ] Append blueprint-update decisions.
+- [ ] Keep entries concise and reasoned.
+- [ ] Do not use this as task tracking.
+- [ ] Do not make it app-global.
+- [ ] Include latest decision summary in `jskit session <id> --json`.
+- [ ] Comment the decision log or a summarized decision report on the GitHub issue near the end.
+- [ ] Add tests that decisions are appended, not overwritten.
+- [ ] Add tests that the final report links or includes decisions.
+
+## Plan Made Step
+
+Goal: produce an implementation plan only after the issue and details are complete.
+
+- [ ] Update `plan_issue.md` to read `plan_details.md`.
+- [ ] Update `plan_issue.md` to read `agent_decisions.md`.
+- [ ] Update `plan_issue.md` to read `.jskit/APP_BLUEPRINT.md`.
+- [ ] Update `plan_issue.md` to read `.jskit/helper-map.md`.
+- [ ] Require plan to include the issue category and UI impact.
+- [ ] Require plan to include exact generator/package decisions.
+- [ ] Require plan to include exact JSKIT inspection commands used or to use.
+- [ ] For CRUD work, require exact server CRUD command or exact reason not applicable.
+- [ ] For non-CRUD UI pages, require exact UI generator command or exact reason not applicable.
+- [ ] For UI-impacting work, require planned Playwright and Deep UI Check path.
+- [ ] For auth-required UI, require local dev auth/bootstrap strategy.
+- [ ] Require plan output tags:
+
+```text
+[plan]
+<implementation plan>
+[/plan]
+
+[agent_decisions]
+<new decisions from planning>
+[/agent_decisions]
+```
+
+- [ ] Save `plan.md`.
+- [ ] Append plan decisions to `agent_decisions.md`.
+- [ ] Comment the approved plan on the GitHub issue immediately after approval.
+- [ ] Ensure this existing behavior is explicit and tested.
+- [ ] Add tests that `plan_made` requires `plan_details.md`.
+- [ ] Add tests that plan comment includes the approved plan.
+
+## Plan Fine Tuning Step
+
+Goal: let the user refine the plan with Codex, then implement in the worktree.
+
+- [ ] Update `fine_tune_plan.md` to read `plan_details.md`.
+- [ ] Update `fine_tune_plan.md` to explicitly say Codex must follow both `plan.md` and `plan_details.md`.
+- [ ] Update `fine_tune_plan.md` to read `agent_decisions.md`.
+- [ ] Update prompt to preserve user refinements as decision-log entries.
+- [ ] Require Codex to append any meaningful implementation deviations to `agent_decisions.md` through tagged output or a session step input.
+- [ ] Keep Codex from creating commits, PRs, merges, or worktree cleanup.
+- [ ] Keep Codex working only inside the session worktree.
+- [ ] Add tests that prompt includes plan details path.
+- [ ] Add tests that prompt includes decisions path.
+
+## Mutation And Commit Model For Repair / Quality Steps
+
+Goal: every Codex step that can edit files must leave the worktree in a known committed or explicitly accepted state before the workflow advances.
+
+- [ ] Define which prompt steps are allowed to mutate files.
+- [ ] Treat Plan Fine Tuning / implementation as mutating.
+- [ ] Treat Deep UI Check as mutating when it fixes scoped UI issues.
+- [ ] Treat Deslop/JSKIT review as mutating when it fixes findings.
+- [ ] Treat check/doctor repair prompts as mutating when they fix failures.
+- [ ] After any mutating Codex quality/repair step, require an accept/commit path before proceeding.
+- [ ] Avoid leaving dirty worktree changes between quality/check steps unless the next step explicitly owns those dirty changes.
+- [ ] Include dirty-worktree status in `jskit session <id> --json`.
+- [ ] Add a generic commit helper for session-owned quality/repair commits where possible.
+- [ ] Commit messages should identify the session and phase, for example `Deep UI check fixes for <session_id>`.
+- [ ] Add tests that Deep UI Check changes are committed or explicitly skipped before deslop/review advances.
+- [ ] Add tests that check-repair changes are committed before rerunning the check step.
+- [ ] Add tests that repeated review pass changes are committed per pass.
+
+## Repeated Deslop / JSKIT Review
+
+Goal: support multiple deslop/JSKIT review passes without hard-coding three duplicated visible step groups.
+
+- [ ] Design repeatable review pass storage under `review_passes/<n>/`.
+- [ ] Keep the visible step model simple.
+- [ ] Avoid reintroducing separate numbered visible steps such as `review_prompt_rendered_1`, `review_prompt_rendered_2`, etc.
+- [ ] Add `reviewPasses[]` to JSON.
+- [ ] Add current review pass number to JSON.
+- [ ] Add maximum review pass setting with a conservative default.
+- [ ] Add prompt support for "run another deslop/JSKIT review pass".
+- [ ] Keep Deslop and JSKIT review as distinct sections in the prompt.
+- [ ] Deslop checks:
+  - [ ] duplicate helpers.
+  - [ ] unnecessary helpers.
+  - [ ] fake-complete UI.
+  - [ ] missing states.
+  - [ ] dead code.
+  - [ ] weak route wiring.
+  - [ ] placeholder copy/code.
+- [ ] JSKIT checks:
+  - [ ] wrong generator choice.
+  - [ ] missed package/runtime seam.
+  - [ ] hand-built CRUD where generated ownership is required.
+  - [ ] direct knex outside approved lanes.
+  - [ ] metadata drift.
+  - [ ] surface/route/ownership mistakes.
+- [ ] Add a way to stop review passes when no important findings remain.
+- [ ] Add a way to request another pass when important findings remain.
+- [ ] Ensure each review pass that changes files has an accept/commit path before the next pass.
+- [ ] Ensure each review pass records the commit SHA or records that no changes were needed.
+- [ ] Add tests for zero-change review pass.
+- [ ] Add tests for review pass with changes.
+- [ ] Add tests for max pass handling.
+
+## Automated Checks Before And After Review
+
+Goal: make checks a first-class session concept, not only an afterthought.
+
+- [ ] Add step before review/deslop: `pre_review_checks_run`.
+- [ ] Add step after review/deslop: `post_review_checks_run`.
+- [ ] Decide button labels:
+  - [ ] `Run checks`
+  - [ ] `Run checks again`
+- [ ] Run the smallest relevant automated checks for the current project.
+- [ ] Prefer existing project script order:
+  - [ ] `npm run verify:local` if present.
+  - [ ] else `npm run verify` if present.
+  - [ ] else `npx jskit app verify`.
+  - [ ] else known fallback scripts if appropriate.
+- [ ] Store stdout/stderr summaries under `checks/`.
+- [ ] Store structured status in JSON.
+- [ ] If pre-review checks fail, block and render repair prompt.
+- [ ] If post-review checks fail, block and render repair prompt.
+- [ ] If a repair prompt changes files, commit the repair before rerunning the same check.
+- [ ] After repair, rerun the same check step rather than arbitrary jumping.
+- [ ] Avoid generic arbitrary state-machine jumping in V1.
+- [ ] Add tests for passing pre-review checks.
+- [ ] Add tests for failing pre-review checks.
+- [ ] Add tests for passing post-review checks.
+- [ ] Add tests for failing post-review checks.
+- [ ] Add tests that blocked check steps are retryable.
+
+## Deep UI Check Before And After Review
+
+Goal: add a focused UI quality pass for visual/client-impacting work.
+
+- [ ] Add step before deslop/review: `deep_ui_check_run`.
+- [ ] Add step after deslop/review: `deep_ui_recheck_run`.
+- [ ] Use `uiImpact` to decide run/skip.
+- [ ] If `uiImpact=none`, write a skipped receipt with reason.
+- [ ] If `uiImpact=possible`, run unless explicitly overridden.
+- [ ] If `uiImpact=definite`, require run.
+- [ ] Create prompt `deep_ui_check.md`.
+- [ ] The prompt must inspect changed UI files, routes, components, layouts, and screenshots if available.
+- [ ] The prompt must check:
+  - [ ] Material Design quality.
+  - [ ] Vuetify best practices.
+  - [ ] visual hierarchy.
+  - [ ] spacing.
+  - [ ] responsive behavior.
+  - [ ] loading states.
+  - [ ] empty states.
+  - [ ] error states.
+  - [ ] disabled states.
+  - [ ] success states.
+  - [ ] accessibility basics.
+  - [ ] route/navigation coherence.
+  - [ ] consistency with existing app style.
+- [ ] The prompt must ask Codex to fix scoped UI issues when clear.
+- [ ] The prompt must not create commits or PRs.
+- [ ] If the Deep UI Check fixes files, require accept/commit before continuing.
+- [ ] If the Deep UI Re-check fixes files, require accept/commit before continuing.
+- [ ] Integrate Playwright guidance:
+  - [ ] run a meaningful route check when possible.
+  - [ ] use local dev auth bootstrap when needed.
+  - [ ] record UI verification with `jskit app verify-ui`.
+  - [ ] call out missing auth bootstrap as a testability gap.
+- [ ] Store UI check output under `ui_checks/`.
+- [ ] Include UI check status in JSON.
+- [ ] Add tests for skipped server-only issue.
+- [ ] Add tests for mandatory UI-impact issue.
+- [ ] Add tests for failed UI check repair prompt.
+- [ ] Add Studio rendering for skipped/running/passed/failed UI checks.
+
+## User Check Step
+
+Goal: keep human verification as a distinct step.
+
+- [ ] Keep existing `user_check_completed` step.
+- [ ] Update prompt to mention plan details and planned acceptance criteria.
+- [ ] Tell user exactly what route, behavior, command, or workflow to inspect.
+- [ ] If user reports failure, render repair prompt and keep session in a retryable state.
+- [ ] If user reports pass, write receipt.
+- [ ] Include user check result in final report.
+- [ ] Add tests for failed user check path if not already covered.
+
+## Blueprint Updated Step
+
+Goal: enrich durable app memory issue by issue.
+
+### Step Position
+
+- [ ] Add `blueprint_updated` after user check and review/check cycles.
+- [ ] Run it before final verification/doctor and before PR creation.
+- [ ] Ensure blueprint changes are included in the session branch.
+- [ ] Commit blueprint changes if changed.
+- [ ] If blueprint is unchanged, write an unchanged receipt.
+
+### Prompt Behavior
+
+- [ ] Create prompt `update_blueprint.md`.
+- [ ] Prompt reads:
+  - [ ] current `.jskit/APP_BLUEPRINT.md` if present.
+  - [ ] issue title/body.
+  - [ ] plan details.
+  - [ ] approved plan.
+  - [ ] agent decisions.
+  - [ ] changed files.
+  - [ ] helper map.
+  - [ ] package/app metadata.
+- [ ] Prompt updates only durable app/product/architecture memory.
+- [ ] Prompt must not include session task tracking.
+- [ ] Prompt must not recreate `.jskit/WORKBOARD.md`.
+- [ ] Prompt must not over-expand tiny issues into broad product rewrites.
+- [ ] Prompt should naturally evolve from a minimal app sketch to a richer app blueprint over many issues.
+- [ ] Prompt output tag:
+
+```text
+[app_blueprint]
+<full updated blueprint markdown>
+[/app_blueprint]
+```
+
+### Runtime Behavior
+
+- [ ] Parse `[app_blueprint]`.
+- [ ] Write `.jskit/APP_BLUEPRINT.md`.
+- [ ] If changed, commit with a clear message.
+- [ ] Append blueprint decision summary to `agent_decisions.md`.
+- [ ] Add blueprint update receipt.
+- [ ] Add blueprint status to JSON.
+- [ ] Add tests for creating a new blueprint.
+- [ ] Add tests for updating an existing blueprint.
+- [ ] Add tests for unchanged blueprint.
+- [ ] Add tests that blueprint update happens before final verification.
+- [ ] Add CLI/session input support for accepting the tagged blueprint output, for example `--blueprint -` or a step-specific equivalent.
+- [ ] Add tests for invalid/missing `[app_blueprint]` output.
+
+## Final Verification / Doctor
+
+Goal: verify the full branch after implementation, review, UI checks, and blueprint update.
+
+- [ ] Keep existing final verification step.
+- [ ] Ensure final verification runs after blueprint update.
+- [ ] Ensure final verification sees all committed changes.
+- [ ] Ensure UI receipt expectations are respected when UI files changed.
+- [ ] Keep doctor failures repairable.
+- [ ] Update doctor failure prompt to mention:
+  - [ ] plan details.
+  - [ ] blueprint update.
+  - [ ] helper map.
+  - [ ] UI checks.
+  - [ ] check receipts.
+- [ ] Add tests that final verification runs after blueprint update.
+- [ ] Add tests that final verification failure blocks PR creation.
+
+## Final Report Step
+
+Goal: generate a clear final report for the issue before PR/merge completion.
+
+- [ ] Add step `final_report_created`.
+- [ ] Position it after final verification and before branch push / PR creation.
+- [ ] Do not require the PR URL in this report; the later final comment can include PR URL after creation/merge.
+- [ ] Generate the final report deterministically from session artifacts in V1.
+- [ ] Do not make final report generation depend on another Codex prompt in V1.
+- [ ] Report must include:
+  - [ ] issue URL.
+  - [ ] issue title.
+  - [ ] plan details summary.
+  - [ ] plan summary.
+  - [ ] files changed.
+  - [ ] commits.
+  - [ ] commands/checks run.
+  - [ ] UI checks run or skipped.
+  - [ ] Playwright/verify-ui status.
+  - [ ] user check result.
+  - [ ] blueprint update status.
+  - [ ] helper map update status.
+  - [ ] remaining unverified gaps.
+  - [ ] important decisions and why.
+- [ ] Write `final_report.md`.
+- [ ] Comment final report on the GitHub issue.
+- [ ] Include final report path/text in JSON.
+- [ ] Add tests that final report is created.
+- [ ] Add tests that final report is commented on issue.
+- [ ] Add tests that final report includes checks and UI checks.
+
+## Branch Pushed And PR Created Step
+
+Goal: keep PR creation as the single visible step that finalizes branch publication.
+
+- [ ] Keep helper map update inside this step.
+- [ ] Ensure helper map changes are committed before push.
+- [ ] Ensure blueprint/final report changes have already been committed or intentionally recorded.
+- [ ] Ensure branch push includes all final commits.
+- [ ] Create PR with issue body and "Closes #".
+- [ ] Preserve existing GitHub auth/remote preconditions.
+- [ ] Keep behavior idempotent when PR already exists if possible.
+- [ ] Add tests that helper map commit occurs before push.
+- [ ] Add tests that final report/blueprint commits are present before push.
+
+## PR Merged / Worktree Removed Step
+
+Goal: merge safely, update local base, clean worktree, and preserve recoverability.
+
+- [ ] Preserve current already-merged PR handling.
+- [ ] Preserve current target-root dirty check.
+- [ ] Preserve current base branch fast-forward checks.
+- [ ] Preserve issue close/comment behavior.
+- [ ] Preserve branch recoverability where possible.
+- [ ] Preserve worktree cleanup.
+- [ ] Ensure final session archive includes:
+  - [ ] final report.
+  - [ ] agent decisions.
+  - [ ] plan details.
+  - [ ] check receipts.
+  - [ ] UI check receipts.
+  - [ ] prompt artifacts.
+- [ ] Add tests for archive contents.
+
+## Studio Integration
+
+Goal: update Studio only after JSKIT JSON supports the workflow.
+
+- [ ] Do not hard-code new step IDs in Studio beyond generic rendering needs.
+- [ ] Render `planDetails`.
+- [ ] Render `issueCategory`.
+- [ ] Render `uiImpact`.
+- [ ] Render `agentDecisions` card/link.
+- [ ] Render `finalReport` card/link.
+- [ ] Render `checks[]`.
+- [ ] Render `uiChecks[]`.
+- [ ] Render `reviewPasses[]`.
+- [ ] Support conditional skipped steps visually.
+- [ ] Support retryable blocked steps visually.
+- [ ] In `Get issue details`, render the Codex conversation and output form inside the step.
+- [ ] In `Plan made`, include plan details context.
+- [ ] In Deep UI Check steps, show run/skip status clearly.
+- [ ] Ensure terminal remains below/alongside todo according to current Studio layout.
+- [ ] Ensure mobile layout keeps Codex terminal usable and collapsible.
+- [ ] Ensure abandoned/completed session views show final report and decisions.
+- [ ] Add tests or browser checks for the new Studio rendering.
+
+## Prompt Inventory
+
+- [ ] Update `new_issue.md`.
+- [ ] Add `plan_details.md`.
+- [ ] Update `plan_issue.md`.
+- [ ] Update `fine_tune_plan.md`.
+- [ ] Add or update `deep_ui_check.md`.
+- [ ] Update `review_changes.md`.
+- [ ] Update `user_check.md`.
+- [ ] Add `update_blueprint.md`.
+- [ ] Update `doctor_failure.md`.
+- [ ] Update `pr_failure.md` if needed.
+- [ ] Add a deterministic final report renderer; do not add a Codex prompt for final report in V1.
+- [ ] Update `final_comment.md` if needed.
+- [ ] Ensure all prompts mention the correct session-owned files.
+- [ ] Ensure no prompt tells Codex to create `.jskit/WORKBOARD.md`.
+- [ ] Ensure no prompt tells Codex to use old long `AGENTS.md` workflow.
+
+## CLI And Parser Work
+
+- [ ] Add input resolution for `--plan-details`, `--plan-details-file`, and `--plan-details -`.
+- [ ] Add input resolution for `--issue-category`.
+- [ ] Add input resolution for `--ui-impact`.
+- [ ] Add input resolution for decision log fragments if needed.
+- [ ] Add input resolution for blueprint update output, for example `--blueprint`, `--blueprint-file`, and `--blueprint -`.
+- [ ] Add extraction helpers:
+  - [ ] `extractIssueCategory`.
+  - [ ] `extractUiImpact`.
+  - [ ] `extractPlanDetails`.
+  - [ ] `extractAgentDecisions`.
+  - [ ] `extractAppBlueprint`.
+- [ ] Add validators for enum values.
+- [ ] Add stable error codes for invalid plan details output.
+- [ ] Add stable error codes for missing classification.
+- [ ] Add stable error codes for missing details.
+- [ ] Add stable repair commands for each new blocked state.
+
+## Preconditions
+
+- [ ] Add `plan_details_exists`.
+- [ ] Add `issue_metadata_exists`.
+- [ ] Add `plan_text_exists` if not already present.
+- [ ] Add separate preconditions for `pre_review_checks_passed` and `post_review_checks_passed` where needed.
+- [ ] Add separate preconditions for `deep_ui_check_satisfied` and `deep_ui_recheck_satisfied` where needed.
+- [ ] Add `blueprint_update_satisfied`.
+- [ ] Add `final_report_exists`.
+- [ ] Add named precondition tests for every new executable step.
+- [ ] Ensure every step except `session_created` declares named preconditions.
+
+## Receipts
+
+- [ ] Add receipt for plan details prompt rendered.
+- [ ] Add receipt for plan details saved.
+- [ ] Add receipt for plan details commented on issue.
+- [ ] Add receipt for plan commented on issue.
+- [ ] Add receipt or metadata for idempotent GitHub comment skip/update.
+- [ ] Add receipt for pre-review checks run.
+- [ ] Add receipt for Deep UI Check run/skipped.
+- [ ] Add receipt for review pass run.
+- [ ] Add receipt for post-review checks run.
+- [ ] Add receipt for Deep UI Re-check run/skipped.
+- [ ] Add receipt for blueprint updated/unchanged.
+- [ ] Add receipt for final report created.
+- [ ] Add receipt for final report commented on issue.
+- [ ] Add tests that receipts are readable and archive with session.
+
+## Tests
+
+- [ ] Add tests for new plan details tag extraction.
+- [ ] Add tests for plan details CLI stdin handling.
+- [ ] Add tests for plan details prompt rendering.
+- [ ] Add tests for plan details GitHub comment.
+- [ ] Add tests for issue classification JSON fields.
+- [ ] Add tests for plan requiring plan details.
+- [ ] Add tests for plan comment on GitHub issue.
+- [ ] Add tests for agent decision append behavior.
+- [ ] Add tests for repeated review pass bookkeeping.
+- [ ] Add tests for pre-review checks.
+- [ ] Add tests for post-review checks.
+- [ ] Add tests for Deep UI Check run.
+- [ ] Add tests for Deep UI Check skipped.
+- [ ] Add tests for blueprint update.
+- [ ] Add tests for final verification order.
+- [ ] Add tests for final report generation.
+- [ ] Add tests for final report GitHub comment.
+- [ ] Add tests for PR creation including blueprint/helper-map/final-report commits.
+- [ ] Add tests for completed archive contents.
+- [ ] Add tests for idempotent GitHub comments.
+- [ ] Add tests for dirty-worktree blocking between quality/check phases.
+- [ ] Update generated docs/reference tests if command exports change.
+- [ ] Run focused session tests.
+- [ ] Run `npm run lint`.
+- [ ] Run `npm run check:runtime-deps`.
+- [ ] Run broader `npm run verify:local` when the implementation is ready.
+
+## Documentation
+
+- [ ] Update `revolution.md` or replace with a current implementation tracker if appropriate.
+- [ ] Update CLI help for new session flags.
+- [ ] Update generated command reference through `npm run agent-docs:build`.
+- [ ] Update agent docs tests that assert old workflow files are not active.
+- [ ] Keep `packages/agent-docs/templates/app/AGENTS.md` tiny.
+- [ ] Document the new Get Issue Details / `plan_details.md` flow.
+- [ ] Document `agent_decisions.md`.
+- [ ] Document blueprint enrichment.
+- [ ] Document conditional Deep UI Check behavior.
+
+## Acceptance Criteria
+
+- [ ] A user can start a session from Studio and never manually copy prompts unless they choose manual mode.
+- [ ] The session asks for detailed issue information before planning.
+- [ ] CRUD details are captured before planning when relevant.
+- [ ] Issue category and UI impact are saved and visible.
+- [ ] The plan reads plan details, blueprint, helper map, and decisions.
+- [ ] The approved plan is commented on the GitHub issue.
+- [ ] Agent decisions are appended throughout the workflow.
+- [ ] Deep UI Check runs for UI-impacting issues and skips cleanly for server-only issues.
+- [ ] Automated checks run before and after review/deslop.
+- [ ] Failed checks are repairable without arbitrary state jumping.
+- [ ] The blueprint is updated before final verification and PR creation.
+- [ ] Final report is created and commented on the GitHub issue.
+- [ ] Helper map still updates inside PR creation.
+- [ ] Studio renders all new state from JSKIT JSON.
+- [ ] Completed sessions archive all important artifacts.
+- [ ] Old long AGENTS/workboard workflow does not come back.

--- a/FINAL_TODO.md
+++ b/FINAL_TODO.md
@@ -769,6 +769,7 @@ Goal: update Studio only after JSKIT JSON supports the workflow.
 
 - [ ] A user can start a session from Studio and never manually copy prompts unless they choose manual mode.
 - [ ] The session asks for detailed issue information before planning.
+- [ ] The accepted details are saved as `plan_details.md`.
 - [ ] CRUD details are captured before planning when relevant.
 - [ ] Issue category and UI impact are saved and visible.
 - [ ] The plan reads plan details, blueprint, helper map, and decisions.
@@ -779,7 +780,9 @@ Goal: update Studio only after JSKIT JSON supports the workflow.
 - [ ] Failed checks are repairable without arbitrary state jumping.
 - [ ] The blueprint is updated before final verification and PR creation.
 - [ ] Final report is created and commented on the GitHub issue.
+- [ ] GitHub issue comments are idempotent on rerun.
 - [ ] Helper map still updates inside PR creation.
+- [ ] Mutating repair/review/UI steps cannot leave unowned dirty changes before advancing.
 - [ ] Studio renders all new state from JSKIT JSON.
 - [ ] Completed sessions archive all important artifacts.
 - [ ] Old long AGENTS/workboard workflow does not come back.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2098,6 +2098,17 @@
       "version": "0.3.5",
       "license": "MIT"
     },
+    "node_modules/@ts-morph/common": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.29.0.tgz",
+      "integrity": "sha512-35oUmphHbJvQ/+UTwFNme/t2p3FoKiGJ5auTjjpNTop2dyREspirjMy82PLSC1pnDJ8ah1GU98hwpVt64YXQsg==",
+      "license": "MIT",
+      "dependencies": {
+        "minimatch": "^10.0.1",
+        "path-browserify": "^1.0.1",
+        "tinyglobby": "^0.2.14"
+      }
+    },
     "node_modules/@types/cors": {
       "version": "2.8.19",
       "license": "MIT",
@@ -2739,6 +2750,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/base64id": {
       "version": "2.0.0",
       "license": "MIT",
@@ -2772,6 +2792,18 @@
     "node_modules/boolbase": {
       "version": "1.0.0",
       "license": "ISC"
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/braces": {
       "version": "3.0.3",
@@ -2920,6 +2952,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/code-block-writer": {
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-13.0.3.tgz",
+      "integrity": "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==",
+      "license": "MIT"
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -4727,6 +4765,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/minisearch": {
       "version": "7.2.0",
       "dev": true,
@@ -5014,6 +5067,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "license": "MIT"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -5935,6 +5994,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ts-morph": {
+      "version": "28.0.0",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-28.0.0.tgz",
+      "integrity": "sha512-Wp3tnZ2bzwxyTZMtgWVzXDfm7lB1Drz+y9DmmYH/L702PQhPyVrp3pkou3yIz4qjS14GY9kcpmLiOOMvl8oG1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@ts-morph/common": "~0.29.0",
+        "code-block-writer": "^13.0.3"
       }
     },
     "node_modules/tslib": {
@@ -7031,7 +7100,9 @@
       "dependencies": {
         "@jskit-ai/jskit-catalog": "0.1.80",
         "@jskit-ai/kernel": "0.1.72",
-        "@jskit-ai/shell-web": "0.1.71"
+        "@jskit-ai/shell-web": "0.1.71",
+        "@vue/compiler-sfc": "^3.5.29",
+        "ts-morph": "^28.0.0"
       },
       "bin": {
         "jskit": "bin/jskit.js"

--- a/tooling/jskit-cli/package.json
+++ b/tooling/jskit-cli/package.json
@@ -22,7 +22,9 @@
   "dependencies": {
     "@jskit-ai/jskit-catalog": "0.1.80",
     "@jskit-ai/kernel": "0.1.72",
-    "@jskit-ai/shell-web": "0.1.71"
+    "@jskit-ai/shell-web": "0.1.71",
+    "@vue/compiler-sfc": "^3.5.29",
+    "ts-morph": "^28.0.0"
   },
   "engines": {
     "node": ">=20 <23"

--- a/tooling/jskit-cli/src/server/commandHandlers/helperMap.js
+++ b/tooling/jskit-cli/src/server/commandHandlers/helperMap.js
@@ -1,0 +1,104 @@
+function writeJson(stdout, payload) {
+  stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+}
+
+function writeErrors(stdout, payload) {
+  for (const error of payload.errors || []) {
+    stdout.write(`[${error.code}] ${error.message}\n`);
+    if (error.repairCommand) {
+      stdout.write(`Repair: ${error.repairCommand}\n`);
+    }
+  }
+}
+
+function writeHelperMapText(stdout, payload) {
+  if (Object.hasOwn(payload, "changed")) {
+    stdout.write(
+      payload.changed
+        ? `Updated helper map at ${payload.helperMapMarkdownPath}.\n`
+        : `Helper map is up to date at ${payload.helperMapMarkdownPath}.\n`
+    );
+    return;
+  }
+  if (payload.exists === false) {
+    stdout.write(`No helper map set at ${payload.helperMapMarkdownPath}. Run jskit helper-map update.\n`);
+    return;
+  }
+  if (payload.markdown) {
+    stdout.write(payload.markdown);
+    return;
+  }
+  stdout.write(`Helper map is up to date at ${payload.helperMapMarkdownPath}.\n`);
+}
+
+function createHelperMapCommands(ctx = {}) {
+  const { resolveAppRootFromCwd } = ctx;
+
+  async function commandHelperMap({
+    positional = [],
+    options = {},
+    cwd,
+    stdout
+  } = {}) {
+    const subcommand = String(positional[0] || "").trim();
+    let payload;
+
+    try {
+      const appRoot = await resolveAppRootFromCwd(cwd);
+      if (positional.length > 1) {
+        payload = {
+          ok: false,
+          errors: [
+            {
+              code: "unexpected_helper_map_argument",
+              message: `Unexpected helper-map argument: ${positional.slice(1).join(" ")}`,
+              repairCommand: "jskit helper-map"
+            }
+          ]
+        };
+      } else if (!subcommand) {
+        const { readHelperMap } = await import("../helperMap.js");
+        payload = await readHelperMap({ targetRoot: appRoot });
+      } else if (subcommand === "update") {
+        const { updateHelperMap } = await import("../helperMap.js");
+        payload = await updateHelperMap({ targetRoot: appRoot });
+      } else {
+        payload = {
+          ok: false,
+          errors: [
+            {
+              code: "unknown_helper_map_subcommand",
+              message: `Unknown helper-map subcommand: ${subcommand}`,
+              repairCommand: "jskit helper-map update"
+            }
+          ]
+        };
+      }
+    } catch (error) {
+      payload = {
+        ok: false,
+        errors: [
+          {
+            code: "helper_map_failed",
+            message: String(error?.message || error),
+            repairCommand: "jskit helper-map update"
+          }
+        ]
+      };
+    }
+
+    if (options.json) {
+      writeJson(stdout, payload);
+    } else if (payload.ok === false) {
+      writeErrors(stdout, payload);
+    } else {
+      writeHelperMapText(stdout, payload);
+    }
+
+    return payload.ok === false ? 1 : 0;
+  }
+
+  return { commandHelperMap };
+}
+
+export { createHelperMapCommands };

--- a/tooling/jskit-cli/src/server/core/commandCatalog.js
+++ b/tooling/jskit-cli/src/server/core/commandCatalog.js
@@ -288,6 +288,44 @@ const COMMAND_DESCRIPTORS = Object.freeze({
       return subcommand === "prompt" || subcommand === "set";
     }
   }),
+  "helper-map": Object.freeze({
+    command: "helper-map",
+    aliases: Object.freeze([]),
+    showInOverview: true,
+    summary: "Read or update the generated app helper map.",
+    minimalUse: "jskit helper-map update",
+    parameters: Object.freeze([
+      Object.freeze({
+        name: "[update]",
+        description: "Without a subcommand, prints the saved helper map. update refreshes .jskit/helper-map files."
+      })
+    ]),
+    defaults: Object.freeze([
+      "The helper map is generated app state, not a hand-maintained workflow file.",
+      "The JSON file lives at .jskit/helper-map.json and the readable map lives at .jskit/helper-map.md.",
+      "Use the map before adding helpers, composables, service functions, maps, or package glue.",
+      "Use --json for a stable machine-readable response."
+    ]),
+    examples: Object.freeze([
+      Object.freeze({
+        label: "Refresh helper map",
+        lines: Object.freeze([
+          "jskit helper-map update",
+          "jskit helper-map --json"
+        ])
+      })
+    ]),
+    fullUse: "jskit helper-map [update] [--json]",
+    showHelpOnBareInvocation: false,
+    handlerName: "commandHelperMap",
+    allowedFlagKeys: Object.freeze(["json"]),
+    inlineOptionMode: "delegate",
+    allowedValueOptionNames: Object.freeze([]),
+    canDelegateInlineOptions: (positional = []) => {
+      const subcommand = String(Array.isArray(positional) ? positional[0] || "" : "").trim();
+      return subcommand === "update";
+    }
+  }),
   add: Object.freeze({
     command: "add",
     aliases: Object.freeze([]),

--- a/tooling/jskit-cli/src/server/core/createCommandHandlers.js
+++ b/tooling/jskit-cli/src/server/core/createCommandHandlers.js
@@ -8,6 +8,7 @@ import { createHealthCommands } from "../commandHandlers/health.js";
 import { createCompletionCommands } from "../commandHandlers/completion.js";
 import { createSessionCommands } from "../commandHandlers/session.js";
 import { createBlueprintCommands } from "../commandHandlers/blueprint.js";
+import { createHelperMapCommands } from "../commandHandlers/helperMap.js";
 
 function createCommandHandlers(deps = {}) {
   const shared = createCommandHandlerShared(deps);
@@ -33,6 +34,7 @@ function createCommandHandlers(deps = {}) {
   const { commandCompletion } = createCompletionCommands(commandContext);
   const { commandSession } = createSessionCommands(commandContext);
   const { commandBlueprint } = createBlueprintCommands(commandContext);
+  const { commandHelperMap } = createHelperMapCommands(commandContext);
 
   return {
     commandList,
@@ -52,7 +54,8 @@ function createCommandHandlers(deps = {}) {
     commandDoctor,
     commandLintDescriptors,
     commandSession,
-    commandBlueprint
+    commandBlueprint,
+    commandHelperMap
   };
 }
 

--- a/tooling/jskit-cli/src/server/helperMap.js
+++ b/tooling/jskit-cli/src/server/helperMap.js
@@ -1,0 +1,463 @@
+import {
+  mkdir,
+  readFile,
+  readdir,
+  stat,
+  writeFile
+} from "node:fs/promises";
+import path from "node:path";
+import { compileScript, parse as parseVueSfc } from "@vue/compiler-sfc";
+import tsMorph from "ts-morph";
+import {
+  HELPER_MAP_JSON_RELATIVE_PATH,
+  HELPER_MAP_MARKDOWN_RELATIVE_PATH
+} from "./helperMapPaths.js";
+
+const {
+  ModuleKind,
+  ModuleResolutionKind,
+  Project,
+  ScriptTarget
+} = tsMorph;
+
+const HELPER_MAP_SCHEMA_VERSION = 1;
+const CODE_EXTENSIONS = new Set([".cjs", ".js", ".jsx", ".mjs", ".ts", ".tsx", ".vue"]);
+const APP_SCAN_ROOTS = Object.freeze(["src", "packages", "config", "server", "scripts"]);
+const EXCLUDED_DIR_NAMES = new Set([
+  ".git",
+  ".jskit",
+  ".npm-cache",
+  "coverage",
+  "dist",
+  "node_modules"
+]);
+const HELPER_NAME_PATTERN =
+  /^(assert|build|coerce|create|ensure|extract|format|get|has|is|list|load|make|map|normalize|parse|read|render|resolve|run|serialize|to|update|use|validate|write)[A-Z_]/u;
+
+async function pathExists(filePath) {
+  try {
+    await stat(filePath);
+    return true;
+  } catch (error) {
+    if (error && error.code === "ENOENT") {
+      return false;
+    }
+    throw error;
+  }
+}
+
+async function readJsonFile(filePath) {
+  return JSON.parse(await readFile(filePath, "utf8"));
+}
+
+function normalizePackageDependencies(packageJson = {}) {
+  const dependencies = {
+    ...(packageJson.dependencies || {}),
+    ...(packageJson.devDependencies || {}),
+    ...(packageJson.peerDependencies || {}),
+    ...(packageJson.optionalDependencies || {})
+  };
+  return Object.keys(dependencies).sort((left, right) => left.localeCompare(right));
+}
+
+function classifySymbol(name = "") {
+  if (!name || name === "default") {
+    return "default";
+  }
+  if (/^use[A-Z]/u.test(name)) {
+    return "composable";
+  }
+  if (/^[A-Z]/u.test(name)) {
+    return "component_or_class";
+  }
+  if (HELPER_NAME_PATTERN.test(name)) {
+    return "helper";
+  }
+  return "export";
+}
+
+function createExportAnalysisProject() {
+  return new Project({
+    skipAddingFilesFromTsConfig: true,
+    compilerOptions: {
+      allowJs: true,
+      checkJs: false,
+      module: ModuleKind.ESNext,
+      moduleResolution: ModuleResolutionKind.NodeNext,
+      target: ScriptTarget.ESNext
+    }
+  });
+}
+
+function kindFromDeclaration(declaration, exportName = "") {
+  if (exportName === "default") {
+    return "default";
+  }
+  switch (declaration.getKindName()) {
+    case "ClassDeclaration":
+      return "class";
+    case "EnumDeclaration":
+      return "enum";
+    case "FunctionDeclaration":
+    case "FunctionExpression":
+    case "MethodDeclaration":
+      return "function";
+    case "InterfaceDeclaration":
+      return "interface";
+    case "TypeAliasDeclaration":
+      return "type";
+    case "VariableDeclaration": {
+      const initializer = typeof declaration.getInitializer === "function"
+        ? declaration.getInitializer()
+        : null;
+      const initializerKind = initializer?.getKindName?.() || "";
+      return initializerKind === "ArrowFunction" || initializerKind === "FunctionExpression"
+        ? "function"
+        : "value";
+    }
+    default:
+      return "export";
+  }
+}
+
+function addSymbol(symbols, symbol) {
+  if (!symbol.name) {
+    return;
+  }
+  const key = `${symbol.name}:${symbol.kind}`;
+  if (symbols.has(key)) {
+    return;
+  }
+  symbols.set(key, {
+    name: symbol.name,
+    kind: symbol.kind,
+    role: classifySymbol(symbol.name)
+  });
+}
+
+function extractExportedSymbols(sourceFile) {
+  const symbols = new Map();
+  for (const [name, declarations] of sourceFile.getExportedDeclarations()) {
+    for (const declaration of declarations) {
+      addSymbol(symbols, {
+        name,
+        kind: kindFromDeclaration(declaration, name)
+      });
+    }
+  }
+
+  return [...symbols.values()].sort((left, right) => {
+    const byName = left.name.localeCompare(right.name);
+    return byName || left.kind.localeCompare(right.kind);
+  });
+}
+
+function extractVueScriptSource(source = "", filePath = "") {
+  const parsed = parseVueSfc(source, {
+    filename: filePath
+  });
+  if (parsed.errors.length > 0) {
+    throw new Error(parsed.errors.map((error) => error.message || String(error)).join("; "));
+  }
+  const descriptor = parsed.descriptor;
+  if (descriptor.scriptSetup) {
+    return compileScript(descriptor, {
+      id: filePath
+    }).content;
+  }
+  if (descriptor.script) {
+    return descriptor.script.content;
+  }
+  return "";
+}
+
+async function addCodeFileToProject(project, file) {
+  if (path.extname(file.absolutePath) !== ".vue") {
+    return project.addSourceFileAtPath(file.absolutePath);
+  }
+  const source = extractVueScriptSource(await readFile(file.absolutePath, "utf8"), file.absolutePath);
+  if (!source.trim()) {
+    return null;
+  }
+  return project.createSourceFile(`${file.absolutePath}.ts`, source, {
+    overwrite: true
+  });
+}
+
+async function walkCodeFiles(rootPath, relativeRoot = "") {
+  const entries = await readdir(rootPath, {
+    withFileTypes: true
+  });
+  const files = [];
+  for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
+    if (EXCLUDED_DIR_NAMES.has(entry.name)) {
+      continue;
+    }
+    const absolutePath = path.join(rootPath, entry.name);
+    const relativePath = path.join(relativeRoot, entry.name).split(path.sep).join("/");
+    if (entry.isDirectory()) {
+      files.push(...await walkCodeFiles(absolutePath, relativePath));
+      continue;
+    }
+    if (!entry.isFile() || !CODE_EXTENSIONS.has(path.extname(entry.name))) {
+      continue;
+    }
+    files.push({
+      absolutePath,
+      relativePath
+    });
+  }
+  return files;
+}
+
+async function collectAppExports(targetRoot) {
+  const scanFiles = [];
+  for (const scanRoot of APP_SCAN_ROOTS) {
+    const rootPath = path.join(targetRoot, scanRoot);
+    if (await pathExists(rootPath)) {
+      scanFiles.push(...await walkCodeFiles(rootPath, scanRoot));
+    }
+  }
+
+  const project = createExportAnalysisProject();
+  const files = [];
+  for (const file of scanFiles.sort((left, right) => left.relativePath.localeCompare(right.relativePath))) {
+    const sourceFile = await addCodeFileToProject(project, file);
+    if (!sourceFile) {
+      continue;
+    }
+    const symbols = extractExportedSymbols(sourceFile);
+    if (symbols.length === 0) {
+      continue;
+    }
+    files.push({
+      path: file.relativePath,
+      exports: symbols
+    });
+  }
+  return files;
+}
+
+function flattenPackageExports(exportsField) {
+  const targets = new Map();
+
+  function addTarget(subpath, target) {
+    if (!target || target.includes("*")) {
+      return;
+    }
+    targets.set(`${subpath}:${target}`, {
+      subpath,
+      target
+    });
+  }
+
+  function collect(value, subpath = ".") {
+    if (typeof value === "string") {
+      addTarget(subpath, value);
+      return;
+    }
+    if (!value || Array.isArray(value) || typeof value !== "object") {
+      return;
+    }
+    const entries = Object.entries(value);
+    const hasSubpathKeys = entries.some(([key]) => key.startsWith("."));
+    for (const [key, nested] of entries) {
+      if (key.startsWith(".")) {
+        collect(nested, key);
+      } else {
+        collect(nested, hasSubpathKeys ? subpath : subpath || ".");
+      }
+    }
+  }
+
+  collect(exportsField, ".");
+  return [...targets.values()].sort((left, right) => {
+    const bySubpath = left.subpath.localeCompare(right.subpath);
+    return bySubpath || left.target.localeCompare(right.target);
+  });
+}
+
+async function collectJskitPackageExports(targetRoot, packageJson = {}) {
+  const packageNames = normalizePackageDependencies(packageJson)
+    .filter((name) => name.startsWith("@jskit-ai/"));
+  const packages = [];
+  const project = createExportAnalysisProject();
+
+  for (const packageName of packageNames) {
+    const packageRoot = path.join(targetRoot, "node_modules", ...packageName.split("/"));
+    const packageJsonPath = path.join(packageRoot, "package.json");
+    if (!await pathExists(packageJsonPath)) {
+      packages.push({
+        name: packageName,
+        installed: false,
+        exports: []
+      });
+      continue;
+    }
+
+    const installedPackageJson = await readJsonFile(packageJsonPath);
+    const exportTargets = flattenPackageExports(installedPackageJson.exports || {});
+    const exports = [];
+    for (const exportTarget of exportTargets) {
+      const normalizedTarget = exportTarget.target.replace(/^\.\//u, "");
+      const targetPath = path.join(packageRoot, normalizedTarget);
+      const ext = path.extname(targetPath);
+      if (!CODE_EXTENSIONS.has(ext) || !await pathExists(targetPath)) {
+        continue;
+      }
+      const sourceFile = await addCodeFileToProject(project, {
+        absolutePath: targetPath,
+        relativePath: normalizedTarget
+      });
+      exports.push({
+        subpath: exportTarget.subpath,
+        target: normalizedTarget.split(path.sep).join("/"),
+        exports: sourceFile ? extractExportedSymbols(sourceFile) : []
+      });
+    }
+
+    packages.push({
+      name: packageName,
+      version: installedPackageJson.version || "",
+      installed: true,
+      exports
+    });
+  }
+
+  return packages;
+}
+
+function renderExportList(symbols = []) {
+  if (symbols.length === 0) {
+    return "    - no exported symbols detected";
+  }
+  return symbols
+    .map((symbol) => `    - ${symbol.name} (${symbol.kind}, ${symbol.role})`)
+    .join("\n");
+}
+
+function renderHelperMapMarkdown(map) {
+  const lines = [
+    "# JSKIT Helper Map",
+    "",
+    "Generated by `jskit helper-map update`. Read this before adding new helpers, composables, service functions, maps, or package glue.",
+    "",
+    `Root package: ${map.rootPackage.name || "unknown"}`,
+    "",
+    "## App-local exports",
+    ""
+  ];
+
+  if (map.app.files.length === 0) {
+    lines.push("No app-local exported helpers or symbols detected.", "");
+  } else {
+    for (const file of map.app.files) {
+      lines.push(`- ${file.path}`, renderExportList(file.exports), "");
+    }
+  }
+
+  lines.push("## Direct JSKIT package exports", "");
+  if (map.jskitPackages.length === 0) {
+    lines.push("No direct `@jskit-ai/*` dependencies were found.", "");
+  } else {
+    for (const packageEntry of map.jskitPackages) {
+      if (!packageEntry.installed) {
+        lines.push(`- ${packageEntry.name}: not installed in node_modules`, "");
+        continue;
+      }
+      lines.push(`- ${packageEntry.name}@${packageEntry.version || "unknown"}`);
+      if (packageEntry.exports.length === 0) {
+        lines.push("    - no exported code files detected");
+      } else {
+        for (const exportEntry of packageEntry.exports) {
+          lines.push(`    - ${exportEntry.subpath} -> ${exportEntry.target}`);
+          for (const symbol of exportEntry.exports) {
+            lines.push(`      - ${symbol.name} (${symbol.kind}, ${symbol.role})`);
+          }
+        }
+      }
+      lines.push("");
+    }
+  }
+
+  return `${lines.join("\n").replace(/\n{3,}/gu, "\n\n").trimEnd()}\n`;
+}
+
+async function buildHelperMap({ targetRoot }) {
+  const packageJsonPath = path.join(targetRoot, "package.json");
+  const packageJson = await readJsonFile(packageJsonPath);
+  const map = {
+    schemaVersion: HELPER_MAP_SCHEMA_VERSION,
+    generatedBy: "jskit helper-map update",
+    rootPackage: {
+      name: packageJson.name || "",
+      version: packageJson.version || ""
+    },
+    app: {
+      files: await collectAppExports(targetRoot)
+    },
+    jskitPackages: await collectJskitPackageExports(targetRoot, packageJson)
+  };
+  return {
+    ok: true,
+    map,
+    helperMapJsonPath: path.join(targetRoot, HELPER_MAP_JSON_RELATIVE_PATH),
+    helperMapMarkdownPath: path.join(targetRoot, HELPER_MAP_MARKDOWN_RELATIVE_PATH)
+  };
+}
+
+async function readHelperMap({ targetRoot }) {
+  const helperMapJsonPath = path.join(targetRoot, HELPER_MAP_JSON_RELATIVE_PATH);
+  const helperMapMarkdownPath = path.join(targetRoot, HELPER_MAP_MARKDOWN_RELATIVE_PATH);
+  if (!await pathExists(helperMapJsonPath)) {
+    return {
+      ok: true,
+      exists: false,
+      helperMapJsonPath,
+      helperMapMarkdownPath,
+      map: null,
+      markdown: ""
+    };
+  }
+  return {
+    ok: true,
+    exists: true,
+    helperMapJsonPath,
+    helperMapMarkdownPath,
+    map: await readJsonFile(helperMapJsonPath),
+    markdown: await pathExists(helperMapMarkdownPath) ? await readFile(helperMapMarkdownPath, "utf8") : ""
+  };
+}
+
+async function updateHelperMap({ targetRoot }) {
+  const payload = await buildHelperMap({ targetRoot });
+  const markdown = renderHelperMapMarkdown(payload.map);
+  const json = `${JSON.stringify(payload.map, null, 2)}\n`;
+  const currentJson = await pathExists(payload.helperMapJsonPath)
+    ? await readFile(payload.helperMapJsonPath, "utf8")
+    : "";
+  const currentMarkdown = await pathExists(payload.helperMapMarkdownPath)
+    ? await readFile(payload.helperMapMarkdownPath, "utf8")
+    : "";
+  const changed = currentJson !== json || currentMarkdown !== markdown;
+  if (changed) {
+    await mkdir(path.dirname(payload.helperMapJsonPath), {
+      recursive: true
+    });
+    await writeFile(payload.helperMapJsonPath, json, "utf8");
+    await writeFile(payload.helperMapMarkdownPath, markdown, "utf8");
+  }
+  return {
+    ...payload,
+    changed,
+    markdown
+  };
+}
+
+export {
+  HELPER_MAP_JSON_RELATIVE_PATH,
+  HELPER_MAP_MARKDOWN_RELATIVE_PATH,
+  buildHelperMap,
+  readHelperMap,
+  updateHelperMap
+};

--- a/tooling/jskit-cli/src/server/helperMapPaths.js
+++ b/tooling/jskit-cli/src/server/helperMapPaths.js
@@ -1,0 +1,7 @@
+const HELPER_MAP_JSON_RELATIVE_PATH = ".jskit/helper-map.json";
+const HELPER_MAP_MARKDOWN_RELATIVE_PATH = ".jskit/helper-map.md";
+
+export {
+  HELPER_MAP_JSON_RELATIVE_PATH,
+  HELPER_MAP_MARKDOWN_RELATIVE_PATH
+};

--- a/tooling/jskit-cli/src/server/sessionRuntime.js
+++ b/tooling/jskit-cli/src/server/sessionRuntime.js
@@ -7,6 +7,7 @@ import {
 import path from "node:path";
 import {
   PLAN_EXECUTION_CODEX_HANDOFF,
+  PLAN_FINE_TUNING_CODEX_HANDOFF,
   REVIEW_EXECUTION_CODEX_HANDOFF,
   SESSION_STATUS,
   STEP_DEFINITIONS,
@@ -52,6 +53,7 @@ import {
   assertGithubOrigin,
   assertIssueTextExists,
   assertIssueUrlExists,
+  assertPlanTextExists,
   assertPrUrlExists,
   assertSessionExists,
   assertTargetRootWritable,
@@ -63,6 +65,10 @@ import {
   renderPrompt,
   renderTemplate
 } from "./sessionRuntime/promptRenderer.js";
+import {
+  HELPER_MAP_JSON_RELATIVE_PATH,
+  HELPER_MAP_MARKDOWN_RELATIVE_PATH
+} from "./helperMapPaths.js";
 
 function invalidSessionIdError(sessionId = "") {
   return createError({
@@ -556,6 +562,21 @@ async function makePlan(paths, options = {}, context = {}) {
       preconditions
     });
   }
+  await writeReceipt(paths, "plan_made", `Saved plan and commented on ${issueUrl}.`);
+  await markStatus(paths, SESSION_STATUS.RUNNING);
+  return buildSessionResponse(paths, {
+    preconditions
+  });
+}
+
+async function renderPlanExecutionPrompt(paths, _options = {}, context = {}) {
+  const preconditions = context.preconditions || [];
+  const issueText = await readTrimmedFile(path.join(paths.sessionRoot, "issue.md"));
+  const issueTitle = await readTrimmedFile(path.join(paths.sessionRoot, "issue_title")) || titleFromIssue(issueText);
+  const issueUrl = await readTrimmedFile(path.join(paths.sessionRoot, "issue_url"));
+  const issueNumber = issueNumberFromUrl(issueUrl);
+  const planPath = path.join(paths.sessionRoot, "plan.md");
+  const planText = await readTrimmedFile(planPath);
   const executionPrompt = await renderPrompt(paths, "execute_plan.md", {
     issue_file: path.join(paths.sessionRoot, "issue.md"),
     issue_number: issueNumber,
@@ -566,12 +587,40 @@ async function makePlan(paths, options = {}, context = {}) {
     worktree: paths.worktree
   });
   await writePromptArtifact(paths, "plan_execution.md", executionPrompt);
-  await writeReceipt(paths, "plan_made", `Saved plan and commented on ${issueUrl}.`);
+  await writeReceipt(paths, "plan_executed", "Started plan execution with Codex.");
   await markStatus(paths, SESSION_STATUS.WAITING_FOR_USER);
   return buildSessionResponse(paths, {
     codex: PLAN_EXECUTION_CODEX_HANDOFF,
     preconditions,
     prompt: executionPrompt,
+    status: SESSION_STATUS.WAITING_FOR_USER
+  });
+}
+
+async function renderPlanFineTuningPrompt(paths, _options = {}, context = {}) {
+  const preconditions = context.preconditions || [];
+  const issueText = await readTrimmedFile(path.join(paths.sessionRoot, "issue.md"));
+  const issueTitle = await readTrimmedFile(path.join(paths.sessionRoot, "issue_title")) || titleFromIssue(issueText);
+  const issueUrl = await readTrimmedFile(path.join(paths.sessionRoot, "issue_url"));
+  const issueNumber = issueNumberFromUrl(issueUrl);
+  const planPath = path.join(paths.sessionRoot, "plan.md");
+  const planText = await readTrimmedFile(planPath);
+  const fineTuningPrompt = await renderPrompt(paths, "fine_tune_plan.md", {
+    issue_file: path.join(paths.sessionRoot, "issue.md"),
+    issue_number: issueNumber,
+    issue_title: issueTitle,
+    issue_url: issueUrl,
+    plan_file: planPath,
+    plan_text: planText,
+    worktree: paths.worktree
+  });
+  await writePromptArtifact(paths, "plan_fine_tuning.md", fineTuningPrompt);
+  await writeReceipt(paths, "plan_fine_tuning", "Started plan fine tuning with Codex.");
+  await markStatus(paths, SESSION_STATUS.WAITING_FOR_USER);
+  return buildSessionResponse(paths, {
+    codex: PLAN_FINE_TUNING_CODEX_HANDOFF,
+    preconditions,
+    prompt: fineTuningPrompt,
     status: SESSION_STATUS.WAITING_FOR_USER
   });
 }
@@ -905,7 +954,262 @@ function issueNumberFromUrl(issueUrl) {
   return match ? match[1] : "";
 }
 
+function parseJsonObject(value) {
+  try {
+    const parsed = JSON.parse(String(value || ""));
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+async function readPrState(paths, prUrl) {
+  const result = await runCommand("gh", ["pr", "view", prUrl, "--json", "state,mergedAt,url,baseRefName"], {
+    cwd: paths.targetRoot,
+    timeout: 1000 * 60
+  });
+  if (!result.ok) {
+    return {
+      ok: false,
+      output: result.output
+    };
+  }
+  const payload = parseJsonObject(result.stdout);
+  return {
+    baseRefName: normalizeText(payload?.baseRefName),
+    mergedAt: payload?.mergedAt || "",
+    ok: Boolean(payload),
+    output: result.output,
+    state: String(payload?.state || "").toUpperCase(),
+    url: payload?.url || prUrl
+  };
+}
+
+function prStateIsMerged(prState) {
+  return Boolean(prState?.ok && prState.state === "MERGED");
+}
+
+async function currentTargetBranch(targetRoot) {
+  const result = await runGit(targetRoot, ["branch", "--show-current"], {
+    timeout: 15000
+  });
+  return result.ok ? normalizeText(result.stdout) : "";
+}
+
+async function assertTargetRootCleanForBaseUpdate(paths) {
+  const status = await runGit(paths.targetRoot, ["status", "--porcelain=v1"], {
+    timeout: 15000
+  });
+  if (!status.ok) {
+    return failSession(paths, {
+      code: "target_root_status_failed",
+      message: status.output || "Failed to inspect target root git status before updating the local base branch.",
+      repairCommand: `git -C ${paths.targetRoot} status --short`
+    });
+  }
+  if (status.stdout.trim()) {
+    return failSession(paths, {
+      code: "target_root_dirty",
+      message: "Target root has uncommitted changes; JSKIT cannot update the local base branch after merging the PR.",
+      repairCommand: `git -C ${paths.targetRoot} status --short`
+    });
+  }
+  return null;
+}
+
+async function assertTargetRootCanUpdateBase(paths, branch) {
+  const cleanFailure = await assertTargetRootCleanForBaseUpdate(paths);
+  if (cleanFailure) {
+    return cleanFailure;
+  }
+
+  const currentBranch = await currentTargetBranch(paths.targetRoot);
+  if (currentBranch !== branch) {
+    return failSession(paths, {
+      code: "target_branch_mismatch",
+      message: `Target root is on branch ${currentBranch || "(detached)"}, but the merged PR targets ${branch}. JSKIT will not merge origin/${branch} into the wrong branch.`,
+      repairCommand: `git -C ${paths.targetRoot} switch ${branch} && git -C ${paths.targetRoot} pull --ff-only origin ${branch}`
+    });
+  }
+
+  return null;
+}
+
+async function assertTargetBaseCanFastForward(paths, branch) {
+  const branchFailure = await assertTargetRootCanUpdateBase(paths, branch);
+  if (branchFailure) {
+    return branchFailure;
+  }
+
+  const fetchResult = await runGit(paths.targetRoot, ["fetch", "origin"], {
+    timeout: 1000 * 60 * 5
+  });
+  if (!fetchResult.ok) {
+    return failSession(paths, {
+      code: "target_fetch_failed",
+      message: fetchResult.output || `Failed to fetch origin before checking local ${branch}.`,
+      repairCommand: `git -C ${paths.targetRoot} fetch origin`
+    });
+  }
+
+  const remoteBranch = `origin/${branch}`;
+  const remoteExists = await runGit(paths.targetRoot, ["rev-parse", "--verify", remoteBranch], {
+    timeout: 15000
+  });
+  if (!remoteExists.ok) {
+    return failSession(paths, {
+      code: "target_remote_branch_missing",
+      message: `Remote base branch ${remoteBranch} does not exist; JSKIT cannot safely update local ${branch} after merge.`,
+      repairCommand: `git -C ${paths.targetRoot} fetch origin`
+    });
+  }
+
+  const ancestor = await runGit(paths.targetRoot, ["merge-base", "--is-ancestor", branch, remoteBranch], {
+    timeout: 15000
+  });
+  if (!ancestor.ok) {
+    return failSession(paths, {
+      code: "target_branch_not_fast_forwardable",
+      message: `Local ${branch} is not an ancestor of ${remoteBranch}; JSKIT will not merge the PR while the local base branch has diverged.`,
+      repairCommand: `git -C ${paths.targetRoot} pull --ff-only origin ${branch}`
+    });
+  }
+
+  return null;
+}
+
+async function updateLocalBaseBranch(paths, baseBranch = "") {
+  const branch = normalizeText(baseBranch) || await currentTargetBranch(paths.targetRoot);
+  if (!branch) {
+    return failSession(paths, {
+      code: "target_branch_missing",
+      message: "Target root is not on a named branch; JSKIT cannot update the local base branch after merging the PR.",
+      repairCommand: `git -C ${paths.targetRoot} branch --show-current`
+    });
+  }
+
+  const branchFailure = await assertTargetRootCanUpdateBase(paths, branch);
+  if (branchFailure) {
+    return branchFailure;
+  }
+
+  const fetchResult = await runGit(paths.targetRoot, ["fetch", "origin"], {
+    timeout: 1000 * 60 * 5
+  });
+  if (!fetchResult.ok) {
+    return failSession(paths, {
+      code: "target_fetch_failed",
+      message: fetchResult.output || `Failed to fetch origin before updating local ${branch}.`,
+      repairCommand: `git -C ${paths.targetRoot} fetch origin`
+    });
+  }
+
+  const pullResult = await runGit(paths.targetRoot, ["pull", "--ff-only", "origin", branch], {
+    timeout: 1000 * 60 * 5
+  });
+  if (!pullResult.ok) {
+    return failSession(paths, {
+      code: "target_pull_failed",
+      message: pullResult.output || `Failed to fast-forward local ${branch} after merging the PR.`,
+      repairCommand: `git -C ${paths.targetRoot} pull --ff-only origin ${branch}`
+    });
+  }
+
+  await writeTextFile(path.join(paths.sessionRoot, "local_base_updated"), `${branch}\n${pullResult.output}\n`);
+  return null;
+}
+
+async function updateHelperMapBeforePr(paths) {
+  let helperMapPayload;
+  try {
+    const { updateHelperMap } = await import("./helperMap.js");
+    helperMapPayload = await updateHelperMap({
+      targetRoot: paths.worktree
+    });
+  } catch (error) {
+    return {
+      ok: false,
+      code: "helper_map_update_failed",
+      message: String(error?.message || error),
+      repairCommand: `git -C ${paths.worktree} status --short`
+    };
+  }
+
+  const statusResult = await runGitInWorktree(paths.worktree, [
+    "status",
+    "--porcelain=v1",
+    "--",
+    HELPER_MAP_JSON_RELATIVE_PATH,
+    HELPER_MAP_MARKDOWN_RELATIVE_PATH
+  ], {
+    timeout: 15000
+  });
+  if (!statusResult.ok) {
+    return {
+      ok: false,
+      code: "helper_map_status_failed",
+      message: statusResult.output || "Failed to inspect helper-map Git status.",
+      repairCommand: `git -C ${paths.worktree} status --short -- ${HELPER_MAP_JSON_RELATIVE_PATH} ${HELPER_MAP_MARKDOWN_RELATIVE_PATH}`
+    };
+  }
+
+  if (!statusResult.stdout.trim()) {
+    return {
+      ok: true,
+      changed: false,
+      message: "Helper map already up to date."
+    };
+  }
+
+  const addResult = await runGitInWorktree(paths.worktree, [
+    "add",
+    HELPER_MAP_JSON_RELATIVE_PATH,
+    HELPER_MAP_MARKDOWN_RELATIVE_PATH
+  ], {
+    timeout: 15000
+  });
+  if (!addResult.ok) {
+    return {
+      ok: false,
+      code: "helper_map_add_failed",
+      message: addResult.output || "Failed to stage helper-map files.",
+      repairCommand: `git -C ${paths.worktree} add ${HELPER_MAP_JSON_RELATIVE_PATH} ${HELPER_MAP_MARKDOWN_RELATIVE_PATH}`
+    };
+  }
+
+  const commitResult = await runGitInWorktree(paths.worktree, [
+    "commit",
+    "-m",
+    `Update JSKIT helper map for ${paths.sessionId}`
+  ], {
+    timeout: 1000 * 60
+  });
+  if (!commitResult.ok) {
+    return {
+      ok: false,
+      code: "helper_map_commit_failed",
+      message: commitResult.output || "Failed to commit helper-map update.",
+      repairCommand: `git -C ${paths.worktree} commit -m "Update JSKIT helper map for ${paths.sessionId}"`
+    };
+  }
+
+  return {
+    ok: true,
+    changed: true,
+    message: `Updated helper map at ${path.relative(paths.worktree, helperMapPayload.helperMapMarkdownPath)}.`
+  };
+}
+
 async function createPr(paths) {
+  const helperMapResult = await updateHelperMapBeforePr(paths);
+  if (!helperMapResult.ok) {
+    return failSession(paths, {
+      code: helperMapResult.code,
+      message: helperMapResult.message,
+      repairCommand: helperMapResult.repairCommand
+    });
+  }
+
   const pushResult = await runGitInWorktree(paths.worktree, ["push", "-u", "origin", "HEAD"], {
     timeout: 1000 * 60 * 5
   });
@@ -952,7 +1256,7 @@ async function createPr(paths) {
   }
   const prUrl = result.stdout.split(/\r?\n/u).map((line) => line.trim()).find(Boolean) || result.stdout;
   await writeTextFile(path.join(paths.sessionRoot, "pr_url"), prUrl);
-  await writeReceipt(paths, "pr_created", `Pushed branch ${paths.branch} and created PR ${prUrl}.`);
+  await writeReceipt(paths, "pr_created", `Pushed branch ${paths.branch} and created PR ${prUrl}. ${helperMapResult.message}`);
   await markStatus(paths, SESSION_STATUS.RUNNING);
   return buildSessionResponse(paths);
 }
@@ -960,20 +1264,40 @@ async function createPr(paths) {
 async function mergePr(paths) {
   const prUrl = await readTrimmedFile(path.join(paths.sessionRoot, "pr_url"));
   const mergeMarkerPath = path.join(paths.sessionRoot, "pr_merge_completed");
+  const baseBranchPath = path.join(paths.sessionRoot, "pr_base_branch");
   const mergeAlreadyCompleted = await readTrimmedFile(mergeMarkerPath);
+  let baseBranch = await readTrimmedFile(baseBranchPath);
   if (!mergeAlreadyCompleted) {
-    const mergeResult = await runCommand("gh", ["pr", "merge", prUrl, "--merge", "--delete-branch"], {
-      cwd: paths.worktree,
-      timeout: 1000 * 60 * 5
-    });
-    if (!mergeResult.ok) {
+    const existingPrState = await readPrState(paths, prUrl);
+    baseBranch = existingPrState.baseRefName || baseBranch || await currentTargetBranch(paths.targetRoot);
+    if (baseBranch) {
+      await writeTextFile(baseBranchPath, `${baseBranch}\n`);
+    }
+    const baseFailure = await assertTargetBaseCanFastForward(paths, baseBranch);
+    if (baseFailure) {
+      return baseFailure;
+    }
+    let prMerged = prStateIsMerged(existingPrState);
+    let mergeResult = null;
+    if (!prMerged) {
+      mergeResult = await runCommand("gh", ["pr", "merge", prUrl, "--merge", "--delete-branch"], {
+        cwd: paths.targetRoot,
+        timeout: 1000 * 60 * 5
+      });
+      if (!mergeResult.ok) {
+        prMerged = prStateIsMerged(await readPrState(paths, prUrl));
+      } else {
+        prMerged = true;
+      }
+    }
+    if (!prMerged) {
       const prompt = await renderPrompt(paths, "pr_failure.md", {
-        doctor_output: mergeResult.output
+        doctor_output: mergeResult?.output || existingPrState.output
       });
       await writePromptArtifact(paths, "pr_merge_failure.md", prompt);
       return failSession(paths, {
         code: "pr_merge_failed",
-        message: mergeResult.output || "Failed to merge PR.",
+        message: mergeResult?.output || existingPrState.output || "Failed to merge PR.",
         repairCommand: `gh pr merge ${prUrl} --merge --delete-branch`,
         prompt
       });
@@ -981,11 +1305,15 @@ async function mergePr(paths) {
     const issueUrl = await readTrimmedFile(path.join(paths.sessionRoot, "issue_url"));
     if (issueUrl) {
       await runCommand("gh", ["issue", "close", issueUrl, "--comment", `Merged PR ${prUrl}.`], {
-        cwd: paths.worktree,
+        cwd: paths.targetRoot,
         timeout: 1000 * 60
       });
     }
     await writeTextFile(mergeMarkerPath, `${prUrl}\n`);
+  }
+  const updateFailure = await updateLocalBaseBranch(paths, baseBranch);
+  if (updateFailure) {
+    return updateFailure;
   }
   if (await hasWorktree(paths)) {
     const result = await runGit(paths.targetRoot, ["worktree", "remove", paths.worktree], {
@@ -999,7 +1327,7 @@ async function mergePr(paths) {
       });
     }
   }
-  await writeReceipt(paths, "pr_merged", `Merged PR ${prUrl} and removed worktree ${paths.worktree}.`);
+  await writeReceipt(paths, "pr_merged", `Merged PR ${prUrl}, updated local ${baseBranch || "base branch"}, and removed worktree ${paths.worktree}.`);
   await markStatus(paths, SESSION_STATUS.RUNNING);
   return buildSessionResponse(paths);
 }
@@ -1037,6 +1365,8 @@ const STEP_RUNNERS = Object.freeze({
   issue_drafted: draftIssue,
   issue_created: createIssue,
   plan_made: makePlan,
+  plan_executed: renderPlanExecutionPrompt,
+  plan_fine_tuning: renderPlanFineTuningPrompt,
   implementation_changes_accepted: acceptImplementationChanges,
   implementation_changes_committed: commitImplementation,
   review_prompt_rendered: renderReviewPrompt,
@@ -1056,6 +1386,7 @@ const PRECONDITION_RUNNERS = Object.freeze({
   github_origin: (paths) => assertGithubOrigin(paths.targetRoot),
   issue_text_exists: assertIssueTextExists,
   issue_url_exists: assertIssueUrlExists,
+  plan_text_exists: assertPlanTextExists,
   pr_url_exists: assertPrUrlExists,
   session_exists: assertSessionExists,
   worktree_exists: assertWorktreeExists

--- a/tooling/jskit-cli/src/server/sessionRuntime/constants.js
+++ b/tooling/jskit-cli/src/server/sessionRuntime/constants.js
@@ -99,7 +99,11 @@ function codexHandoff(expectedOutput, {
 
 const PLAN_EXECUTION_CODEX_HANDOFF = codexHandoff([], {
   autoInject: true,
-  promptActionLabel: "Execute plan"
+  promptActionLabel: "Get Codex to execute plan"
+});
+const PLAN_FINE_TUNING_CODEX_HANDOFF = codexHandoff([], {
+  autoInject: true,
+  promptActionLabel: "Get Codex to fine tune plan"
 });
 const REVIEW_EXECUTION_CODEX_HANDOFF = codexHandoff([], {
   autoInject: true,
@@ -154,8 +158,8 @@ const STEP_DEFINITIONS = Object.freeze([
     preconditions: ["session_exists", "worktree_exists"]
   }),
   defineStep({
-    buttonLabel: "Submit prompt to Codex",
-    description: "Capture the initial change request and send it to Codex to draft a GitHub issue.",
+    buttonLabel: "Set initial prompt",
+    description: "Capture the initial change request and prepare the Codex issue-drafting prompt.",
     id: "issue_prompt_rendered",
     input: Object.freeze({
       label: "What should change?",
@@ -192,15 +196,31 @@ const STEP_DEFINITIONS = Object.freeze([
     preconditions: ["session_exists", "issue_text_exists", "github_auth", "github_origin"]
   }),
   defineStep({
-    buttonLabel: "Execute plan",
+    buttonLabel: "Save plan",
     codex: codexHandoff(PLAN_OUTPUT),
-    description: "Save the approved implementation plan, comment it on the GitHub issue, and submit it to Codex.",
+    description: "Save the approved implementation plan and comment it on the GitHub issue.",
     id: "plan_made",
     input: PLAN_INPUT,
     kind: "codex_output",
-    label: "Plan execution",
+    label: "Plan made",
     nextCommandTemplate: "jskit session {{session_id}} step --plan -",
     preconditions: ["session_exists", "issue_text_exists", "issue_url_exists", "worktree_exists"]
+  }),
+  defineStep({
+    buttonLabel: "Get Codex to execute plan",
+    description: "Submit the approved implementation plan to Codex for the first implementation pass.",
+    id: "plan_executed",
+    kind: "codex_prompt",
+    label: "Plan executed",
+    preconditions: ["session_exists", "issue_text_exists", "issue_url_exists", "plan_text_exists", "worktree_exists"]
+  }),
+  defineStep({
+    buttonLabel: "Get Codex to fine tune plan",
+    description: "Submit the current implementation to Codex for refinement after the first implementation pass.",
+    id: "plan_fine_tuning",
+    kind: "codex_prompt",
+    label: "Plan fine tuning",
+    preconditions: ["session_exists", "issue_text_exists", "issue_url_exists", "plan_text_exists", "worktree_exists"]
   }),
   defineStep({
     buttonLabel: "Accept changes",
@@ -281,10 +301,10 @@ const STEP_DEFINITIONS = Object.freeze([
     preconditions: ["session_exists", "worktree_exists"]
   }),
   defineStep({
-    buttonLabel: "Merge PR and remove worktree",
-    description: "Merge the pull request, close the GitHub issue, and remove the session worktree.",
+    buttonLabel: "Merge PR, update base, remove worktree",
+    description: "Merge the pull request, close the GitHub issue, fast-forward the local base branch, and remove the session worktree.",
     id: "pr_merged",
-    label: "PR merged, worktree removed",
+    label: "PR merged, base updated, worktree removed",
     preconditions: ["session_exists", "pr_url_exists", "worktree_exists"]
   }),
   defineStep({
@@ -315,6 +335,7 @@ export {
   STEP_LABEL_BY_ID,
   STEP_PRECONDITION_NAMES,
   PLAN_EXECUTION_CODEX_HANDOFF,
+  PLAN_FINE_TUNING_CODEX_HANDOFF,
   REVIEW_EXECUTION_CODEX_HANDOFF,
   SESSION_STATE_RELATIVE_PATH
 };

--- a/tooling/jskit-cli/src/server/sessionRuntime/preconditions.js
+++ b/tooling/jskit-cli/src/server/sessionRuntime/preconditions.js
@@ -292,6 +292,33 @@ async function assertIssueUrlExists(paths) {
   };
 }
 
+async function assertPlanTextExists(paths) {
+  const planText = await readTrimmedFile(path.join(paths.sessionRoot, "plan.md"));
+  if (planText) {
+    return {
+      ok: true,
+      precondition: createPrecondition({
+        id: "plan_text_exists",
+        ok: true,
+        message: "Plan text exists."
+      })
+    };
+  }
+  return {
+    ok: false,
+    error: createError({
+      code: "plan_text_missing",
+      message: "Cannot fine-tune a plan before plan.md exists.",
+      repairCommand: `jskit session ${paths.sessionId} step --plan -`
+    }),
+    precondition: createPrecondition({
+      id: "plan_text_exists",
+      ok: false,
+      message: "Plan text exists."
+    })
+  };
+}
+
 async function assertWorktreeExists(paths) {
   if (await hasWorktree(paths)) {
     return {
@@ -353,6 +380,7 @@ export {
   assertGithubOrigin,
   assertIssueTextExists,
   assertIssueUrlExists,
+  assertPlanTextExists,
   assertPrUrlExists,
   assertSessionExists,
   assertTargetRootWritable,

--- a/tooling/jskit-cli/src/server/sessionRuntime/prompts/execute_plan.md
+++ b/tooling/jskit-cli/src/server/sessionRuntime/prompts/execute_plan.md
@@ -7,12 +7,17 @@ Issue body file: {{issue_file}}
 Plan file: {{plan_file}}
 Worktree: {{worktree}}
 
+Approved plan:
+
+{{plan_text}}
+
 Implement the plan in the session worktree. Keep the change scoped to the issue and approved plan.
 
 Implementation rules:
 
 - Inspect the current app before editing. Do not assume a JSKIT app shape without checking files.
-- Prefer existing JSKIT helpers, package runtime seams, generated scaffolds, and documented generators over new local helpers.
+- Read `.jskit/helper-map.md` when it exists before creating helpers, composables, service functions, maps, or package glue.
+- Prefer existing JSKIT helpers, app-local helpers, package runtime seams, generated scaffolds, and documented generators over new local helpers.
 - If the plan calls for a generator or package install, use the planned `jskit` command unless inspection proves it does not apply. If you skip a generator, explain the exact gap.
 - For non-CRUD route pages, use `jskit generate ui-generator page ...` when it fits instead of hand-writing both route files and placement entries.
 - For CRUD work, scaffold the server side first with `crud-server-generator` before CRUD UI or CRUD route work.

--- a/tooling/jskit-cli/src/server/sessionRuntime/prompts/fine_tune_plan.md
+++ b/tooling/jskit-cli/src/server/sessionRuntime/prompts/fine_tune_plan.md
@@ -1,0 +1,37 @@
+Fine-tune the implementation for JSKIT session {{session_id}}.
+
+GitHub issue: {{issue_url}}
+Issue number: {{issue_number}}
+Issue title: {{issue_title}}
+Issue body file: {{issue_file}}
+Plan file: {{plan_file}}
+Worktree: {{worktree}}
+
+Approved plan:
+
+{{plan_text}}
+
+The first implementation pass should already be in the session worktree. Use this step to refine it after user review, user testing, visible defects, or implementation gaps.
+
+Fine-tuning rules:
+
+- Inspect the current worktree changes before editing.
+- Compare the current implementation against the issue and approved plan.
+- If the user has already described what failed or what needs refinement, apply that feedback directly.
+- If the user has not described the problem yet, ask concise questions about what failed before editing.
+- Keep fixes scoped to the issue, approved plan, and user feedback.
+- Do not restart the feature from scratch unless the current implementation is unrecoverable; explain that clearly if it happens.
+- Prefer existing JSKIT helpers, app-local helpers, package runtime seams, generated scaffolds, and documented generators over new local helpers.
+- Read `.jskit/helper-map.md` when it exists before creating helpers, composables, service functions, maps, or package glue.
+- Keep runtime, UI, and data concerns separated.
+- Avoid accidental scope expansion.
+- Do not create old workflow files such as `.jskit/WORKBOARD.md`; the session files and receipts are the workflow record.
+
+After fine tuning:
+
+- Review for repeated code, unnecessary helpers, fragmented functions, placeholder work, missing states, broken route wiring, ownership mistakes, and weak JSKIT reuse.
+- Run the smallest relevant checks you can run safely in the worktree.
+- For changed user-facing UI, run or clearly identify the Playwright verification path. When possible, record UI verification with `jskit app verify-ui --command "<playwright command>" --feature "<label>" --auth-mode <mode>`.
+- Summarize changed files and checks run.
+
+Do not create commits, branches, issues, pull requests, merges, or worktree cleanup yourself. JSKIT session will handle those steps.

--- a/tooling/jskit-cli/src/server/sessionRuntime/prompts/new_issue.md
+++ b/tooling/jskit-cli/src/server/sessionRuntime/prompts/new_issue.md
@@ -2,7 +2,20 @@ Create a GitHub issue from this user request:
 
 {{user_input}}
 
-First inspect the local app enough to understand the request in context. Use package.json, config, .jskit metadata, routes, packages, and any saved app blueprint when available. Classify the current app state as empty, non_jskit_repo, partial_jskit_app, or jskit_app before assuming ordinary feature work is possible.
+First inspect the local app enough to understand the request in context. This issue-drafting step is read-only.
+
+Allowed inspection:
+
+- Read files with commands such as `pwd`, `ls`, `find`, `rg`, `cat`, `sed`, and `git status`.
+- Read package.json, config, .jskit metadata, routes, packages, source files, and any saved app blueprint when available.
+- Classify the current app state as empty, non_jskit_repo, partial_jskit_app, or jskit_app before assuming ordinary feature work is possible.
+
+Do not run workflow, repair, or mutation commands during issue drafting:
+
+- Do not run `jskit session`, `jskit session step`, or any command that advances a JSKIT session.
+- Do not run `gh`, `git add`, `git commit`, `git push`, `npm install`, generators, tests, verification, devlinks, or doctor commands.
+- Do not try to fix missing PATH entries or missing command shims. If a tool is unavailable, continue with read-only file inspection.
+- Do not edit files.
 
 Draft an implementation-ready issue, not a broad product essay.
 

--- a/tooling/jskit-cli/src/server/sessionRuntime/prompts/plan_issue.md
+++ b/tooling/jskit-cli/src/server/sessionRuntime/prompts/plan_issue.md
@@ -8,7 +8,7 @@ Issue title file: {{issue_title_file}}
 Plan file to create: {{plan_file}}
 Worktree: {{worktree}}
 
-Read the issue and inspect the local app before planning. Use the issue files, package.json, .jskit metadata, config, packages, routes, generated references, package docs, and any saved app blueprint when available.
+Read the issue and inspect the local app before planning. Use the issue files, package.json, .jskit metadata, config, packages, routes, generated references, package docs, any saved app blueprint, and `.jskit/helper-map.md` when available.
 
 Start by identifying the app state and the implementation lane:
 
@@ -31,6 +31,7 @@ Planning rules:
 - Do not hand-build CRUD routes, CRUD endpoints, or CRUD page trees before the server CRUD package and shared resource file exist.
 - `feature-server-generator` is for non-CRUD workflows and orchestration, not ordinary persisted entity tables.
 - Keep runtime, UI, and data concerns separated.
+- Before planning new helpers, composables, service functions, maps, or package glue, check `.jskit/helper-map.md` when it exists and prefer existing entries.
 - Keep direct knex exceptional and minimal. Prefer internal json-rest-api seams outside generated CRUD packages and explicit weird-custom feature lanes.
 - For package-owned baseline workflows, plan to install and verify the baseline before inventing custom code around it.
 - For user-facing UI, include Material/Vuetify quality expectations and a Playwright verification path.

--- a/tooling/jskit-cli/src/server/sessionRuntime/prompts/review_changes.md
+++ b/tooling/jskit-cli/src/server/sessionRuntime/prompts/review_changes.md
@@ -11,6 +11,7 @@ Use four passes:
 1. Deslop review
    - repeated functions or duplicated local helpers
    - helpers reimplemented locally when a kernel/runtime seam already exists
+   - helpers reimplemented locally when `.jskit/helper-map.md` already lists a usable app-local helper or JSKIT export
    - placeholder, fake-complete, or vague UI/copy/code structure
    - dead code, unused props/imports, TODO-shaped gaps, or accidental abstractions
    - missing loading, empty, error, permission, or ownership states
@@ -18,6 +19,7 @@ Use four passes:
    - surface or entity ownership mistakes: public, user, workspace, workspace_user
 2. JSKIT review
    - existing helper/runtime seam available?
+   - was `.jskit/helper-map.md` checked before introducing helper-like code?
    - should this have been a package install, generator step, or scaffold extension instead of hand code?
    - if a generator existed, was the exact `jskit` command used or was the gap documented?
    - for CRUD work, was `crud-server-generator scaffold` used before CRUD UI or CRUD route hand-coding?

--- a/tooling/jskit-cli/src/server/sessionRuntime/responses.js
+++ b/tooling/jskit-cli/src/server/sessionRuntime/responses.js
@@ -46,34 +46,8 @@ function createPrecondition({
   });
 }
 
-const LEGACY_CURRENT_STEP_ID_ALIASES = Object.freeze({
-  implementation_changes_detected: "implementation_changes_accepted",
-  review_changes_detected: "review_changes_accepted"
-});
-
-const LEGACY_COMPLETED_STEP_ID_ALIASES = Object.freeze({
-  implementation_changes_detected: Object.freeze(["implementation_changes_accepted"]),
-  review_changes_detected: Object.freeze(["review_changes_accepted", "review_changes_committed"])
-});
-
-const LEGACY_RECEIPT_STEP_ID_ALIASES = Object.freeze({
-  implementation_changes_detected: "implementation_changes_accepted",
-  review_changes_detected: "review_changes_committed"
-});
-
 function normalizeStepId(stepId) {
-  const normalized = normalizeText(stepId);
-  return LEGACY_CURRENT_STEP_ID_ALIASES[normalized] || normalized;
-}
-
-function completedStepIdsForReceipt(stepId) {
-  const normalized = normalizeText(stepId);
-  return LEGACY_COMPLETED_STEP_ID_ALIASES[normalized] || [normalized];
-}
-
-function receiptStepId(stepId) {
-  const normalized = normalizeText(stepId);
-  return LEGACY_RECEIPT_STEP_ID_ALIASES[normalized] || normalizeStepId(normalized);
+  return normalizeText(stepId);
 }
 
 function stepIndex(stepId) {
@@ -84,7 +58,6 @@ function normalizeKnownStepIds(stepIds = []) {
   return Array.from(
     new Set(
       stepIds
-        .flatMap((stepId) => completedStepIdsForReceipt(stepId))
         .map((stepId) => normalizeText(stepId))
         .filter((stepId) => STEP_IDS.includes(stepId))
     )
@@ -98,7 +71,9 @@ function stepCanExposeStoredPrompt(stepId) {
 
 const PROMPT_ARTIFACT_BY_STEP_ID = Object.freeze({
   issue_drafted: "issue_draft.md",
+  plan_executed: "plan_execution.md",
   plan_made: "plan_request.md",
+  plan_fine_tuning: "plan_fine_tuning.md",
   user_check_completed: "user_check.md"
 });
 
@@ -138,7 +113,7 @@ async function readReceiptSteps(paths) {
       .filter((entry) => entry.isFile())
       .map((entry) => entry.name)
       .forEach((receiptName) => {
-        const stepId = receiptStepId(receiptName);
+        const stepId = normalizeStepId(receiptName);
         if (STEP_IDS.includes(stepId)) {
           if (!knownStepRows.has(stepId) || receiptName === stepId) {
             knownStepRows.set(stepId, {

--- a/tooling/jskit-cli/test/helperMapCommand.test.js
+++ b/tooling/jskit-cli/test/helperMapCommand.test.js
@@ -1,0 +1,136 @@
+import assert from "node:assert/strict";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+import { createCliRunner } from "../../testUtils/runCli.js";
+import { withTempDir } from "../../testUtils/tempDir.mjs";
+
+const CLI_PATH = fileURLToPath(new URL("../bin/jskit.js", import.meta.url));
+const runCli = createCliRunner(CLI_PATH);
+
+function parseJsonResult(result) {
+  assert.equal(result.status, 0, result.stderr);
+  return JSON.parse(result.stdout);
+}
+
+test("jskit helper-map update writes deterministic app and package helper maps", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "app");
+    await mkdir(path.join(appRoot, "src", "lib"), {
+      recursive: true
+    });
+    await mkdir(path.join(appRoot, "src", "pages"), {
+      recursive: true
+    });
+    await mkdir(path.join(appRoot, "node_modules", "@jskit-ai", "sample-runtime"), {
+      recursive: true
+    });
+    await writeFile(
+      path.join(appRoot, "package.json"),
+      `${JSON.stringify(
+        {
+          name: "helper-map-app",
+          version: "0.1.0",
+          type: "module",
+          dependencies: {
+            "@jskit-ai/sample-runtime": "0.1.0"
+          }
+        },
+        null,
+        2
+      )}\n`,
+      "utf8"
+    );
+    await writeFile(
+      path.join(appRoot, "src", "lib", "formatTitle.js"),
+      "export function formatTitle(value) {\n  return String(value).trim();\n}\n",
+      "utf8"
+    );
+    await writeFile(
+      path.join(appRoot, "src", "lib", "names.js"),
+      "export const normalizeName = (value) => String(value).trim().toLowerCase();\n",
+      "utf8"
+    );
+    await writeFile(
+      path.join(appRoot, "src", "lib", "index.js"),
+      "export { normalizeName as normalizeHelperName } from './names.js';\n",
+      "utf8"
+    );
+    await writeFile(
+      path.join(appRoot, "src", "pages", "home.vue"),
+      "<script>\nexport function useHomePageTitle() {\n  return 'Home';\n}\n</script>\n<template><main>Home</main></template>\n",
+      "utf8"
+    );
+    await writeFile(
+      path.join(appRoot, "node_modules", "@jskit-ai", "sample-runtime", "package.json"),
+      `${JSON.stringify(
+        {
+          name: "@jskit-ai/sample-runtime",
+          version: "0.1.0",
+          type: "module",
+          exports: {
+            ".": "./index.js",
+            "./helpers": "./helpers.js"
+          }
+        },
+        null,
+        2
+      )}\n`,
+      "utf8"
+    );
+    await writeFile(
+      path.join(appRoot, "node_modules", "@jskit-ai", "sample-runtime", "index.js"),
+      "export function createSampleRuntime() {}\n",
+      "utf8"
+    );
+    await writeFile(
+      path.join(appRoot, "node_modules", "@jskit-ai", "sample-runtime", "helpers.js"),
+      "export const sampleMap = new Map();\n",
+      "utf8"
+    );
+
+    const updated = parseJsonResult(runCli({
+      cwd: appRoot,
+      args: ["helper-map", "update", "--json"]
+    }));
+    assert.equal(updated.ok, true);
+    assert.equal(updated.changed, true);
+    assert.equal(updated.map.generatedBy, "jskit helper-map update");
+    assert.ok(updated.map.app.files.some((file) => {
+      return file.path === "src/lib/formatTitle.js" &&
+        file.exports.some((symbol) => symbol.name === "formatTitle" && symbol.kind === "function");
+    }));
+    assert.ok(updated.map.app.files.some((file) => {
+      return file.path === "src/lib/index.js" &&
+        file.exports.some((symbol) => symbol.name === "normalizeHelperName" && symbol.kind === "function");
+    }));
+    assert.ok(updated.map.app.files.some((file) => {
+      return file.path === "src/pages/home.vue" &&
+        file.exports.some((symbol) => symbol.name === "useHomePageTitle" && symbol.role === "composable");
+    }));
+    assert.equal(updated.map.jskitPackages[0].name, "@jskit-ai/sample-runtime");
+    assert.ok(updated.map.jskitPackages[0].exports.some((entry) => {
+      return entry.exports.some((symbol) => symbol.name === "createSampleRuntime");
+    }));
+
+    const markdown = await readFile(path.join(appRoot, ".jskit", "helper-map.md"), "utf8");
+    assert.match(markdown, /formatTitle/);
+    assert.match(markdown, /normalizeHelperName/);
+    assert.match(markdown, /useHomePageTitle/);
+    assert.match(markdown, /createSampleRuntime/);
+
+    const second = parseJsonResult(runCli({
+      cwd: appRoot,
+      args: ["helper-map", "update", "--json"]
+    }));
+    assert.equal(second.changed, false);
+
+    const read = parseJsonResult(runCli({
+      cwd: appRoot,
+      args: ["helper-map", "--json"]
+    }));
+    assert.equal(read.exists, true);
+    assert.equal(read.map.rootPackage.name, "helper-map-app");
+  });
+});

--- a/tooling/jskit-cli/test/sessionCommand.test.js
+++ b/tooling/jskit-cli/test/sessionCommand.test.js
@@ -118,10 +118,12 @@ async function createGitApp(root, { withRemote = false } = {}) {
   runGit(root, ["config", "user.email", "test@example.com"]);
   runGit(root, ["add", "package.json"]);
   runGit(root, ["commit", "-m", "Initial commit"]);
+  runGit(root, ["branch", "-M", "main"]);
   if (withRemote) {
     const remoteRoot = path.join(path.dirname(root), "github.com", "example", "repo.git");
     runGit(path.dirname(root), ["init", "--bare", remoteRoot]);
     runGit(root, ["remote", "add", "origin", remoteRoot]);
+    runGit(root, ["push", "-u", "origin", "main"]);
   }
 }
 
@@ -145,6 +147,7 @@ async function installFakeGh(binDir, logPath) {
     binDir,
     "gh",
     `#!/usr/bin/env node
+const childProcess = require("node:child_process");
 const fs = require("node:fs");
 const args = process.argv.slice(2);
 fs.appendFileSync(${JSON.stringify(logPath)}, ["gh", ...args].join(" ") + "\\n");
@@ -158,7 +161,31 @@ if (args[0] === "pr" && args[1] === "create") {
   console.log("https://github.com/example/repo/pull/456");
   process.exit(0);
 }
-if (args[0] === "pr" && args[1] === "merge") process.exit(0);
+if (args[0] === "pr" && args[1] === "view") {
+  console.log(JSON.stringify({ baseRefName: "main", state: "OPEN", mergedAt: "", url: args[2] }));
+  process.exit(0);
+}
+if (args[0] === "pr" && args[1] === "merge") {
+  const git = (gitArgs) => childProcess.spawnSync("git", gitArgs, {
+    cwd: process.cwd(),
+    encoding: "utf8"
+  });
+  git(["fetch", "origin"]);
+  const branches = git(["branch", "-r", "--format=%(refname:short)"]).stdout
+    .split(/\\r?\\n/u)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const sessionBranch = branches.find((branch) => branch.startsWith("origin/jskit-studio/"));
+  if (sessionBranch) {
+    const rev = git(["rev-parse", sessionBranch]).stdout.trim();
+    const push = git(["push", "origin", rev + ":refs/heads/main"]);
+    if (push.status !== 0) {
+      console.error(push.stderr || push.stdout);
+      process.exit(push.status || 1);
+    }
+  }
+  process.exit(0);
+}
 console.error("unexpected gh args", args.join(" "));
 process.exit(1);
 `
@@ -242,7 +269,7 @@ test("jskit session JSON exposes JSKIT-owned step UI and Codex handoff contract"
 
     const { promptReadyPayload, worktreePayload } = advanceCliSessionToIssuePrompt(appRoot, created.sessionId);
     assert.equal(worktreePayload.currentStepAction.buttonLabel, "Install dependencies");
-    assert.equal(promptReadyPayload.currentStepAction.buttonLabel, "Submit prompt to Codex");
+    assert.equal(promptReadyPayload.currentStepAction.buttonLabel, "Set initial prompt");
     assert.equal(promptReadyPayload.currentStepAction.index, 3);
     assert.equal(promptReadyPayload.currentStepAction.input.name, "prompt");
     assert.equal(promptReadyPayload.nextCommand, `jskit session ${created.sessionId} step --prompt "<what should change>"`);
@@ -460,6 +487,9 @@ test("jskit session step creates worktree and issue prompt", async () => {
     assert.equal(promptPayload.status, "waiting_for_user");
     assert.equal(promptPayload.currentStep, "issue_drafted");
     assert.match(promptPayload.prompt, /Add customer search/);
+    assert.match(promptPayload.prompt, /This issue-drafting step is read-only/);
+    assert.match(promptPayload.prompt, /Do not run `jskit session`/);
+    assert.match(promptPayload.prompt, /Do not run `gh`, `git add`, `git commit`, `git push`, `npm install`/);
     assert.match(promptPayload.prompt, /\[issue_title\]/);
     assert.match(promptPayload.prompt, /\[issue_text\]/);
     assert.match(
@@ -590,7 +620,7 @@ test("jskit session accepts issue text from stdin and creates a GitHub issue wit
     assert.equal(issueCreated.issueUrl, "https://github.com/example/repo/issues/123");
     assert.equal(issueCreated.currentStep, "plan_made");
     assert.equal(issueCreated.prompt, "");
-    assert.equal(issueCreated.currentStepAction.buttonLabel, "Execute plan");
+    assert.equal(issueCreated.currentStepAction.buttonLabel, "Save plan");
     assert.match(await readFile(logPath, "utf8"), /gh issue create --title Fix useful filters --body-file/);
 
     const planPrompt = runSessionStepJson(appRoot, created.sessionId, { env });
@@ -607,18 +637,38 @@ test("jskit session accepts issue text from stdin and creates a GitHub issue wit
       args: ["--plan", "[plan]\nInspect filters and update the UI.\n[/plan]"],
       env
     });
-    assert.equal(planMade.currentStep, "implementation_changes_accepted");
-    assert.equal(planMade.currentStepAction.buttonLabel, "Accept changes");
-    assert.equal(planMade.currentStepAction.utilityActions[0].kind, "diff");
+    assert.equal(planMade.currentStep, "plan_executed");
+    assert.equal(planMade.currentStepAction.buttonLabel, "Get Codex to execute plan");
     assert.equal(planMade.planText, "Inspect filters and update the UI.");
     assert.ok(planMade.completedSteps.includes("plan_made"));
-    assert.match(planMade.prompt, /Execute the approved implementation plan/);
+    assert.equal(planMade.prompt, "");
     assert.match(await readFile(path.join(planMade.sessionRoot, "plan.md"), "utf8"), /Inspect filters/);
+
+    const executed = runSessionStepJson(appRoot, created.sessionId, { env });
+    assert.equal(executed.currentStep, "plan_fine_tuning");
+    assert.equal(executed.currentStepAction.buttonLabel, "Get Codex to fine tune plan");
+    assert.equal(executed.codex.autoInject, true);
+    assert.equal(executed.codex.promptActionLabel, "Get Codex to execute plan");
+    assert.ok(executed.completedSteps.includes("plan_executed"));
+    assert.match(executed.prompt, /Execute the approved implementation plan/);
     assert.match(
-      await readFile(path.join(planMade.sessionRoot, "prompts", "plan_execution.md"), "utf8"),
+      await readFile(path.join(executed.sessionRoot, "prompts", "plan_execution.md"), "utf8"),
       /Execute the approved implementation plan/
     );
-    await assert.rejects(access(path.join(planMade.sessionRoot, "prompt.md")));
+
+    const fineTuning = runSessionStepJson(appRoot, created.sessionId, { env });
+    assert.equal(fineTuning.currentStep, "implementation_changes_accepted");
+    assert.equal(fineTuning.currentStepAction.buttonLabel, "Accept changes");
+    assert.equal(fineTuning.currentStepAction.utilityActions[0].kind, "diff");
+    assert.equal(fineTuning.codex.autoInject, true);
+    assert.equal(fineTuning.codex.promptActionLabel, "Get Codex to fine tune plan");
+    assert.ok(fineTuning.completedSteps.includes("plan_fine_tuning"));
+    assert.match(fineTuning.prompt, /Fine-tune the implementation/);
+    assert.match(
+      await readFile(path.join(fineTuning.sessionRoot, "prompts", "plan_fine_tuning.md"), "utf8"),
+      /Fine-tune the implementation/
+    );
+    await assert.rejects(access(path.join(fineTuning.sessionRoot, "prompt.md")));
     assert.match(await readFile(logPath, "utf8"), /gh issue comment https:\/\/github\.com\/example\/repo\/issues\/123 --body-file/);
   });
 });
@@ -757,68 +807,6 @@ process.exit(1);
   });
 });
 
-test("jskit session maps legacy change-detection receipts to renamed change steps", async () => {
-  await withTempDir(async (cwd) => {
-    const appRoot = path.join(cwd, "legacy");
-    await createGitApp(appRoot);
-
-    const created = await createSession({ targetRoot: appRoot });
-    await runSessionStep({
-      targetRoot: appRoot,
-      sessionId: created.sessionId
-    });
-    await writeStepReceipts(
-      created.sessionRoot,
-      STEP_IDS.slice(0, STEP_IDS.indexOf("implementation_changes_accepted"))
-    );
-    await writeFile(
-      path.join(created.sessionRoot, "steps", "implementation_changes_detected"),
-      "2026-05-11T00:00:00.000Z\nDetected 1 changed file entries.\n",
-      "utf8"
-    );
-    await writeFile(path.join(created.sessionRoot, "current_step"), "implementation_changes_detected\n", "utf8");
-
-    const inspected = parseJsonResult(runCli({ cwd: appRoot, args: ["session", created.sessionId, "--json"] }));
-    assert.equal(inspected.currentStep, "implementation_changes_committed");
-    assert.ok(inspected.completedSteps.includes("implementation_changes_accepted"));
-
-    const details = await inspectSessionDetails({
-      targetRoot: appRoot,
-      sessionId: created.sessionId
-    });
-    assert.ok(details.receipts.some((receipt) => receipt.stepId === "implementation_changes_accepted"));
-
-    const reviewRoot = path.join(cwd, "legacy-review");
-    await createGitApp(reviewRoot);
-    const reviewSession = await createSession({ targetRoot: reviewRoot });
-    await runSessionStep({
-      targetRoot: reviewRoot,
-      sessionId: reviewSession.sessionId
-    });
-    await writeStepReceipts(
-      reviewSession.sessionRoot,
-      STEP_IDS.slice(0, STEP_IDS.indexOf("review_changes_accepted"))
-    );
-    await writeFile(
-      path.join(reviewSession.sessionRoot, "steps", "review_changes_detected"),
-      "2026-05-11T00:00:00.000Z\nNo review changes detected.\n",
-      "utf8"
-    );
-    await writeFile(path.join(reviewSession.sessionRoot, "current_step"), "review_changes_detected\n", "utf8");
-
-    const reviewInspected = parseJsonResult(runCli({ cwd: reviewRoot, args: ["session", reviewSession.sessionId, "--json"] }));
-    assert.equal(reviewInspected.currentStep, "user_check_completed");
-    assert.ok(reviewInspected.completedSteps.includes("review_changes_accepted"));
-    assert.ok(reviewInspected.completedSteps.includes("review_changes_committed"));
-
-    const reviewDetails = await inspectSessionDetails({
-      targetRoot: reviewRoot,
-      sessionId: reviewSession.sessionId
-    });
-    assert.ok(reviewDetails.receipts.some((receipt) => receipt.stepId === "review_changes_committed"));
-  });
-});
-
 test("jskit session diff inspects worktree changes without advancing the session", async () => {
   await withTempDir(async (cwd) => {
     const appRoot = path.join(cwd, "app");
@@ -875,15 +863,35 @@ test("jskit session can execute review loop, doctor, PR, merge, cleanup, and fin
       args: ["--plan", "[plan]\nImplement the page.\n[/plan]"],
       env
     });
-    assert.equal(planMade.currentStep, "implementation_changes_accepted");
-    assert.equal(planMade.currentStepAction.buttonLabel, "Accept changes");
-    assert.equal(planMade.codex.autoInject, true);
-    assert.equal(planMade.codex.promptActionLabel, "Execute plan");
-    assert.match(planMade.prompt, /Execute the approved implementation plan/);
+    assert.equal(planMade.currentStep, "plan_executed");
+    assert.equal(planMade.currentStepAction.buttonLabel, "Get Codex to execute plan");
+    assert.equal(planMade.prompt, "");
     assert.ok(planMade.completedSteps.includes("plan_made"));
+    const executed = runSessionStepJson(appRoot, created.sessionId, { env });
+    assert.equal(executed.currentStep, "plan_fine_tuning");
+    assert.equal(executed.currentStepAction.buttonLabel, "Get Codex to fine tune plan");
+    assert.equal(executed.codex.autoInject, true);
+    assert.equal(executed.codex.promptActionLabel, "Get Codex to execute plan");
+    assert.match(executed.prompt, /Execute the approved implementation plan/);
+    assert.ok(executed.completedSteps.includes("plan_executed"));
+    const fineTuning = runSessionStepJson(appRoot, created.sessionId, { env });
+    assert.equal(fineTuning.currentStep, "implementation_changes_accepted");
+    assert.equal(fineTuning.currentStepAction.buttonLabel, "Accept changes");
+    assert.equal(fineTuning.codex.autoInject, true);
+    assert.equal(fineTuning.codex.promptActionLabel, "Get Codex to fine tune plan");
+    assert.match(fineTuning.prompt, /Fine-tune the implementation/);
+    assert.ok(fineTuning.completedSteps.includes("plan_fine_tuning"));
 
     const inspect = parseJsonResult(runCli({ cwd: appRoot, args: ["session", created.sessionId, "--json"], env }));
     await writeFile(path.join(inspect.worktree, "feature.txt"), "hello\\n", "utf8");
+    await mkdir(path.join(inspect.worktree, "src", "lib"), {
+      recursive: true
+    });
+    await writeFile(
+      path.join(inspect.worktree, "src", "lib", "formatFeatureTitle.js"),
+      "export function formatFeatureTitle(value) {\n  return String(value).trim();\n}\n",
+      "utf8"
+    );
     const accepted = runSessionStepJson(appRoot, created.sessionId, { env });
     assert.equal(accepted.currentStep, "implementation_changes_committed");
     assert.equal(accepted.prompt, "");
@@ -922,8 +930,16 @@ test("jskit session can execute review loop, doctor, PR, merge, cleanup, and fin
     runSessionStepJson(appRoot, created.sessionId, { env });
     const pr = runSessionStepJson(appRoot, created.sessionId, { env });
     assert.equal(pr.prUrl, "https://github.com/example/repo/pull/456");
+    const helperMap = JSON.parse(await readFile(path.join(inspect.worktree, ".jskit", "helper-map.json"), "utf8"));
+    assert.ok(helperMap.app.files.some((file) => {
+      return file.path === "src/lib/formatFeatureTitle.js" &&
+        file.exports.some((symbol) => symbol.name === "formatFeatureTitle");
+    }));
+    assert.match(runGit(inspect.worktree, ["log", "--oneline", "--max-count=3"]), /Update JSKIT helper map/);
     const merged = runSessionStepJson(appRoot, created.sessionId, { env });
     assert.equal(merged.currentStep, "session_finished");
+    assert.equal(await readFile(path.join(appRoot, "feature.txt"), "utf8"), "hello\\n");
+    assert.match(await readFile(path.join(appRoot, ".jskit", "helper-map.md"), "utf8"), /formatFeatureTitle/);
     await assert.rejects(access(inspect.worktree));
     const finished = runSessionStepJson(appRoot, created.sessionId, { env });
 
@@ -945,8 +961,107 @@ test("jskit session can execute review loop, doctor, PR, merge, cleanup, and fin
     const log = await readFile(logPath, "utf8");
     assert.match(log, /npm run verify:local/);
     assert.match(log, /gh pr create/);
+    assert.match(log, /gh pr view https:\/\/github\.com\/example\/repo\/pull\/456 --json state,mergedAt,url,baseRefName/);
     assert.match(log, /gh pr merge https:\/\/github\.com\/example\/repo\/pull\/456 --merge --delete-branch/);
     assert.match(log, /gh issue comment https:\/\/github\.com\/example\/repo\/issues\/123 --body-file/);
+  });
+});
+
+test("jskit session treats an already-merged PR as merged and removes the worktree", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "app");
+    const binDir = path.join(cwd, "bin");
+    const logPath = path.join(cwd, "commands.log");
+    await createGitApp(appRoot, { withRemote: true });
+    await installFakeCommand(
+      binDir,
+      "gh",
+      `#!/usr/bin/env node
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+fs.appendFileSync(${JSON.stringify(logPath)}, ["gh", ...args].join(" ") + "\\n");
+if (args[0] === "auth" && args[1] === "status") process.exit(0);
+if (args[0] === "issue" && args[1] === "close") process.exit(0);
+if (args[0] === "pr" && args[1] === "view") {
+  console.log(JSON.stringify({ baseRefName: "main", state: "MERGED", mergedAt: "2026-05-12T16:22:32Z", url: args[2] }));
+  process.exit(0);
+}
+if (args[0] === "pr" && args[1] === "merge") {
+  console.error("merge should not run for an already-merged PR");
+  process.exit(1);
+}
+console.error("unexpected gh args", args.join(" "));
+process.exit(1);
+`
+    );
+    const env = {
+      PATH: `${binDir}${path.delimiter}${process.env.PATH || ""}`
+    };
+
+    const created = parseJsonResult(runCli({ cwd: appRoot, args: ["session", "create", "--json"], env }));
+    const worktreePayload = parseJsonResult(runCli({ cwd: appRoot, args: ["session", created.sessionId, "step", "--json"], env }));
+    await writeStepReceipts(
+      worktreePayload.sessionRoot,
+      STEP_IDS.slice(0, STEP_IDS.indexOf("pr_merged"))
+    );
+    await writeFile(path.join(worktreePayload.sessionRoot, "issue_url"), "https://github.com/example/repo/issues/123\n", "utf8");
+    await writeFile(path.join(worktreePayload.sessionRoot, "pr_url"), "https://github.com/example/repo/pull/456\n", "utf8");
+
+    const merged = parseJsonResult(runCli({ cwd: appRoot, args: ["session", created.sessionId, "step", "--json"], env }));
+    assert.equal(merged.currentStep, "session_finished");
+    assert.ok(merged.completedSteps.includes("pr_merged"));
+    await assert.rejects(access(worktreePayload.worktree));
+    const log = await readFile(logPath, "utf8");
+    assert.match(log, /gh pr view https:\/\/github\.com\/example\/repo\/pull\/456 --json state,mergedAt,url,baseRefName/);
+    assert.doesNotMatch(log, /gh pr merge/);
+    assert.match(log, /gh issue close https:\/\/github\.com\/example\/repo\/issues\/123/);
+  });
+});
+
+test("jskit session blocks PR merge cleanup when the target root is dirty", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "app");
+    const binDir = path.join(cwd, "bin");
+    const logPath = path.join(cwd, "commands.log");
+    await createGitApp(appRoot, { withRemote: true });
+    await installFakeCommand(
+      binDir,
+      "gh",
+      `#!/usr/bin/env node
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+fs.appendFileSync(${JSON.stringify(logPath)}, ["gh", ...args].join(" ") + "\\n");
+if (args[0] === "auth" && args[1] === "status") process.exit(0);
+if (args[0] === "pr" && args[1] === "view") {
+  console.log(JSON.stringify({ baseRefName: "main", state: "MERGED", mergedAt: "2026-05-12T16:22:32Z", url: args[2] }));
+  process.exit(0);
+}
+console.error("unexpected gh args", args.join(" "));
+process.exit(1);
+`
+    );
+    const env = {
+      PATH: `${binDir}${path.delimiter}${process.env.PATH || ""}`
+    };
+
+    const created = parseJsonResult(runCli({ cwd: appRoot, args: ["session", "create", "--json"], env }));
+    const worktreePayload = parseJsonResult(runCli({ cwd: appRoot, args: ["session", created.sessionId, "step", "--json"], env }));
+    await writeStepReceipts(
+      worktreePayload.sessionRoot,
+      STEP_IDS.slice(0, STEP_IDS.indexOf("pr_merged"))
+    );
+    await writeFile(path.join(worktreePayload.sessionRoot, "issue_url"), "https://github.com/example/repo/issues/123\n", "utf8");
+    await writeFile(path.join(worktreePayload.sessionRoot, "pr_url"), "https://github.com/example/repo/pull/456\n", "utf8");
+    await writeFile(path.join(appRoot, "local-change.txt"), "dirty\n", "utf8");
+
+    const blocked = parseJsonFailure(runCli({ cwd: appRoot, args: ["session", created.sessionId, "step", "--json"], env }));
+    assert.equal(blocked.errors[0].code, "target_root_dirty");
+    await access(worktreePayload.worktree);
+    await assert.rejects(access(path.join(worktreePayload.sessionRoot, "steps", "pr_merged")));
+    const log = await readFile(logPath, "utf8");
+    assert.match(log, /gh pr view https:\/\/github\.com\/example\/repo\/pull\/456 --json state,mergedAt,url,baseRefName/);
+    assert.doesNotMatch(log, /gh pr merge/);
+    assert.doesNotMatch(log, /gh issue close/);
   });
 });
 


### PR DESCRIPTION
## Summary
- add JSKIT helper-map command/runtime support
- extend session workflow prompts and runtime for plan/detail/fine-tune flow
- add helper-map/session workflow tests and tracking todo

## Verification
- Not run, per request