### PR TITLE
Add JSKIT session PR merge preparation flow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6686,28 +6686,28 @@
     },
     "packages/agent-docs": {
       "name": "@jskit-ai/agent-docs",
-      "version": "0.1.35",
+      "version": "0.1.36",
       "engines": {
         "node": ">=20 <23"
       }
     },
     "packages/assistant": {
       "name": "@jskit-ai/assistant",
-      "version": "0.1.83",
+      "version": "0.1.84",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.74"
+        "@jskit-ai/kernel": "0.1.75"
       }
     },
     "packages/assistant-core": {
       "name": "@jskit-ai/assistant-core",
-      "version": "0.1.50",
+      "version": "0.1.51",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.74",
-        "@jskit-ai/http-runtime": "0.1.73",
-        "@jskit-ai/kernel": "0.1.74",
-        "@jskit-ai/resource-core": "0.1.19",
-        "@jskit-ai/resource-crud-core": "0.1.19",
-        "@jskit-ai/users-core": "0.1.84",
+        "@jskit-ai/database-runtime": "0.1.75",
+        "@jskit-ai/http-runtime": "0.1.74",
+        "@jskit-ai/kernel": "0.1.75",
+        "@jskit-ai/resource-core": "0.1.20",
+        "@jskit-ai/resource-crud-core": "0.1.20",
+        "@jskit-ai/users-core": "0.1.85",
         "dompurify": "^3.3.3",
         "json-rest-schema": "1.x.x",
         "marked": "^17.0.4",
@@ -6720,15 +6720,15 @@
     },
     "packages/assistant-runtime": {
       "name": "@jskit-ai/assistant-runtime",
-      "version": "0.1.45",
+      "version": "0.1.46",
       "dependencies": {
-        "@jskit-ai/assistant-core": "0.1.50",
-        "@jskit-ai/database-runtime": "0.1.74",
-        "@jskit-ai/http-runtime": "0.1.73",
-        "@jskit-ai/kernel": "0.1.74",
-        "@jskit-ai/shell-web": "0.1.73",
-        "@jskit-ai/users-core": "0.1.84",
-        "@jskit-ai/users-web": "0.1.89",
+        "@jskit-ai/assistant-core": "0.1.51",
+        "@jskit-ai/database-runtime": "0.1.75",
+        "@jskit-ai/http-runtime": "0.1.74",
+        "@jskit-ai/kernel": "0.1.75",
+        "@jskit-ai/shell-web": "0.1.74",
+        "@jskit-ai/users-core": "0.1.85",
+        "@jskit-ai/users-web": "0.1.90",
         "json-rest-schema": "1.x.x"
       },
       "peerDependencies": {
@@ -6739,21 +6739,21 @@
     },
     "packages/auth-core": {
       "name": "@jskit-ai/auth-core",
-      "version": "0.1.73",
+      "version": "0.1.74",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0",
-        "@jskit-ai/kernel": "0.1.74",
+        "@jskit-ai/kernel": "0.1.75",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/auth-provider-supabase-core": {
       "name": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.73",
+      "version": "0.1.74",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.73",
-        "@jskit-ai/kernel": "0.1.74",
+        "@jskit-ai/auth-core": "0.1.74",
+        "@jskit-ai/kernel": "0.1.75",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0",
         "json-rest-schema": "1.x.x",
@@ -6762,12 +6762,12 @@
     },
     "packages/auth-web": {
       "name": "@jskit-ai/auth-web",
-      "version": "0.1.75",
+      "version": "0.1.76",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.73",
-        "@jskit-ai/http-runtime": "0.1.73",
-        "@jskit-ai/kernel": "0.1.74",
-        "@jskit-ai/shell-web": "0.1.73",
+        "@jskit-ai/auth-core": "0.1.74",
+        "@jskit-ai/http-runtime": "0.1.74",
+        "@jskit-ai/kernel": "0.1.75",
+        "@jskit-ai/shell-web": "0.1.74",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -6780,38 +6780,38 @@
     },
     "packages/console-core": {
       "name": "@jskit-ai/console-core",
-      "version": "0.1.37",
+      "version": "0.1.38",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.73",
-        "@jskit-ai/database-runtime": "0.1.74",
-        "@jskit-ai/http-runtime": "0.1.73",
-        "@jskit-ai/kernel": "0.1.74",
-        "@jskit-ai/resource-crud-core": "0.1.19",
-        "@jskit-ai/users-core": "0.1.84",
+        "@jskit-ai/auth-core": "0.1.74",
+        "@jskit-ai/database-runtime": "0.1.75",
+        "@jskit-ai/http-runtime": "0.1.74",
+        "@jskit-ai/kernel": "0.1.75",
+        "@jskit-ai/resource-crud-core": "0.1.20",
+        "@jskit-ai/users-core": "0.1.85",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/console-web": {
       "name": "@jskit-ai/console-web",
-      "version": "0.1.42",
+      "version": "0.1.43",
       "dependencies": {
-        "@jskit-ai/auth-web": "0.1.75",
-        "@jskit-ai/console-core": "0.1.37",
-        "@jskit-ai/shell-web": "0.1.73"
+        "@jskit-ai/auth-web": "0.1.76",
+        "@jskit-ai/console-core": "0.1.38",
+        "@jskit-ai/shell-web": "0.1.74"
       }
     },
     "packages/crud-core": {
       "name": "@jskit-ai/crud-core",
-      "version": "0.1.82",
+      "version": "0.1.83",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.74",
-        "@jskit-ai/http-runtime": "0.1.73",
-        "@jskit-ai/kernel": "0.1.74",
-        "@jskit-ai/realtime": "0.1.73",
-        "@jskit-ai/resource-crud-core": "0.1.19",
-        "@jskit-ai/shell-web": "0.1.73",
-        "@jskit-ai/users-core": "0.1.84",
-        "@jskit-ai/users-web": "0.1.89",
+        "@jskit-ai/database-runtime": "0.1.75",
+        "@jskit-ai/http-runtime": "0.1.74",
+        "@jskit-ai/kernel": "0.1.75",
+        "@jskit-ai/realtime": "0.1.74",
+        "@jskit-ai/resource-crud-core": "0.1.20",
+        "@jskit-ai/shell-web": "0.1.74",
+        "@jskit-ai/users-core": "0.1.85",
+        "@jskit-ai/users-web": "0.1.90",
         "json-rest-schema": "1.x.x"
       },
       "peerDependencies": {
@@ -6822,98 +6822,98 @@
     },
     "packages/crud-server-generator": {
       "name": "@jskit-ai/crud-server-generator",
-      "version": "0.1.82",
+      "version": "0.1.83",
       "dependencies": {
         "@babel/parser": "^7.29.2",
-        "@jskit-ai/crud-core": "0.1.82",
-        "@jskit-ai/database-runtime": "0.1.74",
-        "@jskit-ai/http-runtime": "0.1.73",
-        "@jskit-ai/json-rest-api-core": "0.1.19",
-        "@jskit-ai/kernel": "0.1.74",
-        "@jskit-ai/resource-crud-core": "0.1.19",
+        "@jskit-ai/crud-core": "0.1.83",
+        "@jskit-ai/database-runtime": "0.1.75",
+        "@jskit-ai/http-runtime": "0.1.74",
+        "@jskit-ai/json-rest-api-core": "0.1.20",
+        "@jskit-ai/kernel": "0.1.75",
+        "@jskit-ai/resource-crud-core": "0.1.20",
         "recast": "^0.23.11"
       }
     },
     "packages/crud-ui-generator": {
       "name": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.57",
+      "version": "0.1.58",
       "dependencies": {
-        "@jskit-ai/crud-core": "0.1.82",
-        "@jskit-ai/kernel": "0.1.74",
-        "@jskit-ai/resource-crud-core": "0.1.19"
+        "@jskit-ai/crud-core": "0.1.83",
+        "@jskit-ai/kernel": "0.1.75",
+        "@jskit-ai/resource-crud-core": "0.1.20"
       }
     },
     "packages/database-runtime": {
       "name": "@jskit-ai/database-runtime",
-      "version": "0.1.74",
+      "version": "0.1.75",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.74"
+        "@jskit-ai/kernel": "0.1.75"
       }
     },
     "packages/database-runtime-mysql": {
       "name": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.73",
+      "version": "0.1.74",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.74",
-        "@jskit-ai/kernel": "0.1.74"
+        "@jskit-ai/database-runtime": "0.1.75",
+        "@jskit-ai/kernel": "0.1.75"
       }
     },
     "packages/database-runtime-postgres": {
       "name": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.73",
+      "version": "0.1.74",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.74"
+        "@jskit-ai/database-runtime": "0.1.75"
       }
     },
     "packages/feature-server-generator": {
       "name": "@jskit-ai/feature-server-generator",
-      "version": "0.1.16"
+      "version": "0.1.17"
     },
     "packages/google-rewarded-core": {
       "name": "@jskit-ai/google-rewarded-core",
-      "version": "0.1.11"
+      "version": "0.1.12"
     },
     "packages/google-rewarded-web": {
       "name": "@jskit-ai/google-rewarded-web",
-      "version": "0.1.11"
+      "version": "0.1.12"
     },
     "packages/http-runtime": {
       "name": "@jskit-ai/http-runtime",
-      "version": "0.1.73",
+      "version": "0.1.74",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.74",
+        "@jskit-ai/kernel": "0.1.75",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/json-rest-api-core": {
       "name": "@jskit-ai/json-rest-api-core",
-      "version": "0.1.19",
+      "version": "0.1.20",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.74",
+        "@jskit-ai/kernel": "0.1.75",
         "hooked-api": "1.x.x",
         "json-rest-api": "1.x.x"
       }
     },
     "packages/kernel": {
       "name": "@jskit-ai/kernel",
-      "version": "0.1.74",
+      "version": "0.1.75",
       "dependencies": {
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/mobile-capacitor": {
       "name": "@jskit-ai/mobile-capacitor",
-      "version": "0.1.11",
+      "version": "0.1.12",
       "dependencies": {
         "@capacitor/browser": "^7.0.1",
-        "@jskit-ai/kernel": "0.1.74"
+        "@jskit-ai/kernel": "0.1.75"
       }
     },
     "packages/realtime": {
       "name": "@jskit-ai/realtime",
-      "version": "0.1.73",
+      "version": "0.1.74",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.74",
+        "@jskit-ai/kernel": "0.1.75",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",
@@ -6925,24 +6925,24 @@
     },
     "packages/resource-core": {
       "name": "@jskit-ai/resource-core",
-      "version": "0.1.19",
+      "version": "0.1.20",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.74"
+        "@jskit-ai/kernel": "0.1.75"
       }
     },
     "packages/resource-crud-core": {
       "name": "@jskit-ai/resource-crud-core",
-      "version": "0.1.19",
+      "version": "0.1.20",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.74",
-        "@jskit-ai/resource-core": "0.1.19"
+        "@jskit-ai/kernel": "0.1.75",
+        "@jskit-ai/resource-core": "0.1.20"
       }
     },
     "packages/shell-web": {
       "name": "@jskit-ai/shell-web",
-      "version": "0.1.73",
+      "version": "0.1.74",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.74",
+        "@jskit-ai/kernel": "0.1.75",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -6954,25 +6954,25 @@
     },
     "packages/storage-runtime": {
       "name": "@jskit-ai/storage-runtime",
-      "version": "0.1.73",
+      "version": "0.1.74",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.74",
+        "@jskit-ai/kernel": "0.1.75",
         "unstorage": "^1.17.3"
       }
     },
     "packages/ui-generator": {
       "name": "@jskit-ai/ui-generator",
-      "version": "0.1.57",
+      "version": "0.1.58",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.74",
-        "@jskit-ai/shell-web": "0.1.73"
+        "@jskit-ai/kernel": "0.1.75",
+        "@jskit-ai/shell-web": "0.1.74"
       }
     },
     "packages/uploads-image-web": {
       "name": "@jskit-ai/uploads-image-web",
-      "version": "0.1.52",
+      "version": "0.1.53",
       "dependencies": {
-        "@jskit-ai/uploads-runtime": "0.1.52",
+        "@jskit-ai/uploads-runtime": "0.1.53",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",
@@ -6985,37 +6985,37 @@
     },
     "packages/uploads-runtime": {
       "name": "@jskit-ai/uploads-runtime",
-      "version": "0.1.52",
+      "version": "0.1.53",
       "dependencies": {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.74"
+        "@jskit-ai/kernel": "0.1.75"
       }
     },
     "packages/users-core": {
       "name": "@jskit-ai/users-core",
-      "version": "0.1.84",
+      "version": "0.1.85",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.73",
-        "@jskit-ai/database-runtime": "0.1.74",
-        "@jskit-ai/http-runtime": "0.1.73",
-        "@jskit-ai/json-rest-api-core": "0.1.19",
-        "@jskit-ai/kernel": "0.1.74",
-        "@jskit-ai/resource-core": "0.1.19",
-        "@jskit-ai/resource-crud-core": "0.1.19",
-        "@jskit-ai/uploads-runtime": "0.1.52",
+        "@jskit-ai/auth-core": "0.1.74",
+        "@jskit-ai/database-runtime": "0.1.75",
+        "@jskit-ai/http-runtime": "0.1.74",
+        "@jskit-ai/json-rest-api-core": "0.1.20",
+        "@jskit-ai/kernel": "0.1.75",
+        "@jskit-ai/resource-core": "0.1.20",
+        "@jskit-ai/resource-crud-core": "0.1.20",
+        "@jskit-ai/uploads-runtime": "0.1.53",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/users-web": {
       "name": "@jskit-ai/users-web",
-      "version": "0.1.89",
+      "version": "0.1.90",
       "dependencies": {
-        "@jskit-ai/http-runtime": "0.1.73",
-        "@jskit-ai/kernel": "0.1.74",
-        "@jskit-ai/realtime": "0.1.73",
-        "@jskit-ai/shell-web": "0.1.73",
-        "@jskit-ai/uploads-image-web": "0.1.52",
-        "@jskit-ai/users-core": "0.1.84",
+        "@jskit-ai/http-runtime": "0.1.74",
+        "@jskit-ai/kernel": "0.1.75",
+        "@jskit-ai/realtime": "0.1.74",
+        "@jskit-ai/shell-web": "0.1.74",
+        "@jskit-ai/uploads-image-web": "0.1.53",
+        "@jskit-ai/users-core": "0.1.85",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -7027,29 +7027,29 @@
     },
     "packages/workspaces-core": {
       "name": "@jskit-ai/workspaces-core",
-      "version": "0.1.50",
+      "version": "0.1.51",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.73",
-        "@jskit-ai/database-runtime": "0.1.74",
-        "@jskit-ai/http-runtime": "0.1.73",
-        "@jskit-ai/json-rest-api-core": "0.1.19",
-        "@jskit-ai/kernel": "0.1.74",
-        "@jskit-ai/resource-core": "0.1.19",
-        "@jskit-ai/resource-crud-core": "0.1.19",
-        "@jskit-ai/users-core": "0.1.84",
+        "@jskit-ai/auth-core": "0.1.74",
+        "@jskit-ai/database-runtime": "0.1.75",
+        "@jskit-ai/http-runtime": "0.1.74",
+        "@jskit-ai/json-rest-api-core": "0.1.20",
+        "@jskit-ai/kernel": "0.1.75",
+        "@jskit-ai/resource-core": "0.1.20",
+        "@jskit-ai/resource-crud-core": "0.1.20",
+        "@jskit-ai/users-core": "0.1.85",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/workspaces-web": {
       "name": "@jskit-ai/workspaces-web",
-      "version": "0.1.50",
+      "version": "0.1.51",
       "dependencies": {
-        "@jskit-ai/http-runtime": "0.1.73",
-        "@jskit-ai/kernel": "0.1.74",
-        "@jskit-ai/shell-web": "0.1.73",
-        "@jskit-ai/users-core": "0.1.84",
-        "@jskit-ai/users-web": "0.1.89",
-        "@jskit-ai/workspaces-core": "0.1.50",
+        "@jskit-ai/http-runtime": "0.1.74",
+        "@jskit-ai/kernel": "0.1.75",
+        "@jskit-ai/shell-web": "0.1.74",
+        "@jskit-ai/users-core": "0.1.85",
+        "@jskit-ai/users-web": "0.1.90",
+        "@jskit-ai/workspaces-core": "0.1.51",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -7061,7 +7061,7 @@
     },
     "tooling/config-eslint": {
       "name": "@jskit-ai/config-eslint",
-      "version": "0.1.73",
+      "version": "0.1.74",
       "dependencies": {
         "@eslint/js": "^9.39.1",
         "eslint-plugin-vue": "^10.5.1",
@@ -7079,7 +7079,7 @@
     },
     "tooling/create-app": {
       "name": "@jskit-ai/create-app",
-      "version": "0.1.82",
+      "version": "0.1.83",
       "bin": {
         "jskit-create-app": "bin/jskit-create-app.js"
       },
@@ -7089,18 +7089,18 @@
     },
     "tooling/jskit-catalog": {
       "name": "@jskit-ai/jskit-catalog",
-      "version": "0.1.82",
+      "version": "0.1.83",
       "engines": {
         "node": ">=20 <23"
       }
     },
     "tooling/jskit-cli": {
       "name": "@jskit-ai/jskit-cli",
-      "version": "0.2.83",
+      "version": "0.2.84",
       "dependencies": {
-        "@jskit-ai/jskit-catalog": "0.1.82",
-        "@jskit-ai/kernel": "0.1.74",
-        "@jskit-ai/shell-web": "0.1.73",
+        "@jskit-ai/jskit-catalog": "0.1.83",
+        "@jskit-ai/kernel": "0.1.75",
+        "@jskit-ai/shell-web": "0.1.74",
         "@vue/compiler-sfc": "^3.5.29",
         "ts-morph": "^28.0.0"
       },

--- a/packages/agent-docs/package.json
+++ b/packages/agent-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/agent-docs",
-  "version": "0.1.35",
+  "version": "0.1.36",
   "description": "Distributed JSKIT agent references, prompts, guides, and generated reference maps.",
   "type": "module",
   "files": [

--- a/packages/agent-docs/reference/autogen/tooling/jskit-cli.md
+++ b/packages/agent-docs/reference/autogen/tooling/jskit-cli.md
@@ -831,6 +831,7 @@ Exports
 - `listSessions({ targetRoot = process.cwd(), archive = "active" } = {})`
 - `renderTemplate`
 - `recordDependenciesInstalled(paths, { message = "Installed Node dependencies in the session worktree.", preconditions = [] } = {})`
+- `rewindSession({ targetRoot = process.cwd(), sessionId, stepId } = {})`
 - `resolveSessionPaths`
 - `runSessionStep({ targetRoot = process.cwd(), sessionId, options = {} } = {})`
 Local functions
@@ -888,6 +889,20 @@ Local functions
 - `untrackedFiles(worktree)`
 - `untrackedFileDiff(worktree, filePath)`
 - `untrackedFilesDiff(worktree)`
+- `removeSessionPath(paths, ...parts)`
+- `removeSessionRootFile(paths, fileName)`
+- `removePromptArtifact(paths, fileName)`
+- `removeGlobalCodexResult(paths, stepId)`
+- `removeGithubCommentPurpose(paths, purpose)`
+- `removeIssueDetailsMetadata(paths)`
+- `removeCycleDirectories(paths)`
+- `removeCyclePromptArtifacts(paths)`
+- `cancelAllCycleState(paths)`
+- `targetRequiresCycleReset(stepId)`
+- `targetIsAllowedRewindStep(stepId)`
+- `deletedStepIdsForRewindTarget(stepId)`
+- `removeReceiptsForDeletedSteps(paths, deletedStepIds)`
+- `cancelDeletedStepArtifacts(paths, deletedStepIds, { cycleReset = false } = {})`
 - `commitWorktree(paths, { message, allowNoChanges = false } = {})`
 - `uniqueChangedFileList(entries = [])`
 - `changedFilesInWorktree(paths)`
@@ -925,12 +940,12 @@ Local functions
 - `removeSessionWorktree(paths)`
 - `writePrOutcome(paths, outcome)`
 - `assertTargetRootCanUpdateBase(paths, branch)`
-- `assertTargetBaseCanFastForward(paths, branch)`
 - `updateLocalBaseBranch(paths, baseBranch = "")`
 - `updateHelperMapBeforePr(paths)`
 - `createPr(paths)`
 - `closePrWithoutMerge(paths, prUrl, options = {})`
-- `finalizePr(paths, options = {})`
+- `preparePrMerge(paths, options = {}, context = {})`
+- `finalizePr(paths, options = {}, context = {})`
 - `finishSession(paths)`
 - `runNamedPreconditions(paths, names = [])`
 
@@ -960,6 +975,7 @@ Exports
 - `DEEP_UI_CHECK_CODEX_HANDOFF`
 - `AUTOMATED_CHECK_REPAIR_CODEX_HANDOFF`
 - `BLUEPRINT_CODEX_HANDOFF`
+- `PR_MERGE_PREP_CODEX_HANDOFF`
 - `JSKIT_CLI_SHELL_COMMAND`
 - `JSKIT_CLI_SHELL_RULE`
 - `SESSION_STATE_RELATIVE_PATH`

--- a/packages/assistant-core/package.descriptor.mjs
+++ b/packages/assistant-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-core",
-  version: "0.1.50",
+  version: "0.1.51",
   kind: "runtime",
   description: "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
   dependsOn: [
@@ -47,11 +47,11 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/http-runtime": "0.1.73",
-        "@jskit-ai/kernel": "0.1.74",
-        "@jskit-ai/resource-core": "0.1.19",
-        "@jskit-ai/resource-crud-core": "0.1.19",
-        "@jskit-ai/users-core": "0.1.84",
+        "@jskit-ai/http-runtime": "0.1.74",
+        "@jskit-ai/kernel": "0.1.75",
+        "@jskit-ai/resource-core": "0.1.20",
+        "@jskit-ai/resource-crud-core": "0.1.20",
+        "@jskit-ai/users-core": "0.1.85",
         "dompurify": "^3.3.3",
         "json-rest-schema": "1.x.x",
         "marked": "^17.0.4",

--- a/packages/assistant-core/package.json
+++ b/packages/assistant-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-core",
-  "version": "0.1.50",
+  "version": "0.1.51",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,12 +11,12 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.74",
-    "@jskit-ai/http-runtime": "0.1.73",
-    "@jskit-ai/kernel": "0.1.74",
-    "@jskit-ai/resource-crud-core": "0.1.19",
-    "@jskit-ai/resource-core": "0.1.19",
-    "@jskit-ai/users-core": "0.1.84",
+    "@jskit-ai/database-runtime": "0.1.75",
+    "@jskit-ai/http-runtime": "0.1.74",
+    "@jskit-ai/kernel": "0.1.75",
+    "@jskit-ai/resource-crud-core": "0.1.20",
+    "@jskit-ai/resource-core": "0.1.20",
+    "@jskit-ai/users-core": "0.1.85",
     "dompurify": "^3.3.3",
     "json-rest-schema": "1.x.x",
     "marked": "^17.0.4",

--- a/packages/assistant-runtime/package.descriptor.mjs
+++ b/packages/assistant-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-runtime",
-  version: "0.1.45",
+  version: "0.1.46",
   kind: "runtime",
   description: "Shared assistant runtime with per-surface assistant registration.",
   dependsOn: [
@@ -95,13 +95,13 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/assistant-core": "0.1.50",
-        "@jskit-ai/database-runtime": "0.1.74",
-        "@jskit-ai/http-runtime": "0.1.73",
-        "@jskit-ai/kernel": "0.1.74",
-        "@jskit-ai/shell-web": "0.1.73",
-        "@jskit-ai/users-core": "0.1.84",
-        "@jskit-ai/users-web": "0.1.89"
+        "@jskit-ai/assistant-core": "0.1.51",
+        "@jskit-ai/database-runtime": "0.1.75",
+        "@jskit-ai/http-runtime": "0.1.74",
+        "@jskit-ai/kernel": "0.1.75",
+        "@jskit-ai/shell-web": "0.1.74",
+        "@jskit-ai/users-core": "0.1.85",
+        "@jskit-ai/users-web": "0.1.90"
       },
       dev: {}
     },

--- a/packages/assistant-runtime/package.json
+++ b/packages/assistant-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-runtime",
-  "version": "0.1.45",
+  "version": "0.1.46",
   "type": "module",
   "exports": {
     "./client": "./src/client/index.js",
@@ -8,13 +8,13 @@
     "./server/actionIds": "./src/server/actionIds.js"
   },
   "dependencies": {
-    "@jskit-ai/assistant-core": "0.1.50",
-    "@jskit-ai/database-runtime": "0.1.74",
-    "@jskit-ai/http-runtime": "0.1.73",
-    "@jskit-ai/kernel": "0.1.74",
-    "@jskit-ai/shell-web": "0.1.73",
-    "@jskit-ai/users-core": "0.1.84",
-    "@jskit-ai/users-web": "0.1.89",
+    "@jskit-ai/assistant-core": "0.1.51",
+    "@jskit-ai/database-runtime": "0.1.75",
+    "@jskit-ai/http-runtime": "0.1.74",
+    "@jskit-ai/kernel": "0.1.75",
+    "@jskit-ai/shell-web": "0.1.74",
+    "@jskit-ai/users-core": "0.1.85",
+    "@jskit-ai/users-web": "0.1.90",
     "json-rest-schema": "1.x.x"
   },
   "peerDependencies": {

--- a/packages/assistant/package.descriptor.mjs
+++ b/packages/assistant/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant",
-  version: "0.1.83",
+  version: "0.1.84",
   kind: "generator",
   description: "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
   options: {

--- a/packages/assistant/package.json
+++ b/packages/assistant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant",
-  "version": "0.1.83",
+  "version": "0.1.84",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.74"
+    "@jskit-ai/kernel": "0.1.75"
   }
 }

--- a/packages/auth-core/package.descriptor.mjs
+++ b/packages/auth-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-core",
-  "version": "0.1.73",
+  "version": "0.1.74",
   "kind": "runtime",
   "dependsOn": [
     "@jskit-ai/value-app-config-shared"
@@ -69,7 +69,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.74",
+        "@jskit-ai/kernel": "0.1.75",
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0"

--- a/packages/auth-core/package.json
+++ b/packages/auth-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-core",
-  "version": "0.1.73",
+  "version": "0.1.74",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -46,7 +46,7 @@
     "./shared/commands/authSessionReadCommand": "./src/shared/commands/authSessionReadCommand.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.74",
+    "@jskit-ai/kernel": "0.1.75",
     "@fastify/cookie": "^11.0.2",
     "@fastify/csrf-protection": "^7.1.0",
     "@fastify/rate-limit": "^10.3.0",

--- a/packages/auth-provider-supabase-core/package.descriptor.mjs
+++ b/packages/auth-provider-supabase-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.73",
+  "version": "0.1.74",
   "kind": "runtime",
   "options": {
     "auth-supabase-url": {
@@ -83,8 +83,8 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/auth-core": "0.1.73",
-        "@jskit-ai/kernel": "0.1.74",
+        "@jskit-ai/auth-core": "0.1.74",
+        "@jskit-ai/kernel": "0.1.75",
         "dotenv": "^16.4.5",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0"

--- a/packages/auth-provider-supabase-core/package.json
+++ b/packages/auth-provider-supabase-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.73",
+  "version": "0.1.74",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,8 +12,8 @@
     "./client": "./src/client/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.73",
-    "@jskit-ai/kernel": "0.1.74",
+    "@jskit-ai/auth-core": "0.1.74",
+    "@jskit-ai/kernel": "0.1.75",
     "json-rest-schema": "1.x.x",
     "jose": "^6.1.0",
     "@supabase/supabase-js": "^2.57.4",

--- a/packages/auth-web/package.descriptor.mjs
+++ b/packages/auth-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-web",
-  "version": "0.1.75",
+  "version": "0.1.76",
   "kind": "runtime",
   "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
   "dependsOn": [
@@ -247,10 +247,10 @@ export default Object.freeze({
     "dependencies": {
       "runtime": {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/auth-core": "0.1.73",
-        "@jskit-ai/http-runtime": "0.1.73",
-        "@jskit-ai/kernel": "0.1.74",
-        "@jskit-ai/shell-web": "0.1.73"
+        "@jskit-ai/auth-core": "0.1.74",
+        "@jskit-ai/http-runtime": "0.1.74",
+        "@jskit-ai/kernel": "0.1.75",
+        "@jskit-ai/shell-web": "0.1.74"
       },
       "dev": {}
     },

--- a/packages/auth-web/package.json
+++ b/packages/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-web",
-  "version": "0.1.75",
+  "version": "0.1.76",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -18,11 +18,11 @@
     "./client/runtime/useSignOut": "./src/client/runtime/useSignOut.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.73",
+    "@jskit-ai/auth-core": "0.1.74",
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/kernel": "0.1.74",
-    "@jskit-ai/shell-web": "0.1.73",
-    "@jskit-ai/http-runtime": "0.1.73"
+    "@jskit-ai/kernel": "0.1.75",
+    "@jskit-ai/shell-web": "0.1.74",
+    "@jskit-ai/http-runtime": "0.1.74"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/console-core/package.descriptor.mjs
+++ b/packages/console-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-core",
-  version: "0.1.37",
+  version: "0.1.38",
   kind: "runtime",
   description: "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
   dependsOn: [
@@ -85,12 +85,12 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.73",
-        "@jskit-ai/database-runtime": "0.1.74",
-        "@jskit-ai/http-runtime": "0.1.73",
-        "@jskit-ai/kernel": "0.1.74",
-        "@jskit-ai/resource-crud-core": "0.1.19",
-        "@jskit-ai/users-core": "0.1.84"
+        "@jskit-ai/auth-core": "0.1.74",
+        "@jskit-ai/database-runtime": "0.1.75",
+        "@jskit-ai/http-runtime": "0.1.74",
+        "@jskit-ai/kernel": "0.1.75",
+        "@jskit-ai/resource-crud-core": "0.1.20",
+        "@jskit-ai/users-core": "0.1.85"
       },
       dev: {}
     },

--- a/packages/console-core/package.json
+++ b/packages/console-core/package.json
@@ -1,17 +1,17 @@
 {
   "name": "@jskit-ai/console-core",
-  "version": "0.1.37",
+  "version": "0.1.38",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.73",
-    "@jskit-ai/database-runtime": "0.1.74",
-    "@jskit-ai/http-runtime": "0.1.73",
-    "@jskit-ai/kernel": "0.1.74",
-    "@jskit-ai/resource-crud-core": "0.1.19",
-    "@jskit-ai/users-core": "0.1.84",
+    "@jskit-ai/auth-core": "0.1.74",
+    "@jskit-ai/database-runtime": "0.1.75",
+    "@jskit-ai/http-runtime": "0.1.74",
+    "@jskit-ai/kernel": "0.1.75",
+    "@jskit-ai/resource-crud-core": "0.1.20",
+    "@jskit-ai/users-core": "0.1.85",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/console-web/package.descriptor.mjs
+++ b/packages/console-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-web",
-  version: "0.1.42",
+  version: "0.1.43",
   kind: "runtime",
   description: "Authenticated console surface scaffold and surface policy wiring.",
   dependsOn: [
@@ -103,9 +103,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-web": "0.1.75",
-        "@jskit-ai/console-core": "0.1.37",
-        "@jskit-ai/shell-web": "0.1.73",
+        "@jskit-ai/auth-web": "0.1.76",
+        "@jskit-ai/console-core": "0.1.38",
+        "@jskit-ai/shell-web": "0.1.74",
       },
       dev: {}
     },

--- a/packages/console-web/package.json
+++ b/packages/console-web/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/console-web",
-  "version": "0.1.42",
+  "version": "0.1.43",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-web": "0.1.75",
-    "@jskit-ai/console-core": "0.1.37",
-    "@jskit-ai/shell-web": "0.1.73"
+    "@jskit-ai/auth-web": "0.1.76",
+    "@jskit-ai/console-core": "0.1.38",
+    "@jskit-ai/shell-web": "0.1.74"
   }
 }

--- a/packages/crud-core/package.descriptor.mjs
+++ b/packages/crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-core",
-  version: "0.1.82",
+  version: "0.1.83",
   kind: "runtime",
   description: "Shared CRUD helpers used by CRUD modules.",
   dependsOn: [
@@ -28,7 +28,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/crud-core": "0.1.82"
+        "@jskit-ai/crud-core": "0.1.83"
       },
       dev: {}
     },

--- a/packages/crud-core/package.json
+++ b/packages/crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-core",
-  "version": "0.1.82",
+  "version": "0.1.83",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -27,15 +27,15 @@
     "./server/routeContracts": "./src/server/routeContracts.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.74",
-    "@jskit-ai/http-runtime": "0.1.73",
-    "@jskit-ai/kernel": "0.1.74",
+    "@jskit-ai/database-runtime": "0.1.75",
+    "@jskit-ai/http-runtime": "0.1.74",
+    "@jskit-ai/kernel": "0.1.75",
     "json-rest-schema": "1.x.x",
-    "@jskit-ai/realtime": "0.1.73",
-    "@jskit-ai/resource-crud-core": "0.1.19",
-    "@jskit-ai/shell-web": "0.1.73",
-    "@jskit-ai/users-core": "0.1.84",
-    "@jskit-ai/users-web": "0.1.89"
+    "@jskit-ai/realtime": "0.1.74",
+    "@jskit-ai/resource-crud-core": "0.1.20",
+    "@jskit-ai/shell-web": "0.1.74",
+    "@jskit-ai/users-core": "0.1.85",
+    "@jskit-ai/users-web": "0.1.90"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/crud-server-generator/package.descriptor.mjs
+++ b/packages/crud-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-server-generator",
-  version: "0.1.82",
+  version: "0.1.83",
   kind: "generator",
   description: "CRUD server generator with routes, actions, and persistence scaffolding.",
   options: {
@@ -160,14 +160,14 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.73",
-        "@jskit-ai/crud-core": "0.1.82",
-        "@jskit-ai/database-runtime": "0.1.74",
-        "@jskit-ai/http-runtime": "0.1.73",
-        "@jskit-ai/json-rest-api-core": "0.1.19",
-        "@jskit-ai/kernel": "0.1.74",
-        "@jskit-ai/realtime": "0.1.73",
-        "@jskit-ai/resource-crud-core": "0.1.19",
+        "@jskit-ai/auth-core": "0.1.74",
+        "@jskit-ai/crud-core": "0.1.83",
+        "@jskit-ai/database-runtime": "0.1.75",
+        "@jskit-ai/http-runtime": "0.1.74",
+        "@jskit-ai/json-rest-api-core": "0.1.20",
+        "@jskit-ai/kernel": "0.1.75",
+        "@jskit-ai/realtime": "0.1.74",
+        "@jskit-ai/resource-crud-core": "0.1.20",
         "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}"
       },
       dev: {}

--- a/packages/crud-server-generator/package.json
+++ b/packages/crud-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-server-generator",
-  "version": "0.1.82",
+  "version": "0.1.83",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,12 +13,12 @@
   },
   "dependencies": {
     "@babel/parser": "^7.29.2",
-    "@jskit-ai/crud-core": "0.1.82",
-    "@jskit-ai/database-runtime": "0.1.74",
-    "@jskit-ai/http-runtime": "0.1.73",
-    "@jskit-ai/json-rest-api-core": "0.1.19",
-    "@jskit-ai/kernel": "0.1.74",
-    "@jskit-ai/resource-crud-core": "0.1.19",
+    "@jskit-ai/crud-core": "0.1.83",
+    "@jskit-ai/database-runtime": "0.1.75",
+    "@jskit-ai/http-runtime": "0.1.74",
+    "@jskit-ai/json-rest-api-core": "0.1.20",
+    "@jskit-ai/kernel": "0.1.75",
+    "@jskit-ai/resource-crud-core": "0.1.20",
     "recast": "^0.23.11"
   }
 }

--- a/packages/crud-ui-generator/package.descriptor.mjs
+++ b/packages/crud-ui-generator/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { GENERATED_UI_NAVIGATION_ROLE_OPTION } from "@jskit-ai/kernel/shared/sup
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-ui-generator",
-  version: "0.1.57",
+  version: "0.1.58",
   kind: "generator",
   description: "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
   options: {
@@ -175,7 +175,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.89"
+        "@jskit-ai/users-web": "0.1.90"
       },
       dev: {}
     },

--- a/packages/crud-ui-generator/package.json
+++ b/packages/crud-ui-generator/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@jskit-ai/crud-ui-generator",
-  "version": "0.1.57",
+  "version": "0.1.58",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/crud-core": "0.1.82",
-    "@jskit-ai/kernel": "0.1.74",
-    "@jskit-ai/resource-crud-core": "0.1.19"
+    "@jskit-ai/crud-core": "0.1.83",
+    "@jskit-ai/kernel": "0.1.75",
+    "@jskit-ai/resource-crud-core": "0.1.20"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/database-runtime-mysql/package.descriptor.mjs
+++ b/packages/database-runtime-mysql/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-mysql",
-  version: "0.1.73",
+  version: "0.1.74",
   kind: "runtime",
   options: {
     "db-host": {
@@ -91,7 +91,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.74",
+        "@jskit-ai/database-runtime": "0.1.75",
         "mysql2": "^3.11.2"
       },
       dev: {}

--- a/packages/database-runtime-mysql/package.json
+++ b/packages/database-runtime-mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-mysql",
-  "version": "0.1.73",
+  "version": "0.1.74",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,7 +12,7 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.74",
-    "@jskit-ai/kernel": "0.1.74"
+    "@jskit-ai/database-runtime": "0.1.75",
+    "@jskit-ai/kernel": "0.1.75"
   }
 }

--- a/packages/database-runtime-postgres/package.descriptor.mjs
+++ b/packages/database-runtime-postgres/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-postgres",
-  version: "0.1.73",
+  version: "0.1.74",
   kind: "runtime",
   options: {
     "db-host": {
@@ -91,7 +91,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.74",
+        "@jskit-ai/database-runtime": "0.1.75",
         "pg": "^8.13.1"
       },
       dev: {}

--- a/packages/database-runtime-postgres/package.json
+++ b/packages/database-runtime-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-postgres",
-  "version": "0.1.73",
+  "version": "0.1.74",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,6 +12,6 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.74"
+    "@jskit-ai/database-runtime": "0.1.75"
   }
 }

--- a/packages/database-runtime/package.descriptor.mjs
+++ b/packages/database-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime",
-  version: "0.1.74",
+  version: "0.1.75",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -58,7 +58,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.74",
+        "@jskit-ai/kernel": "0.1.75",
         "dotenv": "^16.4.5",
         "knex": "^3.1.0"
       },

--- a/packages/database-runtime/package.json
+++ b/packages/database-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime",
-  "version": "0.1.74",
+  "version": "0.1.75",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -25,6 +25,6 @@
     "./shared/transactions": "./src/shared/transactions.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.74"
+    "@jskit-ai/kernel": "0.1.75"
   }
 }

