### PR TITLE
Add session main sync and devlink hooks

### DIFF
--- a/packages/agent-docs/reference/autogen/tooling/jskit-cli.md
+++ b/packages/agent-docs/reference/autogen/tooling/jskit-cli.md
@@ -859,6 +859,15 @@ Local functions
 - `commandOutputSummary(output = "")`
 - `appendCommandLog(paths, { args = [], command, cwd = "", kind = "command", result } = {})`
 - `runLoggedCommand(paths, kind, command, args = [], options = {})`
+- `readWorktreePackageJson(worktree)`
+- `packageScriptRunArgs(packageManager, scriptName)`
+- `packageScriptCommandForWorktree(worktree, scriptName, { preferredPackageManager = "" } = {})`
+- `sessionPackageScriptEnv(paths, scriptName)`
+- `packageScriptRepairCommand(paths, command, args)`
+- `packageScriptReceiptName(scriptName)`
+- `writeSessionHookReceipt(paths, scriptName, message)`
+- `runOptionalSessionPackageScript(paths, { failureCode, failureMessage, kind, preferredPackageManager = "", preconditions = [], scriptName, timeout = 1000 * 60 * 10 } = {})`
+- `runSessionFinalizationGuard(paths, preconditions = [])`
 - `readIssueMetadata(paths)`
 - `writeIssueMetadata(paths, metadata = {})`
 - `readGithubComments(paths)`
@@ -939,8 +948,11 @@ Local functions
 - `assertTargetRootCleanForBaseUpdate(paths)`
 - `removeSessionWorktree(paths)`
 - `writePrOutcome(paths, outcome)`
+- `mainCheckoutSyncPath(paths)`
+- `writeMainCheckoutSync(paths, payload = {})`
 - `assertTargetRootCanUpdateBase(paths, branch)`
 - `updateLocalBaseBranch(paths, baseBranch = "")`
+- `syncMainCheckout(paths, options = {}, context = {})`
 - `updateHelperMapBeforePr(paths)`
 - `createPr(paths)`
 - `closePrWithoutMerge(paths, prUrl, options = {})`
@@ -1029,6 +1041,7 @@ Exports
 - `assertIssueUrlExists(paths)`
 - `assertAutomatedChecksPassed(paths)`
 - `assertIssueDetailsExists(paths)`
+- `assertMainCheckoutSyncSatisfied(paths)`
 - `assertPlanTextExists(paths)`
 - `assertPrUrlExists(paths)`
 - `assertReadyJskitApp(paths)`

--- a/tooling/create-app/templates/base-shell/package.json
+++ b/tooling/create-app/templates/base-shell/package.json
@@ -13,6 +13,7 @@
     "server:home": "SERVER_SURFACE=home node ./bin/server.js",
     "start": "node ./bin/server.js",
     "devlinks": "jskit app link-local-packages",
+    "postinstall": "bash scripts/devel-link-local-packages-postinstall.sh",
     "dev": "vite",
     "dev:all": "vite",
     "dev:home": "VITE_SURFACE=home vite",

--- a/tooling/create-app/templates/base-shell/scripts/devel-link-local-packages-postinstall.sh
+++ b/tooling/create-app/templates/base-shell/scripts/devel-link-local-packages-postinstall.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Development-only postinstall hook.
+# Normal installs no-op. Set JSKIT_DEVLINKS to opt into local JSKIT package
+# links, for example:
+#   JSKIT_DEVLINKS=/path/to/jskit-ai npm install
+#   JSKIT_DEVLINKS=1 JSKIT_AI_ROOT=/path/to/jskit-ai npm install
+
+SCRIPT_NAME="devel-link-local-packages-postinstall"
+
+log() {
+  printf '[%s] %s\n' "$SCRIPT_NAME" "$*" >&2
+}
+
+fail() {
+  printf '[%s] ERROR: %s\n' "$SCRIPT_NAME" "$*" >&2
+  exit 1
+}
+
+devlinks_value="${JSKIT_DEVLINKS-}"
+case "$devlinks_value" in
+  "" | "0" | "false" | "False" | "FALSE" | "no" | "No" | "NO" | "off" | "Off" | "OFF")
+    log "JSKIT_DEVLINKS is not set; skipping local JSKIT package links."
+    exit 0
+    ;;
+esac
+
+repo_root=""
+case "$devlinks_value" in
+  "1" | "true" | "True" | "TRUE" | "yes" | "Yes" | "YES" | "on" | "On" | "ON" | "auto" | "Auto" | "AUTO")
+    repo_root="${JSKIT_AI_ROOT-}"
+    ;;
+  *)
+    repo_root="$devlinks_value"
+    ;;
+esac
+
+if [ -z "$repo_root" ]; then
+  fail "JSKIT_DEVLINKS is enabled, but no repo root was provided. Set JSKIT_DEVLINKS=/path/to/jskit-ai or JSKIT_AI_ROOT=/path/to/jskit-ai."
+fi
+
+if ! git -C "$repo_root" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  fail "JSKIT_DEVLINKS repo root is not a git work tree: $repo_root"
+fi
+
+repo_root="$(cd "$repo_root" && pwd -P)"
+log "Linking local JSKIT packages from $repo_root."
+npx --no-install jskit app link-local-packages --repo-root "$repo_root"

