### PR TITLE
Refresh package versions and agent doc prompts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6686,28 +6686,28 @@
     },
     "packages/agent-docs": {
       "name": "@jskit-ai/agent-docs",
-      "version": "0.1.38",
+      "version": "0.1.39",
       "engines": {
         "node": ">=20 <23"
       }
     },
     "packages/assistant": {
       "name": "@jskit-ai/assistant",
-      "version": "0.1.86",
+      "version": "0.1.87",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.77"
+        "@jskit-ai/kernel": "0.1.78"
       }
     },
     "packages/assistant-core": {
       "name": "@jskit-ai/assistant-core",
-      "version": "0.1.53",
+      "version": "0.1.54",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.77",
-        "@jskit-ai/http-runtime": "0.1.76",
-        "@jskit-ai/kernel": "0.1.77",
-        "@jskit-ai/resource-core": "0.1.22",
-        "@jskit-ai/resource-crud-core": "0.1.22",
-        "@jskit-ai/users-core": "0.1.87",
+        "@jskit-ai/database-runtime": "0.1.78",
+        "@jskit-ai/http-runtime": "0.1.77",
+        "@jskit-ai/kernel": "0.1.78",
+        "@jskit-ai/resource-core": "0.1.23",
+        "@jskit-ai/resource-crud-core": "0.1.23",
+        "@jskit-ai/users-core": "0.1.88",
         "dompurify": "^3.3.3",
         "json-rest-schema": "1.x.x",
         "marked": "^17.0.4",
@@ -6720,15 +6720,15 @@
     },
     "packages/assistant-runtime": {
       "name": "@jskit-ai/assistant-runtime",
-      "version": "0.1.48",
+      "version": "0.1.49",
       "dependencies": {
-        "@jskit-ai/assistant-core": "0.1.53",
-        "@jskit-ai/database-runtime": "0.1.77",
-        "@jskit-ai/http-runtime": "0.1.76",
-        "@jskit-ai/kernel": "0.1.77",
-        "@jskit-ai/shell-web": "0.1.76",
-        "@jskit-ai/users-core": "0.1.87",
-        "@jskit-ai/users-web": "0.1.92",
+        "@jskit-ai/assistant-core": "0.1.54",
+        "@jskit-ai/database-runtime": "0.1.78",
+        "@jskit-ai/http-runtime": "0.1.77",
+        "@jskit-ai/kernel": "0.1.78",
+        "@jskit-ai/shell-web": "0.1.77",
+        "@jskit-ai/users-core": "0.1.88",
+        "@jskit-ai/users-web": "0.1.93",
         "json-rest-schema": "1.x.x"
       },
       "peerDependencies": {
@@ -6739,21 +6739,21 @@
     },
     "packages/auth-core": {
       "name": "@jskit-ai/auth-core",
-      "version": "0.1.76",
+      "version": "0.1.77",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0",
-        "@jskit-ai/kernel": "0.1.77",
+        "@jskit-ai/kernel": "0.1.78",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/auth-provider-supabase-core": {
       "name": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.76",
+      "version": "0.1.77",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.76",
-        "@jskit-ai/kernel": "0.1.77",
+        "@jskit-ai/auth-core": "0.1.77",
+        "@jskit-ai/kernel": "0.1.78",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0",
         "json-rest-schema": "1.x.x",
@@ -6762,12 +6762,12 @@
     },
     "packages/auth-web": {
       "name": "@jskit-ai/auth-web",
-      "version": "0.1.78",
+      "version": "0.1.79",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.76",
-        "@jskit-ai/http-runtime": "0.1.76",
-        "@jskit-ai/kernel": "0.1.77",
-        "@jskit-ai/shell-web": "0.1.76",
+        "@jskit-ai/auth-core": "0.1.77",
+        "@jskit-ai/http-runtime": "0.1.77",
+        "@jskit-ai/kernel": "0.1.78",
+        "@jskit-ai/shell-web": "0.1.77",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -6780,38 +6780,38 @@
     },
     "packages/console-core": {
       "name": "@jskit-ai/console-core",
-      "version": "0.1.40",
+      "version": "0.1.41",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.76",
-        "@jskit-ai/database-runtime": "0.1.77",
-        "@jskit-ai/http-runtime": "0.1.76",
-        "@jskit-ai/kernel": "0.1.77",
-        "@jskit-ai/resource-crud-core": "0.1.22",
-        "@jskit-ai/users-core": "0.1.87",
+        "@jskit-ai/auth-core": "0.1.77",
+        "@jskit-ai/database-runtime": "0.1.78",
+        "@jskit-ai/http-runtime": "0.1.77",
+        "@jskit-ai/kernel": "0.1.78",
+        "@jskit-ai/resource-crud-core": "0.1.23",
+        "@jskit-ai/users-core": "0.1.88",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/console-web": {
       "name": "@jskit-ai/console-web",
-      "version": "0.1.45",
+      "version": "0.1.46",
       "dependencies": {
-        "@jskit-ai/auth-web": "0.1.78",
-        "@jskit-ai/console-core": "0.1.40",
-        "@jskit-ai/shell-web": "0.1.76"
+        "@jskit-ai/auth-web": "0.1.79",
+        "@jskit-ai/console-core": "0.1.41",
+        "@jskit-ai/shell-web": "0.1.77"
       }
     },
     "packages/crud-core": {
       "name": "@jskit-ai/crud-core",
-      "version": "0.1.85",
+      "version": "0.1.86",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.77",
-        "@jskit-ai/http-runtime": "0.1.76",
-        "@jskit-ai/kernel": "0.1.77",
-        "@jskit-ai/realtime": "0.1.76",
-        "@jskit-ai/resource-crud-core": "0.1.22",
-        "@jskit-ai/shell-web": "0.1.76",
-        "@jskit-ai/users-core": "0.1.87",
-        "@jskit-ai/users-web": "0.1.92",
+        "@jskit-ai/database-runtime": "0.1.78",
+        "@jskit-ai/http-runtime": "0.1.77",
+        "@jskit-ai/kernel": "0.1.78",
+        "@jskit-ai/realtime": "0.1.77",
+        "@jskit-ai/resource-crud-core": "0.1.23",
+        "@jskit-ai/shell-web": "0.1.77",
+        "@jskit-ai/users-core": "0.1.88",
+        "@jskit-ai/users-web": "0.1.93",
         "json-rest-schema": "1.x.x"
       },
       "peerDependencies": {
@@ -6822,98 +6822,98 @@
     },
     "packages/crud-server-generator": {
       "name": "@jskit-ai/crud-server-generator",
-      "version": "0.1.85",
+      "version": "0.1.86",
       "dependencies": {
         "@babel/parser": "^7.29.2",
-        "@jskit-ai/crud-core": "0.1.85",
-        "@jskit-ai/database-runtime": "0.1.77",
-        "@jskit-ai/http-runtime": "0.1.76",
-        "@jskit-ai/json-rest-api-core": "0.1.22",
-        "@jskit-ai/kernel": "0.1.77",
-        "@jskit-ai/resource-crud-core": "0.1.22",
+        "@jskit-ai/crud-core": "0.1.86",
+        "@jskit-ai/database-runtime": "0.1.78",
+        "@jskit-ai/http-runtime": "0.1.77",
+        "@jskit-ai/json-rest-api-core": "0.1.23",
+        "@jskit-ai/kernel": "0.1.78",
+        "@jskit-ai/resource-crud-core": "0.1.23",
         "recast": "^0.23.11"
       }
     },
     "packages/crud-ui-generator": {
       "name": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.60",
+      "version": "0.1.61",
       "dependencies": {
-        "@jskit-ai/crud-core": "0.1.85",
-        "@jskit-ai/kernel": "0.1.77",
-        "@jskit-ai/resource-crud-core": "0.1.22"
+        "@jskit-ai/crud-core": "0.1.86",
+        "@jskit-ai/kernel": "0.1.78",
+        "@jskit-ai/resource-crud-core": "0.1.23"
       }
     },
     "packages/database-runtime": {
       "name": "@jskit-ai/database-runtime",
-      "version": "0.1.77",
+      "version": "0.1.78",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.77"
+        "@jskit-ai/kernel": "0.1.78"
       }
     },
     "packages/database-runtime-mysql": {
       "name": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.76",
+      "version": "0.1.77",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.77",
-        "@jskit-ai/kernel": "0.1.77"
+        "@jskit-ai/database-runtime": "0.1.78",
+        "@jskit-ai/kernel": "0.1.78"
       }
     },
     "packages/database-runtime-postgres": {
       "name": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.76",
+      "version": "0.1.77",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.77"
+        "@jskit-ai/database-runtime": "0.1.78"
       }
     },
     "packages/feature-server-generator": {
       "name": "@jskit-ai/feature-server-generator",
-      "version": "0.1.19"
+      "version": "0.1.20"
     },
     "packages/google-rewarded-core": {
       "name": "@jskit-ai/google-rewarded-core",
-      "version": "0.1.14"
+      "version": "0.1.15"
     },
     "packages/google-rewarded-web": {
       "name": "@jskit-ai/google-rewarded-web",
-      "version": "0.1.14"
+      "version": "0.1.15"
     },
     "packages/http-runtime": {
       "name": "@jskit-ai/http-runtime",
-      "version": "0.1.76",
+      "version": "0.1.77",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.77",
+        "@jskit-ai/kernel": "0.1.78",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/json-rest-api-core": {
       "name": "@jskit-ai/json-rest-api-core",
-      "version": "0.1.22",
+      "version": "0.1.23",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.77",
+        "@jskit-ai/kernel": "0.1.78",
         "hooked-api": "1.x.x",
         "json-rest-api": "1.x.x"
       }
     },
     "packages/kernel": {
       "name": "@jskit-ai/kernel",
-      "version": "0.1.77",
+      "version": "0.1.78",
       "dependencies": {
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/mobile-capacitor": {
       "name": "@jskit-ai/mobile-capacitor",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "dependencies": {
         "@capacitor/browser": "^7.0.1",
-        "@jskit-ai/kernel": "0.1.77"
+        "@jskit-ai/kernel": "0.1.78"
       }
     },
     "packages/realtime": {
       "name": "@jskit-ai/realtime",
-      "version": "0.1.76",
+      "version": "0.1.77",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.77",
+        "@jskit-ai/kernel": "0.1.78",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",
@@ -6925,24 +6925,24 @@
     },
     "packages/resource-core": {
       "name": "@jskit-ai/resource-core",
-      "version": "0.1.22",
+      "version": "0.1.23",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.77"
+        "@jskit-ai/kernel": "0.1.78"
       }
     },
     "packages/resource-crud-core": {
       "name": "@jskit-ai/resource-crud-core",
-      "version": "0.1.22",
+      "version": "0.1.23",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.77",
-        "@jskit-ai/resource-core": "0.1.22"
+        "@jskit-ai/kernel": "0.1.78",
+        "@jskit-ai/resource-core": "0.1.23"
       }
     },
     "packages/shell-web": {
       "name": "@jskit-ai/shell-web",
-      "version": "0.1.76",
+      "version": "0.1.77",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.77",
+        "@jskit-ai/kernel": "0.1.78",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -6954,25 +6954,25 @@
     },
     "packages/storage-runtime": {
       "name": "@jskit-ai/storage-runtime",
-      "version": "0.1.76",
+      "version": "0.1.77",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.77",
+        "@jskit-ai/kernel": "0.1.78",
         "unstorage": "^1.17.3"
       }
     },
     "packages/ui-generator": {
       "name": "@jskit-ai/ui-generator",
-      "version": "0.1.60",
+      "version": "0.1.61",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.77",
-        "@jskit-ai/shell-web": "0.1.76"
+        "@jskit-ai/kernel": "0.1.78",
+        "@jskit-ai/shell-web": "0.1.77"
       }
     },
     "packages/uploads-image-web": {
       "name": "@jskit-ai/uploads-image-web",
-      "version": "0.1.55",
+      "version": "0.1.56",
       "dependencies": {
-        "@jskit-ai/uploads-runtime": "0.1.55",
+        "@jskit-ai/uploads-runtime": "0.1.56",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",
@@ -6985,37 +6985,37 @@
     },
     "packages/uploads-runtime": {
       "name": "@jskit-ai/uploads-runtime",
-      "version": "0.1.55",
+      "version": "0.1.56",
       "dependencies": {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.77"
+        "@jskit-ai/kernel": "0.1.78"
       }
     },
     "packages/users-core": {
       "name": "@jskit-ai/users-core",
-      "version": "0.1.87",
+      "version": "0.1.88",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.76",
-        "@jskit-ai/database-runtime": "0.1.77",
-        "@jskit-ai/http-runtime": "0.1.76",
-        "@jskit-ai/json-rest-api-core": "0.1.22",
-        "@jskit-ai/kernel": "0.1.77",
-        "@jskit-ai/resource-core": "0.1.22",
-        "@jskit-ai/resource-crud-core": "0.1.22",
-        "@jskit-ai/uploads-runtime": "0.1.55",
+        "@jskit-ai/auth-core": "0.1.77",
+        "@jskit-ai/database-runtime": "0.1.78",
+        "@jskit-ai/http-runtime": "0.1.77",
+        "@jskit-ai/json-rest-api-core": "0.1.23",
+        "@jskit-ai/kernel": "0.1.78",
+        "@jskit-ai/resource-core": "0.1.23",
+        "@jskit-ai/resource-crud-core": "0.1.23",
+        "@jskit-ai/uploads-runtime": "0.1.56",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/users-web": {
       "name": "@jskit-ai/users-web",
-      "version": "0.1.92",
+      "version": "0.1.93",
       "dependencies": {
-        "@jskit-ai/http-runtime": "0.1.76",
-        "@jskit-ai/kernel": "0.1.77",
-        "@jskit-ai/realtime": "0.1.76",
-        "@jskit-ai/shell-web": "0.1.76",
-        "@jskit-ai/uploads-image-web": "0.1.55",
-        "@jskit-ai/users-core": "0.1.87",
+        "@jskit-ai/http-runtime": "0.1.77",
+        "@jskit-ai/kernel": "0.1.78",
+        "@jskit-ai/realtime": "0.1.77",
+        "@jskit-ai/shell-web": "0.1.77",
+        "@jskit-ai/uploads-image-web": "0.1.56",
+        "@jskit-ai/users-core": "0.1.88",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -7027,29 +7027,29 @@
     },
     "packages/workspaces-core": {
       "name": "@jskit-ai/workspaces-core",
-      "version": "0.1.53",
+      "version": "0.1.54",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.76",
-        "@jskit-ai/database-runtime": "0.1.77",
-        "@jskit-ai/http-runtime": "0.1.76",
-        "@jskit-ai/json-rest-api-core": "0.1.22",
-        "@jskit-ai/kernel": "0.1.77",
-        "@jskit-ai/resource-core": "0.1.22",
-        "@jskit-ai/resource-crud-core": "0.1.22",
-        "@jskit-ai/users-core": "0.1.87",
+        "@jskit-ai/auth-core": "0.1.77",
+        "@jskit-ai/database-runtime": "0.1.78",
+        "@jskit-ai/http-runtime": "0.1.77",
+        "@jskit-ai/json-rest-api-core": "0.1.23",
+        "@jskit-ai/kernel": "0.1.78",
+        "@jskit-ai/resource-core": "0.1.23",
+        "@jskit-ai/resource-crud-core": "0.1.23",
+        "@jskit-ai/users-core": "0.1.88",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/workspaces-web": {
       "name": "@jskit-ai/workspaces-web",
-      "version": "0.1.53",
+      "version": "0.1.54",
       "dependencies": {
-        "@jskit-ai/http-runtime": "0.1.76",
-        "@jskit-ai/kernel": "0.1.77",
-        "@jskit-ai/shell-web": "0.1.76",
-        "@jskit-ai/users-core": "0.1.87",
-        "@jskit-ai/users-web": "0.1.92",
-        "@jskit-ai/workspaces-core": "0.1.53",
+        "@jskit-ai/http-runtime": "0.1.77",
+        "@jskit-ai/kernel": "0.1.78",
+        "@jskit-ai/shell-web": "0.1.77",
+        "@jskit-ai/users-core": "0.1.88",
+        "@jskit-ai/users-web": "0.1.93",
+        "@jskit-ai/workspaces-core": "0.1.54",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -7061,7 +7061,7 @@
     },
     "tooling/config-eslint": {
       "name": "@jskit-ai/config-eslint",
-      "version": "0.1.76",
+      "version": "0.1.77",
       "dependencies": {
         "@eslint/js": "^9.39.1",
         "eslint-plugin-vue": "^10.5.1",
@@ -7079,7 +7079,7 @@
     },
     "tooling/create-app": {
       "name": "@jskit-ai/create-app",
-      "version": "0.1.85",
+      "version": "0.1.86",
       "bin": {
         "jskit-create-app": "bin/jskit-create-app.js"
       },
@@ -7089,18 +7089,18 @@
     },
     "tooling/jskit-catalog": {
       "name": "@jskit-ai/jskit-catalog",
-      "version": "0.1.85",
+      "version": "0.1.86",
       "engines": {
         "node": ">=20 <23"
       }
     },
     "tooling/jskit-cli": {
       "name": "@jskit-ai/jskit-cli",
-      "version": "0.2.86",
+      "version": "0.2.87",
       "dependencies": {
-        "@jskit-ai/jskit-catalog": "0.1.85",
-        "@jskit-ai/kernel": "0.1.77",
-        "@jskit-ai/shell-web": "0.1.76",
+        "@jskit-ai/jskit-catalog": "0.1.86",
+        "@jskit-ai/kernel": "0.1.78",
+        "@jskit-ai/shell-web": "0.1.77",
         "@vue/compiler-sfc": "^3.5.29",
         "ts-morph": "^28.0.0"
       },

--- a/packages/agent-docs/package.json
+++ b/packages/agent-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/agent-docs",
-  "version": "0.1.38",
+  "version": "0.1.39",
   "description": "Distributed JSKIT agent references, prompts, guides, and generated reference maps.",
   "type": "module",
   "files": [

--- a/packages/assistant-core/package.descriptor.mjs
+++ b/packages/assistant-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-core",
-  version: "0.1.53",
+  version: "0.1.54",
   kind: "runtime",
   description: "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
   dependsOn: [
@@ -47,11 +47,11 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/http-runtime": "0.1.76",
-        "@jskit-ai/kernel": "0.1.77",
-        "@jskit-ai/resource-core": "0.1.22",
-        "@jskit-ai/resource-crud-core": "0.1.22",
-        "@jskit-ai/users-core": "0.1.87",
+        "@jskit-ai/http-runtime": "0.1.77",
+        "@jskit-ai/kernel": "0.1.78",
+        "@jskit-ai/resource-core": "0.1.23",
+        "@jskit-ai/resource-crud-core": "0.1.23",
+        "@jskit-ai/users-core": "0.1.88",
         "dompurify": "^3.3.3",
         "json-rest-schema": "1.x.x",
         "marked": "^17.0.4",

--- a/packages/assistant-core/package.json
+++ b/packages/assistant-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-core",
-  "version": "0.1.53",
+  "version": "0.1.54",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,12 +11,12 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.77",
-    "@jskit-ai/http-runtime": "0.1.76",
-    "@jskit-ai/kernel": "0.1.77",
-    "@jskit-ai/resource-crud-core": "0.1.22",
-    "@jskit-ai/resource-core": "0.1.22",
-    "@jskit-ai/users-core": "0.1.87",
+    "@jskit-ai/database-runtime": "0.1.78",
+    "@jskit-ai/http-runtime": "0.1.77",
+    "@jskit-ai/kernel": "0.1.78",
+    "@jskit-ai/resource-crud-core": "0.1.23",
+    "@jskit-ai/resource-core": "0.1.23",
+    "@jskit-ai/users-core": "0.1.88",
     "dompurify": "^3.3.3",
     "json-rest-schema": "1.x.x",
     "marked": "^17.0.4",

--- a/packages/assistant-runtime/package.descriptor.mjs
+++ b/packages/assistant-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-runtime",
-  version: "0.1.48",
+  version: "0.1.49",
   kind: "runtime",
   description: "Shared assistant runtime with per-surface assistant registration.",
   dependsOn: [
@@ -95,13 +95,13 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/assistant-core": "0.1.53",
-        "@jskit-ai/database-runtime": "0.1.77",
-        "@jskit-ai/http-runtime": "0.1.76",
-        "@jskit-ai/kernel": "0.1.77",
-        "@jskit-ai/shell-web": "0.1.76",
-        "@jskit-ai/users-core": "0.1.87",
-        "@jskit-ai/users-web": "0.1.92"
+        "@jskit-ai/assistant-core": "0.1.54",
+        "@jskit-ai/database-runtime": "0.1.78",
+        "@jskit-ai/http-runtime": "0.1.77",
+        "@jskit-ai/kernel": "0.1.78",
+        "@jskit-ai/shell-web": "0.1.77",
+        "@jskit-ai/users-core": "0.1.88",
+        "@jskit-ai/users-web": "0.1.93"
       },
       dev: {}
     },

--- a/packages/assistant-runtime/package.json
+++ b/packages/assistant-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-runtime",
-  "version": "0.1.48",
+  "version": "0.1.49",
   "type": "module",
   "exports": {
     "./client": "./src/client/index.js",
@@ -8,13 +8,13 @@
     "./server/actionIds": "./src/server/actionIds.js"
   },
   "dependencies": {
-    "@jskit-ai/assistant-core": "0.1.53",
-    "@jskit-ai/database-runtime": "0.1.77",
-    "@jskit-ai/http-runtime": "0.1.76",
-    "@jskit-ai/kernel": "0.1.77",
-    "@jskit-ai/shell-web": "0.1.76",
-    "@jskit-ai/users-core": "0.1.87",
-    "@jskit-ai/users-web": "0.1.92",
+    "@jskit-ai/assistant-core": "0.1.54",
+    "@jskit-ai/database-runtime": "0.1.78",
+    "@jskit-ai/http-runtime": "0.1.77",
+    "@jskit-ai/kernel": "0.1.78",
+    "@jskit-ai/shell-web": "0.1.77",
+    "@jskit-ai/users-core": "0.1.88",
+    "@jskit-ai/users-web": "0.1.93",
     "json-rest-schema": "1.x.x"
   },
   "peerDependencies": {

--- a/packages/assistant/package.descriptor.mjs
+++ b/packages/assistant/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant",
-  version: "0.1.86",
+  version: "0.1.87",
   kind: "generator",
   description: "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
   options: {

--- a/packages/assistant/package.json
+++ b/packages/assistant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant",
-  "version": "0.1.86",
+  "version": "0.1.87",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.77"
+    "@jskit-ai/kernel": "0.1.78"
   }
 }

--- a/packages/auth-core/package.descriptor.mjs
+++ b/packages/auth-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-core",
-  "version": "0.1.76",
+  "version": "0.1.77",
   "kind": "runtime",
   "dependsOn": [
     "@jskit-ai/value-app-config-shared"
@@ -69,7 +69,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.77",
+        "@jskit-ai/kernel": "0.1.78",
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0"

--- a/packages/auth-core/package.json
+++ b/packages/auth-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-core",
-  "version": "0.1.76",
+  "version": "0.1.77",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -46,7 +46,7 @@
     "./shared/commands/authSessionReadCommand": "./src/shared/commands/authSessionReadCommand.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.77",
+    "@jskit-ai/kernel": "0.1.78",
     "@fastify/cookie": "^11.0.2",
     "@fastify/csrf-protection": "^7.1.0",
     "@fastify/rate-limit": "^10.3.0",

--- a/packages/auth-provider-supabase-core/package.descriptor.mjs
+++ b/packages/auth-provider-supabase-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.76",
+  "version": "0.1.77",
   "kind": "runtime",
   "options": {
     "auth-supabase-url": {
@@ -83,8 +83,8 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/auth-core": "0.1.76",
-        "@jskit-ai/kernel": "0.1.77",
+        "@jskit-ai/auth-core": "0.1.77",
+        "@jskit-ai/kernel": "0.1.78",
         "dotenv": "^16.4.5",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0"

--- a/packages/auth-provider-supabase-core/package.json
+++ b/packages/auth-provider-supabase-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.76",
+  "version": "0.1.77",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,8 +12,8 @@
     "./client": "./src/client/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.76",
-    "@jskit-ai/kernel": "0.1.77",
+    "@jskit-ai/auth-core": "0.1.77",
+    "@jskit-ai/kernel": "0.1.78",
     "json-rest-schema": "1.x.x",
     "jose": "^6.1.0",
     "@supabase/supabase-js": "^2.57.4",

--- a/packages/auth-web/package.descriptor.mjs
+++ b/packages/auth-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-web",
-  "version": "0.1.78",
+  "version": "0.1.79",
   "kind": "runtime",
   "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
   "dependsOn": [
@@ -247,10 +247,10 @@ export default Object.freeze({
     "dependencies": {
       "runtime": {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/auth-core": "0.1.76",
-        "@jskit-ai/http-runtime": "0.1.76",
-        "@jskit-ai/kernel": "0.1.77",
-        "@jskit-ai/shell-web": "0.1.76"
+        "@jskit-ai/auth-core": "0.1.77",
+        "@jskit-ai/http-runtime": "0.1.77",
+        "@jskit-ai/kernel": "0.1.78",
+        "@jskit-ai/shell-web": "0.1.77"
       },
       "dev": {}
     },

--- a/packages/auth-web/package.json
+++ b/packages/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-web",
-  "version": "0.1.78",
+  "version": "0.1.79",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -18,11 +18,11 @@
     "./client/runtime/useSignOut": "./src/client/runtime/useSignOut.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.76",
+    "@jskit-ai/auth-core": "0.1.77",
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/kernel": "0.1.77",
-    "@jskit-ai/shell-web": "0.1.76",
-    "@jskit-ai/http-runtime": "0.1.76"
+    "@jskit-ai/kernel": "0.1.78",
+    "@jskit-ai/shell-web": "0.1.77",
+    "@jskit-ai/http-runtime": "0.1.77"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/console-core/package.descriptor.mjs
+++ b/packages/console-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-core",
-  version: "0.1.40",
+  version: "0.1.41",
   kind: "runtime",
   description: "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
   dependsOn: [
@@ -85,12 +85,12 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.76",
-        "@jskit-ai/database-runtime": "0.1.77",
-        "@jskit-ai/http-runtime": "0.1.76",
-        "@jskit-ai/kernel": "0.1.77",
-        "@jskit-ai/resource-crud-core": "0.1.22",
-        "@jskit-ai/users-core": "0.1.87"
+        "@jskit-ai/auth-core": "0.1.77",
+        "@jskit-ai/database-runtime": "0.1.78",
+        "@jskit-ai/http-runtime": "0.1.77",
+        "@jskit-ai/kernel": "0.1.78",
+        "@jskit-ai/resource-crud-core": "0.1.23",
+        "@jskit-ai/users-core": "0.1.88"
       },
       dev: {}
     },

--- a/packages/console-core/package.json
+++ b/packages/console-core/package.json
@@ -1,17 +1,17 @@
 {
   "name": "@jskit-ai/console-core",
-  "version": "0.1.40",
+  "version": "0.1.41",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.76",
-    "@jskit-ai/database-runtime": "0.1.77",
-    "@jskit-ai/http-runtime": "0.1.76",
-    "@jskit-ai/kernel": "0.1.77",
-    "@jskit-ai/resource-crud-core": "0.1.22",
-    "@jskit-ai/users-core": "0.1.87",
+    "@jskit-ai/auth-core": "0.1.77",
+    "@jskit-ai/database-runtime": "0.1.78",
+    "@jskit-ai/http-runtime": "0.1.77",
+    "@jskit-ai/kernel": "0.1.78",
+    "@jskit-ai/resource-crud-core": "0.1.23",
+    "@jskit-ai/users-core": "0.1.88",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/console-web/package.descriptor.mjs
+++ b/packages/console-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-web",
-  version: "0.1.45",
+  version: "0.1.46",
   kind: "runtime",
   description: "Authenticated console surface scaffold and surface policy wiring.",
   dependsOn: [
@@ -103,9 +103,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-web": "0.1.78",
-        "@jskit-ai/console-core": "0.1.40",
-        "@jskit-ai/shell-web": "0.1.76",
+        "@jskit-ai/auth-web": "0.1.79",
+        "@jskit-ai/console-core": "0.1.41",
+        "@jskit-ai/shell-web": "0.1.77",
       },
       dev: {}
     },

--- a/packages/console-web/package.json
+++ b/packages/console-web/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/console-web",
-  "version": "0.1.45",
+  "version": "0.1.46",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-web": "0.1.78",
-    "@jskit-ai/console-core": "0.1.40",
-    "@jskit-ai/shell-web": "0.1.76"
+    "@jskit-ai/auth-web": "0.1.79",
+    "@jskit-ai/console-core": "0.1.41",
+    "@jskit-ai/shell-web": "0.1.77"
   }
 }

--- a/packages/crud-core/package.descriptor.mjs
+++ b/packages/crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-core",
-  version: "0.1.85",
+  version: "0.1.86",
   kind: "runtime",
   description: "Shared CRUD helpers used by CRUD modules.",
   dependsOn: [
@@ -28,7 +28,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/crud-core": "0.1.85"
+        "@jskit-ai/crud-core": "0.1.86"
       },
       dev: {}
     },

--- a/packages/crud-core/package.json
+++ b/packages/crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-core",
-  "version": "0.1.85",
+  "version": "0.1.86",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -27,15 +27,15 @@
     "./server/routeContracts": "./src/server/routeContracts.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.77",
-    "@jskit-ai/http-runtime": "0.1.76",
-    "@jskit-ai/kernel": "0.1.77",
+    "@jskit-ai/database-runtime": "0.1.78",
+    "@jskit-ai/http-runtime": "0.1.77",
+    "@jskit-ai/kernel": "0.1.78",
     "json-rest-schema": "1.x.x",
-    "@jskit-ai/realtime": "0.1.76",
-    "@jskit-ai/resource-crud-core": "0.1.22",
-    "@jskit-ai/shell-web": "0.1.76",
-    "@jskit-ai/users-core": "0.1.87",
-    "@jskit-ai/users-web": "0.1.92"
+    "@jskit-ai/realtime": "0.1.77",
+    "@jskit-ai/resource-crud-core": "0.1.23",
+    "@jskit-ai/shell-web": "0.1.77",
+    "@jskit-ai/users-core": "0.1.88",
+    "@jskit-ai/users-web": "0.1.93"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/crud-server-generator/package.descriptor.mjs
+++ b/packages/crud-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-server-generator",
-  version: "0.1.85",
+  version: "0.1.86",
   kind: "generator",
   description: "CRUD server generator with routes, actions, and persistence scaffolding.",
   options: {
@@ -160,14 +160,14 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.76",
-        "@jskit-ai/crud-core": "0.1.85",
-        "@jskit-ai/database-runtime": "0.1.77",
-        "@jskit-ai/http-runtime": "0.1.76",
-        "@jskit-ai/json-rest-api-core": "0.1.22",
-        "@jskit-ai/kernel": "0.1.77",
-        "@jskit-ai/realtime": "0.1.76",
-        "@jskit-ai/resource-crud-core": "0.1.22",
+        "@jskit-ai/auth-core": "0.1.77",
+        "@jskit-ai/crud-core": "0.1.86",
+        "@jskit-ai/database-runtime": "0.1.78",
+        "@jskit-ai/http-runtime": "0.1.77",
+        "@jskit-ai/json-rest-api-core": "0.1.23",
+        "@jskit-ai/kernel": "0.1.78",
+        "@jskit-ai/realtime": "0.1.77",
+        "@jskit-ai/resource-crud-core": "0.1.23",
         "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}"
       },
       dev: {}

--- a/packages/crud-server-generator/package.json
+++ b/packages/crud-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-server-generator",
-  "version": "0.1.85",
+  "version": "0.1.86",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,12 +13,12 @@
   },
   "dependencies": {
     "@babel/parser": "^7.29.2",
-    "@jskit-ai/crud-core": "0.1.85",
-    "@jskit-ai/database-runtime": "0.1.77",
-    "@jskit-ai/http-runtime": "0.1.76",
-    "@jskit-ai/json-rest-api-core": "0.1.22",
-    "@jskit-ai/kernel": "0.1.77",
-    "@jskit-ai/resource-crud-core": "0.1.22",
+    "@jskit-ai/crud-core": "0.1.86",
+    "@jskit-ai/database-runtime": "0.1.78",
+    "@jskit-ai/http-runtime": "0.1.77",
+    "@jskit-ai/json-rest-api-core": "0.1.23",
+    "@jskit-ai/kernel": "0.1.78",
+    "@jskit-ai/resource-crud-core": "0.1.23",
     "recast": "^0.23.11"
   }
 }

--- a/packages/crud-ui-generator/package.descriptor.mjs
+++ b/packages/crud-ui-generator/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { GENERATED_UI_NAVIGATION_ROLE_OPTION } from "@jskit-ai/kernel/shared/sup
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-ui-generator",
-  version: "0.1.60",
+  version: "0.1.61",
   kind: "generator",
   description: "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
   options: {
@@ -175,7 +175,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.92"
+        "@jskit-ai/users-web": "0.1.93"
       },
       dev: {}
     },

--- a/packages/crud-ui-generator/package.json
+++ b/packages/crud-ui-generator/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@jskit-ai/crud-ui-generator",
-  "version": "0.1.60",
+  "version": "0.1.61",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/crud-core": "0.1.85",
-    "@jskit-ai/kernel": "0.1.77",
-    "@jskit-ai/resource-crud-core": "0.1.22"
+    "@jskit-ai/crud-core": "0.1.86",
+    "@jskit-ai/kernel": "0.1.78",
+    "@jskit-ai/resource-crud-core": "0.1.23"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/database-runtime-mysql/package.descriptor.mjs
+++ b/packages/database-runtime-mysql/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-mysql",
-  version: "0.1.76",
+  version: "0.1.77",
   kind: "runtime",
   options: {
     "db-host": {
@@ -91,7 +91,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.77",
+        "@jskit-ai/database-runtime": "0.1.78",
         "mysql2": "^3.11.2"
       },
       dev: {}

--- a/packages/database-runtime-mysql/package.json
+++ b/packages/database-runtime-mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-mysql",
-  "version": "0.1.76",
+  "version": "0.1.77",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,7 +12,7 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.77",
-    "@jskit-ai/kernel": "0.1.77"
+    "@jskit-ai/database-runtime": "0.1.78",
+    "@jskit-ai/kernel": "0.1.78"
   }
 }

--- a/packages/database-runtime-postgres/package.descriptor.mjs
+++ b/packages/database-runtime-postgres/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-postgres",
-  version: "0.1.76",
+  version: "0.1.77",
   kind: "runtime",
   options: {
     "db-host": {
@@ -91,7 +91,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.77",
+        "@jskit-ai/database-runtime": "0.1.78",
         "pg": "^8.13.1"
       },
       dev: {}

--- a/packages/database-runtime-postgres/package.json
+++ b/packages/database-runtime-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-postgres",
-  "version": "0.1.76",
+  "version": "0.1.77",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,6 +12,6 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.77"
+    "@jskit-ai/database-runtime": "0.1.78"
   }
 }

--- a/packages/database-runtime/package.descriptor.mjs
+++ b/packages/database-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime",
-  version: "0.1.77",
+  version: "0.1.78",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -58,7 +58,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.77",
+        "@jskit-ai/kernel": "0.1.78",
         "dotenv": "^16.4.5",
         "knex": "^3.1.0"
       },

--- a/packages/database-runtime/package.json
+++ b/packages/database-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime",
-  "version": "0.1.77",
+  "version": "0.1.78",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -25,6 +25,6 @@
     "./shared/transactions": "./src/shared/transactions.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.77"
+    "@jskit-ai/kernel": "0.1.78"
   }
 }

