### PR TITLE
Extend JSKIT session readiness workflow

### DIFF
--- a/FINAL_TODO.md
+++ b/FINAL_TODO.md
@@ -5,23 +5,23 @@ This file is the implementation checklist for the next major JSKIT session workf
 ## Ground Rules
 
 - [x] Create this `FINAL_TODO.md` as the shared implementation checklist.
-- [ ] Keep JSKIT as the source of truth for workflow state, steps, prompts, receipts, and session files.
-- [ ] Keep Studio thin: Studio renders JSKIT session JSON and does not own a parallel workflow state machine.
-- [ ] Do not resurrect the old giant `AGENTS.md` workflow.
-- [ ] Move useful old workflow discipline into JSKIT-owned session steps, prompt templates, preconditions, receipts, and JSON.
-- [ ] Keep all new session state filesystem-backed and inspectable under `.jskit/sessions/active/<session_id>/`.
-- [ ] Keep generated durable app memory under `.jskit/`, not in old free-form workboard files.
-- [ ] Add tests for every new session transition and every new JSON contract field.
+- [x] Keep JSKIT as the source of truth for workflow state, steps, prompts, receipts, and session files.
+- [x] Keep Studio thin: Studio renders JSKIT session JSON and does not own a parallel workflow state machine.
+- [x] Do not resurrect the old giant `AGENTS.md` workflow.
+- [x] Move useful old workflow discipline into JSKIT-owned session steps, prompt templates, preconditions, receipts, and JSON.
+- [x] Keep all new session state filesystem-backed and inspectable under `.jskit/sessions/active/<session_id>/`.
+- [x] Keep generated durable app memory under `.jskit/`, not in old free-form workboard files.
+- [x] Add tests for every new session transition and every new JSON contract field.
 
 ## Explicit Non-Goals
 
-- [ ] Do not make issue sessions reason about `empty`, `non_jskit_repo`, or `partial_jskit_app` as normal states.
-- [ ] Do not make Codex recover arbitrary non-JSKIT directories inside the issue workflow.
-- [ ] If a session is somehow started before app setup/app bootup readiness, JSKIT should block with a setup-required error rather than asking Codex to reason about recovery.
-- [ ] Do not add a project picker, app registry, or multi-project behavior.
-- [ ] Do not add a Studio-owned session workflow.
-- [ ] Do not reintroduce `.jskit/WORKBOARD.md`.
-- [ ] Do not make `AGENTS.md` long again.
+- [x] Do not make issue sessions reason about `empty`, `non_jskit_repo`, or `partial_jskit_app` as normal states.
+- [x] Do not make Codex recover arbitrary non-JSKIT directories inside the issue workflow.
+- [x] If a session is somehow started before app setup/app bootup readiness, JSKIT should block with a setup-required error rather than asking Codex to reason about recovery.
+- [x] Do not add a project picker, app registry, or multi-project behavior.
+- [x] Do not add a Studio-owned session workflow.
+- [x] Do not reintroduce `.jskit/WORKBOARD.md`.
+- [x] Do not make `AGENTS.md` long again.
 
 ## Current Groundwork Already In Place
 
@@ -40,120 +40,162 @@ This file is the implementation checklist for the next major JSKIT session workf
 
 The final visible issue session should move through this broad sequence:
 
-- [ ] Session created.
-- [ ] Worktree created.
-- [ ] Dependencies installed.
-- [ ] Initial issue prompt rendered.
-- [ ] Issue drafted.
-- [ ] GitHub issue created.
-- [ ] Get issue details prompt rendered.
-- [ ] Plan details gathered.
-- [ ] Plan made.
-- [ ] Plan fine tuning.
-- [ ] Implementation changes accepted.
-- [ ] Implementation changes committed.
-- [ ] Pre-review checks run.
-- [ ] Deep UI check run or skipped.
-- [ ] Deslop/JSKIT review run.
-- [ ] Review changes accepted.
-- [ ] Review changes committed.
-- [ ] Post-review checks run.
-- [ ] Deep UI re-check run or skipped.
-- [ ] User check completed.
-- [ ] Blueprint updated.
-- [ ] Final verification run.
-- [ ] Final report created and commented.
-- [ ] Branch pushed and PR created.
-- [ ] PR merged, base updated, worktree removed.
-- [ ] Session finished and archived.
+- [x] Session created.
+- [x] Worktree created.
+- [x] Dependencies installed.
+- [x] Initial issue prompt rendered.
+- [x] Issue drafted.
+- [x] GitHub issue created.
+- [x] Get issue details prompt rendered.
+- [x] Plan details gathered.
+- [x] Plan made.
+- [x] Plan fine tuning.
+- [x] Implementation changes accepted.
+- [x] Implementation changes committed.
+- [x] Pre-review checks run.
+- [x] Deep UI check run or skipped.
+- [x] Deslop/JSKIT review run.
+- [x] Review changes accepted.
+- [x] Review changes committed.
+- [x] Post-review checks run.
+- [x] Deep UI re-check run or skipped.
+- [x] User check completed.
+- [x] If user check fails, optionally start a new rework cycle at Plan fine tuning.
+- [x] Blueprint updated.
+- [x] Final verification run.
+- [x] Final report created and commented.
+- [x] Branch pushed and PR created.
+- [x] PR finalized with an explicit outcome, base updated when merged, worktree removed.
+- [x] Session finished and archived.
 
 ## New And Revised Session Artifacts
 
-- [ ] Add `.jskit/sessions/active/<session_id>/plan_details.md`.
-- [ ] Add `.jskit/sessions/active/<session_id>/issue_metadata.json`.
-- [ ] Add `.jskit/sessions/active/<session_id>/agent_decisions.md`.
-- [ ] Add `.jskit/sessions/active/<session_id>/final_report.md`.
-- [ ] Add `.jskit/sessions/active/<session_id>/github_comments.json` for idempotent GitHub issue comments.
-- [ ] Add `.jskit/sessions/active/<session_id>/command_log.jsonl` if ordinary command execution needs durable command/output history beyond receipts.
-- [ ] Add `.jskit/sessions/active/<session_id>/checks/` for structured check receipts.
-- [ ] Add `.jskit/sessions/active/<session_id>/ui_checks/` for structured UI review/check receipts.
-- [ ] Add `.jskit/sessions/active/<session_id>/review_passes/` for repeated deslop/JSKIT review passes.
-- [ ] Keep `.jskit/APP_BLUEPRINT.md` as durable app memory.
-- [ ] Keep `.jskit/helper-map.md` as generated helper/export memory.
-- [ ] Make every artifact path appear in `jskit session <id> --json` when it exists.
+- [x] Add `.jskit/sessions/active/<session_id>/plan_details.md`.
+- [x] Add `.jskit/sessions/active/<session_id>/issue_metadata.json`.
+- [x] Add `.jskit/sessions/active/<session_id>/agent_decisions.md`.
+- [x] Add `.jskit/sessions/active/<session_id>/final_report.md`.
+- [x] Add `.jskit/sessions/active/<session_id>/github_comments.json` for idempotent GitHub issue comments.
+- [x] Add `.jskit/sessions/active/<session_id>/base_branch` captured when the session worktree is created.
+- [x] Add `.jskit/sessions/active/<session_id>/base_commit` captured when the session worktree is created.
+- [x] Add session workflow version metadata to the existing session manifest/state file.
+- [x] Add `.jskit/sessions/active/<session_id>/active_cycle` as a plain text current cycle marker.
+- [x] Add `.jskit/sessions/active/<session_id>/cycles/cycle_###/rework_request.md` for user-requested rework notes.
+- [x] Add cycle-scoped text receipts under `.jskit/sessions/active/<session_id>/steps/cycle_###/<step_id>`.
+- [x] Add `.jskit/sessions/active/<session_id>/command_log.jsonl` if ordinary command execution needs durable command/output history beyond receipts.
+- [x] Add `.jskit/sessions/active/<session_id>/checks/` for structured check receipts.
+- [x] Add `.jskit/sessions/active/<session_id>/ui_checks/` for structured UI review/check receipts.
+- [x] Add `.jskit/sessions/active/<session_id>/review_passes/` for repeated deslop/JSKIT review passes.
+- [x] Keep `.jskit/APP_BLUEPRINT.md` as durable app memory.
+- [x] Keep `.jskit/helper-map.md` as generated helper/export memory.
+- [x] Make every artifact path appear in `jskit session <id> --json` when it exists.
 
 ## Naming Decision: Plan Details
 
-- [ ] Use `plan_details.md` as the canonical accepted details file.
-- [ ] Treat `Get issue details` as the human-facing step label, because the developer is clarifying the issue with Codex.
-- [ ] Do not create a separate long-lived `issue_details.md` unless a compatibility alias is explicitly needed later.
-- [ ] The execution prompt must tell Codex to follow both `plan.md` and `plan_details.md`.
-- [ ] Any GitHub issue comment for the details step should post the accepted contents of `plan_details.md`.
+- [x] Use `plan_details.md` as the canonical accepted details file.
+- [x] Treat `Get issue details` as the human-facing step label, because the developer is clarifying the issue with Codex.
+- [x] Do not create a separate long-lived `issue_details.md` unless a compatibility alias is explicitly needed later.
+- [x] The execution prompt must tell Codex to follow both `plan.md` and `plan_details.md`.
+- [x] Any GitHub issue comment for the details step should post the accepted contents of `plan_details.md`.
 
 ## App Readiness Boundary
 
-- [ ] Treat app boot/app setup as the owner of empty/non-JSKIT/partial-JSKIT recovery.
-- [ ] Before issue work begins, JSKIT session should verify the target looks like a ready JSKIT app.
-- [ ] If readiness is missing, return a stable blocked error such as `app_setup_required`.
-- [ ] The repair guidance should tell Studio/CLI users to run the app setup flow, not ask Codex to recover the app inside an issue session.
-- [ ] Add tests that a non-ready app blocks before issue prompt rendering.
-- [ ] Add tests that issue prompts no longer ask Codex to plan recovery for empty or partial apps.
+- [x] Treat app boot/app setup as the owner of empty/non-JSKIT/partial-JSKIT recovery.
+- [x] Before issue work begins, JSKIT session should verify the target looks like a ready JSKIT app.
+- [x] If readiness is missing, return a stable blocked error such as `app_setup_required`.
+- [x] The repair guidance should tell Studio/CLI users to run the app setup flow, not ask Codex to recover the app inside an issue session.
+- [x] Add tests that a non-ready app blocks before issue prompt rendering.
+- [x] Add tests that issue prompts no longer ask Codex to plan recovery for empty or partial apps.
+
+## Session Workflow Versioning
+
+Goal: avoid corrupting or misrendering sessions created by an older step graph.
+
+- [x] Assign a stable workflow version to all newly created sessions.
+- [x] Include workflow version in session JSON.
+- [x] Do not support legacy workflow versions; hard-block them with `unsupported_workflow_version`.
+- [x] Do not silently map old step ids onto new semantics.
+- [x] Add tests for creating a new-version session.
+- [x] Add tests that an unsupported old workflow version blocks inspection/advancement without corrupting files.
 
 ## JSON Contract Additions
 
-- [ ] Add `appReady` or equivalent setup-readiness status if JSKIT session must block before issue work.
-- [ ] Add `planDetails` as a string.
-- [ ] Add `planDetailsPath` as a string.
-- [ ] Add `issueCategory` with allowed values: `client`, `server`, `client_server`, `tooling`, `unknown`.
-- [ ] Add `uiImpact` with allowed values: `none`, `possible`, `definite`, `unknown`.
-- [ ] Add `agentDecisionsPath`.
-- [ ] Add `agentDecisionsSummary` or `agentDecisionsLatest`.
-- [ ] Add `blueprintPath`.
-- [ ] Add `blueprintExists`.
-- [ ] Add `helperMapPath`.
-- [ ] Add `helperMapExists`.
-- [ ] Add `finalReportPath`.
-- [ ] Add `finalReportText`.
-- [ ] Add `githubComments[]` or comment receipt metadata so Studio can show which issue comments have been posted.
-- [ ] Add `checks[]` with stable objects for automated checks.
-- [ ] Add `uiChecks[]` with stable objects for UI/deep UI checks.
-- [ ] Add `reviewPasses[]` with pass number, status, commit, changed files, and prompt path.
-- [ ] Add `currentStepAction.conditional` for steps that can skip.
-- [ ] Add `currentStepAction.skipReason` when JSKIT can determine why a conditional step is skipped.
-- [ ] Add `currentStepAction.retryable` for blocked check/review/UI steps that should rerun after repair.
-- [ ] Ensure `--json` writes only JSON to stdout.
-- [ ] Contract-test all new fields on active, completed, abandoned, and blocked sessions.
+- [x] Add `appReady` or equivalent setup-readiness status if JSKIT session must block before issue work.
+- [x] Add `workflowVersion`.
+- [x] Add `baseBranch`.
+- [x] Add `baseCommit`.
+- [x] Add `activeCycle`.
+- [x] Add `cycles[]` with cycle number, status, rework request path, and user-check result.
+- [x] Add `issueMetadata`.
+- [x] Add `planDetails` as a string.
+- [x] Add `planDetailsPath` as a string.
+- [x] Add `issueCategory` with allowed values: `client`, `server`, `client_server`, `tooling`, `unknown`.
+- [x] Add `uiImpact` with allowed values: `none`, `possible`, `definite`, `unknown`.
+- [x] Add `agentDecisionsPath`.
+- [x] Add `agentDecisionsSummary` or `agentDecisionsLatest`.
+- [x] Add `blueprintPath`.
+- [x] Add `blueprintExists`.
+- [x] Add `helperMapPath`.
+- [x] Add `helperMapExists`.
+- [x] Add `finalReportPath`.
+- [x] Add `finalReportText`.
+- [x] Add `githubComments[]` or comment receipt metadata so Studio can show which issue comments have been posted.
+- [x] Add `checks[]` with stable objects for automated checks.
+- [x] Add `uiChecks[]` with stable objects for UI/deep UI checks.
+- [x] Add `reviewPasses[]` with pass number, status, commit, changed files, and prompt path.
+- [x] Add optional `stepDefinitions[].displayGroupId` and `stepDefinitions[].displayGroupLabel` for JSKIT-owned visual grouping of related steps.
+- [x] Add `currentStepAction.conditional` for steps that can skip.
+- [x] Add `currentStepAction.skipReason` when JSKIT can determine why a conditional step is skipped.
+- [x] Add `currentStepAction.retryable` for blocked check/review/UI steps that should rerun after repair.
+- [x] Add `currentStepAction.alternateActions[]` for precise allowed transitions such as failed user-check rework.
+- [x] Ensure `currentStepAction.label` is the source of truth for Studio button text.
+- [x] Ensure `currentStepAction.requiredInput` describes when an action is disabled until parsed/edited output is valid.
+- [x] Ensure `--json` writes only JSON to stdout.
+- [x] Contract-test all new fields on active, completed, abandoned, and blocked sessions.
 
 ## Step: Initial Issue Prompt
 
 Goal: create a first implementation-ready issue draft from the user's short request, without mutating the project.
 
-- [ ] Update `new_issue.md` to assume app setup already passed.
-- [ ] Remove normal reasoning around `empty`, `non_jskit_repo`, and `partial_jskit_app`.
-- [ ] Add instruction: if the filesystem contradicts a valid JSKIT app, report setup failure instead of inventing recovery work.
-- [ ] Instruct the agent to read `.jskit/APP_BLUEPRINT.md` when present.
-- [ ] Instruct the agent to read `.jskit/helper-map.md` when present.
-- [ ] Instruct the agent to inspect `package.json`, `.jskit/lock.json`, `config/public.js`, relevant `src/`, and relevant `packages/`.
-- [ ] Mention safe read-only commands: `pwd`, `ls`, `find`, `rg`, `cat`, `sed`, `git status`.
-- [ ] Mention safe JSKIT inspection commands only when available and non-mutating:
-  - [ ] `jskit list`
-  - [ ] `jskit show <package> --details`
-  - [ ] `jskit list-placements`
-- [ ] Keep mutation commands forbidden in issue drafting:
-  - [ ] no `jskit session step`
-  - [ ] no `gh`
-  - [ ] no `git add`
-  - [ ] no `git commit`
-  - [ ] no `git push`
-  - [ ] no `npm install`
-  - [ ] no generators
-  - [ ] no tests
-  - [ ] no doctor
-- [ ] Keep output tags:
-  - [ ] `[issue_title]...[/issue_title]`
-  - [ ] `[issue_text]...[/issue_text]`
-- [ ] Test that issue drafting remains read-only by prompt contract.
-- [ ] Test that generated issue prompt mentions blueprint/helper-map/app inspection.
+- [x] Update `new_issue.md` to assume app setup already passed.
+- [x] Remove normal reasoning around `empty`, `non_jskit_repo`, and `partial_jskit_app`.
+- [x] Add instruction: if the filesystem contradicts a valid JSKIT app, report setup failure instead of inventing recovery work.
+- [x] Instruct the agent to read `.jskit/APP_BLUEPRINT.md` when present.
+- [x] Instruct the agent to read `.jskit/helper-map.md` when present.
+- [x] Instruct the agent to inspect `package.json`, `.jskit/lock.json`, `config/public.js`, relevant `src/`, and relevant `packages/`.
+- [x] Mention safe read-only commands: `pwd`, `ls`, `find`, `rg`, `cat`, `sed`, `git status`.
+- [x] Mention safe JSKIT inspection commands only when available and non-mutating:
+  - [x] `jskit list`
+  - [x] `jskit show <package> --details`
+  - [x] `jskit list-placements`
+- [x] Keep mutation commands forbidden in issue drafting:
+  - [x] no `jskit session step`
+  - [x] no `gh`
+  - [x] no `git add`
+  - [x] no `git commit`
+  - [x] no `git push`
+  - [x] no `npm install`
+  - [x] no generators
+  - [x] no tests
+  - [x] no doctor
+- [x] Keep output tags:
+  - [x] `[issue_title]...[/issue_title]`
+  - [x] `[issue_text]...[/issue_text]`
+- [x] Test that issue drafting remains read-only by prompt contract.
+- [x] Test that generated issue prompt mentions blueprint/helper-map/app inspection.
+
+## GitHub Issue Creation Metadata
+
+Goal: make the created GitHub issue a durable session fact that later steps can safely depend on.
+
+- [x] Keep issue title and body editable after Codex drafts them and before GitHub creation.
+- [x] Disable issue creation until both title and body are valid parsed/edited values.
+- [x] Create the GitHub issue through JSKIT session runtime, not Studio-owned GitHub logic.
+- [x] Write `issue_metadata.json` when the GitHub issue is created.
+- [x] Store issue number, URL, repository owner/name, title, and body in `issue_metadata.json`.
+- [x] Keep issue creation idempotent when rerun after metadata already exists.
+- [x] Add issue metadata to session JSON.
+- [x] Add tests that edited title/body are what get sent to GitHub.
+- [x] Add tests that rerunning issue creation does not create duplicate issues.
 
 ## New Step: Get Issue Details
 
@@ -161,95 +203,96 @@ Goal: let the developer and Codex talk until no important implementation details
 
 ### Step Shape
 
-- [ ] Add JSKIT session steps after `issue_created` and before `plan_made`.
-- [ ] Add internal step `plan_details_prompt_rendered`.
-- [ ] Use visible label `Get issue details` for `plan_details_prompt_rendered`.
-- [ ] Use button label `Start details conversation` for `plan_details_prompt_rendered`.
-- [ ] Add internal step `plan_details_gathered`.
-- [ ] Use visible label `Plan details gathered` for `plan_details_gathered`.
-- [ ] Use button label `Save plan details` for `plan_details_gathered`.
-- [ ] Keep both steps visible in CLI JSON; Studio may visually keep the form/conversation within the same details section using JSKIT-provided metadata, not hard-coded step IDs.
-- [ ] Preserve a clean manual CLI flow.
-- [ ] Preserve Studio's 1:1 rendering of JSKIT-owned steps.
-- [ ] Add prompt artifact path: `prompts/plan_details.md`.
-- [ ] Add accepted details file: `plan_details.md`.
-- [ ] Add metadata file: `issue_metadata.json`.
-- [ ] Append important decisions to `agent_decisions.md`.
-- [ ] Comment accepted plan details on the GitHub issue.
+- [x] Add JSKIT session steps after `issue_created` and before `plan_made`.
+- [x] Add internal step `plan_details_prompt_rendered`.
+- [x] Use visible label `Get issue details` for `plan_details_prompt_rendered`.
+- [x] Use button label `Start details conversation` for `plan_details_prompt_rendered`.
+- [x] Add internal step `plan_details_gathered`.
+- [x] Use visible label `Plan details gathered` for `plan_details_gathered`.
+- [x] Use button label `Save plan details` for `plan_details_gathered`.
+- [x] Keep both steps visible in CLI JSON; Studio may visually keep the form/conversation within the same details section using JSKIT-provided metadata, not hard-coded step IDs.
+- [x] Set the same JSKIT-owned display group metadata on the prompt-rendered and gathered steps so Studio can render them as one coherent details area without knowing the IDs.
+- [x] Preserve a clean manual CLI flow.
+- [x] Preserve Studio's 1:1 rendering of JSKIT-owned steps.
+- [x] Add prompt artifact path: `prompts/plan_details.md`.
+- [x] Add accepted details file: `plan_details.md`.
+- [x] Add metadata file: `issue_metadata.json`.
+- [x] Append important decisions to `agent_decisions.md`.
+- [x] Comment accepted plan details on the GitHub issue.
 
 ### Prompt Behavior
 
-- [ ] Create `tooling/jskit-cli/src/server/sessionRuntime/prompts/plan_details.md`.
-- [ ] The prompt must tell Codex: "No stones unturned."
-- [ ] Codex must read:
-  - [ ] GitHub issue URL and issue text.
-  - [ ] `.jskit/APP_BLUEPRINT.md`.
-  - [ ] `.jskit/helper-map.md`.
-  - [ ] `package.json`.
-  - [ ] `.jskit/lock.json`.
-  - [ ] `config/public.js`.
-  - [ ] relevant `src/` and `packages/`.
-  - [ ] relevant JSKIT package docs or `jskit show ... --details`.
-- [ ] Codex must ask follow-up questions until implementation details are complete.
-- [ ] Codex must ask for final confirmation before emitting final details.
-- [ ] Codex must not edit files during this step.
-- [ ] Codex must not run mutation commands during this step.
+- [x] Create `tooling/jskit-cli/src/server/sessionRuntime/prompts/plan_details.md`.
+- [x] The prompt must tell Codex: "No stones unturned."
+- [x] Codex must read:
+  - [x] GitHub issue URL and issue text.
+  - [x] `.jskit/APP_BLUEPRINT.md`.
+  - [x] `.jskit/helper-map.md`.
+  - [x] `package.json`.
+  - [x] `.jskit/lock.json`.
+  - [x] `config/public.js`.
+  - [x] relevant `src/` and `packages/`.
+  - [x] relevant JSKIT package docs or `jskit show ... --details`.
+- [x] Codex must ask follow-up questions until implementation details are complete.
+- [x] Codex must ask for final confirmation before emitting final details.
+- [x] Codex must not edit files during this step.
+- [x] Codex must not run mutation commands during this step.
 
 ### Required Detail Areas
 
-- [ ] If CRUD or persisted data is involved, require:
-  - [ ] entity/table name.
-  - [ ] field names.
-  - [ ] field types.
-  - [ ] required/optional/nullability.
-  - [ ] defaults.
-  - [ ] uniqueness.
-  - [ ] indexes where relevant.
-  - [ ] relationships.
-  - [ ] ownership: `public`, `user`, `workspace`, `workspace_user`, or explicit exception.
-  - [ ] allowed operations: `list`, `view`, `new`, `edit`, `delete`, or narrower set.
-  - [ ] list fields.
-  - [ ] view form shape.
-  - [ ] edit/new form shape.
-  - [ ] validation rules.
-  - [ ] permissions and role boundaries.
-  - [ ] migration/generator lane.
-  - [ ] exact CRUD generator command or exact reason no CRUD generator applies.
-- [ ] If UI is involved, require:
-  - [ ] route path.
-  - [ ] placement/surface target.
-  - [ ] navigation entry expectations.
-  - [ ] responsive layout expectations.
-  - [ ] loading state.
-  - [ ] empty state.
-  - [ ] error state.
-  - [ ] disabled state.
-  - [ ] success state.
-  - [ ] Material/Vuetify quality expectations.
-  - [ ] Playwright verification path.
-  - [ ] auth/bootstrap strategy if login is needed.
-- [ ] If server-only work is involved, require:
-  - [ ] endpoint/command/job shape.
-  - [ ] request and response shape.
-  - [ ] validation behavior.
-  - [ ] auth/permission behavior.
-  - [ ] persistence ownership if any.
-  - [ ] error behavior.
-  - [ ] verification path.
-- [ ] If package/generator work is involved, require:
-  - [ ] exact `jskit add` or `jskit generate` command.
-  - [ ] reason the package/generator applies.
-  - [ ] expected generated files.
-  - [ ] follow-up custom code areas.
-- [ ] If the request is intentionally tiny, still require:
-  - [ ] exact file/path behavior.
-  - [ ] acceptance criteria.
-  - [ ] whether UI is impacted.
-  - [ ] whether tests/checks are needed.
+- [x] If CRUD or persisted data is involved, require:
+  - [x] entity/table name.
+  - [x] field names.
+  - [x] field types.
+  - [x] required/optional/nullability.
+  - [x] defaults.
+  - [x] uniqueness.
+  - [x] indexes where relevant.
+  - [x] relationships.
+  - [x] ownership: `public`, `user`, `workspace`, `workspace_user`, or explicit exception.
+  - [x] allowed operations: `list`, `view`, `new`, `edit`, `delete`, or narrower set.
+  - [x] list fields.
+  - [x] view form shape.
+  - [x] edit/new form shape.
+  - [x] validation rules.
+  - [x] permissions and role boundaries.
+  - [x] migration/generator lane.
+  - [x] exact CRUD generator command or exact reason no CRUD generator applies.
+- [x] If UI is involved, require:
+  - [x] route path.
+  - [x] placement/surface target.
+  - [x] navigation entry expectations.
+  - [x] responsive layout expectations.
+  - [x] loading state.
+  - [x] empty state.
+  - [x] error state.
+  - [x] disabled state.
+  - [x] success state.
+  - [x] Material/Vuetify quality expectations.
+  - [x] Playwright verification path.
+  - [x] auth/bootstrap strategy if login is needed.
+- [x] If server-only work is involved, require:
+  - [x] endpoint/command/job shape.
+  - [x] request and response shape.
+  - [x] validation behavior.
+  - [x] auth/permission behavior.
+  - [x] persistence ownership if any.
+  - [x] error behavior.
+  - [x] verification path.
+- [x] If package/generator work is involved, require:
+  - [x] exact `jskit add` or `jskit generate` command.
+  - [x] reason the package/generator applies.
+  - [x] expected generated files.
+  - [x] follow-up custom code areas.
+- [x] If the request is intentionally tiny, still require:
+  - [x] exact file/path behavior.
+  - [x] acceptance criteria.
+  - [x] whether UI is impacted.
+  - [x] whether tests/checks are needed.
 
 ### Required Output Tags
 
-- [ ] Require Codex to output:
+- [x] Require Codex to output:
 
 ```text
 [issue_category]
@@ -269,80 +312,98 @@ none | possible | definite
 [/agent_decisions]
 ```
 
-- [ ] Add parser helpers for these tags.
-- [ ] Validate allowed `issue_category` values.
-- [ ] Validate allowed `ui_impact` values.
-- [ ] Reject empty `plan_details`.
-- [ ] Save `agent_decisions` by appending to session `agent_decisions.md`.
-- [ ] Write a receipt when details are saved.
-- [ ] Add tests for valid output.
-- [ ] Add tests for missing tags.
-- [ ] Add tests for invalid category.
-- [ ] Add tests for invalid UI impact.
-- [ ] Add tests that plan details are commented on the GitHub issue.
+- [x] Add parser helpers for these tags.
+- [x] Validate allowed `issue_category` values.
+- [x] Validate allowed `ui_impact` values.
+- [x] Reject empty `plan_details`.
+- [x] Save `agent_decisions` by appending to session `agent_decisions.md`.
+- [x] Write a receipt when details are saved.
+- [x] Add tests for valid output.
+- [x] Add tests for missing tags.
+- [x] Add tests for invalid category.
+- [x] Add tests for invalid UI impact.
+- [x] Add tests that plan details are commented on the GitHub issue.
+
+## Dependency Install Step
+
+Goal: make the session worktree runnable before Codex starts inspecting or editing it.
+
+- [x] Capture `base_branch` and `base_commit` when the worktree is created, before dependency installation.
+- [x] Keep dependency installation as a JSKIT-owned session step immediately after worktree creation.
+- [x] Run dependency installation in the session worktree, not the target root.
+- [x] Use the project package manager/lockfile detected from the worktree.
+- [x] Do not run `devlinks` as part of normal Studio/session workflow.
+- [x] Stream the command output through the same terminal/job mechanism Studio uses for other visible commands.
+- [x] Block Codex startup and later issue work until dependency installation succeeds.
+- [x] Make the step retryable and idempotent.
+- [x] Record command, exit code, and summary in session receipts or `command_log.jsonl`.
+- [x] Add dependency-install status to session JSON.
+- [x] Add tests that base branch/base commit metadata is captured at worktree creation.
+- [x] Add tests that Codex cannot start for a session before dependencies are installed.
+- [x] Add tests that rerunning the dependency step is safe.
 
 ## Issue Classification
 
-- [ ] Store classification in `issue_metadata.json`.
-- [ ] Include `issueCategory` in session JSON.
-- [ ] Include `uiImpact` in session JSON.
-- [ ] Use `uiImpact` to decide whether Deep UI Check steps should run or skip.
-- [ ] Treat `uiImpact=none` as skip for Deep UI Check.
-- [ ] Treat `uiImpact=possible` as run unless the user explicitly marks UI not impacted.
-- [ ] Treat `uiImpact=definite` as mandatory Deep UI Check.
-- [ ] Add an explicit skip/override path for `uiImpact=possible`, requiring a short reason that is stored in `ui_checks/`.
-- [ ] Add repair/error behavior when classification is missing before UI/check steps.
-- [ ] Add Studio display for category and UI impact in the session info cards.
+- [x] Store classification in `issue_metadata.json`.
+- [x] Include `issueCategory` in session JSON.
+- [x] Include `uiImpact` in session JSON.
+- [x] Use `uiImpact` to decide whether Deep UI Check steps should run or skip.
+- [x] Treat `uiImpact=none` as skip for Deep UI Check.
+- [x] Treat `uiImpact=possible` as run unless the user explicitly marks UI not impacted.
+- [x] Treat `uiImpact=definite` as mandatory Deep UI Check.
+- [x] Add an explicit skip/override path for `uiImpact=possible`, requiring a short reason that is stored in `ui_checks/`.
+- [x] Add repair/error behavior when classification is missing before UI/check steps.
+- [x] Add Studio display for category and UI impact in the session info cards.
 
 ## GitHub Comment Idempotency
 
 Goal: rerunning a step must not spam the GitHub issue with duplicate plan/details/final-report comments.
 
-- [ ] Store comment metadata in `github_comments.json`.
-- [ ] Track comment purpose keys such as `plan_details`, `plan`, `agent_decisions`, and `final_report`.
-- [ ] Store comment URL or id when `gh` exposes it.
-- [ ] If a comment already exists for a purpose, update it when supported or skip with a clear receipt.
-- [ ] If update is not feasible in V1, skip duplicate comments after the first successful comment and report the stored comment URL/id.
-- [ ] Add tests that rerunning plan-details comment does not duplicate the issue comment.
-- [ ] Add tests that rerunning plan comment does not duplicate the issue comment.
-- [ ] Add tests that rerunning final-report comment does not duplicate the issue comment.
+- [x] Store comment metadata in `github_comments.json`.
+- [x] Track comment purpose keys such as `plan_details`, `plan`, and `final_report`.
+- [x] Store comment purpose metadata for later display and duplicate suppression.
+- [x] If a comment already exists for a purpose, update it when supported or skip with a clear receipt.
+- [x] If update is not feasible in V1, skip duplicate comments after the first successful comment and report the stored metadata.
+- [x] Add tests that rerunning plan-details comment does not duplicate the issue comment.
+- [x] Add tests that rerunning plan comment does not duplicate the issue comment.
+- [x] Add tests that rerunning final-report comment does not duplicate the issue comment.
 
 ## Agent Decisions Log
 
 Goal: preserve the why behind important choices without resurrecting a workboard.
 
-- [ ] Add session-owned `agent_decisions.md`.
-- [ ] Initialize it with session id, issue URL, and timestamp.
-- [ ] Append decisions from Get Issue Details.
-- [ ] Append generator/package decisions from Plan Made.
-- [ ] Append implementation deviations from Plan Fine Tuning.
-- [ ] Append Deep UI Check decisions.
-- [ ] Append verification decisions.
-- [ ] Append blueprint-update decisions.
-- [ ] Keep entries concise and reasoned.
-- [ ] Do not use this as task tracking.
-- [ ] Do not make it app-global.
-- [ ] Include latest decision summary in `jskit session <id> --json`.
-- [ ] Comment the decision log or a summarized decision report on the GitHub issue near the end.
-- [ ] Add tests that decisions are appended, not overwritten.
-- [ ] Add tests that the final report links or includes decisions.
+- [x] Add session-owned `agent_decisions.md`.
+- [x] Initialize it with session id, issue URL, and timestamp.
+- [x] Append decisions from Get Issue Details.
+- [x] Append generator/package decisions from Plan Made.
+- [x] Append implementation deviations from Plan Fine Tuning.
+- [x] Append Deep UI Check decisions.
+- [x] Append verification decisions.
+- [x] Append blueprint-update decisions.
+- [x] Keep entries concise and reasoned.
+- [x] Do not use this as task tracking.
+- [x] Do not make it app-global.
+- [x] Include latest decision summary in `jskit session <id> --json`.
+- [x] Comment the decision log or a summarized decision report on the GitHub issue near the end.
+- [x] Add tests that decisions are appended, not overwritten.
+- [x] Add tests that the final report links or includes decisions.
 
 ## Plan Made Step
 
 Goal: produce an implementation plan only after the issue and details are complete.
 
-- [ ] Update `plan_issue.md` to read `plan_details.md`.
-- [ ] Update `plan_issue.md` to read `agent_decisions.md`.
-- [ ] Update `plan_issue.md` to read `.jskit/APP_BLUEPRINT.md`.
-- [ ] Update `plan_issue.md` to read `.jskit/helper-map.md`.
-- [ ] Require plan to include the issue category and UI impact.
-- [ ] Require plan to include exact generator/package decisions.
-- [ ] Require plan to include exact JSKIT inspection commands used or to use.
-- [ ] For CRUD work, require exact server CRUD command or exact reason not applicable.
-- [ ] For non-CRUD UI pages, require exact UI generator command or exact reason not applicable.
-- [ ] For UI-impacting work, require planned Playwright and Deep UI Check path.
-- [ ] For auth-required UI, require local dev auth/bootstrap strategy.
-- [ ] Require plan output tags:
+- [x] Update `plan_issue.md` to read `plan_details.md`.
+- [x] Update `plan_issue.md` to read `agent_decisions.md`.
+- [x] Update `plan_issue.md` to read `.jskit/APP_BLUEPRINT.md`.
+- [x] Update `plan_issue.md` to read `.jskit/helper-map.md`.
+- [x] Require plan to include the issue category and UI impact.
+- [x] Require plan to include exact generator/package decisions.
+- [x] Require plan to include exact JSKIT inspection commands used or to use.
+- [x] For CRUD work, require exact server CRUD command or exact reason not applicable.
+- [x] For non-CRUD UI pages, require exact UI generator command or exact reason not applicable.
+- [x] For UI-impacting work, require planned Playwright and Deep UI Check path.
+- [x] For auth-required UI, require local dev auth/bootstrap strategy.
+- [x] Require plan output tags:
 
 ```text
 [plan]
@@ -354,161 +415,210 @@ Goal: produce an implementation plan only after the issue and details are comple
 [/agent_decisions]
 ```
 
-- [ ] Save `plan.md`.
-- [ ] Append plan decisions to `agent_decisions.md`.
-- [ ] Comment the approved plan on the GitHub issue immediately after approval.
-- [ ] Ensure this existing behavior is explicit and tested.
-- [ ] Add tests that `plan_made` requires `plan_details.md`.
-- [ ] Add tests that plan comment includes the approved plan.
+- [x] Save `plan.md`.
+- [x] Append plan decisions to `agent_decisions.md`.
+- [x] Comment the approved plan on the GitHub issue immediately after approval.
+- [x] Expose JSKIT action metadata that lets Studio label the automated action `Create and submit plan`.
+- [x] Expose whether the accepted plan has already been submitted to Codex for implementation.
+- [x] Ensure this existing behavior is explicit and tested.
+- [x] Add tests that `plan_made` requires `plan_details.md`.
+- [x] Add tests that plan comment includes the approved plan.
 
 ## Plan Fine Tuning Step
 
 Goal: let the user refine the plan with Codex, then implement in the worktree.
 
-- [ ] Update `fine_tune_plan.md` to read `plan_details.md`.
-- [ ] Update `fine_tune_plan.md` to explicitly say Codex must follow both `plan.md` and `plan_details.md`.
-- [ ] Update `fine_tune_plan.md` to read `agent_decisions.md`.
-- [ ] Update prompt to preserve user refinements as decision-log entries.
-- [ ] Require Codex to append any meaningful implementation deviations to `agent_decisions.md` through tagged output or a session step input.
-- [ ] Keep Codex from creating commits, PRs, merges, or worktree cleanup.
-- [ ] Keep Codex working only inside the session worktree.
-- [ ] Add tests that prompt includes plan details path.
-- [ ] Add tests that prompt includes decisions path.
+- [x] Update `fine_tune_plan.md` to read `plan_details.md`.
+- [x] Update `fine_tune_plan.md` to explicitly say Codex must follow both `plan.md` and `plan_details.md`.
+- [x] Update `fine_tune_plan.md` to read `agent_decisions.md`.
+- [x] Update prompt to preserve user refinements as decision-log entries.
+- [x] Require Codex to append any meaningful implementation deviations to `agent_decisions.md` through tagged output or a session step input.
+- [x] Keep Codex from creating commits, PRs, merges, or worktree cleanup.
+- [x] Keep Codex working only inside the session worktree.
+- [x] Add tests that prompt includes plan details path.
+- [x] Add tests that prompt includes decisions path.
 
 ## Mutation And Commit Model For Repair / Quality Steps
 
 Goal: every Codex step that can edit files must leave the worktree in a known committed or explicitly accepted state before the workflow advances.
 
-- [ ] Define which prompt steps are allowed to mutate files.
-- [ ] Treat Plan Fine Tuning / implementation as mutating.
-- [ ] Treat Deep UI Check as mutating when it fixes scoped UI issues.
-- [ ] Treat Deslop/JSKIT review as mutating when it fixes findings.
-- [ ] Treat check/doctor repair prompts as mutating when they fix failures.
-- [ ] After any mutating Codex quality/repair step, require an accept/commit path before proceeding.
-- [ ] Avoid leaving dirty worktree changes between quality/check steps unless the next step explicitly owns those dirty changes.
-- [ ] Include dirty-worktree status in `jskit session <id> --json`.
-- [ ] Add a generic commit helper for session-owned quality/repair commits where possible.
-- [ ] Commit messages should identify the session and phase, for example `Deep UI check fixes for <session_id>`.
-- [ ] Add tests that Deep UI Check changes are committed or explicitly skipped before deslop/review advances.
-- [ ] Add tests that check-repair changes are committed before rerunning the check step.
-- [ ] Add tests that repeated review pass changes are committed per pass.
+- [x] Define which prompt steps are allowed to mutate files.
+- [x] Treat Plan Fine Tuning / implementation as mutating.
+- [x] Treat Deep UI Check as mutating when it fixes scoped UI issues.
+- [x] Treat Deslop/JSKIT review as mutating when it fixes findings.
+- [x] Treat check/doctor repair prompts as mutating when they fix failures.
+- [x] After any mutating Codex quality/repair step, require an accept/commit path before proceeding.
+- [x] Avoid leaving dirty worktree changes between quality/check steps unless the next step explicitly owns those dirty changes.
+- [x] Include dirty-worktree status in `jskit session <id> --json`.
+- [x] Expose changed files and a JSKIT-owned diff utility path for acceptance steps.
+- [x] Acceptance steps should let Studio show the current branch/worktree diff before the user accepts changes.
+- [x] Add a generic commit helper for session-owned quality/repair commits where possible.
+- [x] Commit messages should identify the session and phase, for example `Deep UI check fixes for <session_id>`.
+- [x] Add tests that Deep UI Check changes are committed or explicitly skipped before deslop/review advances.
+- [x] Add tests that check-repair changes are committed before rerunning the check step.
+- [x] Add tests that repeated review pass changes are committed per pass.
 
 ## Repeated Deslop / JSKIT Review
 
 Goal: support multiple deslop/JSKIT review passes without hard-coding three duplicated visible step groups.
 
-- [ ] Design repeatable review pass storage under `review_passes/<n>/`.
-- [ ] Keep the visible step model simple.
-- [ ] Avoid reintroducing separate numbered visible steps such as `review_prompt_rendered_1`, `review_prompt_rendered_2`, etc.
-- [ ] Add `reviewPasses[]` to JSON.
-- [ ] Add current review pass number to JSON.
-- [ ] Add maximum review pass setting with a conservative default.
-- [ ] Add prompt support for "run another deslop/JSKIT review pass".
-- [ ] Keep Deslop and JSKIT review as distinct sections in the prompt.
-- [ ] Deslop checks:
-  - [ ] duplicate helpers.
-  - [ ] unnecessary helpers.
-  - [ ] fake-complete UI.
-  - [ ] missing states.
-  - [ ] dead code.
-  - [ ] weak route wiring.
-  - [ ] placeholder copy/code.
-- [ ] JSKIT checks:
-  - [ ] wrong generator choice.
-  - [ ] missed package/runtime seam.
-  - [ ] hand-built CRUD where generated ownership is required.
-  - [ ] direct knex outside approved lanes.
-  - [ ] metadata drift.
-  - [ ] surface/route/ownership mistakes.
-- [ ] Add a way to stop review passes when no important findings remain.
-- [ ] Add a way to request another pass when important findings remain.
-- [ ] Ensure each review pass that changes files has an accept/commit path before the next pass.
-- [ ] Ensure each review pass records the commit SHA or records that no changes were needed.
-- [ ] Add tests for zero-change review pass.
-- [ ] Add tests for review pass with changes.
-- [ ] Add tests for max pass handling.
+- [x] Design repeatable review pass storage under `review_passes/<n>/`.
+- [x] Keep the visible step model simple.
+- [x] Avoid reintroducing separate numbered visible steps such as `review_prompt_rendered_1`, `review_prompt_rendered_2`, etc.
+- [x] Add `reviewPasses[]` to JSON.
+- [x] Add current review pass number to JSON.
+- [x] Add maximum review pass setting with a conservative default.
+- [x] Add prompt support for "run another deslop/JSKIT review pass".
+- [x] Keep Deslop and JSKIT review as distinct sections in the prompt.
+- [x] Deslop checks:
+  - [x] duplicate helpers.
+  - [x] unnecessary helpers.
+  - [x] fake-complete UI.
+  - [x] missing states.
+  - [x] dead code.
+  - [x] weak route wiring.
+  - [x] placeholder copy/code.
+- [x] JSKIT checks:
+  - [x] wrong generator choice.
+  - [x] missed package/runtime seam.
+  - [x] hand-built CRUD where generated ownership is required.
+  - [x] direct knex outside approved lanes.
+  - [x] metadata drift.
+  - [x] surface/route/ownership mistakes.
+- [x] Add a way to stop review passes when no important findings remain.
+- [x] Add a way to request another pass when important findings remain.
+- [x] Ensure each review pass that changes files has an accept/commit path before the next pass.
+- [x] Ensure each review pass records the commit SHA or records that no changes were needed.
+- [x] Add tests for zero-change review pass.
+- [x] Add tests for review pass with changes.
+- [x] Add tests for max pass handling.
 
 ## Automated Checks Before And After Review
 
 Goal: make checks a first-class session concept, not only an afterthought.
 
-- [ ] Add step before review/deslop: `pre_review_checks_run`.
-- [ ] Add step after review/deslop: `post_review_checks_run`.
-- [ ] Use button label `Run checks` for `pre_review_checks_run`.
-- [ ] Use button label `Run checks again` for `post_review_checks_run`.
-- [ ] Run the smallest relevant automated checks for the current project.
-- [ ] Prefer existing project script order:
-  - [ ] `npm run verify:local` if present.
-  - [ ] else `npm run verify` if present.
-  - [ ] else `npx jskit app verify`.
-  - [ ] else known fallback scripts if appropriate.
-- [ ] Store stdout/stderr summaries under `checks/`.
-- [ ] Store structured status in JSON.
-- [ ] If pre-review checks fail, block and render repair prompt.
-- [ ] If post-review checks fail, block and render repair prompt.
-- [ ] If a repair prompt changes files, commit the repair before rerunning the same check.
-- [ ] After repair, rerun the same check step rather than arbitrary jumping.
-- [ ] Avoid generic arbitrary state-machine jumping in V1.
-- [ ] Add tests for passing pre-review checks.
-- [ ] Add tests for failing pre-review checks.
-- [ ] Add tests for passing post-review checks.
-- [ ] Add tests for failing post-review checks.
-- [ ] Add tests that blocked check steps are retryable.
+- [x] Add step before review/deslop: `pre_review_checks_run`.
+- [x] Add step after review/deslop: `post_review_checks_run`.
+- [x] Use button label `Run checks` for `pre_review_checks_run`.
+- [x] Use button label `Run checks again` for `post_review_checks_run`.
+- [x] Run the smallest relevant automated checks for the current project.
+- [x] Prefer existing project script order:
+  - [x] `npm run verify:local` if present.
+  - [x] else `npm run verify` if present.
+  - [x] else `npx jskit app verify`.
+  - [x] else known fallback scripts if appropriate. No additional fallback is currently appropriate beyond JSKIT verification.
+- [x] Store stdout/stderr summaries under `checks/`.
+- [x] Store structured status in JSON.
+- [x] If pre-review checks fail, block and render repair prompt.
+- [x] If post-review checks fail, block and render repair prompt.
+- [x] If a repair prompt changes files, commit the repair before rerunning the same check.
+- [x] After repair, rerun the same check step rather than arbitrary jumping.
+- [x] Avoid generic arbitrary state-machine jumping in V1.
+- [x] Add tests for passing pre-review checks.
+- [x] Add tests for failing pre-review checks.
+- [x] Add tests for passing post-review checks.
+- [x] Add tests for failing post-review checks.
+- [x] Add tests that blocked check steps are retryable.
 
 ## Deep UI Check Before And After Review
 
 Goal: add a focused UI quality pass for visual/client-impacting work.
 
-- [ ] Add step before deslop/review: `deep_ui_check_run`.
-- [ ] Add step after deslop/review: `deep_ui_recheck_run`.
-- [ ] Use `uiImpact` to decide run/skip.
-- [ ] If `uiImpact=none`, write a skipped receipt with reason.
-- [ ] If `uiImpact=possible`, run unless explicitly overridden.
-- [ ] If `uiImpact=definite`, require run.
-- [ ] Create prompt `deep_ui_check.md`.
-- [ ] The prompt must inspect changed UI files, routes, components, layouts, and screenshots if available.
-- [ ] Changed UI files should be derived from the session branch diff against the target base branch, not only the latest commit.
-- [ ] The prompt must check:
-  - [ ] Material Design quality.
-  - [ ] Vuetify best practices.
-  - [ ] visual hierarchy.
-  - [ ] spacing.
-  - [ ] responsive behavior.
-  - [ ] loading states.
-  - [ ] empty states.
-  - [ ] error states.
-  - [ ] disabled states.
-  - [ ] success states.
-  - [ ] accessibility basics.
-  - [ ] route/navigation coherence.
-  - [ ] consistency with existing app style.
-- [ ] The prompt must ask Codex to fix scoped UI issues when clear.
-- [ ] The prompt must not create commits or PRs.
-- [ ] If the Deep UI Check fixes files, require accept/commit before continuing.
-- [ ] If the Deep UI Re-check fixes files, require accept/commit before continuing.
-- [ ] Integrate Playwright guidance:
-  - [ ] run a meaningful route check when possible.
-  - [ ] use local dev auth bootstrap when needed.
-  - [ ] record UI verification with `jskit app verify-ui`.
-  - [ ] call out missing auth bootstrap as a testability gap.
-- [ ] Store UI check output under `ui_checks/`.
-- [ ] Include UI check status in JSON.
-- [ ] Add tests for skipped server-only issue.
-- [ ] Add tests for mandatory UI-impact issue.
-- [ ] Add tests for failed UI check repair prompt.
-- [ ] Add Studio rendering for skipped/running/passed/failed UI checks.
+- [x] Add step before deslop/review: `deep_ui_check_run`.
+- [x] Add step after deslop/review: `deep_ui_recheck_run`.
+- [x] Use `uiImpact` to decide run/skip.
+- [x] If `uiImpact=none`, write a skipped receipt with reason.
+- [x] If `uiImpact=possible`, run unless explicitly overridden.
+- [x] If `uiImpact=definite`, require run.
+- [x] Create prompt `deep_ui_check.md`.
+- [x] The prompt must inspect changed UI files, routes, components, layouts, and screenshots if available.
+- [x] Changed UI files should be derived from the session branch diff against the target base branch, not only the latest commit.
+- [x] Use the captured `baseBranch`/`baseCommit` metadata for branch-wide changed-file calculations.
+- [x] The prompt must check:
+  - [x] Material Design quality.
+  - [x] Vuetify best practices.
+  - [x] visual hierarchy.
+  - [x] spacing.
+  - [x] responsive behavior.
+  - [x] loading states.
+  - [x] empty states.
+  - [x] error states.
+  - [x] disabled states.
+  - [x] success states.
+  - [x] accessibility basics.
+  - [x] route/navigation coherence.
+  - [x] consistency with existing app style.
+- [x] The prompt must ask Codex to fix scoped UI issues when clear.
+- [x] The prompt must not create commits or PRs.
+- [x] If the Deep UI Check fixes files, require accept/commit before continuing.
+- [x] If the Deep UI Re-check fixes files, require accept/commit before continuing.
+- [x] Integrate Playwright guidance:
+  - [x] run a meaningful route check when possible.
+  - [x] use local dev auth bootstrap when needed.
+  - [x] record UI verification with `jskit app verify-ui`.
+  - [x] call out missing auth bootstrap as a testability gap.
+- [x] Store UI check output under `ui_checks/`.
+- [x] Include UI check status in JSON.
+- [x] Add tests for skipped server-only issue.
+- [x] Add tests for mandatory UI-impact issue.
+- [x] Add tests for the Deep UI check prompt/accept/commit repair flow.
+- [x] Add Studio rendering for skipped/running/passed/failed UI checks.
 
 ## User Check Step
 
 Goal: keep human verification as a distinct step.
 
-- [ ] Keep existing `user_check_completed` step.
-- [ ] Update prompt to mention plan details and planned acceptance criteria.
-- [ ] Tell user exactly what route, behavior, command, or workflow to inspect.
-- [ ] If user reports failure, render repair prompt and keep session in a retryable state.
-- [ ] If user reports pass, write receipt.
-- [ ] Include user check result in final report.
-- [ ] Add tests for failed user check path if not already covered.
+- [x] Keep existing `user_check_completed` step.
+- [x] Update prompt to mention plan details and planned acceptance criteria.
+- [x] Tell user exactly what route, behavior, command, or workflow to inspect.
+- [x] If user reports pass, write a passed receipt for the active cycle.
+- [x] If user reports failure, write a failed receipt for the active cycle and expose the precise rework action.
+- [x] Include user check result in final report.
+- [x] Add tests for failed user check path if not already covered.
+
+## Allowed Rework Cycle From Failed User Check
+
+Goal: allow meaningful rework without arbitrary jumping or receipt deletion.
+
+- [x] Do not add a generic "jump to any step" API.
+- [x] Add exactly one V1 allowed back-transition: failed User Check can return to Plan fine tuning.
+- [x] Treat this as starting a new implementation cycle, not rewinding the session.
+- [x] Keep setup/planning receipts global and one-time:
+  - [x] `steps/session_created`
+  - [x] `steps/worktree_created`
+  - [x] `steps/dependencies_installed`
+  - [x] `steps/issue_prompt_rendered`
+  - [x] `steps/issue_drafted`
+  - [x] `steps/issue_created`
+  - [x] `steps/plan_details_prompt_rendered`
+  - [x] `steps/plan_details_gathered`
+  - [x] `steps/plan_made`
+- [x] Store implementation-and-review receipts under the active cycle:
+  - [x] `steps/cycle_001/plan_fine_tuning`
+  - [x] `steps/cycle_001/implementation_changes_accepted`
+  - [x] `steps/cycle_001/implementation_changes_committed`
+  - [x] `steps/cycle_001/pre_review_checks_run`
+  - [x] `steps/cycle_001/deep_ui_check_run`
+  - [x] `steps/cycle_001/review_prompt_rendered`
+  - [x] `steps/cycle_001/review_changes_accepted`
+  - [x] `steps/cycle_001/review_changes_committed`
+  - [x] `steps/cycle_001/post_review_checks_run`
+  - [x] `steps/cycle_001/deep_ui_recheck_run`
+  - [x] `steps/cycle_001/user_check_completed`
+- [x] If user check fails, write the active cycle receipt as failed text, not as a completed pass.
+- [x] Require rework notes before starting the next cycle.
+- [x] Save rework notes as plain markdown under `cycles/cycle_###/rework_request.md`.
+- [x] Increment `active_cycle` and return `currentStep` to `plan_fine_tuning`.
+- [x] Make Plan fine tuning read the latest rework request when cycle number is greater than 1.
+- [x] Keep previous cycle receipts visible as history and exclude them from current-step completion.
+- [x] Compute current workflow truth from global receipts plus the active cycle's receipts.
+- [x] Allow finalization steps only after the active cycle has a passed user check.
+- [x] Add a stable CLI path, for example `jskit session <id> step --user-check failed --rework-notes -`.
+- [x] Add a stable Studio action label such as `Return to Plan fine tuning`.
+- [x] Add tests that failed user check does not delete or overwrite prior receipts.
+- [x] Add tests that a second cycle starts at Plan fine tuning with the rework request available to the prompt.
+- [x] Add tests that finalization is blocked while the active cycle user check is failed or missing.
+- [x] Add tests that previous cycle history is still exposed in session JSON.
 
 ## Blueprint Updated Step
 
@@ -516,31 +626,32 @@ Goal: enrich durable app memory issue by issue.
 
 ### Step Position
 
-- [ ] Add `blueprint_updated` after user check and review/check cycles.
-- [ ] Run it before final verification/doctor and before PR creation.
-- [ ] Ensure blueprint changes are included in the session branch.
-- [ ] Commit blueprint changes if changed.
-- [ ] If blueprint is unchanged, write an unchanged receipt.
+- [x] Add `blueprint_updated` after user check and review/check cycles.
+- [x] Run it before final verification/doctor and before PR creation.
+- [x] Ensure blueprint changes are included in the session branch.
+- [x] Commit blueprint changes if changed.
+- [x] If blueprint is unchanged, write an unchanged receipt.
 
 ### Prompt Behavior
 
-- [ ] Create prompt `update_blueprint.md`.
-- [ ] Prompt reads:
-  - [ ] current `.jskit/APP_BLUEPRINT.md` if present.
-  - [ ] issue title/body.
-  - [ ] plan details.
-  - [ ] approved plan.
-  - [ ] agent decisions.
-  - [ ] changed files.
-  - [ ] helper map.
-  - [ ] package/app metadata.
-- [ ] Prompt updates only durable app/product/architecture memory.
-- [ ] Changed files should be derived from the whole session branch diff against the target base branch.
-- [ ] Prompt must not include session task tracking.
-- [ ] Prompt must not recreate `.jskit/WORKBOARD.md`.
-- [ ] Prompt must not over-expand tiny issues into broad product rewrites.
-- [ ] Prompt should naturally evolve from a minimal app sketch to a richer app blueprint over many issues.
-- [ ] Prompt output tag:
+- [x] Create prompt `update_blueprint.md`.
+- [x] Prompt reads:
+  - [x] current `.jskit/APP_BLUEPRINT.md` if present.
+  - [x] issue title/body.
+  - [x] plan details.
+  - [x] approved plan.
+  - [x] agent decisions.
+  - [x] changed files.
+  - [x] helper map.
+  - [x] package/app metadata.
+- [x] Prompt updates only durable app/product/architecture memory.
+- [x] Changed files should be derived from the whole session branch diff against the target base branch.
+- [x] Use the captured `baseBranch`/`baseCommit` metadata for the blueprint changed-file list.
+- [x] Prompt must not include session task tracking.
+- [x] Prompt must not recreate `.jskit/WORKBOARD.md`.
+- [x] Prompt must not over-expand tiny issues into broad product rewrites.
+- [x] Prompt should naturally evolve from a minimal app sketch to a richer app blueprint over many issues.
+- [x] Prompt output tag:
 
 ```text
 [app_blueprint]
@@ -550,250 +661,312 @@ Goal: enrich durable app memory issue by issue.
 
 ### Runtime Behavior
 
-- [ ] Parse `[app_blueprint]`.
-- [ ] Write `.jskit/APP_BLUEPRINT.md`.
-- [ ] If changed, commit with a clear message.
-- [ ] Append blueprint decision summary to `agent_decisions.md`.
-- [ ] Add blueprint update receipt.
-- [ ] Add blueprint status to JSON.
-- [ ] Add tests for creating a new blueprint.
-- [ ] Add tests for updating an existing blueprint.
-- [ ] Add tests for unchanged blueprint.
-- [ ] Add tests that blueprint update happens before final verification.
-- [ ] Add CLI/session input support for accepting the tagged blueprint output, for example `--blueprint -` or a step-specific equivalent.
-- [ ] Add tests for invalid/missing `[app_blueprint]` output.
+- [x] Parse `[app_blueprint]`.
+- [x] Write `.jskit/APP_BLUEPRINT.md`.
+- [x] If changed, commit with a clear message.
+- [x] Append blueprint decision summary to `agent_decisions.md`.
+- [x] Add blueprint update receipt.
+- [x] Add blueprint status to JSON.
+- [x] Add tests for creating a new blueprint.
+- [x] Add tests for updating an existing blueprint.
+- [x] Add tests for unchanged blueprint.
+- [x] Add tests that blueprint update happens before final verification.
+- [x] Add CLI/session input support for accepting the tagged blueprint output, for example `--blueprint -` or a step-specific equivalent.
+- [x] Add tests for invalid/missing `[app_blueprint]` output.
 
 ## Final Verification / Doctor
 
 Goal: verify the full branch after implementation, review, UI checks, and blueprint update.
 
-- [ ] Keep existing final verification step.
-- [ ] Ensure final verification runs after blueprint update.
-- [ ] Ensure final verification sees all committed changes.
-- [ ] Ensure UI receipt expectations are respected when UI files changed.
-- [ ] Keep doctor failures repairable.
-- [ ] Update doctor failure prompt to mention:
-  - [ ] plan details.
-  - [ ] blueprint update.
-  - [ ] helper map.
-  - [ ] UI checks.
-  - [ ] check receipts.
-- [ ] Add tests that final verification runs after blueprint update.
-- [ ] Add tests that final verification failure blocks PR creation.
+- [x] Keep existing final verification step.
+- [x] Ensure final verification runs after blueprint update.
+- [x] Ensure final verification sees all committed changes.
+- [x] Ensure UI receipt expectations are respected when UI files changed.
+- [x] Keep doctor failures repairable.
+- [x] Update doctor failure prompt to mention:
+  - [x] plan details.
+  - [x] blueprint update.
+  - [x] helper map.
+  - [x] UI checks.
+  - [x] check receipts.
+- [x] Add tests that final verification runs after blueprint update.
+- [x] Add tests that final verification failure blocks PR creation.
 
 ## Final Report Step
 
 Goal: generate a clear final report for the issue before PR/merge completion.
 
-- [ ] Add step `final_report_created`.
-- [ ] Position it after final verification and before branch push / PR creation.
-- [ ] Do not require the PR URL in this report; the later final comment can include PR URL after creation/merge.
-- [ ] Generate the final report deterministically from session artifacts in V1.
-- [ ] Do not make final report generation depend on another Codex prompt in V1.
-- [ ] Report must include:
-  - [ ] issue URL.
-  - [ ] issue title.
-  - [ ] plan details summary.
-  - [ ] plan summary.
-  - [ ] files changed.
-  - [ ] commits.
-  - [ ] commands/checks run.
-  - [ ] UI checks run or skipped.
-  - [ ] Playwright/verify-ui status.
-  - [ ] user check result.
-  - [ ] blueprint update status.
-  - [ ] helper map status if available, or a note that helper map refresh happens during PR creation.
-  - [ ] remaining unverified gaps.
-  - [ ] important decisions and why.
-- [ ] Write `final_report.md`.
-- [ ] Comment final report on the GitHub issue.
-- [ ] Include final report path/text in JSON.
-- [ ] Add tests that final report is created.
-- [ ] Add tests that final report is commented on issue.
-- [ ] Add tests that final report includes checks and UI checks.
+- [x] Add step `final_report_created`.
+- [x] Position it after final verification and before branch push / PR creation.
+- [x] Do not require the PR URL in this report; the later final comment can include PR URL after creation/merge.
+- [x] Generate the final report deterministically from session artifacts in V1.
+- [x] Do not make final report generation depend on another Codex prompt in V1.
+- [x] Keep `final_report.md` as a session artifact, not an app-branch file to commit.
+- [x] Report must include:
+  - [x] issue URL.
+  - [x] issue title.
+  - [x] plan details summary.
+  - [x] plan summary.
+  - [x] files changed.
+  - [x] commits.
+  - [x] commands/checks run.
+  - [x] UI checks run or skipped.
+  - [x] Playwright/verify-ui status.
+  - [x] user check result.
+  - [x] blueprint update status.
+  - [x] helper map status if available, or a note that helper map refresh happens during PR creation.
+  - [x] remaining unverified gaps.
+  - [x] important decisions and why.
+- [x] Write `final_report.md`.
+- [x] Comment final report on the GitHub issue.
+- [x] Include final report path/text in JSON.
+- [x] Add tests that final report is created.
+- [x] Add tests that final report is commented on issue.
+- [x] Add tests that final report includes checks and UI checks.
 
 ## Branch Pushed And PR Created Step
 
 Goal: keep PR creation as the single visible step that finalizes branch publication.
 
-- [ ] Keep helper map update inside this step.
-- [ ] Ensure helper map changes are committed before push.
-- [ ] Ensure blueprint/final report changes have already been committed or intentionally recorded.
-- [ ] Ensure branch push includes all final commits.
-- [ ] Create PR with issue body and "Closes #".
-- [ ] Preserve existing GitHub auth/remote preconditions.
-- [ ] Keep behavior idempotent when PR already exists if possible.
-- [ ] Add tests that helper map commit occurs before push.
-- [ ] Add tests that final report/blueprint commits are present before push.
+- [x] Keep helper map update inside this step.
+- [x] Ensure helper map changes are committed before push.
+- [x] Ensure blueprint changes have already been committed before push.
+- [x] Ensure final report has already been created/commented or intentionally recorded before push.
+- [x] Ensure branch push includes all final commits.
+- [x] Create PR with issue body and "Closes #".
+- [x] Preserve existing GitHub auth/remote preconditions.
+- [x] Keep behavior idempotent when PR already exists if possible.
+- [x] Add tests that helper map commit occurs before push.
+- [x] Add tests that blueprint commits are present before push.
+- [x] Add tests that final report receipts/comments exist before push.
 
-## PR Merged / Worktree Removed Step
+## PR Finalized / Worktree Removed Step
 
-Goal: merge safely, update local base, clean worktree, and preserve recoverability.
+Goal: merge safely when requested, allow successful completion without merge, clean worktree, and preserve recoverability.
 
-- [ ] Preserve current already-merged PR handling.
-- [ ] Preserve current target-root dirty check.
-- [ ] Preserve current base branch fast-forward checks.
-- [ ] Preserve issue close/comment behavior.
-- [ ] Preserve branch recoverability where possible.
-- [ ] Preserve worktree cleanup.
-- [ ] Ensure final session archive includes:
-  - [ ] final report.
-  - [ ] agent decisions.
-  - [ ] plan details.
-  - [ ] check receipts.
-  - [ ] UI check receipts.
-  - [ ] prompt artifacts.
-- [ ] Add tests for archive contents.
+- [x] Preserve current already-merged PR handling.
+- [x] Preserve current target-root dirty check.
+- [x] Preserve current base branch fast-forward checks.
+- [x] Preserve issue close/comment behavior.
+- [x] Preserve branch recoverability where possible.
+- [x] Preserve worktree cleanup.
+- [x] Add successful `closed_without_merge` outcome.
+- [x] Require a close-without-merge reason.
+- [x] Leave the PR open for maintainer review/merge when closing the local session without merge.
+- [x] Expose merge and finish-without-merge as PR finalization choices for Studio.
+- [x] Store PR finalization outcome in session JSON.
+- [x] Add tests for completed sessions that finish without merge.
+- [x] Ensure final session archive includes:
+  - [x] workflow version metadata.
+  - [x] active cycle marker.
+  - [x] all cycle directories and rework requests.
+  - [x] issue metadata.
+  - [x] base branch and base commit metadata.
+  - [x] final report.
+  - [x] agent decisions.
+  - [x] plan details.
+  - [x] GitHub comment metadata.
+  - [x] check receipts.
+  - [x] UI check receipts.
+  - [x] command log if present.
+  - [x] prompt artifacts.
+- [x] Add tests for archive contents.
 
 ## Studio Integration
 
 Goal: update Studio only after JSKIT JSON supports the workflow.
 
-- [ ] Do not hard-code new step IDs in Studio beyond generic rendering needs.
-- [ ] Render `planDetails`.
-- [ ] Render `issueCategory`.
-- [ ] Render `uiImpact`.
-- [ ] Render `agentDecisions` card/link.
-- [ ] Render `finalReport` card/link.
-- [ ] Render `checks[]`.
-- [ ] Render `uiChecks[]`.
-- [ ] Render `reviewPasses[]`.
-- [ ] Support conditional skipped steps visually.
-- [ ] Support retryable blocked steps visually.
-- [ ] In `Get issue details`, render the Codex conversation and output form inside the step.
-- [ ] In `Plan made`, include plan details context.
-- [ ] In Deep UI Check steps, show run/skip status clearly.
-- [ ] Ensure terminal remains below/alongside todo according to current Studio layout.
-- [ ] Ensure mobile layout keeps Codex terminal usable and collapsible.
-- [ ] Ensure abandoned/completed session views show final report and decisions.
+- [x] Do not hard-code new step IDs in Studio beyond generic rendering needs.
+- [x] Render `planDetails`.
+- [x] Render `issueCategory`.
+- [x] Render `uiImpact`.
+- [x] Render `agentDecisions` card/link.
+- [x] Render `finalReport` card/link.
+- [x] Render `checks[]`.
+- [x] Render `uiChecks[]`.
+- [x] Render `reviewPasses[]`.
+- [x] Render `cycles[]` and active cycle status.
+- [x] Render repeatable cycle cues on affected todo rows instead of adding a separate summary panel.
+- [x] Render the JSKIT diff viewer/button on implementation/review/check acceptance steps.
+- [x] Support conditional skipped steps visually.
+- [x] Support retryable blocked steps visually.
+- [x] Render allowed alternate actions from `currentStepAction.alternateActions[]`.
+- [x] Submit alternate actions through JSKIT-provided `submitOptions` metadata.
+- [x] For failed user check, render the rework notes input inside the User Check step.
+- [x] Use `currentStepAction.label` for step buttons instead of Studio-owned labels.
+- [x] Hide output editor/forms until JSKIT has parsed candidate output for that step.
+- [x] Disable action buttons until `currentStepAction.requiredInput` is satisfied.
+- [x] In `Get issue details`, render the Codex conversation and output form inside the step.
+- [x] In `Plan made`, include plan details context.
+- [x] In Deep UI Check steps, show run/skip status clearly.
+- [x] Ensure terminal remains below/alongside todo according to current Studio layout.
+- [x] Ensure mobile layout keeps Codex terminal usable and collapsible.
+- [x] Ensure abandoned/completed session views show final report and decisions.
 - [ ] Add tests or browser checks for the new Studio rendering.
+- [ ] Add browser checks that editor/forms are hidden until parsed output exists.
+- [x] Add browser checks that invalid/incomplete parsed output keeps the action disabled.
 
 ## Prompt Inventory
 
-- [ ] Update `new_issue.md`.
-- [ ] Add `plan_details.md`.
-- [ ] Update `plan_issue.md`.
-- [ ] Update `fine_tune_plan.md`.
-- [ ] Add or update `deep_ui_check.md`.
-- [ ] Update `review_changes.md`.
-- [ ] Update `user_check.md`.
-- [ ] Add `update_blueprint.md`.
-- [ ] Update `doctor_failure.md`.
-- [ ] Update `pr_failure.md` if needed.
-- [ ] Add a deterministic final report renderer; do not add a Codex prompt for final report in V1.
-- [ ] Update `final_comment.md` if needed.
-- [ ] Ensure all prompts mention the correct session-owned files.
-- [ ] Ensure no prompt tells Codex to create `.jskit/WORKBOARD.md`.
-- [ ] Ensure no prompt tells Codex to use old long `AGENTS.md` workflow.
+- [x] Update `new_issue.md`.
+- [x] Add `plan_details.md`.
+- [x] Update `plan_issue.md`.
+- [x] Update `fine_tune_plan.md`.
+- [x] Add or update `deep_ui_check.md`.
+- [x] Update `review_changes.md`.
+- [x] Update `user_check.md`.
+- [x] Add `update_blueprint.md`.
+- [x] Update `doctor_failure.md`.
+- [x] Update `pr_failure.md` if needed.
+- [x] Add a deterministic final report renderer; do not add a Codex prompt for final report in V1.
+- [x] Update `final_comment.md` if needed.
+- [x] Ensure all prompts mention the correct session-owned files.
+- [x] Ensure no prompt tells Codex to create `.jskit/WORKBOARD.md`.
+- [x] Ensure no prompt tells Codex to use old long `AGENTS.md` workflow.
+
+## Prompt Knowledge Migration
+
+Goal: keep the useful old agent guidance, but move it into JSKIT-owned prompts and patterns instead of long app `AGENTS.md` files.
+
+- [x] Review the pre-Studio AGENTS-linked markdown history.
+- [x] Map each useful rule to a current session prompt, JSKIT pattern doc, precondition, or receipt.
+- [x] Drop advice that only supported the retired workboard workflow.
+- [x] Drop advice that asks Codex to manually duplicate JSKIT session steps.
+- [x] Keep `packages/agent-docs/templates/app/AGENTS.md` short and generic.
+- [x] Ensure app `AGENTS.md` points agents to `jskit session` and does not contain the old workflow.
+- [x] Add tests that generated app AGENTS does not reference deleted workflow files.
+- [x] Add tests or docs checks that all current prompt files reference the canonical session artifacts by name.
 
 ## CLI And Parser Work
 
-- [ ] Add input resolution for `--plan-details`, `--plan-details-file`, and `--plan-details -`.
-- [ ] Add input resolution for `--issue-category`.
-- [ ] Add input resolution for `--ui-impact`.
-- [ ] Add input resolution for conditional UI check override, for example `--skip-ui-check --skip-reason "<reason>"`.
-- [ ] Add input resolution for decision log fragments if needed.
-- [ ] Add input resolution for blueprint update output, for example `--blueprint`, `--blueprint-file`, and `--blueprint -`.
-- [ ] Add extraction helpers:
-  - [ ] `extractIssueCategory`.
-  - [ ] `extractUiImpact`.
-  - [ ] `extractPlanDetails`.
-  - [ ] `extractAgentDecisions`.
-  - [ ] `extractAppBlueprint`.
-- [ ] Add validators for enum values.
-- [ ] Add stable error codes for invalid plan details output.
-- [ ] Add stable error codes for missing classification.
-- [ ] Add stable error codes for missing details.
-- [ ] Add stable repair commands for each new blocked state.
+- [x] Add input resolution for `--plan-details`, `--plan-details-file`, and `--plan-details -`.
+- [x] Add input resolution for `--issue-category`.
+- [x] Add input resolution for `--ui-impact`.
+- [x] Add input resolution for conditional UI check override, for example `--skip-ui-check --skip-reason "<reason>"`.
+- [x] Add input resolution for decision log fragments if needed.
+- [x] Add input resolution for blueprint update output, for example `--blueprint`, `--blueprint-file`, and `--blueprint -`.
+- [x] Add extraction helpers:
+  - [x] `extractIssueCategory`.
+  - [x] `extractUiImpact`.
+  - [x] `extractPlanDetails`.
+  - [x] `extractAgentDecisions`.
+  - [x] `extractAppBlueprint`.
+- [x] Ensure tagged-output extraction ignores Codex terminal/status chrome and uses complete marker pairs only.
+- [x] If multiple complete tagged blocks exist, define and test whether JSKIT uses the first or latest complete block.
+- [x] Add validators for enum values.
+- [x] Add stable error codes for invalid plan details output.
+- [x] Add stable error codes for missing classification.
+- [x] Add stable error codes for missing details.
+- [x] Add stable repair commands for each new blocked state.
 
 ## Preconditions
 
-- [ ] Add `plan_details_exists`.
-- [ ] Add `issue_metadata_exists`.
-- [ ] Add `plan_text_exists` if not already present.
-- [ ] Add separate preconditions for `pre_review_checks_passed` and `post_review_checks_passed` where needed.
-- [ ] Add separate preconditions for `deep_ui_check_satisfied` and `deep_ui_recheck_satisfied` where needed.
-- [ ] Add `blueprint_update_satisfied`.
-- [ ] Add `final_report_exists`.
-- [ ] Add named precondition tests for every new executable step.
-- [ ] Ensure every step except `session_created` declares named preconditions.
+- [x] Add `dependencies_installed`.
+- [x] Add `active_cycle_exists`.
+- [x] Add `active_cycle_user_check_passed` for finalization steps.
+- [x] Add `plan_details_exists`.
+- [x] Add `issue_metadata_exists`.
+- [x] Add `plan_text_exists` if not already present.
+- [x] Add separate preconditions for `pre_review_checks_passed` and `post_review_checks_passed` where needed.
+- [x] Add separate preconditions for `deep_ui_check_satisfied` and `deep_ui_recheck_satisfied` where needed.
+- [x] Add `blueprint_update_satisfied`.
+- [x] Add `final_report_exists`.
+- [x] Add named precondition tests for every new executable step.
+- [x] Ensure every step except `session_created` declares named preconditions.
 
 ## Receipts
 
-- [ ] Add receipt for plan details prompt rendered.
-- [ ] Add receipt for plan details saved.
-- [ ] Add receipt for plan details commented on issue.
-- [ ] Add receipt for plan commented on issue.
-- [ ] Add receipt or metadata for idempotent GitHub comment skip/update.
-- [ ] Add receipt for pre-review checks run.
-- [ ] Add receipt for Deep UI Check run/skipped.
-- [ ] Add receipt for review pass run.
-- [ ] Add receipt for post-review checks run.
-- [ ] Add receipt for Deep UI Re-check run/skipped.
-- [ ] Add receipt for blueprint updated/unchanged.
-- [ ] Add receipt for final report created.
-- [ ] Add receipt for final report commented on issue.
-- [ ] Add tests that receipts are readable and archive with session.
+- [x] Add receipt for dependencies installed.
+- [x] Add support for global one-time text receipts and cycle-scoped text receipts.
+- [x] Add receipt for failed user check in the active cycle.
+- [x] Add receipt for starting a new rework cycle.
+- [x] Add receipt for plan details prompt rendered.
+- [x] Add receipt for plan details saved.
+- [x] Add receipt for plan details commented on issue.
+- [x] Add receipt for plan commented on issue.
+- [x] Add receipt or metadata for idempotent GitHub comment skip/update.
+- [x] Add receipt for pre-review checks run.
+- [x] Add receipt for Deep UI Check run/skipped.
+- [x] Add receipt for review pass run.
+- [x] Add receipt for post-review checks run.
+- [x] Add receipt for Deep UI Re-check run/skipped.
+- [x] Add receipt for blueprint updated/unchanged.
+- [x] Add receipt for final report created.
+- [x] Add receipt for final report commented on issue.
+- [x] Add tests that receipts are readable and archive with session.
 
 ## Tests
 
-- [ ] Add tests for new plan details tag extraction.
-- [ ] Add tests for plan details CLI stdin handling.
-- [ ] Add tests for plan details prompt rendering.
-- [ ] Add tests for plan details GitHub comment.
-- [ ] Add tests for issue classification JSON fields.
-- [ ] Add tests for plan requiring plan details.
-- [ ] Add tests for plan comment on GitHub issue.
-- [ ] Add tests for agent decision append behavior.
-- [ ] Add tests for repeated review pass bookkeeping.
-- [ ] Add tests for pre-review checks.
-- [ ] Add tests for post-review checks.
-- [ ] Add tests for Deep UI Check run.
-- [ ] Add tests for Deep UI Check skipped.
-- [ ] Add tests for blueprint update.
-- [ ] Add tests for final verification order.
-- [ ] Add tests for final report generation.
-- [ ] Add tests for final report GitHub comment.
-- [ ] Add tests for PR creation including blueprint/helper-map/final-report commits.
-- [ ] Add tests for completed archive contents.
-- [ ] Add tests for idempotent GitHub comments.
-- [ ] Add tests for dirty-worktree blocking between quality/check phases.
-- [ ] Update generated docs/reference tests if command exports change.
-- [ ] Run focused session tests.
-- [ ] Run `npm run lint`.
-- [ ] Run `npm run check:runtime-deps`.
-- [ ] Run broader `npm run verify:local` when the implementation is ready.
+- [x] Add tests for new plan details tag extraction.
+- [x] Add tests for workflow version creation and unsupported-version blocking.
+- [x] Add tests for dependency installation receipts and JSON.
+- [x] Add tests for base branch/base commit metadata.
+- [x] Add tests for active cycle marker creation.
+- [x] Add tests for cycle-scoped receipt reading and current-step calculation.
+- [x] Add tests for issue metadata creation and JSON.
+- [x] Add tests for tagged issue title/body extraction from noisy Codex terminal output.
+- [x] Add tests for plan details CLI stdin handling.
+- [x] Add tests for plan details prompt rendering.
+- [x] Add tests for plan details GitHub comment.
+- [x] Add tests for issue classification JSON fields.
+- [x] Add tests for plan requiring plan details.
+- [x] Add tests for plan comment on GitHub issue.
+- [x] Add tests for agent decision append behavior.
+- [x] Add tests for repeated review pass bookkeeping.
+- [x] Add tests for pre-review checks.
+- [x] Add tests for post-review checks.
+- [x] Add tests for Deep UI Check run.
+- [x] Add tests for Deep UI Check skipped.
+- [x] Add tests for blueprint update.
+- [x] Add tests for final verification order.
+- [x] Add tests for final report generation.
+- [x] Add tests for final report GitHub comment.
+- [x] Add tests for PR creation including blueprint/helper-map commits and final-report receipt/comment metadata.
+- [x] Add tests for completed archive contents.
+- [x] Add tests for idempotent GitHub comments.
+- [x] Add tests for dirty-worktree blocking between quality/check phases.
+- [x] Add tests for failed user check starting a new rework cycle.
+- [x] Add tests for rework notes appearing in the next Plan fine tuning prompt.
+- [x] Add tests that finalization requires a passed user check in the active cycle.
+- [x] Update generated docs/reference tests if command exports change.
+- [x] Run focused session tests.
+- [x] Run `npm run lint`.
+- [x] Run `npm run check:runtime-deps`.
+- [x] Run broader `npm run verify:local` when the implementation is ready.
 
 ## Documentation
 
-- [ ] Update `revolution.md` or replace with a current implementation tracker if appropriate.
-- [ ] Update CLI help for new session flags.
-- [ ] Update generated command reference through `npm run agent-docs:build`.
-- [ ] Update agent docs tests that assert old workflow files are not active.
-- [ ] Keep `packages/agent-docs/templates/app/AGENTS.md` tiny.
-- [ ] Document the new Get Issue Details / `plan_details.md` flow.
-- [ ] Document `agent_decisions.md`.
-- [ ] Document blueprint enrichment.
-- [ ] Document conditional Deep UI Check behavior.
+- [x] Update `revolution.md` or replace with a current implementation tracker if appropriate.
+- [x] Update CLI help for new session flags.
+- [x] Update generated command reference through `npm run agent-docs:build`.
+- [x] Update agent docs tests that assert old workflow files are not active.
+- [x] Keep `packages/agent-docs/templates/app/AGENTS.md` tiny.
+- [x] Document the new Get Issue Details / `plan_details.md` flow.
+- [x] Document `agent_decisions.md`.
+- [x] Document blueprint enrichment.
+- [x] Document conditional Deep UI Check behavior.
+- [x] Document the allowed User Check rework cycle and cycle-scoped receipt layout.
 
 ## Acceptance Criteria
 
-- [ ] A user can start a session from Studio and never manually copy prompts unless they choose manual mode.
-- [ ] The session asks for detailed issue information before planning.
-- [ ] The accepted details are saved as `plan_details.md`.
-- [ ] CRUD details are captured before planning when relevant.
-- [ ] Issue category and UI impact are saved and visible.
-- [ ] The plan reads plan details, blueprint, helper map, and decisions.
-- [ ] The approved plan is commented on the GitHub issue.
-- [ ] Agent decisions are appended throughout the workflow.
-- [ ] Deep UI Check runs for UI-impacting issues and skips cleanly for server-only issues.
-- [ ] Automated checks run before and after review/deslop.
-- [ ] Failed checks are repairable without arbitrary state jumping.
-- [ ] The blueprint is updated before final verification and PR creation.
-- [ ] Final report is created and commented on the GitHub issue.
-- [ ] GitHub issue comments are idempotent on rerun.
-- [ ] Helper map still updates inside PR creation.
-- [ ] Mutating repair/review/UI steps cannot leave unowned dirty changes before advancing.
-- [ ] Studio renders all new state from JSKIT JSON.
-- [ ] Completed sessions archive all important artifacts.
-- [ ] Old long AGENTS/workboard workflow does not come back.
+- [x] A user can start a session from Studio and never manually copy prompts unless they choose manual mode.
+- [x] The session asks for detailed issue information before planning.
+- [x] The accepted details are saved as `plan_details.md`.
+- [x] CRUD details are captured before planning when relevant.
+- [x] Issue category and UI impact are saved and visible.
+- [x] The plan reads plan details, blueprint, helper map, and decisions.
+- [x] The approved plan is commented on the GitHub issue.
+- [x] Agent decisions are appended throughout the workflow.
+- [x] Deep UI Check runs for UI-impacting issues and skips cleanly for server-only issues.
+- [x] Automated checks run before and after review/deslop.
+- [x] Failed checks are repairable without arbitrary state jumping.
+- [x] Failed user check can start a new Plan fine tuning cycle without deleting prior receipts.
+- [x] No arbitrary step jumping is available.
+- [x] The blueprint is updated before final verification and PR creation.
+- [x] Final report is created and commented on the GitHub issue.
+- [x] GitHub issue comments are idempotent on rerun.
+- [x] Helper map still updates inside PR creation.
+- [x] Mutating repair/review/UI steps cannot leave unowned dirty changes before advancing.
+- [x] Studio renders all new state from JSKIT JSON.
+- [x] Completed sessions archive all important artifacts.
+- [x] Old long AGENTS/workboard workflow does not come back.

--- a/packages/agent-docs/guide/agent/app-setup/initial-scaffolding.md
+++ b/packages/agent-docs/guide/agent/app-setup/initial-scaffolding.md
@@ -30,6 +30,19 @@ npm install
 
 After that promotion, the overwritten app `AGENTS.md` stays deliberately small. Use `jskit session` for issue-driven work; session state and prompts live under `.jskit/sessions/` in the target app.
 
+Issue sessions are executable workflow state, not prose instructions. The important durable files are:
+
+- `issue.md` and `issue_title` for the approved GitHub issue.
+- `plan_details.md` for the confirmed implementation details gathered before planning.
+- `plan.md` for the approved implementation plan.
+- `agent_decisions.md` for concise decisions and why they were made.
+- `.jskit/APP_BLUEPRINT.md` for durable app/product/architecture memory that grows across issues.
+- `review_passes/`, `checks/`, `ui_checks/`, and `command_log.jsonl` for review, verification, UI check, and command receipts.
+
+The Deep UI Check steps use the saved issue classification: server-only work can be skipped with a receipt, possible UI work can be skipped only with an explicit reason, and definite UI work must run. If the User Check fails, JSKIT starts a new cycle under `cycles/cycle_###/` and cycle-scoped receipts under `steps/cycle_###/`; do not delete older cycle receipts.
+
+Studio and other tools should read `jskit session <session_id> --json` rather than scraping those files directly. Manual agents should follow the current `jskit session <session_id> step` output and avoid recreating the old workboard workflow.
+
 After creating the real app scaffolding (the base shell, not the seed wrapper), you will need to run `npm install` to install dependencies.
 
 If you already know you want a small non-workspace baseline right after the scaffold, this is the shortest reproducible path:

--- a/packages/agent-docs/reference/autogen/tooling/jskit-cli.md
+++ b/packages/agent-docs/reference/autogen/tooling/jskit-cli.md
@@ -453,6 +453,14 @@ Local functions
 Exports
 - `createHealthCommands(ctx = {})`
 
+### `src/server/commandHandlers/helperMap.js`
+Exports
+- `createHelperMapCommands(ctx = {})`
+Local functions
+- `writeJson(stdout, payload)`
+- `writeErrors(stdout, payload)`
+- `writeHelperMapText(stdout, payload)`
+
 ### `src/server/commandHandlers/list.js`
 Exports
 - `createListCommands(ctx = {})`
@@ -765,6 +773,36 @@ Local functions
 - `printTopLevelHelp(stream = process.stderr)`
 - `printCommandHelp(stream = process.stderr, command = "")`
 
+### `src/server/helperMap.js`
+Exports
+- `HELPER_MAP_JSON_RELATIVE_PATH`
+- `HELPER_MAP_MARKDOWN_RELATIVE_PATH`
+- `buildHelperMap({ targetRoot })`
+- `readHelperMap({ targetRoot })`
+- `updateHelperMap({ targetRoot })`
+Local functions
+- `pathExists(filePath)`
+- `readJsonFile(filePath)`
+- `normalizePackageDependencies(packageJson = {})`
+- `classifySymbol(name = "")`
+- `createExportAnalysisProject()`
+- `kindFromDeclaration(declaration, exportName = "")`
+- `addSymbol(symbols, symbol)`
+- `extractExportedSymbols(sourceFile)`
+- `extractVueScriptSource(source = "", filePath = "")`
+- `addCodeFileToProject(project, file)`
+- `walkCodeFiles(rootPath, relativeRoot = "")`
+- `collectAppExports(targetRoot)`
+- `flattenPackageExports(exportsField)`
+- `collectJskitPackageExports(targetRoot, packageJson = {})`
+- `renderExportList(symbols = [])`
+- `renderHelperMapMarkdown(map)`
+
+### `src/server/helperMapPaths.js`
+Exports
+- `HELPER_MAP_JSON_RELATIVE_PATH`
+- `HELPER_MAP_MARKDOWN_RELATIVE_PATH`
+
 ### `src/server/index.js`
 Exports
 - `runCli`
@@ -776,6 +814,7 @@ Exports
 - `STEP_IDS`
 - `STEP_PRECONDITION_NAMES`
 - `abandonSession({ targetRoot = process.cwd(), sessionId } = {})`
+- `adoptDependenciesInstalled({ targetRoot = process.cwd(), sessionId, message = "" } = {})`
 - `adoptCodexThreadId({ targetRoot = process.cwd(), sessionId, codexThreadId } = {})`
 - `buildSessionResponse`
 - `buildSessionErrorResponse`
@@ -783,6 +822,7 @@ Exports
 - `createSessionId`
 - `extractIssueTitle(value = "")`
 - `extractIssueText(value = "")`
+- `extractPlanDetails(value = "")`
 - `extractPlanText(value = "")`
 - `inspectSession({ targetRoot = process.cwd(), sessionId } = {})`
 - `inspectSessionDiff({ targetRoot = process.cwd(), sessionId } = {})`
@@ -790,6 +830,7 @@ Exports
 - `isValidSessionId`
 - `listSessions({ targetRoot = process.cwd(), archive = "active" } = {})`
 - `renderTemplate`
+- `recordDependenciesInstalled(paths, { message = "Installed Node dependencies in the session worktree.", preconditions = [] } = {})`
 - `resolveSessionPaths`
 - `runSessionStep({ targetRoot = process.cwd(), sessionId, options = {} } = {})`
 Local functions
@@ -798,15 +839,43 @@ Local functions
 - `existingSessionContext({ targetRoot = process.cwd(), sessionId } = {})`
 - `withExistingSession(input, handler)`
 - `extractMarkedText(value = "", marker = "")`
+- `extractIssueCategory(value = "")`
+- `extractUiImpact(value = "")`
+- `extractAgentDecisions(value = "")`
+- `normalizeIssueCategory(value = "")`
+- `normalizeUiImpact(value = "")`
+- `writePromptArtifact(paths, fileName, prompt)`
+- `commandText(command, args = [])`
+- `commandOutputSummary(output = "")`
+- `appendCommandLog(paths, { args = [], command, cwd = "", kind = "command", result } = {})`
+- `runLoggedCommand(paths, kind, command, args = [], options = {})`
+- `readIssueMetadata(paths)`
+- `writeIssueMetadata(paths, metadata = {})`
+- `readGithubComments(paths)`
+- `writeGithubComments(paths, comments = {})`
+- `commentOnIssueOnce(paths, { bodyFile, issueUrl, purpose })`
+- `appendAgentDecisions(paths, decisions = "")`
+- `appendAgentDecisionsInput(paths, options = {})`
+- `recordIssueInAgentDecisions(paths, issueUrl = "")`
+- `issueMetadataFromUrl(issueUrl = "")`
+- `nextCycleNumber(cycle = "001")`
 - `normalizeArchiveFilter(archive = "active")`
 - `emptySessionDetails(response)`
 - `removeEmptyStaleWorktreeDirectory(paths)`
 - `createWorktree(paths, _options = {}, context = {})`
+- `parsePackageManager(value = "")`
+- `hasWorktreeFile(worktree, fileName)`
+- `dependencyInstallCommandForWorktree(worktree)`
+- `installDependencies(paths, _options = {}, context = {})`
 - `renderIssuePrompt(paths, options = {})`
 - `draftIssue(paths, options = {})`
 - `titleFromIssue(issueText)`
 - `createIssue(paths, _options = {}, context = {})`
+- `renderPlanDetailsPrompt(paths, _options = {}, context = {})`
+- `savePlanDetails(paths, options = {}, context = {})`
 - `makePlan(paths, options = {}, context = {})`
+- `renderPlanExecutionPrompt(paths, _options = {}, context = {})`
+- `renderPlanFineTuningPrompt(paths, _options = {}, context = {})`
 - `worktreeStatus(worktree)`
 - `untrackedFiles(worktree)`
 - `untrackedFileDiff(worktree, filePath)`
@@ -815,32 +884,87 @@ Local functions
 - `commitWorktree(paths, { message, allowNoChanges = false } = {})`
 - `commitImplementation(paths)`
 - `changedFilesFromLastCommit(paths)`
+- `changedFilesSinceBase(paths)`
+- `nextReviewPassNumber(pass = "")`
+- `readCurrentReviewPass(paths)`
+- `writeCurrentReviewPass(paths, pass)`
+- `resolveReviewPassForPrompt(paths)`
+- `writeReviewPassJson(paths, pass, fileName, payload)`
+- `currentHead(paths)`
 - `renderReviewPrompt(paths)`
-- `detectAndCommitReviewChanges(paths)`
+- `acceptReviewChanges(paths, options = {})`
+- `commitReviewChanges(paths)`
+- `runAutomatedChecks(paths, { stepId, label })`
+- `readCheckResult(paths, stepId)`
+- `maybeCommitCheckRepair(paths, { label, stepId })`
+- `uiCheckAcceptStepId(stepId)`
+- `uiCheckCommitStepId(stepId)`
+- `uiCheckSourceStepId(stepId)`
+- `uiCheckLabelForStep(stepId)`
+- `writeUiCheckJson(paths, fileName, payload)`
+- `runDeepUiCheck(paths, { stepId, label, phase }, options = {}, context = {})`
+- `acceptUiCheckChanges(paths, { stepId }, _options = {}, context = {})`
+- `commitUiCheckChanges(paths, { stepId }, _options = {}, context = {})`
 - `userCheck(paths, options = {})`
+- `updateBlueprint(paths, options = {}, context = {})`
 - `readPackageJson(root)`
 - `doctorCommandForWorktree(worktree)`
 - `runDoctor(paths)`
+- `maybeCommitDoctorRepair(paths)`
+- `commitLinesSinceBase(paths)`
+- `readCheckSummaries(paths)`
+- `readUiCheckSummaries(paths)`
+- `readReviewPassSummaries(paths)`
+- `createFinalReport(paths, _options = {}, context = {})`
 - `issueNumberFromUrl(issueUrl)`
+- `parseJsonObject(value)`
+- `readPrState(paths, prUrl)`
+- `readCurrentBranchPrState(paths)`
+- `prStateIsMerged(prState)`
+- `prStateIsClosed(prState)`
+- `currentTargetBranch(targetRoot)`
+- `assertTargetRootCleanForBaseUpdate(paths)`
+- `removeSessionWorktree(paths)`
+- `writePrOutcome(paths, outcome)`
+- `assertTargetRootCanUpdateBase(paths, branch)`
+- `assertTargetBaseCanFastForward(paths, branch)`
+- `updateLocalBaseBranch(paths, baseBranch = "")`
+- `updateHelperMapBeforePr(paths)`
 - `createPr(paths)`
-- `mergePr(paths)`
+- `closePrWithoutMerge(paths, prUrl, options = {})`
+- `finalizePr(paths, options = {})`
 - `finishSession(paths)`
 - `runNamedPreconditions(paths, names = [])`
+
+### `src/server/sessionRuntime/appReadiness.js`
+Exports
+- `inspectReadyJskitAppRoot(rootPath)`
+Local functions
+- `pathExists(filePath)`
+- `directoryExists(filePath)`
 
 ### `src/server/sessionRuntime/constants.js`
 Exports
 - `PROMPT_DIRECTORY`
 - `SESSION_ID_PATTERN`
 - `SESSION_STATUS`
+- `SESSION_WORKFLOW_VERSION`
+- `REVIEW_PASS_LIMIT`
+- `CYCLE_STEP_IDS`
 - `STEP_DEFINITION_BY_ID`
 - `STEP_DEFINITIONS`
 - `STEP_IDS`
 - `STEP_LABEL_BY_ID`
 - `STEP_PRECONDITION_NAMES`
+- `PLAN_EXECUTION_CODEX_HANDOFF`
+- `PLAN_FINE_TUNING_CODEX_HANDOFF`
+- `REVIEW_EXECUTION_CODEX_HANDOFF`
+- `DEEP_UI_CHECK_CODEX_HANDOFF`
+- `BLUEPRINT_CODEX_HANDOFF`
 - `SESSION_STATE_RELATIVE_PATH`
 Local functions
-- `codexHandoff(expectedOutput)`
-- `defineStep({ buttonLabel, codex = undefined, description, id, input = INPUT_NONE, kind = "automatic", label, nextCommandTemplate = "jskit session {{session_id}} step", preconditions = [], utilityActions = [] })`
+- `codexHandoff(expectedOutput, { autoInject = false, promptActionLabel = "" } = {})`
+- `defineStep({ buttonLabel, codex = undefined, description, id, input = INPUT_NONE, kind = "automatic", label, nextCommandTemplate = "jskit session {{session_id}} step", preconditions = [], utilityActions = [], displayGroupId = "", displayGroupLabel = "" })`
 
 ### `src/server/sessionRuntime/io.js`
 Exports
@@ -870,13 +994,26 @@ Local functions
 ### `src/server/sessionRuntime/preconditions.js`
 Exports
 - `applyPreconditions(paths, checks = [])`
+- `assertActiveCycleExists(paths)`
+- `assertActiveCycleUserCheckPassed(paths)`
+- `assertBlueprintUpdateSatisfied(paths)`
+- `assertDeepUiCheckSatisfied(paths)`
+- `assertDeepUiRecheckSatisfied(paths)`
+- `assertDependenciesInstalled(paths)`
+- `assertFinalReportExists(paths)`
 - `assertGhAuth(targetRoot)`
 - `assertGitCurrentBranch(targetRoot)`
 - `assertGitRepository(targetRoot)`
 - `assertGithubOrigin(targetRoot)`
+- `assertIssueMetadataExists(paths)`
 - `assertIssueTextExists(paths)`
 - `assertIssueUrlExists(paths)`
+- `assertPostReviewChecksPassed(paths)`
+- `assertPreReviewChecksPassed(paths)`
+- `assertPlanDetailsExists(paths)`
+- `assertPlanTextExists(paths)`
 - `assertPrUrlExists(paths)`
+- `assertReadyJskitApp(paths)`
 - `assertSessionExists(paths)`
 - `assertTargetRootWritable(targetRoot)`
 - `assertWorktreeExists(paths)`
@@ -884,6 +1021,8 @@ Exports
 - `hasWorktree`
 Local functions
 - `resolveGitCommonDirectory(targetRoot)`
+- `pathExists(filePath)`
+- `assertActiveCycleStepReceipt(paths, { code, id, message, stepId })`
 
 ### `src/server/sessionRuntime/promptRenderer.js`
 Exports
@@ -894,26 +1033,53 @@ Exports
 ### `src/server/sessionRuntime/responses.js`
 Exports
 - `buildSessionErrorResponse({ targetRoot = process.cwd(), sessionId = "", code, message, repairCommand = "", status = SESSION_STATUS.BLOCKED, preconditions = [], errors = undefined } = {})`
-- `buildSessionResponse(paths, { ok = true, errors = [], preconditions = [], prompt = undefined, status = undefined } = {})`
+- `buildSessionResponse(paths, { codex = undefined, ok = true, errors = [], preconditions = [], prompt = undefined, status = undefined } = {})`
 - `buildStepDefinitions()`
 - `createError({ code, message, repairCommand = "" })`
 - `createPrecondition({ id, ok, message })`
 - `failSession(paths, { code, message, repairCommand = "", preconditions = [], status = SESSION_STATUS.BLOCKED, prompt = "" })`
 - `markCurrentStep(paths, stepId)`
 - `markStatus(paths, status)`
+- `normalizeReviewPassNumber(value = "")`
+- `readActiveCycle(paths)`
 - `readReceiptSteps(paths)`
+- `readReviewPasses(paths)`
 - `readSessionArtifacts(paths)`
+- `reviewPassDirectoryName(pass = DEFAULT_REVIEW_PASS)`
+- `reviewPassRoot(paths, pass)`
+- `writeActiveCycle(paths, cycle)`
+- `writeCycleReceipt(paths, receiptName, message, { cycle = "" } = {})`
 - `writeReceipt(paths, stepId, message)`
 Local functions
 - `normalizeStepId(stepId)`
 - `stepIndex(stepId)`
 - `normalizeKnownStepIds(stepIds = [])`
 - `stepCanExposeStoredPrompt(stepId)`
-- `readCompletedSteps(sessionRoot)`
+- `normalizeCycleNumber(value = "")`
+- `cycleDirectoryName(cycle = DEFAULT_ACTIVE_CYCLE)`
+- `isCycleStepId(stepId = "")`
+- `readWorkflowVersion(paths)`
+- `cycleStepsRoot(paths, cycle)`
+- `cycleRoot(paths, cycle)`
+- `parseJsonFileIfExists(filePath)`
+- `readReviewPassNumbers(paths)`
+- `readReviewPassInfo(paths, pass)`
+- `readPromptForStep(paths, stepId)`
+- `readStepFileNames(stepsRoot)`
+- `readCompletedSteps(paths)`
+- `applyReviewPassCompletionOverlay(paths, completedSteps = [])`
+- `readCycleInfo(paths, cycle)`
+- `readCycles(paths, activeCycle)`
+- `readStructuredChecks(paths)`
+- `readStructuredUiChecks(paths)`
+- `readWorktreeStatus(paths, worktreeReady)`
 - `resolveNextStep(completedSteps = [])`
 - `cloneContractValue(value)`
 - `publicStepDefinition(step, index)`
-- `buildCurrentStepAction(stepId)`
+- `stepIsRetryableWhenBlocked(stepId)`
+- `stepIsConditional(stepId)`
+- `skipReasonForStep(stepId, artifacts = {})`
+- `buildCurrentStepAction(stepId, artifacts = {})`
 - `buildCodexHandoff(stepId)`
 - `buildNextCommand(sessionId, stepId)`
 

--- a/packages/agent-docs/site/guide/app-setup/initial-scaffolding.md
+++ b/packages/agent-docs/site/guide/app-setup/initial-scaffolding.md
@@ -28,6 +28,19 @@ npm install
 
 After that promotion, the overwritten app `AGENTS.md` stays deliberately small. Use `jskit session` for issue-driven work; session state and prompts live under `.jskit/sessions/` in the target app.
 
+Issue sessions are executable workflow state, not prose instructions. The important durable files are:
+
+- `issue.md` and `issue_title` for the approved GitHub issue.
+- `plan_details.md` for the confirmed implementation details gathered before planning.
+- `plan.md` for the approved implementation plan.
+- `agent_decisions.md` for concise decisions and why they were made.
+- `.jskit/APP_BLUEPRINT.md` for durable app/product/architecture memory that grows across issues.
+- `review_passes/`, `checks/`, `ui_checks/`, and `command_log.jsonl` for review, verification, UI check, and command receipts.
+
+The Deep UI Check steps use the saved issue classification: server-only work can be skipped with a receipt, possible UI work can be skipped only with an explicit reason, and definite UI work must run. If the User Check fails, JSKIT starts a new cycle under `cycles/cycle_###/` and cycle-scoped receipts under `steps/cycle_###/`; do not delete older cycle receipts.
+
+Studio and other tools should read `jskit session <session_id> --json` rather than scraping those files directly. Manual agents should follow the current `jskit session <session_id> step` output and avoid recreating the old workboard workflow.
+
 After creating the real app scaffolding (the base shell, not the seed wrapper), you will need to run `npm install` to install dependencies.
 
 If you already know you want a small non-workspace baseline right after the scaffold, this is the shortest reproducible path:

--- a/packages/auth-web/test/providerRuntime.test.js
+++ b/packages/auth-web/test/providerRuntime.test.js
@@ -6,9 +6,14 @@ import { AuthWebServiceProvider } from "../src/server/providers/AuthWebServicePr
 
 function createFastifyStub() {
   const routes = [];
+  const hooks = [];
   return {
+    hooks,
     routes,
     errorHandler: null,
+    addHook(name, handler) {
+      hooks.push({ name, handler });
+    },
     route(definition) {
       routes.push(definition);
     },

--- a/packages/feature-server-generator/test/packageDescriptor.test.js
+++ b/packages/feature-server-generator/test/packageDescriptor.test.js
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
+import { createRequire } from "node:module";
 import test from "node:test";
 import descriptor from "../package.descriptor.mjs";
+
+const require = createRequire(import.meta.url);
+const kernelPackage = require("../../kernel/package.json");
 
 test("feature-server-generator exposes the scaffold primary subcommand contract", () => {
   assert.equal(descriptor.kind, "generator");
@@ -76,6 +80,6 @@ test("feature-server-generator scopes persistence dependencies to persistent mod
       notEquals: "orchestrator"
     }
   });
-  assert.equal(runtimeDependencies["@jskit-ai/kernel"], "0.1.69");
+  assert.equal(runtimeDependencies["@jskit-ai/kernel"], kernelPackage.version);
   assert.equal(runtimeDependencies["json-rest-schema"], "1.x.x");
 });

--- a/revolution.md
+++ b/revolution.md
@@ -1,5 +1,7 @@
 # JSKIT Session Revolution Plan
 
+Current tracker: `FINAL_TODO.md` is the active implementation checklist for the post-Studio session workflow. This file records the original revolution milestone and remains useful background, but new work should be tracked in `FINAL_TODO.md`.
+
 ## Core Direction
 
 - [x] Define the new source of truth: `jskit session` becomes the only supported issue workflow contract.

--- a/tooling/jskit-cli/src/server/appBlueprint.js
+++ b/tooling/jskit-cli/src/server/appBlueprint.js
@@ -28,7 +28,7 @@ function resolveAppBlueprintPaths(targetRoot = process.cwd()) {
 function extractAppBlueprintText(value = "") {
   const text = normalizeText(value);
   const match = /\[app_blueprint\]([\s\S]*?)\[\/app_blueprint\]/u.exec(text);
-  return normalizeText(match ? match[1] : text);
+  return normalizeText(match ? match[1] : "");
 }
 
 async function readAppPromptTemplate(paths, templateName) {

--- a/tooling/jskit-cli/src/server/commandHandlers/session.js
+++ b/tooling/jskit-cli/src/server/commandHandlers/session.js
@@ -192,18 +192,118 @@ async function resolveStepInputs({
     return plan;
   }
 
+  const planDetails = await resolveTextInput({
+    codePrefix: "plan_details",
+    fileOption: "plan-details-file",
+    inlineOptions,
+    io,
+    repairCommand: `jskit session ${sessionId} step --plan-details -`,
+    cwd,
+    sessionId,
+    stdinOption: "-",
+    textOption: "plan-details"
+  });
+  if (planDetails.ok === false) {
+    return planDetails;
+  }
+
+  const reworkNotes = await resolveTextInput({
+    codePrefix: "rework_notes",
+    fileOption: "rework-notes-file",
+    inlineOptions,
+    io,
+    repairCommand: `jskit session ${sessionId} step --user-check failed --rework-notes -`,
+    cwd,
+    sessionId,
+    stdinOption: "-",
+    textOption: "rework-notes"
+  });
+  if (reworkNotes.ok === false) {
+    return reworkNotes;
+  }
+
+  const skipReason = await resolveTextInput({
+    codePrefix: "skip_reason",
+    fileOption: "skip-reason-file",
+    inlineOptions,
+    io,
+    repairCommand: `jskit session ${sessionId} step --skip-ui-check --skip-reason "<reason>"`,
+    cwd,
+    sessionId,
+    stdinOption: "-",
+    textOption: "skip-reason"
+  });
+  if (skipReason.ok === false) {
+    return skipReason;
+  }
+
+  const agentDecisions = await resolveTextInput({
+    codePrefix: "agent_decisions",
+    fileOption: "agent-decisions-file",
+    inlineOptions,
+    io,
+    repairCommand: `jskit session ${sessionId} step --agent-decisions -`,
+    cwd,
+    sessionId,
+    stdinOption: "-",
+    textOption: "agent-decisions"
+  });
+  if (agentDecisions.ok === false) {
+    return agentDecisions;
+  }
+
+  const closeReason = await resolveTextInput({
+    codePrefix: "close_reason",
+    fileOption: "close-reason-file",
+    inlineOptions,
+    io,
+    repairCommand: `jskit session ${sessionId} step --close-without-merge --close-reason "<reason>"`,
+    cwd,
+    sessionId,
+    stdinOption: "-",
+    textOption: "close-reason"
+  });
+  if (closeReason.ok === false) {
+    return closeReason;
+  }
+
+  const blueprint = await resolveTextInput({
+    codePrefix: "blueprint",
+    fileOption: "blueprint-file",
+    inlineOptions,
+    io,
+    repairCommand: `jskit session ${sessionId} step --blueprint -`,
+    cwd,
+    sessionId,
+    stdinOption: "-",
+    textOption: "blueprint"
+  });
+  if (blueprint.ok === false) {
+    return blueprint;
+  }
+
   return {
+    agentDecisions: agentDecisions.value,
+    blueprint: blueprint.value,
+    closeReason: closeReason.value,
     issue: issue.value,
     issueTitle: issueTitle.value,
     ok: true,
-    plan: plan.value
+    plan: plan.value,
+    planDetails: planDetails.value,
+    reworkNotes: reworkNotes.value,
+    skipReason: skipReason.value
   };
 }
 
 function normalizeStepOptions(inlineOptions = {}) {
   return {
     ...inlineOptions,
+    closeWithoutMerge: inlineOptions["close-without-merge"] === "true" || inlineOptions.closeWithoutMerge === true,
     prompt: inlineOptions.prompt,
+    reviewFindings: inlineOptions["review-findings"] || inlineOptions.reviewFindings,
+    reviewFindingsRemaining: inlineOptions["review-findings-remaining"] === "true" || inlineOptions.reviewFindingsRemaining === true,
+    skipUiCheck: inlineOptions["skip-ui-check"] === "true" || inlineOptions.skipUiCheck === true,
     userCheck: inlineOptions["user-check"] || inlineOptions.userCheck
   };
 }
@@ -258,7 +358,13 @@ function createSessionCommands() {
                 ...normalizeStepOptions(inlineOptions),
                 issue: stepInputs.issue,
                 issueTitle: stepInputs.issueTitle,
-                plan: stepInputs.plan
+                plan: stepInputs.plan,
+                planDetails: stepInputs.planDetails,
+                reworkNotes: stepInputs.reworkNotes,
+                skipReason: stepInputs.skipReason,
+                agentDecisions: stepInputs.agentDecisions,
+                closeReason: stepInputs.closeReason,
+                blueprint: stepInputs.blueprint
               }
             });
       } else if (second === "abandon") {

--- a/tooling/jskit-cli/src/server/core/argParser.js
+++ b/tooling/jskit-cli/src/server/core/argParser.js
@@ -137,6 +137,14 @@ function parseArgs(argv, { createCliError } = {}) {
       options.inlineOptions.install = "true";
       continue;
     }
+    if (token === "--skip-ui-check") {
+      options.inlineOptions["skip-ui-check"] = "true";
+      continue;
+    }
+    if (token === "--close-without-merge") {
+      options.inlineOptions["close-without-merge"] = "true";
+      continue;
+    }
 
     if (token.startsWith("--")) {
       const withoutPrefix = token.slice(2);

--- a/tooling/jskit-cli/src/server/core/commandCatalog.js
+++ b/tooling/jskit-cli/src/server/core/commandCatalog.js
@@ -224,7 +224,14 @@ const COMMAND_DESCRIPTORS = Object.freeze({
       "Use --json for the stable machine-readable contract consumed by JSKIT AI Studio.",
       "Use --issue - to read approved issue body from stdin.",
       "Use --issue-title when the approved issue title is separate from the body.",
-      "Use --plan - to read the approved implementation plan from stdin."
+      "Use --plan-details - to read confirmed implementation details from stdin.",
+      "Use --plan - to read the approved implementation plan from stdin.",
+      "Use --rework-notes - with --user-check failed to start the allowed rework cycle.",
+      "Use --agent-decisions - to append session-local decision log entries from implementation, UI review, verification, or repair phases.",
+      "Use --review-findings-remaining true --review-findings \"<findings>\" when an accepted review pass needs another pass.",
+      "Use --skip-ui-check --skip-reason \"<reason>\" only when uiImpact is possible and the Deep UI Check is intentionally skipped.",
+      "Use --close-without-merge --close-reason \"<reason>\" at PR finalization to complete the session without merging.",
+      "Use --blueprint - to accept the tagged app blueprint update."
     ]),
     examples: Object.freeze([
       Object.freeze({
@@ -234,13 +241,20 @@ const COMMAND_DESCRIPTORS = Object.freeze({
           "jskit session 2026-05-11_21-42-08 step",
           "jskit session 2026-05-11_21-42-08 step --prompt \"Fix the customer filters\"",
           "jskit session 2026-05-11_21-42-08 step --issue-title \"Fix customer filters\" --issue -",
+          "jskit session 2026-05-11_21-42-08 step --plan-details -",
           "jskit session 2026-05-11_21-42-08 step --plan -",
+          "jskit session 2026-05-11_21-42-08 step --agent-decisions -",
+          "jskit session 2026-05-11_21-42-08 step --review-findings-remaining true --review-findings \"A helper duplication fix needs another pass\"",
+          "jskit session 2026-05-11_21-42-08 step --skip-ui-check --skip-reason \"No user-facing UI changes\"",
+          "jskit session 2026-05-11_21-42-08 step --blueprint -",
+          "jskit session 2026-05-11_21-42-08 step --close-without-merge --close-reason \"Prototype kept for reference\"",
+          "jskit session 2026-05-11_21-42-08 step --user-check failed --rework-notes -",
           "jskit session 2026-05-11_21-42-08 diff --json"
         ])
       })
     ]),
     fullUse:
-      "jskit session [create|<sessionId>] [step|diff|abandon|adopt-codex-thread] [--prompt <text>] [--issue-title <text>|--issue-title-file <path>] [--issue <text>|--issue-file <path>] [--plan <text>|--plan-file <path>] [--user-check <passed|failed>] [--codex-thread-id <id>] [--abandoned|--completed|--all] [--json]",
+      "jskit session [create|<sessionId>] [step|diff|abandon|adopt-codex-thread] [--prompt <text>] [--issue-title <text>|--issue-title-file <path>] [--issue <text>|--issue-file <path>] [--plan-details <text>|--plan-details-file <path>] [--plan <text>|--plan-file <path>] [--agent-decisions <text>|--agent-decisions-file <path>] [--review-findings-remaining true --review-findings <text>] [--skip-ui-check --skip-reason <text>] [--close-without-merge --close-reason <text>] [--blueprint <text>|--blueprint-file <path>] [--user-check <passed|failed>] [--rework-notes <text>|--rework-notes-file <path>] [--codex-thread-id <id>] [--abandoned|--completed|--all] [--json]",
     showHelpOnBareInvocation: false,
     handlerName: "commandSession",
     allowedFlagKeys: Object.freeze(["json", "abandoned", "completed", "all"]),

--- a/tooling/jskit-cli/src/server/sessionRuntime.js
+++ b/tooling/jskit-cli/src/server/sessionRuntime.js
@@ -1,4 +1,5 @@
 import {
+  appendFile,
   mkdir,
   readFile,
   readdir,
@@ -6,15 +7,20 @@ import {
 } from "node:fs/promises";
 import path from "node:path";
 import {
+  BLUEPRINT_CODEX_HANDOFF,
+  DEEP_UI_CHECK_CODEX_HANDOFF,
   PLAN_EXECUTION_CODEX_HANDOFF,
   PLAN_FINE_TUNING_CODEX_HANDOFF,
+  REVIEW_PASS_LIMIT,
   REVIEW_EXECUTION_CODEX_HANDOFF,
   SESSION_STATUS,
+  SESSION_WORKFLOW_VERSION,
   STEP_DEFINITIONS,
   STEP_IDS,
   STEP_PRECONDITION_NAMES
 } from "./sessionRuntime/constants.js";
 import {
+  fileExists,
   normalizeText,
   readTextIfExists,
   readTrimmedFile,
@@ -41,20 +47,38 @@ import {
   failSession,
   markCurrentStep,
   markStatus,
+  normalizeReviewPassNumber,
+  readActiveCycle,
   readReceiptSteps,
+  readReviewPasses,
   readSessionArtifacts,
+  reviewPassRoot,
+  writeActiveCycle,
+  writeCycleReceipt,
   writeReceipt
 } from "./sessionRuntime/responses.js";
 import {
   applyPreconditions,
+  assertActiveCycleExists,
+  assertActiveCycleUserCheckPassed,
+  assertBlueprintUpdateSatisfied,
+  assertDeepUiCheckSatisfied,
+  assertDeepUiRecheckSatisfied,
+  assertDependenciesInstalled,
+  assertFinalReportExists,
   assertGhAuth,
   assertGitCurrentBranch,
   assertGitRepository,
   assertGithubOrigin,
+  assertIssueMetadataExists,
   assertIssueTextExists,
   assertIssueUrlExists,
+  assertPostReviewChecksPassed,
+  assertPreReviewChecksPassed,
+  assertPlanDetailsExists,
   assertPlanTextExists,
   assertPrUrlExists,
+  assertReadyJskitApp,
   assertSessionExists,
   assertTargetRootWritable,
   assertWorktreeExists,
@@ -69,6 +93,10 @@ import {
   HELPER_MAP_JSON_RELATIVE_PATH,
   HELPER_MAP_MARKDOWN_RELATIVE_PATH
 } from "./helperMapPaths.js";
+import {
+  extractAppBlueprintText,
+  writeAppBlueprint
+} from "./appBlueprint.js";
 
 function invalidSessionIdError(sessionId = "") {
   return createError({
@@ -136,9 +164,9 @@ function extractMarkedText(value = "", marker = "") {
   if (!normalizedMarker) {
     return "";
   }
-  const pattern = new RegExp(`\\[${normalizedMarker}\\]([\\s\\S]*?)\\[/${normalizedMarker}\\]`, "u");
-  const match = pattern.exec(text);
-  return normalizeText(match ? match[1] : "");
+  const pattern = new RegExp(`\\[${normalizedMarker}\\]([\\s\\S]*?)\\[/${normalizedMarker}\\]`, "gu");
+  const matches = [...text.matchAll(pattern)];
+  return normalizeText(matches.length > 0 ? matches[matches.length - 1][1] : "");
 }
 
 function extractIssueTitle(value = "") {
@@ -153,8 +181,224 @@ function extractPlanText(value = "") {
   return extractMarkedText(value, "plan") || normalizeText(value);
 }
 
+function extractPlanDetails(value = "") {
+  return extractMarkedText(value, "plan_details");
+}
+
+function extractIssueCategory(value = "") {
+  return extractMarkedText(value, "issue_category");
+}
+
+function extractUiImpact(value = "") {
+  return extractMarkedText(value, "ui_impact");
+}
+
+function extractAgentDecisions(value = "") {
+  return extractMarkedText(value, "agent_decisions");
+}
+
+function normalizeIssueCategory(value = "") {
+  const category = normalizeText(value).toLowerCase();
+  return ["client", "server", "client_server", "tooling", "unknown"].includes(category)
+    ? category
+    : "";
+}
+
+function normalizeUiImpact(value = "") {
+  const impact = normalizeText(value).toLowerCase();
+  return ["none", "possible", "definite", "unknown"].includes(impact)
+    ? impact
+    : "";
+}
+
 async function writePromptArtifact(paths, fileName, prompt) {
   await writeTextFile(path.join(paths.sessionRoot, "prompts", fileName), prompt);
+}
+
+function commandText(command, args = []) {
+  return [command, ...args].map((part) => {
+    const value = String(part || "");
+    return /^[A-Za-z0-9_./:=@,+-]+$/u.test(value)
+      ? value
+      : `'${value.replaceAll("'", "'\\''")}'`;
+  }).join(" ");
+}
+
+function commandOutputSummary(output = "") {
+  const normalized = normalizeText(output);
+  if (normalized.length <= 1800) {
+    return normalized;
+  }
+  return normalized.slice(-1800);
+}
+
+async function appendCommandLog(paths, {
+  args = [],
+  command,
+  cwd = "",
+  kind = "command",
+  result
+} = {}) {
+  if (!paths?.sessionRoot || !command || !result) {
+    return;
+  }
+  const entry = {
+    at: timestampForReceipt(),
+    command: commandText(command, args),
+    cwd,
+    exitCode: Number.isInteger(result.exitCode) ? result.exitCode : null,
+    kind,
+    ok: result.ok === true,
+    outputSummary: commandOutputSummary(result.output)
+  };
+  await appendFile(path.join(paths.sessionRoot, "command_log.jsonl"), `${JSON.stringify(entry)}\n`, "utf8");
+}
+
+async function runLoggedCommand(paths, kind, command, args = [], options = {}) {
+  const result = await runCommand(command, args, options);
+  await appendCommandLog(paths, {
+    args,
+    command,
+    cwd: options.cwd || "",
+    kind,
+    result
+  });
+  return result;
+}
+
+async function readIssueMetadata(paths) {
+  const source = await readTextIfExists(path.join(paths.sessionRoot, "issue_metadata.json"));
+  if (!source) {
+    return {};
+  }
+  try {
+    const parsed = JSON.parse(source);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+async function writeIssueMetadata(paths, metadata = {}) {
+  const existing = await readIssueMetadata(paths);
+  const next = {
+    ...existing,
+    ...metadata
+  };
+  await writeTextFile(path.join(paths.sessionRoot, "issue_metadata.json"), `${JSON.stringify(next, null, 2)}\n`);
+  return next;
+}
+
+async function readGithubComments(paths) {
+  const source = await readTextIfExists(path.join(paths.sessionRoot, "github_comments.json"));
+  if (!source) {
+    return {};
+  }
+  const parsed = parseJsonObject(source);
+  return parsed || {};
+}
+
+async function writeGithubComments(paths, comments = {}) {
+  await writeTextFile(path.join(paths.sessionRoot, "github_comments.json"), `${JSON.stringify(comments, null, 2)}\n`);
+}
+
+async function commentOnIssueOnce(paths, {
+  bodyFile,
+  issueUrl,
+  purpose
+}) {
+  const normalizedPurpose = normalizeText(purpose);
+  if (!issueUrl || !normalizedPurpose) {
+    return {
+      ok: true,
+      skipped: true
+    };
+  }
+  const comments = await readGithubComments(paths);
+  if (comments[normalizedPurpose]) {
+    return {
+      ok: true,
+      skipped: true
+    };
+  }
+  const result = await runLoggedCommand(paths, "github_issue_comment", "gh", ["issue", "comment", issueUrl, "--body-file", bodyFile], {
+    cwd: paths.targetRoot,
+    timeout: 1000 * 60
+  });
+  if (!result.ok) {
+    return {
+      ok: false,
+      output: result.output
+    };
+  }
+  comments[normalizedPurpose] = {
+    bodyFile,
+    commentedAt: timestampForReceipt(),
+    issueUrl,
+    purpose: normalizedPurpose
+  };
+  await writeGithubComments(paths, comments);
+  return {
+    ok: true,
+    skipped: false
+  };
+}
+
+async function appendAgentDecisions(paths, decisions = "") {
+  const normalized = normalizeText(decisions);
+  if (!normalized) {
+    return;
+  }
+  const decisionsPath = path.join(paths.sessionRoot, "agent_decisions.md");
+  const existing = await readTextIfExists(decisionsPath);
+  await writeTextFile(
+    decisionsPath,
+    `${existing}${existing && !existing.endsWith("\n") ? "\n" : ""}${normalized}\n`
+  );
+}
+
+async function appendAgentDecisionsInput(paths, options = {}) {
+  const source = normalizeText(options.agentDecisions || options["agent-decisions"]);
+  if (!source) {
+    return;
+  }
+  await appendAgentDecisions(paths, extractAgentDecisions(source) || source);
+}
+
+async function recordIssueInAgentDecisions(paths, issueUrl = "") {
+  const normalizedIssueUrl = normalizeText(issueUrl);
+  if (!normalizedIssueUrl) {
+    return;
+  }
+  const decisionsPath = path.join(paths.sessionRoot, "agent_decisions.md");
+  const existing = await readTextIfExists(decisionsPath);
+  if (existing.includes(`Issue: ${normalizedIssueUrl}`)) {
+    return;
+  }
+  await writeTextFile(
+    decisionsPath,
+    `${existing}${existing && !existing.endsWith("\n") ? "\n" : ""}Issue: ${normalizedIssueUrl}\n\n`
+  );
+}
+
+function issueMetadataFromUrl(issueUrl = "") {
+  const match = /^https:\/\/github\.com\/([^/\s]+)\/([^/\s]+)\/issues\/(\d+)(?:\b|$)/u.exec(normalizeText(issueUrl));
+  if (!match) {
+    return {
+      issueNumber: "",
+      owner: "",
+      repository: ""
+    };
+  }
+  return {
+    issueNumber: match[3],
+    owner: match[1],
+    repository: match[2]
+  };
+}
+
+function nextCycleNumber(cycle = "001") {
+  return String(Number.parseInt(String(cycle || "1"), 10) + 1).padStart(3, "0");
 }
 
 async function createSession({
@@ -192,6 +436,9 @@ async function createSession({
   await ensureStudioGitExclude(initialPaths.targetRoot);
   await mkdir(initialPaths.sessionRoot, { recursive: true });
   await writeTextFile(path.join(initialPaths.sessionRoot, "transcript.log"), "");
+  await writeTextFile(path.join(initialPaths.sessionRoot, "agent_decisions.md"), `# Agent Decisions\n\nSession: ${initialPaths.sessionId}\nCreated: ${now.toISOString()}\n\n`);
+  await writeTextFile(path.join(initialPaths.sessionRoot, "workflow_version"), `${SESSION_WORKFLOW_VERSION}\n`);
+  await writeActiveCycle(initialPaths, "001");
   await markStatus(initialPaths, SESSION_STATUS.PENDING);
   await writeReceipt(initialPaths, "session_created", `Created JSKIT Studio issue session ${initialPaths.sessionId}.`);
 
@@ -347,7 +594,19 @@ async function removeEmptyStaleWorktreeDirectory(paths) {
 
 async function createWorktree(paths, _options = {}, context = {}) {
   const preconditions = context.preconditions || [];
+  const [baseBranchResult, baseCommitResult] = await Promise.all([
+    runGit(paths.targetRoot, ["branch", "--show-current"], { timeout: 15000 }),
+    runGit(paths.targetRoot, ["rev-parse", "--verify", "HEAD"], { timeout: 15000 })
+  ]);
+  const baseBranch = normalizeText(baseBranchResult.stdout);
+  const baseCommit = normalizeText(baseCommitResult.stdout);
   if (await hasWorktree(paths)) {
+    if (baseBranch && !await readTrimmedFile(path.join(paths.sessionRoot, "base_branch"))) {
+      await writeTextFile(path.join(paths.sessionRoot, "base_branch"), `${baseBranch}\n`);
+    }
+    if (baseCommit && !await readTrimmedFile(path.join(paths.sessionRoot, "base_commit"))) {
+      await writeTextFile(path.join(paths.sessionRoot, "base_commit"), `${baseCommit}\n`);
+    }
     await writeReceipt(paths, "worktree_created", `Reused existing worktree ${paths.worktree}.`);
     await markStatus(paths, SESSION_STATUS.RUNNING);
     return buildSessionResponse(paths, {
@@ -365,7 +624,8 @@ async function createWorktree(paths, _options = {}, context = {}) {
       preconditions
     });
   }
-  const result = await runGit(paths.targetRoot, ["worktree", "add", "-b", paths.branch, paths.worktree, "HEAD"], {
+  const result = await runLoggedCommand(paths, "git_worktree_add", "git", ["worktree", "add", "-b", paths.branch, paths.worktree, "HEAD"], {
+    cwd: paths.targetRoot,
     timeout: 30000
   });
   if (!result.ok) {
@@ -375,6 +635,12 @@ async function createWorktree(paths, _options = {}, context = {}) {
       repairCommand: `git worktree add -b ${paths.branch} ${paths.worktree} HEAD`,
       preconditions
     });
+  }
+  if (baseBranch) {
+    await writeTextFile(path.join(paths.sessionRoot, "base_branch"), `${baseBranch}\n`);
+  }
+  if (baseCommit) {
+    await writeTextFile(path.join(paths.sessionRoot, "base_commit"), `${baseCommit}\n`);
   }
   await writeReceipt(paths, "worktree_created", `Created worktree ${paths.worktree} on branch ${paths.branch}.`);
   await markStatus(paths, SESSION_STATUS.RUNNING);
@@ -394,22 +660,79 @@ async function recordDependenciesInstalled(paths, {
   });
 }
 
+function parsePackageManager(value = "") {
+  const normalized = normalizeText(value);
+  const match = /^([a-z][a-z0-9-]*)(?:@(.+))?$/u.exec(normalized);
+  if (!match) {
+    return {
+      name: "",
+      version: ""
+    };
+  }
+  return {
+    name: match[1],
+    version: match[2] || ""
+  };
+}
+
+async function hasWorktreeFile(worktree, fileName) {
+  return fileExists(path.join(worktree, fileName));
+}
+
+async function dependencyInstallCommandForWorktree(worktree) {
+  const packageJsonSource = await readTextIfExists(path.join(worktree, "package.json"));
+  let packageManager = {
+    name: "",
+    version: ""
+  };
+  if (packageJsonSource) {
+    try {
+      const packageJson = JSON.parse(packageJsonSource);
+      packageManager = parsePackageManager(packageJson?.packageManager);
+    } catch {
+      packageManager = {
+        name: "",
+        version: ""
+      };
+    }
+  }
+  const hasPackageLock = await hasWorktreeFile(worktree, "package-lock.json") ||
+    await hasWorktreeFile(worktree, "npm-shrinkwrap.json");
+  const hasPnpmLock = await hasWorktreeFile(worktree, "pnpm-lock.yaml");
+  const hasYarnLock = await hasWorktreeFile(worktree, "yarn.lock");
+  const hasBunLock = await hasWorktreeFile(worktree, "bun.lock") ||
+    await hasWorktreeFile(worktree, "bun.lockb");
+
+  if (packageManager.name === "pnpm" || (!packageManager.name && hasPnpmLock)) {
+    return ["pnpm", hasPnpmLock ? ["install", "--frozen-lockfile"] : ["install"]];
+  }
+  if (packageManager.name === "yarn" || (!packageManager.name && hasYarnLock)) {
+    const major = Number.parseInt(packageManager.version.split(".")[0] || "1", 10);
+    return ["yarn", hasYarnLock && major >= 2 ? ["install", "--immutable"] : hasYarnLock ? ["install", "--frozen-lockfile"] : ["install"]];
+  }
+  if (packageManager.name === "bun" || (!packageManager.name && hasBunLock)) {
+    return ["bun", hasBunLock ? ["install", "--frozen-lockfile"] : ["install"]];
+  }
+  return ["npm", hasPackageLock ? ["ci"] : ["install"]];
+}
+
 async function installDependencies(paths, _options = {}, context = {}) {
   const preconditions = context.preconditions || [];
-  const result = await runCommand("npm", ["install"], {
+  const [command, args] = await dependencyInstallCommandForWorktree(paths.worktree);
+  const result = await runLoggedCommand(paths, "dependencies_install", command, args, {
     cwd: paths.worktree,
     timeout: 1000 * 60 * 10
   });
   if (!result.ok) {
     return failSession(paths, {
       code: "dependencies_install_failed",
-      message: result.output || "npm install failed in the session worktree.",
-      repairCommand: `cd ${paths.worktree} && npm install`,
+      message: result.output || `${command} ${args.join(" ")} failed in the session worktree.`,
+      repairCommand: `cd ${paths.worktree} && ${command} ${args.join(" ")}`,
       preconditions
     });
   }
   return recordDependenciesInstalled(paths, {
-    message: result.output || "Installed Node dependencies in the session worktree.",
+    message: result.output || `Installed Node dependencies in the session worktree with ${command} ${args.join(" ")}.`,
     preconditions
   });
 }
@@ -471,7 +794,14 @@ async function draftIssue(paths, options = {}) {
       repairCommand: `jskit session ${paths.sessionId} step --issue -`
     });
   }
-  const issueTitle = normalizeText(options.issueTitle) || extractIssueTitle(options.issue) || titleFromIssue(issueText);
+  const issueTitle = normalizeText(options.issueTitle) || extractIssueTitle(options.issue);
+  if (!issueTitle) {
+    return failSession(paths, {
+      code: "issue_title_required",
+      message: "The issue drafting step requires an approved issue title.",
+      repairCommand: `jskit session ${paths.sessionId} step --issue-title "<title>" --issue -`
+    });
+  }
   await writeTextFile(path.join(paths.sessionRoot, "issue.md"), issueText);
   await writeTextFile(path.join(paths.sessionRoot, "issue_title"), issueTitle);
   await writeReceipt(paths, "issue_drafted", "Saved approved issue text.");
@@ -489,9 +819,25 @@ function titleFromIssue(issueText) {
 
 async function createIssue(paths, _options = {}, context = {}) {
   const preconditions = context.preconditions || [];
+  const existingIssueUrl = await readTrimmedFile(path.join(paths.sessionRoot, "issue_url"));
   const issueText = await readTrimmedFile(path.join(paths.sessionRoot, "issue.md"));
   const issueTitle = await readTrimmedFile(path.join(paths.sessionRoot, "issue_title")) || titleFromIssue(issueText);
-  const result = await runCommand("gh", [
+  if (existingIssueUrl) {
+    await writeIssueMetadata(paths, {
+      ...issueMetadataFromUrl(existingIssueUrl),
+      issueBody: issueText,
+      issueBodyPath: path.join(paths.sessionRoot, "issue.md"),
+      issueTitle,
+      issueUrl: existingIssueUrl
+    });
+    await recordIssueInAgentDecisions(paths, existingIssueUrl);
+    await writeReceipt(paths, "issue_created", `Reused GitHub issue ${existingIssueUrl}.`);
+    await markStatus(paths, SESSION_STATUS.RUNNING);
+    return buildSessionResponse(paths, {
+      preconditions
+    });
+  }
+  const result = await runLoggedCommand(paths, "github_issue_create", "gh", [
     "issue",
     "create",
     "--title",
@@ -512,7 +858,107 @@ async function createIssue(paths, _options = {}, context = {}) {
   }
   const issueUrl = result.stdout.split(/\r?\n/u).map((line) => line.trim()).find(Boolean) || result.stdout;
   await writeTextFile(path.join(paths.sessionRoot, "issue_url"), issueUrl);
+  await writeIssueMetadata(paths, {
+    ...issueMetadataFromUrl(issueUrl),
+    issueBody: issueText,
+    issueBodyPath: path.join(paths.sessionRoot, "issue.md"),
+    issueTitle,
+    issueUrl
+  });
+  await recordIssueInAgentDecisions(paths, issueUrl);
   await writeReceipt(paths, "issue_created", `Created GitHub issue ${issueUrl}.`);
+  await markStatus(paths, SESSION_STATUS.RUNNING);
+  return buildSessionResponse(paths, {
+    preconditions
+  });
+}
+
+async function renderPlanDetailsPrompt(paths, _options = {}, context = {}) {
+  const preconditions = context.preconditions || [];
+  const issueText = await readTrimmedFile(path.join(paths.sessionRoot, "issue.md"));
+  const issueTitle = await readTrimmedFile(path.join(paths.sessionRoot, "issue_title")) || titleFromIssue(issueText);
+  const issueUrl = await readTrimmedFile(path.join(paths.sessionRoot, "issue_url"));
+  const issueNumber = issueNumberFromUrl(issueUrl);
+  const prompt = await renderPrompt(paths, "plan_details.md", {
+    issue_file: path.join(paths.sessionRoot, "issue.md"),
+    issue_number: issueNumber,
+    issue_text: issueText,
+    issue_title: issueTitle,
+    issue_url: issueUrl,
+    plan_details_file: path.join(paths.sessionRoot, "plan_details.md"),
+    worktree: paths.worktree
+  });
+  await writePromptArtifact(paths, "plan_details.md", prompt);
+  await writeReceipt(paths, "plan_details_prompt_rendered", "Started issue details conversation.");
+  await markStatus(paths, SESSION_STATUS.WAITING_FOR_USER);
+  return buildSessionResponse(paths, {
+    ok: true,
+    preconditions,
+    prompt,
+    status: SESSION_STATUS.WAITING_FOR_USER
+  });
+}
+
+async function savePlanDetails(paths, options = {}, context = {}) {
+  const preconditions = context.preconditions || [];
+  const source = normalizeText(options.planDetails || options["plan-details"]);
+  const planDetails = extractPlanDetails(source);
+  if (!planDetails) {
+    return failSession(paths, {
+      code: "plan_details_required",
+      message: "The details step requires --plan-details, --plan-details-file, or --plan-details -.",
+      repairCommand: `jskit session ${paths.sessionId} step --plan-details -`,
+      preconditions
+    });
+  }
+
+  const issueCategory = normalizeIssueCategory(options.issueCategory || options["issue-category"] || extractIssueCategory(source));
+  const uiImpact = normalizeUiImpact(options.uiImpact || options["ui-impact"] || extractUiImpact(source));
+  if (!issueCategory) {
+    return failSession(paths, {
+      code: "issue_category_invalid",
+      message: "Plan details must include [issue_category]client, server, client_server, tooling, or unknown[/issue_category].",
+      repairCommand: `jskit session ${paths.sessionId} step --plan-details -`,
+      preconditions
+    });
+  }
+  if (!uiImpact) {
+    return failSession(paths, {
+      code: "ui_impact_invalid",
+      message: "Plan details must include [ui_impact]none, possible, definite, or unknown[/ui_impact].",
+      repairCommand: `jskit session ${paths.sessionId} step --plan-details -`,
+      preconditions
+    });
+  }
+
+  await writeTextFile(path.join(paths.sessionRoot, "plan_details.md"), planDetails);
+  await writeIssueMetadata(paths, {
+    issueCategory,
+    uiImpact,
+    planDetailsPath: path.join(paths.sessionRoot, "plan_details.md")
+  });
+
+  const decisions = extractAgentDecisions(source);
+  await appendAgentDecisions(paths, decisions);
+
+  const issueUrl = await readTrimmedFile(path.join(paths.sessionRoot, "issue_url"));
+  if (issueUrl) {
+    const commentResult = await commentOnIssueOnce(paths, {
+      bodyFile: path.join(paths.sessionRoot, "plan_details.md"),
+      issueUrl,
+      purpose: "plan_details"
+    });
+    if (!commentResult.ok) {
+      return failSession(paths, {
+        code: "plan_details_comment_failed",
+        message: commentResult.output || "Failed to comment the plan details on the GitHub issue.",
+        repairCommand: `gh issue comment ${issueUrl} --body-file ${path.join(paths.sessionRoot, "plan_details.md")}`,
+        preconditions
+      });
+    }
+  }
+
+  await writeReceipt(paths, "plan_details_gathered", "Saved confirmed implementation details and recorded the GitHub issue comment.");
   await markStatus(paths, SESSION_STATUS.RUNNING);
   return buildSessionResponse(paths, {
     preconditions
@@ -525,16 +971,24 @@ async function makePlan(paths, options = {}, context = {}) {
   const issueTitle = await readTrimmedFile(path.join(paths.sessionRoot, "issue_title")) || titleFromIssue(issueText);
   const issueUrl = await readTrimmedFile(path.join(paths.sessionRoot, "issue_url"));
   const issueNumber = issueNumberFromUrl(issueUrl);
+  const planDetails = await readTrimmedFile(path.join(paths.sessionRoot, "plan_details.md"));
   const planText = extractPlanText(options.plan);
+  const agentDecisionsPath = path.join(paths.sessionRoot, "agent_decisions.md");
+  const agentDecisionsText = await readTextIfExists(agentDecisionsPath);
 
   if (!planText) {
     const prompt = await renderPrompt(paths, "plan_issue.md", {
+      agent_decisions_file: agentDecisionsPath,
+      agent_decisions_text: agentDecisionsText,
+      app_blueprint_file: path.join(paths.worktree, ".jskit", "APP_BLUEPRINT.md"),
       issue_file: path.join(paths.sessionRoot, "issue.md"),
       issue_number: issueNumber,
       issue_text: issueText,
       issue_title: issueTitle,
       issue_title_file: path.join(paths.sessionRoot, "issue_title"),
       issue_url: issueUrl,
+      plan_details_file: path.join(paths.sessionRoot, "plan_details.md"),
+      plan_details_text: planDetails,
       plan_file: path.join(paths.sessionRoot, "plan.md"),
       worktree: paths.worktree
     });
@@ -550,9 +1004,11 @@ async function makePlan(paths, options = {}, context = {}) {
 
   const planPath = path.join(paths.sessionRoot, "plan.md");
   await writeTextFile(planPath, planText);
-  const commentResult = await runCommand("gh", ["issue", "comment", issueUrl, "--body-file", planPath], {
-    cwd: paths.targetRoot,
-    timeout: 1000 * 60
+  await appendAgentDecisions(paths, extractAgentDecisions(options.plan));
+  const commentResult = await commentOnIssueOnce(paths, {
+    bodyFile: planPath,
+    issueUrl,
+    purpose: "plan"
   });
   if (!commentResult.ok) {
     return failSession(paths, {
@@ -562,7 +1018,7 @@ async function makePlan(paths, options = {}, context = {}) {
       preconditions
     });
   }
-  await writeReceipt(paths, "plan_made", `Saved plan and commented on ${issueUrl}.`);
+  await writeReceipt(paths, "plan_made", `Saved plan and recorded the GitHub issue comment for ${issueUrl}.`);
   await markStatus(paths, SESSION_STATUS.RUNNING);
   return buildSessionResponse(paths, {
     preconditions
@@ -577,11 +1033,15 @@ async function renderPlanExecutionPrompt(paths, _options = {}, context = {}) {
   const issueNumber = issueNumberFromUrl(issueUrl);
   const planPath = path.join(paths.sessionRoot, "plan.md");
   const planText = await readTrimmedFile(planPath);
+  const planDetailsPath = path.join(paths.sessionRoot, "plan_details.md");
+  const planDetails = await readTrimmedFile(planDetailsPath);
   const executionPrompt = await renderPrompt(paths, "execute_plan.md", {
     issue_file: path.join(paths.sessionRoot, "issue.md"),
     issue_number: issueNumber,
     issue_title: issueTitle,
     issue_url: issueUrl,
+    plan_details_file: planDetailsPath,
+    plan_details_text: planDetails,
     plan_file: planPath,
     plan_text: planText,
     worktree: paths.worktree
@@ -599,19 +1059,33 @@ async function renderPlanExecutionPrompt(paths, _options = {}, context = {}) {
 
 async function renderPlanFineTuningPrompt(paths, _options = {}, context = {}) {
   const preconditions = context.preconditions || [];
+  const activeCycle = await readActiveCycle(paths);
   const issueText = await readTrimmedFile(path.join(paths.sessionRoot, "issue.md"));
   const issueTitle = await readTrimmedFile(path.join(paths.sessionRoot, "issue_title")) || titleFromIssue(issueText);
   const issueUrl = await readTrimmedFile(path.join(paths.sessionRoot, "issue_url"));
   const issueNumber = issueNumberFromUrl(issueUrl);
   const planPath = path.join(paths.sessionRoot, "plan.md");
   const planText = await readTrimmedFile(planPath);
+  const planDetailsPath = path.join(paths.sessionRoot, "plan_details.md");
+  const planDetails = await readTrimmedFile(planDetailsPath);
+  const reworkRequestPath = path.join(paths.sessionRoot, "cycles", `cycle_${activeCycle}`, "rework_request.md");
+  const reworkRequest = await readTextIfExists(reworkRequestPath);
+  const agentDecisionsPath = path.join(paths.sessionRoot, "agent_decisions.md");
+  const agentDecisionsText = await readTextIfExists(agentDecisionsPath);
   const fineTuningPrompt = await renderPrompt(paths, "fine_tune_plan.md", {
+    agent_decisions_file: agentDecisionsPath,
+    agent_decisions_text: agentDecisionsText,
+    active_cycle: activeCycle,
     issue_file: path.join(paths.sessionRoot, "issue.md"),
     issue_number: issueNumber,
     issue_title: issueTitle,
     issue_url: issueUrl,
+    plan_details_file: planDetailsPath,
+    plan_details_text: planDetails,
     plan_file: planPath,
     plan_text: planText,
+    rework_request: reworkRequest,
+    rework_request_file: reworkRequest ? reworkRequestPath : "",
     worktree: paths.worktree
   });
   await writePromptArtifact(paths, "plan_fine_tuning.md", fineTuningPrompt);
@@ -831,11 +1305,79 @@ async function changedFilesFromLastCommit(paths) {
   return result.stdout.split(/\r?\n/u).map((line) => line.trim()).filter(Boolean).join("\n");
 }
 
-async function renderReviewPrompt(paths) {
-  const prompt = await renderPrompt(paths, "review_changes.md", {
-    changed_files: await changedFilesFromLastCommit(paths)
+async function changedFilesSinceBase(paths) {
+  const baseCommit = await readTrimmedFile(path.join(paths.sessionRoot, "base_commit"));
+  const args = baseCommit
+    ? ["diff", "--name-only", `${baseCommit}..HEAD`]
+    : ["show", "--name-only", "--format=", "HEAD"];
+  const result = await runGitInWorktree(paths.worktree, args, {
+    timeout: 15000
   });
+  if (!result.ok) {
+    return "";
+  }
+  return result.stdout.split(/\r?\n/u).map((line) => line.trim()).filter(Boolean).join("\n");
+}
+
+function nextReviewPassNumber(pass = "") {
+  const current = Number.parseInt(normalizeReviewPassNumber(pass), 10);
+  return String(current + 1).padStart(3, "0");
+}
+
+async function readCurrentReviewPass(paths) {
+  return normalizeReviewPassNumber(await readTrimmedFile(path.join(paths.sessionRoot, "review_passes", "current_pass")));
+}
+
+async function writeCurrentReviewPass(paths, pass) {
+  await writeTextFile(path.join(paths.sessionRoot, "review_passes", "current_pass"), `${normalizeReviewPassNumber(pass)}\n`);
+}
+
+async function resolveReviewPassForPrompt(paths) {
+  const passes = await readReviewPasses(paths);
+  const latestPass = passes.at(-1);
+  if (!latestPass) {
+    return "001";
+  }
+  if (!["committed", "no_changes"].includes(latestPass.status)) {
+    return latestPass.pass;
+  }
+  const nextPass = nextReviewPassNumber(latestPass.pass);
+  return Number.parseInt(nextPass, 10) > REVIEW_PASS_LIMIT ? latestPass.pass : nextPass;
+}
+
+async function writeReviewPassJson(paths, pass, fileName, payload) {
+  const root = reviewPassRoot(paths, pass);
+  await mkdir(root, { recursive: true });
+  await writeTextFile(path.join(root, fileName), `${JSON.stringify(payload, null, 2)}\n`);
+}
+
+async function currentHead(paths) {
+  const result = await runGitInWorktree(paths.worktree, ["rev-parse", "HEAD"], {
+    timeout: 15000
+  });
+  return result.ok ? result.stdout.trim() : "";
+}
+
+async function renderReviewPrompt(paths) {
+  const reviewPass = await resolveReviewPassForPrompt(paths);
+  await writeCurrentReviewPass(paths, reviewPass);
+  const prompt = await renderPrompt(paths, "review_changes.md", {
+    changed_files: await changedFilesFromLastCommit(paths),
+    review_pass_limit: String(REVIEW_PASS_LIMIT),
+    review_pass_number: reviewPass
+  });
+  const passRoot = reviewPassRoot(paths, reviewPass);
   await writePromptArtifact(paths, "review.md", prompt);
+  await mkdir(passRoot, { recursive: true });
+  await writeTextFile(path.join(passRoot, "prompt.md"), prompt);
+  await writeReviewPassJson(paths, reviewPass, "prompt.json", {
+    changedFiles: (await changedFilesFromLastCommit(paths)).split(/\r?\n/u).filter(Boolean),
+    maxPasses: REVIEW_PASS_LIMIT,
+    pass: reviewPass,
+    promptPath: path.join(passRoot, "prompt.md"),
+    status: "prompted",
+    startedAt: timestampForReceipt()
+  });
   await writeReceipt(paths, "review_prompt_rendered", "Started code review.");
   await markStatus(paths, SESSION_STATUS.WAITING_FOR_USER);
   return buildSessionResponse(paths, {
@@ -845,7 +1387,7 @@ async function renderReviewPrompt(paths) {
   });
 }
 
-async function acceptReviewChanges(paths) {
+async function acceptReviewChanges(paths, options = {}) {
   const status = await worktreeStatus(paths.worktree);
   if (!status.ok) {
     return failSession(paths, {
@@ -857,6 +1399,18 @@ async function acceptReviewChanges(paths) {
   const message = status.changedFiles.length > 0
     ? `Accepted ${status.changedFiles.length} review changed file entries for commit.`
     : "Accepted review with no file changes.";
+  const reviewPass = await readCurrentReviewPass(paths);
+  const findingsRemaining = options.reviewFindingsRemaining === true ||
+    normalizeText(options["review-findings-remaining"]).toLowerCase() === "true";
+  const remainingFindings = normalizeText(options.reviewFindings || options["review-findings"]);
+  await writeReviewPassJson(paths, reviewPass, "accepted.json", {
+    acceptedAt: timestampForReceipt(),
+    changedFiles: status.changedFiles,
+    findingsRemaining,
+    remainingFindings,
+    pass: reviewPass,
+    status: status.changedFiles.length > 0 ? "accepted_with_changes" : "accepted_no_changes"
+  });
   await writeReceipt(paths, "review_changes_accepted", message);
   await markStatus(paths, SESSION_STATUS.RUNNING);
   return buildSessionResponse(paths);
@@ -877,9 +1431,300 @@ async function commitReviewChanges(paths) {
   const message = result.changedFiles?.length
     ? "Committed review changes."
     : "No review changes detected.";
+  const reviewPass = await readCurrentReviewPass(paths);
+  await writeReviewPassJson(paths, reviewPass, "committed.json", {
+    changedFiles: result.changedFiles || [],
+    commit: result.changedFiles?.length ? await currentHead(paths) : "",
+    committedAt: timestampForReceipt(),
+    pass: reviewPass,
+    status: result.changedFiles?.length ? "committed" : "no_changes"
+  });
   await writeReceipt(paths, "review_changes_committed", message);
   await markStatus(paths, SESSION_STATUS.RUNNING);
   return buildSessionResponse(paths);
+}
+
+async function runAutomatedChecks(paths, {
+  stepId,
+  label
+}) {
+  const repairCommitFailure = await maybeCommitCheckRepair(paths, {
+    label,
+    stepId
+  });
+  if (repairCommitFailure) {
+    return repairCommitFailure;
+  }
+  const [command, args] = await doctorCommandForWorktree(paths.worktree);
+  const result = await runLoggedCommand(paths, stepId, command, args, {
+    cwd: paths.worktree,
+    timeout: 1000 * 60 * 15
+  });
+  const checksRoot = path.join(paths.sessionRoot, "checks");
+  await mkdir(checksRoot, { recursive: true });
+  await writeTextFile(path.join(checksRoot, `${stepId}.log`), result.output);
+  await writeTextFile(
+    path.join(checksRoot, `${stepId}.json`),
+    `${JSON.stringify({
+      command: [command, ...args].join(" "),
+      exitCode: result.exitCode,
+      ok: result.ok === true,
+      stepId
+    }, null, 2)}\n`
+  );
+  if (!result.ok) {
+    const prompt = await renderPrompt(paths, "doctor_failure.md", {
+      doctor_output: result.output
+    });
+    await writePromptArtifact(paths, `${stepId}_failure.md`, prompt);
+    return failSession(paths, {
+      code: `${stepId}_failed`,
+      message: `${label} failed. Paste the repair prompt into Codex, then rerun this step.`,
+      repairCommand: `${command} ${args.join(" ")}`,
+      prompt
+    });
+  }
+  await writeReceipt(paths, stepId, `${label} passed: ${command} ${args.join(" ")}.`);
+  await markStatus(paths, SESSION_STATUS.RUNNING);
+  return buildSessionResponse(paths);
+}
+
+async function readCheckResult(paths, stepId) {
+  return parseJsonObject(await readTextIfExists(path.join(paths.sessionRoot, "checks", `${stepId}.json`)));
+}
+
+async function maybeCommitCheckRepair(paths, {
+  label,
+  stepId
+}) {
+  const previousResult = await readCheckResult(paths, stepId);
+  if (!previousResult || previousResult.ok !== false) {
+    return null;
+  }
+  const status = await worktreeStatus(paths.worktree);
+  if (!status.ok) {
+    return failSession(paths, {
+      code: "git_status_failed",
+      message: status.output || "Failed to inspect check repair changes.",
+      repairCommand: `git -C ${paths.worktree} status --short`
+    });
+  }
+  if (status.changedFiles.length < 1) {
+    return null;
+  }
+  const result = await commitWorktree(paths, {
+    message: `${label} repairs for ${paths.sessionId}`
+  });
+  if (!result.ok) {
+    return failSession(paths, {
+      code: "check_repair_commit_failed",
+      message: result.output || `Failed to commit ${label} repair changes.`,
+      repairCommand: `git -C ${paths.worktree} status --short`
+    });
+  }
+  await writeTextFile(path.join(paths.sessionRoot, "checks", `${stepId}_repair_commit.json`), `${JSON.stringify({
+    changedFiles: result.changedFiles || [],
+    commit: await currentHead(paths),
+    committedAt: timestampForReceipt(),
+    ok: true,
+    stepId
+  }, null, 2)}\n`);
+  return null;
+}
+
+function uiCheckAcceptStepId(stepId) {
+  return stepId === "deep_ui_recheck_run"
+    ? "deep_ui_recheck_changes_accepted"
+    : "deep_ui_check_changes_accepted";
+}
+
+function uiCheckCommitStepId(stepId) {
+  return stepId === "deep_ui_recheck_run"
+    ? "deep_ui_recheck_changes_committed"
+    : "deep_ui_check_changes_committed";
+}
+
+function uiCheckSourceStepId(stepId) {
+  if (stepId === "deep_ui_recheck_changes_accepted" || stepId === "deep_ui_recheck_changes_committed") {
+    return "deep_ui_recheck_run";
+  }
+  return "deep_ui_check_run";
+}
+
+function uiCheckLabelForStep(stepId) {
+  return stepId === "deep_ui_recheck_run" ? "Deep UI re-check" : "Deep UI check";
+}
+
+async function writeUiCheckJson(paths, fileName, payload) {
+  const uiChecksRoot = path.join(paths.sessionRoot, "ui_checks");
+  await mkdir(uiChecksRoot, { recursive: true });
+  await writeTextFile(path.join(uiChecksRoot, `${fileName}.json`), `${JSON.stringify(payload, null, 2)}\n`);
+}
+
+async function runDeepUiCheck(paths, {
+  stepId,
+  label,
+  phase
+}, options = {}, context = {}) {
+  const preconditions = context.preconditions || [];
+  const issueMetadata = await readIssueMetadata(paths);
+  const uiImpact = normalizeUiImpact(issueMetadata.uiImpact) || "unknown";
+  const skipRequested = options.skipUiCheck === true || normalizeText(options["skip-ui-check"]).toLowerCase() === "true";
+  const skipReason = normalizeText(options.skipReason || options["skip-reason"]);
+  const shouldSkip = uiImpact === "none" || skipRequested;
+  if (shouldSkip) {
+    if (skipRequested && uiImpact !== "possible") {
+      return failSession(paths, {
+        code: "ui_check_skip_not_allowed",
+        message: `Deep UI check can only be manually skipped when uiImpact is possible. Current uiImpact is ${uiImpact}.`,
+        repairCommand: `jskit session ${paths.sessionId} step`,
+        preconditions
+      });
+    }
+    if (skipRequested && !skipReason) {
+      return failSession(paths, {
+        code: "ui_check_skip_reason_required",
+        message: "Skipping a possible Deep UI check requires --skip-reason.",
+        repairCommand: `jskit session ${paths.sessionId} step --skip-ui-check --skip-reason "<reason>"`,
+        preconditions
+      });
+    }
+    const reason = uiImpact === "none" ? "uiImpact is none." : skipReason;
+    await writeUiCheckJson(paths, stepId, {
+      ok: true,
+      phase,
+      reason,
+      status: "skipped",
+      stepId,
+      uiImpact
+    });
+    await writeUiCheckJson(paths, uiCheckAcceptStepId(stepId), {
+      ok: true,
+      phase,
+      reason,
+      sourceStepId: stepId,
+      status: "skipped",
+      stepId: uiCheckAcceptStepId(stepId),
+      uiImpact
+    });
+    await writeUiCheckJson(paths, uiCheckCommitStepId(stepId), {
+      ok: true,
+      phase,
+      reason,
+      sourceStepId: stepId,
+      status: "skipped",
+      stepId: uiCheckCommitStepId(stepId),
+      uiImpact
+    });
+    await writeReceipt(paths, stepId, `${label} skipped: ${reason}`);
+    await writeReceipt(paths, uiCheckAcceptStepId(stepId), `${label} changes skipped: ${reason}`);
+    await writeReceipt(paths, uiCheckCommitStepId(stepId), `${label} commit skipped: ${reason}`);
+    await markStatus(paths, SESSION_STATUS.RUNNING);
+    return buildSessionResponse(paths, {
+      preconditions
+    });
+  }
+
+  const issueUrl = await readTrimmedFile(path.join(paths.sessionRoot, "issue_url"));
+  const issueText = await readTrimmedFile(path.join(paths.sessionRoot, "issue.md"));
+  const issueTitle = await readTrimmedFile(path.join(paths.sessionRoot, "issue_title")) || titleFromIssue(issueText);
+  const prompt = await renderPrompt(paths, "deep_ui_check.md", {
+    changed_files: await changedFilesSinceBase(paths),
+    issue_file: path.join(paths.sessionRoot, "issue.md"),
+    issue_number: issueNumberFromUrl(issueUrl),
+    issue_title: issueTitle,
+    issue_url: issueUrl,
+    phase,
+    plan_details_file: path.join(paths.sessionRoot, "plan_details.md"),
+    plan_file: path.join(paths.sessionRoot, "plan.md"),
+    ui_impact: uiImpact,
+    worktree: paths.worktree
+  });
+  await writePromptArtifact(paths, `${stepId}.md`, prompt);
+  await writeUiCheckJson(paths, stepId, {
+    ok: true,
+    phase,
+    promptPath: path.join(paths.sessionRoot, "prompts", `${stepId}.md`),
+    status: "prompted",
+    stepId,
+    uiImpact
+  });
+  await writeReceipt(paths, stepId, `${label} prompt rendered for uiImpact=${uiImpact}.`);
+  await markStatus(paths, SESSION_STATUS.WAITING_FOR_USER);
+  return buildSessionResponse(paths, {
+    codex: DEEP_UI_CHECK_CODEX_HANDOFF,
+    preconditions,
+    prompt,
+    status: SESSION_STATUS.WAITING_FOR_USER
+  });
+}
+
+async function acceptUiCheckChanges(paths, {
+  stepId
+}, _options = {}, context = {}) {
+  const preconditions = context.preconditions || [];
+  const sourceStepId = uiCheckSourceStepId(stepId);
+  const status = await worktreeStatus(paths.worktree);
+  if (!status.ok) {
+    return failSession(paths, {
+      code: "git_status_failed",
+      message: status.output || "Failed to inspect Deep UI changes.",
+      repairCommand: `git -C ${paths.worktree} status --short`,
+      preconditions
+    });
+  }
+  const label = uiCheckLabelForStep(sourceStepId);
+  await writeUiCheckJson(paths, stepId, {
+    acceptedAt: timestampForReceipt(),
+    changedFiles: status.changedFiles,
+    ok: true,
+    sourceStepId,
+    status: status.changedFiles.length > 0 ? "accepted_with_changes" : "accepted_no_changes",
+    stepId
+  });
+  await writeReceipt(paths, stepId, status.changedFiles.length > 0
+    ? `Accepted ${status.changedFiles.length} ${label} changed file entries for commit.`
+    : `Accepted ${label} with no file changes.`);
+  await markStatus(paths, SESSION_STATUS.RUNNING);
+  return buildSessionResponse(paths, {
+    preconditions
+  });
+}
+
+async function commitUiCheckChanges(paths, {
+  stepId
+}, _options = {}, context = {}) {
+  const preconditions = context.preconditions || [];
+  const sourceStepId = uiCheckSourceStepId(stepId);
+  const label = uiCheckLabelForStep(sourceStepId);
+  const result = await commitWorktree(paths, {
+    allowNoChanges: true,
+    message: `${label} fixes for ${paths.sessionId}`
+  });
+  if (!result.ok) {
+    return failSession(paths, {
+      code: "deep_ui_commit_failed",
+      message: result.output || `Failed to commit ${label} changes.`,
+      repairCommand: `git -C ${paths.worktree} status --short`,
+      preconditions
+    });
+  }
+  await writeUiCheckJson(paths, stepId, {
+    changedFiles: result.changedFiles || [],
+    commit: result.changedFiles?.length ? await currentHead(paths) : "",
+    committedAt: timestampForReceipt(),
+    ok: true,
+    sourceStepId,
+    status: result.changedFiles?.length ? "committed" : "no_changes",
+    stepId
+  });
+  await writeReceipt(paths, stepId, result.changedFiles?.length
+    ? `Committed ${label} changes.`
+    : `${label} needed no file changes.`);
+  await markStatus(paths, SESSION_STATUS.RUNNING);
+  return buildSessionResponse(paths, {
+    preconditions
+  });
 }
 
 async function userCheck(paths, options = {}) {
@@ -890,18 +1735,145 @@ async function userCheck(paths, options = {}) {
     return buildSessionResponse(paths);
   }
   if (result === "failed" || result === "fail" || result === "no") {
-    return failSession(paths, {
-      code: "user_check_failed",
-      message: "User check was reported as failed. Continue in Codex, then retry this step with --user-check passed.",
-      repairCommand: `jskit session ${paths.sessionId} step --user-check passed`
+    const activeCycle = await readActiveCycle(paths);
+    await writeCycleReceipt(paths, "user_check_failed", "User reported that manual verification failed.", {
+      cycle: activeCycle
     });
+    const reworkNotes = normalizeText(options.reworkNotes || options["rework-notes"]);
+    if (!reworkNotes) {
+      await markStatus(paths, SESSION_STATUS.BLOCKED);
+      return buildSessionResponse(paths, {
+        ok: false,
+        errors: [
+          createError({
+            code: "user_check_failed",
+            message: "User check failed. Provide rework notes to start a new Plan fine tuning cycle.",
+            repairCommand: `jskit session ${paths.sessionId} step --user-check failed --rework-notes -`
+          })
+        ],
+        status: SESSION_STATUS.BLOCKED
+      });
+    }
+    const nextCycle = nextCycleNumber(activeCycle);
+    await writeTextFile(path.join(paths.sessionRoot, "cycles", `cycle_${nextCycle}`, "rework_request.md"), `${reworkNotes}\n`);
+    await writeActiveCycle(paths, nextCycle);
+    await writeCycleReceipt(paths, "cycle_started", `Started rework cycle ${nextCycle}.`, {
+      cycle: nextCycle
+    });
+    await markCurrentStep(paths, "plan_fine_tuning");
+    await markStatus(paths, SESSION_STATUS.RUNNING);
+    return buildSessionResponse(paths);
   }
-  const prompt = await renderPrompt(paths, "user_check.md");
+  const issueText = await readTrimmedFile(path.join(paths.sessionRoot, "issue.md"));
+  const issueUrl = await readTrimmedFile(path.join(paths.sessionRoot, "issue_url"));
+  const issueTitle = await readTrimmedFile(path.join(paths.sessionRoot, "issue_title")) || titleFromIssue(issueText);
+  const prompt = await renderPrompt(paths, "user_check.md", {
+    issue_file: path.join(paths.sessionRoot, "issue.md"),
+    issue_title: issueTitle,
+    issue_url: issueUrl,
+    plan_details_file: path.join(paths.sessionRoot, "plan_details.md"),
+    plan_details_text: await readTrimmedFile(path.join(paths.sessionRoot, "plan_details.md")),
+    plan_file: path.join(paths.sessionRoot, "plan.md"),
+    plan_text: await readTrimmedFile(path.join(paths.sessionRoot, "plan.md"))
+  });
   await writePromptArtifact(paths, "user_check.md", prompt);
   await markStatus(paths, SESSION_STATUS.WAITING_FOR_USER);
   return buildSessionResponse(paths, {
     prompt,
     status: SESSION_STATUS.WAITING_FOR_USER
+  });
+}
+
+async function updateBlueprint(paths, options = {}, context = {}) {
+  const preconditions = context.preconditions || [];
+  const blueprintSource = normalizeText(options.blueprint);
+  const issueText = await readTrimmedFile(path.join(paths.sessionRoot, "issue.md"));
+  const issueTitle = await readTrimmedFile(path.join(paths.sessionRoot, "issue_title")) || titleFromIssue(issueText);
+  const issueUrl = await readTrimmedFile(path.join(paths.sessionRoot, "issue_url"));
+  const issueNumber = issueNumberFromUrl(issueUrl);
+  const planPath = path.join(paths.sessionRoot, "plan.md");
+  const planDetailsPath = path.join(paths.sessionRoot, "plan_details.md");
+  const agentDecisionsPath = path.join(paths.sessionRoot, "agent_decisions.md");
+  const blueprintPath = path.join(paths.worktree, ".jskit", "APP_BLUEPRINT.md");
+
+  if (!blueprintSource) {
+    const prompt = await renderPrompt(paths, "update_blueprint.md", {
+      agent_decisions_file: agentDecisionsPath,
+      app_blueprint_file: blueprintPath,
+      changed_files: await changedFilesSinceBase(paths),
+      issue_file: path.join(paths.sessionRoot, "issue.md"),
+      issue_number: issueNumber,
+      issue_title: issueTitle,
+      issue_url: issueUrl,
+      plan_details_file: planDetailsPath,
+      plan_file: planPath,
+      worktree: paths.worktree
+    });
+    await writePromptArtifact(paths, "update_blueprint.md", prompt);
+    await markStatus(paths, SESSION_STATUS.WAITING_FOR_USER);
+    return buildSessionResponse(paths, {
+      codex: BLUEPRINT_CODEX_HANDOFF,
+      ok: true,
+      preconditions,
+      prompt,
+      status: SESSION_STATUS.WAITING_FOR_USER
+    });
+  }
+
+  const blueprintText = extractAppBlueprintText(blueprintSource);
+  if (!blueprintText) {
+    return failSession(paths, {
+      code: "app_blueprint_required",
+      message: "The blueprint step requires [app_blueprint]...[/app_blueprint] output.",
+      repairCommand: `jskit session ${paths.sessionId} step --blueprint -`,
+      preconditions
+    });
+  }
+
+  const before = await readTextIfExists(blueprintPath);
+  const result = await writeAppBlueprint({
+    appBlueprint: blueprintSource,
+    targetRoot: paths.worktree
+  });
+  if (!result.ok) {
+    return failSession(paths, {
+      code: result.errors?.[0]?.code || "app_blueprint_write_failed",
+      message: result.errors?.[0]?.message || "Failed to write app blueprint.",
+      repairCommand: result.errors?.[0]?.repairCommand || `jskit session ${paths.sessionId} step --blueprint -`,
+      preconditions
+    });
+  }
+  await appendAgentDecisions(paths, extractAgentDecisions(blueprintSource));
+  if (before.trim() !== blueprintText.trim()) {
+    const addResult = await runGitInWorktree(paths.worktree, ["add", ".jskit/APP_BLUEPRINT.md"], {
+      timeout: 15000
+    });
+    if (!addResult.ok) {
+      return failSession(paths, {
+        code: "blueprint_stage_failed",
+        message: addResult.output || "Failed to stage app blueprint update.",
+        repairCommand: `git -C ${paths.worktree} add .jskit/APP_BLUEPRINT.md`,
+        preconditions
+      });
+    }
+    const commitResult = await runGitInWorktree(paths.worktree, ["commit", "-m", `Update app blueprint for ${paths.sessionId}`], {
+      timeout: 1000 * 60
+    });
+    if (!commitResult.ok) {
+      return failSession(paths, {
+        code: "blueprint_commit_failed",
+        message: commitResult.output || "Failed to commit app blueprint update.",
+        repairCommand: `git -C ${paths.worktree} status --short`,
+        preconditions
+      });
+    }
+    await writeReceipt(paths, "blueprint_updated", "Updated and committed app blueprint.");
+  } else {
+    await writeReceipt(paths, "blueprint_updated", "App blueprint already up to date.");
+  }
+  await markStatus(paths, SESSION_STATUS.RUNNING);
+  return buildSessionResponse(paths, {
+    preconditions
   });
 }
 
@@ -926,8 +1898,12 @@ async function doctorCommandForWorktree(worktree) {
 }
 
 async function runDoctor(paths) {
+  const repairCommitFailure = await maybeCommitDoctorRepair(paths);
+  if (repairCommitFailure) {
+    return repairCommitFailure;
+  }
   const [command, args] = await doctorCommandForWorktree(paths.worktree);
-  const result = await runCommand(command, args, {
+  const result = await runLoggedCommand(paths, "doctor_run", command, args, {
     cwd: paths.worktree,
     timeout: 1000 * 60 * 15
   });
@@ -949,6 +1925,194 @@ async function runDoctor(paths) {
   return buildSessionResponse(paths);
 }
 
+async function maybeCommitDoctorRepair(paths) {
+  if (!await fileExists(path.join(paths.sessionRoot, "doctor.log")) || await fileExists(path.join(paths.sessionRoot, "steps", "doctor_run"))) {
+    return null;
+  }
+  const status = await worktreeStatus(paths.worktree);
+  if (!status.ok) {
+    return failSession(paths, {
+      code: "git_status_failed",
+      message: status.output || "Failed to inspect verification repair changes.",
+      repairCommand: `git -C ${paths.worktree} status --short`
+    });
+  }
+  if (status.changedFiles.length < 1) {
+    return null;
+  }
+  const result = await commitWorktree(paths, {
+    message: `Verification repairs for ${paths.sessionId}`
+  });
+  if (!result.ok) {
+    return failSession(paths, {
+      code: "doctor_repair_commit_failed",
+      message: result.output || "Failed to commit verification repair changes.",
+      repairCommand: `git -C ${paths.worktree} status --short`
+    });
+  }
+  await writeTextFile(path.join(paths.sessionRoot, "doctor_repair_commit.json"), `${JSON.stringify({
+    changedFiles: result.changedFiles || [],
+    commit: await currentHead(paths),
+    committedAt: timestampForReceipt(),
+    ok: true
+  }, null, 2)}\n`);
+  return null;
+}
+
+async function commitLinesSinceBase(paths) {
+  const baseCommit = await readTrimmedFile(path.join(paths.sessionRoot, "base_commit"));
+  const args = baseCommit
+    ? ["log", "--oneline", `${baseCommit}..HEAD`]
+    : ["log", "--oneline", "--max-count=10"];
+  const result = await runGitInWorktree(paths.worktree, args, {
+    timeout: 15000
+  });
+  return result.ok ? result.stdout.trim() : "";
+}
+
+async function readCheckSummaries(paths) {
+  const checksRoot = path.join(paths.sessionRoot, "checks");
+  try {
+    const entries = await readdir(checksRoot, { withFileTypes: true });
+    const summaries = [];
+    for (const entry of entries.filter((item) => item.isFile() && item.name.endsWith(".json")).sort((left, right) => left.name.localeCompare(right.name))) {
+      const source = await readTextIfExists(path.join(checksRoot, entry.name));
+      const parsed = parseJsonObject(source);
+      if (parsed) {
+        summaries.push(`- ${parsed.stepId}: ${parsed.ok ? "passed" : "failed"} (${parsed.command})`);
+      }
+    }
+    return summaries.join("\n");
+  } catch {
+    return "";
+  }
+}
+
+async function readUiCheckSummaries(paths) {
+  const uiChecksRoot = path.join(paths.sessionRoot, "ui_checks");
+  try {
+    const entries = await readdir(uiChecksRoot, { withFileTypes: true });
+    const summaries = [];
+    for (const entry of entries.filter((item) => item.isFile() && item.name.endsWith(".json")).sort((left, right) => left.name.localeCompare(right.name))) {
+      const source = await readTextIfExists(path.join(uiChecksRoot, entry.name));
+      const parsed = parseJsonObject(source);
+      if (parsed) {
+        summaries.push(`- ${parsed.stepId}: ${parsed.status || (parsed.ok ? "passed" : "failed")}${parsed.reason ? ` (${parsed.reason})` : ""}`);
+      }
+    }
+    return summaries.join("\n");
+  } catch {
+    return "";
+  }
+}
+
+async function readReviewPassSummaries(paths) {
+  const passes = await readReviewPasses(paths);
+  return passes
+    .map((entry) => {
+      const changedFiles = Array.isArray(entry.changedFiles) && entry.changedFiles.length
+        ? `; changed files: ${entry.changedFiles.join(", ")}`
+        : "";
+      const commit = entry.commit ? `; commit: ${entry.commit}` : "";
+      return `- ${entry.label}: ${entry.status}${commit}${changedFiles}`;
+    })
+    .join("\n");
+}
+
+async function createFinalReport(paths, _options = {}, context = {}) {
+  const preconditions = context.preconditions || [];
+  const issueUrl = await readTrimmedFile(path.join(paths.sessionRoot, "issue_url"));
+  const issueTitle = await readTrimmedFile(path.join(paths.sessionRoot, "issue_title"));
+  const planDetails = await readTrimmedFile(path.join(paths.sessionRoot, "plan_details.md"));
+  const planText = await readTrimmedFile(path.join(paths.sessionRoot, "plan.md"));
+  const agentDecisions = await readTextIfExists(path.join(paths.sessionRoot, "agent_decisions.md"));
+  const filesChanged = await changedFilesSinceBase(paths);
+  const commits = await commitLinesSinceBase(paths);
+  const checks = await readCheckSummaries(paths);
+  const uiChecks = await readUiCheckSummaries(paths);
+  const reviewPasses = await readReviewPassSummaries(paths);
+  const commandLogPath = path.join(paths.sessionRoot, "command_log.jsonl");
+  const blueprintStatus = await readTextIfExists(path.join(paths.sessionRoot, "steps", "blueprint_updated"));
+  const userCheck = await readTextIfExists(path.join(paths.sessionRoot, "steps", `cycle_${await readActiveCycle(paths)}`, "user_check_completed"));
+  const report = [
+    `# Final Report: ${issueTitle || paths.sessionId}`,
+    "",
+    `Issue: ${issueUrl || "(missing)"}`,
+    `Session: ${paths.sessionId}`,
+    "",
+    "## Plan Details",
+    "",
+    planDetails || "No plan details recorded.",
+    "",
+    "## Plan",
+    "",
+    planText || "No plan recorded.",
+    "",
+    "## Files Changed",
+    "",
+    filesChanged || "No changed files detected against the session base.",
+    "",
+    "## Commits",
+    "",
+    commits || "No commits detected against the session base.",
+    "",
+    "## Checks",
+    "",
+    checks || "No structured checks recorded.",
+    "",
+    "## UI Checks",
+    "",
+    uiChecks || "No structured UI checks recorded.",
+    "",
+    "## Review Passes",
+    "",
+    reviewPasses || "No structured review passes recorded.",
+    "",
+    "## Command Log",
+    "",
+    await fileExists(commandLogPath) ? commandLogPath : "No command log recorded.",
+    "",
+    "## User Check",
+    "",
+    userCheck.trim() || "No user check receipt recorded.",
+    "",
+    "## Blueprint",
+    "",
+    blueprintStatus.trim() || "No blueprint receipt recorded.",
+    "",
+    "## Remaining Unverified Gaps",
+    "",
+    "Review the check and UI check sections above; no additional gaps were recorded by JSKIT.",
+    "",
+    "## Decisions",
+    "",
+    agentDecisions.trim() || "No decision log recorded.",
+    ""
+  ].join("\n");
+  const reportPath = path.join(paths.sessionRoot, "final_report.md");
+  await writeTextFile(reportPath, report);
+  if (issueUrl) {
+    const commentResult = await commentOnIssueOnce(paths, {
+      bodyFile: reportPath,
+      issueUrl,
+      purpose: "final_report"
+    });
+    if (!commentResult.ok) {
+      return failSession(paths, {
+        code: "final_report_comment_failed",
+        message: commentResult.output || "Failed to comment final report on the GitHub issue.",
+        repairCommand: `gh issue comment ${issueUrl} --body-file ${reportPath}`,
+        preconditions
+      });
+    }
+  }
+  await writeReceipt(paths, "final_report_created", "Created final report and recorded the GitHub issue comment.");
+  await markStatus(paths, SESSION_STATUS.RUNNING);
+  return buildSessionResponse(paths, {
+    preconditions
+  });
+}
+
 function issueNumberFromUrl(issueUrl) {
   const match = /\/issues\/(\d+)(?:\b|$)/u.exec(String(issueUrl || ""));
   return match ? match[1] : "";
@@ -964,7 +2128,11 @@ function parseJsonObject(value) {
 }
 
 async function readPrState(paths, prUrl) {
-  const result = await runCommand("gh", ["pr", "view", prUrl, "--json", "state,mergedAt,url,baseRefName"], {
+  const prRef = normalizeText(prUrl);
+  const args = prRef
+    ? ["pr", "view", prRef, "--json", "state,mergedAt,url,baseRefName"]
+    : ["pr", "view", "--json", "state,mergedAt,url,baseRefName"];
+  const result = await runLoggedCommand(paths, prRef ? "github_pr_view" : "github_pr_view_current_branch", "gh", args, {
     cwd: paths.targetRoot,
     timeout: 1000 * 60
   });
@@ -981,12 +2149,38 @@ async function readPrState(paths, prUrl) {
     ok: Boolean(payload),
     output: result.output,
     state: String(payload?.state || "").toUpperCase(),
-    url: payload?.url || prUrl
+    url: payload?.url || prRef
+  };
+}
+
+async function readCurrentBranchPrState(paths) {
+  const result = await runLoggedCommand(paths, "github_pr_view_current_branch", "gh", ["pr", "view", "--json", "state,mergedAt,url,baseRefName"], {
+    cwd: paths.worktree,
+    timeout: 1000 * 60
+  });
+  if (!result.ok) {
+    return {
+      ok: false,
+      output: result.output
+    };
+  }
+  const payload = parseJsonObject(result.stdout);
+  return {
+    baseRefName: normalizeText(payload?.baseRefName),
+    mergedAt: payload?.mergedAt || "",
+    ok: Boolean(payload?.url),
+    output: result.output,
+    state: String(payload?.state || "").toUpperCase(),
+    url: payload?.url || ""
   };
 }
 
 function prStateIsMerged(prState) {
   return Boolean(prState?.ok && prState.state === "MERGED");
+}
+
+function prStateIsClosed(prState) {
+  return Boolean(prState?.ok && prState.state === "CLOSED");
 }
 
 async function currentTargetBranch(targetRoot) {
@@ -1017,6 +2211,30 @@ async function assertTargetRootCleanForBaseUpdate(paths) {
   return null;
 }
 
+async function removeSessionWorktree(paths) {
+  if (await hasWorktree(paths)) {
+    const result = await runLoggedCommand(paths, "git_worktree_remove", "git", ["worktree", "remove", paths.worktree], {
+      cwd: paths.targetRoot,
+      timeout: 1000 * 60
+    });
+    if (!result.ok) {
+      return failSession(paths, {
+        code: "worktree_remove_failed",
+        message: result.output || "Failed to remove worktree.",
+        repairCommand: `git worktree remove ${paths.worktree}`
+      });
+    }
+  }
+  return null;
+}
+
+async function writePrOutcome(paths, outcome) {
+  await writeTextFile(path.join(paths.sessionRoot, "pr_outcome.json"), `${JSON.stringify({
+    recordedAt: timestampForReceipt(),
+    ...outcome
+  }, null, 2)}\n`);
+}
+
 async function assertTargetRootCanUpdateBase(paths, branch) {
   const cleanFailure = await assertTargetRootCleanForBaseUpdate(paths);
   if (cleanFailure) {
@@ -1041,7 +2259,8 @@ async function assertTargetBaseCanFastForward(paths, branch) {
     return branchFailure;
   }
 
-  const fetchResult = await runGit(paths.targetRoot, ["fetch", "origin"], {
+  const fetchResult = await runLoggedCommand(paths, "git_fetch_origin", "git", ["fetch", "origin"], {
+    cwd: paths.targetRoot,
     timeout: 1000 * 60 * 5
   });
   if (!fetchResult.ok) {
@@ -1104,7 +2323,8 @@ async function updateLocalBaseBranch(paths, baseBranch = "") {
     });
   }
 
-  const pullResult = await runGit(paths.targetRoot, ["pull", "--ff-only", "origin", branch], {
+  const pullResult = await runLoggedCommand(paths, "git_pull_base", "git", ["pull", "--ff-only", "origin", branch], {
+    cwd: paths.targetRoot,
     timeout: 1000 * 60 * 5
   });
   if (!pullResult.ok) {
@@ -1210,7 +2430,8 @@ async function createPr(paths) {
     });
   }
 
-  const pushResult = await runGitInWorktree(paths.worktree, ["push", "-u", "origin", "HEAD"], {
+  const pushResult = await runLoggedCommand(paths, "git_push_branch", "git", ["push", "-u", "origin", "HEAD"], {
+    cwd: paths.worktree,
     timeout: 1000 * 60 * 5
   });
   if (!pushResult.ok) {
@@ -1219,6 +2440,13 @@ async function createPr(paths) {
       message: pushResult.output || "Failed to push session branch.",
       repairCommand: `git -C ${paths.worktree} push -u origin HEAD`
     });
+  }
+  const existingPrState = await readCurrentBranchPrState(paths);
+  if (existingPrState.ok && existingPrState.url && !prStateIsClosed(existingPrState)) {
+    await writeTextFile(path.join(paths.sessionRoot, "pr_url"), existingPrState.url);
+    await writeReceipt(paths, "pr_created", `Pushed branch ${paths.branch} and reused existing PR ${existingPrState.url}. ${helperMapResult.message}`);
+    await markStatus(paths, SESSION_STATUS.RUNNING);
+    return buildSessionResponse(paths);
   }
   const issueUrl = await readTrimmedFile(path.join(paths.sessionRoot, "issue_url"));
   const issueText = await readTrimmedFile(path.join(paths.sessionRoot, "issue.md"));
@@ -1231,7 +2459,7 @@ async function createPr(paths) {
   ].join("\n").trim();
   const bodyPath = path.join(paths.sessionRoot, "pr_body.md");
   await writeTextFile(bodyPath, body);
-  const result = await runCommand("gh", [
+  const result = await runLoggedCommand(paths, "github_pr_create", "gh", [
     "pr",
     "create",
     "--title",
@@ -1243,6 +2471,13 @@ async function createPr(paths) {
     timeout: 1000 * 60
   });
   if (!result.ok || !result.stdout) {
+    const fallbackPrState = await readCurrentBranchPrState(paths);
+    if (fallbackPrState.ok && fallbackPrState.url && !prStateIsClosed(fallbackPrState)) {
+      await writeTextFile(path.join(paths.sessionRoot, "pr_url"), fallbackPrState.url);
+      await writeReceipt(paths, "pr_created", `Pushed branch ${paths.branch} and reused existing PR ${fallbackPrState.url}. ${helperMapResult.message}`);
+      await markStatus(paths, SESSION_STATUS.RUNNING);
+      return buildSessionResponse(paths);
+    }
     const prompt = await renderPrompt(paths, "pr_failure.md", {
       doctor_output: result.output
     });
@@ -1261,8 +2496,73 @@ async function createPr(paths) {
   return buildSessionResponse(paths);
 }
 
-async function mergePr(paths) {
+async function closePrWithoutMerge(paths, prUrl, options = {}) {
+  const reason = normalizeText(options.closeReason || options["close-reason"]);
+  if (!reason) {
+    return failSession(paths, {
+      code: "close_without_merge_reason_required",
+      message: "Finishing without merging requires --close-reason.",
+      repairCommand: `jskit session ${paths.sessionId} step --close-without-merge --close-reason "<reason>"`
+    });
+  }
+  const prState = await readPrState(paths, prUrl);
+  if (!prState.ok) {
+    return failSession(paths, {
+      code: "pr_state_failed",
+      message: prState.output || "Failed to inspect PR before closing without merge.",
+      repairCommand: `gh pr view ${prUrl} --json state,mergedAt,url,baseRefName`
+    });
+  }
+  if (prStateIsMerged(prState)) {
+    return failSession(paths, {
+      code: "pr_already_merged",
+      message: "Cannot finish without merging because the PR is already merged.",
+      repairCommand: `jskit session ${paths.sessionId} step`
+    });
+  }
+  if (!prStateIsClosed(prState)) {
+    const commentResult = await runLoggedCommand(paths, "github_pr_comment", "gh", ["pr", "comment", prUrl, "--body", `JSKIT session ${paths.sessionId} finished without merging. Reason: ${reason}`], {
+      cwd: paths.targetRoot,
+      timeout: 1000 * 60
+    });
+    if (!commentResult.ok) {
+      return failSession(paths, {
+        code: "pr_comment_failed",
+        message: commentResult.output || "Failed to comment on PR before finishing without merge.",
+        repairCommand: `gh pr comment ${prUrl} --body "<reason>"`
+      });
+    }
+  }
+  const issueUrl = await readTrimmedFile(path.join(paths.sessionRoot, "issue_url"));
+  if (issueUrl) {
+    await runLoggedCommand(paths, "github_issue_comment", "gh", ["issue", "comment", issueUrl, "--body", `JSKIT session ${paths.sessionId} finished without merging PR ${prUrl}. Reason: ${reason}`], {
+      cwd: paths.targetRoot,
+      timeout: 1000 * 60
+    });
+  }
+  const removeFailure = await removeSessionWorktree(paths);
+  if (removeFailure) {
+    return removeFailure;
+  }
+  await writePrOutcome(paths, {
+    issueUrl,
+    outcome: "closed_without_merge",
+    prUrl,
+    prState: prState.state,
+    reason
+  });
+  await writeReceipt(paths, "pr_finalized", `Finished without merging PR ${prUrl}; PR left open and worktree removed ${paths.worktree}. Reason: ${reason}`);
+  await markStatus(paths, SESSION_STATUS.RUNNING);
+  return buildSessionResponse(paths);
+}
+
+async function finalizePr(paths, options = {}) {
   const prUrl = await readTrimmedFile(path.join(paths.sessionRoot, "pr_url"));
+  const closeWithoutMerge = options.closeWithoutMerge === true ||
+    normalizeText(options["close-without-merge"]).toLowerCase() === "true";
+  if (closeWithoutMerge) {
+    return closePrWithoutMerge(paths, prUrl, options);
+  }
   const mergeMarkerPath = path.join(paths.sessionRoot, "pr_merge_completed");
   const baseBranchPath = path.join(paths.sessionRoot, "pr_base_branch");
   const mergeAlreadyCompleted = await readTrimmedFile(mergeMarkerPath);
@@ -1280,7 +2580,7 @@ async function mergePr(paths) {
     let prMerged = prStateIsMerged(existingPrState);
     let mergeResult = null;
     if (!prMerged) {
-      mergeResult = await runCommand("gh", ["pr", "merge", prUrl, "--merge", "--delete-branch"], {
+      mergeResult = await runLoggedCommand(paths, "github_pr_merge", "gh", ["pr", "merge", prUrl, "--merge", "--delete-branch"], {
         cwd: paths.targetRoot,
         timeout: 1000 * 60 * 5
       });
@@ -1304,30 +2604,28 @@ async function mergePr(paths) {
     }
     const issueUrl = await readTrimmedFile(path.join(paths.sessionRoot, "issue_url"));
     if (issueUrl) {
-      await runCommand("gh", ["issue", "close", issueUrl, "--comment", `Merged PR ${prUrl}.`], {
+      await runLoggedCommand(paths, "github_issue_close", "gh", ["issue", "close", issueUrl, "--comment", `Merged PR ${prUrl}.`], {
         cwd: paths.targetRoot,
         timeout: 1000 * 60
       });
     }
+    await writePrOutcome(paths, {
+      baseBranch,
+      issueUrl,
+      outcome: "merged",
+      prUrl
+    });
     await writeTextFile(mergeMarkerPath, `${prUrl}\n`);
   }
   const updateFailure = await updateLocalBaseBranch(paths, baseBranch);
   if (updateFailure) {
     return updateFailure;
   }
-  if (await hasWorktree(paths)) {
-    const result = await runGit(paths.targetRoot, ["worktree", "remove", paths.worktree], {
-      timeout: 1000 * 60
-    });
-    if (!result.ok) {
-      return failSession(paths, {
-        code: "worktree_remove_failed",
-        message: result.output || "Failed to remove worktree.",
-        repairCommand: `git worktree remove ${paths.worktree}`
-      });
-    }
+  const removeFailure = await removeSessionWorktree(paths);
+  if (removeFailure) {
+    return removeFailure;
   }
-  await writeReceipt(paths, "pr_merged", `Merged PR ${prUrl}, updated local ${baseBranch || "base branch"}, and removed worktree ${paths.worktree}.`);
+  await writeReceipt(paths, "pr_finalized", `Merged PR ${prUrl}, updated local ${baseBranch || "base branch"}, and removed worktree ${paths.worktree}.`);
   await markStatus(paths, SESSION_STATUS.RUNNING);
   return buildSessionResponse(paths);
 }
@@ -1336,20 +2634,24 @@ async function finishSession(paths) {
   const prUrl = await readTrimmedFile(path.join(paths.sessionRoot, "pr_url"));
   const issueUrl = await readTrimmedFile(path.join(paths.sessionRoot, "issue_url"));
   const codexThreadId = await readTrimmedFile(path.join(paths.sessionRoot, "codex_thread_id"));
+  const prOutcome = parseJsonObject(await readTextIfExists(path.join(paths.sessionRoot, "pr_outcome.json")));
   const prompt = await renderPrompt(paths, "final_comment.md", {
     codex_thread_id: codexThreadId,
     issue_url: issueUrl,
+    pr_outcome: prOutcome?.outcome || "unknown",
+    pr_outcome_reason: prOutcome?.reason || "",
     pr_url: prUrl,
+    session_id: paths.sessionId,
     transcript_log: path.join(paths.completedSessionRoot, "transcript.log")
   });
   await writeTextFile(path.join(paths.sessionRoot, "final_comment.md"), prompt);
   if (issueUrl) {
-    await runCommand("gh", ["issue", "comment", issueUrl, "--body-file", path.join(paths.sessionRoot, "final_comment.md")], {
+    await runLoggedCommand(paths, "github_issue_comment", "gh", ["issue", "comment", issueUrl, "--body-file", path.join(paths.sessionRoot, "final_comment.md")], {
       cwd: paths.targetRoot,
       timeout: 1000 * 60
     });
   }
-  await writeReceipt(paths, "session_finished", `Finished session ${paths.sessionId}.`);
+  await writeReceipt(paths, "session_finished", `Finished session ${paths.sessionId} with PR outcome ${prOutcome?.outcome || "unknown"}.`);
   await markStatus(paths, SESSION_STATUS.FINISHED);
   await markCurrentStep(paths, "");
   const archivedPaths = await archiveSession(paths, "completed");
@@ -1364,30 +2666,76 @@ const STEP_RUNNERS = Object.freeze({
   issue_prompt_rendered: renderIssuePrompt,
   issue_drafted: draftIssue,
   issue_created: createIssue,
+  plan_details_prompt_rendered: renderPlanDetailsPrompt,
+  plan_details_gathered: savePlanDetails,
   plan_made: makePlan,
   plan_executed: renderPlanExecutionPrompt,
   plan_fine_tuning: renderPlanFineTuningPrompt,
   implementation_changes_accepted: acceptImplementationChanges,
   implementation_changes_committed: commitImplementation,
+  pre_review_checks_run: (paths) => runAutomatedChecks(paths, {
+    label: "Pre-review checks",
+    stepId: "pre_review_checks_run"
+  }),
+  deep_ui_check_run: (paths, options, context) => runDeepUiCheck(paths, {
+    label: "Deep UI check",
+    phase: "pre_review",
+    stepId: "deep_ui_check_run"
+  }, options, context),
+  deep_ui_check_changes_accepted: (paths, options, context) => acceptUiCheckChanges(paths, {
+    stepId: "deep_ui_check_changes_accepted"
+  }, options, context),
+  deep_ui_check_changes_committed: (paths, options, context) => commitUiCheckChanges(paths, {
+    stepId: "deep_ui_check_changes_committed"
+  }, options, context),
   review_prompt_rendered: renderReviewPrompt,
   review_changes_accepted: acceptReviewChanges,
   review_changes_committed: commitReviewChanges,
+  post_review_checks_run: (paths) => runAutomatedChecks(paths, {
+    label: "Post-review checks",
+    stepId: "post_review_checks_run"
+  }),
+  deep_ui_recheck_run: (paths, options, context) => runDeepUiCheck(paths, {
+    label: "Deep UI re-check",
+    phase: "post_review",
+    stepId: "deep_ui_recheck_run"
+  }, options, context),
+  deep_ui_recheck_changes_accepted: (paths, options, context) => acceptUiCheckChanges(paths, {
+    stepId: "deep_ui_recheck_changes_accepted"
+  }, options, context),
+  deep_ui_recheck_changes_committed: (paths, options, context) => commitUiCheckChanges(paths, {
+    stepId: "deep_ui_recheck_changes_committed"
+  }, options, context),
   user_check_completed: userCheck,
+  blueprint_updated: updateBlueprint,
   doctor_run: runDoctor,
+  final_report_created: createFinalReport,
   pr_created: createPr,
-  pr_merged: mergePr,
+  pr_finalized: finalizePr,
   session_finished: finishSession
 });
 
 const PRECONDITION_RUNNERS = Object.freeze({
+  active_cycle_exists: assertActiveCycleExists,
+  active_cycle_user_check_passed: assertActiveCycleUserCheckPassed,
+  blueprint_update_satisfied: assertBlueprintUpdateSatisfied,
+  deep_ui_check_satisfied: assertDeepUiCheckSatisfied,
+  deep_ui_recheck_satisfied: assertDeepUiRecheckSatisfied,
+  dependencies_installed: assertDependenciesInstalled,
+  final_report_exists: assertFinalReportExists,
   git_current_branch: (paths) => assertGitCurrentBranch(paths.targetRoot),
   git_repository: (paths) => assertGitRepository(paths.targetRoot),
   github_auth: (paths) => assertGhAuth(paths.targetRoot),
   github_origin: (paths) => assertGithubOrigin(paths.targetRoot),
+  issue_metadata_exists: assertIssueMetadataExists,
   issue_text_exists: assertIssueTextExists,
   issue_url_exists: assertIssueUrlExists,
+  post_review_checks_passed: assertPostReviewChecksPassed,
+  pre_review_checks_passed: assertPreReviewChecksPassed,
+  plan_details_exists: assertPlanDetailsExists,
   plan_text_exists: assertPlanTextExists,
   pr_url_exists: assertPrUrlExists,
+  ready_jskit_app: assertReadyJskitApp,
   session_exists: assertSessionExists,
   worktree_exists: assertWorktreeExists
 });
@@ -1412,6 +2760,18 @@ async function runSessionStep({
       return buildSessionResponse(paths, {
         ok: true,
         status: artifacts.status
+      });
+    }
+    if (artifacts.workflowVersion !== SESSION_WORKFLOW_VERSION) {
+      return buildSessionResponse(paths, {
+        ok: false,
+        errors: [
+          createError({
+            code: "unsupported_workflow_version",
+            message: `Session ${paths.sessionId} uses workflow version ${artifacts.workflowVersion || "unknown"}, but this JSKIT runtime expects ${SESSION_WORKFLOW_VERSION}.`
+          })
+        ],
+        status: SESSION_STATUS.BLOCKED
       });
     }
     const nextStep = artifacts.nextStep;
@@ -1440,6 +2800,7 @@ async function runSessionStep({
         preconditions: stepPreconditions.preconditions
       });
     }
+    await appendAgentDecisionsInput(paths, options);
     return runner(paths, options, {
       preconditions: stepPreconditions.preconditions
     });
@@ -1459,7 +2820,7 @@ async function abandonSession({
     }
     const issueUrl = await readTrimmedFile(path.join(paths.sessionRoot, "issue_url"));
     if (issueUrl) {
-      const closeIssueResult = await runCommand("gh", ["issue", "close", issueUrl, "--comment", `Abandoned JSKIT Studio session ${paths.sessionId}.`], {
+      const closeIssueResult = await runLoggedCommand(paths, "github_issue_close", "gh", ["issue", "close", issueUrl, "--comment", `Abandoned JSKIT Studio session ${paths.sessionId}.`], {
         cwd: paths.targetRoot,
         timeout: 1000 * 60
       });
@@ -1473,7 +2834,8 @@ async function abandonSession({
       }
     }
     if (await hasWorktree(paths)) {
-      await runGit(paths.targetRoot, ["worktree", "remove", "--force", paths.worktree], {
+      await runLoggedCommand(paths, "git_worktree_remove", "git", ["worktree", "remove", "--force", paths.worktree], {
+        cwd: paths.targetRoot,
         timeout: 1000 * 60
       });
     }
@@ -1536,6 +2898,7 @@ export {
   createSessionId,
   extractIssueTitle,
   extractIssueText,
+  extractPlanDetails,
   extractPlanText,
   inspectSession,
   inspectSessionDiff,

--- a/tooling/jskit-cli/src/server/sessionRuntime/appReadiness.js
+++ b/tooling/jskit-cli/src/server/sessionRuntime/appReadiness.js
@@ -1,0 +1,55 @@
+import { access, stat } from "node:fs/promises";
+import { constants as fsConstants } from "node:fs";
+import path from "node:path";
+
+const REQUIRED_READY_FILES = Object.freeze([
+  "package.json",
+  ".jskit/lock.json",
+  "config/public.js"
+]);
+const REQUIRED_READY_DIRECTORIES = Object.freeze([
+  "src",
+  "packages"
+]);
+
+async function pathExists(filePath) {
+  try {
+    await access(filePath, fsConstants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function directoryExists(filePath) {
+  try {
+    return (await stat(filePath)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+async function inspectReadyJskitAppRoot(rootPath) {
+  const missing = [];
+  for (const relativePath of REQUIRED_READY_FILES) {
+    if (!await pathExists(path.join(rootPath, relativePath))) {
+      missing.push(relativePath);
+    }
+  }
+  for (const relativePath of REQUIRED_READY_DIRECTORIES) {
+    if (!await directoryExists(path.join(rootPath, relativePath))) {
+      missing.push(`${relativePath}/`);
+    }
+  }
+  return {
+    missing,
+    ok: missing.length < 1,
+    requiredDirectories: [...REQUIRED_READY_DIRECTORIES],
+    requiredFiles: [...REQUIRED_READY_FILES],
+    rootPath
+  };
+}
+
+export {
+  inspectReadyJskitAppRoot
+};

--- a/tooling/jskit-cli/src/server/sessionRuntime/constants.js
+++ b/tooling/jskit-cli/src/server/sessionRuntime/constants.js
@@ -13,6 +13,8 @@ const SESSION_STATUS = Object.freeze({
 
 const SESSION_ID_PATTERN = /^\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}(?:-[a-z0-9]{4})?$/u;
 const SESSION_STATE_RELATIVE_PATH = ".jskit/sessions";
+const SESSION_WORKFLOW_VERSION = "2";
+const REVIEW_PASS_LIMIT = 3;
 const PROMPT_DIRECTORY = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "prompts");
 
 const INPUT_NONE = Object.freeze({ type: "none" });
@@ -72,6 +74,54 @@ const PLAN_OUTPUT = Object.freeze({
   multiline: true,
   required: true
 });
+const BLUEPRINT_INPUT = Object.freeze({
+  extract: "app_blueprint",
+  formatHint: "markdown",
+  label: "Updated app blueprint",
+  multiline: true,
+  name: "blueprint",
+  required: true,
+  type: "text"
+});
+const BLUEPRINT_OUTPUT = Object.freeze({
+  extract: "app_blueprint",
+  field: "blueprint",
+  formatHint: "markdown",
+  label: "Updated app blueprint",
+  multiline: true,
+  required: true
+});
+const PLAN_DETAILS_INPUT = Object.freeze({
+  extract: "plan_details",
+  formatHint: "markdown",
+  label: "Confirmed implementation details",
+  multiline: true,
+  name: "planDetails",
+  required: true,
+  type: "text"
+});
+const PLAN_DETAILS_OUTPUT = Object.freeze({
+  extract: "plan_details",
+  field: "planDetails",
+  formatHint: "markdown",
+  label: "Plan details",
+  multiline: true,
+  required: true
+});
+const ISSUE_CATEGORY_OUTPUT = Object.freeze({
+  extract: "issue_category",
+  field: "issueCategory",
+  formatHint: "text",
+  label: "Issue category",
+  required: true
+});
+const UI_IMPACT_OUTPUT = Object.freeze({
+  extract: "ui_impact",
+  field: "uiImpact",
+  formatHint: "text",
+  label: "UI impact",
+  required: true
+});
 const USER_CHECK_INPUT = Object.freeze({
   label: "User check result",
   name: "userCheck",
@@ -109,6 +159,13 @@ const REVIEW_EXECUTION_CODEX_HANDOFF = codexHandoff([], {
   autoInject: true,
   promptActionLabel: "Start review"
 });
+const DEEP_UI_CHECK_CODEX_HANDOFF = codexHandoff([], {
+  autoInject: true,
+  promptActionLabel: "Run Deep UI check"
+});
+const BLUEPRINT_CODEX_HANDOFF = codexHandoff(BLUEPRINT_OUTPUT, {
+  promptActionLabel: "Update blueprint"
+});
 
 function defineStep({
   buttonLabel,
@@ -120,18 +177,24 @@ function defineStep({
   label,
   nextCommandTemplate = "jskit session {{session_id}} step",
   preconditions = [],
-  utilityActions = []
+  requiresExplicitRun = false,
+  utilityActions = [],
+  displayGroupId = "",
+  displayGroupLabel = ""
 }) {
   return Object.freeze({
     buttonLabel,
     codex,
     description,
+    displayGroupId,
+    displayGroupLabel,
     id,
     input,
     kind,
     label,
     nextCommandTemplate,
     preconditions: Object.freeze([...preconditions]),
+    requiresExplicitRun,
     utilityActions: Object.freeze([...utilityActions])
   });
 }
@@ -172,10 +235,10 @@ const STEP_DEFINITIONS = Object.freeze([
     kind: "human_input",
     label: "Initial issue prompt",
     nextCommandTemplate: "jskit session {{session_id}} step --prompt \"<what should change>\"",
-    preconditions: ["session_exists"]
+    preconditions: ["session_exists", "worktree_exists", "dependencies_installed", "ready_jskit_app"]
   }),
   defineStep({
-    buttonLabel: "Save issue draft",
+    buttonLabel: "Finalise issue",
     codex: codexHandoff([
       ISSUE_TITLE_OUTPUT,
       ISSUE_TEXT_OUTPUT
@@ -186,14 +249,50 @@ const STEP_DEFINITIONS = Object.freeze([
     kind: "codex_output",
     label: "Issue drafted",
     nextCommandTemplate: "jskit session {{session_id}} step --issue -",
-    preconditions: ["session_exists"]
+    preconditions: ["session_exists", "worktree_exists", "dependencies_installed", "ready_jskit_app"]
   }),
   defineStep({
-    buttonLabel: "Create GitHub issue",
+    buttonLabel: "Create issue",
     description: "Create the GitHub issue from the approved draft.",
     id: "issue_created",
     label: "Issue created",
-    preconditions: ["session_exists", "issue_text_exists", "github_auth", "github_origin"]
+    preconditions: ["session_exists", "worktree_exists", "dependencies_installed", "ready_jskit_app", "issue_text_exists", "github_auth", "github_origin"],
+    requiresExplicitRun: true
+  }),
+  defineStep({
+    buttonLabel: "Start details conversation",
+    codex: codexHandoff([
+      ISSUE_CATEGORY_OUTPUT,
+      UI_IMPACT_OUTPUT,
+      PLAN_DETAILS_OUTPUT
+    ], {
+      autoInject: true,
+      promptActionLabel: "Start details conversation"
+    }),
+    description: "Ask Codex to gather the missing implementation details before planning.",
+    displayGroupId: "plan_details",
+    displayGroupLabel: "Get issue details",
+    id: "plan_details_prompt_rendered",
+    kind: "codex_prompt",
+    label: "Get issue details",
+    preconditions: ["session_exists", "worktree_exists", "dependencies_installed", "ready_jskit_app", "issue_text_exists", "issue_url_exists"]
+  }),
+  defineStep({
+    buttonLabel: "Save plan details",
+    codex: codexHandoff([
+      ISSUE_CATEGORY_OUTPUT,
+      UI_IMPACT_OUTPUT,
+      PLAN_DETAILS_OUTPUT
+    ]),
+    description: "Save the confirmed implementation details and classification from Codex.",
+    displayGroupId: "plan_details",
+    displayGroupLabel: "Get issue details",
+    id: "plan_details_gathered",
+    input: PLAN_DETAILS_INPUT,
+    kind: "codex_output",
+    label: "Plan details gathered",
+    nextCommandTemplate: "jskit session {{session_id}} step --plan-details -",
+    preconditions: ["session_exists", "worktree_exists", "dependencies_installed", "ready_jskit_app", "issue_text_exists", "issue_url_exists"]
   }),
   defineStep({
     buttonLabel: "Save plan",
@@ -204,7 +303,7 @@ const STEP_DEFINITIONS = Object.freeze([
     kind: "codex_output",
     label: "Plan made",
     nextCommandTemplate: "jskit session {{session_id}} step --plan -",
-    preconditions: ["session_exists", "issue_text_exists", "issue_url_exists", "worktree_exists"]
+    preconditions: ["session_exists", "worktree_exists", "dependencies_installed", "ready_jskit_app", "issue_text_exists", "issue_url_exists", "plan_details_exists", "issue_metadata_exists"]
   }),
   defineStep({
     buttonLabel: "Get Codex to execute plan",
@@ -212,7 +311,7 @@ const STEP_DEFINITIONS = Object.freeze([
     id: "plan_executed",
     kind: "codex_prompt",
     label: "Plan executed",
-    preconditions: ["session_exists", "issue_text_exists", "issue_url_exists", "plan_text_exists", "worktree_exists"]
+    preconditions: ["session_exists", "worktree_exists", "dependencies_installed", "ready_jskit_app", "issue_text_exists", "issue_url_exists", "plan_details_exists", "issue_metadata_exists", "plan_text_exists"]
   }),
   defineStep({
     buttonLabel: "Get Codex to fine tune plan",
@@ -220,7 +319,7 @@ const STEP_DEFINITIONS = Object.freeze([
     id: "plan_fine_tuning",
     kind: "codex_prompt",
     label: "Plan fine tuning",
-    preconditions: ["session_exists", "issue_text_exists", "issue_url_exists", "plan_text_exists", "worktree_exists"]
+    preconditions: ["session_exists", "worktree_exists", "dependencies_installed", "ready_jskit_app", "issue_text_exists", "issue_url_exists", "plan_details_exists", "issue_metadata_exists", "plan_text_exists", "active_cycle_exists"]
   }),
   defineStep({
     buttonLabel: "Accept changes",
@@ -228,7 +327,7 @@ const STEP_DEFINITIONS = Object.freeze([
     id: "implementation_changes_accepted",
     kind: "user_check",
     label: "Changes accepted",
-    preconditions: ["session_exists", "worktree_exists"],
+    preconditions: ["session_exists", "worktree_exists", "dependencies_installed", "ready_jskit_app", "issue_metadata_exists", "active_cycle_exists"],
     utilityActions: Object.freeze([
       Object.freeze({
         id: "session_diff",
@@ -243,7 +342,48 @@ const STEP_DEFINITIONS = Object.freeze([
     description: "Commit the accepted implementation changes in the session worktree.",
     id: "implementation_changes_committed",
     label: "Changes committed",
-    preconditions: ["session_exists", "worktree_exists"]
+    preconditions: ["session_exists", "worktree_exists", "dependencies_installed", "ready_jskit_app", "issue_metadata_exists", "active_cycle_exists"]
+  }),
+  defineStep({
+    buttonLabel: "Run checks",
+    description: "Run automated checks before the deslop/JSKIT review pass.",
+    id: "pre_review_checks_run",
+    label: "Pre-review checks run",
+    preconditions: ["session_exists", "worktree_exists", "dependencies_installed", "ready_jskit_app", "issue_metadata_exists", "active_cycle_exists"]
+  }),
+  defineStep({
+    buttonLabel: "Run Deep UI check",
+    description: "Run or skip the focused UI quality pass before deslop/JSKIT review.",
+    id: "deep_ui_check_run",
+    label: "Deep UI check run",
+    preconditions: ["session_exists", "worktree_exists", "dependencies_installed", "ready_jskit_app", "issue_metadata_exists", "active_cycle_exists", "pre_review_checks_passed"]
+  }),
+  defineStep({
+    buttonLabel: "Accept Deep UI changes",
+    description: "Review the Deep UI Check diff and accept it as ready to commit, or record that no changes were needed.",
+    displayGroupId: "deep_ui_check",
+    displayGroupLabel: "Deep UI check",
+    id: "deep_ui_check_changes_accepted",
+    kind: "user_check",
+    label: "Deep UI changes accepted",
+    preconditions: ["session_exists", "worktree_exists", "dependencies_installed", "ready_jskit_app", "issue_metadata_exists", "active_cycle_exists", "pre_review_checks_passed"],
+    utilityActions: Object.freeze([
+      Object.freeze({
+        id: "session_diff",
+        kind: "diff",
+        label: "Review changes",
+        nextCommandTemplate: "jskit session {{session_id}} diff"
+      })
+    ])
+  }),
+  defineStep({
+    buttonLabel: "Commit Deep UI changes",
+    description: "Commit accepted Deep UI Check changes, or record that no changes were needed.",
+    displayGroupId: "deep_ui_check",
+    displayGroupLabel: "Deep UI check",
+    id: "deep_ui_check_changes_committed",
+    label: "Deep UI changes committed",
+    preconditions: ["session_exists", "worktree_exists", "dependencies_installed", "ready_jskit_app", "issue_metadata_exists", "active_cycle_exists", "pre_review_checks_passed"]
   }),
   defineStep({
     buttonLabel: "Start review",
@@ -251,7 +391,7 @@ const STEP_DEFINITIONS = Object.freeze([
     id: "review_prompt_rendered",
     kind: "codex_prompt",
     label: "Review execution",
-    preconditions: ["session_exists", "worktree_exists"]
+    preconditions: ["session_exists", "worktree_exists", "dependencies_installed", "ready_jskit_app", "issue_metadata_exists", "active_cycle_exists", "pre_review_checks_passed", "deep_ui_check_satisfied"]
   }),
   defineStep({
     buttonLabel: "Accept review changes",
@@ -259,7 +399,7 @@ const STEP_DEFINITIONS = Object.freeze([
     id: "review_changes_accepted",
     kind: "user_check",
     label: "Review changes accepted",
-    preconditions: ["session_exists", "worktree_exists"],
+    preconditions: ["session_exists", "worktree_exists", "dependencies_installed", "ready_jskit_app", "issue_metadata_exists", "active_cycle_exists", "pre_review_checks_passed", "deep_ui_check_satisfied"],
     utilityActions: Object.freeze([
       Object.freeze({
         id: "session_diff",
@@ -274,7 +414,48 @@ const STEP_DEFINITIONS = Object.freeze([
     description: "Commit accepted review changes, or record that no review changes were needed.",
     id: "review_changes_committed",
     label: "Review changes committed",
-    preconditions: ["session_exists", "worktree_exists"]
+    preconditions: ["session_exists", "worktree_exists", "dependencies_installed", "ready_jskit_app", "issue_metadata_exists", "active_cycle_exists", "pre_review_checks_passed", "deep_ui_check_satisfied"]
+  }),
+  defineStep({
+    buttonLabel: "Run checks again",
+    description: "Run automated checks after the deslop/JSKIT review pass.",
+    id: "post_review_checks_run",
+    label: "Post-review checks run",
+    preconditions: ["session_exists", "worktree_exists", "dependencies_installed", "ready_jskit_app", "issue_metadata_exists", "active_cycle_exists", "pre_review_checks_passed", "deep_ui_check_satisfied"]
+  }),
+  defineStep({
+    buttonLabel: "Run Deep UI re-check",
+    description: "Run or skip the focused UI quality pass after deslop/JSKIT review.",
+    id: "deep_ui_recheck_run",
+    label: "Deep UI re-check run",
+    preconditions: ["session_exists", "worktree_exists", "dependencies_installed", "ready_jskit_app", "issue_metadata_exists", "active_cycle_exists", "pre_review_checks_passed", "deep_ui_check_satisfied", "post_review_checks_passed"]
+  }),
+  defineStep({
+    buttonLabel: "Accept Deep UI re-check changes",
+    description: "Review the Deep UI Re-check diff and accept it as ready to commit, or record that no changes were needed.",
+    displayGroupId: "deep_ui_recheck",
+    displayGroupLabel: "Deep UI re-check",
+    id: "deep_ui_recheck_changes_accepted",
+    kind: "user_check",
+    label: "Deep UI re-check changes accepted",
+    preconditions: ["session_exists", "worktree_exists", "dependencies_installed", "ready_jskit_app", "issue_metadata_exists", "active_cycle_exists", "pre_review_checks_passed", "deep_ui_check_satisfied", "post_review_checks_passed"],
+    utilityActions: Object.freeze([
+      Object.freeze({
+        id: "session_diff",
+        kind: "diff",
+        label: "Review changes",
+        nextCommandTemplate: "jskit session {{session_id}} diff"
+      })
+    ])
+  }),
+  defineStep({
+    buttonLabel: "Commit Deep UI re-check changes",
+    description: "Commit accepted Deep UI Re-check changes, or record that no changes were needed.",
+    displayGroupId: "deep_ui_recheck",
+    displayGroupLabel: "Deep UI re-check",
+    id: "deep_ui_recheck_changes_committed",
+    label: "Deep UI re-check changes committed",
+    preconditions: ["session_exists", "worktree_exists", "dependencies_installed", "ready_jskit_app", "issue_metadata_exists", "active_cycle_exists", "pre_review_checks_passed", "deep_ui_check_satisfied", "post_review_checks_passed"]
   }),
   defineStep({
     buttonLabel: "Save user check",
@@ -284,27 +465,45 @@ const STEP_DEFINITIONS = Object.freeze([
     kind: "user_check",
     label: "User check",
     nextCommandTemplate: "jskit session {{session_id}} step --user-check passed",
-    preconditions: ["session_exists"]
+    preconditions: ["session_exists", "worktree_exists", "dependencies_installed", "ready_jskit_app", "issue_metadata_exists", "active_cycle_exists", "pre_review_checks_passed", "deep_ui_check_satisfied", "post_review_checks_passed", "deep_ui_recheck_satisfied"]
+  }),
+  defineStep({
+    buttonLabel: "Update blueprint",
+    codex: BLUEPRINT_CODEX_HANDOFF,
+    description: "Update durable app memory from the accepted issue work.",
+    id: "blueprint_updated",
+    input: BLUEPRINT_INPUT,
+    kind: "codex_output",
+    label: "Blueprint updated",
+    nextCommandTemplate: "jskit session {{session_id}} step --blueprint -",
+    preconditions: ["session_exists", "worktree_exists", "dependencies_installed", "ready_jskit_app", "issue_metadata_exists", "active_cycle_exists", "pre_review_checks_passed", "deep_ui_check_satisfied", "post_review_checks_passed", "deep_ui_recheck_satisfied", "active_cycle_user_check_passed"]
   }),
   defineStep({
     buttonLabel: "Run verification",
     description: "Run the project verification command in the session worktree.",
     id: "doctor_run",
     label: "Verification run",
-    preconditions: ["session_exists", "worktree_exists"]
+    preconditions: ["session_exists", "worktree_exists", "dependencies_installed", "ready_jskit_app", "issue_metadata_exists", "active_cycle_exists", "pre_review_checks_passed", "deep_ui_check_satisfied", "post_review_checks_passed", "deep_ui_recheck_satisfied", "active_cycle_user_check_passed", "blueprint_update_satisfied"]
+  }),
+  defineStep({
+    buttonLabel: "Create final report",
+    description: "Create and comment the deterministic final session report.",
+    id: "final_report_created",
+    label: "Final report created",
+    preconditions: ["session_exists", "worktree_exists", "dependencies_installed", "ready_jskit_app", "issue_metadata_exists", "active_cycle_exists", "pre_review_checks_passed", "deep_ui_check_satisfied", "post_review_checks_passed", "deep_ui_recheck_satisfied", "active_cycle_user_check_passed", "blueprint_update_satisfied"]
   }),
   defineStep({
     buttonLabel: "Push branch and create PR",
     description: "Push the session branch to origin and create a GitHub pull request.",
     id: "pr_created",
     label: "Branch pushed, PR created",
-    preconditions: ["session_exists", "worktree_exists"]
+    preconditions: ["session_exists", "worktree_exists", "dependencies_installed", "ready_jskit_app", "issue_metadata_exists", "active_cycle_exists", "pre_review_checks_passed", "deep_ui_check_satisfied", "post_review_checks_passed", "deep_ui_recheck_satisfied", "active_cycle_user_check_passed", "blueprint_update_satisfied", "final_report_exists"]
   }),
   defineStep({
-    buttonLabel: "Merge PR, update base, remove worktree",
-    description: "Merge the pull request, close the GitHub issue, fast-forward the local base branch, and remove the session worktree.",
-    id: "pr_merged",
-    label: "PR merged, base updated, worktree removed",
+    buttonLabel: "Finalize PR",
+    description: "Merge the pull request or finish without merging, record the outcome, and remove the session worktree.",
+    id: "pr_finalized",
+    label: "PR finalized, worktree removed",
     preconditions: ["session_exists", "pr_url_exists", "worktree_exists"]
   }),
   defineStep({
@@ -319,6 +518,23 @@ const STEP_DEFINITIONS = Object.freeze([
 const STEP_IDS = Object.freeze(STEP_DEFINITIONS.map((step) => step.id));
 const STEP_LABEL_BY_ID = Object.freeze(Object.fromEntries(STEP_DEFINITIONS.map((step) => [step.id, step.label])));
 const STEP_DEFINITION_BY_ID = Object.freeze(Object.fromEntries(STEP_DEFINITIONS.map((step) => [step.id, step])));
+const CYCLE_STEP_IDS = Object.freeze([
+  "plan_fine_tuning",
+  "implementation_changes_accepted",
+  "implementation_changes_committed",
+  "pre_review_checks_run",
+  "deep_ui_check_run",
+  "deep_ui_check_changes_accepted",
+  "deep_ui_check_changes_committed",
+  "review_prompt_rendered",
+  "review_changes_accepted",
+  "review_changes_committed",
+  "post_review_checks_run",
+  "deep_ui_recheck_run",
+  "deep_ui_recheck_changes_accepted",
+  "deep_ui_recheck_changes_committed",
+  "user_check_completed"
+]);
 const STEP_PRECONDITION_NAMES = Object.freeze(Object.fromEntries(
   STEP_DEFINITIONS
     .filter((step) => step.id !== "session_created")
@@ -329,6 +545,9 @@ export {
   PROMPT_DIRECTORY,
   SESSION_ID_PATTERN,
   SESSION_STATUS,
+  SESSION_WORKFLOW_VERSION,
+  REVIEW_PASS_LIMIT,
+  CYCLE_STEP_IDS,
   STEP_DEFINITION_BY_ID,
   STEP_DEFINITIONS,
   STEP_IDS,
@@ -337,5 +556,7 @@ export {
   PLAN_EXECUTION_CODEX_HANDOFF,
   PLAN_FINE_TUNING_CODEX_HANDOFF,
   REVIEW_EXECUTION_CODEX_HANDOFF,
+  DEEP_UI_CHECK_CODEX_HANDOFF,
+  BLUEPRINT_CODEX_HANDOFF,
   SESSION_STATE_RELATIVE_PATH
 };

--- a/tooling/jskit-cli/src/server/sessionRuntime/preconditions.js
+++ b/tooling/jskit-cli/src/server/sessionRuntime/preconditions.js
@@ -24,6 +24,9 @@ import {
 import {
   hasWorktree
 } from "./worktrees.js";
+import {
+  inspectReadyJskitAppRoot
+} from "./appReadiness.js";
 
 async function assertTargetRootWritable(targetRoot) {
   try {
@@ -238,6 +241,246 @@ async function assertSessionExists(paths) {
   };
 }
 
+async function pathExists(filePath) {
+  try {
+    await access(filePath, fsConstants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function assertDependenciesInstalled(paths) {
+  if (await pathExists(path.join(paths.sessionRoot, "steps", "dependencies_installed"))) {
+    return {
+      ok: true,
+      precondition: createPrecondition({
+        id: "dependencies_installed",
+        ok: true,
+        message: "Session worktree dependencies have been installed."
+      })
+    };
+  }
+  return {
+    ok: false,
+    error: createError({
+      code: "dependencies_not_installed",
+      message: "Cannot start issue work until dependencies are installed in the session worktree.",
+      repairCommand: `jskit session ${paths.sessionId} step`
+    }),
+    precondition: createPrecondition({
+      id: "dependencies_installed",
+      ok: false,
+      message: "Session worktree dependencies have been installed."
+    })
+  };
+}
+
+async function assertReadyJskitApp(paths) {
+  const root = paths.worktree || paths.targetRoot;
+  const readiness = await inspectReadyJskitAppRoot(root);
+  if (readiness.ok) {
+    return {
+      ok: true,
+      precondition: createPrecondition({
+        id: "ready_jskit_app",
+        ok: true,
+        message: "Session worktree has the required JSKIT app markers."
+      })
+    };
+  }
+  return {
+    ok: false,
+    error: createError({
+      code: "app_setup_required",
+      message: `Issue sessions require a ready JSKIT app. Missing: ${readiness.missing.join(", ")}.`,
+      repairCommand: "Run the app setup flow before starting issue work."
+    }),
+    precondition: createPrecondition({
+      id: "ready_jskit_app",
+      ok: false,
+      message: "Session worktree has the required JSKIT app markers."
+    })
+  };
+}
+
+async function assertActiveCycleExists(paths) {
+  const activeCycle = await readTrimmedFile(path.join(paths.sessionRoot, "active_cycle"));
+  if (/^\d+$/u.test(activeCycle)) {
+    return {
+      ok: true,
+      precondition: createPrecondition({
+        id: "active_cycle_exists",
+        ok: true,
+        message: "Active cycle marker exists."
+      })
+    };
+  }
+  return {
+    ok: false,
+    error: createError({
+      code: "active_cycle_missing",
+      message: "Session active_cycle is missing or invalid."
+    }),
+    precondition: createPrecondition({
+      id: "active_cycle_exists",
+      ok: false,
+      message: "Active cycle marker exists."
+    })
+  };
+}
+
+async function assertActiveCycleUserCheckPassed(paths) {
+  const activeCycle = await readTrimmedFile(path.join(paths.sessionRoot, "active_cycle"));
+  const receiptPath = path.join(paths.sessionRoot, "steps", `cycle_${activeCycle}`, "user_check_completed");
+  if (await pathExists(receiptPath)) {
+    return {
+      ok: true,
+      precondition: createPrecondition({
+        id: "active_cycle_user_check_passed",
+        ok: true,
+        message: "The active cycle user check has passed."
+      })
+    };
+  }
+  return {
+    ok: false,
+    error: createError({
+      code: "user_check_not_passed",
+      message: "Finalization cannot continue until the active cycle user check has passed.",
+      repairCommand: `jskit session ${paths.sessionId} step --user-check passed`
+    }),
+    precondition: createPrecondition({
+      id: "active_cycle_user_check_passed",
+      ok: false,
+      message: "The active cycle user check has passed."
+    })
+  };
+}
+
+async function assertActiveCycleStepReceipt(paths, {
+  code,
+  id,
+  message,
+  stepId
+}) {
+  const activeCycle = await readTrimmedFile(path.join(paths.sessionRoot, "active_cycle"));
+  const receiptPath = path.join(paths.sessionRoot, "steps", `cycle_${activeCycle}`, stepId);
+  if (await pathExists(receiptPath)) {
+    return {
+      ok: true,
+      precondition: createPrecondition({
+        id,
+        ok: true,
+        message
+      })
+    };
+  }
+  return {
+    ok: false,
+    error: createError({
+      code,
+      message,
+      repairCommand: `jskit session ${paths.sessionId} step`
+    }),
+    precondition: createPrecondition({
+      id,
+      ok: false,
+      message
+    })
+  };
+}
+
+async function assertPreReviewChecksPassed(paths) {
+  return assertActiveCycleStepReceipt(paths, {
+    code: "pre_review_checks_not_passed",
+    id: "pre_review_checks_passed",
+    message: "Pre-review checks have passed.",
+    stepId: "pre_review_checks_run"
+  });
+}
+
+async function assertPostReviewChecksPassed(paths) {
+  return assertActiveCycleStepReceipt(paths, {
+    code: "post_review_checks_not_passed",
+    id: "post_review_checks_passed",
+    message: "Post-review checks have passed.",
+    stepId: "post_review_checks_run"
+  });
+}
+
+async function assertDeepUiCheckSatisfied(paths) {
+  return assertActiveCycleStepReceipt(paths, {
+    code: "deep_ui_check_not_satisfied",
+    id: "deep_ui_check_satisfied",
+    message: "Deep UI check is satisfied.",
+    stepId: "deep_ui_check_changes_committed"
+  });
+}
+
+async function assertDeepUiRecheckSatisfied(paths) {
+  return assertActiveCycleStepReceipt(paths, {
+    code: "deep_ui_recheck_not_satisfied",
+    id: "deep_ui_recheck_satisfied",
+    message: "Deep UI re-check is satisfied.",
+    stepId: "deep_ui_recheck_changes_committed"
+  });
+}
+
+async function assertIssueMetadataExists(paths) {
+  const source = await readTextIfExists(path.join(paths.sessionRoot, "issue_metadata.json"));
+  if (!source) {
+    return {
+      ok: false,
+      error: createError({
+        code: "issue_metadata_missing",
+        message: "Cannot continue before issue_metadata.json records the issue category and UI impact.",
+        repairCommand: `jskit session ${paths.sessionId} step --plan-details -`
+      }),
+      precondition: createPrecondition({
+        id: "issue_metadata_exists",
+        ok: false,
+        message: "Issue metadata records issue category and UI impact."
+      })
+    };
+  }
+
+  let metadata = null;
+  try {
+    metadata = JSON.parse(source);
+  } catch {
+    metadata = null;
+  }
+  const issueCategory = String(metadata?.issueCategory || "").trim().toLowerCase();
+  const uiImpact = String(metadata?.uiImpact || "").trim().toLowerCase();
+  const validIssueCategories = new Set(["client", "server", "client_server", "tooling", "unknown"]);
+  const validUiImpacts = new Set(["none", "possible", "definite", "unknown"]);
+  if (validIssueCategories.has(issueCategory) && validUiImpacts.has(uiImpact)) {
+    return {
+      ok: true,
+      precondition: createPrecondition({
+        id: "issue_metadata_exists",
+        ok: true,
+        message: "Issue metadata records issue category and UI impact."
+      })
+    };
+  }
+
+  return {
+    ok: false,
+    error: createError({
+      code: "issue_metadata_invalid",
+      message: "issue_metadata.json must include a valid issueCategory and uiImpact.",
+      repairCommand: `jskit session ${paths.sessionId} step --plan-details -`
+    }),
+    precondition: createPrecondition({
+      id: "issue_metadata_exists",
+      ok: false,
+      message: "Issue metadata records issue category and UI impact."
+    })
+  };
+}
+
 async function assertIssueTextExists(paths) {
   const issueText = await readTrimmedFile(path.join(paths.sessionRoot, "issue.md"));
   if (issueText) {
@@ -319,6 +562,85 @@ async function assertPlanTextExists(paths) {
   };
 }
 
+async function assertPlanDetailsExists(paths) {
+  const planDetails = await readTrimmedFile(path.join(paths.sessionRoot, "plan_details.md"));
+  if (planDetails) {
+    return {
+      ok: true,
+      precondition: createPrecondition({
+        id: "plan_details_exists",
+        ok: true,
+        message: "Plan details exist."
+      })
+    };
+  }
+  return {
+    ok: false,
+    error: createError({
+      code: "plan_details_missing",
+      message: "Cannot create a plan before plan_details.md exists.",
+      repairCommand: `jskit session ${paths.sessionId} step --plan-details -`
+    }),
+    precondition: createPrecondition({
+      id: "plan_details_exists",
+      ok: false,
+      message: "Plan details exist."
+    })
+  };
+}
+
+async function assertBlueprintUpdateSatisfied(paths) {
+  if (await pathExists(path.join(paths.sessionRoot, "steps", "blueprint_updated"))) {
+    return {
+      ok: true,
+      precondition: createPrecondition({
+        id: "blueprint_update_satisfied",
+        ok: true,
+        message: "Blueprint update step is complete."
+      })
+    };
+  }
+  return {
+    ok: false,
+    error: createError({
+      code: "blueprint_update_missing",
+      message: "Cannot continue before the blueprint update step is complete.",
+      repairCommand: `jskit session ${paths.sessionId} step --blueprint -`
+    }),
+    precondition: createPrecondition({
+      id: "blueprint_update_satisfied",
+      ok: false,
+      message: "Blueprint update step is complete."
+    })
+  };
+}
+
+async function assertFinalReportExists(paths) {
+  if (await pathExists(path.join(paths.sessionRoot, "final_report.md"))) {
+    return {
+      ok: true,
+      precondition: createPrecondition({
+        id: "final_report_exists",
+        ok: true,
+        message: "Final report exists."
+      })
+    };
+  }
+  return {
+    ok: false,
+    error: createError({
+      code: "final_report_missing",
+      message: "Cannot publish the PR before final_report.md exists.",
+      repairCommand: `jskit session ${paths.sessionId} step`
+    }),
+    precondition: createPrecondition({
+      id: "final_report_exists",
+      ok: false,
+      message: "Final report exists."
+    })
+  };
+}
+
 async function assertWorktreeExists(paths) {
   if (await hasWorktree(paths)) {
     return {
@@ -374,14 +696,26 @@ async function assertPrUrlExists(paths) {
 
 export {
   applyPreconditions,
+  assertActiveCycleExists,
+  assertActiveCycleUserCheckPassed,
+  assertBlueprintUpdateSatisfied,
+  assertDeepUiCheckSatisfied,
+  assertDeepUiRecheckSatisfied,
+  assertDependenciesInstalled,
+  assertFinalReportExists,
   assertGhAuth,
   assertGitCurrentBranch,
   assertGitRepository,
   assertGithubOrigin,
+  assertIssueMetadataExists,
   assertIssueTextExists,
   assertIssueUrlExists,
+  assertPostReviewChecksPassed,
+  assertPreReviewChecksPassed,
+  assertPlanDetailsExists,
   assertPlanTextExists,
   assertPrUrlExists,
+  assertReadyJskitApp,
   assertSessionExists,
   assertTargetRootWritable,
   assertWorktreeExists,

--- a/tooling/jskit-cli/src/server/sessionRuntime/prompts/deep_ui_check.md
+++ b/tooling/jskit-cli/src/server/sessionRuntime/prompts/deep_ui_check.md
@@ -1,0 +1,45 @@
+Deep UI quality check for JSKIT session {{session_id}}.
+
+Phase: {{phase}}
+GitHub issue: {{issue_url}}
+Issue number: {{issue_number}}
+Issue title: {{issue_title}}
+Issue body file: {{issue_file}}
+Plan details file (`plan_details.md`): {{plan_details_file}}
+Plan file (`plan.md`): {{plan_file}}
+UI impact: {{ui_impact}}
+Worktree: {{worktree}}
+
+Changed files since the session base:
+
+{{changed_files}}
+
+Run a focused UI quality pass for the current worktree. If this is not UI-impacting after inspection, say exactly why and do not edit files. If the issue touches UI, inspect the changed routes, views, components, placements, layouts, and styles.
+
+Check:
+
+- Material Design quality.
+- Vuetify best practices.
+- visual hierarchy and density.
+- spacing and alignment.
+- responsive behavior on mobile, tablet, and desktop.
+- loading, empty, error, disabled, and success states where relevant.
+- accessibility basics.
+- route and navigation coherence.
+- consistency with the existing app style.
+
+When clear scoped UI issues exist, fix them in the worktree. Keep fixes limited to the issue, confirmed plan details, and approved plan.
+
+Use Playwright for a meaningful route check when possible. If login is required, use a development-only auth bootstrap path. When possible, record UI verification with:
+
+`jskit app verify-ui --command "<playwright command>" --feature "<label>" --auth-mode <mode>`
+
+Do not create commits, branches, issues, pull requests, merges, or worktree cleanup. JSKIT session owns those steps.
+
+If this pass makes UI fixes, intentionally skips UI work after inspection, changes a design direction, or leaves a meaningful UI verification gap, include concise decision entries with reasons in this exact marker block:
+
+```text
+[agent_decisions]
+<Deep UI decisions or "No new decisions.">
+[/agent_decisions]
+```

--- a/tooling/jskit-cli/src/server/sessionRuntime/prompts/doctor_failure.md
+++ b/tooling/jskit-cli/src/server/sessionRuntime/prompts/doctor_failure.md
@@ -16,6 +16,7 @@ Fix the root cause in this worktree. Do not silence the failure or remove checks
 
 Diagnosis rules:
 
+- Re-read the issue, `plan_details.md`, `plan.md`, `agent_decisions.md`, `.jskit/APP_BLUEPRINT.md`, `.jskit/helper-map.md`, check receipts, and UI check receipts before repairing.
 - Identify whether the failure is dependency/setup, JSKIT metadata, generated contract drift, routing/surface wiring, CRUD ownership, UI verification receipt, test-auth, or ordinary application code.
 - Prefer repairing the JSKIT-owned contract or generated metadata over adding local-path hacks.
 - Do not run `npm install` only because optional agent docs are missing. Run installs only when the failure or a JSKIT setup/session step requires dependency repair.
@@ -24,3 +25,11 @@ Diagnosis rules:
 - If login is required, use the app's development auth bootstrap path rather than a live external auth flow.
 
 Do not push, open a PR, merge, or remove the worktree. When the fix is ready, report the root cause, files changed, verification, and anything still unverified. The user or Studio will rerun the JSKIT session step.
+
+If the repair records a meaningful verification decision, tradeoff, missing coverage, or root-cause explanation future steps should know, include concise entries with reasons in this exact marker block:
+
+```text
+[agent_decisions]
+<verification or repair decisions, or "No new decisions.">
+[/agent_decisions]
+```

--- a/tooling/jskit-cli/src/server/sessionRuntime/prompts/execute_plan.md
+++ b/tooling/jskit-cli/src/server/sessionRuntime/prompts/execute_plan.md
@@ -4,18 +4,24 @@ GitHub issue: {{issue_url}}
 Issue number: {{issue_number}}
 Issue title: {{issue_title}}
 Issue body file: {{issue_file}}
-Plan file: {{plan_file}}
+Plan details file (`plan_details.md`): {{plan_details_file}}
+Plan file (`plan.md`): {{plan_file}}
 Worktree: {{worktree}}
+
+Confirmed plan details:
+
+{{plan_details_text}}
 
 Approved plan:
 
 {{plan_text}}
 
-Implement the plan in the session worktree. Keep the change scoped to the issue and approved plan.
+Implement the plan in the session worktree. Keep the change scoped to the issue, confirmed plan details, and approved plan.
 
 Implementation rules:
 
-- Inspect the current app before editing. Do not assume a JSKIT app shape without checking files.
+- Inspect the current app before editing. App setup has already passed; if required JSKIT app files are missing, report setup failure rather than inventing recovery work.
+- Follow both `{{plan_details_file}}` and `{{plan_file}}`. If they disagree, ask for clarification before changing files.
 - Read `.jskit/helper-map.md` when it exists before creating helpers, composables, service functions, maps, or package glue.
 - Prefer existing JSKIT helpers, app-local helpers, package runtime seams, generated scaffolds, and documented generators over new local helpers.
 - If the plan calls for a generator or package install, use the planned `jskit` command unless inspection proves it does not apply. If you skip a generator, explain the exact gap.
@@ -36,5 +42,12 @@ After making changes:
 - Run the smallest relevant checks you can run safely in the worktree.
 - For changed user-facing UI, run or clearly identify the Playwright verification path. When possible, record UI verification with `jskit app verify-ui --command "<playwright command>" --feature "<label>" --auth-mode <mode>`.
 - Summarize changed files and checks run.
+- If implementation deviated from the approved plan, generator choices, package ownership, helper reuse, UI verification path, or data ownership, include concise decision entries with reasons in this exact marker block:
+
+```text
+[agent_decisions]
+<implementation decisions or "No new decisions.">
+[/agent_decisions]
+```
 
 Do not create commits, branches, issues, pull requests, merges, or worktree cleanup yourself. JSKIT session will handle those steps.

--- a/tooling/jskit-cli/src/server/sessionRuntime/prompts/final_comment.md
+++ b/tooling/jskit-cli/src/server/sessionRuntime/prompts/final_comment.md
@@ -1,8 +1,10 @@
 Codex thread id: {{codex_thread_id}}
 Issue session status: finished
 PR: {{pr_url}}
+PR outcome: {{pr_outcome}}
+Outcome reason: {{pr_outcome_reason}}
 Local transcript: {{transcript_log}}
 
 Summary:
 
-Session {{session_id}} finished and merged.
+Session {{session_id}} finished with PR outcome `{{pr_outcome}}`.

--- a/tooling/jskit-cli/src/server/sessionRuntime/prompts/fine_tune_plan.md
+++ b/tooling/jskit-cli/src/server/sessionRuntime/prompts/fine_tune_plan.md
@@ -4,22 +4,37 @@ GitHub issue: {{issue_url}}
 Issue number: {{issue_number}}
 Issue title: {{issue_title}}
 Issue body file: {{issue_file}}
-Plan file: {{plan_file}}
+Plan details file (`plan_details.md`): {{plan_details_file}}
+Plan file (`plan.md`): {{plan_file}}
+Agent decisions file (`agent_decisions.md`): {{agent_decisions_file}}
+Active cycle: {{active_cycle}}
 Worktree: {{worktree}}
+
+Confirmed plan details:
+
+{{plan_details_text}}
 
 Approved plan:
 
 {{plan_text}}
+
+Known decisions:
+
+{{agent_decisions_text}}
+
+User rework request for this cycle:
+
+{{rework_request}}
 
 The first implementation pass should already be in the session worktree. Use this step to refine it after user review, user testing, visible defects, or implementation gaps.
 
 Fine-tuning rules:
 
 - Inspect the current worktree changes before editing.
-- Compare the current implementation against the issue and approved plan.
+- Compare the current implementation against the issue, confirmed plan details, and approved plan. Follow both `{{plan_details_file}}` and `{{plan_file}}`.
 - If the user has already described what failed or what needs refinement, apply that feedback directly.
 - If the user has not described the problem yet, ask concise questions about what failed before editing.
-- Keep fixes scoped to the issue, approved plan, and user feedback.
+- Keep fixes scoped to the issue, confirmed plan details, approved plan, and user feedback.
 - Do not restart the feature from scratch unless the current implementation is unrecoverable; explain that clearly if it happens.
 - Prefer existing JSKIT helpers, app-local helpers, package runtime seams, generated scaffolds, and documented generators over new local helpers.
 - Read `.jskit/helper-map.md` when it exists before creating helpers, composables, service functions, maps, or package glue.
@@ -33,5 +48,12 @@ After fine tuning:
 - Run the smallest relevant checks you can run safely in the worktree.
 - For changed user-facing UI, run or clearly identify the Playwright verification path. When possible, record UI verification with `jskit app verify-ui --command "<playwright command>" --feature "<label>" --auth-mode <mode>`.
 - Summarize changed files and checks run.
+- If fine tuning changes a previously recorded decision, adds an implementation deviation, or resolves a user rework request with a material tradeoff, include concise decision entries with reasons in this exact marker block:
+
+```text
+[agent_decisions]
+<fine-tuning decisions or "No new decisions.">
+[/agent_decisions]
+```
 
 Do not create commits, branches, issues, pull requests, merges, or worktree cleanup yourself. JSKIT session will handle those steps.

--- a/tooling/jskit-cli/src/server/sessionRuntime/prompts/new_issue.md
+++ b/tooling/jskit-cli/src/server/sessionRuntime/prompts/new_issue.md
@@ -2,13 +2,14 @@ Create a GitHub issue from this user request:
 
 {{user_input}}
 
-First inspect the local app enough to understand the request in context. This issue-drafting step is read-only.
+First inspect the local app enough to understand the request in context. App setup has already passed before this prompt is rendered; treat this as a ready JSKIT app. This issue-drafting step is read-only.
 
 Allowed inspection:
 
 - Read files with commands such as `pwd`, `ls`, `find`, `rg`, `cat`, `sed`, and `git status`.
-- Read package.json, config, .jskit metadata, routes, packages, source files, and any saved app blueprint when available.
-- Classify the current app state as empty, non_jskit_repo, partial_jskit_app, or jskit_app before assuming ordinary feature work is possible.
+- Read package.json, `.jskit/lock.json`, config, routes, packages, source files, `.jskit/APP_BLUEPRINT.md`, and `.jskit/helper-map.md` when available.
+- Use non-mutating JSKIT inspection commands when available and relevant: `jskit list`, `jskit show <package> --details`, and `jskit list-placements`.
+- If the filesystem contradicts a ready JSKIT app, stop and report that app setup must be rerun. Do not draft a recovery issue inside this session.
 
 Do not run workflow, repair, or mutation commands during issue drafting:
 
@@ -21,7 +22,6 @@ Draft an implementation-ready issue, not a broad product essay.
 
 Preserve these JSKIT boundaries:
 
-- If the app is empty or a partial JSKIT app, the issue should be about bootstrap or recovery before feature implementation.
 - If platform choices are still provisional, make the issue resolve those choices before installing tenancy-sensitive packages.
 - Do not ask the developer to redesign standard JSKIT package-owned workflows from scratch. Treat selected package workflows as defaults unless the request asks for overrides, restrictions, or custom additions.
 - For persisted app-owned data, prefer generated/package ownership over direct hand-built persistence. A new ordinary table should usually become a server CRUD-owned entity before CRUD UI or route work.

--- a/tooling/jskit-cli/src/server/sessionRuntime/prompts/plan_details.md
+++ b/tooling/jskit-cli/src/server/sessionRuntime/prompts/plan_details.md
@@ -1,0 +1,44 @@
+Gather exact implementation details for JSKIT session {{session_id}}.
+
+GitHub issue: {{issue_url}}
+Issue number: {{issue_number}}
+Issue title: {{issue_title}}
+Issue body file: {{issue_file}}
+Plan details file to create (`plan_details.md`): {{plan_details_file}}
+Worktree: {{worktree}}
+
+This step exists before planning. Do not edit files, create commits, create branches, create issues, create pull requests, merge, or clean worktrees.
+
+No stones unturned:
+
+- Read the issue and inspect the app enough to understand the implementation surface.
+- Read `.jskit/APP_BLUEPRINT.md` and `.jskit/helper-map.md` when present.
+- Read package.json, `.jskit/lock.json`, `config/public.js`, relevant `src/`, relevant `packages/`, and relevant package docs or `jskit show ... --details`.
+- Ask follow-up questions until all important implementation details are known.
+- Ask for final confirmation before emitting final details.
+
+For CRUD or persisted data, confirm entity/table name, fields, field types, nullability, defaults, uniqueness, indexes, relationships, ownership, allowed operations, list/view/form shape, validation, permissions, migration/generator lane, and exact CRUD generator command or exact reason no CRUD generator applies.
+
+For UI, confirm route path, surface/placement target, navigation expectations, responsive layout, loading/empty/error/disabled/success states, Material/Vuetify expectations, Playwright verification path, and auth/bootstrap strategy if needed.
+
+For server-only work, confirm endpoint/command/job shape, request/response shape, validation, auth/permission behavior, persistence ownership, error behavior, and verification path.
+
+For package/generator work, confirm exact `jskit add` or `jskit generate` command, why it applies, expected generated files, and follow-up custom code areas.
+
+When the details are confirmed, output only the final classification, details, and decision notes surrounded by these exact markers:
+
+[issue_category]
+client | server | client_server | tooling | unknown
+[/issue_category]
+
+[ui_impact]
+none | possible | definite | unknown
+[/ui_impact]
+
+[plan_details]
+<confirmed implementation details in Markdown>
+[/plan_details]
+
+[agent_decisions]
+<concise decision entries with reasons>
+[/agent_decisions]

--- a/tooling/jskit-cli/src/server/sessionRuntime/prompts/plan_issue.md
+++ b/tooling/jskit-cli/src/server/sessionRuntime/prompts/plan_issue.md
@@ -5,14 +5,24 @@ Issue number: {{issue_number}}
 Issue title: {{issue_title}}
 Issue body file: {{issue_file}}
 Issue title file: {{issue_title_file}}
-Plan file to create: {{plan_file}}
+Plan details file (`plan_details.md`): {{plan_details_file}}
+Agent decisions file (`agent_decisions.md`): {{agent_decisions_file}}
+App blueprint file (`.jskit/APP_BLUEPRINT.md`): {{app_blueprint_file}}
+Plan file to create (`plan.md`): {{plan_file}}
 Worktree: {{worktree}}
 
-Read the issue and inspect the local app before planning. Use the issue files, package.json, .jskit metadata, config, packages, routes, generated references, package docs, any saved app blueprint, and `.jskit/helper-map.md` when available.
+Read the issue, confirmed plan details, agent decisions, and local app before planning. Use the issue files, plan details file, package.json, .jskit metadata, config, packages, routes, generated references, package docs, any saved app blueprint, and `.jskit/helper-map.md` when available.
 
-Start by identifying the app state and the implementation lane:
+Confirmed implementation details:
 
-- empty, non_jskit_repo, partial_jskit_app, or jskit_app
+{{plan_details_text}}
+
+Known decisions:
+
+{{agent_decisions_text}}
+
+Start by identifying the implementation lane:
+
 - package install
 - generator scaffolding
 - custom local code
@@ -21,6 +31,7 @@ Start by identifying the app state and the implementation lane:
 Planning rules:
 
 - Keep the plan scoped to the issue. Avoid "while I am here" work.
+- Follow the confirmed plan details and preserve the issue category and UI impact in the plan. If details are insufficient, say exactly what is missing instead of inventing foundational details.
 - Prefer vertical slices that produce visible or end-to-end progress.
 - If the work is too broad to review confidently, split it into clear chunks.
 - Make generator decisions concrete. Name the exact `jskit` commands to run when a generator or package install applies.
@@ -42,10 +53,14 @@ If setup values are needed, ask plainly using exact env var or option names. For
 
 If the issue is not clear enough to plan safely, ask the user concise follow-up questions first.
 
-When the plan is ready, output only the final plan surrounded by these exact markers:
+When the plan is ready, output only the final plan and any new decisions surrounded by these exact markers:
 
 [plan]
 <implementation plan in Markdown>
 [/plan]
 
-Keep the plan concrete and implementation-oriented. Include the likely files or areas to touch, ordered steps, generator commands to consider, review expectations, and checks that should be run.
+[agent_decisions]
+<new planning decisions with reasons, or "No new decisions.">
+[/agent_decisions]
+
+Keep the plan concrete and implementation-oriented. Include the issue category, UI impact, likely files or areas to touch, ordered steps, generator commands to consider, review expectations, and checks that should be run.

--- a/tooling/jskit-cli/src/server/sessionRuntime/prompts/review_changes.md
+++ b/tooling/jskit-cli/src/server/sessionRuntime/prompts/review_changes.md
@@ -1,5 +1,7 @@
 Review changes for session {{session_id}}.
 
+Review pass: {{review_pass_number}} of {{review_pass_limit}}.
+
 Changed files from the latest commit:
 
 {{changed_files}}
@@ -42,4 +44,4 @@ Use four passes:
 
 Do not create commits, branches, pull requests, merges, or worktree cleanup yourself. JSKIT session owns those steps.
 
-When finished, report findings ordered by severity, fixes made, changed files, checks run, and anything still unverified. If there are no important findings, say so explicitly and list residual risk.
+When finished, report findings ordered by severity, fixes made, changed files, checks run, and anything still unverified. If important findings remain after this pass, say exactly what remains so JSKIT Studio can request another review pass. If there are no important findings, say so explicitly and list residual risk.

--- a/tooling/jskit-cli/src/server/sessionRuntime/prompts/update_blueprint.md
+++ b/tooling/jskit-cli/src/server/sessionRuntime/prompts/update_blueprint.md
@@ -1,0 +1,36 @@
+Update the durable JSKIT app blueprint for session {{session_id}}.
+
+GitHub issue: {{issue_url}}
+Issue number: {{issue_number}}
+Issue title: {{issue_title}}
+Issue body file: {{issue_file}}
+Plan details file (`plan_details.md`): {{plan_details_file}}
+Plan file (`plan.md`): {{plan_file}}
+Agent decisions file (`agent_decisions.md`): {{agent_decisions_file}}
+Current blueprint file (`.jskit/APP_BLUEPRINT.md`): {{app_blueprint_file}}
+Worktree: {{worktree}}
+
+Use the accepted issue work to update only durable app/product/architecture memory. Read the current blueprint when present, issue title/body, plan details, approved plan, agent decisions, helper map, package/app metadata, and changed files.
+
+Changed files since the session base:
+
+{{changed_files}}
+
+Rules:
+
+- Do not use this as task tracking.
+- Do not recreate `.jskit/WORKBOARD.md`.
+- Do not over-expand tiny issues into broad product rewrites.
+- Preserve useful existing blueprint content.
+- Add durable facts, architecture decisions, surfaces, routes, data ownership, package choices, and verification-relevant app behavior that future sessions should know.
+- Keep the result concise enough to remain useful over many issues.
+
+When ready, output only:
+
+[app_blueprint]
+<full updated blueprint markdown>
+[/app_blueprint]
+
+[agent_decisions]
+<new blueprint decisions with reasons, or "No new decisions.">
+[/agent_decisions]

--- a/tooling/jskit-cli/src/server/sessionRuntime/prompts/user_check.md
+++ b/tooling/jskit-cli/src/server/sessionRuntime/prompts/user_check.md
@@ -1,6 +1,20 @@
 User check for session {{session_id}}.
 
+Issue: {{issue_url}}
+Issue title: {{issue_title}}
+Issue body file: {{issue_file}}
+Plan details file (`plan_details.md`): {{plan_details_file}}
+Plan file (`plan.md`): {{plan_file}}
+
 The code should already be built or runnable according to the implementation instructions.
+
+Confirmed plan details:
+
+{{plan_details_text}}
+
+Approved plan:
+
+{{plan_text}}
 
 Ask the user to test the changed behavior in the app and report whether it works as intended. Be specific about the user-visible behavior, route, command, or workflow to inspect.
 

--- a/tooling/jskit-cli/src/server/sessionRuntime/responses.js
+++ b/tooling/jskit-cli/src/server/sessionRuntime/responses.js
@@ -1,6 +1,9 @@
 import { mkdir, readdir } from "node:fs/promises";
 import path from "node:path";
 import {
+  CYCLE_STEP_IDS,
+  REVIEW_PASS_LIMIT,
+  SESSION_WORKFLOW_VERSION,
   SESSION_STATUS,
   STEP_DEFINITION_BY_ID,
   STEP_DEFINITIONS,
@@ -12,6 +15,7 @@ import {
   normalizeText,
   readTextIfExists,
   readTrimmedFile,
+  runGitInWorktree,
   timestampForReceipt,
   writeTextFile
 } from "./io.js";
@@ -21,6 +25,9 @@ import {
 import {
   hasWorktree
 } from "./worktrees.js";
+import {
+  inspectReadyJskitAppRoot
+} from "./appReadiness.js";
 
 function createError({
   code,
@@ -69,11 +76,125 @@ function stepCanExposeStoredPrompt(stepId) {
   return Boolean(step?.codex || step?.kind === "human_input");
 }
 
+const DEFAULT_ACTIVE_CYCLE = "001";
+const DEFAULT_REVIEW_PASS = "001";
+
+function normalizeCycleNumber(value = "") {
+  const normalized = normalizeText(value).replace(/^cycle_/u, "");
+  if (!/^\d+$/u.test(normalized)) {
+    return DEFAULT_ACTIVE_CYCLE;
+  }
+  return String(Number.parseInt(normalized, 10)).padStart(3, "0");
+}
+
+function cycleDirectoryName(cycle = DEFAULT_ACTIVE_CYCLE) {
+  return `cycle_${normalizeCycleNumber(cycle)}`;
+}
+
+function isCycleStepId(stepId = "") {
+  return CYCLE_STEP_IDS.includes(normalizeStepId(stepId));
+}
+
+async function readWorkflowVersion(paths) {
+  return readTrimmedFile(path.join(paths.sessionRoot, "workflow_version"));
+}
+
+async function readActiveCycle(paths) {
+  const cycle = await readTrimmedFile(path.join(paths.sessionRoot, "active_cycle"));
+  return normalizeCycleNumber(cycle || DEFAULT_ACTIVE_CYCLE);
+}
+
+async function writeActiveCycle(paths, cycle) {
+  await writeTextFile(path.join(paths.sessionRoot, "active_cycle"), `${normalizeCycleNumber(cycle)}\n`);
+}
+
+function cycleStepsRoot(paths, cycle) {
+  return path.join(paths.sessionRoot, "steps", cycleDirectoryName(cycle));
+}
+
+function cycleRoot(paths, cycle) {
+  return path.join(paths.sessionRoot, "cycles", cycleDirectoryName(cycle));
+}
+
+function normalizeReviewPassNumber(value = "") {
+  const normalized = normalizeText(value).replace(/^pass_/u, "");
+  if (!/^\d+$/u.test(normalized)) {
+    return DEFAULT_REVIEW_PASS;
+  }
+  return String(Number.parseInt(normalized, 10)).padStart(3, "0");
+}
+
+function reviewPassDirectoryName(pass = DEFAULT_REVIEW_PASS) {
+  return `pass_${normalizeReviewPassNumber(pass)}`;
+}
+
+function reviewPassRoot(paths, pass) {
+  return path.join(paths.sessionRoot, "review_passes", reviewPassDirectoryName(pass));
+}
+
+async function parseJsonFileIfExists(filePath) {
+  const source = await readTextIfExists(filePath);
+  if (!source) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(source);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+async function readReviewPassNumbers(paths) {
+  try {
+    const entries = await readdir(path.join(paths.sessionRoot, "review_passes"), { withFileTypes: true });
+    return entries
+      .filter((entry) => entry.isDirectory() && /^pass_\d+$/u.test(entry.name))
+      .map((entry) => normalizeReviewPassNumber(entry.name))
+      .sort((left, right) => Number.parseInt(left, 10) - Number.parseInt(right, 10));
+  } catch {
+    return [];
+  }
+}
+
+async function readReviewPassInfo(paths, pass) {
+  const normalizedPass = normalizeReviewPassNumber(pass);
+  const root = reviewPassRoot(paths, normalizedPass);
+  const [prompt, accepted, committed] = await Promise.all([
+    parseJsonFileIfExists(path.join(root, "prompt.json")),
+    parseJsonFileIfExists(path.join(root, "accepted.json")),
+    parseJsonFileIfExists(path.join(root, "committed.json"))
+  ]);
+  const status = committed?.status || accepted?.status || prompt?.status || "unknown";
+  const changedFiles = Array.isArray(committed?.changedFiles)
+    ? committed.changedFiles
+    : Array.isArray(accepted?.changedFiles) ? accepted.changedFiles : [];
+  return {
+    pass: normalizedPass,
+    label: reviewPassDirectoryName(normalizedPass),
+    status,
+    promptPath: prompt?.promptPath || path.join(root, "prompt.md"),
+    acceptedAt: accepted?.acceptedAt || "",
+    changedFiles,
+    commit: committed?.commit || "",
+    committedAt: committed?.committedAt || "",
+    findingsRemaining: accepted?.findingsRemaining === true,
+    maxPasses: REVIEW_PASS_LIMIT
+  };
+}
+
+async function readReviewPasses(paths) {
+  const passes = await readReviewPassNumbers(paths);
+  return Promise.all(passes.map((pass) => readReviewPassInfo(paths, pass)));
+}
+
 const PROMPT_ARTIFACT_BY_STEP_ID = Object.freeze({
   issue_drafted: "issue_draft.md",
+  plan_details_gathered: "plan_details.md",
   plan_executed: "plan_execution.md",
   plan_made: "plan_request.md",
   plan_fine_tuning: "plan_fine_tuning.md",
+  blueprint_updated: "update_blueprint.md",
   user_check_completed: "user_check.md"
 });
 
@@ -91,16 +212,182 @@ async function readPromptForStep(paths, stepId) {
   return readTextIfExists(path.join(paths.sessionRoot, "prompt.md"));
 }
 
-async function readCompletedSteps(sessionRoot) {
-  const stepsRoot = path.join(sessionRoot, "steps");
+async function readStepFileNames(stepsRoot) {
   try {
     const entries = await readdir(stepsRoot, { withFileTypes: true });
-    return normalizeKnownStepIds(entries
+    return entries
       .filter((entry) => entry.isFile())
-      .map((entry) => entry.name));
+      .map((entry) => entry.name);
   } catch {
     return [];
   }
+}
+
+async function readCompletedSteps(paths) {
+  const stepsRoot = path.join(paths.sessionRoot, "steps");
+  const activeCycle = await readActiveCycle(paths);
+  const globalStepIds = normalizeKnownStepIds(
+    (await readStepFileNames(stepsRoot)).filter((stepId) => !isCycleStepId(stepId))
+  );
+  const cycleStepIds = normalizeKnownStepIds(await readStepFileNames(cycleStepsRoot(paths, activeCycle)));
+  return applyReviewPassCompletionOverlay(paths, normalizeKnownStepIds([...globalStepIds, ...cycleStepIds]));
+}
+
+const REVIEW_STEP_IDS = Object.freeze([
+  "review_prompt_rendered",
+  "review_changes_accepted",
+  "review_changes_committed"
+]);
+
+async function applyReviewPassCompletionOverlay(paths, completedSteps = []) {
+  const completed = new Set(completedSteps);
+  if (!REVIEW_STEP_IDS.some((stepId) => completed.has(stepId))) {
+    return normalizeKnownStepIds([...completed]);
+  }
+  const reviewPasses = await readReviewPasses(paths);
+  const latestPass = reviewPasses.at(-1);
+  if (!latestPass) {
+    REVIEW_STEP_IDS.forEach((stepId) => completed.delete(stepId));
+    return normalizeKnownStepIds([...completed]);
+  }
+  const latestPassNumber = Number.parseInt(latestPass.pass, 10);
+  const latestPassCommitted = latestPass.status === "committed" || latestPass.status === "no_changes";
+  const anotherPassRequired = latestPassCommitted && latestPass.findingsRemaining === true && latestPassNumber < REVIEW_PASS_LIMIT;
+  if (anotherPassRequired) {
+    REVIEW_STEP_IDS.forEach((stepId) => completed.delete(stepId));
+    return normalizeKnownStepIds([...completed]);
+  }
+  if (latestPass.status === "prompted") {
+    completed.add("review_prompt_rendered");
+    completed.delete("review_changes_accepted");
+    completed.delete("review_changes_committed");
+    return normalizeKnownStepIds([...completed]);
+  }
+  if (latestPass.status === "accepted_with_changes" || latestPass.status === "accepted_no_changes") {
+    completed.add("review_prompt_rendered");
+    completed.add("review_changes_accepted");
+    completed.delete("review_changes_committed");
+    return normalizeKnownStepIds([...completed]);
+  }
+  if (latestPass.status === "committed" || latestPass.status === "no_changes") {
+    REVIEW_STEP_IDS.forEach((stepId) => completed.add(stepId));
+  }
+  return normalizeKnownStepIds([...completed]);
+}
+
+async function readCycleInfo(paths, cycle) {
+  const normalizedCycle = normalizeCycleNumber(cycle);
+  const root = cycleRoot(paths, normalizedCycle);
+  const userCheckPassed = await readTextIfExists(path.join(cycleStepsRoot(paths, normalizedCycle), "user_check_completed"));
+  const userCheckFailed = await readTextIfExists(path.join(cycleStepsRoot(paths, normalizedCycle), "user_check_failed"));
+  const reworkRequestPath = path.join(root, "rework_request.md");
+  const reworkRequest = await readTextIfExists(reworkRequestPath);
+  return {
+    cycle: normalizedCycle,
+    label: cycleDirectoryName(normalizedCycle),
+    reworkRequestPath: reworkRequest ? reworkRequestPath : "",
+    status: userCheckPassed ? "passed" : userCheckFailed ? "failed" : "active",
+    userCheckResult: userCheckPassed ? "passed" : userCheckFailed ? "failed" : "",
+    userCheckReceipt: (userCheckPassed || userCheckFailed).trim()
+  };
+}
+
+async function readCycles(paths, activeCycle) {
+  const cycles = new Set([normalizeCycleNumber(activeCycle || DEFAULT_ACTIVE_CYCLE)]);
+  for (const root of [path.join(paths.sessionRoot, "steps"), path.join(paths.sessionRoot, "cycles")]) {
+    try {
+      const entries = await readdir(root, { withFileTypes: true });
+      for (const entry of entries) {
+        if (entry.isDirectory() && /^cycle_\d+$/u.test(entry.name)) {
+          cycles.add(normalizeCycleNumber(entry.name));
+        }
+      }
+    } catch {
+      // Missing cycle directories are normal for older sessions.
+    }
+  }
+  return Promise.all([...cycles]
+    .sort((left, right) => Number.parseInt(left, 10) - Number.parseInt(right, 10))
+    .map((cycle) => readCycleInfo(paths, cycle)));
+}
+
+async function readStructuredChecks(paths) {
+  const checksRoot = path.join(paths.sessionRoot, "checks");
+  try {
+    const entries = await readdir(checksRoot, { withFileTypes: true });
+    const checks = [];
+    for (const entry of entries.filter((item) => item.isFile() && item.name.endsWith(".json")).sort((left, right) => left.name.localeCompare(right.name))) {
+      const source = await readTextIfExists(path.join(checksRoot, entry.name));
+      try {
+        const parsed = JSON.parse(source);
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+          checks.push(parsed);
+        }
+      } catch {
+        // Ignore malformed check metadata; the raw log remains on disk.
+      }
+    }
+    return checks;
+  } catch {
+    return [];
+  }
+}
+
+async function readStructuredUiChecks(paths) {
+  const uiChecksRoot = path.join(paths.sessionRoot, "ui_checks");
+  try {
+    const entries = await readdir(uiChecksRoot, { withFileTypes: true });
+    const checks = [];
+    for (const entry of entries.filter((item) => item.isFile() && item.name.endsWith(".json")).sort((left, right) => left.name.localeCompare(right.name))) {
+      const source = await readTextIfExists(path.join(uiChecksRoot, entry.name));
+      try {
+        const parsed = JSON.parse(source);
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+          checks.push(parsed);
+        }
+      } catch {
+        // Ignore malformed UI check metadata; the raw prompt/log remains on disk.
+      }
+    }
+    return checks;
+  } catch {
+    return [];
+  }
+}
+
+async function readWorktreeStatus(paths, worktreeReady) {
+  if (!worktreeReady) {
+    return {
+      changedFiles: [],
+      dirty: false,
+      ok: true,
+      status: "missing",
+      statusText: ""
+    };
+  }
+  const result = await runGitInWorktree(paths.worktree, ["status", "--porcelain=v1"], {
+    timeout: 15000
+  });
+  if (!result.ok) {
+    return {
+      changedFiles: [],
+      dirty: false,
+      ok: false,
+      status: "unknown",
+      statusText: result.output
+    };
+  }
+  const changedFiles = result.stdout
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  return {
+    changedFiles,
+    dirty: changedFiles.length > 0,
+    ok: true,
+    status: changedFiles.length > 0 ? "dirty" : "clean",
+    statusText: result.stdout
+  };
 }
 
 async function readReceiptSteps(paths) {
@@ -145,11 +432,34 @@ async function readReceiptSteps(paths) {
         return left.stepId.localeCompare(right.stepId);
       });
 
-    return Promise.all(stepRows.map(async ({ receiptName, stepId }) => ({
+    const globalReceipts = await Promise.all(stepRows.map(async ({ receiptName, stepId }) => ({
+      cycle: "",
       label: STEP_LABEL_BY_ID[stepId] || stepId,
       receipt: (await readTextIfExists(path.join(stepsRoot, receiptName))).trim(),
       stepId
     })));
+
+    const cycleReceipts = [];
+    const cycleDirectories = entries
+      .filter((entry) => entry.isDirectory() && /^cycle_\d+$/u.test(entry.name))
+      .map((entry) => entry.name)
+      .sort();
+    for (const cycleDirectory of cycleDirectories) {
+      const cycle = normalizeCycleNumber(cycleDirectory);
+      const cycleRootPath = path.join(stepsRoot, cycleDirectory);
+      const cycleStepIds = await readStepFileNames(cycleRootPath);
+      for (const receiptName of cycleStepIds) {
+        const stepId = normalizeStepId(receiptName);
+        cycleReceipts.push({
+          cycle,
+          label: STEP_LABEL_BY_ID[stepId] || stepId,
+          receipt: (await readTextIfExists(path.join(cycleRootPath, receiptName))).trim(),
+          stepId
+        });
+      }
+    }
+
+    return [...globalReceipts, ...cycleReceipts];
   } catch {
     return [];
   }
@@ -172,14 +482,35 @@ function cloneContractValue(value) {
   );
 }
 
+function stepRepeatabilityContract(stepId) {
+  if (!CYCLE_STEP_IDS.includes(normalizeStepId(stepId))) {
+    return {
+      repeatable: false,
+      repeatableGroupId: "",
+      repeatableGroupLabel: "",
+      repeatableLabel: ""
+    };
+  }
+  return {
+    repeatable: true,
+    repeatableGroupId: "rework_cycle",
+    repeatableGroupLabel: "Rework cycle",
+    repeatableLabel: "Cycle step"
+  };
+}
+
 function publicStepDefinition(step, index) {
   return {
     description: step.description,
+    displayGroupId: step.displayGroupId || "",
+    displayGroupLabel: step.displayGroupLabel || "",
     id: step.id,
     index,
     input: cloneContractValue(step.input),
     kind: step.kind,
     label: step.label,
+    ...stepRepeatabilityContract(step.id),
+    requiresExplicitRun: step.requiresExplicitRun === true,
     utilityActions: cloneContractValue(step.utilityActions || [])
   };
 }
@@ -188,17 +519,108 @@ function buildStepDefinitions() {
   return STEP_DEFINITIONS.map((step, index) => publicStepDefinition(step, index));
 }
 
-function buildCurrentStepAction(stepId) {
+function stepIsRetryableWhenBlocked(stepId) {
+  return [
+    "pre_review_checks_run",
+    "deep_ui_check_run",
+    "post_review_checks_run",
+    "deep_ui_recheck_run",
+    "doctor_run"
+  ].includes(normalizeStepId(stepId));
+}
+
+function stepIsConditional(stepId) {
+  return [
+    "deep_ui_check_run",
+    "deep_ui_recheck_run"
+  ].includes(normalizeStepId(stepId));
+}
+
+function skipReasonForStep(stepId, artifacts = {}) {
+  if (stepIsConditional(stepId) && artifacts.uiImpact === "none") {
+    return "uiImpact is none.";
+  }
+  return "";
+}
+
+function buildCurrentStepAction(stepId, artifacts = {}) {
   const step = STEP_DEFINITION_BY_ID[stepId];
   if (!step) {
     return null;
   }
+  const alternateActions = [];
+  if (step.id === "user_check_completed") {
+    alternateActions.push({
+      id: "return_to_plan_fine_tuning",
+      input: {
+        formatHint: "markdown",
+        label: "What needs to be reworked?",
+        multiline: true,
+        name: "reworkNotes",
+        required: true,
+        type: "text"
+      },
+      label: "Return to Plan fine tuning",
+      presentation: "exclusive",
+      requiredErrorCode: "user_check_failed",
+      submitOptions: {
+        userCheck: "failed"
+      },
+      targetStep: "plan_fine_tuning"
+    });
+  }
+  if (step.id === "review_changes_accepted") {
+    alternateActions.push({
+      id: "request_another_review_pass",
+      input: {
+        formatHint: "markdown",
+        label: "What important findings remain?",
+        multiline: true,
+        name: "reviewFindings",
+        required: true,
+        type: "text"
+      },
+      label: "Run another review pass",
+      presentation: "secondary",
+      submitOptions: {
+        reviewFindingsRemaining: true
+      },
+      targetStep: "review_prompt_rendered"
+    });
+  }
+  if (step.id === "pr_finalized") {
+    alternateActions.push({
+      id: "close_without_merge",
+      input: {
+        formatHint: "markdown",
+        label: "Why is this session finishing without merge?",
+        multiline: true,
+        name: "closeReason",
+        required: true,
+        type: "text"
+      },
+      label: "Finish without merge",
+      presentation: "secondary",
+      submitOptions: {
+        closeWithoutMerge: true
+      },
+      targetStep: "pr_finalized"
+    });
+  }
   return {
+    alternateActions,
     buttonLabel: step.buttonLabel,
     description: step.description,
     index: STEP_IDS.indexOf(step.id),
     input: cloneContractValue(step.input),
     kind: step.kind,
+    label: step.buttonLabel,
+    ...stepRepeatabilityContract(step.id),
+    requiredInput: cloneContractValue(step.input),
+    requiresExplicitRun: step.requiresExplicitRun === true,
+    conditional: stepIsConditional(step.id),
+    retryable: artifacts.status === SESSION_STATUS.BLOCKED && stepIsRetryableWhenBlocked(step.id),
+    skipReason: skipReasonForStep(step.id, artifacts),
     stepId: step.id,
     utilityActions: cloneContractValue(step.utilityActions || [])
   };
@@ -210,7 +632,26 @@ function buildCodexHandoff(stepId) {
 }
 
 async function readSessionArtifacts(paths) {
-  const [status, rawCurrentStep, issueUrl, prUrl, issueText, issueTitle, planText, codexThreadId] = await Promise.all([
+  const [
+    status,
+    rawCurrentStep,
+    issueUrl,
+    prUrl,
+    issueText,
+    issueTitle,
+    planText,
+    planDetails,
+    agentDecisions,
+    finalReportText,
+    githubCommentsText,
+    codexThreadId,
+    workflowVersion,
+    baseBranch,
+    baseCommit,
+    issueMetadataText,
+    planExecutionReceipt,
+    prOutcomeText
+  ] = await Promise.all([
     readTrimmedFile(path.join(paths.sessionRoot, "status")),
     readTrimmedFile(path.join(paths.sessionRoot, "current_step")),
     readTrimmedFile(path.join(paths.sessionRoot, "issue_url")),
@@ -218,13 +659,60 @@ async function readSessionArtifacts(paths) {
     readTextIfExists(path.join(paths.sessionRoot, "issue.md")),
     readTrimmedFile(path.join(paths.sessionRoot, "issue_title")),
     readTextIfExists(path.join(paths.sessionRoot, "plan.md")),
-    readTrimmedFile(path.join(paths.sessionRoot, "codex_thread_id"))
+    readTextIfExists(path.join(paths.sessionRoot, "plan_details.md")),
+    readTextIfExists(path.join(paths.sessionRoot, "agent_decisions.md")),
+    readTextIfExists(path.join(paths.sessionRoot, "final_report.md")),
+    readTextIfExists(path.join(paths.sessionRoot, "github_comments.json")),
+    readTrimmedFile(path.join(paths.sessionRoot, "codex_thread_id")),
+    readWorkflowVersion(paths),
+    readTrimmedFile(path.join(paths.sessionRoot, "base_branch")),
+    readTrimmedFile(path.join(paths.sessionRoot, "base_commit")),
+    readTextIfExists(path.join(paths.sessionRoot, "issue_metadata.json")),
+    readTextIfExists(path.join(paths.sessionRoot, "steps", "plan_executed")),
+    readTextIfExists(path.join(paths.sessionRoot, "pr_outcome.json"))
   ]);
-  const currentStep = normalizeStepId(rawCurrentStep);
+  let issueMetadata = null;
+  if (issueMetadataText) {
+    try {
+      issueMetadata = JSON.parse(issueMetadataText);
+    } catch {
+      issueMetadata = null;
+    }
+  }
+  let githubComments = {};
+  if (githubCommentsText) {
+    try {
+      const parsed = JSON.parse(githubCommentsText);
+      githubComments = parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+    } catch {
+      githubComments = {};
+    }
+  }
+  let prOutcome = null;
+  if (prOutcomeText) {
+    try {
+      const parsed = JSON.parse(prOutcomeText);
+      prOutcome = parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : null;
+    } catch {
+      prOutcome = null;
+    }
+  }
+  const activeCycle = await readActiveCycle(paths);
+  const cycles = await readCycles(paths, activeCycle);
+  const checks = await readStructuredChecks(paths);
+  const uiChecks = await readStructuredUiChecks(paths);
+  const reviewPasses = await readReviewPasses(paths);
   const worktreeReady = await hasWorktree(paths);
-  let completedSteps = await readCompletedSteps(paths.sessionRoot);
-  const worktreeRemovalCompleted = completedSteps.includes("pr_merged") ||
-    completedSteps.includes("worktree_removed");
+  const worktreeStatus = await readWorktreeStatus(paths, worktreeReady);
+  const commandLogPath = path.join(paths.sessionRoot, "command_log.jsonl");
+  const dependencyInstallReceipt = await readTextIfExists(path.join(paths.sessionRoot, "steps", "dependencies_installed"));
+  const appRootForArtifacts = worktreeReady ? paths.worktree : paths.targetRoot;
+  const appReady = await inspectReadyJskitAppRoot(appRootForArtifacts);
+  const blueprintPath = path.join(appRootForArtifacts, ".jskit", "APP_BLUEPRINT.md");
+  const helperMapPath = path.join(appRootForArtifacts, ".jskit", "helper-map.md");
+  const currentStep = normalizeStepId(rawCurrentStep);
+  let completedSteps = await readCompletedSteps(paths);
+  const worktreeRemovalCompleted = completedSteps.includes("pr_finalized");
   const worktreeReceiptInvalid = !worktreeReady &&
     completedSteps.includes("worktree_created") &&
     !worktreeRemovalCompleted &&
@@ -246,15 +734,58 @@ async function readSessionArtifacts(paths) {
     codexThreadId,
     completedSteps,
     currentStep: effectiveCurrentStep,
+    activeCycle,
+    appReady,
+    baseBranch,
+    baseCommit,
+    blueprintExists: await fileExists(blueprintPath),
+    blueprintPath,
+    cycles,
+    checks,
+    uiChecks,
+    reviewPasses,
+    currentReviewPass: reviewPasses.at(-1)?.pass || "",
+    commandLogExists: await fileExists(commandLogPath),
+    commandLogPath,
+    dependencyInstall: {
+      installed: Boolean(dependencyInstallReceipt.trim()),
+      receipt: dependencyInstallReceipt.trim(),
+      status: dependencyInstallReceipt.trim()
+        ? "installed"
+        : worktreeReady ? "pending" : "waiting_for_worktree"
+    },
+    helperMapExists: await fileExists(helperMapPath),
+    helperMapPath,
+    githubComments,
+    issueMetadata,
+    issueCategory: normalizeText(issueMetadata?.issueCategory || ""),
+    uiImpact: normalizeText(issueMetadata?.uiImpact || ""),
+    agentDecisions: agentDecisions.trim(),
+    agentDecisionsLatest: agentDecisions
+      .split(/\r?\n/u)
+      .map((line) => line.trim())
+      .filter((line) => line && !line.startsWith("#") && !line.startsWith("Session:"))
+      .slice(-5)
+      .join("\n"),
     issueTitle,
     issueText: issueText.trim(),
     issueUrl,
     nextStep,
     prUrl,
+    prOutcome,
+    planExecution: {
+      promptPath: planExecutionReceipt.trim() ? path.join(paths.sessionRoot, "prompts", "plan_execution.md") : "",
+      receipt: planExecutionReceipt.trim(),
+      submitted: Boolean(planExecutionReceipt.trim())
+    },
     planText: planText.trim(),
+    planDetails: planDetails.trim(),
+    finalReportText: finalReportText.trim(),
     prompt: prompt.trim(),
     status: status || SESSION_STATUS.PENDING,
-    worktreeReady
+    workflowVersion,
+    worktreeReady,
+    worktreeStatus
   };
 }
 
@@ -277,6 +808,68 @@ async function buildSessionResponse(paths, {
   const responsePaths = paths.sessionId ? await pathsForExistingSession(paths) : paths;
   const artifacts = responsePaths.sessionRoot ? await readSessionArtifacts(responsePaths) : {};
   const resolvedStatus = status || artifacts.status || (ok ? SESSION_STATUS.PENDING : SESSION_STATUS.BLOCKED);
+  if (responsePaths.sessionRoot && await fileExists(responsePaths.sessionRoot) && artifacts.workflowVersion !== SESSION_WORKFLOW_VERSION) {
+    return {
+      ok: false,
+      sessionId: paths.sessionId || "",
+      status: SESSION_STATUS.BLOCKED,
+      currentStep: "",
+      completedSteps: artifacts.completedSteps || [],
+      workflowVersion: artifacts.workflowVersion || "",
+      baseBranch: artifacts.baseBranch || "",
+      baseCommit: artifacts.baseCommit || "",
+      blueprintPath: artifacts.blueprintPath || "",
+      blueprintExists: artifacts.blueprintExists === true,
+      activeCycle: artifacts.activeCycle || "",
+      appReady: cloneContractValue(artifacts.appReady || null),
+      cycles: cloneContractValue(artifacts.cycles || []),
+      checks: cloneContractValue(artifacts.checks || []),
+      dependencyInstall: cloneContractValue(artifacts.dependencyInstall || null),
+      uiChecks: cloneContractValue(artifacts.uiChecks || []),
+      reviewPasses: cloneContractValue(artifacts.reviewPasses || []),
+      currentReviewPass: artifacts.currentReviewPass || "",
+      commandLogExists: artifacts.commandLogExists === true,
+      commandLogPath: artifacts.commandLogPath || "",
+      stepDefinitions: buildStepDefinitions(),
+      currentStepAction: null,
+      codex: null,
+      prompt: "",
+      nextCommand: "",
+      issueUrl: artifacts.issueUrl || "",
+      issueTitle: artifacts.issueTitle || "",
+      issueText: artifacts.issueText || "",
+      issueMetadata: cloneContractValue(artifacts.issueMetadata || null),
+      githubComments: cloneContractValue(artifacts.githubComments || {}),
+      issueCategory: artifacts.issueCategory || "",
+      uiImpact: artifacts.uiImpact || "",
+      agentDecisionsPath: artifacts.agentDecisions ? path.join(responsePaths.sessionRoot, "agent_decisions.md") : "",
+      agentDecisionsLatest: artifacts.agentDecisionsLatest || "",
+      planExecution: cloneContractValue(artifacts.planExecution || null),
+      planText: artifacts.planText || "",
+      planDetails: artifacts.planDetails || "",
+      planDetailsPath: artifacts.planDetails ? path.join(responsePaths.sessionRoot, "plan_details.md") : "",
+      finalReportPath: artifacts.finalReportText ? path.join(responsePaths.sessionRoot, "final_report.md") : "",
+      finalReportText: artifacts.finalReportText || "",
+      helperMapPath: artifacts.helperMapPath || "",
+      helperMapExists: artifacts.helperMapExists === true,
+      prUrl: artifacts.prUrl || "",
+      prOutcome: cloneContractValue(artifacts.prOutcome || null),
+      preconditions,
+      errors: [
+        createError({
+          code: "unsupported_workflow_version",
+          message: `Session ${paths.sessionId || ""} uses workflow version ${artifacts.workflowVersion || "missing"}, but this JSKIT runtime expects ${SESSION_WORKFLOW_VERSION}.`
+        })
+      ],
+      archive: responsePaths.archive || "active",
+      sessionRoot: responsePaths.sessionRoot || "",
+      worktree: paths.worktree || "",
+      worktreeReady: artifacts.worktreeReady === true,
+      worktreeStatus: cloneContractValue(artifacts.worktreeStatus || null),
+      branch: paths.branch || "",
+      codexThreadId: artifacts.codexThreadId || ""
+    };
+  }
   const currentStep = artifacts.currentStep || artifacts.nextStep || "";
   const responsePrompt = typeof prompt === "string"
     ? prompt
@@ -288,22 +881,52 @@ async function buildSessionResponse(paths, {
     status: resolvedStatus,
     currentStep,
     completedSteps: artifacts.completedSteps || [],
+    workflowVersion: artifacts.workflowVersion || "",
+    baseBranch: artifacts.baseBranch || "",
+    baseCommit: artifacts.baseCommit || "",
+    blueprintPath: artifacts.blueprintPath || "",
+    blueprintExists: artifacts.blueprintExists === true,
+    activeCycle: artifacts.activeCycle || "",
+    appReady: cloneContractValue(artifacts.appReady || null),
+    cycles: cloneContractValue(artifacts.cycles || []),
+    checks: cloneContractValue(artifacts.checks || []),
+    dependencyInstall: cloneContractValue(artifacts.dependencyInstall || null),
+    uiChecks: cloneContractValue(artifacts.uiChecks || []),
+    reviewPasses: cloneContractValue(artifacts.reviewPasses || []),
+    currentReviewPass: artifacts.currentReviewPass || "",
+    commandLogExists: artifacts.commandLogExists === true,
+    commandLogPath: artifacts.commandLogPath || "",
     stepDefinitions: buildStepDefinitions(),
-    currentStepAction: buildCurrentStepAction(currentStep),
+    currentStepAction: buildCurrentStepAction(currentStep, artifacts),
     codex: codex === undefined ? buildCodexHandoff(currentStep) : cloneContractValue(codex),
     prompt: responsePrompt,
     nextCommand: buildNextCommand(paths.sessionId || "", currentStep),
     issueUrl: artifacts.issueUrl || "",
     issueTitle: artifacts.issueTitle || "",
     issueText: artifacts.issueText || "",
+    issueMetadata: cloneContractValue(artifacts.issueMetadata || null),
+    githubComments: cloneContractValue(artifacts.githubComments || {}),
+    issueCategory: artifacts.issueCategory || "",
+    uiImpact: artifacts.uiImpact || "",
+    agentDecisionsPath: artifacts.agentDecisions ? path.join(responsePaths.sessionRoot, "agent_decisions.md") : "",
+    agentDecisionsLatest: artifacts.agentDecisionsLatest || "",
+    planExecution: cloneContractValue(artifacts.planExecution || null),
     planText: artifacts.planText || "",
+    planDetails: artifacts.planDetails || "",
+    planDetailsPath: artifacts.planDetails ? path.join(responsePaths.sessionRoot, "plan_details.md") : "",
+    finalReportPath: artifacts.finalReportText ? path.join(responsePaths.sessionRoot, "final_report.md") : "",
+    finalReportText: artifacts.finalReportText || "",
+    helperMapPath: artifacts.helperMapPath || "",
+    helperMapExists: artifacts.helperMapExists === true,
     prUrl: artifacts.prUrl || "",
+    prOutcome: cloneContractValue(artifacts.prOutcome || null),
     preconditions,
     errors,
     archive: responsePaths.archive || (resolvedStatus === SESSION_STATUS.FINISHED ? "completed" : resolvedStatus === SESSION_STATUS.ABANDONED ? "abandoned" : "active"),
     sessionRoot: responsePaths.sessionRoot || "",
     worktree: paths.worktree || "",
     worktreeReady: artifacts.worktreeReady === true,
+    worktreeStatus: cloneContractValue(artifacts.worktreeStatus || null),
     branch: paths.branch || "",
     codexThreadId: artifacts.codexThreadId || ""
   };
@@ -336,6 +959,21 @@ function buildSessionErrorResponse({
     status,
     currentStep: "",
     completedSteps: [],
+    workflowVersion: "",
+    baseBranch: "",
+    baseCommit: "",
+    blueprintPath: "",
+    blueprintExists: false,
+    activeCycle: "",
+    appReady: null,
+    cycles: [],
+    checks: [],
+    dependencyInstall: null,
+    uiChecks: [],
+    reviewPasses: [],
+    currentReviewPass: "",
+    commandLogExists: false,
+    commandLogPath: "",
     stepDefinitions: buildStepDefinitions(),
     currentStepAction: null,
     codex: null,
@@ -343,15 +981,30 @@ function buildSessionErrorResponse({
     nextCommand: "",
     issueTitle: "",
     issueText: "",
+    issueMetadata: null,
+    githubComments: {},
+    issueCategory: "",
+    uiImpact: "",
+    agentDecisionsPath: "",
+    agentDecisionsLatest: "",
+    planExecution: null,
     planText: "",
+    planDetails: "",
+    planDetailsPath: "",
+    finalReportPath: "",
+    finalReportText: "",
+    helperMapPath: "",
+    helperMapExists: false,
     issueUrl: "",
     prUrl: "",
+    prOutcome: null,
     preconditions,
     errors: errorList,
     archive: "",
     sessionRoot: "",
     worktree: "",
     worktreeReady: false,
+    worktreeStatus: null,
     branch: "",
     codexThreadId: "",
     targetRoot: normalizedTargetRoot
@@ -367,13 +1020,27 @@ async function markCurrentStep(paths, stepId) {
 }
 
 async function writeReceipt(paths, stepId, message) {
-  await mkdir(path.join(paths.sessionRoot, "steps"), { recursive: true });
+  const activeCycle = await readActiveCycle(paths);
+  const root = isCycleStepId(stepId) ? cycleStepsRoot(paths, activeCycle) : path.join(paths.sessionRoot, "steps");
+  await mkdir(root, { recursive: true });
   await writeTextFile(
-    path.join(paths.sessionRoot, "steps", stepId),
+    path.join(root, stepId),
     `${timestampForReceipt()}\n${normalizeText(message) || STEP_LABEL_BY_ID[stepId] || stepId}`
   );
-  const completedSteps = await readCompletedSteps(paths.sessionRoot);
+  const completedSteps = await readCompletedSteps(paths);
   await markCurrentStep(paths, resolveNextStep(completedSteps));
+}
+
+async function writeCycleReceipt(paths, receiptName, message, {
+  cycle = ""
+} = {}) {
+  const activeCycle = normalizeCycleNumber(cycle || await readActiveCycle(paths));
+  const root = cycleStepsRoot(paths, activeCycle);
+  await mkdir(root, { recursive: true });
+  await writeTextFile(
+    path.join(root, normalizeText(receiptName)),
+    `${timestampForReceipt()}\n${normalizeText(message) || normalizeText(receiptName)}`
+  );
 }
 
 async function failSession(paths, {
@@ -411,7 +1078,14 @@ export {
   failSession,
   markCurrentStep,
   markStatus,
+  normalizeReviewPassNumber,
+  readActiveCycle,
   readReceiptSteps,
+  readReviewPasses,
   readSessionArtifacts,
+  reviewPassDirectoryName,
+  reviewPassRoot,
+  writeActiveCycle,
+  writeCycleReceipt,
   writeReceipt
 };

--- a/tooling/jskit-cli/test/sessionCommand.test.js
+++ b/tooling/jskit-cli/test/sessionCommand.test.js
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { chmod, mkdir, readFile, writeFile, access } from "node:fs/promises";
+import { access, chmod, mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { spawnSync } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -11,6 +11,7 @@ import {
   STEP_IDS,
   STEP_PRECONDITION_NAMES,
   createSession,
+  extractPlanDetails,
   extractIssueTitle,
   extractIssueText,
   extractPlanText,
@@ -22,6 +23,7 @@ import {
 } from "../src/server/appBlueprint.js";
 
 const CLI_PATH = fileURLToPath(new URL("../bin/jskit.js", import.meta.url));
+const PROMPT_ROOT = fileURLToPath(new URL("../src/server/sessionRuntime/prompts/", import.meta.url));
 const runCli = createCliRunner(CLI_PATH);
 
 async function writeExecutable(filePath, source) {
@@ -37,13 +39,56 @@ async function installFakeCommand(binDir, commandName, source) {
 }
 
 function parseJsonResult(result) {
-  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
   return JSON.parse(result.stdout);
 }
 
 function parseJsonFailure(result) {
   assert.notEqual(result.status, 0);
   return JSON.parse(result.stdout);
+}
+
+const SESSION_CONTRACT_FIELDS = Object.freeze([
+  "activeCycle",
+  "agentDecisionsLatest",
+  "agentDecisionsPath",
+  "appReady",
+  "baseBranch",
+  "baseCommit",
+  "blueprintExists",
+  "blueprintPath",
+  "checks",
+  "codexThreadId",
+  "commandLogExists",
+  "commandLogPath",
+  "completedSteps",
+  "currentStepAction",
+  "currentReviewPass",
+  "cycles",
+  "dependencyInstall",
+  "finalReportPath",
+  "finalReportText",
+  "githubComments",
+  "helperMapExists",
+  "helperMapPath",
+  "issueCategory",
+  "issueMetadata",
+  "planDetails",
+  "planDetailsPath",
+  "planExecution",
+  "prOutcome",
+  "reviewPasses",
+  "stepDefinitions",
+  "uiChecks",
+  "uiImpact",
+  "workflowVersion",
+  "worktreeStatus"
+]);
+
+function assertSessionContractFields(payload) {
+  for (const field of SESSION_CONTRACT_FIELDS) {
+    assert.ok(Object.hasOwn(payload, field), `session JSON is missing ${field}`);
+  }
 }
 
 function runSessionStepJson(cwd, sessionId, {
@@ -76,12 +121,42 @@ function advanceCliSessionToIssuePrompt(cwd, sessionId, { env = undefined } = {}
   const worktreePayload = runSessionStepJson(cwd, sessionId, { env });
   assert.equal(worktreePayload.currentStep, "dependencies_installed");
   assert.equal(worktreePayload.worktreeReady, true);
+  assert.equal(worktreePayload.dependencyInstall.status, "pending");
   const promptReadyPayload = runSessionStepJson(cwd, sessionId, { env });
   assert.equal(promptReadyPayload.currentStep, "issue_prompt_rendered");
   assert.equal(promptReadyPayload.currentStepAction.input.name, "prompt");
+  assert.equal(promptReadyPayload.dependencyInstall.status, "installed");
   return {
     promptReadyPayload,
     worktreePayload
+  };
+}
+
+function saveCliSessionPlanDetails(cwd, sessionId, { env = undefined } = {}) {
+  const detailsPrompt = runSessionStepJson(cwd, sessionId, { env });
+  assert.equal(detailsPrompt.currentStep, "plan_details_gathered");
+  assert.match(detailsPrompt.prompt, /Gather exact implementation details/);
+  const reloadedDetailsPrompt = parseJsonResult(runCli({
+    cwd,
+    args: ["session", sessionId, "--json"],
+    env
+  }));
+  assert.equal(reloadedDetailsPrompt.currentStep, "plan_details_gathered");
+  assert.match(reloadedDetailsPrompt.prompt, /Gather exact implementation details/);
+  const detailsSaved = runSessionStepJson(cwd, sessionId, {
+    args: ["--plan-details", "-"],
+    env,
+    input: planDetailsOutput()
+  });
+  assert.equal(detailsSaved.currentStep, "plan_made");
+  assert.equal(detailsSaved.planDetails, "Confirmed details are sufficient to plan the requested change.");
+  assert.equal(detailsSaved.issueMetadata.issueCategory, "client");
+  assert.equal(detailsSaved.issueMetadata.uiImpact, "possible");
+  assert.equal(detailsSaved.issueCategory, "client");
+  assert.equal(detailsSaved.uiImpact, "possible");
+  return {
+    detailsPrompt,
+    detailsSaved
   };
 }
 
@@ -113,10 +188,18 @@ async function createGitApp(root, { withRemote = false } = {}) {
     )}\n`,
     "utf8"
   );
+  await mkdir(path.join(root, ".jskit"), { recursive: true });
+  await mkdir(path.join(root, "config"), { recursive: true });
+  await mkdir(path.join(root, "src"), { recursive: true });
+  await mkdir(path.join(root, "packages"), { recursive: true });
+  await writeFile(path.join(root, ".jskit", "lock.json"), "{\n  \"lockVersion\": 1,\n  \"installedPackages\": {}\n}\n", "utf8");
+  await writeFile(path.join(root, "config", "public.js"), "export default { tenancyMode: \"none\", surfaces: [] };\n", "utf8");
+  await writeFile(path.join(root, "src", ".gitkeep"), "", "utf8");
+  await writeFile(path.join(root, "packages", ".gitkeep"), "", "utf8");
   runGit(root, ["init"]);
   runGit(root, ["config", "user.name", "JSKIT Test"]);
   runGit(root, ["config", "user.email", "test@example.com"]);
-  runGit(root, ["add", "package.json"]);
+  runGit(root, ["add", "."]);
   runGit(root, ["commit", "-m", "Initial commit"]);
   runGit(root, ["branch", "-M", "main"]);
   if (withRemote) {
@@ -135,11 +218,115 @@ async function createUncommittedGitApp(root) {
   runGit(root, ["config", "user.email", "test@example.com"]);
 }
 
+async function createPackageOnlyGitApp(root) {
+  await mkdir(root, { recursive: true });
+  await writeFile(path.join(root, "package.json"), "{\"name\":\"package-only-app\",\"scripts\":{\"verify:local\":\"node -e \\\"process.exit(0)\\\"\"}}\n", "utf8");
+  runGit(root, ["init"]);
+  runGit(root, ["config", "user.name", "JSKIT Test"]);
+  runGit(root, ["config", "user.email", "test@example.com"]);
+  runGit(root, ["add", "package.json"]);
+  runGit(root, ["commit", "-m", "Initial commit"]);
+}
+
 async function writeStepReceipts(sessionRoot, stepIds) {
   await mkdir(path.join(sessionRoot, "steps"), { recursive: true });
+  const steps = new Set(stepIds);
+  const cycleStepIds = new Set([
+    "plan_fine_tuning",
+    "implementation_changes_accepted",
+    "implementation_changes_committed",
+    "pre_review_checks_run",
+    "deep_ui_check_run",
+    "deep_ui_check_changes_accepted",
+    "deep_ui_check_changes_committed",
+    "review_prompt_rendered",
+    "review_changes_accepted",
+    "review_changes_committed",
+    "post_review_checks_run",
+    "deep_ui_recheck_run",
+    "deep_ui_recheck_changes_accepted",
+    "deep_ui_recheck_changes_committed",
+    "user_check_completed"
+  ]);
   for (const stepId of stepIds) {
-    await writeFile(path.join(sessionRoot, "steps", stepId), `2026-05-11T00:00:00.000Z\n${stepId}\n`, "utf8");
+    const root = cycleStepIds.has(stepId)
+      ? path.join(sessionRoot, "steps", "cycle_001")
+      : path.join(sessionRoot, "steps");
+    await mkdir(root, { recursive: true });
+    await writeFile(path.join(root, stepId), `2026-05-11T00:00:00.000Z\n${stepId}\n`, "utf8");
   }
+  if (steps.has("review_prompt_rendered")) {
+    const passRoot = path.join(sessionRoot, "review_passes", "pass_001");
+    await mkdir(passRoot, { recursive: true });
+    await writeFile(path.join(sessionRoot, "review_passes", "current_pass"), "001\n", "utf8");
+    await writeFile(path.join(passRoot, "prompt.md"), "Review pass prompt.\n", "utf8");
+    await writeFile(
+      path.join(passRoot, "prompt.json"),
+      `${JSON.stringify({
+        changedFiles: [],
+        maxPasses: 3,
+        pass: "001",
+        promptPath: path.join(passRoot, "prompt.md"),
+        status: "prompted",
+        startedAt: "2026-05-11T00:00:00.000Z"
+      }, null, 2)}\n`,
+      "utf8"
+    );
+  }
+  if (steps.has("review_changes_accepted")) {
+    const passRoot = path.join(sessionRoot, "review_passes", "pass_001");
+    await mkdir(passRoot, { recursive: true });
+    await writeFile(
+      path.join(passRoot, "accepted.json"),
+      `${JSON.stringify({
+        acceptedAt: "2026-05-11T00:00:00.000Z",
+        changedFiles: [],
+        findingsRemaining: false,
+        pass: "001",
+        remainingFindings: "",
+        status: "accepted_no_changes"
+      }, null, 2)}\n`,
+      "utf8"
+    );
+  }
+  if (steps.has("review_changes_committed")) {
+    const passRoot = path.join(sessionRoot, "review_passes", "pass_001");
+    await mkdir(passRoot, { recursive: true });
+    await writeFile(
+      path.join(passRoot, "committed.json"),
+      `${JSON.stringify({
+        changedFiles: [],
+        commit: "",
+        committedAt: "2026-05-11T00:00:00.000Z",
+        pass: "001",
+        status: "no_changes"
+      }, null, 2)}\n`,
+      "utf8"
+    );
+  }
+}
+
+function planDetailsOutput({
+  category = "client",
+  uiImpact = "possible",
+  body = "Confirmed details are sufficient to plan the requested change."
+} = {}) {
+  return `[issue_category]\n${category}\n[/issue_category]\n\n[ui_impact]\n${uiImpact}\n[/ui_impact]\n\n[plan_details]\n${body}\n[/plan_details]\n\n[agent_decisions]\n- Use the smallest JSKIT-owned implementation path.\n[/agent_decisions]`;
+}
+
+async function writeIssueMetadata(sessionRoot, {
+  category = "client",
+  uiImpact = "possible"
+} = {}) {
+  await writeFile(
+    path.join(sessionRoot, "issue_metadata.json"),
+    `${JSON.stringify({
+      issueCategory: category,
+      planDetailsPath: path.join(sessionRoot, "plan_details.md"),
+      uiImpact
+    }, null, 2)}\n`,
+    "utf8"
+  );
 }
 
 async function installFakeGh(binDir, logPath) {
@@ -162,9 +349,17 @@ if (args[0] === "pr" && args[1] === "create") {
   process.exit(0);
 }
 if (args[0] === "pr" && args[1] === "view") {
-  console.log(JSON.stringify({ baseRefName: "main", state: "OPEN", mergedAt: "", url: args[2] }));
+  const explicitUrl = args[2] && !args[2].startsWith("--") ? args[2] : "";
+  const existingUrl = process.env.FAKE_GH_EXISTING_PR_URL || "";
+  const url = explicitUrl || existingUrl;
+  if (!url) {
+    console.error("no pull request found for current branch");
+    process.exit(1);
+  }
+  console.log(JSON.stringify({ baseRefName: "main", state: process.env.FAKE_GH_PR_STATE || "OPEN", mergedAt: "", url }));
   process.exit(0);
 }
+if (args[0] === "pr" && args[1] === "comment") process.exit(0);
 if (args[0] === "pr" && args[1] === "merge") {
   const git = (gitArgs) => childProcess.spawnSync("git", gitArgs, {
     cwd: process.cwd(),
@@ -204,6 +399,18 @@ process.exit(0);
   );
 }
 
+async function installFakePnpm(binDir, logPath) {
+  await installFakeCommand(
+    binDir,
+    "pnpm",
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+fs.appendFileSync(${JSON.stringify(logPath)}, ["pnpm", ...process.argv.slice(2)].join(" ") + "\\n");
+process.exit(0);
+`
+  );
+}
+
 test("jskit session create writes file-backed state, receipt, and local git exclude", async () => {
   await withTempDir(async (cwd) => {
     const appRoot = path.join(cwd, "app");
@@ -220,6 +427,15 @@ test("jskit session create writes file-backed state, receipt, and local git excl
     assert.equal(payload.sessionRoot, path.join(appRoot, ".jskit", "sessions", "active", payload.sessionId));
     assert.equal(payload.worktree, path.join(payload.sessionRoot, "worktree"));
     assert.equal(payload.worktreeReady, false);
+    assert.equal(payload.worktreeStatus.status, "missing");
+    assert.equal(payload.worktreeStatus.dirty, false);
+    assert.equal(payload.workflowVersion, "2");
+    assert.equal(payload.appReady.ok, true);
+    assert.deepEqual(payload.appReady.missing, []);
+    assert.equal(payload.dependencyInstall.status, "waiting_for_worktree");
+    assert.equal(payload.dependencyInstall.installed, false);
+    assert.equal(payload.activeCycle, "001");
+    assert.equal(payload.cycles[0].cycle, "001");
     assert.equal(payload.currentStep, "worktree_created");
     assert.deepEqual(payload.completedSteps, ["session_created"]);
     assert.deepEqual(payload.stepDefinitions.map((step) => step.id), STEP_IDS);
@@ -227,6 +443,8 @@ test("jskit session create writes file-backed state, receipt, and local git excl
     assert.equal(payload.currentStepAction.buttonLabel, "Create worktree");
     assert.equal(await readFile(path.join(appRoot, ".git", "info", "exclude"), "utf8").then((body) => body.includes(".jskit/sessions/")), true);
     assert.equal(await readFile(path.join(payload.sessionRoot, "steps", "session_created"), "utf8").then((body) => body.includes("Created JSKIT Studio issue session")), true);
+    assert.equal(await readFile(path.join(payload.sessionRoot, "workflow_version"), "utf8"), "2\n");
+    assert.equal(await readFile(path.join(payload.sessionRoot, "active_cycle"), "utf8"), "001\n");
   });
 });
 
@@ -253,9 +471,38 @@ test("jskit session JSON exposes JSKIT-owned step UI and Codex handoff contract"
     await createGitApp(appRoot);
 
     const created = parseJsonResult(runCli({ cwd: appRoot, args: ["session", "create", "--json"] }));
+    assertSessionContractFields(created);
     assert.deepEqual(created.stepDefinitions.map((step) => step.id), STEP_DEFINITIONS.map((step) => step.id));
     assert.deepEqual(created.stepDefinitions.map((step) => step.index), STEP_DEFINITIONS.map((_step, index) => index));
     assert.equal(created.stepDefinitions.find((step) => step.id === "issue_prompt_rendered").kind, "human_input");
+    assert.deepEqual(
+      {
+        repeatable: created.stepDefinitions.find((step) => step.id === "issue_created").repeatable,
+        repeatableGroupId: created.stepDefinitions.find((step) => step.id === "issue_created").repeatableGroupId,
+        repeatableGroupLabel: created.stepDefinitions.find((step) => step.id === "issue_created").repeatableGroupLabel,
+        repeatableLabel: created.stepDefinitions.find((step) => step.id === "issue_created").repeatableLabel
+      },
+      {
+        repeatable: false,
+        repeatableGroupId: "",
+        repeatableGroupLabel: "",
+        repeatableLabel: ""
+      }
+    );
+    assert.deepEqual(
+      {
+        repeatable: created.stepDefinitions.find((step) => step.id === "plan_fine_tuning").repeatable,
+        repeatableGroupId: created.stepDefinitions.find((step) => step.id === "plan_fine_tuning").repeatableGroupId,
+        repeatableGroupLabel: created.stepDefinitions.find((step) => step.id === "plan_fine_tuning").repeatableGroupLabel,
+        repeatableLabel: created.stepDefinitions.find((step) => step.id === "plan_fine_tuning").repeatableLabel
+      },
+      {
+        repeatable: true,
+        repeatableGroupId: "rework_cycle",
+        repeatableGroupLabel: "Rework cycle",
+        repeatableLabel: "Cycle step"
+      }
+    );
     assert.deepEqual(created.stepDefinitions.find((step) => step.id === "issue_prompt_rendered").input, {
       label: "What should change?",
       multiline: true,
@@ -265,6 +512,8 @@ test("jskit session JSON exposes JSKIT-owned step UI and Codex handoff contract"
       type: "text"
     });
     assert.equal(Object.hasOwn(created.stepDefinitions[0], "preconditions"), false);
+    assert.equal(created.stepDefinitions.find((step) => step.id === "issue_drafted").requiresExplicitRun, false);
+    assert.equal(created.stepDefinitions.find((step) => step.id === "issue_created").requiresExplicitRun, true);
     assert.equal(created.codex, null);
 
     const { promptReadyPayload, worktreePayload } = advanceCliSessionToIssuePrompt(appRoot, created.sessionId);
@@ -278,6 +527,7 @@ test("jskit session JSON exposes JSKIT-owned step UI and Codex handoff contract"
       args: ["--prompt", "Add account recovery"]
     });
     assert.equal(promptPayload.currentStep, "issue_drafted");
+    assert.equal(promptPayload.currentStepAction.buttonLabel, "Finalise issue");
     assert.deepEqual(promptPayload.currentStepAction.input, {
       fields: [
         {
@@ -369,6 +619,26 @@ test("jskit session returns JSON failures for unreadable issue files", async () 
   });
 });
 
+test("jskit session requires an approved issue title before saving the issue draft", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "app");
+    await createGitApp(appRoot);
+
+    const created = parseJsonResult(runCli({ cwd: appRoot, args: ["session", "create", "--json"] }));
+    advanceCliSessionToIssuePrompt(appRoot, created.sessionId);
+    runSessionStepJson(appRoot, created.sessionId, {
+      args: ["--prompt", "Fix missing title"]
+    });
+    const payload = runSessionStepJsonFailure(appRoot, created.sessionId, {
+      args: ["--issue", "[issue_text]Fix missing title.[/issue_text]"]
+    });
+
+    assert.equal(payload.ok, false);
+    assert.equal(payload.errors[0].code, "issue_title_required");
+    assert.equal(payload.currentStep, "issue_drafted");
+  });
+});
+
 test("createSession returns structured failures for invalid explicit session ids", async () => {
   await withTempDir(async (cwd) => {
     const appRoot = path.join(cwd, "app");
@@ -398,6 +668,31 @@ test("session ids get deterministic suffixes when two sessions start in the same
   });
 });
 
+test("old workflow versions hard-block inspection and advancement", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "app");
+    await createGitApp(appRoot);
+
+    const created = await createSession({ targetRoot: appRoot });
+    await writeFile(path.join(created.sessionRoot, "workflow_version"), "1\n", "utf8");
+
+    const inspected = await inspectSessionDetails({
+      targetRoot: appRoot,
+      sessionId: created.sessionId
+    });
+    assert.equal(inspected.ok, false);
+    assert.equal(inspected.workflowVersion, "1");
+    assert.equal(inspected.errors[0].code, "unsupported_workflow_version");
+
+    const advanced = await runSessionStep({
+      targetRoot: appRoot,
+      sessionId: created.sessionId
+    });
+    assert.equal(advanced.ok, false);
+    assert.equal(advanced.errors[0].code, "unsupported_workflow_version");
+  });
+});
+
 test("issue draft extraction accepts separate codex title and body wrappers", () => {
   const output = [
     "Before",
@@ -423,11 +718,36 @@ test("plan extraction accepts the codex plan wrapper", () => {
   );
 });
 
+test("plan details extraction accepts the codex plan_details wrapper", () => {
+  assert.equal(
+    extractPlanDetails("Before\n[plan_details]\nGathered fields.\n[/plan_details]\nAfter"),
+    "Gathered fields."
+  );
+  assert.equal(extractPlanDetails("Gathered fields."), "");
+});
+
+test("tagged extraction uses the latest complete marker pair and ignores terminal chrome", () => {
+  const output = [
+    "gpt-5.5 default · /workspace Shell mode",
+    "[plan_details]",
+    "First draft.",
+    "[/plan_details]",
+    "status: thinking",
+    "[plan_details]",
+    "Final confirmed details.",
+    "[/plan_details]",
+    "[plan_details]",
+    "Incomplete draft."
+  ].join("\n");
+  assert.equal(extractPlanDetails(output), "Final confirmed details.");
+});
+
 test("app blueprint extraction accepts the codex app_blueprint wrapper", () => {
   assert.equal(
     extractAppBlueprintText("Before\n[app_blueprint]\n# App Blueprint\n\nBuild a field app.\n[/app_blueprint]\nAfter"),
     "# App Blueprint\n\nBuild a field app."
   );
+  assert.equal(extractAppBlueprintText("# App Blueprint\n\nBuild a field app."), "");
 });
 
 test("jskit blueprint prompt and set manage app-level blueprint outside sessions", async () => {
@@ -469,6 +789,34 @@ test("every executable session step declares named preconditions", () => {
   for (const stepId of executableStepIds) {
     assert.ok(STEP_PRECONDITION_NAMES[stepId].length > 0, `${stepId} must declare preconditions`);
   }
+  assert.ok(STEP_PRECONDITION_NAMES.deep_ui_check_run.includes("pre_review_checks_passed"));
+  assert.ok(STEP_PRECONDITION_NAMES.review_prompt_rendered.includes("deep_ui_check_satisfied"));
+  assert.ok(STEP_PRECONDITION_NAMES.deep_ui_recheck_run.includes("post_review_checks_passed"));
+  assert.ok(STEP_PRECONDITION_NAMES.user_check_completed.includes("deep_ui_recheck_satisfied"));
+  assert.ok(STEP_PRECONDITION_NAMES.pr_created.includes("post_review_checks_passed"));
+});
+
+test("session prompts reference canonical session artifacts", async () => {
+  const promptEntries = await readdir(PROMPT_ROOT);
+  const prompts = Object.fromEntries(await Promise.all(promptEntries
+    .filter((entry) => entry.endsWith(".md"))
+    .map(async (entry) => [entry, await readFile(path.join(PROMPT_ROOT, entry), "utf8")])));
+
+  for (const body of Object.values(prompts)) {
+    assert.doesNotMatch(body, /workflow\/(?:app-state|bootstrap|scoping|workboard|feature-delivery|review)\.md/);
+  }
+
+  assert.match(prompts["plan_details.md"], /plan_details\.md/);
+  assert.match(prompts["plan_issue.md"], /plan_details\.md/);
+  assert.match(prompts["plan_issue.md"], /agent_decisions\.md/);
+  assert.match(prompts["execute_plan.md"], /plan_details\.md/);
+  assert.match(prompts["execute_plan.md"], /agent_decisions/);
+  assert.match(prompts["fine_tune_plan.md"], /plan_details\.md/);
+  assert.match(prompts["fine_tune_plan.md"], /agent_decisions\.md/);
+  assert.match(prompts["review_changes.md"], /\.jskit\/helper-map\.md/);
+  assert.match(prompts["doctor_failure.md"], /agent_decisions\.md/);
+  assert.match(prompts["update_blueprint.md"], /\.jskit\/APP_BLUEPRINT\.md/);
+  assert.match(prompts["update_blueprint.md"], /agent_decisions\.md/);
 });
 
 test("jskit session step creates worktree and issue prompt", async () => {
@@ -480,6 +828,9 @@ test("jskit session step creates worktree and issue prompt", async () => {
     const { promptReadyPayload, worktreePayload } = advanceCliSessionToIssuePrompt(appRoot, created.sessionId);
     assert.equal(promptReadyPayload.currentStep, "issue_prompt_rendered");
     await access(worktreePayload.worktree);
+    assert.equal(worktreePayload.baseBranch, "main");
+    assert.match(worktreePayload.baseCommit, /^[0-9a-f]{40}$/u);
+    assert.equal(await readFile(path.join(worktreePayload.sessionRoot, "base_branch"), "utf8"), "main\n");
 
     const promptPayload = runSessionStepJson(appRoot, created.sessionId, {
       args: ["--prompt", "Add customer search"]
@@ -501,6 +852,45 @@ test("jskit session step creates worktree and issue prompt", async () => {
     const failure = runSessionStepJsonFailure(appRoot, created.sessionId);
     assert.equal(failure.ok, false);
     assert.equal(failure.errors[0].code, "issue_required");
+  });
+});
+
+test("jskit session blocks issue work until app setup markers exist", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "package-only");
+    await createPackageOnlyGitApp(appRoot);
+
+    const created = parseJsonResult(runCli({ cwd: appRoot, args: ["session", "create", "--json"] }));
+    runSessionStepJson(appRoot, created.sessionId);
+    runSessionStepJson(appRoot, created.sessionId);
+    const blocked = runSessionStepJsonFailure(appRoot, created.sessionId, {
+      args: ["--prompt", "Add an about page"]
+    });
+
+    assert.equal(blocked.errors[0].code, "app_setup_required");
+    assert.equal(blocked.preconditions.at(-1).id, "ready_jskit_app");
+    assert.equal(blocked.preconditions.at(-1).ok, false);
+    assert.equal(blocked.appReady.ok, false);
+    assert.deepEqual(blocked.appReady.missing, [".jskit/lock.json", "config/public.js", "src/", "packages/"]);
+  });
+});
+
+test("issue drafting prompt assumes app setup passed and mentions canonical app context", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "app");
+    await createGitApp(appRoot);
+
+    const created = parseJsonResult(runCli({ cwd: appRoot, args: ["session", "create", "--json"] }));
+    advanceCliSessionToIssuePrompt(appRoot, created.sessionId);
+    const promptPayload = runSessionStepJson(appRoot, created.sessionId, {
+      args: ["--prompt", "Add an about page"]
+    });
+
+    assert.match(promptPayload.prompt, /App setup has already passed/);
+    assert.match(promptPayload.prompt, /\.jskit\/APP_BLUEPRINT\.md/);
+    assert.match(promptPayload.prompt, /\.jskit\/helper-map\.md/);
+    assert.doesNotMatch(promptPayload.prompt, /Classify the current app state as empty/);
+    assert.doesNotMatch(promptPayload.prompt, /partial JSKIT app/);
   });
 });
 
@@ -529,6 +919,64 @@ test("jskit session does not treat a stale empty directory as a worktree", async
     assert.match(await readFile(path.join(created.worktree, ".git"), "utf8"), /gitdir:/);
     const dependenciesInstalled = runSessionStepJson(appRoot, created.sessionId);
     assert.equal(dependenciesInstalled.currentStep, "issue_prompt_rendered");
+  });
+});
+
+test("dependency installation step is safe to retry before completion receipt is final", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "app");
+    const binDir = path.join(cwd, "bin");
+    const logPath = path.join(cwd, "commands.log");
+    await createGitApp(appRoot);
+    await installFakeNpm(binDir, logPath);
+    const env = {
+      PATH: `${binDir}${path.delimiter}${process.env.PATH || ""}`
+    };
+
+    const created = parseJsonResult(runCli({ cwd: appRoot, args: ["session", "create", "--json"], env }));
+    const worktreePayload = runSessionStepJson(appRoot, created.sessionId, { env });
+    assert.equal(worktreePayload.currentStep, "dependencies_installed");
+    const firstInstall = runSessionStepJson(appRoot, created.sessionId, { env });
+    assert.equal(firstInstall.currentStep, "issue_prompt_rendered");
+    assert.equal(firstInstall.dependencyInstall.status, "installed");
+
+    await rm(path.join(created.sessionRoot, "steps", "dependencies_installed"));
+    await writeFile(path.join(created.sessionRoot, "current_step"), "dependencies_installed\n", "utf8");
+    const rerunInstall = runSessionStepJson(appRoot, created.sessionId, { env });
+    assert.equal(rerunInstall.currentStep, "issue_prompt_rendered");
+    assert.equal(rerunInstall.dependencyInstall.status, "installed");
+    assert.equal((await readFile(logPath, "utf8")).match(/npm install/g)?.length, 2);
+
+    const lockedRoot = path.join(cwd, "locked");
+    const lockedLogPath = path.join(cwd, "locked-commands.log");
+    await createGitApp(lockedRoot);
+    await writeFile(path.join(lockedRoot, "package-lock.json"), JSON.stringify({
+      lockfileVersion: 3,
+      name: "session-test-app",
+      packages: {}
+    }), "utf8");
+    runGit(lockedRoot, ["add", "package-lock.json"]);
+    runGit(lockedRoot, ["commit", "-m", "Add npm lockfile"]);
+    await installFakeNpm(binDir, lockedLogPath);
+    const lockedSession = parseJsonResult(runCli({ cwd: lockedRoot, args: ["session", "create", "--json"], env }));
+    runSessionStepJson(lockedRoot, lockedSession.sessionId, { env });
+    runSessionStepJson(lockedRoot, lockedSession.sessionId, { env });
+    assert.match(await readFile(lockedLogPath, "utf8"), /npm ci/);
+
+    const pnpmRoot = path.join(cwd, "pnpm");
+    const pnpmLogPath = path.join(cwd, "pnpm-commands.log");
+    await createGitApp(pnpmRoot);
+    const packageJson = JSON.parse(await readFile(path.join(pnpmRoot, "package.json"), "utf8"));
+    packageJson.packageManager = "pnpm@9.12.0";
+    await writeFile(path.join(pnpmRoot, "package.json"), `${JSON.stringify(packageJson, null, 2)}\n`, "utf8");
+    await writeFile(path.join(pnpmRoot, "pnpm-lock.yaml"), "lockfileVersion: '9.0'\n", "utf8");
+    runGit(pnpmRoot, ["add", "package.json", "pnpm-lock.yaml"]);
+    runGit(pnpmRoot, ["commit", "-m", "Use pnpm"]);
+    await installFakePnpm(binDir, pnpmLogPath);
+    const pnpmSession = parseJsonResult(runCli({ cwd: pnpmRoot, args: ["session", "create", "--json"], env }));
+    runSessionStepJson(pnpmRoot, pnpmSession.sessionId, { env });
+    runSessionStepJson(pnpmRoot, pnpmSession.sessionId, { env });
+    assert.match(await readFile(pnpmLogPath, "utf8"), /pnpm install --frozen-lockfile/);
   });
 });
 
@@ -613,28 +1061,42 @@ test("jskit session accepts issue text from stdin and creates a GitHub issue wit
       input: "Make filters useful."
     });
     assert.equal(issueDrafted.currentStep, "issue_created");
+    assert.equal(issueDrafted.currentStepAction.buttonLabel, "Create issue");
+    assert.equal(issueDrafted.currentStepAction.requiresExplicitRun, true);
     assert.equal(issueDrafted.issueTitle, "Fix useful filters");
     assert.equal(issueDrafted.issueText, "Make filters useful.");
 
     const issueCreated = runSessionStepJson(appRoot, created.sessionId, { env });
     assert.equal(issueCreated.issueUrl, "https://github.com/example/repo/issues/123");
-    assert.equal(issueCreated.currentStep, "plan_made");
+    assert.equal(issueCreated.currentStep, "plan_details_prompt_rendered");
+    assert.equal(issueCreated.issueMetadata.issueNumber, "123");
+    assert.equal(issueCreated.issueMetadata.owner, "example");
+    assert.equal(issueCreated.issueMetadata.repository, "repo");
+    assert.equal(issueCreated.issueMetadata.issueTitle, "Fix useful filters");
+    assert.equal(issueCreated.issueMetadata.issueBody, "Make filters useful.");
     assert.equal(issueCreated.prompt, "");
-    assert.equal(issueCreated.currentStepAction.buttonLabel, "Save plan");
+    assert.equal(issueCreated.currentStepAction.buttonLabel, "Start details conversation");
     assert.match(await readFile(logPath, "utf8"), /gh issue create --title Fix useful filters --body-file/);
+    const { detailsSaved } = saveCliSessionPlanDetails(appRoot, created.sessionId, { env });
+    const decisionLog = await readFile(path.join(detailsSaved.sessionRoot, "agent_decisions.md"), "utf8");
+    assert.match(decisionLog, /Issue: https:\/\/github\.com\/example\/repo\/issues\/123/);
+    assert.match(decisionLog, /Use the smallest JSKIT-owned implementation path/);
+    assert.equal(detailsSaved.githubComments.plan_details.purpose, "plan_details");
 
     const planPrompt = runSessionStepJson(appRoot, created.sessionId, { env });
     assert.equal(planPrompt.currentStep, "plan_made");
     assert.match(planPrompt.prompt, /Create an implementation plan/);
     assert.match(planPrompt.prompt, /\[plan\]/);
     assert.match(planPrompt.prompt, /https:\/\/github\.com\/example\/repo\/issues\/123/);
+    assert.match(planPrompt.prompt, /Agent decisions file .*agent_decisions\.md/);
+    assert.match(planPrompt.prompt, /Make generator decisions concrete/);
     assert.match(
       await readFile(path.join(planPrompt.sessionRoot, "prompts", "plan_request.md"), "utf8"),
       /Create an implementation plan/
     );
 
     const planMade = runSessionStepJson(appRoot, created.sessionId, {
-      args: ["--plan", "[plan]\nInspect filters and update the UI.\n[/plan]"],
+      args: ["--plan", "[plan]\nInspect filters and update the UI.\n[/plan]\n[agent_decisions]\n- Use the list UI generator only if placements match.\n[/agent_decisions]"],
       env
     });
     assert.equal(planMade.currentStep, "plan_executed");
@@ -642,15 +1104,28 @@ test("jskit session accepts issue text from stdin and creates a GitHub issue wit
     assert.equal(planMade.planText, "Inspect filters and update the UI.");
     assert.ok(planMade.completedSteps.includes("plan_made"));
     assert.equal(planMade.prompt, "");
+    assert.equal(planMade.planExecution.submitted, false);
+    assert.equal(planMade.githubComments.plan.purpose, "plan");
     assert.match(await readFile(path.join(planMade.sessionRoot, "plan.md"), "utf8"), /Inspect filters/);
+    assert.match(await readFile(path.join(planMade.sessionRoot, "agent_decisions.md"), "utf8"), /Use the list UI generator only if placements match/);
 
-    const executed = runSessionStepJson(appRoot, created.sessionId, { env });
+    const executed = runSessionStepJson(appRoot, created.sessionId, {
+      args: ["--agent-decisions", "-"],
+      env,
+      input: "[agent_decisions]\n- Implementation can reuse the existing filter route without adding a package.\n[/agent_decisions]"
+    });
     assert.equal(executed.currentStep, "plan_fine_tuning");
     assert.equal(executed.currentStepAction.buttonLabel, "Get Codex to fine tune plan");
     assert.equal(executed.codex.autoInject, true);
     assert.equal(executed.codex.promptActionLabel, "Get Codex to execute plan");
     assert.ok(executed.completedSteps.includes("plan_executed"));
+    assert.equal(executed.planExecution.submitted, true);
+    assert.match(executed.planExecution.promptPath, /plan_execution\.md$/);
     assert.match(executed.prompt, /Execute the approved implementation plan/);
+    assert.match(
+      await readFile(path.join(executed.sessionRoot, "agent_decisions.md"), "utf8"),
+      /Use the smallest JSKIT-owned implementation path[\s\S]*Use the list UI generator only if placements match[\s\S]*Implementation can reuse the existing filter route/
+    );
     assert.match(
       await readFile(path.join(executed.sessionRoot, "prompts", "plan_execution.md"), "utf8"),
       /Execute the approved implementation plan/
@@ -664,12 +1139,193 @@ test("jskit session accepts issue text from stdin and creates a GitHub issue wit
     assert.equal(fineTuning.codex.promptActionLabel, "Get Codex to fine tune plan");
     assert.ok(fineTuning.completedSteps.includes("plan_fine_tuning"));
     assert.match(fineTuning.prompt, /Fine-tune the implementation/);
+    assert.match(fineTuning.prompt, /Agent decisions file .*agent_decisions\.md/);
     assert.match(
       await readFile(path.join(fineTuning.sessionRoot, "prompts", "plan_fine_tuning.md"), "utf8"),
       /Fine-tune the implementation/
     );
     await assert.rejects(access(path.join(fineTuning.sessionRoot, "prompt.md")));
     assert.match(await readFile(logPath, "utf8"), /gh issue comment https:\/\/github\.com\/example\/repo\/issues\/123 --body-file/);
+  });
+});
+
+test("issue creation reuses an existing issue URL without creating duplicates", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "app");
+    const binDir = path.join(cwd, "bin");
+    const logPath = path.join(cwd, "commands.log");
+    await createGitApp(appRoot);
+    runGit(appRoot, ["remote", "add", "origin", "https://github.com/example/repo.git"]);
+    await installFakeGh(binDir, logPath);
+    const env = {
+      PATH: `${binDir}${path.delimiter}${process.env.PATH || ""}`
+    };
+
+    const created = parseJsonResult(runCli({ cwd: appRoot, args: ["session", "create", "--json"], env }));
+    advanceCliSessionToIssuePrompt(appRoot, created.sessionId, { env });
+    runSessionStepJson(appRoot, created.sessionId, {
+      args: ["--prompt", "Fix issue duplication"],
+      env
+    });
+    runSessionStepJson(appRoot, created.sessionId, {
+      args: ["--issue-title", "Fix issue duplication", "--issue", "[issue_text]Avoid duplicate issue creation.[/issue_text]"],
+      env
+    });
+    const firstIssue = runSessionStepJson(appRoot, created.sessionId, { env });
+    assert.equal(firstIssue.issueUrl, "https://github.com/example/repo/issues/123");
+
+    await rm(path.join(created.sessionRoot, "steps", "issue_created"));
+    await writeFile(path.join(created.sessionRoot, "current_step"), "issue_created\n", "utf8");
+    const reusedIssue = runSessionStepJson(appRoot, created.sessionId, { env });
+    assert.equal(reusedIssue.issueUrl, "https://github.com/example/repo/issues/123");
+    assert.equal(reusedIssue.currentStep, "plan_details_prompt_rendered");
+    assert.equal((await readFile(logPath, "utf8")).match(/gh issue create/g)?.length, 1);
+  });
+});
+
+test("plan details output rejects missing required tags and invalid classifications", async () => {
+  await withTempDir(async (cwd) => {
+    const cases = [
+      {
+        code: "plan_details_required",
+        input: "[issue_category]\nclient\n[/issue_category]\n\n[ui_impact]\npossible\n[/ui_impact]"
+      },
+      {
+        code: "issue_category_invalid",
+        input: planDetailsOutput({ category: "feature" })
+      },
+      {
+        code: "ui_impact_invalid",
+        input: planDetailsOutput({ uiImpact: "maybe" })
+      }
+    ];
+
+    for (const [index, testCase] of cases.entries()) {
+      const appRoot = path.join(cwd, `app-${index}`);
+      const binDir = path.join(cwd, `bin-${index}`);
+      const logPath = path.join(cwd, `commands-${index}.log`);
+      await createGitApp(appRoot);
+      runGit(appRoot, ["remote", "add", "origin", "https://github.com/example/repo.git"]);
+      await installFakeGh(binDir, logPath);
+      const env = {
+        PATH: `${binDir}${path.delimiter}${process.env.PATH || ""}`
+      };
+
+      const created = parseJsonResult(runCli({ cwd: appRoot, args: ["session", "create", "--json"], env }));
+      advanceCliSessionToIssuePrompt(appRoot, created.sessionId, { env });
+      runSessionStepJson(appRoot, created.sessionId, {
+        args: ["--prompt", "Fix details"],
+        env
+      });
+      runSessionStepJson(appRoot, created.sessionId, {
+        args: ["--issue-title", "Fix details", "--issue", "[issue_text]Make details clearer.[/issue_text]"],
+        env
+      });
+      runSessionStepJson(appRoot, created.sessionId, { env });
+      runSessionStepJson(appRoot, created.sessionId, { env });
+
+      const failure = runSessionStepJsonFailure(appRoot, created.sessionId, {
+        args: ["--plan-details", "-"],
+        env,
+        input: testCase.input
+      });
+
+      assert.equal(failure.errors[0].code, testCase.code);
+      assert.equal(failure.currentStep, "plan_details_gathered");
+      assert.equal(failure.ok, false);
+    }
+  });
+});
+
+test("GitHub issue comments are skipped when purpose metadata already exists", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "app");
+    const binDir = path.join(cwd, "bin");
+    const logPath = path.join(cwd, "commands.log");
+    await createGitApp(appRoot);
+    await installFakeGh(binDir, logPath);
+    const env = {
+      PATH: `${binDir}${path.delimiter}${process.env.PATH || ""}`
+    };
+
+    const created = parseJsonResult(runCli({ cwd: appRoot, args: ["session", "create", "--json"], env }));
+    runSessionStepJson(appRoot, created.sessionId, { env });
+    await writeFile(path.join(created.sessionRoot, "issue_url"), "https://github.com/example/repo/issues/123\n", "utf8");
+    await writeFile(path.join(created.sessionRoot, "issue_title"), "Fix duplicate comments\n", "utf8");
+    await writeFile(path.join(created.sessionRoot, "issue.md"), "Fix duplicate comments.\n", "utf8");
+    await writeStepReceipts(created.sessionRoot, STEP_IDS.slice(0, STEP_IDS.indexOf("plan_details_gathered")));
+    await writeFile(
+      path.join(created.sessionRoot, "github_comments.json"),
+      `${JSON.stringify({
+        plan_details: {
+          bodyFile: path.join(created.sessionRoot, "plan_details.md"),
+          commentedAt: "2026-05-11T00:00:00.000Z",
+          issueUrl: "https://github.com/example/repo/issues/123",
+          purpose: "plan_details"
+        }
+      }, null, 2)}\n`,
+      "utf8"
+    );
+
+    const detailsSaved = runSessionStepJson(appRoot, created.sessionId, {
+      args: ["--plan-details", "-"],
+      env,
+      input: planDetailsOutput()
+    });
+    assert.equal(detailsSaved.githubComments.plan_details.purpose, "plan_details");
+
+    await writeFile(
+      path.join(created.sessionRoot, "github_comments.json"),
+      `${JSON.stringify({
+        ...detailsSaved.githubComments,
+        plan: {
+          bodyFile: path.join(created.sessionRoot, "plan.md"),
+          commentedAt: "2026-05-11T00:00:00.000Z",
+          issueUrl: "https://github.com/example/repo/issues/123",
+          purpose: "plan"
+        }
+      }, null, 2)}\n`,
+      "utf8"
+    );
+    const planSaved = runSessionStepJson(appRoot, created.sessionId, {
+      args: ["--plan", "[plan]\nFix the comments.\n[/plan]"],
+      env
+    });
+    assert.equal(planSaved.githubComments.plan.purpose, "plan");
+
+    const finalRoot = path.join(cwd, "final-app");
+    const finalLogPath = path.join(cwd, "final-commands.log");
+    await createGitApp(finalRoot);
+    await installFakeGh(binDir, finalLogPath);
+    const finalCreated = parseJsonResult(runCli({ cwd: finalRoot, args: ["session", "create", "--json"], env }));
+    runSessionStepJson(finalRoot, finalCreated.sessionId, { env });
+    await writeFile(path.join(finalCreated.sessionRoot, "issue_url"), "https://github.com/example/repo/issues/123\n", "utf8");
+    await writeFile(path.join(finalCreated.sessionRoot, "issue_title"), "Fix duplicate final report comments\n", "utf8");
+    await writeFile(path.join(finalCreated.sessionRoot, "issue.md"), "Fix duplicate final report comments.\n", "utf8");
+    await writeFile(path.join(finalCreated.sessionRoot, "plan_details.md"), "Confirmed details.\n", "utf8");
+    await writeIssueMetadata(finalCreated.sessionRoot);
+    await writeFile(path.join(finalCreated.sessionRoot, "plan.md"), "Confirmed plan.\n", "utf8");
+    await writeFile(
+      path.join(finalCreated.sessionRoot, "github_comments.json"),
+      `${JSON.stringify({
+        final_report: {
+          bodyFile: path.join(finalCreated.sessionRoot, "final_report.md"),
+          commentedAt: "2026-05-11T00:00:00.000Z",
+          issueUrl: "https://github.com/example/repo/issues/123",
+          purpose: "final_report"
+        }
+      }, null, 2)}\n`,
+      "utf8"
+    );
+    await writeStepReceipts(finalCreated.sessionRoot, STEP_IDS.slice(0, STEP_IDS.indexOf("final_report_created")));
+
+    const finalReport = runSessionStepJson(finalRoot, finalCreated.sessionId, { env });
+    assert.equal(finalReport.githubComments.final_report.purpose, "final_report");
+
+    const log = await readFile(logPath, "utf8").catch(() => "");
+    const finalLog = await readFile(finalLogPath, "utf8").catch(() => "");
+    assert.doesNotMatch(log, /gh issue comment/);
+    assert.doesNotMatch(finalLog, /gh issue comment/);
   });
 });
 
@@ -701,19 +1357,21 @@ process.exit(1);
       env
     });
     runSessionStepJson(appRoot, created.sessionId, {
-      args: ["--issue", "[issue_text]# Fix auth[/issue_text]"],
+      args: ["--issue-title", "Fix auth", "--issue", "[issue_text]# Fix auth[/issue_text]"],
       env
     });
 
     const failure = runSessionStepJsonFailure(appRoot, created.sessionId, { env });
+    assertSessionContractFields(failure);
     assert.equal(failure.ok, false);
     assert.equal(failure.status, "blocked");
     assert.equal(failure.currentStep, "issue_created");
     assert.equal(failure.errors[0].code, "github_auth_missing");
-    assert.deepEqual(
-      Object.keys(failure).slice(0, 15),
-      ["ok", "sessionId", "status", "currentStep", "completedSteps", "stepDefinitions", "currentStepAction", "codex", "prompt", "nextCommand", "issueUrl", "issueTitle", "issueText", "planText", "prUrl"]
-    );
+    assert.ok(Object.hasOwn(failure, "workflowVersion"));
+    assert.ok(Object.hasOwn(failure, "activeCycle"));
+    assert.ok(Object.hasOwn(failure, "cycles"));
+    assert.ok(Object.hasOwn(failure, "stepDefinitions"));
+    assert.ok(Object.hasOwn(failure, "issueMetadata"));
     assert.equal(await readFile(path.join(failure.sessionRoot, "issue_title"), "utf8"), "Fix auth\n");
     assert.equal(await readFile(path.join(failure.sessionRoot, "issue.md"), "utf8"), "# Fix auth\n");
   });
@@ -758,11 +1416,55 @@ process.exit(1);
       env
     });
     runSessionStepJson(appRoot, created.sessionId, {
-      args: ["--issue", "# Fix"],
+      args: ["--issue-title", "Fix", "--issue", "# Fix"],
       env
     });
     const missingOrigin = runSessionStepJsonFailure(appRoot, created.sessionId, { env });
     assert.equal(missingOrigin.errors[0].code, "github_origin_missing");
+
+    const metadataRoot = path.join(cwd, "metadata");
+    await createGitApp(metadataRoot);
+    const metadataSession = await createSession({ targetRoot: metadataRoot });
+    await runSessionStep({
+      targetRoot: metadataRoot,
+      sessionId: metadataSession.sessionId
+    });
+    await writeFile(path.join(metadataSession.sessionRoot, "issue.md"), "Fix metadata.\n", "utf8");
+    await writeFile(path.join(metadataSession.sessionRoot, "issue_title"), "Fix metadata\n", "utf8");
+    await writeFile(path.join(metadataSession.sessionRoot, "issue_url"), "https://github.com/example/repo/issues/123\n", "utf8");
+    await writeFile(path.join(metadataSession.sessionRoot, "plan_details.md"), "Confirmed details.\n", "utf8");
+    await writeStepReceipts(metadataSession.sessionRoot, STEP_IDS.slice(0, STEP_IDS.indexOf("plan_made")));
+    const missingMetadata = await runSessionStep({
+      targetRoot: metadataRoot,
+      sessionId: metadataSession.sessionId,
+      options: {
+        plan: "[plan]\nUse metadata.\n[/plan]"
+      }
+    });
+    assert.equal(missingMetadata.ok, false);
+    assert.equal(missingMetadata.errors[0].code, "issue_metadata_missing");
+
+    const cycleRoot = path.join(cwd, "cycle");
+    await createGitApp(cycleRoot);
+    const cycleSession = await createSession({ targetRoot: cycleRoot });
+    await runSessionStep({
+      targetRoot: cycleRoot,
+      sessionId: cycleSession.sessionId
+    });
+    await writeFile(path.join(cycleSession.sessionRoot, "issue.md"), "Fix cycle.\n", "utf8");
+    await writeFile(path.join(cycleSession.sessionRoot, "issue_title"), "Fix cycle\n", "utf8");
+    await writeFile(path.join(cycleSession.sessionRoot, "issue_url"), "https://github.com/example/repo/issues/123\n", "utf8");
+    await writeFile(path.join(cycleSession.sessionRoot, "plan_details.md"), "Confirmed details.\n", "utf8");
+    await writeIssueMetadata(cycleSession.sessionRoot);
+    await writeFile(path.join(cycleSession.sessionRoot, "plan.md"), "Confirmed plan.\n", "utf8");
+    await writeStepReceipts(cycleSession.sessionRoot, STEP_IDS.slice(0, STEP_IDS.indexOf("plan_fine_tuning")));
+    await rm(path.join(cycleSession.sessionRoot, "active_cycle"));
+    const missingActiveCycle = await runSessionStep({
+      targetRoot: cycleRoot,
+      sessionId: cycleSession.sessionId
+    });
+    assert.equal(missingActiveCycle.ok, false);
+    assert.equal(missingActiveCycle.errors[0].code, "active_cycle_missing");
 
     const manualRoot = path.join(cwd, "manual");
     await createGitApp(manualRoot);
@@ -782,6 +1484,7 @@ process.exit(1);
       targetRoot: changesRoot,
       sessionId: changes.sessionId
     });
+    await writeIssueMetadata(changes.sessionRoot);
     await writeStepReceipts(changes.sessionRoot, STEP_IDS.slice(0, STEP_IDS.indexOf("implementation_changes_accepted")));
     const missingChanges = await runSessionStep({
       targetRoot: changesRoot,
@@ -797,7 +1500,8 @@ process.exit(1);
       targetRoot: prRoot,
       sessionId: pr.sessionId
     });
-    await writeStepReceipts(pr.sessionRoot, STEP_IDS.slice(0, STEP_IDS.indexOf("pr_merged")));
+    await writeIssueMetadata(pr.sessionRoot);
+    await writeStepReceipts(pr.sessionRoot, STEP_IDS.slice(0, STEP_IDS.indexOf("pr_finalized")));
     const missingPr = await runSessionStep({
       targetRoot: prRoot,
       sessionId: pr.sessionId
@@ -817,6 +1521,12 @@ test("jskit session diff inspects worktree changes without advancing the session
     await writeFile(path.join(worktreePayload.worktree, "package.json"), "{\"name\":\"changed-app\"}\n", "utf8");
     await writeFile(path.join(worktreePayload.worktree, "feature.txt"), "new file\n", "utf8");
 
+    const inspectedBeforeDiff = parseJsonResult(runCli({ cwd: appRoot, args: ["session", created.sessionId, "--json"] }));
+    assert.equal(inspectedBeforeDiff.worktreeStatus.status, "dirty");
+    assert.equal(inspectedBeforeDiff.worktreeStatus.dirty, true);
+    assert.ok(inspectedBeforeDiff.worktreeStatus.changedFiles.some((line) => line.includes("package.json")));
+    assert.ok(inspectedBeforeDiff.worktreeStatus.changedFiles.some((line) => line.includes("feature.txt")));
+
     const diffPayload = parseJsonResult(runCli({ cwd: appRoot, args: ["session", created.sessionId, "diff", "--json"] }));
     assert.equal(diffPayload.ok, true);
     assert.equal(diffPayload.currentStep, "dependencies_installed");
@@ -829,6 +1539,558 @@ test("jskit session diff inspects worktree changes without advancing the session
     const inspected = parseJsonResult(runCli({ cwd: appRoot, args: ["session", created.sessionId, "--json"] }));
     assert.equal(inspected.currentStep, "dependencies_installed");
     assert.deepEqual(inspected.completedSteps, ["session_created", "worktree_created"]);
+  });
+});
+
+test("failed user check can start a new plan fine tuning cycle without deleting receipts", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "app");
+    await createGitApp(appRoot);
+
+    const created = parseJsonResult(runCli({ cwd: appRoot, args: ["session", "create", "--json"] }));
+    runSessionStepJson(appRoot, created.sessionId);
+    await writeFile(path.join(created.sessionRoot, "issue.md"), "Fix the button.\n", "utf8");
+    await writeFile(path.join(created.sessionRoot, "issue_title"), "Fix button\n", "utf8");
+    await writeFile(path.join(created.sessionRoot, "issue_url"), "https://github.com/example/repo/issues/123\n", "utf8");
+    await writeFile(path.join(created.sessionRoot, "plan_details.md"), "Button should submit the form.\n", "utf8");
+    await writeIssueMetadata(created.sessionRoot);
+    await writeFile(path.join(created.sessionRoot, "plan.md"), "Update the button handler.\n", "utf8");
+    await writeStepReceipts(created.sessionRoot, STEP_IDS.slice(0, STEP_IDS.indexOf("user_check_completed")));
+
+    const failed = runSessionStepJson(appRoot, created.sessionId, {
+      args: ["--user-check", "failed", "--rework-notes", "-"],
+      input: "The button still does not submit."
+    });
+    assert.equal(failed.activeCycle, "002");
+    assert.equal(failed.currentStep, "plan_fine_tuning");
+    assert.equal(failed.cycles.find((cycle) => cycle.cycle === "001").userCheckResult, "failed");
+    assert.equal(failed.cycles.find((cycle) => cycle.cycle === "002").status, "active");
+    assert.match(
+      await readFile(path.join(created.sessionRoot, "steps", "cycle_001", "user_check_failed"), "utf8"),
+      /User reported/
+    );
+    assert.equal(
+      await readFile(path.join(created.sessionRoot, "cycles", "cycle_002", "rework_request.md"), "utf8"),
+      "The button still does not submit.\n"
+    );
+
+    const prompt = runSessionStepJson(appRoot, created.sessionId);
+    assert.equal(prompt.currentStep, "implementation_changes_accepted");
+    assert.match(prompt.prompt, /The button still does not submit/);
+    assert.match(prompt.prompt, /Active cycle: 002/);
+  });
+});
+
+test("finalization cannot advance while active-cycle user check is missing or failed", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "app");
+    await createGitApp(appRoot);
+
+    const created = parseJsonResult(runCli({ cwd: appRoot, args: ["session", "create", "--json"] }));
+    runSessionStepJson(appRoot, created.sessionId);
+    await writeFile(path.join(created.sessionRoot, "issue.md"), "Fix the missing check.\n", "utf8");
+    await writeFile(path.join(created.sessionRoot, "issue_title"), "Fix missing check\n", "utf8");
+    await writeFile(path.join(created.sessionRoot, "issue_url"), "https://github.com/example/repo/issues/123\n", "utf8");
+    await writeFile(path.join(created.sessionRoot, "plan_details.md"), "Confirmed details.\n", "utf8");
+    await writeIssueMetadata(created.sessionRoot);
+    await writeFile(path.join(created.sessionRoot, "plan.md"), "Confirmed plan.\n", "utf8");
+    await writeStepReceipts(created.sessionRoot, STEP_IDS.slice(0, STEP_IDS.indexOf("user_check_completed")));
+
+    const missingCheck = runSessionStepJson(appRoot, created.sessionId, {
+      args: ["--blueprint", "[app_blueprint]\n# Should Not Save\n[/app_blueprint]"]
+    });
+    assert.equal(missingCheck.currentStep, "user_check_completed");
+    assert.match(missingCheck.prompt, /User check/);
+    await assert.rejects(access(path.join(created.sessionRoot, "steps", "blueprint_updated")));
+
+    const failedCheck = runSessionStepJsonFailure(appRoot, created.sessionId, {
+      args: ["--user-check", "failed"]
+    });
+    assert.equal(failedCheck.status, "blocked");
+    assert.equal(failedCheck.currentStep, "user_check_completed");
+    assert.equal(failedCheck.errors[0].code, "user_check_failed");
+    await assert.rejects(access(path.join(created.sessionRoot, "steps", "blueprint_updated")));
+  });
+});
+
+test("pre-review and post-review check failures block with retryable action metadata", async () => {
+  await withTempDir(async (cwd) => {
+    const checkCases = [
+      {
+        expectedCode: "pre_review_checks_run_failed",
+        stepId: "pre_review_checks_run"
+      },
+      {
+        expectedCode: "post_review_checks_run_failed",
+        stepId: "post_review_checks_run"
+      }
+    ];
+
+    for (const checkCase of checkCases) {
+      const appRoot = path.join(cwd, checkCase.stepId);
+      await createGitApp(appRoot);
+      const packageJsonPath = path.join(appRoot, "package.json");
+      const packageJson = JSON.parse(await readFile(packageJsonPath, "utf8"));
+      packageJson.scripts["verify:local"] = "node -e \"process.exit(2)\"";
+      await writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`, "utf8");
+      runGit(appRoot, ["add", "package.json"]);
+      runGit(appRoot, ["commit", "-m", "Make checks fail"]);
+
+      const created = parseJsonResult(runCli({ cwd: appRoot, args: ["session", "create", "--json"] }));
+      runSessionStepJson(appRoot, created.sessionId);
+      await writeFile(path.join(created.sessionRoot, "issue_url"), "https://github.com/example/repo/issues/123\n", "utf8");
+      await writeFile(path.join(created.sessionRoot, "issue_title"), "Fail checks\n", "utf8");
+      await writeFile(path.join(created.sessionRoot, "issue.md"), "Fail checks.\n", "utf8");
+      await writeFile(path.join(created.sessionRoot, "plan_details.md"), "Confirmed details.\n", "utf8");
+      await writeIssueMetadata(created.sessionRoot);
+      await writeFile(path.join(created.sessionRoot, "plan.md"), "Confirmed plan.\n", "utf8");
+      await writeStepReceipts(created.sessionRoot, STEP_IDS.slice(0, STEP_IDS.indexOf(checkCase.stepId)));
+
+      const failed = runSessionStepJsonFailure(appRoot, created.sessionId);
+      assert.equal(failed.errors[0].code, checkCase.expectedCode);
+      assert.equal(failed.currentStep, checkCase.stepId);
+      assert.equal(failed.currentStepAction.retryable, true);
+      assert.match(failed.prompt, /doctor or verification step failed/);
+      await access(path.join(created.sessionRoot, "checks", `${checkCase.stepId}.json`));
+      await assert.rejects(access(path.join(created.sessionRoot, "steps", "cycle_001", checkCase.stepId)));
+
+      const worktreePackageJsonPath = path.join(failed.worktree, "package.json");
+      const worktreePackageJson = JSON.parse(await readFile(worktreePackageJsonPath, "utf8"));
+      worktreePackageJson.scripts["verify:local"] = "node -e \"process.exit(0)\"";
+      await writeFile(worktreePackageJsonPath, `${JSON.stringify(worktreePackageJson, null, 2)}\n`, "utf8");
+      await writeFile(path.join(failed.worktree, `${checkCase.stepId}-repair.txt`), "repair\n", "utf8");
+
+      const repaired = runSessionStepJson(appRoot, created.sessionId);
+      assert.equal(repaired.currentStep, checkCase.stepId === "pre_review_checks_run" ? "deep_ui_check_run" : "deep_ui_recheck_run");
+      assert.ok(repaired.completedSteps.includes(checkCase.stepId));
+      assert.match(runGit(failed.worktree, ["log", "--oneline", "--max-count=1"]), /checks repairs/);
+      await access(path.join(created.sessionRoot, "checks", `${checkCase.stepId}_repair_commit.json`));
+    }
+  });
+});
+
+test("server-only sessions skip both deep UI check steps with structured receipts", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "app");
+    const binDir = path.join(cwd, "bin");
+    const logPath = path.join(cwd, "commands.log");
+    await createGitApp(appRoot);
+    runGit(appRoot, ["remote", "add", "origin", "https://github.com/example/repo.git"]);
+    await installFakeGh(binDir, logPath);
+    await installFakeNpm(binDir, logPath);
+    const env = {
+      PATH: `${binDir}${path.delimiter}${process.env.PATH || ""}`
+    };
+
+    const created = parseJsonResult(runCli({ cwd: appRoot, args: ["session", "create", "--json"], env }));
+    advanceCliSessionToIssuePrompt(appRoot, created.sessionId, { env });
+    runSessionStepJson(appRoot, created.sessionId, {
+      args: ["--prompt", "Add a server health endpoint"],
+      env
+    });
+    runSessionStepJson(appRoot, created.sessionId, {
+      args: ["--issue-title", "Add health endpoint", "--issue", "[issue_text]Add a server-only health endpoint.[/issue_text]"],
+      env
+    });
+    runSessionStepJson(appRoot, created.sessionId, { env });
+    runSessionStepJson(appRoot, created.sessionId, { env });
+    runSessionStepJson(appRoot, created.sessionId, {
+      args: ["--plan-details", "-"],
+      env,
+      input: planDetailsOutput({
+        body: "Add a server-only health endpoint with no user interface changes.",
+        category: "server",
+        uiImpact: "none"
+      })
+    });
+    runSessionStepJson(appRoot, created.sessionId, { env });
+    runSessionStepJson(appRoot, created.sessionId, {
+      args: ["--plan", "[plan]\nAdd a server health endpoint.\n[/plan]"],
+      env
+    });
+    runSessionStepJson(appRoot, created.sessionId, { env });
+    runSessionStepJson(appRoot, created.sessionId, { env });
+
+    const inspect = parseJsonResult(runCli({ cwd: appRoot, args: ["session", created.sessionId, "--json"], env }));
+    await writeFile(path.join(inspect.worktree, "server-health.txt"), "ok\n", "utf8");
+    runSessionStepJson(appRoot, created.sessionId, { env });
+    runSessionStepJson(appRoot, created.sessionId, { env });
+    const preReviewChecks = runSessionStepJson(appRoot, created.sessionId, { env });
+    assert.equal(preReviewChecks.currentStep, "deep_ui_check_run");
+    assert.equal(preReviewChecks.currentStepAction.conditional, true);
+    assert.equal(preReviewChecks.currentStepAction.skipReason, "uiImpact is none.");
+    const skippedPreReviewUi = runSessionStepJson(appRoot, created.sessionId, { env });
+    assert.equal(skippedPreReviewUi.currentStep, "review_prompt_rendered");
+    assert.equal(skippedPreReviewUi.prompt, "");
+    assert.equal(skippedPreReviewUi.uiChecks.find((entry) => entry.stepId === "deep_ui_check_run")?.status, "skipped");
+
+    runSessionStepJson(appRoot, created.sessionId, { env });
+    runSessionStepJson(appRoot, created.sessionId, { env });
+    runSessionStepJson(appRoot, created.sessionId, { env });
+    runSessionStepJson(appRoot, created.sessionId, { env });
+    const skippedPostReviewUi = runSessionStepJson(appRoot, created.sessionId, { env });
+
+    assert.equal(skippedPostReviewUi.currentStep, "user_check_completed");
+    assert.equal(skippedPostReviewUi.uiChecks.find((entry) => entry.stepId === "deep_ui_recheck_run")?.status, "skipped");
+    assert.equal(skippedPostReviewUi.uiChecks.length, 6);
+    assert.match(
+      await readFile(path.join(created.sessionRoot, "steps", "cycle_001", "deep_ui_check_run"), "utf8"),
+      /skipped: uiImpact is none/
+    );
+    assert.match(
+      await readFile(path.join(created.sessionRoot, "steps", "cycle_001", "deep_ui_check_changes_committed"), "utf8"),
+      /commit skipped: uiImpact is none/
+    );
+    assert.match(
+      await readFile(path.join(created.sessionRoot, "steps", "cycle_001", "deep_ui_recheck_run"), "utf8"),
+      /skipped: uiImpact is none/
+    );
+    assert.match(
+      await readFile(path.join(created.sessionRoot, "steps", "cycle_001", "deep_ui_recheck_changes_committed"), "utf8"),
+      /commit skipped: uiImpact is none/
+    );
+  });
+});
+
+test("possible UI-impact sessions can explicitly skip Deep UI check with a reason", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "app");
+    const binDir = path.join(cwd, "bin");
+    const logPath = path.join(cwd, "commands.log");
+    await createGitApp(appRoot);
+    runGit(appRoot, ["remote", "add", "origin", "https://github.com/example/repo.git"]);
+    await installFakeGh(binDir, logPath);
+    await installFakeNpm(binDir, logPath);
+    const env = {
+      PATH: `${binDir}${path.delimiter}${process.env.PATH || ""}`
+    };
+
+    const created = parseJsonResult(runCli({ cwd: appRoot, args: ["session", "create", "--json"], env }));
+    advanceCliSessionToIssuePrompt(appRoot, created.sessionId, { env });
+    runSessionStepJson(appRoot, created.sessionId, {
+      args: ["--prompt", "Adjust a server route"],
+      env
+    });
+    runSessionStepJson(appRoot, created.sessionId, {
+      args: ["--issue-title", "Adjust route", "--issue", "[issue_text]Adjust a server route that might affect UI callers.[/issue_text]"],
+      env
+    });
+    runSessionStepJson(appRoot, created.sessionId, { env });
+    runSessionStepJson(appRoot, created.sessionId, { env });
+    runSessionStepJson(appRoot, created.sessionId, {
+      args: ["--plan-details", "-"],
+      env,
+      input: planDetailsOutput({
+        body: "The route response shape remains unchanged, so no rendered UI path changes.",
+        category: "server",
+        uiImpact: "possible"
+      })
+    });
+    runSessionStepJson(appRoot, created.sessionId, { env });
+    runSessionStepJson(appRoot, created.sessionId, {
+      args: ["--plan", "[plan]\nAdjust the server route without changing UI contract.\n[/plan]"],
+      env
+    });
+    runSessionStepJson(appRoot, created.sessionId, { env });
+    runSessionStepJson(appRoot, created.sessionId, { env });
+
+    const inspect = parseJsonResult(runCli({ cwd: appRoot, args: ["session", created.sessionId, "--json"], env }));
+    await writeFile(path.join(inspect.worktree, "server-route.txt"), "route\n", "utf8");
+    runSessionStepJson(appRoot, created.sessionId, { env });
+    runSessionStepJson(appRoot, created.sessionId, { env });
+    const checksPassed = runSessionStepJson(appRoot, created.sessionId, { env });
+    assert.equal(checksPassed.currentStep, "deep_ui_check_run");
+
+    const missingReason = runSessionStepJsonFailure(appRoot, created.sessionId, {
+      args: ["--skip-ui-check"],
+      env
+    });
+    assert.equal(missingReason.errors[0].code, "ui_check_skip_reason_required");
+
+    const skipped = runSessionStepJson(appRoot, created.sessionId, {
+      args: ["--skip-ui-check", "--skip-reason", "Route response shape is unchanged."],
+      env
+    });
+    assert.equal(skipped.currentStep, "review_prompt_rendered");
+    const check = skipped.uiChecks.find((entry) => entry.stepId === "deep_ui_check_run");
+    assert.equal(check?.status, "skipped");
+    assert.equal(check?.reason, "Route response shape is unchanged.");
+    assert.match(
+      await readFile(path.join(created.sessionRoot, "steps", "cycle_001", "deep_ui_check_run"), "utf8"),
+      /Route response shape is unchanged/
+    );
+  });
+});
+
+test("definite UI-impact sessions render the deep UI check prompt", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "app");
+    const binDir = path.join(cwd, "bin");
+    const logPath = path.join(cwd, "commands.log");
+    await createGitApp(appRoot);
+    runGit(appRoot, ["remote", "add", "origin", "https://github.com/example/repo.git"]);
+    await installFakeGh(binDir, logPath);
+    await installFakeNpm(binDir, logPath);
+    const env = {
+      PATH: `${binDir}${path.delimiter}${process.env.PATH || ""}`
+    };
+
+    const created = parseJsonResult(runCli({ cwd: appRoot, args: ["session", "create", "--json"], env }));
+    advanceCliSessionToIssuePrompt(appRoot, created.sessionId, { env });
+    runSessionStepJson(appRoot, created.sessionId, {
+      args: ["--prompt", "Improve the home page UI"],
+      env
+    });
+    runSessionStepJson(appRoot, created.sessionId, {
+      args: ["--issue-title", "Improve home page UI", "--issue", "[issue_text]Improve the home page UI.[/issue_text]"],
+      env
+    });
+    runSessionStepJson(appRoot, created.sessionId, { env });
+    runSessionStepJson(appRoot, created.sessionId, { env });
+    runSessionStepJson(appRoot, created.sessionId, {
+      args: ["--plan-details", "-"],
+      env,
+      input: planDetailsOutput({
+        body: "Improve visual hierarchy and responsive layout on the home page.",
+        category: "client",
+        uiImpact: "definite"
+      })
+    });
+    runSessionStepJson(appRoot, created.sessionId, { env });
+    runSessionStepJson(appRoot, created.sessionId, {
+      args: ["--plan", "[plan]\nImprove home page visual hierarchy.\n[/plan]"],
+      env
+    });
+    runSessionStepJson(appRoot, created.sessionId, { env });
+    runSessionStepJson(appRoot, created.sessionId, { env });
+
+    const inspect = parseJsonResult(runCli({ cwd: appRoot, args: ["session", created.sessionId, "--json"], env }));
+    await writeFile(path.join(inspect.worktree, "src", "home-ui.txt"), "ui\n", "utf8");
+    runSessionStepJson(appRoot, created.sessionId, { env });
+    runSessionStepJson(appRoot, created.sessionId, { env });
+    const checksPassed = runSessionStepJson(appRoot, created.sessionId, { env });
+    assert.equal(checksPassed.currentStep, "deep_ui_check_run");
+    assert.equal(checksPassed.currentStepAction.conditional, true);
+    assert.equal(checksPassed.currentStepAction.skipReason, "");
+
+    const blockedSkip = runSessionStepJsonFailure(appRoot, created.sessionId, {
+      args: ["--skip-ui-check", "--skip-reason", "Skip requested incorrectly."],
+      env
+    });
+    assert.equal(blockedSkip.errors[0].code, "ui_check_skip_not_allowed");
+
+    const deepUi = runSessionStepJson(appRoot, created.sessionId, { env });
+    assert.equal(deepUi.currentStep, "deep_ui_check_changes_accepted");
+    assert.match(deepUi.prompt, /Deep UI quality check/);
+    assert.match(deepUi.prompt, /UI impact: definite/);
+    assert.equal(deepUi.uiChecks.find((entry) => entry.stepId === "deep_ui_check_run")?.status, "prompted");
+    const deepUiAccepted = runSessionStepJson(appRoot, created.sessionId, { env });
+    assert.equal(deepUiAccepted.currentStep, "deep_ui_check_changes_committed");
+    assert.equal(deepUiAccepted.uiChecks.find((entry) => entry.stepId === "deep_ui_check_changes_accepted")?.status, "accepted_no_changes");
+    const deepUiCommitted = runSessionStepJson(appRoot, created.sessionId, { env });
+    assert.equal(deepUiCommitted.currentStep, "review_prompt_rendered");
+    assert.equal(deepUiCommitted.uiChecks.find((entry) => entry.stepId === "deep_ui_check_changes_committed")?.status, "no_changes");
+  });
+});
+
+test("review passes can repeat and finish with a no-change pass", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "app");
+    const binDir = path.join(cwd, "bin");
+    const logPath = path.join(cwd, "commands.log");
+    await createGitApp(appRoot);
+    await installFakeNpm(binDir, logPath);
+    const env = {
+      PATH: `${binDir}${path.delimiter}${process.env.PATH || ""}`
+    };
+
+    const created = parseJsonResult(runCli({ cwd: appRoot, args: ["session", "create", "--json"], env }));
+    runSessionStepJson(appRoot, created.sessionId, { env });
+    const session = parseJsonResult(runCli({ cwd: appRoot, args: ["session", created.sessionId, "--json"], env }));
+    await writeFile(path.join(session.sessionRoot, "issue_url"), "https://github.com/example/repo/issues/123\n", "utf8");
+    await writeFile(path.join(session.sessionRoot, "issue_title"), "Repeat review\n", "utf8");
+    await writeFile(path.join(session.sessionRoot, "issue.md"), "Repeat review passes.\n", "utf8");
+    await writeFile(path.join(session.sessionRoot, "plan_details.md"), "Confirmed details.\n", "utf8");
+    await writeFile(path.join(session.sessionRoot, "plan.md"), "Confirmed plan.\n", "utf8");
+    await writeIssueMetadata(session.sessionRoot);
+    await writeStepReceipts(session.sessionRoot, STEP_IDS.slice(0, STEP_IDS.indexOf("review_prompt_rendered")));
+
+    const firstPrompt = runSessionStepJson(appRoot, created.sessionId, { env });
+    assert.equal(firstPrompt.currentStep, "review_changes_accepted");
+    assert.equal(firstPrompt.currentReviewPass, "001");
+    await writeFile(path.join(firstPrompt.worktree, "review-pass-one.txt"), "one\n", "utf8");
+    const firstAccepted = runSessionStepJson(appRoot, created.sessionId, {
+      args: ["--review-findings-remaining", "true", "--review-findings", "A helper duplication fix needs another pass."],
+      env
+    });
+    assert.equal(firstAccepted.currentStep, "review_changes_committed");
+    assert.equal(firstAccepted.reviewPasses[0].findingsRemaining, true);
+    const firstCommitted = runSessionStepJson(appRoot, created.sessionId, { env });
+    assert.equal(firstCommitted.currentStep, "review_prompt_rendered");
+    assert.equal(firstCommitted.reviewPasses[0].status, "committed");
+    assert.match(firstCommitted.reviewPasses[0].commit, /^[0-9a-f]{40}$/u);
+
+    const secondPrompt = runSessionStepJson(appRoot, created.sessionId, { env });
+    assert.equal(secondPrompt.currentStep, "review_changes_accepted");
+    assert.equal(secondPrompt.currentReviewPass, "002");
+    assert.equal(secondPrompt.reviewPasses.length, 2);
+    const secondAccepted = runSessionStepJson(appRoot, created.sessionId, { env });
+    assert.equal(secondAccepted.currentStep, "review_changes_committed");
+    assert.equal(secondAccepted.reviewPasses[1].status, "accepted_no_changes");
+    const secondCommitted = runSessionStepJson(appRoot, created.sessionId, { env });
+    assert.equal(secondCommitted.currentStep, "post_review_checks_run");
+    assert.equal(secondCommitted.reviewPasses[1].status, "no_changes");
+    assert.equal(secondCommitted.reviewPasses[1].commit, "");
+  });
+});
+
+test("review pass repetition stops at the configured pass limit", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "app");
+    const binDir = path.join(cwd, "bin");
+    const logPath = path.join(cwd, "commands.log");
+    await createGitApp(appRoot);
+    await installFakeNpm(binDir, logPath);
+    const env = {
+      PATH: `${binDir}${path.delimiter}${process.env.PATH || ""}`
+    };
+
+    const created = parseJsonResult(runCli({ cwd: appRoot, args: ["session", "create", "--json"], env }));
+    runSessionStepJson(appRoot, created.sessionId, { env });
+    const session = parseJsonResult(runCli({ cwd: appRoot, args: ["session", created.sessionId, "--json"], env }));
+    await writeFile(path.join(session.sessionRoot, "issue_url"), "https://github.com/example/repo/issues/123\n", "utf8");
+    await writeFile(path.join(session.sessionRoot, "issue_title"), "Max review\n", "utf8");
+    await writeFile(path.join(session.sessionRoot, "issue.md"), "Max review passes.\n", "utf8");
+    await writeFile(path.join(session.sessionRoot, "plan_details.md"), "Confirmed details.\n", "utf8");
+    await writeFile(path.join(session.sessionRoot, "plan.md"), "Confirmed plan.\n", "utf8");
+    await writeIssueMetadata(session.sessionRoot);
+    await writeStepReceipts(session.sessionRoot, STEP_IDS.slice(0, STEP_IDS.indexOf("review_prompt_rendered")));
+
+    let payload = null;
+    for (const pass of ["001", "002", "003"]) {
+      const prompted = runSessionStepJson(appRoot, created.sessionId, { env });
+      assert.equal(prompted.currentStep, "review_changes_accepted");
+      assert.equal(prompted.currentReviewPass, pass);
+      await writeFile(path.join(prompted.worktree, `review-pass-${pass}.txt`), `${pass}\n`, "utf8");
+      runSessionStepJson(appRoot, created.sessionId, {
+        args: ["--review-findings-remaining", "true", "--review-findings", `Important findings remain after pass ${pass}.`],
+        env
+      });
+      payload = runSessionStepJson(appRoot, created.sessionId, { env });
+    }
+    assert.equal(payload.currentStep, "post_review_checks_run");
+    assert.equal(payload.reviewPasses.length, 3);
+    assert.equal(payload.reviewPasses[2].findingsRemaining, true);
+  });
+});
+
+test("blueprint update step handles changed, unchanged, and invalid tagged output", async () => {
+  await withTempDir(async (cwd) => {
+    const changedRoot = path.join(cwd, "changed");
+    await createGitApp(changedRoot);
+    const changedSession = parseJsonResult(runCli({ cwd: changedRoot, args: ["session", "create", "--json"] }));
+    const changedWorktree = runSessionStepJson(changedRoot, changedSession.sessionId);
+    await writeFile(path.join(changedSession.sessionRoot, "issue_url"), "https://github.com/example/repo/issues/123\n", "utf8");
+    await writeFile(path.join(changedSession.sessionRoot, "issue_title"), "Update blueprint\n", "utf8");
+    await writeFile(path.join(changedSession.sessionRoot, "issue.md"), "Update blueprint.\n", "utf8");
+    await writeFile(path.join(changedSession.sessionRoot, "plan_details.md"), "Confirmed details.\n", "utf8");
+    await writeIssueMetadata(changedSession.sessionRoot);
+    await writeFile(path.join(changedSession.sessionRoot, "plan.md"), "Confirmed plan.\n", "utf8");
+    await writeStepReceipts(changedSession.sessionRoot, STEP_IDS.slice(0, STEP_IDS.indexOf("blueprint_updated")));
+
+    const changed = runSessionStepJson(changedRoot, changedSession.sessionId, {
+      args: ["--blueprint", "[app_blueprint]\n# Updated Blueprint\n\nThe app now tracks field work.\n[/app_blueprint]\n[agent_decisions]\n- Keep blueprint concise.\n[/agent_decisions]"]
+    });
+    assert.equal(changed.currentStep, "doctor_run");
+    assert.match(await readFile(path.join(changedWorktree.worktree, ".jskit", "APP_BLUEPRINT.md"), "utf8"), /Updated Blueprint/);
+    assert.match(runGit(changedWorktree.worktree, ["log", "--oneline", "--max-count=1"]), /Update app blueprint/);
+    assert.match(await readFile(path.join(changedSession.sessionRoot, "agent_decisions.md"), "utf8"), /Keep blueprint concise/);
+
+    const unchangedRoot = path.join(cwd, "unchanged");
+    await createGitApp(unchangedRoot);
+    await writeFile(path.join(unchangedRoot, ".jskit", "APP_BLUEPRINT.md"), "# Existing Blueprint\n\nAlready current.\n", "utf8");
+    runGit(unchangedRoot, ["add", ".jskit/APP_BLUEPRINT.md"]);
+    runGit(unchangedRoot, ["commit", "-m", "Add existing blueprint"]);
+    const unchangedSession = parseJsonResult(runCli({ cwd: unchangedRoot, args: ["session", "create", "--json"] }));
+    const unchangedWorktree = runSessionStepJson(unchangedRoot, unchangedSession.sessionId);
+    await writeFile(path.join(unchangedSession.sessionRoot, "issue_url"), "https://github.com/example/repo/issues/123\n", "utf8");
+    await writeFile(path.join(unchangedSession.sessionRoot, "issue_title"), "Keep blueprint\n", "utf8");
+    await writeFile(path.join(unchangedSession.sessionRoot, "issue.md"), "Keep blueprint.\n", "utf8");
+    await writeFile(path.join(unchangedSession.sessionRoot, "plan_details.md"), "Confirmed details.\n", "utf8");
+    await writeIssueMetadata(unchangedSession.sessionRoot);
+    await writeFile(path.join(unchangedSession.sessionRoot, "plan.md"), "Confirmed plan.\n", "utf8");
+    await writeStepReceipts(unchangedSession.sessionRoot, STEP_IDS.slice(0, STEP_IDS.indexOf("blueprint_updated")));
+
+    const unchanged = runSessionStepJson(unchangedRoot, unchangedSession.sessionId, {
+      args: ["--blueprint", "[app_blueprint]\n# Existing Blueprint\n\nAlready current.\n[/app_blueprint]"]
+    });
+    assert.equal(unchanged.currentStep, "doctor_run");
+    assert.equal(runGit(unchangedWorktree.worktree, ["status", "--porcelain=v1"]), "");
+    assert.match(
+      await readFile(path.join(unchangedSession.sessionRoot, "steps", "blueprint_updated"), "utf8"),
+      /already up to date/
+    );
+
+    const invalidRoot = path.join(cwd, "invalid");
+    await createGitApp(invalidRoot);
+    const invalidSession = parseJsonResult(runCli({ cwd: invalidRoot, args: ["session", "create", "--json"] }));
+    runSessionStepJson(invalidRoot, invalidSession.sessionId);
+    await writeFile(path.join(invalidSession.sessionRoot, "issue_url"), "https://github.com/example/repo/issues/123\n", "utf8");
+    await writeFile(path.join(invalidSession.sessionRoot, "issue_title"), "Invalid blueprint\n", "utf8");
+    await writeFile(path.join(invalidSession.sessionRoot, "issue.md"), "Invalid blueprint.\n", "utf8");
+    await writeFile(path.join(invalidSession.sessionRoot, "plan_details.md"), "Confirmed details.\n", "utf8");
+    await writeIssueMetadata(invalidSession.sessionRoot);
+    await writeFile(path.join(invalidSession.sessionRoot, "plan.md"), "Confirmed plan.\n", "utf8");
+    await writeStepReceipts(invalidSession.sessionRoot, STEP_IDS.slice(0, STEP_IDS.indexOf("blueprint_updated")));
+
+    const invalid = runSessionStepJsonFailure(invalidRoot, invalidSession.sessionId, {
+      args: ["--blueprint", "No tagged blueprint"]
+    });
+    assert.equal(invalid.errors[0].code, "app_blueprint_required");
+    assert.equal(invalid.currentStep, "blueprint_updated");
+  });
+});
+
+test("final verification failure keeps the session blocked before PR creation", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "app");
+    await createGitApp(appRoot);
+    const packageJsonPath = path.join(appRoot, "package.json");
+    const packageJson = JSON.parse(await readFile(packageJsonPath, "utf8"));
+    packageJson.scripts["verify:local"] = "node -e \"process.exit(2)\"";
+    await writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`, "utf8");
+    runGit(appRoot, ["add", "package.json"]);
+    runGit(appRoot, ["commit", "-m", "Make verification fail"]);
+
+    const created = parseJsonResult(runCli({ cwd: appRoot, args: ["session", "create", "--json"] }));
+    runSessionStepJson(appRoot, created.sessionId);
+    await writeFile(path.join(created.sessionRoot, "issue_url"), "https://github.com/example/repo/issues/123\n", "utf8");
+    await writeFile(path.join(created.sessionRoot, "issue_title"), "Fail verification\n", "utf8");
+    await writeFile(path.join(created.sessionRoot, "issue.md"), "Fail verification.\n", "utf8");
+    await writeFile(path.join(created.sessionRoot, "plan_details.md"), "Confirmed details.\n", "utf8");
+    await writeIssueMetadata(created.sessionRoot);
+    await writeFile(path.join(created.sessionRoot, "plan.md"), "Confirmed plan.\n", "utf8");
+    await writeStepReceipts(created.sessionRoot, STEP_IDS.slice(0, STEP_IDS.indexOf("doctor_run")));
+
+    const failed = runSessionStepJsonFailure(appRoot, created.sessionId);
+
+    assert.equal(failed.errors[0].code, "doctor_failed");
+    assert.equal(failed.currentStep, "doctor_run");
+    assert.equal(failed.currentStepAction.retryable, true);
+    assert.equal(failed.status, "blocked");
+    await assert.rejects(access(path.join(created.sessionRoot, "steps", "doctor_run")));
+    await assert.rejects(access(path.join(created.sessionRoot, "pr_url")));
+
+    const worktreePackageJsonPath = path.join(failed.worktree, "package.json");
+    const worktreePackageJson = JSON.parse(await readFile(worktreePackageJsonPath, "utf8"));
+    worktreePackageJson.scripts["verify:local"] = "node -e \"process.exit(0)\"";
+    await writeFile(worktreePackageJsonPath, `${JSON.stringify(worktreePackageJson, null, 2)}\n`, "utf8");
+    await writeFile(path.join(failed.worktree, "verification-repair.txt"), "repair\n", "utf8");
+    const repaired = runSessionStepJson(appRoot, created.sessionId);
+    assert.equal(repaired.currentStep, "final_report_created");
+    assert.ok(repaired.completedSteps.includes("doctor_run"));
+    assert.match(runGit(failed.worktree, ["log", "--oneline", "--max-count=1"]), /Verification repairs/);
+    await access(path.join(created.sessionRoot, "doctor_repair_commit.json"));
   });
 });
 
@@ -851,11 +2113,12 @@ test("jskit session can execute review loop, doctor, PR, merge, cleanup, and fin
       env
     });
     runSessionStepJson(appRoot, created.sessionId, {
-      args: ["--issue", "# Add a page"],
+      args: ["--issue-title", "Add a page", "--issue", "# Add a page"],
       env
     });
     const issueCreated = runSessionStepJson(appRoot, created.sessionId, { env });
-    assert.equal(issueCreated.currentStep, "plan_made");
+    assert.equal(issueCreated.currentStep, "plan_details_prompt_rendered");
+    saveCliSessionPlanDetails(appRoot, created.sessionId, { env });
     const planPrompt = runSessionStepJson(appRoot, created.sessionId, { env });
     assert.equal(planPrompt.currentStep, "plan_made");
     assert.match(planPrompt.prompt, /Create an implementation plan/);
@@ -897,10 +2160,25 @@ test("jskit session can execute review loop, doctor, PR, merge, cleanup, and fin
     assert.equal(accepted.prompt, "");
     assert.ok(accepted.completedSteps.includes("implementation_changes_accepted"));
     const committed = runSessionStepJson(appRoot, created.sessionId, { env });
-    assert.equal(committed.currentStep, "review_prompt_rendered");
+    assert.equal(committed.currentStep, "pre_review_checks_run");
     assert.equal(committed.prompt, "");
-    assert.equal(committed.currentStepAction.buttonLabel, "Start review");
+    assert.equal(committed.currentStepAction.buttonLabel, "Run checks");
+    const preReview = runSessionStepJson(appRoot, created.sessionId, { env });
+    assert.equal(preReview.currentStep, "deep_ui_check_run");
+    assert.ok(preReview.completedSteps.includes("pre_review_checks_run"));
+    assert.equal(preReview.currentStepAction.buttonLabel, "Run Deep UI check");
+    const deepUi = runSessionStepJson(appRoot, created.sessionId, { env });
+    assert.equal(deepUi.currentStep, "deep_ui_check_changes_accepted");
+    assert.ok(deepUi.completedSteps.includes("deep_ui_check_run"));
+    assert.match(deepUi.prompt, /Deep UI quality check/);
+    assert.equal(deepUi.codex.promptActionLabel, "Run Deep UI check");
     assert.equal(committed.stepDefinitions.find((step) => step.id === "review_prompt_rendered").label, "Review execution");
+    const deepUiAccepted = runSessionStepJson(appRoot, created.sessionId, { env });
+    assert.equal(deepUiAccepted.currentStep, "deep_ui_check_changes_committed");
+    assert.ok(deepUiAccepted.completedSteps.includes("deep_ui_check_changes_accepted"));
+    const deepUiCommitted = runSessionStepJson(appRoot, created.sessionId, { env });
+    assert.equal(deepUiCommitted.currentStep, "review_prompt_rendered");
+    assert.ok(deepUiCommitted.completedSteps.includes("deep_ui_check_changes_committed"));
 
     const review = runSessionStepJson(appRoot, created.sessionId, { env });
     assert.equal(review.currentStep, "review_changes_accepted");
@@ -909,25 +2187,74 @@ test("jskit session can execute review loop, doctor, PR, merge, cleanup, and fin
     assert.equal(review.codex.autoInject, true);
     assert.equal(review.codex.promptActionLabel, "Start review");
     assert.match(review.prompt, /Review changes/);
+    assert.match(review.prompt, /Review pass: 001 of 3/);
+    assert.equal(review.currentReviewPass, "001");
+    assert.equal(review.reviewPasses.length, 1);
+    assert.equal(review.reviewPasses[0].status, "prompted");
+    assert.equal(review.reviewPasses[0].promptPath, path.join(review.sessionRoot, "review_passes", "pass_001", "prompt.md"));
     assert.match(
       await readFile(path.join(review.sessionRoot, "prompts", "review.md"), "utf8"),
       /Review changes/
     );
+    assert.match(
+      await readFile(path.join(review.sessionRoot, "review_passes", "pass_001", "prompt.md"), "utf8"),
+      /Review pass: 001 of 3/
+    );
+    await writeFile(path.join(inspect.worktree, "review-fix.txt"), "reviewed\\n", "utf8");
     const reviewAccepted = runSessionStepJson(appRoot, created.sessionId, { env });
     assert.equal(reviewAccepted.currentStep, "review_changes_committed");
     assert.ok(reviewAccepted.completedSteps.includes("review_changes_accepted"));
+    assert.equal(reviewAccepted.reviewPasses[0].status, "accepted_with_changes");
+    assert.deepEqual(reviewAccepted.reviewPasses[0].changedFiles, ["?? review-fix.txt"]);
     const reviewCommitted = runSessionStepJson(appRoot, created.sessionId, { env });
-    assert.equal(reviewCommitted.currentStep, "user_check_completed");
+    assert.equal(reviewCommitted.currentStep, "post_review_checks_run");
     assert.ok(reviewCommitted.completedSteps.includes("review_changes_committed"));
+    assert.equal(reviewCommitted.reviewPasses[0].status, "committed");
+    assert.match(reviewCommitted.reviewPasses[0].commit, /^[0-9a-f]{40}$/u);
+    const postReview = runSessionStepJson(appRoot, created.sessionId, { env });
+    assert.equal(postReview.currentStep, "deep_ui_recheck_run");
+    assert.ok(postReview.completedSteps.includes("post_review_checks_run"));
+    const deepUiRecheck = runSessionStepJson(appRoot, created.sessionId, { env });
+    assert.equal(deepUiRecheck.currentStep, "deep_ui_recheck_changes_accepted");
+    assert.ok(deepUiRecheck.completedSteps.includes("deep_ui_recheck_run"));
+    const deepUiRecheckAccepted = runSessionStepJson(appRoot, created.sessionId, { env });
+    assert.equal(deepUiRecheckAccepted.currentStep, "deep_ui_recheck_changes_committed");
+    assert.ok(deepUiRecheckAccepted.completedSteps.includes("deep_ui_recheck_changes_accepted"));
+    const deepUiRecheckCommitted = runSessionStepJson(appRoot, created.sessionId, { env });
+    assert.equal(deepUiRecheckCommitted.currentStep, "user_check_completed");
+    assert.ok(deepUiRecheckCommitted.completedSteps.includes("deep_ui_recheck_changes_committed"));
     const check = runSessionStepJson(appRoot, created.sessionId, { env });
     assert.equal(check.currentStep, "user_check_completed");
     assert.match(check.prompt, /User check/);
-    runSessionStepJson(appRoot, created.sessionId, {
+    const userChecked = runSessionStepJson(appRoot, created.sessionId, {
       args: ["--user-check", "passed"],
       env
     });
+    assert.equal(userChecked.currentStep, "blueprint_updated");
 
-    runSessionStepJson(appRoot, created.sessionId, { env });
+    const blueprintPrompt = runSessionStepJson(appRoot, created.sessionId, { env });
+    assert.equal(blueprintPrompt.currentStep, "blueprint_updated");
+    assert.match(blueprintPrompt.prompt, /Update the durable JSKIT app blueprint/);
+    const blueprintUpdated = runSessionStepJson(appRoot, created.sessionId, {
+      args: ["--blueprint", "[app_blueprint]\n# Session Test App\n\nAdds a simple feature page.\n[/app_blueprint]\n[agent_decisions]\n- Record the simple feature in the blueprint.\n[/agent_decisions]"],
+      env
+    });
+    assert.equal(blueprintUpdated.currentStep, "doctor_run");
+    assert.match(await readFile(path.join(inspect.worktree, ".jskit", "APP_BLUEPRINT.md"), "utf8"), /Session Test App/);
+
+    const finalVerification = runSessionStepJson(appRoot, created.sessionId, { env });
+    assert.equal(finalVerification.currentStep, "final_report_created");
+    const finalReport = runSessionStepJson(appRoot, created.sessionId, { env });
+    assert.equal(finalReport.currentStep, "pr_created");
+    assert.match(finalReport.finalReportText, /Final Report/);
+    assert.match(finalReport.finalReportText, /## Checks/);
+    assert.match(finalReport.finalReportText, /## UI Checks/);
+    assert.match(finalReport.finalReportText, /## Review Passes/);
+    assert.match(finalReport.finalReportText, /## Command Log/);
+    assert.match(finalReport.finalReportText, /## Remaining Unverified Gaps/);
+    assert.match(finalReport.finalReportText, /## Decisions/);
+    assert.match(finalReport.finalReportText, /Record the simple feature in the blueprint/);
+    assert.equal(finalReport.githubComments.final_report.purpose, "final_report");
     const pr = runSessionStepJson(appRoot, created.sessionId, { env });
     assert.equal(pr.prUrl, "https://github.com/example/repo/pull/456");
     const helperMap = JSON.parse(await readFile(path.join(inspect.worktree, ".jskit", "helper-map.json"), "utf8"));
@@ -936,18 +2263,45 @@ test("jskit session can execute review loop, doctor, PR, merge, cleanup, and fin
         file.exports.some((symbol) => symbol.name === "formatFeatureTitle");
     }));
     assert.match(runGit(inspect.worktree, ["log", "--oneline", "--max-count=3"]), /Update JSKIT helper map/);
+    assert.match(runGit(inspect.worktree, ["show", `origin/${pr.branch}:.jskit/helper-map.md`]), /formatFeatureTitle/);
     const merged = runSessionStepJson(appRoot, created.sessionId, { env });
     assert.equal(merged.currentStep, "session_finished");
+    assert.equal(merged.prOutcome.outcome, "merged");
     assert.equal(await readFile(path.join(appRoot, "feature.txt"), "utf8"), "hello\\n");
     assert.match(await readFile(path.join(appRoot, ".jskit", "helper-map.md"), "utf8"), /formatFeatureTitle/);
     await assert.rejects(access(inspect.worktree));
     const finished = runSessionStepJson(appRoot, created.sessionId, { env });
+    assertSessionContractFields(finished);
 
     assert.equal(finished.status, "finished");
     assert.equal(finished.currentStep, "");
     assert.equal(finished.archive, "completed");
+    assert.equal(finished.prOutcome.outcome, "merged");
     assert.equal(finished.sessionRoot, path.join(appRoot, ".jskit", "sessions", "completed", created.sessionId));
     await access(finished.sessionRoot);
+    await access(path.join(finished.sessionRoot, "workflow_version"));
+    await access(path.join(finished.sessionRoot, "active_cycle"));
+    await access(path.join(finished.sessionRoot, "steps", "cycle_001"));
+    await access(path.join(finished.sessionRoot, "issue_metadata.json"));
+    await access(path.join(finished.sessionRoot, "base_branch"));
+    await access(path.join(finished.sessionRoot, "base_commit"));
+    await access(path.join(finished.sessionRoot, "final_report.md"));
+    await access(path.join(finished.sessionRoot, "agent_decisions.md"));
+    await access(path.join(finished.sessionRoot, "plan_details.md"));
+    await access(path.join(finished.sessionRoot, "github_comments.json"));
+    await access(path.join(finished.sessionRoot, "pr_outcome.json"));
+    await access(path.join(finished.sessionRoot, "command_log.jsonl"));
+    await access(path.join(finished.sessionRoot, "checks", "pre_review_checks_run.json"));
+    await access(path.join(finished.sessionRoot, "ui_checks", "deep_ui_check_run.json"));
+    await access(path.join(finished.sessionRoot, "review_passes", "pass_001", "prompt.md"));
+    await access(path.join(finished.sessionRoot, "review_passes", "pass_001", "accepted.json"));
+    await access(path.join(finished.sessionRoot, "review_passes", "pass_001", "committed.json"));
+    await access(path.join(finished.sessionRoot, "prompts", "issue_draft.md"));
+    const commandLog = await readFile(path.join(finished.sessionRoot, "command_log.jsonl"), "utf8");
+    assert.match(commandLog, /"kind":"dependencies_install"/);
+    assert.match(commandLog, /"kind":"pre_review_checks_run"/);
+    assert.match(commandLog, /"kind":"github_pr_create"/);
+    assert.match(commandLog, /"kind":"github_pr_merge"/);
     await assert.rejects(access(path.join(appRoot, ".jskit", "sessions", "active", created.sessionId)));
     const listed = parseJsonResult(runCli({ cwd: appRoot, args: ["session", "--json"], env }));
     assert.equal(listed.archive, "active");
@@ -964,6 +2318,45 @@ test("jskit session can execute review loop, doctor, PR, merge, cleanup, and fin
     assert.match(log, /gh pr view https:\/\/github\.com\/example\/repo\/pull\/456 --json state,mergedAt,url,baseRefName/);
     assert.match(log, /gh pr merge https:\/\/github\.com\/example\/repo\/pull\/456 --merge --delete-branch/);
     assert.match(log, /gh issue comment https:\/\/github\.com\/example\/repo\/issues\/123 --body-file/);
+  });
+});
+
+test("jskit session reuses an existing current-branch PR during PR creation", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "app");
+    const binDir = path.join(cwd, "bin");
+    const logPath = path.join(cwd, "commands.log");
+    await createGitApp(appRoot, { withRemote: true });
+    await installFakeGh(binDir, logPath);
+    await installFakeNpm(binDir, logPath);
+    const existingPrUrl = "https://github.com/example/repo/pull/789";
+    const env = {
+      FAKE_GH_EXISTING_PR_URL: existingPrUrl,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH || ""}`
+    };
+
+    const created = parseJsonResult(runCli({ cwd: appRoot, args: ["session", "create", "--json"], env }));
+    advanceCliSessionToIssuePrompt(appRoot, created.sessionId, { env });
+    const session = parseJsonResult(runCli({ cwd: appRoot, args: ["session", created.sessionId, "--json"], env }));
+
+    await writeFile(path.join(session.sessionRoot, "issue_url"), "https://github.com/example/repo/issues/123\n", "utf8");
+    await writeFile(path.join(session.sessionRoot, "issue_title"), "Reuse existing PR\n", "utf8");
+    await writeFile(path.join(session.sessionRoot, "issue.md"), "Reuse an existing branch PR.\n", "utf8");
+    await writeFile(path.join(session.sessionRoot, "plan_details.md"), "Details are complete.\n", "utf8");
+    await writeFile(path.join(session.sessionRoot, "plan.md"), "Plan is approved.\n", "utf8");
+    await writeFile(path.join(session.sessionRoot, "final_report.md"), "# Final Report\n", "utf8");
+    await writeIssueMetadata(session.sessionRoot);
+    await writeStepReceipts(session.sessionRoot, STEP_IDS.slice(0, STEP_IDS.indexOf("pr_created")));
+
+    const pr = runSessionStepJson(appRoot, created.sessionId, { env });
+    assert.equal(pr.currentStep, "pr_finalized");
+    assert.equal(pr.prUrl, existingPrUrl);
+    assert.match(await readFile(path.join(session.sessionRoot, "steps", "pr_created"), "utf8"), /reused existing PR/);
+    const log = await readFile(logPath, "utf8");
+    assert.match(log, /gh pr view --json state,mergedAt,url,baseRefName/);
+    assert.doesNotMatch(log, /gh pr create/);
+    const commandLog = await readFile(path.join(session.sessionRoot, "command_log.jsonl"), "utf8");
+    assert.match(commandLog, /"kind":"github_pr_view_current_branch"/);
   });
 });
 
@@ -1002,14 +2395,16 @@ process.exit(1);
     const worktreePayload = parseJsonResult(runCli({ cwd: appRoot, args: ["session", created.sessionId, "step", "--json"], env }));
     await writeStepReceipts(
       worktreePayload.sessionRoot,
-      STEP_IDS.slice(0, STEP_IDS.indexOf("pr_merged"))
+      STEP_IDS.slice(0, STEP_IDS.indexOf("pr_finalized"))
     );
     await writeFile(path.join(worktreePayload.sessionRoot, "issue_url"), "https://github.com/example/repo/issues/123\n", "utf8");
     await writeFile(path.join(worktreePayload.sessionRoot, "pr_url"), "https://github.com/example/repo/pull/456\n", "utf8");
+    await writeIssueMetadata(worktreePayload.sessionRoot);
 
     const merged = parseJsonResult(runCli({ cwd: appRoot, args: ["session", created.sessionId, "step", "--json"], env }));
     assert.equal(merged.currentStep, "session_finished");
-    assert.ok(merged.completedSteps.includes("pr_merged"));
+    assert.ok(merged.completedSteps.includes("pr_finalized"));
+    assert.equal(merged.prOutcome.outcome, "merged");
     await assert.rejects(access(worktreePayload.worktree));
     const log = await readFile(logPath, "utf8");
     assert.match(log, /gh pr view https:\/\/github\.com\/example\/repo\/pull\/456 --json state,mergedAt,url,baseRefName/);
@@ -1048,20 +2443,74 @@ process.exit(1);
     const worktreePayload = parseJsonResult(runCli({ cwd: appRoot, args: ["session", created.sessionId, "step", "--json"], env }));
     await writeStepReceipts(
       worktreePayload.sessionRoot,
-      STEP_IDS.slice(0, STEP_IDS.indexOf("pr_merged"))
+      STEP_IDS.slice(0, STEP_IDS.indexOf("pr_finalized"))
     );
     await writeFile(path.join(worktreePayload.sessionRoot, "issue_url"), "https://github.com/example/repo/issues/123\n", "utf8");
     await writeFile(path.join(worktreePayload.sessionRoot, "pr_url"), "https://github.com/example/repo/pull/456\n", "utf8");
+    await writeIssueMetadata(worktreePayload.sessionRoot);
     await writeFile(path.join(appRoot, "local-change.txt"), "dirty\n", "utf8");
 
     const blocked = parseJsonFailure(runCli({ cwd: appRoot, args: ["session", created.sessionId, "step", "--json"], env }));
     assert.equal(blocked.errors[0].code, "target_root_dirty");
     await access(worktreePayload.worktree);
-    await assert.rejects(access(path.join(worktreePayload.sessionRoot, "steps", "pr_merged")));
+    await assert.rejects(access(path.join(worktreePayload.sessionRoot, "steps", "pr_finalized")));
     const log = await readFile(logPath, "utf8");
     assert.match(log, /gh pr view https:\/\/github\.com\/example\/repo\/pull\/456 --json state,mergedAt,url,baseRefName/);
     assert.doesNotMatch(log, /gh pr merge/);
     assert.doesNotMatch(log, /gh issue close/);
+  });
+});
+
+test("jskit session can finish successfully without merging the PR", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "app");
+    const binDir = path.join(cwd, "bin");
+    const logPath = path.join(cwd, "commands.log");
+    await createGitApp(appRoot);
+    await installFakeGh(binDir, logPath);
+    const env = {
+      PATH: `${binDir}${path.delimiter}${process.env.PATH || ""}`
+    };
+
+    const created = parseJsonResult(runCli({ cwd: appRoot, args: ["session", "create", "--json"], env }));
+    const worktreePayload = parseJsonResult(runCli({ cwd: appRoot, args: ["session", created.sessionId, "step", "--json"], env }));
+    await writeStepReceipts(
+      worktreePayload.sessionRoot,
+      STEP_IDS.slice(0, STEP_IDS.indexOf("pr_finalized"))
+    );
+    await writeFile(path.join(worktreePayload.sessionRoot, "issue_url"), "https://github.com/example/repo/issues/123\n", "utf8");
+    await writeFile(path.join(worktreePayload.sessionRoot, "pr_url"), "https://github.com/example/repo/pull/456\n", "utf8");
+    await writeIssueMetadata(worktreePayload.sessionRoot);
+
+    const missingReason = parseJsonFailure(runCli({
+      cwd: appRoot,
+      args: ["session", created.sessionId, "step", "--close-without-merge", "--json"],
+      env
+    }));
+    assert.equal(missingReason.errors[0].code, "close_without_merge_reason_required");
+
+    const closed = parseJsonResult(runCli({
+      cwd: appRoot,
+      args: ["session", created.sessionId, "step", "--close-without-merge", "--close-reason", "Prototype not approved for merge.", "--json"],
+      env
+    }));
+    assert.equal(closed.currentStep, "session_finished");
+    assert.equal(closed.prOutcome.outcome, "closed_without_merge");
+    assert.equal(closed.prOutcome.reason, "Prototype not approved for merge.");
+    await assert.rejects(access(worktreePayload.worktree));
+
+    const finished = parseJsonResult(runCli({ cwd: appRoot, args: ["session", created.sessionId, "step", "--json"], env }));
+    assertSessionContractFields(finished);
+    assert.equal(finished.status, "finished");
+    assert.equal(finished.archive, "completed");
+    assert.equal(finished.prOutcome.outcome, "closed_without_merge");
+
+    const log = await readFile(logPath, "utf8");
+    assert.match(log, /gh pr comment https:\/\/github\.com\/example\/repo\/pull\/456 --body JSKIT session/);
+    assert.match(log, /gh issue comment https:\/\/github\.com\/example\/repo\/issues\/123 --body JSKIT session/);
+    assert.doesNotMatch(log, /gh pr close/);
+    assert.doesNotMatch(log, /gh issue close/);
+    assert.doesNotMatch(log, /gh pr merge/);
   });
 });
 
@@ -1081,6 +2530,7 @@ test("jskit session abandon closes issue, removes worktree, and marks state aban
     await writeFile(path.join(worktreePayload.sessionRoot, "issue_url"), "https://github.com/example/repo/issues/999\\n", "utf8");
 
     const abandoned = parseJsonResult(runCli({ cwd: appRoot, args: ["session", created.sessionId, "abandon", "--json"], env }));
+    assertSessionContractFields(abandoned);
     assert.equal(abandoned.status, "abandoned");
     assert.equal(abandoned.archive, "abandoned");
     assert.equal(abandoned.sessionRoot, path.join(appRoot, ".jskit", "sessions", "abandoned", created.sessionId));


### PR DESCRIPTION
## Summary
- add app readiness/session boundary handling and expanded session workflow steps
- add plan-details, deep UI check, and blueprint update prompt templates
- update session JSON/docs/tests for the expanded workflow contract

## Verification
- Not run, per request