--- a/tooling/create-app/templates/base-shell/tests/server/minimalShell.validator.test.js
+++ b/tooling/create-app/templates/base-shell/tests/server/minimalShell.validator.test.js
@@ -10,6 +10,7 @@ const APP_ROOT = path.resolve(__dirname, "../..");
 
 const EXPECTED_MANAGED_SCRIPTS = Object.freeze({
   devlinks: "jskit app link-local-packages",
+  postinstall: "bash scripts/devel-link-local-packages-postinstall.sh",
   verify: "jskit app verify && npm run --if-present verify:app",
   release: "jskit app release",
   "jskit:update": "jskit app update-packages"

--- a/tooling/create-app/test/createApp.test.js
+++ b/tooling/create-app/test/createApp.test.js
@@ -120,7 +120,7 @@ test("create-app scaffolds the base shell with placeholder replacements", async 
     assert.equal(packageJson.name, "sample-app");
     assert.equal(packageJson.scripts.preinstall, undefined);
     assert.equal(packageJson.scripts["verdaccio:reset:publish"], undefined);
-    assert.equal(packageJson.scripts.postinstall, undefined);
+    assert.equal(packageJson.scripts.postinstall, "bash scripts/devel-link-local-packages-postinstall.sh");
     assert.equal(packageJson.scripts["dev:all"], "vite");
     assert.equal(packageJson.scripts["dev:home"], "VITE_SURFACE=home vite");
     assert.equal(packageJson.scripts["dev:console"], undefined);
@@ -158,6 +158,10 @@ test("create-app scaffolds the base shell with placeholder replacements", async 
     assert.equal(packageJson.dependencies.pinia, "^3.0.4");
     assert.equal(packageJson.dependencies["@tanstack/vue-query"], "^5.90.5");
     assert.equal(packageJson.devDependencies["@playwright/test"], "^1.57.0");
+    const devlinkPostinstall = await readFile(path.join(appRoot, "scripts/devel-link-local-packages-postinstall.sh"), "utf8");
+    assert.match(devlinkPostinstall, /JSKIT_DEVLINKS is not set; skipping local JSKIT package links/);
+    assert.match(devlinkPostinstall, /npx --no-install jskit app link-local-packages --repo-root "\$repo_root"/);
+    assert.doesNotMatch(devlinkPostinstall, /Development\/current\/jskit-ai/);
     await assert.rejects(access(path.join(appRoot, "scripts/copy-local-packages.sh")), /ENOENT/);
     await assert.rejects(access(path.join(appRoot, "scripts/link-local-jskit-packages.sh")), /ENOENT/);
     await assert.rejects(access(path.join(appRoot, "scripts/release.sh")), /ENOENT/);

--- a/tooling/jskit-cli/src/server/commandHandlers/session.js
+++ b/tooling/jskit-cli/src/server/commandHandlers/session.js
@@ -320,6 +320,7 @@ function normalizeStepOptions(inlineOptions = {}) {
     mergePr: inlineOptions["merge-pr"] === "true" || inlineOptions.mergePr === true,
     prompt: inlineOptions.prompt,
     reviewFindings: inlineOptions["review-findings"] || inlineOptions.reviewFindings,
+    skipMainSync: inlineOptions["skip-main-sync"] === "true" || inlineOptions.skipMainSync === true,
     skipUiCheck: inlineOptions["skip-ui-check"] === "true" || inlineOptions.skipUiCheck === true,
     userCheck: inlineOptions["user-check"] || inlineOptions.userCheck
   };

--- a/tooling/jskit-cli/src/server/core/argParser.js
+++ b/tooling/jskit-cli/src/server/core/argParser.js
@@ -149,6 +149,10 @@ function parseArgs(argv, { createCliError } = {}) {
       options.inlineOptions["skip-merge"] = "true";
       continue;
     }
+    if (token === "--skip-main-sync") {
+      options.inlineOptions["skip-main-sync"] = "true";
+      continue;
+    }
 
     if (token.startsWith("--")) {
       const withoutPrefix = token.slice(2);

--- a/tooling/jskit-cli/src/server/core/commandCatalog.js
+++ b/tooling/jskit-cli/src/server/core/commandCatalog.js
@@ -237,6 +237,7 @@ const COMMAND_DESCRIPTORS = Object.freeze({
       "Use --continue-to-merge true when the user decides to advance from preparation to merge decision.",
       "Use --merge-pr true at PR finalization to merge the pull request.",
       "Use --skip-merge at PR finalization to complete the session without merging.",
+      "Use --skip-main-sync at Main checkout synced to explicitly leave the main checkout untouched.",
       "Run the blueprint step once to render its Codex prompt, then again after Codex updates .jskit/APP_BLUEPRINT.md."
     ]),
     examples: Object.freeze([
@@ -259,6 +260,7 @@ const COMMAND_DESCRIPTORS = Object.freeze({
           "jskit session 2026-05-11_21-42-08 step --continue-to-merge true",
           "jskit session 2026-05-11_21-42-08 step --merge-pr true",
           "jskit session 2026-05-11_21-42-08 step --skip-merge",
+          "jskit session 2026-05-11_21-42-08 step --skip-main-sync",
           "jskit session 2026-05-11_21-42-08 step --user-check failed --rework-notes -",
           "jskit session 2026-05-11_21-42-08 rewind --step plan_made --json",
           "jskit session 2026-05-11_21-42-08 diff --json"
@@ -266,7 +268,7 @@ const COMMAND_DESCRIPTORS = Object.freeze({
       })
     ]),
     fullUse:
-      "jskit session [create|<sessionId>] [step|diff|rewind|abandon|adopt-codex-thread] [--step <step_id>] [--prompt <text>] [--issue-title <text>|--issue-title-file <path>] [--issue <text>|--issue-file <path>] [--issue-details <text>|--issue-details-file <path>] [--plan <text>|--plan-file <path>] [--codex-result <text>|--codex-result-file <path>] [--agent-decisions <text>|--agent-decisions-file <path>] [--review-findings-remaining true --review-findings <text>|--review-findings-remaining false] [--skip-ui-check --skip-reason <text>] [--prepare-merge true|--continue-to-merge true|--merge-pr true|--skip-merge] [--user-check <passed|failed>] [--rework-notes <text>|--rework-notes-file <path>] [--codex-thread-id <id>] [--abandoned|--completed|--all] [--json]",
+      "jskit session [create|<sessionId>] [step|diff|rewind|abandon|adopt-codex-thread] [--step <step_id>] [--prompt <text>] [--issue-title <text>|--issue-title-file <path>] [--issue <text>|--issue-file <path>] [--issue-details <text>|--issue-details-file <path>] [--plan <text>|--plan-file <path>] [--codex-result <text>|--codex-result-file <path>] [--agent-decisions <text>|--agent-decisions-file <path>] [--review-findings-remaining true --review-findings <text>|--review-findings-remaining false] [--skip-ui-check --skip-reason <text>] [--prepare-merge true|--continue-to-merge true|--merge-pr true|--skip-merge|--skip-main-sync] [--user-check <passed|failed>] [--rework-notes <text>|--rework-notes-file <path>] [--codex-thread-id <id>] [--abandoned|--completed|--all] [--json]",
     showHelpOnBareInvocation: false,
     handlerName: "commandSession",
     allowedFlagKeys: Object.freeze(["json", "abandoned", "completed", "all"]),

--- a/tooling/jskit-cli/src/server/sessionRuntime.js
+++ b/tooling/jskit-cli/src/server/sessionRuntime.js
@@ -80,6 +80,7 @@ import {
   assertIssueUrlExists,
   assertAutomatedChecksPassed,
   assertIssueDetailsExists,
+  assertMainCheckoutSyncSatisfied,
   assertPlanTextExists,
   assertPrUrlExists,
   assertReadyJskitApp,
@@ -97,6 +98,9 @@ import {
   HELPER_MAP_JSON_RELATIVE_PATH,
   HELPER_MAP_MARKDOWN_RELATIVE_PATH
 } from "./helperMapPaths.js";
+
+const SESSION_PROVISION_PACKAGE_SCRIPT = "jskit:provision-session";
+const SESSION_FINALIZATION_GUARD_PACKAGE_SCRIPT = "jskit:finalization-guard";
 
 function invalidSessionIdError(sessionId = "") {
   return createError({
@@ -355,6 +359,125 @@ async function runLoggedCommand(paths, kind, command, args = [], options = {}) {
     result
   });
   return result;
+}
+
+async function readWorktreePackageJson(worktree) {
+  const source = await readTextIfExists(path.join(worktree, "package.json"));
+  if (!source) {
+    return {};
+  }
+  try {
+    const parsed = JSON.parse(source);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function packageScriptRunArgs(packageManager, scriptName) {
+  if (packageManager === "pnpm") {
+    return ["pnpm", ["run", scriptName]];
+  }
+  if (packageManager === "yarn") {
+    return ["yarn", ["run", scriptName]];
+  }
+  if (packageManager === "bun") {
+    return ["bun", ["run", scriptName]];
+  }
+  return ["npm", ["run", "--silent", scriptName]];
+}
+
+async function packageScriptCommandForWorktree(worktree, scriptName, {
+  preferredPackageManager = ""
+} = {}) {
+  const packageJson = await readWorktreePackageJson(worktree);
+  const script = packageJson?.scripts?.[scriptName];
+  if (typeof script !== "string" || !normalizeText(script)) {
+    return null;
+  }
+  const packageManager = preferredPackageManager || (await dependencyInstallCommandForWorktree(worktree))[0];
+  const [command, args] = packageScriptRunArgs(packageManager, scriptName);
+  return {
+    args,
+    command
+  };
+}
+
+function sessionPackageScriptEnv(paths, scriptName) {
+  return {
+    JSKIT_SESSION_ID: paths.sessionId,
+    JSKIT_SESSION_PACKAGE_SCRIPT: scriptName,
+    JSKIT_SESSION_ROOT: paths.sessionRoot,
+    JSKIT_TARGET_ROOT: paths.targetRoot,
+    JSKIT_WORKTREE_ROOT: paths.worktree
+  };
+}
+
+function packageScriptRepairCommand(paths, command, args) {
+  return `cd ${paths.worktree} && ${command} ${args.join(" ")}`;
+}
+
+function packageScriptReceiptName(scriptName) {
+  return normalizeText(scriptName).replace(/[^a-zA-Z0-9._-]+/gu, "_");
+}
+
+async function writeSessionHookReceipt(paths, scriptName, message) {
+  await writeTextFile(
+    path.join(paths.sessionRoot, "hooks", packageScriptReceiptName(scriptName)),
+    `${timestampForReceipt()}\n${normalizeText(message) || `${scriptName} completed.`}`
+  );
+}
+
+async function runOptionalSessionPackageScript(paths, {
+  failureCode,
+  failureMessage,
+  kind,
+  preferredPackageManager = "",
+  preconditions = [],
+  scriptName,
+  timeout = 1000 * 60 * 10
+} = {}) {
+  const scriptCommand = await packageScriptCommandForWorktree(paths.worktree, scriptName, {
+    preferredPackageManager
+  });
+  if (!scriptCommand) {
+    return {
+      ok: true,
+      ran: false
+    };
+  }
+  const result = await runLoggedCommand(paths, kind, scriptCommand.command, scriptCommand.args, {
+    cwd: paths.worktree,
+    env: sessionPackageScriptEnv(paths, scriptName),
+    timeout
+  });
+  if (!result.ok) {
+    return {
+      ok: false,
+      response: await failSession(paths, {
+        code: failureCode,
+        message: result.output || failureMessage,
+        preconditions,
+        repairCommand: packageScriptRepairCommand(paths, scriptCommand.command, scriptCommand.args)
+      })
+    };
+  }
+  await writeSessionHookReceipt(paths, scriptName, result.output || `${scriptName} completed.`);
+  return {
+    ok: true,
+    ran: true,
+    result
+  };
+}
+
+async function runSessionFinalizationGuard(paths, preconditions = []) {
+  return runOptionalSessionPackageScript(paths, {
+    failureCode: "session_finalization_guard_failed",
+    failureMessage: `${SESSION_FINALIZATION_GUARD_PACKAGE_SCRIPT} failed in the session worktree.`,
+    kind: "session_finalization_guard",
+    preconditions,
+    scriptName: SESSION_FINALIZATION_GUARD_PACKAGE_SCRIPT
+  });
 }
 
 async function readIssueMetadata(paths) {
@@ -822,8 +945,20 @@ async function installDependencies(paths, _options = {}, context = {}) {
       preconditions
     });
   }
+  const provisionResult = await runOptionalSessionPackageScript(paths, {
+    failureCode: "session_provision_failed",
+    failureMessage: `${SESSION_PROVISION_PACKAGE_SCRIPT} failed in the session worktree.`,
+    kind: "session_provision",
+    preferredPackageManager: command,
+    preconditions,
+    scriptName: SESSION_PROVISION_PACKAGE_SCRIPT
+  });
+  if (!provisionResult.ok) {
+    return provisionResult.response;
+  }
+  const installMessage = result.output || `Installed Node dependencies in the session worktree with ${command} ${args.join(" ")}.`;
   return recordDependenciesInstalled(paths, {
-    message: result.output || `Installed Node dependencies in the session worktree with ${command} ${args.join(" ")}.`,
+    message: provisionResult.ran ? `${installMessage}\n${SESSION_PROVISION_PACKAGE_SCRIPT} completed.` : installMessage,
     preconditions
   });
 }
@@ -1453,10 +1588,15 @@ const STEP_CANCELERS = Object.freeze({
       removeSessionRootFile(paths, "pr_outcome.json")
     ]);
   },
+  main_checkout_synced: async (paths) => {
+    await Promise.all([
+      removeSessionRootFile(paths, "local_base_updated"),
+      removeSessionRootFile(paths, "main_checkout_sync.json")
+    ]);
+  },
   session_finished: async (paths) => {
     await Promise.all([
-      removeSessionRootFile(paths, "final_comment.md"),
-      removeSessionRootFile(paths, "local_base_updated")
+      removeSessionRootFile(paths, "final_comment.md")
     ]);
   }
 });
@@ -2442,6 +2582,17 @@ async function writePrOutcome(paths, outcome) {
   }, null, 2)}\n`);
 }
 
+function mainCheckoutSyncPath(paths) {
+  return path.join(paths.sessionRoot, "main_checkout_sync.json");
+}
+
+async function writeMainCheckoutSync(paths, payload = {}) {
+  await writeTextFile(mainCheckoutSyncPath(paths), `${JSON.stringify({
+    recordedAt: timestampForReceipt(),
+    ...payload
+  }, null, 2)}\n`);
+}
+
 async function assertTargetRootCanUpdateBase(paths, branch) {
   const cleanFailure = await assertTargetRootCleanForBaseUpdate(paths);
   if (cleanFailure) {
@@ -2500,6 +2651,54 @@ async function updateLocalBaseBranch(paths, baseBranch = "") {
 
   await writeTextFile(path.join(paths.sessionRoot, "local_base_updated"), `${branch}\n${pullResult.output}\n`);
   return null;
+}
+
+async function syncMainCheckout(paths, options = {}, context = {}) {
+  const prOutcome = parseJsonObject(await readTextIfExists(path.join(paths.sessionRoot, "pr_outcome.json")));
+  const preconditions = context.preconditions || [];
+  if (!prOutcome?.outcome) {
+    return failSession(paths, {
+      code: "pr_outcome_missing",
+      message: "Cannot sync the main checkout before PR finalization records an outcome.",
+      preconditions,
+      repairCommand: `jskit session ${paths.sessionId} step`
+    });
+  }
+
+  const skipRequested = options.skipMainSync === true ||
+    normalizeText(options["skip-main-sync"]).toLowerCase() === "true";
+  const skipReason = normalizeText(options.skipReason || options["skip-reason"]) ||
+    "User skipped main checkout sync.";
+  if (skipRequested || prOutcome.outcome !== "merged") {
+    const reason = prOutcome.outcome === "merged"
+      ? skipReason
+      : `PR outcome is ${prOutcome.outcome}; no main checkout sync is required.`;
+    await writeMainCheckoutSync(paths, {
+      branch: prOutcome.baseBranch || "",
+      outcome: prOutcome.outcome,
+      reason,
+      status: "skipped"
+    });
+    await writeReceipt(paths, "main_checkout_synced", `Main checkout sync skipped: ${reason}`);
+    await markStatus(paths, SESSION_STATUS.RUNNING);
+    return buildSessionResponse(paths);
+  }
+
+  const baseBranch = prOutcome.baseBranch || await readTrimmedFile(path.join(paths.sessionRoot, "pr_base_branch"));
+  const syncFailure = await updateLocalBaseBranch(paths, baseBranch);
+  if (syncFailure) {
+    return syncFailure;
+  }
+
+  const branch = normalizeText(baseBranch) || await currentTargetBranch(paths.targetRoot);
+  await writeMainCheckoutSync(paths, {
+    branch,
+    outcome: prOutcome.outcome,
+    status: "synced"
+  });
+  await writeReceipt(paths, "main_checkout_synced", `Fast-forwarded target checkout branch ${branch}.`);
+  await markStatus(paths, SESSION_STATUS.RUNNING);
+  return buildSessionResponse(paths);
 }
 
 async function updateHelperMapBeforePr(paths) {
@@ -2762,6 +2961,10 @@ async function finalizePr(paths, options = {}, context = {}) {
     options.skipMerge === true ||
     normalizeText(options["skip-merge"]).toLowerCase() === "true";
   if (closeWithoutMerge) {
+    const guardResult = await runSessionFinalizationGuard(paths, preconditions);
+    if (!guardResult.ok) {
+      return guardResult.response;
+    }
     return closePrWithoutMerge(paths, prUrl, options);
   }
   const mergePr = options.mergePr === true ||
@@ -2773,6 +2976,10 @@ async function finalizePr(paths, options = {}, context = {}) {
       repairCommand: `jskit session ${paths.sessionId} step --merge-pr true`,
       preconditions
     });
+  }
+  const guardResult = await runSessionFinalizationGuard(paths, preconditions);
+  if (!guardResult.ok) {
+    return guardResult.response;
   }
   const mergeMarkerPath = path.join(paths.sessionRoot, "pr_merge_completed");
   const baseBranchPath = path.join(paths.sessionRoot, "pr_base_branch");
@@ -2835,13 +3042,6 @@ async function finishSession(paths) {
   const issueUrl = await readTrimmedFile(path.join(paths.sessionRoot, "issue_url"));
   const codexThreadId = await readTrimmedFile(path.join(paths.sessionRoot, "codex_thread_id"));
   const prOutcome = parseJsonObject(await readTextIfExists(path.join(paths.sessionRoot, "pr_outcome.json")));
-  if (prOutcome?.outcome === "merged") {
-    const baseBranch = prOutcome.baseBranch || await readTrimmedFile(path.join(paths.sessionRoot, "pr_base_branch"));
-    const updateFailure = await updateLocalBaseBranch(paths, baseBranch);
-    if (updateFailure) {
-      return updateFailure;
-    }
-  }
   const removeFailure = await removeSessionWorktree(paths);
   if (removeFailure) {
     return removeFailure;
@@ -2898,6 +3098,7 @@ const STEP_RUNNERS = Object.freeze({
   pr_created: createPr,
   pr_merge_prepared: preparePrMerge,
   pr_finalized: finalizePr,
+  main_checkout_synced: syncMainCheckout,
   session_finished: finishSession
 });
 
@@ -2918,6 +3119,7 @@ const PRECONDITION_RUNNERS = Object.freeze({
   issue_url_exists: assertIssueUrlExists,
   automated_checks_passed: assertAutomatedChecksPassed,
   issue_details_exists: assertIssueDetailsExists,
+  main_checkout_sync_satisfied: assertMainCheckoutSyncSatisfied,
   plan_text_exists: assertPlanTextExists,
   pr_url_exists: assertPrUrlExists,
   ready_jskit_app: assertReadyJskitApp,

--- a/tooling/jskit-cli/src/server/sessionRuntime/constants.js
+++ b/tooling/jskit-cli/src/server/sessionRuntime/constants.js
@@ -537,11 +537,19 @@ const STEP_DEFINITIONS = Object.freeze([
     })
   }),
   defineStep({
+    buttonLabel: "Sync main checkout",
+    description: "JSKIT fast-forwards the main checkout after a merged PR, or records an explicit skip before cleanup.",
+    id: "main_checkout_synced",
+    label: "Main checkout synced",
+    preconditions: ["session_exists", "worktree_exists"],
+    requiresExplicitRun: true
+  }),
+  defineStep({
     buttonLabel: "Finish session",
-    description: "JSKIT updates the local base branch when needed, removes the session worktree, writes the final receipt, and archives the completed session.",
+    description: "JSKIT removes the session worktree, writes the final receipt, and archives the completed session.",
     id: "session_finished",
     label: "Worktree removed, session finished",
-    preconditions: ["session_exists"]
+    preconditions: ["session_exists", "main_checkout_sync_satisfied"]
   })
 ]);
 

--- a/tooling/jskit-cli/src/server/sessionRuntime/preconditions.js
+++ b/tooling/jskit-cli/src/server/sessionRuntime/preconditions.js
@@ -710,6 +710,33 @@ async function assertPrUrlExists(paths) {
   };
 }
 
+async function assertMainCheckoutSyncSatisfied(paths) {
+  const receiptPath = path.join(paths.sessionRoot, "steps", "main_checkout_synced");
+  if (await pathExists(receiptPath)) {
+    return {
+      ok: true,
+      precondition: createPrecondition({
+        id: "main_checkout_sync_satisfied",
+        ok: true,
+        message: "Main checkout sync has been completed or skipped."
+      })
+    };
+  }
+  return {
+    ok: false,
+    error: createError({
+      code: "main_checkout_sync_required",
+      message: "Main checkout sync must be completed or explicitly skipped before session cleanup.",
+      repairCommand: jskitCommand(`session ${paths.sessionId} step`)
+    }),
+    precondition: createPrecondition({
+      id: "main_checkout_sync_satisfied",
+      ok: false,
+      message: "Main checkout sync has been completed or skipped."
+    })
+  };
+}
+
 export {
   applyPreconditions,
   assertAcceptedChangesCommitted,
@@ -728,6 +755,7 @@ export {
   assertIssueUrlExists,
   assertAutomatedChecksPassed,
   assertIssueDetailsExists,
+  assertMainCheckoutSyncSatisfied,
   assertPlanTextExists,
   assertPrUrlExists,
   assertReadyJskitApp,

--- a/tooling/jskit-cli/src/server/sessionRuntime/responses.js
+++ b/tooling/jskit-cli/src/server/sessionRuntime/responses.js
@@ -590,7 +590,8 @@ function buildStepDefinitions() {
 function stepIsRetryableWhenBlocked(stepId) {
   return [
     "automated_checks_run",
-    "deep_ui_check_run"
+    "deep_ui_check_run",
+    "main_checkout_synced"
   ].includes(normalizeStepId(stepId));
 }
 
@@ -695,6 +696,21 @@ function buildCurrentStepAction(stepId, artifacts = {}) {
       targetStep: "pr_finalized"
     });
   }
+  if (step.id === "main_checkout_synced") {
+    alternateActions.push({
+      id: "skip_main_checkout_sync",
+      helpText: "Leave the main checkout untouched and continue with session cleanup.",
+      input: {
+        type: "none"
+      },
+      label: "Skip sync",
+      presentation: "secondary",
+      submitOptions: {
+        skipMainSync: true
+      },
+      targetStep: "main_checkout_synced"
+    });
+  }
   const dynamicButtonLabel = (() => {
     if (step.id === "plan_executed" && planExecutionPrompted && !planExecutionSubmitted) {
       return "Go to next step";
@@ -707,6 +723,9 @@ function buildCurrentStepAction(stepId, artifacts = {}) {
     }
     if (step.id === "plan_made" && planReworkMode && !artifacts.prompt && hasActiveReworkRequest) {
       return "Get Codex to create revised plan";
+    }
+    if (step.id === "main_checkout_synced" && artifacts.prOutcome?.outcome && artifacts.prOutcome.outcome !== "merged") {
+      return "Record no sync needed";
     }
     return buttonLabel;
   })();
@@ -722,6 +741,9 @@ function buildCurrentStepAction(stepId, artifacts = {}) {
     }
     if (step.id === "plan_made" && planReworkMode && hasActiveReworkRequest) {
       return "Codex writes a revised implementation plan from the user's rework notes for this cycle.";
+    }
+    if (step.id === "main_checkout_synced" && artifacts.prOutcome?.outcome && artifacts.prOutcome.outcome !== "merged") {
+      return "The PR was not merged, so JSKIT will record main checkout sync as skipped before cleanup.";
     }
     return step.description;
   })();
@@ -791,7 +813,8 @@ async function readSessionArtifacts(paths) {
     baseCommit,
     issueMetadataText,
     planExecutionReceipt,
-    prOutcomeText
+    prOutcomeText,
+    mainCheckoutSyncText
   ] = await Promise.all([
     readTrimmedFile(path.join(paths.sessionRoot, "status")),
     readTrimmedFile(path.join(paths.sessionRoot, "current_step")),
@@ -810,7 +833,8 @@ async function readSessionArtifacts(paths) {
     readTrimmedFile(path.join(paths.sessionRoot, "base_commit")),
     readTextIfExists(path.join(paths.sessionRoot, "issue_metadata.json")),
     readTextIfExists(path.join(cycleStepsRoot(paths, activeCycle), "plan_executed")),
-    readTextIfExists(path.join(paths.sessionRoot, "pr_outcome.json"))
+    readTextIfExists(path.join(paths.sessionRoot, "pr_outcome.json")),
+    readTextIfExists(path.join(paths.sessionRoot, "main_checkout_sync.json"))
   ]);
   let issueMetadata = null;
   if (issueMetadataText) {
@@ -836,6 +860,15 @@ async function readSessionArtifacts(paths) {
       prOutcome = parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : null;
     } catch {
       prOutcome = null;
+    }
+  }
+  let mainCheckoutSync = null;
+  if (mainCheckoutSyncText) {
+    try {
+      const parsed = JSON.parse(mainCheckoutSyncText);
+      mainCheckoutSync = parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : null;
+    } catch {
+      mainCheckoutSync = null;
     }
   }
   const cycles = await readCycles(paths, activeCycle);
@@ -915,6 +948,7 @@ async function readSessionArtifacts(paths) {
     nextStep,
     prUrl,
     prOutcome,
+    mainCheckoutSync,
     planExecution: {
       prompted: planExecutionPromptExists,
       promptPath: planExecutionPromptExists ? planExecutionPromptPath : "",
@@ -997,6 +1031,7 @@ async function buildSessionResponse(paths, {
       helperMapExists: artifacts.helperMapExists === true,
       prUrl: artifacts.prUrl || "",
       prOutcome: cloneContractValue(artifacts.prOutcome || null),
+      mainCheckoutSync: cloneContractValue(artifacts.mainCheckoutSync || null),
       preconditions,
       errors: [
         createError({
@@ -1063,6 +1098,7 @@ async function buildSessionResponse(paths, {
     helperMapExists: artifacts.helperMapExists === true,
     prUrl: artifacts.prUrl || "",
     prOutcome: cloneContractValue(artifacts.prOutcome || null),
+    mainCheckoutSync: cloneContractValue(artifacts.mainCheckoutSync || null),
     preconditions,
     errors,
     archive: responsePaths.archive || (resolvedStatus === SESSION_STATUS.FINISHED ? "completed" : resolvedStatus === SESSION_STATUS.ABANDONED ? "abandoned" : "active"),

--- a/tooling/jskit-cli/test/sessionCommand.test.js
+++ b/tooling/jskit-cli/test/sessionCommand.test.js
@@ -272,6 +272,17 @@ async function createPackageOnlyGitApp(root) {
   runGit(root, ["commit", "-m", "Initial commit"]);
 }
 
+async function addPackageScripts(root, scripts) {
+  const packageJsonPath = path.join(root, "package.json");
+  const packageJson = JSON.parse(await readFile(packageJsonPath, "utf8"));
+  packageJson.scripts = {
+    ...(packageJson.scripts || {}),
+    ...scripts
+  };
+  await writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`, "utf8");
+  runGit(root, ["add", "package.json"]);
+}
+
 async function writeStepReceipts(sessionRoot, stepIds) {
   await mkdir(path.join(sessionRoot, "steps"), { recursive: true });
   const steps = new Set(stepIds);
@@ -543,6 +554,9 @@ test("jskit session JSON exposes JSKIT-owned step UI and Codex handoff contract"
     assert.equal(created.stepDefinitions.find((step) => step.id === "pr_finalized").requiresExplicitRun, true);
     assert.equal(created.stepDefinitions.find((step) => step.id === "pr_finalized").label, "PR finalized");
     assert.equal(created.stepDefinitions.find((step) => step.id === "pr_finalized").kind, "automatic");
+    assert.equal(created.stepDefinitions.find((step) => step.id === "main_checkout_synced").requiresExplicitRun, true);
+    assert.equal(created.stepDefinitions.find((step) => step.id === "main_checkout_synced").label, "Main checkout synced");
+    assert.equal(created.stepDefinitions.find((step) => step.id === "main_checkout_synced").kind, "automatic");
     assert.equal(created.stepDefinitions.find((step) => step.id === "issue_details_gathered").label, "Issue details gathered");
     assert.equal(created.stepDefinitions.find((step) => step.id === "issue_details_gathered").input.label, "Confirmed issue details");
     assert.deepEqual(created.stepDefinitions.find((step) => step.id === "dependencies_installed").automation, { mode: "terminal" });
@@ -551,6 +565,7 @@ test("jskit session JSON exposes JSKIT-owned step UI and Codex handoff contract"
     assert.deepEqual(created.stepDefinitions.find((step) => step.id === "plan_executed").automation, { mode: "codex_prompt" });
     assert.deepEqual(created.stepDefinitions.find((step) => step.id === "pr_merge_prepared").automation, { mode: "manual" });
     assert.deepEqual(created.stepDefinitions.find((step) => step.id === "pr_finalized").automation, { mode: "manual" });
+    assert.deepEqual(created.stepDefinitions.find((step) => step.id === "main_checkout_synced").automation, { mode: "manual" });
     assert.equal(created.stepDefinitions.find((step) => step.id === "review_prompt_rendered").codex.responseContract.resolvePrompt.templateFile, "resolve_deslop_findings.md");
     assert.equal(Object.hasOwn(created.stepDefinitions.find((step) => step.id === "pr_merge_prepared").codex, "responseContract"), false);
     assert.equal(created.stepDefinitions.find((step) => step.id === "pr_merge_prepared").utilityActions[0].label, "Get Codex ready to merge PR");
@@ -558,6 +573,7 @@ test("jskit session JSON exposes JSKIT-owned step UI and Codex handoff contract"
     assert.deepEqual(created.stepDefinitions.find((step) => step.id === "review_changes_accepted").submitOptions, { reviewFindingsRemaining: false });
     assert.deepEqual(created.stepDefinitions.find((step) => step.id === "pr_merge_prepared").submitOptions, { continueToMerge: true });
     assert.deepEqual(created.stepDefinitions.find((step) => step.id === "pr_finalized").submitOptions, { mergePr: true });
+    assert.deepEqual(created.stepDefinitions.find((step) => step.id === "main_checkout_synced").submitOptions, {});
     assert.equal(created.codex, null);
 
     const { promptReadyPayload, worktreePayload } = advanceCliSessionToIssuePrompt(appRoot, created.sessionId);
@@ -642,6 +658,95 @@ test("jskit session returns JSON failures for invalid session ids", async () => 
     assert.equal(payload.ok, false);
     assert.equal(payload.sessionId, "invalid");
     assert.equal(payload.errors[0].code, "invalid_session_id");
+  });
+});
+
+test("jskit session runs the optional provisioning package script after dependency install", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "app");
+    await createGitApp(appRoot);
+    await mkdir(path.join(appRoot, "scripts"), { recursive: true });
+    await writeFile(
+      path.join(appRoot, "scripts", "provision-session.mjs"),
+      `import { writeFileSync } from "node:fs";
+import path from "node:path";
+
+writeFileSync(path.join(process.env.JSKIT_SESSION_ROOT, "provision-env.json"), JSON.stringify({
+  cwd: process.cwd(),
+  packageScript: process.env.JSKIT_SESSION_PACKAGE_SCRIPT,
+  sessionId: process.env.JSKIT_SESSION_ID,
+  sessionRoot: process.env.JSKIT_SESSION_ROOT,
+  targetRoot: process.env.JSKIT_TARGET_ROOT,
+  worktreeRoot: process.env.JSKIT_WORKTREE_ROOT
+}, null, 2) + "\\n");
+`,
+      "utf8"
+    );
+    await addPackageScripts(appRoot, {
+      "jskit:provision-session": "node ./scripts/provision-session.mjs"
+    });
+    runGit(appRoot, ["add", "scripts/provision-session.mjs"]);
+    runGit(appRoot, ["commit", "-m", "Add session provisioning hook"]);
+
+    const created = parseJsonResult(runCli({
+      cwd: appRoot,
+      args: ["session", "create", "--json"]
+    }));
+    const worktreePayload = runSessionStepJson(appRoot, created.sessionId);
+    assert.equal(worktreePayload.currentStep, "dependencies_installed");
+    const installed = runSessionStepJson(appRoot, created.sessionId);
+
+    assert.equal(installed.currentStep, "issue_prompt_rendered");
+    assert.ok(installed.completedSteps.includes("dependencies_installed"));
+    const provisionEnv = JSON.parse(await readFile(path.join(created.sessionRoot, "provision-env.json"), "utf8"));
+    assert.equal(provisionEnv.cwd, installed.worktree);
+    assert.equal(provisionEnv.packageScript, "jskit:provision-session");
+    assert.equal(provisionEnv.sessionId, created.sessionId);
+    assert.equal(provisionEnv.sessionRoot, created.sessionRoot);
+    assert.equal(provisionEnv.targetRoot, appRoot);
+    assert.equal(provisionEnv.worktreeRoot, installed.worktree);
+    await access(path.join(created.sessionRoot, "hooks", "jskit_provision-session"));
+    const commandLog = await readFile(path.join(created.sessionRoot, "command_log.jsonl"), "utf8");
+    assert.match(commandLog, /"kind":"session_provision"/);
+  });
+});
+
+test("jskit session blocks PR finalization when the optional finalization guard fails", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "app");
+    await createGitApp(appRoot);
+    await mkdir(path.join(appRoot, "scripts"), { recursive: true });
+    await writeFile(
+      path.join(appRoot, "scripts", "finalization-guard.mjs"),
+      "process.stderr.write('sibling repo has unpreserved changes\\n'); process.exit(42);\n",
+      "utf8"
+    );
+    await addPackageScripts(appRoot, {
+      "jskit:finalization-guard": "node ./scripts/finalization-guard.mjs"
+    });
+    runGit(appRoot, ["add", "scripts/finalization-guard.mjs"]);
+    runGit(appRoot, ["commit", "-m", "Add finalization guard hook"]);
+
+    const created = parseJsonResult(runCli({
+      cwd: appRoot,
+      args: ["session", "create", "--json"]
+    }));
+    const worktreePayload = runSessionStepJson(appRoot, created.sessionId);
+    await writeStepReceipts(
+      worktreePayload.sessionRoot,
+      STEP_IDS.slice(0, STEP_IDS.indexOf("pr_finalized"))
+    );
+    await writeFile(path.join(worktreePayload.sessionRoot, "pr_url"), "https://github.com/example/repo/pull/456\n", "utf8");
+
+    const blocked = runSessionStepJsonFailure(appRoot, created.sessionId, {
+      args: ["--merge-pr", "true"]
+    });
+    assert.equal(blocked.errors[0].code, "session_finalization_guard_failed");
+    assert.match(blocked.errors[0].message, /unpreserved changes/);
+    await assert.rejects(access(path.join(worktreePayload.sessionRoot, "steps", "pr_finalized")));
+    const commandLog = await readFile(path.join(worktreePayload.sessionRoot, "command_log.jsonl"), "utf8");
+    assert.match(commandLog, /"kind":"session_finalization_guard"/);
+    assert.doesNotMatch(commandLog, /"kind":"github_pr_view"/);
   });
 });
 