--- a/packages/feature-server-generator/package.descriptor.mjs
+++ b/packages/feature-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/feature-server-generator",
-  version: "0.1.19",
+  version: "0.1.20",
   kind: "generator",
   description: "Scaffold substantial non-CRUD server feature packages with provider, actions, service, and optional persistence seams.",
   options: {
@@ -174,7 +174,7 @@ export default Object.freeze({
             equals: "json-rest"
           }
         },
-        "@jskit-ai/kernel": "0.1.77",
+        "@jskit-ai/kernel": "0.1.78",
         "json-rest-schema": "1.x.x",
         "@local/${option:feature-name|kebab}": "file:packages/${option:feature-name|kebab}"
       },

--- a/packages/feature-server-generator/package.json
+++ b/packages/feature-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/feature-server-generator",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "type": "module",
   "scripts": {
     "test": "node --test"

--- a/packages/google-rewarded-core/package.descriptor.mjs
+++ b/packages/google-rewarded-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/google-rewarded-core",
-  version: "0.1.14",
+  version: "0.1.15",
   kind: "runtime",
   description: "Google rewarded workflow runtime plus internal CRUD providers for rules, provider configs, watch sessions, and unlock receipts.",
   dependsOn: [
@@ -128,14 +128,14 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.76",
-        "@jskit-ai/crud-core": "0.1.85",
-        "@jskit-ai/database-runtime": "0.1.77",
-        "@jskit-ai/http-runtime": "0.1.76",
-        "@jskit-ai/json-rest-api-core": "0.1.22",
-        "@jskit-ai/kernel": "0.1.77",
-        "@jskit-ai/resource-crud-core": "0.1.22",
-        "@jskit-ai/workspaces-core": "0.1.53"
+        "@jskit-ai/auth-core": "0.1.77",
+        "@jskit-ai/crud-core": "0.1.86",
+        "@jskit-ai/database-runtime": "0.1.78",
+        "@jskit-ai/http-runtime": "0.1.77",
+        "@jskit-ai/json-rest-api-core": "0.1.23",
+        "@jskit-ai/kernel": "0.1.78",
+        "@jskit-ai/resource-crud-core": "0.1.23",
+        "@jskit-ai/workspaces-core": "0.1.54"
       },
       dev: {}
     },