--- a/packages/feature-server-generator/package.descriptor.mjs
+++ b/packages/feature-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/feature-server-generator",
-  version: "0.1.16",
+  version: "0.1.17",
   kind: "generator",
   description: "Scaffold substantial non-CRUD server feature packages with provider, actions, service, and optional persistence seams.",
   options: {
@@ -174,7 +174,7 @@ export default Object.freeze({
             equals: "json-rest"
           }
         },
-        "@jskit-ai/kernel": "0.1.74",
+        "@jskit-ai/kernel": "0.1.75",
         "json-rest-schema": "1.x.x",
         "@local/${option:feature-name|kebab}": "file:packages/${option:feature-name|kebab}"
       },

--- a/packages/feature-server-generator/package.json
+++ b/packages/feature-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/feature-server-generator",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "type": "module",
   "scripts": {
     "test": "node --test"

--- a/packages/google-rewarded-core/package.descriptor.mjs
+++ b/packages/google-rewarded-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/google-rewarded-core",
-  version: "0.1.11",
+  version: "0.1.12",
   kind: "runtime",
   description: "Google rewarded workflow runtime plus internal CRUD providers for rules, provider configs, watch sessions, and unlock receipts.",
   dependsOn: [
@@ -128,14 +128,14 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.73",
-        "@jskit-ai/crud-core": "0.1.82",
-        "@jskit-ai/database-runtime": "0.1.74",
-        "@jskit-ai/http-runtime": "0.1.73",
-        "@jskit-ai/json-rest-api-core": "0.1.19",
-        "@jskit-ai/kernel": "0.1.74",
-        "@jskit-ai/resource-crud-core": "0.1.19",
-        "@jskit-ai/workspaces-core": "0.1.50"
+        "@jskit-ai/auth-core": "0.1.74",
+        "@jskit-ai/crud-core": "0.1.83",
+        "@jskit-ai/database-runtime": "0.1.75",
+        "@jskit-ai/http-runtime": "0.1.74",
+        "@jskit-ai/json-rest-api-core": "0.1.20",
+        "@jskit-ai/kernel": "0.1.75",
+        "@jskit-ai/resource-crud-core": "0.1.20",
+        "@jskit-ai/workspaces-core": "0.1.51"
       },
       dev: {}
     },