@@ -2591,8 +2696,18 @@ test("jskit session can execute review loop, PR, merge, cleanup, and finish", as
       args: ["--merge-pr", "true"],
       env
     });
-    assert.equal(merged.currentStep, "session_finished");
+    assert.equal(merged.currentStep, "main_checkout_synced");
     assert.equal(merged.prOutcome.outcome, "merged");
+    assert.equal(merged.currentStepAction.buttonLabel, "Sync main checkout");
+    assert.equal(merged.currentStepAction.requiresExplicitRun, true);
+    assert.equal(merged.currentStepAction.alternateActions[0].id, "skip_main_checkout_sync");
+    assert.deepEqual(merged.currentStepAction.alternateActions[0].submitOptions, { skipMainSync: true });
+    await access(inspect.worktree);
+    const synced = runSessionStepJson(appRoot, created.sessionId, { env });
+    assert.equal(synced.currentStep, "session_finished");
+    assert.equal(synced.mainCheckoutSync.status, "synced");
+    assert.equal(synced.mainCheckoutSync.branch, "main");
+    assert.ok(synced.completedSteps.includes("main_checkout_synced"));
     await access(inspect.worktree);
     const finished = runSessionStepJson(appRoot, created.sessionId, { env });
     assertSessionContractFields(finished);