--- a/packages/google-rewarded-core/package.json
+++ b/packages/google-rewarded-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/google-rewarded-core",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/google-rewarded-web/package.descriptor.mjs
+++ b/packages/google-rewarded-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/google-rewarded-web",
-  version: "0.1.14",
+  version: "0.1.15",
   kind: "runtime",
   description: "Google rewarded client runtime with a fullscreen gate host and GPT orchestration.",
   dependsOn: [
@@ -46,10 +46,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/google-rewarded-core": "0.1.14",
-        "@jskit-ai/http-runtime": "0.1.76",
-        "@jskit-ai/kernel": "0.1.77",
-        "@jskit-ai/shell-web": "0.1.76"
+        "@jskit-ai/google-rewarded-core": "0.1.15",
+        "@jskit-ai/http-runtime": "0.1.77",
+        "@jskit-ai/kernel": "0.1.78",
+        "@jskit-ai/shell-web": "0.1.77"
       },
       dev: {}
     },

--- a/packages/google-rewarded-web/package.json
+++ b/packages/google-rewarded-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/google-rewarded-web",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/http-runtime/package.descriptor.mjs
+++ b/packages/http-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/http-runtime",
-  "version": "0.1.76",
+  "version": "0.1.77",
   "kind": "runtime",
   "dependsOn": [],
   "capabilities": {
@@ -67,7 +67,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.77"
+        "@jskit-ai/kernel": "0.1.78"
       },
       "dev": {}
     },