--- a/packages/google-rewarded-core/package.json
+++ b/packages/google-rewarded-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/google-rewarded-core",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/google-rewarded-web/package.descriptor.mjs
+++ b/packages/google-rewarded-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/google-rewarded-web",
-  version: "0.1.11",
+  version: "0.1.12",
   kind: "runtime",
   description: "Google rewarded client runtime with a fullscreen gate host and GPT orchestration.",
   dependsOn: [
@@ -46,10 +46,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/google-rewarded-core": "0.1.11",
-        "@jskit-ai/http-runtime": "0.1.73",
-        "@jskit-ai/kernel": "0.1.74",
-        "@jskit-ai/shell-web": "0.1.73"
+        "@jskit-ai/google-rewarded-core": "0.1.12",
+        "@jskit-ai/http-runtime": "0.1.74",
+        "@jskit-ai/kernel": "0.1.75",
+        "@jskit-ai/shell-web": "0.1.74"
       },
       dev: {}
     },

--- a/packages/google-rewarded-web/package.json
+++ b/packages/google-rewarded-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/google-rewarded-web",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/http-runtime/package.descriptor.mjs
+++ b/packages/http-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/http-runtime",
-  "version": "0.1.73",
+  "version": "0.1.74",
   "kind": "runtime",
   "dependsOn": [],
   "capabilities": {
@@ -67,7 +67,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.74"
+        "@jskit-ai/kernel": "0.1.75"
       },
       "dev": {}
     },

--- a/packages/http-runtime/package.json
+++ b/packages/http-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/http-runtime",
-  "version": "0.1.73",
+  "version": "0.1.74",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -18,7 +18,7 @@
     "./shared/validators/operationValidation": "./src/shared/validators/operationValidation.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.74",
+    "@jskit-ai/kernel": "0.1.75",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/json-rest-api-core/package.descriptor.mjs
+++ b/packages/json-rest-api-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/json-rest-api-core",
-  version: "0.1.19",
+  version: "0.1.20",
   kind: "runtime",
   description: "Shared internal json-rest-api host runtime for JSKIT server packages.",
   dependsOn: [

--- a/packages/json-rest-api-core/package.json
+++ b/packages/json-rest-api-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/json-rest-api-core",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,6 +11,6 @@
   "dependencies": {
     "hooked-api": "1.x.x",
     "json-rest-api": "1.x.x",
-    "@jskit-ai/kernel": "0.1.74"
+    "@jskit-ai/kernel": "0.1.75"
   }
 }

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/kernel",
-  "version": "0.1.74",
+  "version": "0.1.75",
   "type": "module",
   "dependencies": {
     "json-rest-schema": "1.x.x"

--- a/packages/mobile-capacitor/package.descriptor.mjs
+++ b/packages/mobile-capacitor/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/mobile-capacitor",
-  version: "0.1.11",
+  version: "0.1.12",
   kind: "runtime",
   description: "Thin Capacitor client integration for JSKIT mobile-shell launch routing and auth callback completion.",
   dependsOn: [
@@ -62,8 +62,8 @@ export default Object.freeze({
         "@capacitor/app": "^7.1.0",
         "@capacitor/browser": "^7.0.1",
         "@capacitor/core": "^7.4.3",
-        "@jskit-ai/kernel": "0.1.74",
-        "@jskit-ai/shell-web": "0.1.73"
+        "@jskit-ai/kernel": "0.1.75",
+        "@jskit-ai/shell-web": "0.1.74"
       },
       dev: {
         "@capacitor/cli": "^7.4.3"

--- a/packages/mobile-capacitor/package.json
+++ b/packages/mobile-capacitor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/mobile-capacitor",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,6 +12,6 @@
   },
   "dependencies": {
     "@capacitor/browser": "^7.0.1",
-    "@jskit-ai/kernel": "0.1.74"
+    "@jskit-ai/kernel": "0.1.75"
   }
 }

--- a/packages/realtime/package.descriptor.mjs
+++ b/packages/realtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/realtime",
-  version: "0.1.73",
+  version: "0.1.74",
   kind: "runtime",
   description: "Thin, generic realtime runtime wrappers for socket.io server and client.",
   options: {
@@ -95,7 +95,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.74",
+        "@jskit-ai/kernel": "0.1.75",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/realtime",
-  "version": "0.1.73",
+  "version": "0.1.74",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@socket.io/redis-adapter": "^8.3.0",
-    "@jskit-ai/kernel": "0.1.74",
+    "@jskit-ai/kernel": "0.1.75",
     "redis": "^5.8.2",
     "socket.io": "^4.8.3",
     "socket.io-client": "^4.8.3"

--- a/packages/resource-core/package.descriptor.mjs
+++ b/packages/resource-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/resource-core",
-  version: "0.1.19",
+  version: "0.1.20",
   kind: "runtime",
   description: "Generic resource-definition helpers and schema-definition normalization.",
   dependsOn: [
@@ -22,7 +22,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/resource-core": "0.1.19"
+        "@jskit-ai/resource-core": "0.1.20"
       },
       dev: {}
     },

--- a/packages/resource-core/package.json
+++ b/packages/resource-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/resource-core",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./shared/resource": "./src/shared/resource.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.74"
+    "@jskit-ai/kernel": "0.1.75"
   }
 }

--- a/packages/resource-crud-core/package.descriptor.mjs
+++ b/packages/resource-crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/resource-crud-core",
-  version: "0.1.19",
+  version: "0.1.20",
   kind: "runtime",
   description: "CRUD-specific resource-definition helpers and namespace support.",
   dependsOn: [
@@ -23,7 +23,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/resource-crud-core": "0.1.19"
+        "@jskit-ai/resource-crud-core": "0.1.20"
       },
       dev: {}
     },

--- a/packages/resource-crud-core/package.json
+++ b/packages/resource-crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/resource-crud-core",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./shared/crudResource": "./src/shared/crudResource.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.74",
-    "@jskit-ai/resource-core": "0.1.19"
+    "@jskit-ai/kernel": "0.1.75",
+    "@jskit-ai/resource-core": "0.1.20"
   }
 }

--- a/packages/shell-web/package.descriptor.mjs
+++ b/packages/shell-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/shell-web",
-  version: "0.1.73",
+  version: "0.1.74",
   kind: "runtime",
   description: "Web shell layout runtime with outlet-based placement contributions.",
   dependsOn: [],
@@ -291,7 +291,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/kernel": "0.1.74"
+        "@jskit-ai/kernel": "0.1.75"
       },
       dev: {}
     },

--- a/packages/shell-web/package.json
+++ b/packages/shell-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/shell-web",
-  "version": "0.1.73",
+  "version": "0.1.74",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/kernel": "0.1.74"
+    "@jskit-ai/kernel": "0.1.75"
   },
   "peerDependencies": {
     "pinia": "^3.0.4",

--- a/packages/storage-runtime/package.descriptor.mjs
+++ b/packages/storage-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/storage-runtime",
-  version: "0.1.73",
+  version: "0.1.74",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -50,7 +50,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.74",
+        "@jskit-ai/kernel": "0.1.75",
         "unstorage": "^1.17.3"
       },
       dev: {}

--- a/packages/storage-runtime/package.json
+++ b/packages/storage-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/storage-runtime",
-  "version": "0.1.73",
+  "version": "0.1.74",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./server/providers/StorageRuntimeServiceProvider": "./src/server/providers/StorageRuntimeServiceProvider.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.74",
+    "@jskit-ai/kernel": "0.1.75",
     "unstorage": "^1.17.3"
   }
 }

--- a/packages/ui-generator/package.descriptor.mjs
+++ b/packages/ui-generator/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { GENERATED_UI_NAVIGATION_ROLE_OPTION } from "@jskit-ai/kernel/shared/sup
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/ui-generator",
-  version: "0.1.57",
+  version: "0.1.58",
   kind: "generator",
   description: "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
   options: {
@@ -371,7 +371,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.89"
+        "@jskit-ai/users-web": "0.1.90"
       },
       dev: {}
     },

--- a/packages/ui-generator/package.json
+++ b/packages/ui-generator/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/ui-generator",
-  "version": "0.1.57",
+  "version": "0.1.58",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.74",
-    "@jskit-ai/shell-web": "0.1.73"
+    "@jskit-ai/kernel": "0.1.75",
+    "@jskit-ai/shell-web": "0.1.74"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/uploads-image-web/package.descriptor.mjs
+++ b/packages/uploads-image-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-image-web",
-  version: "0.1.52",
+  version: "0.1.53",
   kind: "runtime",
   description: "Reusable client-side image upload runtime with pre-upload image editing.",
   dependsOn: [
@@ -65,7 +65,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/uploads-runtime": "0.1.52",
+        "@jskit-ai/uploads-runtime": "0.1.53",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-image-web/package.json
+++ b/packages/uploads-image-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-image-web",
-  "version": "0.1.52",
+  "version": "0.1.53",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,7 +13,7 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/uploads-runtime": "0.1.52",
+    "@jskit-ai/uploads-runtime": "0.1.53",
     "@uppy/compressor": "^3.1.0",
     "@uppy/core": "^5.2.0",
     "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-runtime/package.descriptor.mjs
+++ b/packages/uploads-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-runtime",
-  version: "0.1.52",
+  version: "0.1.53",
   kind: "runtime",
   description: "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
   dependsOn: [
@@ -71,7 +71,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.74"
+        "@jskit-ai/kernel": "0.1.75"
       },
       dev: {}
     },

--- a/packages/uploads-runtime/package.json
+++ b/packages/uploads-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-runtime",
-  "version": "0.1.52",
+  "version": "0.1.53",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,6 +16,6 @@
   },
   "dependencies": {
     "@fastify/multipart": "^9.4.0",
-    "@jskit-ai/kernel": "0.1.74"
+    "@jskit-ai/kernel": "0.1.75"
   }
 }

--- a/packages/users-core/package.descriptor.mjs
+++ b/packages/users-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-core",
-  version: "0.1.84",
+  version: "0.1.85",
   kind: "runtime",
   description: "Users/account runtime plus HTTP routes for account features.",
   dependsOn: [
@@ -143,16 +143,16 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.73",
-        "@jskit-ai/crud-core": "0.1.82",
-        "@jskit-ai/database-runtime": "0.1.74",
-        "@jskit-ai/http-runtime": "0.1.73",
-        "@jskit-ai/json-rest-api-core": "0.1.19",
-        "@jskit-ai/kernel": "0.1.74",
-        "@jskit-ai/resource-core": "0.1.19",
-        "@jskit-ai/resource-crud-core": "0.1.19",
+        "@jskit-ai/auth-core": "0.1.74",
+        "@jskit-ai/crud-core": "0.1.83",
+        "@jskit-ai/database-runtime": "0.1.75",
+        "@jskit-ai/http-runtime": "0.1.74",
+        "@jskit-ai/json-rest-api-core": "0.1.20",
+        "@jskit-ai/kernel": "0.1.75",
+        "@jskit-ai/resource-core": "0.1.20",
+        "@jskit-ai/resource-crud-core": "0.1.20",
         "@local/users": "file:packages/users",
-        "@jskit-ai/uploads-runtime": "0.1.52"
+        "@jskit-ai/uploads-runtime": "0.1.53"
       },
       dev: {}
     },

--- a/packages/users-core/package.json
+++ b/packages/users-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-core",
-  "version": "0.1.84",
+  "version": "0.1.85",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,14 +11,14 @@
     "./shared/resources/userSettingsResource": "./src/shared/resources/userSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.73",
-    "@jskit-ai/database-runtime": "0.1.74",
-    "@jskit-ai/http-runtime": "0.1.73",
-    "@jskit-ai/json-rest-api-core": "0.1.19",
-    "@jskit-ai/kernel": "0.1.74",
-    "@jskit-ai/resource-crud-core": "0.1.19",
-    "@jskit-ai/resource-core": "0.1.19",
-    "@jskit-ai/uploads-runtime": "0.1.52",
+    "@jskit-ai/auth-core": "0.1.74",
+    "@jskit-ai/database-runtime": "0.1.75",
+    "@jskit-ai/http-runtime": "0.1.74",
+    "@jskit-ai/json-rest-api-core": "0.1.20",
+    "@jskit-ai/kernel": "0.1.75",
+    "@jskit-ai/resource-crud-core": "0.1.20",
+    "@jskit-ai/resource-core": "0.1.20",
+    "@jskit-ai/uploads-runtime": "0.1.53",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/users-web/package.descriptor.mjs
+++ b/packages/users-web/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { HOME_COG_OUTLET } from "./src/shared/toolsOutletContracts.js";
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-web",
-  version: "0.1.89",
+  version: "0.1.90",
   kind: "runtime",
   description: "Users web module: account/profile UI plus shared users web widgets.",
   dependsOn: [
@@ -278,12 +278,12 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/http-runtime": "0.1.73",
-        "@jskit-ai/realtime": "0.1.73",
-        "@jskit-ai/kernel": "0.1.74",
-        "@jskit-ai/shell-web": "0.1.73",
-        "@jskit-ai/uploads-image-web": "0.1.52",
-        "@jskit-ai/users-core": "0.1.84"
+        "@jskit-ai/http-runtime": "0.1.74",
+        "@jskit-ai/realtime": "0.1.74",
+        "@jskit-ai/kernel": "0.1.75",
+        "@jskit-ai/shell-web": "0.1.74",
+        "@jskit-ai/uploads-image-web": "0.1.53",
+        "@jskit-ai/users-core": "0.1.85"
       },
       dev: {}
     },

--- a/packages/users-web/package.json
+++ b/packages/users-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-web",
-  "version": "0.1.89",
+  "version": "0.1.90",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -44,12 +44,12 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/http-runtime": "0.1.73",
-    "@jskit-ai/kernel": "0.1.74",
-    "@jskit-ai/realtime": "0.1.73",
-    "@jskit-ai/shell-web": "0.1.73",
-    "@jskit-ai/uploads-image-web": "0.1.52",
-    "@jskit-ai/users-core": "0.1.84"
+    "@jskit-ai/http-runtime": "0.1.74",
+    "@jskit-ai/kernel": "0.1.75",
+    "@jskit-ai/realtime": "0.1.74",
+    "@jskit-ai/shell-web": "0.1.74",
+    "@jskit-ai/uploads-image-web": "0.1.53",
+    "@jskit-ai/users-core": "0.1.85"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/workspaces-core/package.descriptor.mjs
+++ b/packages/workspaces-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-core",
-  version: "0.1.50",
+  version: "0.1.51",
   kind: "runtime",
   description: "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
   dependsOn: [
@@ -142,10 +142,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/json-rest-api-core": "0.1.19",
-        "@jskit-ai/resource-core": "0.1.19",
-        "@jskit-ai/resource-crud-core": "0.1.19",
-        "@jskit-ai/users-core": "0.1.84"
+        "@jskit-ai/json-rest-api-core": "0.1.20",
+        "@jskit-ai/resource-core": "0.1.20",
+        "@jskit-ai/resource-crud-core": "0.1.20",
+        "@jskit-ai/users-core": "0.1.85"
       },
       dev: {}
     },

--- a/packages/workspaces-core/package.json
+++ b/packages/workspaces-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-core",
-  "version": "0.1.50",
+  "version": "0.1.51",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -17,14 +17,14 @@
     "./shared/resources/workspaceSettingsResource": "./src/shared/resources/workspaceSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.73",