@@ -2617,6 +2732,8 @@ test("jskit session can execute review loop, PR, merge, cleanup, and finish", as
     await access(path.join(finished.sessionRoot, "issue_details.md"));
     await access(path.join(finished.sessionRoot, "github_comments.json"));
     await access(path.join(finished.sessionRoot, "pr_outcome.json"));
+    await access(path.join(finished.sessionRoot, "main_checkout_sync.json"));
+    await access(path.join(finished.sessionRoot, "local_base_updated"));
     await access(path.join(finished.sessionRoot, "command_log.jsonl"));
     await access(path.join(finished.sessionRoot, "checks", "automated_checks_run.json"));
     await access(path.join(finished.sessionRoot, "ui_checks", "deep_ui_check_run.json"));
@@ -2629,6 +2746,7 @@ test("jskit session can execute review loop, PR, merge, cleanup, and finish", as
     assert.match(commandLog, /"kind":"github_pr_create"/);
     assert.match(commandLog, /"kind":"github_pr_view"/);
     assert.match(commandLog, /"kind":"github_pr_merge"/);
+    assert.match(commandLog, /"kind":"git_pull_base"/);
     await assert.rejects(access(path.join(appRoot, ".jskit", "sessions", "active", created.sessionId)));
     const listed = parseJsonResult(runCli({ cwd: appRoot, args: ["session", "--json"], env }));
     assert.equal(listed.archive, "active");
@@ -2731,7 +2849,7 @@ process.exit(1);
     const decisionRequired = parseJsonFailure(runCli({ cwd: appRoot, args: ["session", created.sessionId, "step", "--json"], env }));
     assert.equal(decisionRequired.errors[0].code, "pr_finalize_decision_required");
     const merged = parseJsonResult(runCli({ cwd: appRoot, args: ["session", created.sessionId, "step", "--merge-pr", "true", "--json"], env }));
-    assert.equal(merged.currentStep, "session_finished");
+    assert.equal(merged.currentStep, "main_checkout_synced");
     assert.ok(merged.completedSteps.includes("pr_finalized"));
     assert.equal(merged.prOutcome.outcome, "merged");
     await access(worktreePayload.worktree);
@@ -2742,7 +2860,7 @@ process.exit(1);
   });
 });
 