--- a/packages/http-runtime/package.json
+++ b/packages/http-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/http-runtime",
-  "version": "0.1.76",
+  "version": "0.1.77",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -18,7 +18,7 @@
     "./shared/validators/operationValidation": "./src/shared/validators/operationValidation.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.77",
+    "@jskit-ai/kernel": "0.1.78",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/json-rest-api-core/package.descriptor.mjs
+++ b/packages/json-rest-api-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/json-rest-api-core",
-  version: "0.1.22",
+  version: "0.1.23",
   kind: "runtime",
   description: "Shared internal json-rest-api host runtime for JSKIT server packages.",
   dependsOn: [

--- a/packages/json-rest-api-core/package.json
+++ b/packages/json-rest-api-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/json-rest-api-core",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,6 +11,6 @@
   "dependencies": {
     "hooked-api": "1.x.x",
     "json-rest-api": "1.x.x",
-    "@jskit-ai/kernel": "0.1.77"
+    "@jskit-ai/kernel": "0.1.78"
   }
 }

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/kernel",
-  "version": "0.1.77",
+  "version": "0.1.78",
   "type": "module",
   "dependencies": {
     "json-rest-schema": "1.x.x"

--- a/packages/mobile-capacitor/package.descriptor.mjs
+++ b/packages/mobile-capacitor/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/mobile-capacitor",
-  version: "0.1.14",
+  version: "0.1.15",
   kind: "runtime",
   description: "Thin Capacitor client integration for JSKIT mobile-shell launch routing and auth callback completion.",
   dependsOn: [
@@ -62,8 +62,8 @@ export default Object.freeze({
         "@capacitor/app": "^7.1.0",
         "@capacitor/browser": "^7.0.1",
         "@capacitor/core": "^7.4.3",
-        "@jskit-ai/kernel": "0.1.77",
-        "@jskit-ai/shell-web": "0.1.76"
+        "@jskit-ai/kernel": "0.1.78",
+        "@jskit-ai/shell-web": "0.1.77"
       },
       dev: {
         "@capacitor/cli": "^7.4.3"

--- a/packages/mobile-capacitor/package.json
+++ b/packages/mobile-capacitor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/mobile-capacitor",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,6 +12,6 @@
   },
   "dependencies": {
     "@capacitor/browser": "^7.0.1",
-    "@jskit-ai/kernel": "0.1.77"
+    "@jskit-ai/kernel": "0.1.78"
   }
 }

--- a/packages/realtime/package.descriptor.mjs
+++ b/packages/realtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/realtime",
-  version: "0.1.76",
+  version: "0.1.77",
   kind: "runtime",
   description: "Thin, generic realtime runtime wrappers for socket.io server and client.",
   options: {
@@ -95,7 +95,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.77",
+        "@jskit-ai/kernel": "0.1.78",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/realtime",
-  "version": "0.1.76",
+  "version": "0.1.77",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@socket.io/redis-adapter": "^8.3.0",
-    "@jskit-ai/kernel": "0.1.77",
+    "@jskit-ai/kernel": "0.1.78",
     "redis": "^5.8.2",
     "socket.io": "^4.8.3",
     "socket.io-client": "^4.8.3"

--- a/packages/resource-core/package.descriptor.mjs
+++ b/packages/resource-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/resource-core",
-  version: "0.1.22",
+  version: "0.1.23",
   kind: "runtime",
   description: "Generic resource-definition helpers and schema-definition normalization.",
   dependsOn: [
@@ -22,7 +22,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/resource-core": "0.1.22"
+        "@jskit-ai/resource-core": "0.1.23"
       },
       dev: {}
     },

--- a/packages/resource-core/package.json
+++ b/packages/resource-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/resource-core",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./shared/resource": "./src/shared/resource.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.77"
+    "@jskit-ai/kernel": "0.1.78"
   }
 }

--- a/packages/resource-crud-core/package.descriptor.mjs
+++ b/packages/resource-crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/resource-crud-core",
-  version: "0.1.22",
+  version: "0.1.23",
   kind: "runtime",
   description: "CRUD-specific resource-definition helpers and namespace support.",
   dependsOn: [
@@ -23,7 +23,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/resource-crud-core": "0.1.22"
+        "@jskit-ai/resource-crud-core": "0.1.23"
       },
       dev: {}
     },

--- a/packages/resource-crud-core/package.json
+++ b/packages/resource-crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/resource-crud-core",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./shared/crudResource": "./src/shared/crudResource.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.77",
-    "@jskit-ai/resource-core": "0.1.22"
+    "@jskit-ai/kernel": "0.1.78",
+    "@jskit-ai/resource-core": "0.1.23"
   }
 }

--- a/packages/shell-web/package.descriptor.mjs
+++ b/packages/shell-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/shell-web",
-  version: "0.1.76",
+  version: "0.1.77",
   kind: "runtime",
   description: "Web shell layout runtime with outlet-based placement contributions.",
   dependsOn: [],
@@ -291,7 +291,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/kernel": "0.1.77"
+        "@jskit-ai/kernel": "0.1.78"
       },
       dev: {}
     },

--- a/packages/shell-web/package.json
+++ b/packages/shell-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/shell-web",
-  "version": "0.1.76",
+  "version": "0.1.77",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/kernel": "0.1.77"
+    "@jskit-ai/kernel": "0.1.78"
   },
   "peerDependencies": {
     "pinia": "^3.0.4",

--- a/packages/storage-runtime/package.descriptor.mjs
+++ b/packages/storage-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/storage-runtime",
-  version: "0.1.76",
+  version: "0.1.77",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -50,7 +50,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.77",
+        "@jskit-ai/kernel": "0.1.78",
         "unstorage": "^1.17.3"
       },
       dev: {}

--- a/packages/storage-runtime/package.json
+++ b/packages/storage-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/storage-runtime",
-  "version": "0.1.76",
+  "version": "0.1.77",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./server/providers/StorageRuntimeServiceProvider": "./src/server/providers/StorageRuntimeServiceProvider.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.77",
+    "@jskit-ai/kernel": "0.1.78",
     "unstorage": "^1.17.3"
   }
 }

--- a/packages/ui-generator/package.descriptor.mjs
+++ b/packages/ui-generator/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { GENERATED_UI_NAVIGATION_ROLE_OPTION } from "@jskit-ai/kernel/shared/sup
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/ui-generator",
-  version: "0.1.60",
+  version: "0.1.61",
   kind: "generator",
   description: "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
   options: {
@@ -371,7 +371,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.92"
+        "@jskit-ai/users-web": "0.1.93"
       },
       dev: {}
     },