-    "@jskit-ai/database-runtime": "0.1.74",
-    "@jskit-ai/http-runtime": "0.1.73",
-    "@jskit-ai/json-rest-api-core": "0.1.19",
-    "@jskit-ai/kernel": "0.1.74",
-    "@jskit-ai/resource-crud-core": "0.1.19",
-    "@jskit-ai/resource-core": "0.1.19",
-    "@jskit-ai/users-core": "0.1.84",
+    "@jskit-ai/auth-core": "0.1.74",
+    "@jskit-ai/database-runtime": "0.1.75",
+    "@jskit-ai/http-runtime": "0.1.74",
+    "@jskit-ai/json-rest-api-core": "0.1.20",
+    "@jskit-ai/kernel": "0.1.75",
+    "@jskit-ai/resource-crud-core": "0.1.20",
+    "@jskit-ai/resource-core": "0.1.20",
+    "@jskit-ai/users-core": "0.1.85",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/workspaces-web/package.descriptor.mjs
+++ b/packages/workspaces-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-web",
-  version: "0.1.50",
+  version: "0.1.51",
   kind: "runtime",
   description: "Workspace web module: workspace selector, tools widget, workspace surfaces, and members/settings UI.",
   dependsOn: [
@@ -231,8 +231,8 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/workspaces-core": "0.1.50",
-        "@jskit-ai/users-web": "0.1.89"
+        "@jskit-ai/workspaces-core": "0.1.51",
+        "@jskit-ai/users-web": "0.1.90"
       },
       dev: {}
     },

--- a/packages/workspaces-web/package.json
+++ b/packages/workspaces-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-web",
-  "version": "0.1.50",
+  "version": "0.1.51",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -15,12 +15,12 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/http-runtime": "0.1.73",
-    "@jskit-ai/kernel": "0.1.74",
-    "@jskit-ai/shell-web": "0.1.73",
-    "@jskit-ai/users-core": "0.1.84",
-    "@jskit-ai/users-web": "0.1.89",
-    "@jskit-ai/workspaces-core": "0.1.50"
+    "@jskit-ai/http-runtime": "0.1.74",
+    "@jskit-ai/kernel": "0.1.75",
+    "@jskit-ai/shell-web": "0.1.74",
+    "@jskit-ai/users-core": "0.1.85",
+    "@jskit-ai/users-web": "0.1.90",
+    "@jskit-ai/workspaces-core": "0.1.51"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/tooling/config-eslint/package.json
+++ b/tooling/config-eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/config-eslint",
-  "version": "0.1.73",
+  "version": "0.1.74",
   "description": "Shared flat ESLint presets for JSKIT projects.",
   "type": "module",
   "files": [

--- a/tooling/create-app/package.descriptor.mjs
+++ b/tooling/create-app/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/create-app",
-  "version": "0.1.82",
+  "version": "0.1.83",
   "dependsOn": [],
   "capabilities": {
     "provides": [

--- a/tooling/create-app/package.json
+++ b/tooling/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/create-app",
-  "version": "0.1.82",
+  "version": "0.1.83",
   "description": "Scaffold minimal JSKIT app shells.",
   "type": "module",
   "files": [

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -6,11 +6,11 @@
   "packages": [
     {
       "packageId": "@jskit-ai/assistant",
-      "version": "0.1.83",
+      "version": "0.1.84",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant",
-        "version": "0.1.83",
+        "version": "0.1.84",
         "kind": "generator",
         "description": "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
         "options": {
@@ -347,11 +347,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-core",
-      "version": "0.1.50",
+      "version": "0.1.51",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-core",
-        "version": "0.1.50",
+        "version": "0.1.51",
         "kind": "runtime",
         "description": "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
         "dependsOn": [
@@ -399,11 +399,11 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/http-runtime": "0.1.73",
-              "@jskit-ai/kernel": "0.1.74",
-              "@jskit-ai/resource-core": "0.1.19",
-              "@jskit-ai/resource-crud-core": "0.1.19",
-              "@jskit-ai/users-core": "0.1.84",
+              "@jskit-ai/http-runtime": "0.1.74",
+              "@jskit-ai/kernel": "0.1.75",
+              "@jskit-ai/resource-core": "0.1.20",
+              "@jskit-ai/resource-crud-core": "0.1.20",
+              "@jskit-ai/users-core": "0.1.85",
               "dompurify": "^3.3.3",
               "json-rest-schema": "1.x.x",
               "marked": "^17.0.4",
@@ -422,11 +422,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-runtime",
-      "version": "0.1.45",
+      "version": "0.1.46",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-runtime",
-        "version": "0.1.45",
+        "version": "0.1.46",
         "kind": "runtime",
         "description": "Shared assistant runtime with per-surface assistant registration.",
         "dependsOn": [
@@ -522,13 +522,13 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/assistant-core": "0.1.50",
-              "@jskit-ai/database-runtime": "0.1.74",
-              "@jskit-ai/http-runtime": "0.1.73",
-              "@jskit-ai/kernel": "0.1.74",
-              "@jskit-ai/shell-web": "0.1.73",
-              "@jskit-ai/users-core": "0.1.84",
-              "@jskit-ai/users-web": "0.1.89"
+              "@jskit-ai/assistant-core": "0.1.51",
+              "@jskit-ai/database-runtime": "0.1.75",
+              "@jskit-ai/http-runtime": "0.1.74",
+              "@jskit-ai/kernel": "0.1.75",
+              "@jskit-ai/shell-web": "0.1.74",
+              "@jskit-ai/users-core": "0.1.85",
+              "@jskit-ai/users-web": "0.1.90"
             },
             "dev": {}
           },
@@ -583,11 +583,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-core",
-      "version": "0.1.73",
+      "version": "0.1.74",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-core",
-        "version": "0.1.73",
+        "version": "0.1.74",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/value-app-config-shared"
@@ -655,7 +655,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.74",
+              "@jskit-ai/kernel": "0.1.75",
               "@fastify/cookie": "^11.0.2",
               "@fastify/csrf-protection": "^7.1.0",
               "@fastify/rate-limit": "^10.3.0"
@@ -673,11 +673,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.73",
+      "version": "0.1.74",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-supabase-core",
-        "version": "0.1.73",
+        "version": "0.1.74",
         "kind": "runtime",
         "options": {
           "auth-supabase-url": {
@@ -759,8 +759,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.73",
-              "@jskit-ai/kernel": "0.1.74",
+              "@jskit-ai/auth-core": "0.1.74",
+              "@jskit-ai/kernel": "0.1.75",
               "dotenv": "^16.4.5",
               "@supabase/supabase-js": "^2.57.4",
               "jose": "^6.1.0"
@@ -825,11 +825,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-web",
-      "version": "0.1.75",
+      "version": "0.1.76",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-web",
-        "version": "0.1.75",
+        "version": "0.1.76",
         "kind": "runtime",
         "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
         "dependsOn": [
@@ -1085,10 +1085,10 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/auth-core": "0.1.73",
-              "@jskit-ai/http-runtime": "0.1.73",
-              "@jskit-ai/kernel": "0.1.74",
-              "@jskit-ai/shell-web": "0.1.73"
+              "@jskit-ai/auth-core": "0.1.74",
+              "@jskit-ai/http-runtime": "0.1.74",
+              "@jskit-ai/kernel": "0.1.75",
+              "@jskit-ai/shell-web": "0.1.74"
             },
             "dev": {}
           },
@@ -1167,11 +1167,11 @@
     },
     {
       "packageId": "@jskit-ai/console-core",
-      "version": "0.1.37",
+      "version": "0.1.38",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-core",
-        "version": "0.1.37",
+        "version": "0.1.38",
         "kind": "runtime",
         "description": "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
         "dependsOn": [
@@ -1255,12 +1255,12 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.73",
-              "@jskit-ai/database-runtime": "0.1.74",
-              "@jskit-ai/http-runtime": "0.1.73",
-              "@jskit-ai/kernel": "0.1.74",
-              "@jskit-ai/resource-crud-core": "0.1.19",
-              "@jskit-ai/users-core": "0.1.84"
+              "@jskit-ai/auth-core": "0.1.74",
+              "@jskit-ai/database-runtime": "0.1.75",
+              "@jskit-ai/http-runtime": "0.1.74",
+              "@jskit-ai/kernel": "0.1.75",
+              "@jskit-ai/resource-crud-core": "0.1.20",
+              "@jskit-ai/users-core": "0.1.85"
             },
             "dev": {}
           },
@@ -1285,11 +1285,11 @@
     },
     {
       "packageId": "@jskit-ai/console-web",
-      "version": "0.1.42",
+      "version": "0.1.43",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-web",
-        "version": "0.1.42",
+        "version": "0.1.43",
         "kind": "runtime",
         "description": "Authenticated console surface scaffold and surface policy wiring.",
         "dependsOn": [
@@ -1399,9 +1399,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-web": "0.1.75",
-              "@jskit-ai/console-core": "0.1.37",
-              "@jskit-ai/shell-web": "0.1.73"
+              "@jskit-ai/auth-web": "0.1.76",
+              "@jskit-ai/console-core": "0.1.38",
+              "@jskit-ai/shell-web": "0.1.74"
             },
             "dev": {}
           },
@@ -1508,11 +1508,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-core",
-      "version": "0.1.82",
+      "version": "0.1.83",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-core",
-        "version": "0.1.82",
+        "version": "0.1.83",
         "kind": "runtime",
         "description": "Shared CRUD helpers used by CRUD modules.",
         "dependsOn": [
@@ -1541,7 +1541,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/crud-core": "0.1.82"
+              "@jskit-ai/crud-core": "0.1.83"
             },
             "dev": {}
           },
@@ -1555,11 +1555,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-server-generator",
-      "version": "0.1.82",
+      "version": "0.1.83",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-server-generator",
-        "version": "0.1.82",
+        "version": "0.1.83",
         "kind": "generator",
         "description": "CRUD server generator with routes, actions, and persistence scaffolding.",
         "options": {
@@ -1726,14 +1726,14 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.73",
-              "@jskit-ai/crud-core": "0.1.82",
-              "@jskit-ai/database-runtime": "0.1.74",
-              "@jskit-ai/http-runtime": "0.1.73",
-              "@jskit-ai/json-rest-api-core": "0.1.19",
-              "@jskit-ai/kernel": "0.1.74",
-              "@jskit-ai/realtime": "0.1.73",
-              "@jskit-ai/resource-crud-core": "0.1.19",
+              "@jskit-ai/auth-core": "0.1.74",
+              "@jskit-ai/crud-core": "0.1.83",
+              "@jskit-ai/database-runtime": "0.1.75",
+              "@jskit-ai/http-runtime": "0.1.74",
+              "@jskit-ai/json-rest-api-core": "0.1.20",
+              "@jskit-ai/kernel": "0.1.75",
+              "@jskit-ai/realtime": "0.1.74",
+              "@jskit-ai/resource-crud-core": "0.1.20",
               "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}"
             },
             "dev": {}
@@ -1865,11 +1865,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.57",
+      "version": "0.1.58",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-ui-generator",
-        "version": "0.1.57",
+        "version": "0.1.58",
         "kind": "generator",
         "description": "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
         "options": {
@@ -2068,7 +2068,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.89"
+              "@jskit-ai/users-web": "0.1.90"
             },
             "dev": {}
           },
@@ -2327,11 +2327,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime",
-      "version": "0.1.74",
+      "version": "0.1.75",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime",
-        "version": "0.1.74",
+        "version": "0.1.75",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -2388,7 +2388,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.74",
+              "@jskit-ai/kernel": "0.1.75",
               "dotenv": "^16.4.5",
               "knex": "^3.1.0"
             },
@@ -2423,11 +2423,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.73",
+      "version": "0.1.74",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-mysql",
-        "version": "0.1.73",
+        "version": "0.1.74",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -2517,7 +2517,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.74",
+              "@jskit-ai/database-runtime": "0.1.75",
               "mysql2": "^3.11.2"
             },
             "dev": {}
@@ -2588,11 +2588,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.73",
+      "version": "0.1.74",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-postgres",
-        "version": "0.1.73",
+        "version": "0.1.74",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -2682,7 +2682,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.74",
+              "@jskit-ai/database-runtime": "0.1.75",
               "pg": "^8.13.1"
             },
             "dev": {}
@@ -2753,11 +2753,11 @@
     },
     {
       "packageId": "@jskit-ai/feature-server-generator",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/feature-server-generator",
-        "version": "0.1.16",
+        "version": "0.1.17",
         "kind": "generator",
         "description": "Scaffold substantial non-CRUD server feature packages with provider, actions, service, and optional persistence seams.",
         "options": {
@@ -2942,7 +2942,7 @@
                   "equals": "json-rest"
                 }
               },
-              "@jskit-ai/kernel": "0.1.74",
+              "@jskit-ai/kernel": "0.1.75",
               "json-rest-schema": "1.x.x",
               "@local/${option:feature-name|kebab}": "file:packages/${option:feature-name|kebab}"
             },
@@ -3055,11 +3055,11 @@
     },
     {
       "packageId": "@jskit-ai/google-rewarded-core",
-      "version": "0.1.11",
+      "version": "0.1.12",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/google-rewarded-core",
-        "version": "0.1.11",
+        "version": "0.1.12",
         "kind": "runtime",
         "description": "Google rewarded workflow runtime plus internal CRUD providers for rules, provider configs, watch sessions, and unlock receipts.",
         "dependsOn": [
@@ -3186,14 +3186,14 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.73",
-              "@jskit-ai/crud-core": "0.1.82",
-              "@jskit-ai/database-runtime": "0.1.74",
-              "@jskit-ai/http-runtime": "0.1.73",
-              "@jskit-ai/json-rest-api-core": "0.1.19",
-              "@jskit-ai/kernel": "0.1.74",
-              "@jskit-ai/resource-crud-core": "0.1.19",
-              "@jskit-ai/workspaces-core": "0.1.50"
+              "@jskit-ai/auth-core": "0.1.74",
+              "@jskit-ai/crud-core": "0.1.83",
+              "@jskit-ai/database-runtime": "0.1.75",
+              "@jskit-ai/http-runtime": "0.1.74",
+              "@jskit-ai/json-rest-api-core": "0.1.20",
+              "@jskit-ai/kernel": "0.1.75",
+              "@jskit-ai/resource-crud-core": "0.1.20",
+              "@jskit-ai/workspaces-core": "0.1.51"
             },
             "dev": {}
           },
@@ -3245,11 +3245,11 @@
     },
     {
       "packageId": "@jskit-ai/google-rewarded-web",
-      "version": "0.1.11",
+      "version": "0.1.12",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/google-rewarded-web",
-        "version": "0.1.11",
+        "version": "0.1.12",
         "kind": "runtime",
         "description": "Google rewarded client runtime with a fullscreen gate host and GPT orchestration.",
         "dependsOn": [
@@ -3296,10 +3296,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/google-rewarded-core": "0.1.11",
-              "@jskit-ai/http-runtime": "0.1.73",
-              "@jskit-ai/kernel": "0.1.74",
-              "@jskit-ai/shell-web": "0.1.73"
+              "@jskit-ai/google-rewarded-core": "0.1.12",
+              "@jskit-ai/http-runtime": "0.1.74",
+              "@jskit-ai/kernel": "0.1.75",
+              "@jskit-ai/shell-web": "0.1.74"
             },
             "dev": {}
           },
@@ -3317,11 +3317,11 @@
     },
     {
       "packageId": "@jskit-ai/http-runtime",
-      "version": "0.1.73",
+      "version": "0.1.74",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/http-runtime",
-        "version": "0.1.73",
+        "version": "0.1.74",
         "kind": "runtime",
         "dependsOn": [],
         "capabilities": {
@@ -3387,7 +3387,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.74"
+              "@jskit-ai/kernel": "0.1.75"
             },
             "dev": {}
           },
@@ -3401,11 +3401,11 @@
     },
     {
       "packageId": "@jskit-ai/json-rest-api-core",
-      "version": "0.1.19",
+      "version": "0.1.20",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/json-rest-api-core",
-        "version": "0.1.19",
+        "version": "0.1.20",
         "kind": "runtime",
         "description": "Shared internal json-rest-api host runtime for JSKIT server packages.",
         "dependsOn": [
@@ -3465,11 +3465,11 @@
     },
     {
       "packageId": "@jskit-ai/mobile-capacitor",
-      "version": "0.1.11",
+      "version": "0.1.12",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/mobile-capacitor",
-        "version": "0.1.11",
+        "version": "0.1.12",
         "kind": "runtime",
         "description": "Thin Capacitor client integration for JSKIT mobile-shell launch routing and auth callback completion.",
         "dependsOn": [
@@ -3532,8 +3532,8 @@
               "@capacitor/app": "^7.1.0",
               "@capacitor/browser": "^7.0.1",
               "@capacitor/core": "^7.4.3",
-              "@jskit-ai/kernel": "0.1.74",
-              "@jskit-ai/shell-web": "0.1.73"
+              "@jskit-ai/kernel": "0.1.75",
+              "@jskit-ai/shell-web": "0.1.74"
             },
             "dev": {
               "@capacitor/cli": "^7.4.3"
@@ -3585,11 +3585,11 @@
     },
     {
       "packageId": "@jskit-ai/realtime",
-      "version": "0.1.73",
+      "version": "0.1.74",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/realtime",
-        "version": "0.1.73",
+        "version": "0.1.74",
         "kind": "runtime",
         "description": "Thin, generic realtime runtime wrappers for socket.io server and client.",
         "options": {
@@ -3685,7 +3685,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.74",
+              "@jskit-ai/kernel": "0.1.75",
               "@socket.io/redis-adapter": "^8.3.0",
               "redis": "^5.8.2",
               "socket.io": "^4.8.3",
@@ -3734,11 +3734,11 @@
     },
     {
       "packageId": "@jskit-ai/resource-core",
-      "version": "0.1.19",
+      "version": "0.1.20",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/resource-core",
-        "version": "0.1.19",
+        "version": "0.1.20",
         "kind": "runtime",
         "description": "Generic resource-definition helpers and schema-definition normalization.",
         "dependsOn": [
@@ -3761,7 +3761,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/resource-core": "0.1.19"
+              "@jskit-ai/resource-core": "0.1.20"
             },
             "dev": {}
           },
@@ -3776,11 +3776,11 @@
     },
     {
       "packageId": "@jskit-ai/resource-crud-core",
-      "version": "0.1.19",
+      "version": "0.1.20",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/resource-crud-core",
-        "version": "0.1.19",
+        "version": "0.1.20",
         "kind": "runtime",
         "description": "CRUD-specific resource-definition helpers and namespace support.",
         "dependsOn": [
@@ -3804,7 +3804,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/resource-crud-core": "0.1.19"
+              "@jskit-ai/resource-crud-core": "0.1.20"
             },
             "dev": {}
           },
@@ -3819,11 +3819,11 @@
     },
     {
       "packageId": "@jskit-ai/shell-web",
-      "version": "0.1.73",
+      "version": "0.1.74",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/shell-web",
-        "version": "0.1.73",
+        "version": "0.1.74",
         "kind": "runtime",
         "description": "Web shell layout runtime with outlet-based placement contributions.",
         "dependsOn": [],
@@ -4149,7 +4149,7 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/kernel": "0.1.74"
+              "@jskit-ai/kernel": "0.1.75"
             },
             "dev": {}
           },