-test("jskit session blocks final cleanup when the target root is dirty", async () => {
+test("jskit session blocks main checkout sync when the target root is dirty", async () => {
   await withTempDir(async (cwd) => {
     const appRoot = path.join(cwd, "app");
     const binDir = path.join(cwd, "bin");
@@ -2780,14 +2898,27 @@ process.exit(1);
     await writeFile(path.join(appRoot, "local-change.txt"), "dirty\n", "utf8");
 
     const merged = parseJsonResult(runCli({ cwd: appRoot, args: ["session", created.sessionId, "step", "--merge-pr", "true", "--json"], env }));
-    assert.equal(merged.currentStep, "session_finished");
+    assert.equal(merged.currentStep, "main_checkout_synced");
     assert.ok(merged.completedSteps.includes("pr_finalized"));
 
     const blocked = parseJsonFailure(runCli({ cwd: appRoot, args: ["session", created.sessionId, "step", "--json"], env }));
     assert.equal(blocked.errors[0].code, "target_root_dirty");
+    assert.equal(blocked.currentStep, "main_checkout_synced");
     await access(worktreePayload.worktree);
     await access(path.join(worktreePayload.sessionRoot, "steps", "pr_finalized"));
+    await assert.rejects(access(path.join(worktreePayload.sessionRoot, "steps", "main_checkout_synced")));
     await assert.rejects(access(path.join(worktreePayload.sessionRoot, "steps", "session_finished")));
+
+    const skipped = parseJsonResult(runCli({ cwd: appRoot, args: ["session", created.sessionId, "step", "--skip-main-sync", "--json"], env }));
+    assert.equal(skipped.currentStep, "session_finished");
+    assert.equal(skipped.mainCheckoutSync.status, "skipped");
+    assert.match(skipped.mainCheckoutSync.reason, /User skipped/);
+    await access(path.join(worktreePayload.sessionRoot, "steps", "main_checkout_synced"));
+
+    const finished = parseJsonResult(runCli({ cwd: appRoot, args: ["session", created.sessionId, "step", "--json"], env }));
+    assert.equal(finished.status, "finished");
+    await assert.rejects(access(worktreePayload.worktree));
+
     const log = await readFile(logPath, "utf8");
     assert.match(log, /gh pr view https:\/\/github\.com\/example\/repo\/pull\/456 --json state,mergedAt,url,baseRefName/);
     assert.doesNotMatch(log, /gh pr merge/);
@@ -2821,10 +2952,17 @@ test("jskit session can finish successfully without merging the PR", async () =>
       args: ["session", created.sessionId, "step", "--skip-merge", "--json"],
       env
     }));
-    assert.equal(closed.currentStep, "session_finished");
+    assert.equal(closed.currentStep, "main_checkout_synced");
     assert.equal(closed.prOutcome.outcome, "closed_without_merge");
     assert.equal(closed.prOutcome.reason, "User skipped merge in JSKIT Studio.");
+    assert.equal(closed.currentStepAction.buttonLabel, "Record no sync needed");
     await access(worktreePayload.worktree);
+
+    const skippedSync = parseJsonResult(runCli({ cwd: appRoot, args: ["session", created.sessionId, "step", "--json"], env }));
+    assert.equal(skippedSync.currentStep, "session_finished");
+    assert.equal(skippedSync.mainCheckoutSync.status, "skipped");
+    assert.equal(skippedSync.mainCheckoutSync.outcome, "closed_without_merge");
+    await access(path.join(worktreePayload.sessionRoot, "steps", "main_checkout_synced"));
 
     const finished = parseJsonResult(runCli({ cwd: appRoot, args: ["session", created.sessionId, "step", "--json"], env }));
     assertSessionContractFields(finished);


### PR DESCRIPTION
Summary:
- add an explicit session main-checkout sync step with skip support and persisted sync outcome metadata
- add optional session package hooks for provisioning and finalization guard scripts
- add an opt-in create-app devlinks postinstall script without hardcoded repo paths

Tests:
- npm --workspace @jskit-ai/jskit-cli test
- npm --workspace @jskit-ai/create-app test