--- a/packages/ui-generator/package.json
+++ b/packages/ui-generator/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/ui-generator",
-  "version": "0.1.60",
+  "version": "0.1.61",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.77",
-    "@jskit-ai/shell-web": "0.1.76"
+    "@jskit-ai/kernel": "0.1.78",
+    "@jskit-ai/shell-web": "0.1.77"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/uploads-image-web/package.descriptor.mjs
+++ b/packages/uploads-image-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-image-web",
-  version: "0.1.55",
+  version: "0.1.56",
   kind: "runtime",
   description: "Reusable client-side image upload runtime with pre-upload image editing.",
   dependsOn: [
@@ -65,7 +65,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/uploads-runtime": "0.1.55",
+        "@jskit-ai/uploads-runtime": "0.1.56",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-image-web/package.json
+++ b/packages/uploads-image-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-image-web",
-  "version": "0.1.55",
+  "version": "0.1.56",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,7 +13,7 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/uploads-runtime": "0.1.55",
+    "@jskit-ai/uploads-runtime": "0.1.56",
     "@uppy/compressor": "^3.1.0",
     "@uppy/core": "^5.2.0",
     "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-runtime/package.descriptor.mjs
+++ b/packages/uploads-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-runtime",
-  version: "0.1.55",
+  version: "0.1.56",
   kind: "runtime",
   description: "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
   dependsOn: [
@@ -71,7 +71,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.77"
+        "@jskit-ai/kernel": "0.1.78"
       },
       dev: {}
     },

--- a/packages/uploads-runtime/package.json
+++ b/packages/uploads-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-runtime",
-  "version": "0.1.55",
+  "version": "0.1.56",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,6 +16,6 @@
   },
   "dependencies": {
     "@fastify/multipart": "^9.4.0",
-    "@jskit-ai/kernel": "0.1.77"
+    "@jskit-ai/kernel": "0.1.78"
   }
 }

--- a/packages/users-core/package.descriptor.mjs
+++ b/packages/users-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-core",
-  version: "0.1.87",
+  version: "0.1.88",
   kind: "runtime",
   description: "Users/account runtime plus HTTP routes for account features.",
   dependsOn: [
@@ -143,16 +143,16 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.76",
-        "@jskit-ai/crud-core": "0.1.85",
-        "@jskit-ai/database-runtime": "0.1.77",
-        "@jskit-ai/http-runtime": "0.1.76",
-        "@jskit-ai/json-rest-api-core": "0.1.22",
-        "@jskit-ai/kernel": "0.1.77",
-        "@jskit-ai/resource-core": "0.1.22",
-        "@jskit-ai/resource-crud-core": "0.1.22",
+        "@jskit-ai/auth-core": "0.1.77",
+        "@jskit-ai/crud-core": "0.1.86",
+        "@jskit-ai/database-runtime": "0.1.78",
+        "@jskit-ai/http-runtime": "0.1.77",
+        "@jskit-ai/json-rest-api-core": "0.1.23",
+        "@jskit-ai/kernel": "0.1.78",
+        "@jskit-ai/resource-core": "0.1.23",
+        "@jskit-ai/resource-crud-core": "0.1.23",
         "@local/users": "file:packages/users",
-        "@jskit-ai/uploads-runtime": "0.1.55"
+        "@jskit-ai/uploads-runtime": "0.1.56"
       },
       dev: {}
     },

--- a/packages/users-core/package.json
+++ b/packages/users-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-core",
-  "version": "0.1.87",
+  "version": "0.1.88",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,14 +11,14 @@
     "./shared/resources/userSettingsResource": "./src/shared/resources/userSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.76",
-    "@jskit-ai/database-runtime": "0.1.77",
-    "@jskit-ai/http-runtime": "0.1.76",
-    "@jskit-ai/json-rest-api-core": "0.1.22",
-    "@jskit-ai/kernel": "0.1.77",
-    "@jskit-ai/resource-crud-core": "0.1.22",
-    "@jskit-ai/resource-core": "0.1.22",
-    "@jskit-ai/uploads-runtime": "0.1.55",
+    "@jskit-ai/auth-core": "0.1.77",
+    "@jskit-ai/database-runtime": "0.1.78",
+    "@jskit-ai/http-runtime": "0.1.77",
+    "@jskit-ai/json-rest-api-core": "0.1.23",
+    "@jskit-ai/kernel": "0.1.78",
+    "@jskit-ai/resource-crud-core": "0.1.23",
+    "@jskit-ai/resource-core": "0.1.23",
+    "@jskit-ai/uploads-runtime": "0.1.56",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/users-web/package.descriptor.mjs
+++ b/packages/users-web/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { HOME_COG_OUTLET } from "./src/shared/toolsOutletContracts.js";
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-web",
-  version: "0.1.92",
+  version: "0.1.93",
   kind: "runtime",
   description: "Users web module: account/profile UI plus shared users web widgets.",
   dependsOn: [
@@ -278,12 +278,12 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/http-runtime": "0.1.76",
-        "@jskit-ai/realtime": "0.1.76",
-        "@jskit-ai/kernel": "0.1.77",
-        "@jskit-ai/shell-web": "0.1.76",
-        "@jskit-ai/uploads-image-web": "0.1.55",
-        "@jskit-ai/users-core": "0.1.87"
+        "@jskit-ai/http-runtime": "0.1.77",
+        "@jskit-ai/realtime": "0.1.77",
+        "@jskit-ai/kernel": "0.1.78",
+        "@jskit-ai/shell-web": "0.1.77",
+        "@jskit-ai/uploads-image-web": "0.1.56",
+        "@jskit-ai/users-core": "0.1.88"
       },
       dev: {}
     },

--- a/packages/users-web/package.json
+++ b/packages/users-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-web",
-  "version": "0.1.92",
+  "version": "0.1.93",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -44,12 +44,12 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/http-runtime": "0.1.76",
-    "@jskit-ai/kernel": "0.1.77",
-    "@jskit-ai/realtime": "0.1.76",
-    "@jskit-ai/shell-web": "0.1.76",
-    "@jskit-ai/uploads-image-web": "0.1.55",
-    "@jskit-ai/users-core": "0.1.87"
+    "@jskit-ai/http-runtime": "0.1.77",
+    "@jskit-ai/kernel": "0.1.78",
+    "@jskit-ai/realtime": "0.1.77",
+    "@jskit-ai/shell-web": "0.1.77",
+    "@jskit-ai/uploads-image-web": "0.1.56",
+    "@jskit-ai/users-core": "0.1.88"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/workspaces-core/package.descriptor.mjs
+++ b/packages/workspaces-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-core",
-  version: "0.1.53",
+  version: "0.1.54",
   kind: "runtime",
   description: "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
   dependsOn: [
@@ -142,10 +142,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/json-rest-api-core": "0.1.22",
-        "@jskit-ai/resource-core": "0.1.22",
-        "@jskit-ai/resource-crud-core": "0.1.22",
-        "@jskit-ai/users-core": "0.1.87"
+        "@jskit-ai/json-rest-api-core": "0.1.23",
+        "@jskit-ai/resource-core": "0.1.23",
+        "@jskit-ai/resource-crud-core": "0.1.23",
+        "@jskit-ai/users-core": "0.1.88"
       },
       dev: {}
     },

--- a/packages/workspaces-core/package.json
+++ b/packages/workspaces-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-core",
-  "version": "0.1.53",
+  "version": "0.1.54",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -17,14 +17,14 @@
     "./shared/resources/workspaceSettingsResource": "./src/shared/resources/workspaceSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.76",
-    "@jskit-ai/database-runtime": "0.1.77",
-    "@jskit-ai/http-runtime": "0.1.76",
-    "@jskit-ai/json-rest-api-core": "0.1.22",
-    "@jskit-ai/kernel": "0.1.77",
-    "@jskit-ai/resource-crud-core": "0.1.22",
-    "@jskit-ai/resource-core": "0.1.22",
-    "@jskit-ai/users-core": "0.1.87",
+    "@jskit-ai/auth-core": "0.1.77",
+    "@jskit-ai/database-runtime": "0.1.78",
+    "@jskit-ai/http-runtime": "0.1.77",
+    "@jskit-ai/json-rest-api-core": "0.1.23",
+    "@jskit-ai/kernel": "0.1.78",
+    "@jskit-ai/resource-crud-core": "0.1.23",
+    "@jskit-ai/resource-core": "0.1.23",
+    "@jskit-ai/users-core": "0.1.88",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/workspaces-web/package.descriptor.mjs
+++ b/packages/workspaces-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-web",
-  version: "0.1.53",
+  version: "0.1.54",
   kind: "runtime",
   description: "Workspace web module: workspace selector, tools widget, workspace surfaces, and members/settings UI.",
   dependsOn: [
@@ -231,8 +231,8 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/workspaces-core": "0.1.53",
-        "@jskit-ai/users-web": "0.1.92"
+        "@jskit-ai/workspaces-core": "0.1.54",
+        "@jskit-ai/users-web": "0.1.93"
       },
       dev: {}
     },