@@ -4349,11 +4349,11 @@
     },
     {
       "packageId": "@jskit-ai/storage-runtime",
-      "version": "0.1.73",
+      "version": "0.1.74",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/storage-runtime",
-        "version": "0.1.73",
+        "version": "0.1.74",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -4402,7 +4402,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.74",
+              "@jskit-ai/kernel": "0.1.75",
               "unstorage": "^1.17.3"
             },
             "dev": {}
@@ -4418,11 +4418,11 @@
     },
     {
       "packageId": "@jskit-ai/ui-generator",
-      "version": "0.1.57",
+      "version": "0.1.58",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/ui-generator",
-        "version": "0.1.57",
+        "version": "0.1.58",
         "kind": "generator",
         "description": "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
         "options": {
@@ -4855,7 +4855,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.89"
+              "@jskit-ai/users-web": "0.1.90"
             },
             "dev": {}
           },
@@ -4870,11 +4870,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-image-web",
-      "version": "0.1.52",
+      "version": "0.1.53",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-image-web",
-        "version": "0.1.52",
+        "version": "0.1.53",
         "kind": "runtime",
         "description": "Reusable client-side image upload runtime with pre-upload image editing.",
         "dependsOn": [
@@ -4938,7 +4938,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/uploads-runtime": "0.1.52",
+              "@jskit-ai/uploads-runtime": "0.1.53",
               "@uppy/compressor": "^3.1.0",
               "@uppy/core": "^5.2.0",
               "@uppy/dashboard": "^5.1.1",
@@ -4958,11 +4958,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-runtime",
-      "version": "0.1.52",
+      "version": "0.1.53",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-runtime",
-        "version": "0.1.52",
+        "version": "0.1.53",
         "kind": "runtime",
         "description": "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
         "dependsOn": [
@@ -5032,7 +5032,7 @@
           "dependencies": {
             "runtime": {
               "@fastify/multipart": "^9.4.0",
-              "@jskit-ai/kernel": "0.1.74"
+              "@jskit-ai/kernel": "0.1.75"
             },
             "dev": {}
           },
@@ -5047,11 +5047,11 @@
     },
     {
       "packageId": "@jskit-ai/users-core",
-      "version": "0.1.84",
+      "version": "0.1.85",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-core",
-        "version": "0.1.84",
+        "version": "0.1.85",
         "kind": "runtime",
         "description": "Users/account runtime plus HTTP routes for account features.",
         "dependsOn": [
@@ -5192,16 +5192,16 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.73",
-              "@jskit-ai/crud-core": "0.1.82",
-              "@jskit-ai/database-runtime": "0.1.74",
-              "@jskit-ai/http-runtime": "0.1.73",
-              "@jskit-ai/json-rest-api-core": "0.1.19",
-              "@jskit-ai/kernel": "0.1.74",
-              "@jskit-ai/resource-core": "0.1.19",
-              "@jskit-ai/resource-crud-core": "0.1.19",
+              "@jskit-ai/auth-core": "0.1.74",
+              "@jskit-ai/crud-core": "0.1.83",
+              "@jskit-ai/database-runtime": "0.1.75",
+              "@jskit-ai/http-runtime": "0.1.74",
+              "@jskit-ai/json-rest-api-core": "0.1.20",
+              "@jskit-ai/kernel": "0.1.75",
+              "@jskit-ai/resource-core": "0.1.20",
+              "@jskit-ai/resource-crud-core": "0.1.20",
               "@local/users": "file:packages/users",
-              "@jskit-ai/uploads-runtime": "0.1.52"
+              "@jskit-ai/uploads-runtime": "0.1.53"
             },
             "dev": {}
           },
@@ -5418,11 +5418,11 @@
     },
     {
       "packageId": "@jskit-ai/users-web",
-      "version": "0.1.89",
+      "version": "0.1.90",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-web",
-        "version": "0.1.89",
+        "version": "0.1.90",
         "kind": "runtime",
         "description": "Users web module: account/profile UI plus shared users web widgets.",
         "dependsOn": [
@@ -5717,12 +5717,12 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/http-runtime": "0.1.73",
-              "@jskit-ai/realtime": "0.1.73",
-              "@jskit-ai/kernel": "0.1.74",
-              "@jskit-ai/shell-web": "0.1.73",
-              "@jskit-ai/uploads-image-web": "0.1.52",
-              "@jskit-ai/users-core": "0.1.84"
+              "@jskit-ai/http-runtime": "0.1.74",
+              "@jskit-ai/realtime": "0.1.74",
+              "@jskit-ai/kernel": "0.1.75",
+              "@jskit-ai/shell-web": "0.1.74",
+              "@jskit-ai/uploads-image-web": "0.1.53",
+              "@jskit-ai/users-core": "0.1.85"
             },
             "dev": {}
           },
@@ -5891,11 +5891,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-core",
-      "version": "0.1.50",
+      "version": "0.1.51",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-core",
-        "version": "0.1.50",
+        "version": "0.1.51",
         "kind": "runtime",
         "description": "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
         "dependsOn": [
@@ -6036,10 +6036,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/json-rest-api-core": "0.1.19",
-              "@jskit-ai/resource-core": "0.1.19",
-              "@jskit-ai/resource-crud-core": "0.1.19",
-              "@jskit-ai/users-core": "0.1.84"
+              "@jskit-ai/json-rest-api-core": "0.1.20",
+              "@jskit-ai/resource-core": "0.1.20",
+              "@jskit-ai/resource-crud-core": "0.1.20",
+              "@jskit-ai/users-core": "0.1.85"
             },
             "dev": {}
           },
@@ -6211,11 +6211,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-web",
-      "version": "0.1.50",
+      "version": "0.1.51",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-web",
-        "version": "0.1.50",
+        "version": "0.1.51",
         "kind": "runtime",
         "description": "Workspace web module: workspace selector, tools widget, workspace surfaces, and members/settings UI.",
         "dependsOn": [
@@ -6471,8 +6471,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/workspaces-core": "0.1.50",
-              "@jskit-ai/users-web": "0.1.89"
+              "@jskit-ai/workspaces-core": "0.1.51",
+              "@jskit-ai/users-web": "0.1.90"
             },
             "dev": {}
           },