--- a/packages/workspaces-web/package.json
+++ b/packages/workspaces-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-web",
-  "version": "0.1.53",
+  "version": "0.1.54",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -15,12 +15,12 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/http-runtime": "0.1.76",
-    "@jskit-ai/kernel": "0.1.77",
-    "@jskit-ai/shell-web": "0.1.76",
-    "@jskit-ai/users-core": "0.1.87",
-    "@jskit-ai/users-web": "0.1.92",
-    "@jskit-ai/workspaces-core": "0.1.53"
+    "@jskit-ai/http-runtime": "0.1.77",
+    "@jskit-ai/kernel": "0.1.78",
+    "@jskit-ai/shell-web": "0.1.77",
+    "@jskit-ai/users-core": "0.1.88",
+    "@jskit-ai/users-web": "0.1.93",
+    "@jskit-ai/workspaces-core": "0.1.54"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/tooling/config-eslint/package.json
+++ b/tooling/config-eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/config-eslint",
-  "version": "0.1.76",
+  "version": "0.1.77",
   "description": "Shared flat ESLint presets for JSKIT projects.",
   "type": "module",
   "files": [

--- a/tooling/create-app/package.descriptor.mjs
+++ b/tooling/create-app/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/create-app",
-  "version": "0.1.85",
+  "version": "0.1.86",
   "dependsOn": [],
   "capabilities": {
     "provides": [

--- a/tooling/create-app/package.json
+++ b/tooling/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/create-app",
-  "version": "0.1.85",
+  "version": "0.1.86",
   "description": "Scaffold minimal JSKIT app shells.",
   "type": "module",
   "files": [

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -6,11 +6,11 @@
   "packages": [
     {
       "packageId": "@jskit-ai/assistant",
-      "version": "0.1.86",
+      "version": "0.1.87",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant",
-        "version": "0.1.86",
+        "version": "0.1.87",
         "kind": "generator",
         "description": "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
         "options": {
@@ -347,11 +347,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-core",
-      "version": "0.1.53",
+      "version": "0.1.54",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-core",
-        "version": "0.1.53",
+        "version": "0.1.54",
         "kind": "runtime",
         "description": "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
         "dependsOn": [
@@ -399,11 +399,11 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/http-runtime": "0.1.76",
-              "@jskit-ai/kernel": "0.1.77",
-              "@jskit-ai/resource-core": "0.1.22",
-              "@jskit-ai/resource-crud-core": "0.1.22",
-              "@jskit-ai/users-core": "0.1.87",
+              "@jskit-ai/http-runtime": "0.1.77",
+              "@jskit-ai/kernel": "0.1.78",
+              "@jskit-ai/resource-core": "0.1.23",
+              "@jskit-ai/resource-crud-core": "0.1.23",
+              "@jskit-ai/users-core": "0.1.88",
               "dompurify": "^3.3.3",
               "json-rest-schema": "1.x.x",
               "marked": "^17.0.4",
@@ -422,11 +422,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-runtime",
-      "version": "0.1.48",
+      "version": "0.1.49",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-runtime",
-        "version": "0.1.48",
+        "version": "0.1.49",
         "kind": "runtime",
         "description": "Shared assistant runtime with per-surface assistant registration.",
         "dependsOn": [
@@ -522,13 +522,13 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/assistant-core": "0.1.53",
-              "@jskit-ai/database-runtime": "0.1.77",
-              "@jskit-ai/http-runtime": "0.1.76",
-              "@jskit-ai/kernel": "0.1.77",
-              "@jskit-ai/shell-web": "0.1.76",
-              "@jskit-ai/users-core": "0.1.87",
-              "@jskit-ai/users-web": "0.1.92"
+              "@jskit-ai/assistant-core": "0.1.54",
+              "@jskit-ai/database-runtime": "0.1.78",
+              "@jskit-ai/http-runtime": "0.1.77",
+              "@jskit-ai/kernel": "0.1.78",
+              "@jskit-ai/shell-web": "0.1.77",
+              "@jskit-ai/users-core": "0.1.88",
+              "@jskit-ai/users-web": "0.1.93"
             },
             "dev": {}
           },
@@ -583,11 +583,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-core",
-      "version": "0.1.76",
+      "version": "0.1.77",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-core",
-        "version": "0.1.76",
+        "version": "0.1.77",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/value-app-config-shared"
@@ -655,7 +655,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.77",
+              "@jskit-ai/kernel": "0.1.78",
               "@fastify/cookie": "^11.0.2",
               "@fastify/csrf-protection": "^7.1.0",
               "@fastify/rate-limit": "^10.3.0"
@@ -673,11 +673,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.76",
+      "version": "0.1.77",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-supabase-core",
-        "version": "0.1.76",
+        "version": "0.1.77",
         "kind": "runtime",
         "options": {
           "auth-supabase-url": {
@@ -759,8 +759,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.76",
-              "@jskit-ai/kernel": "0.1.77",
+              "@jskit-ai/auth-core": "0.1.77",
+              "@jskit-ai/kernel": "0.1.78",
               "dotenv": "^16.4.5",
               "@supabase/supabase-js": "^2.57.4",
               "jose": "^6.1.0"
@@ -825,11 +825,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-web",
-      "version": "0.1.78",
+      "version": "0.1.79",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-web",
-        "version": "0.1.78",
+        "version": "0.1.79",
         "kind": "runtime",
         "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
         "dependsOn": [
@@ -1085,10 +1085,10 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/auth-core": "0.1.76",
-              "@jskit-ai/http-runtime": "0.1.76",
-              "@jskit-ai/kernel": "0.1.77",
-              "@jskit-ai/shell-web": "0.1.76"
+              "@jskit-ai/auth-core": "0.1.77",
+              "@jskit-ai/http-runtime": "0.1.77",
+              "@jskit-ai/kernel": "0.1.78",
+              "@jskit-ai/shell-web": "0.1.77"
             },
             "dev": {}
           },
@@ -1167,11 +1167,11 @@
     },
     {
       "packageId": "@jskit-ai/console-core",
-      "version": "0.1.40",
+      "version": "0.1.41",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-core",
-        "version": "0.1.40",
+        "version": "0.1.41",
         "kind": "runtime",
         "description": "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
         "dependsOn": [
@@ -1255,12 +1255,12 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.76",
-              "@jskit-ai/database-runtime": "0.1.77",
-              "@jskit-ai/http-runtime": "0.1.76",
-              "@jskit-ai/kernel": "0.1.77",
-              "@jskit-ai/resource-crud-core": "0.1.22",
-              "@jskit-ai/users-core": "0.1.87"
+              "@jskit-ai/auth-core": "0.1.77",
+              "@jskit-ai/database-runtime": "0.1.78",
+              "@jskit-ai/http-runtime": "0.1.77",
+              "@jskit-ai/kernel": "0.1.78",
+              "@jskit-ai/resource-crud-core": "0.1.23",
+              "@jskit-ai/users-core": "0.1.88"
             },
             "dev": {}
           },
@@ -1285,11 +1285,11 @@
     },
     {
       "packageId": "@jskit-ai/console-web",
-      "version": "0.1.45",
+      "version": "0.1.46",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-web",
-        "version": "0.1.45",
+        "version": "0.1.46",
         "kind": "runtime",
         "description": "Authenticated console surface scaffold and surface policy wiring.",
         "dependsOn": [
@@ -1399,9 +1399,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-web": "0.1.78",
-              "@jskit-ai/console-core": "0.1.40",
-              "@jskit-ai/shell-web": "0.1.76"
+              "@jskit-ai/auth-web": "0.1.79",
+              "@jskit-ai/console-core": "0.1.41",
+              "@jskit-ai/shell-web": "0.1.77"
             },
             "dev": {}
           },
@@ -1508,11 +1508,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-core",
-      "version": "0.1.85",
+      "version": "0.1.86",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-core",
-        "version": "0.1.85",
+        "version": "0.1.86",
         "kind": "runtime",
         "description": "Shared CRUD helpers used by CRUD modules.",
         "dependsOn": [
@@ -1541,7 +1541,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/crud-core": "0.1.85"
+              "@jskit-ai/crud-core": "0.1.86"
             },
             "dev": {}
           },
@@ -1555,11 +1555,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-server-generator",
-      "version": "0.1.85",
+      "version": "0.1.86",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-server-generator",
-        "version": "0.1.85",
+        "version": "0.1.86",
         "kind": "generator",
         "description": "CRUD server generator with routes, actions, and persistence scaffolding.",
         "options": {
@@ -1726,14 +1726,14 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.76",
-              "@jskit-ai/crud-core": "0.1.85",
-              "@jskit-ai/database-runtime": "0.1.77",
-              "@jskit-ai/http-runtime": "0.1.76",
-              "@jskit-ai/json-rest-api-core": "0.1.22",
-              "@jskit-ai/kernel": "0.1.77",
-              "@jskit-ai/realtime": "0.1.76",
-              "@jskit-ai/resource-crud-core": "0.1.22",
+              "@jskit-ai/auth-core": "0.1.77",
+              "@jskit-ai/crud-core": "0.1.86",
+              "@jskit-ai/database-runtime": "0.1.78",
+              "@jskit-ai/http-runtime": "0.1.77",
+              "@jskit-ai/json-rest-api-core": "0.1.23",
+              "@jskit-ai/kernel": "0.1.78",
+              "@jskit-ai/realtime": "0.1.77",
+              "@jskit-ai/resource-crud-core": "0.1.23",
               "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}"
             },
             "dev": {}
@@ -1865,11 +1865,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.60",
+      "version": "0.1.61",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-ui-generator",
-        "version": "0.1.60",
+        "version": "0.1.61",
         "kind": "generator",
         "description": "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
         "options": {
@@ -2068,7 +2068,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.92"
+              "@jskit-ai/users-web": "0.1.93"
             },
             "dev": {}
           },
@@ -2327,11 +2327,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime",
-      "version": "0.1.77",
+      "version": "0.1.78",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime",
-        "version": "0.1.77",
+        "version": "0.1.78",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -2388,7 +2388,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.77",
+              "@jskit-ai/kernel": "0.1.78",
               "dotenv": "^16.4.5",
               "knex": "^3.1.0"
             },
@@ -2423,11 +2423,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.76",
+      "version": "0.1.77",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-mysql",
-        "version": "0.1.76",
+        "version": "0.1.77",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -2517,7 +2517,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.77",
+              "@jskit-ai/database-runtime": "0.1.78",
               "mysql2": "^3.11.2"
             },
             "dev": {}
@@ -2588,11 +2588,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.76",
+      "version": "0.1.77",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-postgres",
-        "version": "0.1.76",
+        "version": "0.1.77",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -2682,7 +2682,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.77",
+              "@jskit-ai/database-runtime": "0.1.78",
               "pg": "^8.13.1"
             },
             "dev": {}
@@ -2753,11 +2753,11 @@
     },
     {
       "packageId": "@jskit-ai/feature-server-generator",
-      "version": "0.1.19",
+      "version": "0.1.20",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/feature-server-generator",
-        "version": "0.1.19",
+        "version": "0.1.20",
         "kind": "generator",
         "description": "Scaffold substantial non-CRUD server feature packages with provider, actions, service, and optional persistence seams.",
         "options": {
@@ -2942,7 +2942,7 @@
                   "equals": "json-rest"
                 }
               },
-              "@jskit-ai/kernel": "0.1.77",
+              "@jskit-ai/kernel": "0.1.78",
               "json-rest-schema": "1.x.x",
               "@local/${option:feature-name|kebab}": "file:packages/${option:feature-name|kebab}"
             },
@@ -3055,11 +3055,11 @@
     },
     {
       "packageId": "@jskit-ai/google-rewarded-core",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/google-rewarded-core",
-        "version": "0.1.14",
+        "version": "0.1.15",
         "kind": "runtime",
         "description": "Google rewarded workflow runtime plus internal CRUD providers for rules, provider configs, watch sessions, and unlock receipts.",
         "dependsOn": [
@@ -3186,14 +3186,14 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.76",
-              "@jskit-ai/crud-core": "0.1.85",
-              "@jskit-ai/database-runtime": "0.1.77",
-              "@jskit-ai/http-runtime": "0.1.76",
-              "@jskit-ai/json-rest-api-core": "0.1.22",
-              "@jskit-ai/kernel": "0.1.77",
-              "@jskit-ai/resource-crud-core": "0.1.22",
-              "@jskit-ai/workspaces-core": "0.1.53"
+              "@jskit-ai/auth-core": "0.1.77",
+              "@jskit-ai/crud-core": "0.1.86",
+              "@jskit-ai/database-runtime": "0.1.78",
+              "@jskit-ai/http-runtime": "0.1.77",
+              "@jskit-ai/json-rest-api-core": "0.1.23",
+              "@jskit-ai/kernel": "0.1.78",
+              "@jskit-ai/resource-crud-core": "0.1.23",
+              "@jskit-ai/workspaces-core": "0.1.54"
             },
             "dev": {}
           },
@@ -3245,11 +3245,11 @@
     },
     {
       "packageId": "@jskit-ai/google-rewarded-web",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/google-rewarded-web",
-        "version": "0.1.14",
+        "version": "0.1.15",
         "kind": "runtime",
         "description": "Google rewarded client runtime with a fullscreen gate host and GPT orchestration.",
         "dependsOn": [
@@ -3296,10 +3296,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/google-rewarded-core": "0.1.14",
-              "@jskit-ai/http-runtime": "0.1.76",
-              "@jskit-ai/kernel": "0.1.77",
-              "@jskit-ai/shell-web": "0.1.76"
+              "@jskit-ai/google-rewarded-core": "0.1.15",
+              "@jskit-ai/http-runtime": "0.1.77",
+              "@jskit-ai/kernel": "0.1.78",
+              "@jskit-ai/shell-web": "0.1.77"
             },
             "dev": {}
           },
@@ -3317,11 +3317,11 @@
     },
     {
       "packageId": "@jskit-ai/http-runtime",
-      "version": "0.1.76",
+      "version": "0.1.77",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/http-runtime",
-        "version": "0.1.76",
+        "version": "0.1.77",
         "kind": "runtime",
         "dependsOn": [],
         "capabilities": {
@@ -3387,7 +3387,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.77"
+              "@jskit-ai/kernel": "0.1.78"
             },
             "dev": {}
           },
@@ -3401,11 +3401,11 @@
     },
     {
       "packageId": "@jskit-ai/json-rest-api-core",
-      "version": "0.1.22",
+      "version": "0.1.23",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/json-rest-api-core",
-        "version": "0.1.22",
+        "version": "0.1.23",
         "kind": "runtime",
         "description": "Shared internal json-rest-api host runtime for JSKIT server packages.",
         "dependsOn": [
@@ -3465,11 +3465,11 @@
     },
     {
       "packageId": "@jskit-ai/mobile-capacitor",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/mobile-capacitor",
-        "version": "0.1.14",
+        "version": "0.1.15",
         "kind": "runtime",
         "description": "Thin Capacitor client integration for JSKIT mobile-shell launch routing and auth callback completion.",
         "dependsOn": [
@@ -3532,8 +3532,8 @@
               "@capacitor/app": "^7.1.0",
               "@capacitor/browser": "^7.0.1",
               "@capacitor/core": "^7.4.3",
-              "@jskit-ai/kernel": "0.1.77",
-              "@jskit-ai/shell-web": "0.1.76"
+              "@jskit-ai/kernel": "0.1.78",
+              "@jskit-ai/shell-web": "0.1.77"
             },
             "dev": {
               "@capacitor/cli": "^7.4.3"
@@ -3585,11 +3585,11 @@
     },
     {
       "packageId": "@jskit-ai/realtime",
-      "version": "0.1.76",
+      "version": "0.1.77",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/realtime",
-        "version": "0.1.76",
+        "version": "0.1.77",
         "kind": "runtime",
         "description": "Thin, generic realtime runtime wrappers for socket.io server and client.",
         "options": {
@@ -3685,7 +3685,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.77",
+              "@jskit-ai/kernel": "0.1.78",
               "@socket.io/redis-adapter": "^8.3.0",
               "redis": "^5.8.2",
               "socket.io": "^4.8.3",
@@ -3734,11 +3734,11 @@
     },
     {
       "packageId": "@jskit-ai/resource-core",
-      "version": "0.1.22",
+      "version": "0.1.23",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/resource-core",
-        "version": "0.1.22",
+        "version": "0.1.23",
         "kind": "runtime",
         "description": "Generic resource-definition helpers and schema-definition normalization.",
         "dependsOn": [
@@ -3761,7 +3761,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/resource-core": "0.1.22"
+              "@jskit-ai/resource-core": "0.1.23"
             },
             "dev": {}
           },
@@ -3776,11 +3776,11 @@
     },
     {
       "packageId": "@jskit-ai/resource-crud-core",
-      "version": "0.1.22",
+      "version": "0.1.23",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/resource-crud-core",
-        "version": "0.1.22",
+        "version": "0.1.23",
         "kind": "runtime",
         "description": "CRUD-specific resource-definition helpers and namespace support.",
         "dependsOn": [
@@ -3804,7 +3804,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/resource-crud-core": "0.1.22"
+              "@jskit-ai/resource-crud-core": "0.1.23"
             },
             "dev": {}
           },
@@ -3819,11 +3819,11 @@
     },
     {
       "packageId": "@jskit-ai/shell-web",
-      "version": "0.1.76",
+      "version": "0.1.77",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/shell-web",
-        "version": "0.1.76",
+        "version": "0.1.77",
         "kind": "runtime",
         "description": "Web shell layout runtime with outlet-based placement contributions.",
         "dependsOn": [],
@@ -4149,7 +4149,7 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/kernel": "0.1.77"
+              "@jskit-ai/kernel": "0.1.78"
             },
             "dev": {}
           },
@@ -4349,11 +4349,11 @@
     },
     {
       "packageId": "@jskit-ai/storage-runtime",
-      "version": "0.1.76",
+      "version": "0.1.77",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/storage-runtime",
-        "version": "0.1.76",
+        "version": "0.1.77",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -4402,7 +4402,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.77",
+              "@jskit-ai/kernel": "0.1.78",
               "unstorage": "^1.17.3"
             },
             "dev": {}
@@ -4418,11 +4418,11 @@
     },
     {
       "packageId": "@jskit-ai/ui-generator",
-      "version": "0.1.60",
+      "version": "0.1.61",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/ui-generator",
-        "version": "0.1.60",
+        "version": "0.1.61",
         "kind": "generator",
         "description": "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
         "options": {
@@ -4855,7 +4855,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.92"
+              "@jskit-ai/users-web": "0.1.93"
             },
             "dev": {}
           },
@@ -4870,11 +4870,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-image-web",
-      "version": "0.1.55",
+      "version": "0.1.56",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-image-web",
-        "version": "0.1.55",
+        "version": "0.1.56",
         "kind": "runtime",
         "description": "Reusable client-side image upload runtime with pre-upload image editing.",
         "dependsOn": [
@@ -4938,7 +4938,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/uploads-runtime": "0.1.55",
+              "@jskit-ai/uploads-runtime": "0.1.56",
               "@uppy/compressor": "^3.1.0",
               "@uppy/core": "^5.2.0",
               "@uppy/dashboard": "^5.1.1",
@@ -4958,11 +4958,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-runtime",
-      "version": "0.1.55",
+      "version": "0.1.56",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-runtime",
-        "version": "0.1.55",
+        "version": "0.1.56",
         "kind": "runtime",
         "description": "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
         "dependsOn": [
@@ -5032,7 +5032,7 @@
           "dependencies": {
             "runtime": {
               "@fastify/multipart": "^9.4.0",
-              "@jskit-ai/kernel": "0.1.77"
+              "@jskit-ai/kernel": "0.1.78"
             },
             "dev": {}
           },
@@ -5047,11 +5047,11 @@
     },
     {
       "packageId": "@jskit-ai/users-core",
-      "version": "0.1.87",
+      "version": "0.1.88",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-core",
-        "version": "0.1.87",
+        "version": "0.1.88",
         "kind": "runtime",
         "description": "Users/account runtime plus HTTP routes for account features.",
         "dependsOn": [
@@ -5192,16 +5192,16 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.76",
-              "@jskit-ai/crud-core": "0.1.85",
-              "@jskit-ai/database-runtime": "0.1.77",
-              "@jskit-ai/http-runtime": "0.1.76",
-              "@jskit-ai/json-rest-api-core": "0.1.22",
-              "@jskit-ai/kernel": "0.1.77",
-              "@jskit-ai/resource-core": "0.1.22",
-              "@jskit-ai/resource-crud-core": "0.1.22",
+              "@jskit-ai/auth-core": "0.1.77",
+              "@jskit-ai/crud-core": "0.1.86",
+              "@jskit-ai/database-runtime": "0.1.78",
+              "@jskit-ai/http-runtime": "0.1.77",
+              "@jskit-ai/json-rest-api-core": "0.1.23",
+              "@jskit-ai/kernel": "0.1.78",
+              "@jskit-ai/resource-core": "0.1.23",
+              "@jskit-ai/resource-crud-core": "0.1.23",
               "@local/users": "file:packages/users",
-              "@jskit-ai/uploads-runtime": "0.1.55"
+              "@jskit-ai/uploads-runtime": "0.1.56"
             },
             "dev": {}
           },
@@ -5418,11 +5418,11 @@
     },
     {
       "packageId": "@jskit-ai/users-web",
-      "version": "0.1.92",
+      "version": "0.1.93",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-web",
-        "version": "0.1.92",
+        "version": "0.1.93",
         "kind": "runtime",
         "description": "Users web module: account/profile UI plus shared users web widgets.",
         "dependsOn": [
@@ -5717,12 +5717,12 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/http-runtime": "0.1.76",
-              "@jskit-ai/realtime": "0.1.76",
-              "@jskit-ai/kernel": "0.1.77",
-              "@jskit-ai/shell-web": "0.1.76",
-              "@jskit-ai/uploads-image-web": "0.1.55",
-              "@jskit-ai/users-core": "0.1.87"
+              "@jskit-ai/http-runtime": "0.1.77",
+              "@jskit-ai/realtime": "0.1.77",
+              "@jskit-ai/kernel": "0.1.78",
+              "@jskit-ai/shell-web": "0.1.77",
+              "@jskit-ai/uploads-image-web": "0.1.56",
+              "@jskit-ai/users-core": "0.1.88"
             },
             "dev": {}
           },
@@ -5891,11 +5891,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-core",
-      "version": "0.1.53",
+      "version": "0.1.54",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-core",
-        "version": "0.1.53",
+        "version": "0.1.54",
         "kind": "runtime",
         "description": "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
         "dependsOn": [
@@ -6036,10 +6036,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/json-rest-api-core": "0.1.22",
-              "@jskit-ai/resource-core": "0.1.22",
-              "@jskit-ai/resource-crud-core": "0.1.22",
-              "@jskit-ai/users-core": "0.1.87"
+              "@jskit-ai/json-rest-api-core": "0.1.23",
+              "@jskit-ai/resource-core": "0.1.23",
+              "@jskit-ai/resource-crud-core": "0.1.23",
+              "@jskit-ai/users-core": "0.1.88"
             },
             "dev": {}
           },
@@ -6211,11 +6211,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-web",
-      "version": "0.1.53",
+      "version": "0.1.54",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-web",
-        "version": "0.1.53",
+        "version": "0.1.54",
         "kind": "runtime",
         "description": "Workspace web module: workspace selector, tools widget, workspace surfaces, and members/settings UI.",
         "dependsOn": [
@@ -6471,8 +6471,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/workspaces-core": "0.1.53",
-              "@jskit-ai/users-web": "0.1.92"
+              "@jskit-ai/workspaces-core": "0.1.54",
+              "@jskit-ai/users-web": "0.1.93"
             },
             "dev": {}
           },