--- a/tooling/jskit-catalog/package.json
+++ b/tooling/jskit-catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-catalog",
-  "version": "0.1.82",
+  "version": "0.1.83",
   "description": "Published metadata catalog for JSKIT package descriptors.",
   "type": "module",
   "files": [

--- a/tooling/jskit-cli/package.json
+++ b/tooling/jskit-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-cli",
-  "version": "0.2.83",
+  "version": "0.2.84",
   "description": "Bundle and package orchestration CLI for JSKIT apps.",
   "type": "module",
   "files": [
@@ -20,9 +20,9 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/jskit-catalog": "0.1.82",
-    "@jskit-ai/kernel": "0.1.74",
-    "@jskit-ai/shell-web": "0.1.73",
+    "@jskit-ai/jskit-catalog": "0.1.83",
+    "@jskit-ai/kernel": "0.1.75",
+    "@jskit-ai/shell-web": "0.1.74",
     "@vue/compiler-sfc": "^3.5.29",
     "ts-morph": "^28.0.0"
   },

--- a/tooling/jskit-cli/src/server/commandHandlers/appCommandCatalog.js
+++ b/tooling/jskit-cli/src/server/commandHandlers/appCommandCatalog.js
@@ -51,7 +51,7 @@ const APP_COMMAND_DEFINITIONS = Object.freeze({
     options: Object.freeze([
       Object.freeze({
         label: "--command <shell-command>",
-        description: "Targeted Playwright command to run, for example: npx playwright test tests/e2e/contacts.spec.ts -g filters."
+        description: "Targeted UI verification command to run. If it uses Playwright against a local app, the command/environment must start or reuse a reachable app server first."
       }),
       Object.freeze({
         label: "--feature <label>",
@@ -68,6 +68,7 @@ const APP_COMMAND_DEFINITIONS = Object.freeze({
     ]),
     defaults: Object.freeze([
       "Requires a git working tree so the receipt can record the currently changed UI files.",
+      "Does not start the app server; make --command self-contained for UI tests that need one.",
       "Writes .jskit/verification/ui.json after the command succeeds.",
       "Doctor expects the receipt to match the current dirty UI file set, or the same --against <base-ref> delta when used."
     ])

--- a/tooling/jskit-cli/src/server/commandHandlers/session.js
+++ b/tooling/jskit-cli/src/server/commandHandlers/session.js
@@ -7,6 +7,7 @@ import {
   inspectSessionDiff,
   inspectSessionDetails,
   listSessions,
+  rewindSession,
   runSessionStep
 } from "../sessionRuntime.js";
 
@@ -270,7 +271,7 @@ async function resolveStepInputs({
     fileOption: "close-reason-file",
     inlineOptions,
     io,
-    repairCommand: `jskit session ${sessionId} step --close-without-merge --close-reason "<reason>"`,
+    repairCommand: `jskit session ${sessionId} step --skip-merge --close-reason "<reason>"`,
     cwd,
     sessionId,
     stdinOption: "-",
@@ -312,7 +313,10 @@ async function resolveStepInputs({
 function normalizeStepOptions(inlineOptions = {}) {
   const options = {
     ...inlineOptions,
-    closeWithoutMerge: inlineOptions["close-without-merge"] === "true" || inlineOptions.closeWithoutMerge === true,
+    closeWithoutMerge: inlineOptions["close-without-merge"] === "true" ||
+      inlineOptions.closeWithoutMerge === true ||
+      inlineOptions["skip-merge"] === "true" ||
+      inlineOptions.skipMerge === true,
     mergePr: inlineOptions["merge-pr"] === "true" || inlineOptions.mergePr === true,
     prompt: inlineOptions.prompt,
     reviewFindings: inlineOptions["review-findings"] || inlineOptions.reviewFindings,
@@ -394,6 +398,12 @@ function createSessionCommands() {
         payload = await inspectSessionDiff({
           targetRoot: cwd,
           sessionId: first
+        });
+      } else if (second === "rewind") {
+        payload = await rewindSession({
+          targetRoot: cwd,
+          sessionId: first,
+          stepId: inlineOptions.step
         });
       } else if (second === "adopt-codex-thread") {
         payload = await adoptCodexThreadId({

--- a/tooling/jskit-cli/src/server/core/argParser.js
+++ b/tooling/jskit-cli/src/server/core/argParser.js
@@ -145,6 +145,10 @@ function parseArgs(argv, { createCliError } = {}) {
       options.inlineOptions["close-without-merge"] = "true";
       continue;
     }
+    if (token === "--skip-merge") {
+      options.inlineOptions["skip-merge"] = "true";
+      continue;
+    }
 
     if (token.startsWith("--")) {
       const withoutPrefix = token.slice(2);

--- a/tooling/jskit-cli/src/server/core/commandCatalog.js
+++ b/tooling/jskit-cli/src/server/core/commandCatalog.js
@@ -212,8 +212,8 @@ const COMMAND_DESCRIPTORS = Object.freeze({
         description: "Create a session, inspect a session, or run a session subcommand."
       }),
       Object.freeze({
-        name: "[step|abandon|adopt-codex-thread]",
-        description: "Run the next step, inspect a diff, abandon a session, or attach a Codex thread id."
+        name: "[step|diff|rewind|abandon|adopt-codex-thread]",
+        description: "Run the next step, inspect a diff, rewind a session, abandon a session, or attach a Codex thread id."
       })
     ]),
     defaults: Object.freeze([
@@ -227,13 +227,16 @@ const COMMAND_DESCRIPTORS = Object.freeze({
       "Use --issue-details - to read confirmed issue details from stdin.",
       "Use --plan - to read the approved implementation plan from stdin.",
       "Use --codex-result - after Codex prompt steps to read the final marked Codex result from stdin.",
+      "Use rewind --step <step_id> to delete a completed step and later JSKIT-owned session artifacts; only plan_made is allowed inside the repeatable cycle.",
       "Use --rework-notes - with --user-check failed to start the next plan cycle.",
       "Use --agent-decisions - to append session-local decision log entries from implementation, UI review, verification, or repair phases.",
       "Use --review-findings-remaining true --review-findings \"<findings>\" when an accepted review pass needs another pass.",
       "Use --review-findings-remaining false only when the review/deslop loop is done.",
       "Use --skip-ui-check --skip-reason \"<reason>\" only when uiImpact is possible and the Deep UI Check is intentionally skipped.",
+      "Use --prepare-merge true at PR merge preparation to render the Codex prep prompt.",
+      "Use --continue-to-merge true when the user decides to advance from preparation to merge decision.",
       "Use --merge-pr true at PR finalization to merge the pull request.",
-      "Use --close-without-merge --close-reason \"<reason>\" at PR finalization to complete the session without merging.",
+      "Use --skip-merge at PR finalization to complete the session without merging.",
       "Run the blueprint step once to render its Codex prompt, then again after Codex updates .jskit/APP_BLUEPRINT.md."
     ]),
     examples: Object.freeze([
@@ -252,15 +255,18 @@ const COMMAND_DESCRIPTORS = Object.freeze({
           "jskit session 2026-05-11_21-42-08 step --review-findings-remaining false",
           "jskit session 2026-05-11_21-42-08 step --skip-ui-check --skip-reason \"No user-facing UI changes\"",
           "jskit session 2026-05-11_21-42-08 step",
+          "jskit session 2026-05-11_21-42-08 step --prepare-merge true",
+          "jskit session 2026-05-11_21-42-08 step --continue-to-merge true",
           "jskit session 2026-05-11_21-42-08 step --merge-pr true",
-          "jskit session 2026-05-11_21-42-08 step --close-without-merge --close-reason \"Prototype kept for reference\"",
+          "jskit session 2026-05-11_21-42-08 step --skip-merge",
           "jskit session 2026-05-11_21-42-08 step --user-check failed --rework-notes -",
+          "jskit session 2026-05-11_21-42-08 rewind --step plan_made --json",
           "jskit session 2026-05-11_21-42-08 diff --json"
         ])
       })
     ]),
     fullUse:
-      "jskit session [create|<sessionId>] [step|diff|abandon|adopt-codex-thread] [--prompt <text>] [--issue-title <text>|--issue-title-file <path>] [--issue <text>|--issue-file <path>] [--issue-details <text>|--issue-details-file <path>] [--plan <text>|--plan-file <path>] [--codex-result <text>|--codex-result-file <path>] [--agent-decisions <text>|--agent-decisions-file <path>] [--review-findings-remaining true --review-findings <text>|--review-findings-remaining false] [--skip-ui-check --skip-reason <text>] [--merge-pr true|--close-without-merge --close-reason <text>] [--user-check <passed|failed>] [--rework-notes <text>|--rework-notes-file <path>] [--codex-thread-id <id>] [--abandoned|--completed|--all] [--json]",
+      "jskit session [create|<sessionId>] [step|diff|rewind|abandon|adopt-codex-thread] [--step <step_id>] [--prompt <text>] [--issue-title <text>|--issue-title-file <path>] [--issue <text>|--issue-file <path>] [--issue-details <text>|--issue-details-file <path>] [--plan <text>|--plan-file <path>] [--codex-result <text>|--codex-result-file <path>] [--agent-decisions <text>|--agent-decisions-file <path>] [--review-findings-remaining true --review-findings <text>|--review-findings-remaining false] [--skip-ui-check --skip-reason <text>] [--prepare-merge true|--continue-to-merge true|--merge-pr true|--skip-merge] [--user-check <passed|failed>] [--rework-notes <text>|--rework-notes-file <path>] [--codex-thread-id <id>] [--abandoned|--completed|--all] [--json]",
     showHelpOnBareInvocation: false,
     handlerName: "commandSession",
     allowedFlagKeys: Object.freeze(["json", "abandoned", "completed", "all"]),

--- a/tooling/jskit-cli/src/server/sessionRuntime.js
+++ b/tooling/jskit-cli/src/server/sessionRuntime.js
@@ -3,6 +3,7 @@ import {
   mkdir,
   readFile,
   readdir,
+  rm,
   rmdir
 } from "node:fs/promises";
 import path from "node:path";
@@ -13,6 +14,7 @@ import {
   DEEP_UI_CHECK_CODEX_HANDOFF,
   ISSUE_DETAILS_CODEX_HANDOFF,
   PLAN_EXECUTION_CODEX_HANDOFF,
+  PR_MERGE_PREP_CODEX_HANDOFF,
   REVIEW_PASS_LIMIT,
   REVIEW_EXECUTION_CODEX_HANDOFF,
   SESSION_STATUS,
@@ -1282,6 +1284,328 @@ async function inspectSessionDiff({
   });
 }
 
+const FIRST_REWINDABLE_STEP_ID = "dependencies_installed";
+const CYCLE_REWIND_TARGET_STEP_ID = "plan_made";
+const REWIND_CLOSED_STATUSES = Object.freeze([
+  SESSION_STATUS.ABANDONED,
+  SESSION_STATUS.FINISHED
+]);
+
+async function removeSessionPath(paths, ...parts) {
+  await rm(path.join(paths.sessionRoot, ...parts), {
+    force: true,
+    recursive: true
+  });
+}
+
+async function removeSessionRootFile(paths, fileName) {
+  await removeSessionPath(paths, fileName);
+}
+
+async function removePromptArtifact(paths, fileName) {
+  await removeSessionPath(paths, "prompts", fileName);
+}
+
+async function removeGlobalCodexResult(paths, stepId) {
+  await removeSessionPath(paths, "codex_results", `${stepId}.md`);
+}
+
+async function removeGithubCommentPurpose(paths, purpose) {
+  const comments = await readGithubComments(paths);
+  if (!Object.hasOwn(comments, purpose)) {
+    return;
+  }
+  delete comments[purpose];
+  if (Object.keys(comments).length === 0) {
+    await removeSessionRootFile(paths, "github_comments.json");
+    return;
+  }
+  await writeGithubComments(paths, comments);
+}
+
+async function removeIssueDetailsMetadata(paths) {
+  const metadata = await readIssueMetadata(paths);
+  if (Object.keys(metadata).length === 0) {
+    return;
+  }
+  delete metadata.issueCategory;
+  delete metadata.issueDetailsPath;
+  delete metadata.uiImpact;
+  if (Object.keys(metadata).length === 0) {
+    await removeSessionRootFile(paths, "issue_metadata.json");
+    return;
+  }
+  await writeTextFile(path.join(paths.sessionRoot, "issue_metadata.json"), `${JSON.stringify(metadata, null, 2)}\n`);
+}
+
+async function removeCycleDirectories(paths) {
+  for (const rootName of ["steps", "cycles"]) {
+    const root = path.join(paths.sessionRoot, rootName);
+    let entries = [];
+    try {
+      entries = await readdir(root, { withFileTypes: true });
+    } catch {
+      entries = [];
+    }
+    await Promise.all(entries
+      .filter((entry) => entry.isDirectory() && /^cycle_\d+$/u.test(entry.name))
+      .map((entry) => rm(path.join(root, entry.name), {
+        force: true,
+        recursive: true
+      })));
+  }
+}
+
+async function removeCyclePromptArtifacts(paths) {
+  const promptsRoot = path.join(paths.sessionRoot, "prompts");
+  let entries = [];
+  try {
+    entries = await readdir(promptsRoot, { withFileTypes: true });
+  } catch {
+    entries = [];
+  }
+  const cyclePromptPattern = /^cycle_\d+_(?:plan_request|plan_execution)\.md$/u;
+  const cyclePromptFiles = entries
+    .filter((entry) => entry.isFile() && cyclePromptPattern.test(entry.name))
+    .map((entry) => entry.name);
+  await Promise.all([
+    ...cyclePromptFiles.map((fileName) => removePromptArtifact(paths, fileName)),
+    removePromptArtifact(paths, "automated_checks_run.md"),
+    removePromptArtifact(paths, "deep_ui_check_run.md"),
+    removePromptArtifact(paths, "review.md"),
+    removePromptArtifact(paths, "user_check.md")
+  ]);
+}
+
+async function cancelAllCycleState(paths) {
+  await Promise.all([
+    removeCycleDirectories(paths),
+    removeCyclePromptArtifacts(paths),
+    removeSessionPath(paths, "checks"),
+    removeSessionPath(paths, "ui_checks"),
+    removeSessionPath(paths, "review_passes")
+  ]);
+  await writeActiveCycle(paths, "001");
+}
+
+const STEP_CANCELERS = Object.freeze({
+  dependencies_installed: async () => {},
+  issue_prompt_rendered: async (paths) => {
+    await removePromptArtifact(paths, "issue_draft.md");
+  },
+  issue_drafted: async (paths) => {
+    await Promise.all([
+      removeSessionRootFile(paths, "issue.md"),
+      removeSessionRootFile(paths, "issue_title")
+    ]);
+  },
+  issue_created: async (paths) => {
+    await Promise.all([
+      removeSessionRootFile(paths, "issue_url"),
+      removeSessionRootFile(paths, "issue_metadata.json")
+    ]);
+  },
+  issue_details_gathered: async (paths) => {
+    await Promise.all([
+      removePromptArtifact(paths, "issue_details.md"),
+      removeSessionRootFile(paths, "issue_details.md"),
+      removeGithubCommentPurpose(paths, "issue_details"),
+      removeIssueDetailsMetadata(paths)
+    ]);
+  },
+  plan_made: cancelAllCycleState,
+  plan_executed: cancelAllCycleState,
+  deep_ui_check_run: cancelAllCycleState,
+  review_prompt_rendered: cancelAllCycleState,
+  review_changes_accepted: cancelAllCycleState,
+  automated_checks_run: cancelAllCycleState,
+  user_check_completed: cancelAllCycleState,
+  changes_committed: async (paths) => {
+    await removeSessionRootFile(paths, "changes_committed.json");
+  },
+  blueprint_updated: async (paths) => {
+    await Promise.all([
+      removePromptArtifact(paths, "update_blueprint.md"),
+      removeGlobalCodexResult(paths, "blueprint_updated")
+    ]);
+  },
+  final_report_created: async (paths) => {
+    await Promise.all([
+      removeSessionRootFile(paths, "final_report.md"),
+      removeGithubCommentPurpose(paths, "final_report")
+    ]);
+  },
+  pr_created: async (paths) => {
+    await Promise.all([
+      removePromptArtifact(paths, "pr_create_failure.md"),
+      removeSessionRootFile(paths, "pr_body.md"),
+      removeSessionRootFile(paths, "pr_url")
+    ]);
+  },
+  pr_merge_prepared: async (paths) => {
+    await removePromptArtifact(paths, "prepare_pr_merge.md");
+  },
+  pr_finalized: async (paths) => {
+    await Promise.all([
+      removePromptArtifact(paths, "pr_merge_failure.md"),
+      removeSessionRootFile(paths, "pr_base_branch"),
+      removeSessionRootFile(paths, "pr_merge_completed"),
+      removeSessionRootFile(paths, "pr_outcome.json")
+    ]);
+  },
+  session_finished: async (paths) => {
+    await Promise.all([
+      removeSessionRootFile(paths, "final_comment.md"),
+      removeSessionRootFile(paths, "local_base_updated")
+    ]);
+  }
+});
+
+function targetRequiresCycleReset(stepId) {
+  const targetIndex = STEP_IDS.indexOf(stepId);
+  const planIndex = STEP_IDS.indexOf(CYCLE_REWIND_TARGET_STEP_ID);
+  return targetIndex >= 0 && targetIndex <= planIndex;
+}
+
+function targetIsAllowedRewindStep(stepId) {
+  if (!STEP_IDS.includes(stepId)) {
+    return false;
+  }
+  if (stepId === "session_created" || stepId === "worktree_created") {
+    return false;
+  }
+  if (CYCLE_STEP_IDS.includes(stepId)) {
+    return stepId === CYCLE_REWIND_TARGET_STEP_ID;
+  }
+  return STEP_IDS.indexOf(stepId) >= STEP_IDS.indexOf(FIRST_REWINDABLE_STEP_ID);
+}
+
+function deletedStepIdsForRewindTarget(stepId) {
+  const targetIndex = STEP_IDS.indexOf(stepId);
+  return targetIndex < 0 ? [] : STEP_IDS.slice(targetIndex);
+}
+
+async function removeReceiptsForDeletedSteps(paths, deletedStepIds) {
+  await Promise.all(deletedStepIds
+    .filter((stepId) => !CYCLE_STEP_IDS.includes(stepId))
+    .map((stepId) => removeSessionPath(paths, "steps", stepId)));
+}
+
+async function cancelDeletedStepArtifacts(paths, deletedStepIds, {
+  cycleReset = false
+} = {}) {
+  const cancelerIds = cycleReset
+    ? deletedStepIds.filter((stepId) => !CYCLE_STEP_IDS.includes(stepId)).concat(CYCLE_REWIND_TARGET_STEP_ID)
+    : deletedStepIds;
+  const calledCycleCancel = new Set();
+  for (const stepId of cancelerIds) {
+    const canceler = STEP_CANCELERS[stepId];
+    if (typeof canceler !== "function") {
+      continue;
+    }
+    if (CYCLE_STEP_IDS.includes(stepId)) {
+      if (calledCycleCancel.has(CYCLE_REWIND_TARGET_STEP_ID)) {
+        continue;
+      }
+      calledCycleCancel.add(CYCLE_REWIND_TARGET_STEP_ID);
+    }
+    await canceler(paths);
+  }
+}
+
+async function rewindSession({
+  targetRoot = process.cwd(),
+  sessionId,
+  stepId
+} = {}) {
+  return withExistingSession({ targetRoot, sessionId }, async (paths) => {
+    const artifacts = await readSessionArtifacts(paths);
+    const normalizedStepId = normalizeText(stepId);
+    const currentStatus = artifacts.status || SESSION_STATUS.PENDING;
+
+    if (paths.archive && paths.archive !== "active") {
+      return buildSessionResponse(paths, {
+        ok: false,
+        errors: [
+          createError({
+            code: "session_archived_read_only",
+            message: `Session ${paths.sessionId} is archived and cannot be rewound.`
+          })
+        ],
+        status: currentStatus
+      });
+    }
+
+    if (REWIND_CLOSED_STATUSES.includes(currentStatus)) {
+      return buildSessionResponse(paths, {
+        ok: false,
+        errors: [
+          createError({
+            code: "session_closed_read_only",
+            message: `Session ${paths.sessionId} is ${currentStatus} and cannot be rewound.`
+          })
+        ],
+        status: currentStatus
+      });
+    }
+
+    if (artifacts.workflowVersion !== SESSION_WORKFLOW_VERSION) {
+      return buildSessionResponse(paths, {
+        ok: false,
+        errors: [
+          createError({
+            code: "unsupported_workflow_version",
+            message: `Session ${paths.sessionId} uses workflow version ${artifacts.workflowVersion || "unknown"}, but this JSKIT runtime expects ${SESSION_WORKFLOW_VERSION}.`
+          })
+        ],
+        status: SESSION_STATUS.BLOCKED
+      });
+    }
+
+    if (!targetIsAllowedRewindStep(normalizedStepId)) {
+      const cycleHint = CYCLE_STEP_IDS.includes(normalizedStepId)
+        ? " Only Plan made can be used as a cycle rewind target; it resets all cycle/rework state."
+        : "";
+      return buildSessionResponse(paths, {
+        ok: false,
+        errors: [
+          createError({
+            code: "rewind_step_not_allowed",
+            message: `Cannot rewind session ${paths.sessionId} to ${normalizedStepId || "(missing)"}.${cycleHint}`
+          })
+        ],
+        status: currentStatus
+      });
+    }
+
+    if (!artifacts.completedSteps.includes(normalizedStepId)) {
+      return buildSessionResponse(paths, {
+        ok: false,
+        errors: [
+          createError({
+            code: "rewind_step_not_completed",
+            message: `Cannot rewind session ${paths.sessionId} to ${normalizedStepId} because that step is not completed.`
+          })
+        ],
+        status: currentStatus
+      });
+    }
+
+    const deletedStepIds = deletedStepIdsForRewindTarget(normalizedStepId);
+    const cycleReset = targetRequiresCycleReset(normalizedStepId);
+    await removeReceiptsForDeletedSteps(paths, deletedStepIds);
+    await cancelDeletedStepArtifacts(paths, deletedStepIds, { cycleReset });
+    if (cycleReset) {
+      await writeActiveCycle(paths, "001");
+    }
+    await markCurrentStep(paths, normalizedStepId);
+    await markStatus(paths, SESSION_STATUS.PENDING);
+    return buildSessionResponse(paths, {
+      status: SESSION_STATUS.PENDING
+    });
+  });
+}
+
 async function commitWorktree(paths, {
   message,
   allowNoChanges = false
@@ -2136,50 +2460,6 @@ async function assertTargetRootCanUpdateBase(paths, branch) {
   return null;
 }
 
-async function assertTargetBaseCanFastForward(paths, branch) {
-  const branchFailure = await assertTargetRootCanUpdateBase(paths, branch);
-  if (branchFailure) {
-    return branchFailure;
-  }
-
-  const fetchResult = await runLoggedCommand(paths, "git_fetch_origin", "git", ["fetch", "origin"], {
-    cwd: paths.targetRoot,
-    timeout: 1000 * 60 * 5
-  });
-  if (!fetchResult.ok) {
-    return failSession(paths, {
-      code: "target_fetch_failed",
-      message: fetchResult.output || `Failed to fetch origin before checking local ${branch}.`,
-      repairCommand: `git -C ${paths.targetRoot} fetch origin`
-    });
-  }
-
-  const remoteBranch = `origin/${branch}`;
-  const remoteExists = await runGit(paths.targetRoot, ["rev-parse", "--verify", remoteBranch], {
-    timeout: 15000
-  });
-  if (!remoteExists.ok) {
-    return failSession(paths, {
-      code: "target_remote_branch_missing",
-      message: `Remote base branch ${remoteBranch} does not exist; JSKIT cannot safely update local ${branch} after merge.`,
-      repairCommand: `git -C ${paths.targetRoot} fetch origin`
-    });
-  }
-
-  const ancestor = await runGit(paths.targetRoot, ["merge-base", "--is-ancestor", branch, remoteBranch], {
-    timeout: 15000
-  });
-  if (!ancestor.ok) {
-    return failSession(paths, {
-      code: "target_branch_not_fast_forwardable",
-      message: `Local ${branch} is not an ancestor of ${remoteBranch}; JSKIT will not merge the PR while the local base branch has diverged.`,
-      repairCommand: `git -C ${paths.targetRoot} pull --ff-only origin ${branch}`
-    });
-  }
-
-  return null;
-}
-
 async function updateLocalBaseBranch(paths, baseBranch = "") {
   const branch = normalizeText(baseBranch) || await currentTargetBranch(paths.targetRoot);
   if (!branch) {
@@ -2380,14 +2660,7 @@ async function createPr(paths) {
 }
 
 async function closePrWithoutMerge(paths, prUrl, options = {}) {
-  const reason = normalizeText(options.closeReason || options["close-reason"]);
-  if (!reason) {
-    return failSession(paths, {
-      code: "close_without_merge_reason_required",
-      message: "Finishing without merging requires --close-reason.",
-      repairCommand: `jskit session ${paths.sessionId} step --close-without-merge --close-reason "<reason>"`
-    });
-  }
+  const reason = normalizeText(options.closeReason || options["close-reason"]) || "User skipped merge in JSKIT Studio.";
   const prState = await readPrState(paths, prUrl);
   if (!prState.ok) {
     return failSession(paths, {
@@ -2423,10 +2696,6 @@ async function closePrWithoutMerge(paths, prUrl, options = {}) {
       timeout: 1000 * 60
     });
   }
-  const removeFailure = await removeSessionWorktree(paths);
-  if (removeFailure) {
-    return removeFailure;
-  }
   await writePrOutcome(paths, {
     issueUrl,
     outcome: "closed_without_merge",
@@ -2434,15 +2703,64 @@ async function closePrWithoutMerge(paths, prUrl, options = {}) {
     prState: prState.state,
     reason
   });
-  await writeReceipt(paths, "pr_finalized", `Finished without merging PR ${prUrl}; PR left open and worktree removed ${paths.worktree}. Reason: ${reason}`);
+  await writeReceipt(paths, "pr_finalized", `Finished without merging PR ${prUrl}; PR left open. Reason: ${reason}`);
   await markStatus(paths, SESSION_STATUS.RUNNING);
   return buildSessionResponse(paths);
 }
 
-async function finalizePr(paths, options = {}) {
+async function preparePrMerge(paths, options = {}, context = {}) {
+  const preconditions = context.preconditions || [];
+  const prepareMerge = options.prepareMerge === true ||
+    normalizeText(options["prepare-merge"]).toLowerCase() === "true";
+  const continueToMerge = options.continueToMerge === true ||
+    normalizeText(options["continue-to-merge"]).toLowerCase() === "true";
+
+  if (prepareMerge) {
+    const prUrl = await readTrimmedFile(path.join(paths.sessionRoot, "pr_url"));
+    const baseBranch = await readTrimmedFile(path.join(paths.sessionRoot, "pr_base_branch")) ||
+      await readTrimmedFile(path.join(paths.sessionRoot, "base_branch")) ||
+      await currentTargetBranch(paths.targetRoot);
+    const prompt = await renderPrompt(paths, "prepare_pr_merge.md", {
+      base_branch: baseBranch,
+      final_report_file: path.join(paths.sessionRoot, "final_report.md"),
+      issue_url: await readTrimmedFile(path.join(paths.sessionRoot, "issue_url")),
+      pr_url: prUrl,
+      target_root: paths.targetRoot
+    });
+    await writePromptArtifact(paths, "prepare_pr_merge.md", prompt);
+    await markStatus(paths, SESSION_STATUS.WAITING_FOR_USER);
+    return buildSessionResponse(paths, {
+      codex: PR_MERGE_PREP_CODEX_HANDOFF,
+      ok: true,
+      preconditions,
+      prompt,
+      status: SESSION_STATUS.WAITING_FOR_USER
+    });
+  }
+
+  if (!continueToMerge) {
+    return failSession(paths, {
+      code: "pr_merge_prepare_decision_required",
+      message: "Choose whether to ask Codex to prepare the PR for merge or continue to the merge decision.",
+      repairCommand: `jskit session ${paths.sessionId} step --continue-to-merge true`,
+      preconditions
+    });
+  }
+
+  await writeReceipt(paths, "pr_merge_prepared", "User continued from PR merge preparation to the merge decision.");
+  await markStatus(paths, SESSION_STATUS.RUNNING);
+  return buildSessionResponse(paths, {
+    preconditions
+  });
+}
+
+async function finalizePr(paths, options = {}, context = {}) {
+  const preconditions = context.preconditions || [];
   const prUrl = await readTrimmedFile(path.join(paths.sessionRoot, "pr_url"));
   const closeWithoutMerge = options.closeWithoutMerge === true ||
-    normalizeText(options["close-without-merge"]).toLowerCase() === "true";
+    normalizeText(options["close-without-merge"]).toLowerCase() === "true" ||
+    options.skipMerge === true ||
+    normalizeText(options["skip-merge"]).toLowerCase() === "true";
   if (closeWithoutMerge) {
     return closePrWithoutMerge(paths, prUrl, options);
   }
@@ -2451,8 +2769,9 @@ async function finalizePr(paths, options = {}) {
   if (!mergePr) {
     return failSession(paths, {
       code: "pr_finalize_decision_required",
-      message: "Choose whether to merge the PR or finish without merging.",
-      repairCommand: `jskit session ${paths.sessionId} step --merge-pr true`
+      message: "Choose whether to merge the PR or skip merge.",
+      repairCommand: `jskit session ${paths.sessionId} step --merge-pr true`,
+      preconditions
     });
   }
   const mergeMarkerPath = path.join(paths.sessionRoot, "pr_merge_completed");
@@ -2464,10 +2783,6 @@ async function finalizePr(paths, options = {}) {
     baseBranch = existingPrState.baseRefName || baseBranch || await currentTargetBranch(paths.targetRoot);
     if (baseBranch) {
       await writeTextFile(baseBranchPath, `${baseBranch}\n`);
-    }
-    const baseFailure = await assertTargetBaseCanFastForward(paths, baseBranch);
-    if (baseFailure) {
-      return baseFailure;
     }
     let prMerged = prStateIsMerged(existingPrState);
     let mergeResult = null;
@@ -2491,6 +2806,7 @@ async function finalizePr(paths, options = {}) {
         code: "pr_merge_failed",
         message: mergeResult?.output || existingPrState.output || "Failed to merge PR.",
         repairCommand: `gh pr merge ${prUrl} --merge --delete-branch`,
+        preconditions,
         prompt
       });
     }
@@ -2509,15 +2825,7 @@ async function finalizePr(paths, options = {}) {
     });
     await writeTextFile(mergeMarkerPath, `${prUrl}\n`);
   }
-  const updateFailure = await updateLocalBaseBranch(paths, baseBranch);
-  if (updateFailure) {
-    return updateFailure;
-  }
-  const removeFailure = await removeSessionWorktree(paths);
-  if (removeFailure) {
-    return removeFailure;
-  }
-  await writeReceipt(paths, "pr_finalized", `Merged PR ${prUrl}, updated local ${baseBranch || "base branch"}, and removed worktree ${paths.worktree}.`);
+  await writeReceipt(paths, "pr_finalized", `Merged PR ${prUrl}.`);
   await markStatus(paths, SESSION_STATUS.RUNNING);
   return buildSessionResponse(paths);
 }
@@ -2527,6 +2835,17 @@ async function finishSession(paths) {
   const issueUrl = await readTrimmedFile(path.join(paths.sessionRoot, "issue_url"));
   const codexThreadId = await readTrimmedFile(path.join(paths.sessionRoot, "codex_thread_id"));
   const prOutcome = parseJsonObject(await readTextIfExists(path.join(paths.sessionRoot, "pr_outcome.json")));
+  if (prOutcome?.outcome === "merged") {
+    const baseBranch = prOutcome.baseBranch || await readTrimmedFile(path.join(paths.sessionRoot, "pr_base_branch"));
+    const updateFailure = await updateLocalBaseBranch(paths, baseBranch);
+    if (updateFailure) {
+      return updateFailure;
+    }
+  }
+  const removeFailure = await removeSessionWorktree(paths);
+  if (removeFailure) {
+    return removeFailure;
+  }
   const prompt = await renderPrompt(paths, "final_comment.md", {
     codex_thread_id: codexThreadId,
     issue_url: issueUrl,
@@ -2543,7 +2862,7 @@ async function finishSession(paths) {
       timeout: 1000 * 60
     });
   }
-  await writeReceipt(paths, "session_finished", `Finished session ${paths.sessionId} with PR outcome ${prOutcome?.outcome || "unknown"}.`);
+  await writeReceipt(paths, "session_finished", `Removed worktree ${paths.worktree} and finished session ${paths.sessionId} with PR outcome ${prOutcome?.outcome || "unknown"}.`);
   await markStatus(paths, SESSION_STATUS.FINISHED);
   await markCurrentStep(paths, "");
   const archivedPaths = await archiveSession(paths, "completed");
@@ -2577,6 +2896,7 @@ const STEP_RUNNERS = Object.freeze({
   blueprint_updated: updateBlueprint,
   final_report_created: createFinalReport,
   pr_created: createPr,
+  pr_merge_prepared: preparePrMerge,
   pr_finalized: finalizePr,
   session_finished: finishSession
 });
@@ -2772,6 +3092,7 @@ export {
   listSessions,
   renderTemplate,
   recordDependenciesInstalled,
+  rewindSession,
   resolveSessionPaths,
   runSessionStep
 };

--- a/tooling/jskit-cli/src/server/sessionRuntime/constants.js
+++ b/tooling/jskit-cli/src/server/sessionRuntime/constants.js
@@ -263,6 +263,12 @@ const BLUEPRINT_CODEX_HANDOFF = codexHandoff([], {
   promptActionLabel: "Update blueprint",
   responseContract: JSKIT_STEP_RESULT_CONTRACT
 });
+const PR_MERGE_PREP_CODEX_HANDOFF = codexHandoff([], {
+  autoInject: true,
+  promptActionLabel: "Get Codex ready to merge PR",
+  promptWaitingText: "Codex is preparing the PR for merge. Continue only when you decide the PR is ready.",
+  responseContract: null
+});
 
 function defineStep({
   buttonLabel,
@@ -498,10 +504,32 @@ const STEP_DEFINITIONS = Object.freeze([
     preconditions: ["session_exists", "worktree_exists", "dependencies_installed", "ready_jskit_app", "issue_metadata_exists", "active_cycle_exists", "automated_checks_passed", "deep_ui_check_satisfied", "active_cycle_user_check_passed", "accepted_changes_committed", "blueprint_update_satisfied", "final_report_exists"]
   }),
   defineStep({
+    buttonLabel: "Continue to merge",
+    codex: PR_MERGE_PREP_CODEX_HANDOFF,
+    description: "User can ask Codex to prepare the pull request for merge, then explicitly continue to the merge decision.",
+    id: "pr_merge_prepared",
+    label: "PR merge prepared",
+    preconditions: ["session_exists", "pr_url_exists", "worktree_exists"],
+    requiresExplicitRun: true,
+    submitOptions: Object.freeze({
+      continueToMerge: true
+    }),
+    utilityActions: Object.freeze([
+      Object.freeze({
+        id: "prepare_pr_merge",
+        kind: "codex_prompt",
+        label: "Get Codex ready to merge PR",
+        submitOptions: Object.freeze({
+          prepareMerge: true
+        })
+      })
+    ])
+  }),
+  defineStep({
     buttonLabel: "Merge PR",
-    description: "User chooses whether JSKIT merges the pull request or finishes without merge; JSKIT then removes the session worktree.",
+    description: "User chooses whether JSKIT merges the pull request or skips merge; JSKIT records the PR outcome.",
     id: "pr_finalized",
-    label: "PR finalized, worktree removed",
+    label: "PR finalized",
     preconditions: ["session_exists", "pr_url_exists", "worktree_exists"],
     requiresExplicitRun: true,
     submitOptions: Object.freeze({
@@ -510,9 +538,9 @@ const STEP_DEFINITIONS = Object.freeze([
   }),
   defineStep({
     buttonLabel: "Finish session",
-    description: "JSKIT writes the final receipt and archives the completed session.",
+    description: "JSKIT updates the local base branch when needed, removes the session worktree, writes the final receipt, and archives the completed session.",
     id: "session_finished",
-    label: "Session finished",
+    label: "Worktree removed, session finished",
     preconditions: ["session_exists"]
   })
 ]);
@@ -553,6 +581,7 @@ export {
   DEEP_UI_CHECK_CODEX_HANDOFF,
   AUTOMATED_CHECK_REPAIR_CODEX_HANDOFF,
   BLUEPRINT_CODEX_HANDOFF,
+  PR_MERGE_PREP_CODEX_HANDOFF,
   JSKIT_CLI_SHELL_COMMAND,
   JSKIT_CLI_SHELL_RULE,
   SESSION_STATE_RELATIVE_PATH

--- a/tooling/jskit-cli/src/server/sessionRuntime/prompts/deep_ui_check.md
+++ b/tooling/jskit-cli/src/server/sessionRuntime/prompts/deep_ui_check.md
@@ -34,6 +34,8 @@ Use Playwright for a meaningful route check when possible. If login is required,
 
 `npx --no-install jskit app verify-ui --command "<playwright command>" --feature "<label>" --auth-mode <mode>`
 
+Important: `npx --no-install jskit app verify-ui` does not start the app server. Before running it, make sure the app is reachable by Playwright. If a local server is needed, inspect `.jskit/config/testrun_command` when present and use the app's documented server command, or start the server explicitly and wait for it before invoking `verify-ui`. Do not first run a bare Playwright command against a stopped server.
+
 Do not create commits, branches, issues, pull requests, merges, or worktree cleanup. JSKIT session owns those steps.
 
 If this pass makes UI fixes, intentionally skips UI work after inspection, changes a design direction, or leaves a meaningful UI verification gap, include concise decision entries with reasons in this exact marker block:

--- a/tooling/jskit-cli/src/server/sessionRuntime/prompts/execute_plan.md
+++ b/tooling/jskit-cli/src/server/sessionRuntime/prompts/execute_plan.md
@@ -41,6 +41,7 @@ After making changes:
 - Review for repeated code, unnecessary helpers, fragmented functions, placeholder work, missing states, broken route wiring, ownership mistakes, and weak JSKIT reuse.
 - Run the smallest relevant checks you can run safely in the worktree.
 - For changed user-facing UI, run or clearly identify the Playwright verification path. When possible, record UI verification with `npx --no-install jskit app verify-ui --command "<playwright command>" --feature "<label>" --auth-mode <mode>`.
+- `npx --no-install jskit app verify-ui` does not start the app server. Before using it for Playwright, make sure the app is reachable. If a local server is needed, inspect `.jskit/config/testrun_command` when present and use the app's documented server command, or start the server explicitly and wait for it before invoking `verify-ui`. Do not first run a bare Playwright command against a stopped server.
 - Summarize changed files and checks run.
 - If implementation deviated from the approved plan, generator choices, package ownership, helper reuse, UI verification path, or data ownership, include concise decision entries with reasons in this exact marker block:
 

--- a/tooling/jskit-cli/src/server/sessionRuntime/prompts/prepare_pr_merge.md
+++ b/tooling/jskit-cli/src/server/sessionRuntime/prompts/prepare_pr_merge.md
@@ -1,0 +1,22 @@
+Prepare the JSKIT session pull request for merge.
+
+Session: {{session_id}}
+Worktree: {{worktree}}
+Target root: {{target_root}}
+Branch: {{branch}}
+Base branch: {{base_branch}}
+Pull request: {{pr_url}}
+Issue: {{issue_url}}
+Final report: {{final_report_file}}
+
+Your job is to get the pull request into a state where the user can decide whether to press the JSKIT Merge PR button.
+
+Required boundaries:
+
+- Inspect the pull request state, checks, and branch status.
+- Resolve merge conflicts or failing checks if the fix is clear and in scope.
+- Commit and push any preparation changes to the session branch.
+- Do not merge the pull request.
+- Do not remove the worktree, archive the session, update the local base branch, or write JSKIT receipts. JSKIT owns deterministic cleanup after the user decides.
+
+When you are done, summarize what you checked, what changed, and whether you believe the PR is ready for the user to merge.

--- a/tooling/jskit-cli/src/server/sessionRuntime/prompts/review_changes.md
+++ b/tooling/jskit-cli/src/server/sessionRuntime/prompts/review_changes.md
@@ -51,6 +51,7 @@ Use four passes:
    - run the smallest relevant verification commands for the changed scope
    - any changed user-facing UI should be exercised with Playwright when possible
    - UI verification should normally be recorded through `npx --no-install jskit app verify-ui`
+   - `npx --no-install jskit app verify-ui` does not start the app server; if Playwright needs a local server, inspect `.jskit/config/testrun_command` when present and start or wrap the documented server command before invoking `verify-ui`
    - if login is required, use the chosen local test-auth path instead of live external auth
    - if there is no usable local auth bootstrap path, record it as a blocking testability gap
 

--- a/tooling/jskit-cli/src/server/sessionRuntime/responses.js
+++ b/tooling/jskit-cli/src/server/sessionRuntime/responses.js
@@ -241,6 +241,7 @@ const PROMPT_ARTIFACT_BY_STEP_ID = Object.freeze({
   deep_ui_check_run: "deep_ui_check_run.md",
   automated_checks_run: "automated_checks_run.md",
   blueprint_updated: "update_blueprint.md",
+  pr_merge_prepared: "prepare_pr_merge.md",
   user_check_completed: "user_check.md"
 });
 
@@ -681,17 +682,12 @@ function buildCurrentStepAction(stepId, artifacts = {}) {
   }
   if (step.id === "pr_finalized") {
     alternateActions.push({
-      id: "close_without_merge",
-      helpText: "Leave the PR open, record the reason, and remove the session worktree without merging.",
+      id: "skip_merge",
+      helpText: "Leave the PR open and record the skipped-merge outcome; final cleanup removes the session worktree.",
       input: {
-        formatHint: "markdown",
-        label: "Why is this session finishing without merge?",
-        multiline: true,
-        name: "closeReason",
-        required: true,
-        type: "text"
+        type: "none"
       },
-      label: "Finish without merge",
+      label: "Skip merge",
       presentation: "secondary",
       submitOptions: {
         closeWithoutMerge: true
@@ -858,7 +854,7 @@ async function readSessionArtifacts(paths) {
   const helperMapPath = path.join(appRootForArtifacts, ".jskit", "helper-map.md");
   const currentStep = normalizeStepId(rawCurrentStep);
   let completedSteps = await readCompletedSteps(paths);
-  const worktreeRemovalCompleted = completedSteps.includes("pr_finalized");
+  const worktreeRemovalCompleted = completedSteps.includes("session_finished");
   const worktreeReceiptInvalid = !worktreeReady &&
     completedSteps.includes("worktree_created") &&
     !worktreeRemovalCompleted &&

--- a/tooling/jskit-cli/test/sessionCommand.test.js
+++ b/tooling/jskit-cli/test/sessionCommand.test.js
@@ -16,6 +16,7 @@ import {
   extractIssueText,
   extractPlanText,
   inspectSessionDetails,
+  rewindSession,
   runSessionStep
 } from "../src/server/sessionRuntime.js";
 import {
@@ -114,6 +115,26 @@ function runSessionStepJsonFailure(cwd, sessionId, {
     args: ["session", sessionId, "step", ...args, "--json"],
     env,
     input
+  }));
+}
+
+function rewindSessionJson(cwd, sessionId, stepId, {
+  env = undefined
+} = {}) {
+  return parseJsonResult(runCli({
+    cwd,
+    args: ["session", sessionId, "rewind", "--step", stepId, "--json"],
+    env
+  }));
+}
+
+function rewindSessionJsonFailure(cwd, sessionId, stepId, {
+  env = undefined
+} = {}) {
+  return parseJsonFailure(runCli({
+    cwd,
+    args: ["session", sessionId, "rewind", "--step", stepId, "--json"],
+    env
   }));
 }
 
@@ -516,16 +537,26 @@ test("jskit session JSON exposes JSKIT-owned step UI and Codex handoff contract"
     assert.equal(created.stepDefinitions.find((step) => step.id === "issue_created").requiresExplicitRun, false);
     assert.equal(created.stepDefinitions.find((step) => step.id === "final_report_created").requiresExplicitRun, false);
     assert.equal(created.stepDefinitions.find((step) => step.id === "pr_created").requiresExplicitRun, false);
+    assert.equal(created.stepDefinitions.find((step) => step.id === "pr_merge_prepared").requiresExplicitRun, true);
+    assert.equal(created.stepDefinitions.find((step) => step.id === "pr_merge_prepared").label, "PR merge prepared");
+    assert.equal(created.stepDefinitions.find((step) => step.id === "pr_merge_prepared").kind, "automatic");
     assert.equal(created.stepDefinitions.find((step) => step.id === "pr_finalized").requiresExplicitRun, true);
+    assert.equal(created.stepDefinitions.find((step) => step.id === "pr_finalized").label, "PR finalized");
+    assert.equal(created.stepDefinitions.find((step) => step.id === "pr_finalized").kind, "automatic");
     assert.equal(created.stepDefinitions.find((step) => step.id === "issue_details_gathered").label, "Issue details gathered");
     assert.equal(created.stepDefinitions.find((step) => step.id === "issue_details_gathered").input.label, "Confirmed issue details");
     assert.deepEqual(created.stepDefinitions.find((step) => step.id === "dependencies_installed").automation, { mode: "terminal" });
     assert.deepEqual(created.stepDefinitions.find((step) => step.id === "issue_created").automation, { mode: "immediate" });
     assert.deepEqual(created.stepDefinitions.find((step) => step.id === "issue_drafted").automation, { mode: "codex_output_prompt" });
     assert.deepEqual(created.stepDefinitions.find((step) => step.id === "plan_executed").automation, { mode: "codex_prompt" });
+    assert.deepEqual(created.stepDefinitions.find((step) => step.id === "pr_merge_prepared").automation, { mode: "manual" });
     assert.deepEqual(created.stepDefinitions.find((step) => step.id === "pr_finalized").automation, { mode: "manual" });
     assert.equal(created.stepDefinitions.find((step) => step.id === "review_prompt_rendered").codex.responseContract.resolvePrompt.templateFile, "resolve_deslop_findings.md");
+    assert.equal(Object.hasOwn(created.stepDefinitions.find((step) => step.id === "pr_merge_prepared").codex, "responseContract"), false);
+    assert.equal(created.stepDefinitions.find((step) => step.id === "pr_merge_prepared").utilityActions[0].label, "Get Codex ready to merge PR");
+    assert.deepEqual(created.stepDefinitions.find((step) => step.id === "pr_merge_prepared").utilityActions[0].submitOptions, { prepareMerge: true });
     assert.deepEqual(created.stepDefinitions.find((step) => step.id === "review_changes_accepted").submitOptions, { reviewFindingsRemaining: false });
+    assert.deepEqual(created.stepDefinitions.find((step) => step.id === "pr_merge_prepared").submitOptions, { continueToMerge: true });
     assert.deepEqual(created.stepDefinitions.find((step) => step.id === "pr_finalized").submitOptions, { mergePr: true });
     assert.equal(created.codex, null);
 
@@ -611,6 +642,154 @@ test("jskit session returns JSON failures for invalid session ids", async () => 
     assert.equal(payload.ok, false);
     assert.equal(payload.sessionId, "invalid");
     assert.equal(payload.errors[0].code, "invalid_session_id");
+  });
+});
+
+test("jskit session rewind deletes target and later normal-step artifacts", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "app");
+    await createGitApp(appRoot);
+
+    const created = parseJsonResult(runCli({
+      cwd: appRoot,
+      args: ["session", "create", "--json"]
+    }));
+    advanceCliSessionToIssuePrompt(appRoot, created.sessionId);
+    const prompted = runSessionStepJson(appRoot, created.sessionId, {
+      args: ["--prompt", "Add session rewind"]
+    });
+    assert.equal(prompted.currentStep, "issue_drafted");
+
+    const rewound = rewindSessionJson(appRoot, created.sessionId, "dependencies_installed");
+    assert.equal(rewound.ok, true);
+    assert.equal(rewound.status, "pending");
+    assert.equal(rewound.currentStep, "dependencies_installed");
+    assert.deepEqual(rewound.completedSteps, ["session_created", "worktree_created"]);
+    assert.equal(rewound.dependencyInstall.installed, false);
+    assert.equal(rewound.dependencyInstall.status, "pending");
+    assert.equal(rewound.prompt, "");
+    assert.equal(rewound.currentStepAction.stepId, "dependencies_installed");
+
+    await assert.rejects(access(path.join(rewound.sessionRoot, "steps", "dependencies_installed")));
+    await assert.rejects(access(path.join(rewound.sessionRoot, "steps", "issue_prompt_rendered")));
+    await assert.rejects(access(path.join(rewound.sessionRoot, "prompts", "issue_draft.md")));
+  });
+});
+
+test("jskit session rewind to plan_made clears cycle and rework state", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "app");
+    await createGitApp(appRoot);
+
+    const created = parseJsonResult(runCli({
+      cwd: appRoot,
+      args: ["session", "create", "--json"]
+    }));
+    advanceCliSessionToIssuePrompt(appRoot, created.sessionId);
+    const sessionRoot = created.sessionRoot;
+    await writeFile(path.join(sessionRoot, "issue.md"), "Issue body.\n", "utf8");
+    await writeFile(path.join(sessionRoot, "issue_title"), "Issue title\n", "utf8");
+    await writeFile(path.join(sessionRoot, "issue_url"), "https://github.com/example/repo/issues/123\n", "utf8");
+    await writeFile(path.join(sessionRoot, "issue_details.md"), "Issue details.\n", "utf8");
+    await writeIssueMetadata(sessionRoot, {
+      category: "client",
+      uiImpact: "possible"
+    });
+    await writeStepReceipts(sessionRoot, [
+      "issue_prompt_rendered",
+      "issue_drafted",
+      "issue_created",
+      "issue_details_gathered",
+      "plan_made",
+      "plan_executed",
+      "deep_ui_check_run",
+      "review_prompt_rendered",
+      "review_changes_accepted",
+      "automated_checks_run",
+      "user_check_completed",
+      "changes_committed",
+      "final_report_created"
+    ]);
+    await writeCyclePlan(sessionRoot, "Cycle 001 plan.\n", "001");
+    await writeCyclePlan(sessionRoot, "Cycle 002 plan.\n", "002");
+    await mkdir(path.join(sessionRoot, "steps", "cycle_002"), { recursive: true });
+    await writeFile(path.join(sessionRoot, "steps", "cycle_002", "plan_made"), "2026-05-11T00:00:00.000Z\nplan_made\n", "utf8");
+    await writeFile(path.join(sessionRoot, "steps", "cycle_002", "cycle_started"), "2026-05-11T00:00:00.000Z\ncycle_started\n", "utf8");
+    await writeFile(path.join(sessionRoot, "active_cycle"), "002\n", "utf8");
+    await mkdir(path.join(sessionRoot, "prompts"), { recursive: true });
+    await writeFile(path.join(sessionRoot, "prompts", "cycle_002_plan_request.md"), "Cycle 002 prompt.\n", "utf8");
+    await mkdir(path.join(sessionRoot, "checks"), { recursive: true });
+    await writeFile(path.join(sessionRoot, "checks", "automated_checks_run.json"), "{\"stepId\":\"automated_checks_run\"}\n", "utf8");
+    await mkdir(path.join(sessionRoot, "ui_checks"), { recursive: true });
+    await writeFile(path.join(sessionRoot, "ui_checks", "deep_ui_check_run.json"), "{\"stepId\":\"deep_ui_check_run\"}\n", "utf8");
+    await mkdir(path.join(sessionRoot, "cycles", "cycle_002"), { recursive: true });
+    await writeFile(path.join(sessionRoot, "cycles", "cycle_002", "rework_request.md"), "Fix the result.\n", "utf8");
+    await writeFile(path.join(sessionRoot, "changes_committed.json"), "{\"commit\":\"abc123\"}\n", "utf8");
+    await writeFile(path.join(sessionRoot, "final_report.md"), "Final report.\n", "utf8");
+
+    const rewound = await rewindSession({
+      targetRoot: appRoot,
+      sessionId: created.sessionId,
+      stepId: "plan_made"
+    });
+    assert.equal(rewound.ok, true);
+    assert.equal(rewound.status, "pending");
+    assert.equal(rewound.currentStep, "plan_made");
+    assert.equal(rewound.currentStepAction.stepId, "plan_made");
+    assert.equal(rewound.activeCycle, "001");
+    assert.deepEqual(rewound.cycles.map((cycle) => cycle.cycle), ["001"]);
+    assert.deepEqual(rewound.checks, []);
+    assert.deepEqual(rewound.uiChecks, []);
+    assert.deepEqual(rewound.reviewPasses, []);
+    assert.equal(rewound.planText, "");
+    assert.equal(rewound.prompt, "");
+    assert.deepEqual(rewound.completedSteps, [
+      "session_created",
+      "worktree_created",
+      "dependencies_installed",
+      "issue_prompt_rendered",
+      "issue_drafted",
+      "issue_created",
+      "issue_details_gathered"
+    ]);
+
+    await assert.rejects(access(path.join(sessionRoot, "steps", "cycle_001")));
+    await assert.rejects(access(path.join(sessionRoot, "steps", "cycle_002")));
+    await assert.rejects(access(path.join(sessionRoot, "cycles", "cycle_001")));
+    await assert.rejects(access(path.join(sessionRoot, "cycles", "cycle_002")));
+    await assert.rejects(access(path.join(sessionRoot, "checks")));
+    await assert.rejects(access(path.join(sessionRoot, "ui_checks")));
+    await assert.rejects(access(path.join(sessionRoot, "review_passes")));
+    await assert.rejects(access(path.join(sessionRoot, "changes_committed.json")));
+    await assert.rejects(access(path.join(sessionRoot, "final_report.md")));
+    assert.equal(await readFile(path.join(sessionRoot, "issue_details.md"), "utf8"), "Issue details.\n");
+  });
+});
+
+test("jskit session rewind rejects disallowed, incomplete, and closed targets without mutation", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "app");
+    await createGitApp(appRoot);
+
+    const created = parseJsonResult(runCli({
+      cwd: appRoot,
+      args: ["session", "create", "--json"]
+    }));
+    advanceCliSessionToIssuePrompt(appRoot, created.sessionId);
+    const sessionRoot = created.sessionRoot;
+    await writeStepReceipts(sessionRoot, ["plan_made", "plan_executed"]);
+
+    const disallowed = rewindSessionJsonFailure(appRoot, created.sessionId, "plan_executed");
+    assert.equal(disallowed.errors[0].code, "rewind_step_not_allowed");
+    assert.equal(await readFile(path.join(sessionRoot, "steps", "cycle_001", "plan_executed"), "utf8").then((body) => body.includes("plan_executed")), true);
+
+    const incomplete = rewindSessionJsonFailure(appRoot, created.sessionId, "issue_created");
+    assert.equal(incomplete.errors[0].code, "rewind_step_not_completed");
+
+    await writeFile(path.join(sessionRoot, "status"), "finished\n", "utf8");
+    const closed = rewindSessionJsonFailure(appRoot, created.sessionId, "dependencies_installed");
+    assert.equal(closed.errors[0].code, "session_closed_read_only");
+    await access(path.join(sessionRoot, "steps", "dependencies_installed"));
   });
 });
 
@@ -831,11 +1010,15 @@ test("session prompts reference canonical session artifacts", async () => {
   assert.match(prompts["plan_issue.md"], /agent_decisions\.md/);
   assert.match(prompts["execute_plan.md"], /issue_details\.md/);
   assert.match(prompts["execute_plan.md"], /agent_decisions/);
+  assert.match(prompts["execute_plan.md"], /verify-ui` does not start the app server/);
   assert.ok(!Object.hasOwn(prompts, "fine_tune_plan.md"));
   assert.match(prompts["review_changes.md"], /\.jskit\/helper-map\.md/);
+  assert.match(prompts["review_changes.md"], /verify-ui` does not start the app server/);
+  assert.match(prompts["deep_ui_check.md"], /verify-ui` does not start the app server/);
   assert.match(prompts["resolve_deslop_findings.md"], /\[resolve_deslop_findings\]/);
   assert.match(prompts["update_blueprint.md"], /\.jskit\/APP_BLUEPRINT\.md/);
   assert.match(prompts["update_blueprint.md"], /agent_decisions\.md/);
+  assert.match(prompts["prepare_pr_merge.md"], /Do not merge the pull request/);
 });
 
 test("jskit session step creates worktree and issue prompt", async () => {
@@ -2367,9 +2550,11 @@ test("jskit session can execute review loop, PR, merge, cleanup, and finish", as
     assert.equal(finalReport.githubComments.final_report.purpose, "final_report");
     const pr = runSessionStepJson(appRoot, created.sessionId, { env });
     assert.equal(pr.prUrl, "https://github.com/example/repo/pull/456");
-    assert.equal(pr.currentStep, "pr_finalized");
-    assert.equal(pr.currentStepAction.buttonLabel, "Merge PR");
+    assert.equal(pr.currentStep, "pr_merge_prepared");
+    assert.equal(pr.currentStepAction.buttonLabel, "Continue to merge");
     assert.equal(pr.currentStepAction.requiresExplicitRun, true);
+    assert.equal(pr.currentStepAction.utilityActions[0].id, "prepare_pr_merge");
+    assert.equal(pr.currentStepAction.utilityActions[0].label, "Get Codex ready to merge PR");
     const helperMap = JSON.parse(await readFile(path.join(inspect.worktree, ".jskit", "helper-map.json"), "utf8"));
     assert.ok(helperMap.app.files.some((file) => {
       return file.path === "src/lib/formatFeatureTitle.js" &&
@@ -2377,6 +2562,29 @@ test("jskit session can execute review loop, PR, merge, cleanup, and finish", as
     }));
     assert.match(runGit(inspect.worktree, ["log", "--oneline", "--max-count=3"]), /Update JSKIT helper map/);
     assert.match(runGit(inspect.worktree, ["show", `origin/${pr.branch}:.jskit/helper-map.md`]), /formatFeatureTitle/);
+    const prepareDecisionRequired = runSessionStepJsonFailure(appRoot, created.sessionId, { env });
+    assert.equal(prepareDecisionRequired.errors[0].code, "pr_merge_prepare_decision_required");
+    const mergePrepPrompt = runSessionStepJson(appRoot, created.sessionId, {
+      args: ["--prepare-merge", "true"],
+      env
+    });
+    assert.equal(mergePrepPrompt.currentStep, "pr_merge_prepared");
+    assert.equal(mergePrepPrompt.status, "waiting_for_user");
+    assert.match(mergePrepPrompt.prompt, /Prepare the JSKIT session pull request for merge/);
+    assert.doesNotMatch(mergePrepPrompt.prompt, /\[jskit_step_result\]/);
+    assert.equal(Object.hasOwn(mergePrepPrompt.codex, "responseContract"), false);
+    await access(inspect.worktree);
+    await assert.rejects(access(path.join(pr.sessionRoot, "steps", "pr_merge_prepared")));
+    const mergeDecision = runSessionStepJson(appRoot, created.sessionId, {
+      args: ["--continue-to-merge", "true"],
+      env
+    });
+    assert.equal(mergeDecision.currentStep, "pr_finalized");
+    assert.equal(mergeDecision.currentStepAction.buttonLabel, "Merge PR");
+    assert.equal(mergeDecision.currentStepAction.alternateActions[0].id, "skip_merge");
+    assert.equal(mergeDecision.currentStepAction.alternateActions[0].label, "Skip merge");
+    assert.deepEqual(mergeDecision.currentStepAction.alternateActions[0].input, { type: "none" });
+    await access(path.join(pr.sessionRoot, "steps", "pr_merge_prepared"));
     const mergeDecisionRequired = runSessionStepJsonFailure(appRoot, created.sessionId, { env });
     assert.equal(mergeDecisionRequired.errors[0].code, "pr_finalize_decision_required");
     const merged = runSessionStepJson(appRoot, created.sessionId, {
@@ -2385,11 +2593,12 @@ test("jskit session can execute review loop, PR, merge, cleanup, and finish", as
     });
     assert.equal(merged.currentStep, "session_finished");
     assert.equal(merged.prOutcome.outcome, "merged");
+    await access(inspect.worktree);
+    const finished = runSessionStepJson(appRoot, created.sessionId, { env });
+    assertSessionContractFields(finished);
     assert.equal(await readFile(path.join(appRoot, "feature.txt"), "utf8"), "hello\\n");
     assert.match(await readFile(path.join(appRoot, ".jskit", "helper-map.md"), "utf8"), /formatFeatureTitle/);
     await assert.rejects(access(inspect.worktree));
-    const finished = runSessionStepJson(appRoot, created.sessionId, { env });
-    assertSessionContractFields(finished);
 
     assert.equal(finished.status, "finished");
     assert.equal(finished.currentStep, "");
@@ -2418,6 +2627,7 @@ test("jskit session can execute review loop, PR, merge, cleanup, and finish", as
     const commandLog = await readFile(path.join(finished.sessionRoot, "command_log.jsonl"), "utf8");
     assert.match(commandLog, /"kind":"dependencies_install"/);
     assert.match(commandLog, /"kind":"github_pr_create"/);
+    assert.match(commandLog, /"kind":"github_pr_view"/);
     assert.match(commandLog, /"kind":"github_pr_merge"/);
     await assert.rejects(access(path.join(appRoot, ".jskit", "sessions", "active", created.sessionId)));
     const listed = parseJsonResult(runCli({ cwd: appRoot, args: ["session", "--json"], env }));
@@ -2433,6 +2643,7 @@ test("jskit session can execute review loop, PR, merge, cleanup, and finish", as
     assert.match(log, /gh pr create/);
     assert.match(log, /gh pr view https:\/\/github\.com\/example\/repo\/pull\/456 --json state,mergedAt,url,baseRefName/);
     assert.match(log, /gh pr merge https:\/\/github\.com\/example\/repo\/pull\/456 --merge --delete-branch/);
+    assert.match(log, /gh issue close https:\/\/github\.com\/example\/repo\/issues\/123/);
     assert.match(log, /gh issue comment https:\/\/github\.com\/example\/repo\/issues\/123 --body-file/);
   });
 });
@@ -2465,7 +2676,7 @@ test("jskit session reuses an existing current-branch PR during PR creation", as
     await writeStepReceipts(session.sessionRoot, STEP_IDS.slice(0, STEP_IDS.indexOf("pr_created")));
 
     const pr = runSessionStepJson(appRoot, created.sessionId, { env });
-    assert.equal(pr.currentStep, "pr_finalized");
+    assert.equal(pr.currentStep, "pr_merge_prepared");
     assert.equal(pr.prUrl, existingPrUrl);
     assert.match(await readFile(path.join(session.sessionRoot, "steps", "pr_created"), "utf8"), /reused existing PR/);
     const log = await readFile(logPath, "utf8");
@@ -2476,7 +2687,7 @@ test("jskit session reuses an existing current-branch PR during PR creation", as
   });
 });
 
-test("jskit session treats an already-merged PR as merged and removes the worktree", async () => {
+test("jskit session treats an already-merged PR as merged before final cleanup", async () => {
   await withTempDir(async (cwd) => {
     const appRoot = path.join(cwd, "app");
     const binDir = path.join(cwd, "bin");
@@ -2523,7 +2734,7 @@ process.exit(1);
     assert.equal(merged.currentStep, "session_finished");
     assert.ok(merged.completedSteps.includes("pr_finalized"));
     assert.equal(merged.prOutcome.outcome, "merged");
-    await assert.rejects(access(worktreePayload.worktree));
+    await access(worktreePayload.worktree);
     const log = await readFile(logPath, "utf8");
     assert.match(log, /gh pr view https:\/\/github\.com\/example\/repo\/pull\/456 --json state,mergedAt,url,baseRefName/);
     assert.doesNotMatch(log, /gh pr merge/);
@@ -2531,7 +2742,7 @@ process.exit(1);
   });
 });
 
-test("jskit session blocks PR merge cleanup when the target root is dirty", async () => {
+test("jskit session blocks final cleanup when the target root is dirty", async () => {
   await withTempDir(async (cwd) => {
     const appRoot = path.join(cwd, "app");
     const binDir = path.join(cwd, "bin");
@@ -2568,14 +2779,19 @@ process.exit(1);
     await writeIssueMetadata(worktreePayload.sessionRoot);
     await writeFile(path.join(appRoot, "local-change.txt"), "dirty\n", "utf8");
 
-    const blocked = parseJsonFailure(runCli({ cwd: appRoot, args: ["session", created.sessionId, "step", "--merge-pr", "true", "--json"], env }));
+    const merged = parseJsonResult(runCli({ cwd: appRoot, args: ["session", created.sessionId, "step", "--merge-pr", "true", "--json"], env }));
+    assert.equal(merged.currentStep, "session_finished");
+    assert.ok(merged.completedSteps.includes("pr_finalized"));
+
+    const blocked = parseJsonFailure(runCli({ cwd: appRoot, args: ["session", created.sessionId, "step", "--json"], env }));
     assert.equal(blocked.errors[0].code, "target_root_dirty");
     await access(worktreePayload.worktree);
-    await assert.rejects(access(path.join(worktreePayload.sessionRoot, "steps", "pr_finalized")));
+    await access(path.join(worktreePayload.sessionRoot, "steps", "pr_finalized"));
+    await assert.rejects(access(path.join(worktreePayload.sessionRoot, "steps", "session_finished")));
     const log = await readFile(logPath, "utf8");
     assert.match(log, /gh pr view https:\/\/github\.com\/example\/repo\/pull\/456 --json state,mergedAt,url,baseRefName/);
     assert.doesNotMatch(log, /gh pr merge/);
-    assert.doesNotMatch(log, /gh issue close/);
+    assert.match(log, /gh issue close https:\/\/github\.com\/example\/repo\/issues\/123/);
   });
 });
 
@@ -2600,28 +2816,22 @@ test("jskit session can finish successfully without merging the PR", async () =>
     await writeFile(path.join(worktreePayload.sessionRoot, "pr_url"), "https://github.com/example/repo/pull/456\n", "utf8");
     await writeIssueMetadata(worktreePayload.sessionRoot);
 
-    const missingReason = parseJsonFailure(runCli({
-      cwd: appRoot,
-      args: ["session", created.sessionId, "step", "--close-without-merge", "--json"],
-      env
-    }));
-    assert.equal(missingReason.errors[0].code, "close_without_merge_reason_required");
-
     const closed = parseJsonResult(runCli({
       cwd: appRoot,
-      args: ["session", created.sessionId, "step", "--close-without-merge", "--close-reason", "Prototype not approved for merge.", "--json"],
+      args: ["session", created.sessionId, "step", "--skip-merge", "--json"],
       env
     }));
     assert.equal(closed.currentStep, "session_finished");
     assert.equal(closed.prOutcome.outcome, "closed_without_merge");
-    assert.equal(closed.prOutcome.reason, "Prototype not approved for merge.");
-    await assert.rejects(access(worktreePayload.worktree));
+    assert.equal(closed.prOutcome.reason, "User skipped merge in JSKIT Studio.");
+    await access(worktreePayload.worktree);
 
     const finished = parseJsonResult(runCli({ cwd: appRoot, args: ["session", created.sessionId, "step", "--json"], env }));
     assertSessionContractFields(finished);
     assert.equal(finished.status, "finished");
     assert.equal(finished.archive, "completed");
     assert.equal(finished.prOutcome.outcome, "closed_without_merge");
+    await assert.rejects(access(worktreePayload.worktree));
 
     const log = await readFile(logPath, "utf8");
     assert.match(log, /gh pr comment https:\/\/github\.com\/example\/repo\/pull\/456 --body JSKIT session/);


### PR DESCRIPTION
## Summary
- add a manual PR merge-prep step before the merge decision in JSKIT sessions
- defer worktree cleanup and local base updates until session finish
- add session rewind support and expand session command coverage
- refresh package/catalog metadata for the CLI change

## Tests
- npm --workspace tooling/jskit-cli test
- git diff --check