--- a/tooling/jskit-catalog/package.json
+++ b/tooling/jskit-catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-catalog",
-  "version": "0.1.85",
+  "version": "0.1.86",
   "description": "Published metadata catalog for JSKIT package descriptors.",
   "type": "module",
   "files": [

--- a/tooling/jskit-cli/package.json
+++ b/tooling/jskit-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-cli",
-  "version": "0.2.86",
+  "version": "0.2.87",
   "description": "Bundle and package orchestration CLI for JSKIT apps.",
   "type": "module",
   "files": [
@@ -20,9 +20,9 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/jskit-catalog": "0.1.85",
-    "@jskit-ai/kernel": "0.1.77",
-    "@jskit-ai/shell-web": "0.1.76",
+    "@jskit-ai/jskit-catalog": "0.1.86",
+    "@jskit-ai/kernel": "0.1.78",
+    "@jskit-ai/shell-web": "0.1.77",
     "@vue/compiler-sfc": "^3.5.29",
     "ts-morph": "^28.0.0"
   },

--- a/tooling/jskit-cli/src/server/sessionRuntime/prompts/automated_checks.md
+++ b/tooling/jskit-cli/src/server/sessionRuntime/prompts/automated_checks.md
@@ -13,7 +13,8 @@ Run the command in the session worktree. If it fails, diagnose the root cause, f
 Rules:
 
 - Fix the underlying cause. Do not remove checks, weaken verification, or hide failures to make the command pass.
-- Prefer JSKIT-owned helpers, generators, package seams, and documented commands over local hacks.
+- Prefer JSKIT-owned helpers, generators, package seams, agent docs, package descriptors, and documented commands over local hacks.
+- If a failure involves JSKIT architecture, generator ownership, CRUD, surfaces, placements, client/server contracts, or UI verification, read the relevant docs under `node_modules/@jskit-ai/agent-docs/` or `packages/agent-docs/` before repairing it.
 - Use `npx --no-install jskit ...` for JSKIT CLI commands you run directly from the shell.
 - Keep fixes scoped to the current issue, issue details, and active plan.
 - Do not create commits, branches, issues, pull requests, merges, or worktree cleanup. JSKIT session owns those steps.

--- a/tooling/jskit-cli/src/server/sessionRuntime/prompts/deep_ui_check.md
+++ b/tooling/jskit-cli/src/server/sessionRuntime/prompts/deep_ui_check.md
@@ -16,6 +16,8 @@ Changed files since the session base:
 
 Run a focused UI quality pass for the current worktree. If this is not UI-impacting after inspection, say exactly why and do not edit files. If the issue touches UI, inspect the changed routes, views, components, placements, layouts, and styles.
 
+Before changing user-facing JSKIT UI, read the relevant JSKIT agent docs when available: `node_modules/@jskit-ai/agent-docs/patterns/ui-testing.md`, `node_modules/@jskit-ai/agent-docs/patterns/page-scaffolding.md`, `node_modules/@jskit-ai/agent-docs/patterns/placements.md`, and `node_modules/@jskit-ai/agent-docs/patterns/surfaces.md`. If working inside the JSKIT monorepo or a devlinked sibling, use the equivalent `packages/agent-docs/...` paths.
+
 Check:
 
 - Material Design quality.

--- a/tooling/jskit-cli/src/server/sessionRuntime/prompts/execute_plan.md
+++ b/tooling/jskit-cli/src/server/sessionRuntime/prompts/execute_plan.md
@@ -22,6 +22,8 @@ Implementation rules:
 
 - Inspect the current app before editing. App setup has already passed; if required JSKIT app files are missing, report setup failure rather than inventing recovery work.
 - Follow both `{{issue_details_file}}` and `{{plan_file}}`. If they disagree, ask for clarification before changing files.
+- Before implementing JSKIT app structure, generators, CRUD, surfaces, placements, app setup, package-owned workflows, or UI verification paths, read the relevant JSKIT agent docs. Start with `node_modules/@jskit-ai/agent-docs/DISTR_AGENT.md`, `node_modules/@jskit-ai/agent-docs/guide/agent/index.md`, and `node_modules/@jskit-ai/agent-docs/patterns/INDEX.md` when present. If working inside the JSKIT monorepo or a devlinked sibling, use `packages/agent-docs/...` as the source-tree equivalent.
+- Read specific pattern docs before touching their lane, such as CRUD scaffolding/repository mapping, page scaffolding, surfaces, placements, client requests, live actions, generated UI contract tracking, and UI testing. Prefer these docs and package descriptors over reverse-engineering framework rules from source files.
 - Read `.jskit/helper-map.md` when it exists before creating helpers, composables, service functions, maps, or package glue.
 - Prefer existing JSKIT helpers, app-local helpers, package runtime seams, generated scaffolds, and documented generators over new local helpers.
 - If the plan calls for a generator or package install, use the planned `npx --no-install jskit` command unless inspection proves it does not apply. If you skip a generator, explain the exact gap.

--- a/tooling/jskit-cli/src/server/sessionRuntime/prompts/issue_details.md
+++ b/tooling/jskit-cli/src/server/sessionRuntime/prompts/issue_details.md
@@ -14,6 +14,7 @@ No stones unturned:
 - Read the issue and inspect the app enough to understand the implementation surface.
 - Read `.jskit/APP_BLUEPRINT.md` and `.jskit/helper-map.md` when present.
 - Read package.json, `.jskit/lock.json`, `config/public.js`, relevant `src/`, relevant `packages/`, and relevant package docs or `npx --no-install jskit show ... --details`.
+- Read JSKIT agent docs before inferring framework patterns from source. Start with `node_modules/@jskit-ai/agent-docs/DISTR_AGENT.md`, `node_modules/@jskit-ai/agent-docs/guide/agent/index.md`, and `node_modules/@jskit-ai/agent-docs/patterns/INDEX.md` when present. If working inside the JSKIT monorepo or a devlinked sibling, use `packages/agent-docs/...` as the source-tree equivalent. Then read the specific pattern docs that match the issue: CRUD, page scaffolding, surfaces, placements, client requests, live actions, generated UI contracts, or UI testing.
 - Ask follow-up questions until all important issue details are known.
 - Ask the user for whatever is still needed.
 - Ask for final confirmation before emitting final details.
@@ -26,6 +27,8 @@ For UI, confirm route path, surface/placement target, navigation expectations, r
 For server-only work, confirm endpoint/command/job shape, request/response shape, validation, auth/permission behavior, persistence ownership, error behavior, and verification path.
 
 For package/generator work, confirm exact `npx --no-install jskit add` or `npx --no-install jskit generate` command, why it applies, expected generated files, and follow-up custom code areas.
+
+When source files and docs appear to disagree, ask or record the discrepancy. Do not silently prefer code archaeology over package-owned JSKIT guide and pattern docs.
 
 When the details are confirmed, output only the final classification, details, and decision notes surrounded by these exact markers:
 

--- a/tooling/jskit-cli/src/server/sessionRuntime/prompts/new_issue.md
+++ b/tooling/jskit-cli/src/server/sessionRuntime/prompts/new_issue.md
@@ -9,6 +9,7 @@ Allowed inspection:
 - Read files with commands such as `pwd`, `ls`, `find`, `rg`, `cat`, `sed`, and `git status`.
 - Read package.json, `.jskit/lock.json`, config, routes, packages, source files, `.jskit/APP_BLUEPRINT.md`, and `.jskit/helper-map.md` when available.
 - Use non-mutating JSKIT inspection commands when available and relevant: `npx --no-install jskit list`, `npx --no-install jskit show <package> --details`, and `npx --no-install jskit list-placements`.
+- Read JSKIT agent docs before inferring framework patterns from source. Start with `node_modules/@jskit-ai/agent-docs/DISTR_AGENT.md`, `node_modules/@jskit-ai/agent-docs/guide/agent/index.md`, and `node_modules/@jskit-ai/agent-docs/patterns/INDEX.md` when present. If working inside the JSKIT monorepo or a devlinked sibling, use `packages/agent-docs/...` as the source-tree equivalent. Then read only the relevant pattern docs for the request, such as CRUD, page scaffolding, surfaces, placements, client requests, live actions, or UI testing.
 - If the filesystem contradicts a ready JSKIT app, stop and report that app setup must be rerun. Do not draft a recovery issue inside this session.
 
 Do not run workflow, repair, or mutation commands during issue drafting:
@@ -27,6 +28,7 @@ Preserve these JSKIT boundaries:
 - For persisted app-owned data, prefer generated/package ownership over direct hand-built persistence. A new ordinary table should usually become a server CRUD-owned entity before CRUD UI or route work.
 - For non-CRUD app pages, prefer the JSKIT UI generator when it fits.
 - Keep direct knex or low-level runtime work exceptional and explicitly justified.
+- Prefer documented JSKIT guide and pattern docs over reverse-engineering framework architecture from source files. Use source inspection to understand this app and verify details, not as the first source of JSKIT design rules.
 - Do not include workflow bookkeeping such as old workboards in the issue body. JSKIT session state and receipts are the workflow tracker.
 
 Ask concise clarifying questions if the request is not specific enough to produce a useful implementation issue. Ask only for details that materially change the ticket.

--- a/tooling/jskit-cli/src/server/sessionRuntime/prompts/plan_issue.md
+++ b/tooling/jskit-cli/src/server/sessionRuntime/prompts/plan_issue.md
@@ -28,6 +28,10 @@ Rework request:
 
 Read the issue, confirmed issue details, rework request when present, agent decisions, and local app before planning. Use the issue files, issue details file, package.json, .jskit metadata, config, packages, routes, generated references, package docs, any saved app blueprint, and `.jskit/helper-map.md` when available.
 
+Before deriving JSKIT architecture from source files, read the package-owned agent docs that apply to this work. Start with `node_modules/@jskit-ai/agent-docs/DISTR_AGENT.md`, `node_modules/@jskit-ai/agent-docs/guide/agent/index.md`, and `node_modules/@jskit-ai/agent-docs/patterns/INDEX.md` when present. If the worktree is the JSKIT monorepo or a devlinked sibling, use the equivalent `packages/agent-docs/...` paths. Then read the specific pattern docs needed for the lane, such as `patterns/crud-scaffolding.md`, `patterns/crud-repository-mapping.md`, `patterns/page-scaffolding.md`, `patterns/placements.md`, `patterns/surfaces.md`, `patterns/client-requests.md`, `patterns/live-actions.md`, `patterns/generated-ui-contract-tracking.md`, or `patterns/ui-testing.md`.
+
+If these docs are unavailable, continue with app inspection and say that the agent docs were unavailable. Do not compensate by inventing framework rules from isolated source files.
+
 Confirmed issue details:
 
 {{issue_details_text}}
@@ -50,6 +54,7 @@ Planning rules:
 - Prefer vertical slices that produce visible or end-to-end progress.
 - If the work is too broad to review confidently, split it into clear chunks.
 - Make generator decisions concrete. Name the exact `npx --no-install jskit` commands to run when a generator or package install applies.
+- Base JSKIT lane and generator decisions on the agent docs and package descriptors first, then verify against the local codebase.
 - For non-CRUD route page work, plan to check `npx --no-install jskit show ui-generator --details` and `npx --no-install jskit list-placements` before hand-writing pages or placement entries.
 - For CRUD work, plan server ownership first. Name the `npx --no-install jskit generate crud-server-generator scaffold ...` command before any CRUD UI plan.
 - For CRUD-owned tables, plan around the real database table shape. Do not plan a separate hand-written migration for a table that `crud-server-generator` will own.

--- a/tooling/jskit-cli/src/server/sessionRuntime/prompts/review_changes.md
+++ b/tooling/jskit-cli/src/server/sessionRuntime/prompts/review_changes.md
@@ -32,6 +32,7 @@ Use four passes:
    - broken flows, missing route wiring, missing migrations, or stale generated metadata
    - surface or entity ownership mistakes: public, user, workspace, workspace_user
 2. JSKIT review
+   - were relevant `@jskit-ai/agent-docs` guide or pattern docs consulted before inferring JSKIT architecture from source?
    - existing helper/runtime seam available?
    - was `.jskit/helper-map.md` checked before introducing helper-like code?
    - should this have been a package install, generator step, or scaffold extension instead of hand code?

--- a/tooling/jskit-cli/test/sessionCommand.test.js
+++ b/tooling/jskit-cli/test/sessionCommand.test.js
@@ -1165,15 +1165,22 @@ test("session prompts reference canonical session artifacts", async () => {
   }
 
   assert.match(prompts["issue_details.md"], /issue_details\.md/);
+  assert.match(prompts["issue_details.md"], /@jskit-ai\/agent-docs/);
   assert.doesNotMatch(prompts["issue_details.md"], /\[issue_details_conversation_ready\]/);
+  assert.match(prompts["new_issue.md"], /@jskit-ai\/agent-docs/);
   assert.match(prompts["plan_issue.md"], /issue_details\.md/);
   assert.match(prompts["plan_issue.md"], /agent_decisions\.md/);
+  assert.match(prompts["plan_issue.md"], /patterns\/INDEX\.md/);
   assert.match(prompts["execute_plan.md"], /issue_details\.md/);
   assert.match(prompts["execute_plan.md"], /agent_decisions/);
+  assert.match(prompts["execute_plan.md"], /@jskit-ai\/agent-docs/);
   assert.match(prompts["execute_plan.md"], /verify-ui` does not start the app server/);
   assert.ok(!Object.hasOwn(prompts, "fine_tune_plan.md"));
   assert.match(prompts["review_changes.md"], /\.jskit\/helper-map\.md/);
+  assert.match(prompts["review_changes.md"], /@jskit-ai\/agent-docs/);
   assert.match(prompts["review_changes.md"], /verify-ui` does not start the app server/);
+  assert.match(prompts["automated_checks.md"], /@jskit-ai\/agent-docs/);
+  assert.match(prompts["deep_ui_check.md"], /@jskit-ai\/agent-docs/);
   assert.match(prompts["deep_ui_check.md"], /verify-ui` does not start the app server/);
   assert.match(prompts["resolve_deslop_findings.md"], /\[resolve_deslop_findings\]/);
   assert.match(prompts["update_blueprint.md"], /\.jskit\/APP_BLUEPRINT\.md/);


### PR DESCRIPTION
Summary:
- refresh package versions across manifests, descriptors, lockfile, and catalog metadata
- update JSKIT session prompts to direct agents to package-owned agent docs before inferring framework patterns
- extend prompt contract tests for the new agent-doc guidance

Tests:
- Not run locally.