### PR TITLE
Make plan execution advance manually

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6686,28 +6686,28 @@
     },
     "packages/agent-docs": {
       "name": "@jskit-ai/agent-docs",
-      "version": "0.1.39",
+      "version": "0.1.40",
       "engines": {
         "node": ">=20 <23"
       }
     },
     "packages/assistant": {
       "name": "@jskit-ai/assistant",
-      "version": "0.1.87",
+      "version": "0.1.88",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.78"
+        "@jskit-ai/kernel": "0.1.79"
       }
     },
     "packages/assistant-core": {
       "name": "@jskit-ai/assistant-core",
-      "version": "0.1.54",
+      "version": "0.1.55",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.78",
-        "@jskit-ai/http-runtime": "0.1.77",
-        "@jskit-ai/kernel": "0.1.78",
-        "@jskit-ai/resource-core": "0.1.23",
-        "@jskit-ai/resource-crud-core": "0.1.23",
-        "@jskit-ai/users-core": "0.1.88",
+        "@jskit-ai/database-runtime": "0.1.79",
+        "@jskit-ai/http-runtime": "0.1.78",
+        "@jskit-ai/kernel": "0.1.79",
+        "@jskit-ai/resource-core": "0.1.24",
+        "@jskit-ai/resource-crud-core": "0.1.24",
+        "@jskit-ai/users-core": "0.1.89",
         "dompurify": "^3.3.3",
         "json-rest-schema": "1.x.x",
         "marked": "^17.0.4",
@@ -6720,15 +6720,15 @@
     },
     "packages/assistant-runtime": {
       "name": "@jskit-ai/assistant-runtime",
-      "version": "0.1.49",
+      "version": "0.1.50",
       "dependencies": {
-        "@jskit-ai/assistant-core": "0.1.54",
-        "@jskit-ai/database-runtime": "0.1.78",
-        "@jskit-ai/http-runtime": "0.1.77",
-        "@jskit-ai/kernel": "0.1.78",
-        "@jskit-ai/shell-web": "0.1.77",
-        "@jskit-ai/users-core": "0.1.88",
-        "@jskit-ai/users-web": "0.1.93",
+        "@jskit-ai/assistant-core": "0.1.55",
+        "@jskit-ai/database-runtime": "0.1.79",
+        "@jskit-ai/http-runtime": "0.1.78",
+        "@jskit-ai/kernel": "0.1.79",
+        "@jskit-ai/shell-web": "0.1.78",
+        "@jskit-ai/users-core": "0.1.89",
+        "@jskit-ai/users-web": "0.1.94",
         "json-rest-schema": "1.x.x"
       },
       "peerDependencies": {
@@ -6739,21 +6739,21 @@
     },
     "packages/auth-core": {
       "name": "@jskit-ai/auth-core",
-      "version": "0.1.77",
+      "version": "0.1.78",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0",
-        "@jskit-ai/kernel": "0.1.78",
+        "@jskit-ai/kernel": "0.1.79",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/auth-provider-supabase-core": {
       "name": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.77",
+      "version": "0.1.78",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.77",
-        "@jskit-ai/kernel": "0.1.78",
+        "@jskit-ai/auth-core": "0.1.78",
+        "@jskit-ai/kernel": "0.1.79",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0",
         "json-rest-schema": "1.x.x",
@@ -6762,12 +6762,12 @@
     },
     "packages/auth-web": {
       "name": "@jskit-ai/auth-web",
-      "version": "0.1.79",
+      "version": "0.1.80",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.77",
-        "@jskit-ai/http-runtime": "0.1.77",
-        "@jskit-ai/kernel": "0.1.78",
-        "@jskit-ai/shell-web": "0.1.77",
+        "@jskit-ai/auth-core": "0.1.78",
+        "@jskit-ai/http-runtime": "0.1.78",
+        "@jskit-ai/kernel": "0.1.79",
+        "@jskit-ai/shell-web": "0.1.78",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -6780,38 +6780,38 @@
     },
     "packages/console-core": {
       "name": "@jskit-ai/console-core",
-      "version": "0.1.41",
+      "version": "0.1.42",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.77",
-        "@jskit-ai/database-runtime": "0.1.78",
-        "@jskit-ai/http-runtime": "0.1.77",
-        "@jskit-ai/kernel": "0.1.78",
-        "@jskit-ai/resource-crud-core": "0.1.23",
-        "@jskit-ai/users-core": "0.1.88",
+        "@jskit-ai/auth-core": "0.1.78",
+        "@jskit-ai/database-runtime": "0.1.79",
+        "@jskit-ai/http-runtime": "0.1.78",
+        "@jskit-ai/kernel": "0.1.79",
+        "@jskit-ai/resource-crud-core": "0.1.24",
+        "@jskit-ai/users-core": "0.1.89",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/console-web": {
       "name": "@jskit-ai/console-web",
-      "version": "0.1.46",
+      "version": "0.1.47",
       "dependencies": {
-        "@jskit-ai/auth-web": "0.1.79",
-        "@jskit-ai/console-core": "0.1.41",
-        "@jskit-ai/shell-web": "0.1.77"
+        "@jskit-ai/auth-web": "0.1.80",
+        "@jskit-ai/console-core": "0.1.42",
+        "@jskit-ai/shell-web": "0.1.78"
       }
     },
     "packages/crud-core": {
       "name": "@jskit-ai/crud-core",
-      "version": "0.1.86",
+      "version": "0.1.87",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.78",
-        "@jskit-ai/http-runtime": "0.1.77",
-        "@jskit-ai/kernel": "0.1.78",
-        "@jskit-ai/realtime": "0.1.77",
-        "@jskit-ai/resource-crud-core": "0.1.23",
-        "@jskit-ai/shell-web": "0.1.77",
-        "@jskit-ai/users-core": "0.1.88",
-        "@jskit-ai/users-web": "0.1.93",
+        "@jskit-ai/database-runtime": "0.1.79",
+        "@jskit-ai/http-runtime": "0.1.78",
+        "@jskit-ai/kernel": "0.1.79",
+        "@jskit-ai/realtime": "0.1.78",
+        "@jskit-ai/resource-crud-core": "0.1.24",
+        "@jskit-ai/shell-web": "0.1.78",
+        "@jskit-ai/users-core": "0.1.89",
+        "@jskit-ai/users-web": "0.1.94",
         "json-rest-schema": "1.x.x"
       },
       "peerDependencies": {
@@ -6822,98 +6822,98 @@
     },
     "packages/crud-server-generator": {
       "name": "@jskit-ai/crud-server-generator",
-      "version": "0.1.86",
+      "version": "0.1.87",
       "dependencies": {
         "@babel/parser": "^7.29.2",
-        "@jskit-ai/crud-core": "0.1.86",
-        "@jskit-ai/database-runtime": "0.1.78",
-        "@jskit-ai/http-runtime": "0.1.77",
-        "@jskit-ai/json-rest-api-core": "0.1.23",
-        "@jskit-ai/kernel": "0.1.78",
-        "@jskit-ai/resource-crud-core": "0.1.23",
+        "@jskit-ai/crud-core": "0.1.87",
+        "@jskit-ai/database-runtime": "0.1.79",
+        "@jskit-ai/http-runtime": "0.1.78",
+        "@jskit-ai/json-rest-api-core": "0.1.24",
+        "@jskit-ai/kernel": "0.1.79",
+        "@jskit-ai/resource-crud-core": "0.1.24",
         "recast": "^0.23.11"
       }
     },
     "packages/crud-ui-generator": {
       "name": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.61",
+      "version": "0.1.62",
       "dependencies": {
-        "@jskit-ai/crud-core": "0.1.86",
-        "@jskit-ai/kernel": "0.1.78",
-        "@jskit-ai/resource-crud-core": "0.1.23"
+        "@jskit-ai/crud-core": "0.1.87",
+        "@jskit-ai/kernel": "0.1.79",
+        "@jskit-ai/resource-crud-core": "0.1.24"
       }
     },
     "packages/database-runtime": {
       "name": "@jskit-ai/database-runtime",
-      "version": "0.1.78",
+      "version": "0.1.79",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.78"
+        "@jskit-ai/kernel": "0.1.79"
       }
     },
     "packages/database-runtime-mysql": {
       "name": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.77",
+      "version": "0.1.78",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.78",
-        "@jskit-ai/kernel": "0.1.78"
+        "@jskit-ai/database-runtime": "0.1.79",
+        "@jskit-ai/kernel": "0.1.79"
       }
     },
     "packages/database-runtime-postgres": {
       "name": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.77",
+      "version": "0.1.78",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.78"
+        "@jskit-ai/database-runtime": "0.1.79"
       }
     },
     "packages/feature-server-generator": {
       "name": "@jskit-ai/feature-server-generator",
-      "version": "0.1.20"
+      "version": "0.1.21"
     },
     "packages/google-rewarded-core": {
       "name": "@jskit-ai/google-rewarded-core",
-      "version": "0.1.15"
+      "version": "0.1.16"
     },
     "packages/google-rewarded-web": {
       "name": "@jskit-ai/google-rewarded-web",
-      "version": "0.1.15"
+      "version": "0.1.16"
     },
     "packages/http-runtime": {
       "name": "@jskit-ai/http-runtime",
-      "version": "0.1.77",
+      "version": "0.1.78",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.78",
+        "@jskit-ai/kernel": "0.1.79",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/json-rest-api-core": {
       "name": "@jskit-ai/json-rest-api-core",
-      "version": "0.1.23",
+      "version": "0.1.24",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.78",
+        "@jskit-ai/kernel": "0.1.79",
         "hooked-api": "1.x.x",
         "json-rest-api": "1.x.x"
       }
     },
     "packages/kernel": {
       "name": "@jskit-ai/kernel",
-      "version": "0.1.78",
+      "version": "0.1.79",
       "dependencies": {
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/mobile-capacitor": {
       "name": "@jskit-ai/mobile-capacitor",
-      "version": "0.1.15",
+      "version": "0.1.16",
       "dependencies": {
         "@capacitor/browser": "^7.0.1",
-        "@jskit-ai/kernel": "0.1.78"
+        "@jskit-ai/kernel": "0.1.79"
       }
     },
     "packages/realtime": {
       "name": "@jskit-ai/realtime",
-      "version": "0.1.77",
+      "version": "0.1.78",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.78",
+        "@jskit-ai/kernel": "0.1.79",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",
@@ -6925,24 +6925,24 @@
     },
     "packages/resource-core": {
       "name": "@jskit-ai/resource-core",
-      "version": "0.1.23",
+      "version": "0.1.24",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.78"
+        "@jskit-ai/kernel": "0.1.79"
       }
     },
     "packages/resource-crud-core": {
       "name": "@jskit-ai/resource-crud-core",
-      "version": "0.1.23",
+      "version": "0.1.24",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.78",
-        "@jskit-ai/resource-core": "0.1.23"
+        "@jskit-ai/kernel": "0.1.79",
+        "@jskit-ai/resource-core": "0.1.24"
       }
     },
     "packages/shell-web": {
       "name": "@jskit-ai/shell-web",
-      "version": "0.1.77",
+      "version": "0.1.78",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.78",
+        "@jskit-ai/kernel": "0.1.79",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -6954,25 +6954,25 @@
     },
     "packages/storage-runtime": {
       "name": "@jskit-ai/storage-runtime",
-      "version": "0.1.77",
+      "version": "0.1.78",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.78",
+        "@jskit-ai/kernel": "0.1.79",
         "unstorage": "^1.17.3"
       }
     },
     "packages/ui-generator": {
       "name": "@jskit-ai/ui-generator",
-      "version": "0.1.61",
+      "version": "0.1.62",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.78",
-        "@jskit-ai/shell-web": "0.1.77"
+        "@jskit-ai/kernel": "0.1.79",
+        "@jskit-ai/shell-web": "0.1.78"
       }
     },
     "packages/uploads-image-web": {
       "name": "@jskit-ai/uploads-image-web",
-      "version": "0.1.56",
+      "version": "0.1.57",
       "dependencies": {
-        "@jskit-ai/uploads-runtime": "0.1.56",
+        "@jskit-ai/uploads-runtime": "0.1.57",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",
@@ -6985,37 +6985,37 @@
     },
     "packages/uploads-runtime": {
       "name": "@jskit-ai/uploads-runtime",
-      "version": "0.1.56",
+      "version": "0.1.57",
       "dependencies": {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.78"
+        "@jskit-ai/kernel": "0.1.79"
       }
     },
     "packages/users-core": {
       "name": "@jskit-ai/users-core",
-      "version": "0.1.88",
+      "version": "0.1.89",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.77",
-        "@jskit-ai/database-runtime": "0.1.78",
-        "@jskit-ai/http-runtime": "0.1.77",
-        "@jskit-ai/json-rest-api-core": "0.1.23",
-        "@jskit-ai/kernel": "0.1.78",
-        "@jskit-ai/resource-core": "0.1.23",
-        "@jskit-ai/resource-crud-core": "0.1.23",
-        "@jskit-ai/uploads-runtime": "0.1.56",
+        "@jskit-ai/auth-core": "0.1.78",
+        "@jskit-ai/database-runtime": "0.1.79",
+        "@jskit-ai/http-runtime": "0.1.78",
+        "@jskit-ai/json-rest-api-core": "0.1.24",
+        "@jskit-ai/kernel": "0.1.79",
+        "@jskit-ai/resource-core": "0.1.24",
+        "@jskit-ai/resource-crud-core": "0.1.24",
+        "@jskit-ai/uploads-runtime": "0.1.57",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/users-web": {
       "name": "@jskit-ai/users-web",
-      "version": "0.1.93",
+      "version": "0.1.94",
       "dependencies": {
-        "@jskit-ai/http-runtime": "0.1.77",
-        "@jskit-ai/kernel": "0.1.78",
-        "@jskit-ai/realtime": "0.1.77",
-        "@jskit-ai/shell-web": "0.1.77",
-        "@jskit-ai/uploads-image-web": "0.1.56",
-        "@jskit-ai/users-core": "0.1.88",
+        "@jskit-ai/http-runtime": "0.1.78",
+        "@jskit-ai/kernel": "0.1.79",
+        "@jskit-ai/realtime": "0.1.78",
+        "@jskit-ai/shell-web": "0.1.78",
+        "@jskit-ai/uploads-image-web": "0.1.57",
+        "@jskit-ai/users-core": "0.1.89",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -7027,29 +7027,29 @@
     },
     "packages/workspaces-core": {
       "name": "@jskit-ai/workspaces-core",
-      "version": "0.1.54",
+      "version": "0.1.55",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.77",
-        "@jskit-ai/database-runtime": "0.1.78",
-        "@jskit-ai/http-runtime": "0.1.77",
-        "@jskit-ai/json-rest-api-core": "0.1.23",
-        "@jskit-ai/kernel": "0.1.78",
-        "@jskit-ai/resource-core": "0.1.23",
-        "@jskit-ai/resource-crud-core": "0.1.23",
-        "@jskit-ai/users-core": "0.1.88",
+        "@jskit-ai/auth-core": "0.1.78",
+        "@jskit-ai/database-runtime": "0.1.79",
+        "@jskit-ai/http-runtime": "0.1.78",
+        "@jskit-ai/json-rest-api-core": "0.1.24",
+        "@jskit-ai/kernel": "0.1.79",
+        "@jskit-ai/resource-core": "0.1.24",
+        "@jskit-ai/resource-crud-core": "0.1.24",
+        "@jskit-ai/users-core": "0.1.89",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/workspaces-web": {
       "name": "@jskit-ai/workspaces-web",
-      "version": "0.1.54",
+      "version": "0.1.55",
       "dependencies": {
-        "@jskit-ai/http-runtime": "0.1.77",
-        "@jskit-ai/kernel": "0.1.78",
-        "@jskit-ai/shell-web": "0.1.77",
-        "@jskit-ai/users-core": "0.1.88",
-        "@jskit-ai/users-web": "0.1.93",
-        "@jskit-ai/workspaces-core": "0.1.54",
+        "@jskit-ai/http-runtime": "0.1.78",
+        "@jskit-ai/kernel": "0.1.79",
+        "@jskit-ai/shell-web": "0.1.78",
+        "@jskit-ai/users-core": "0.1.89",
+        "@jskit-ai/users-web": "0.1.94",
+        "@jskit-ai/workspaces-core": "0.1.55",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -7061,7 +7061,7 @@
     },
     "tooling/config-eslint": {
       "name": "@jskit-ai/config-eslint",
-      "version": "0.1.77",
+      "version": "0.1.78",
       "dependencies": {
         "@eslint/js": "^9.39.1",
         "eslint-plugin-vue": "^10.5.1",
@@ -7079,7 +7079,7 @@
     },
     "tooling/create-app": {
       "name": "@jskit-ai/create-app",
-      "version": "0.1.86",
+      "version": "0.1.87",
       "bin": {
         "jskit-create-app": "bin/jskit-create-app.js"
       },
@@ -7089,18 +7089,18 @@
     },
     "tooling/jskit-catalog": {
       "name": "@jskit-ai/jskit-catalog",
-      "version": "0.1.86",
+      "version": "0.1.87",
       "engines": {
         "node": ">=20 <23"
       }
     },
     "tooling/jskit-cli": {
       "name": "@jskit-ai/jskit-cli",
-      "version": "0.2.87",
+      "version": "0.2.88",
       "dependencies": {
-        "@jskit-ai/jskit-catalog": "0.1.86",
-        "@jskit-ai/kernel": "0.1.78",
-        "@jskit-ai/shell-web": "0.1.77",
+        "@jskit-ai/jskit-catalog": "0.1.87",
+        "@jskit-ai/kernel": "0.1.79",
+        "@jskit-ai/shell-web": "0.1.78",
         "@vue/compiler-sfc": "^3.5.29",
         "ts-morph": "^28.0.0"
       },

--- a/packages/agent-docs/package.json
+++ b/packages/agent-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/agent-docs",
-  "version": "0.1.39",
+  "version": "0.1.40",
   "description": "Distributed JSKIT agent references, prompts, guides, and generated reference maps.",
   "type": "module",
   "files": [

--- a/packages/assistant-core/package.descriptor.mjs
+++ b/packages/assistant-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-core",
-  version: "0.1.54",
+  version: "0.1.55",
   kind: "runtime",
   description: "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
   dependsOn: [
@@ -47,11 +47,11 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/http-runtime": "0.1.77",
-        "@jskit-ai/kernel": "0.1.78",
-        "@jskit-ai/resource-core": "0.1.23",
-        "@jskit-ai/resource-crud-core": "0.1.23",
-        "@jskit-ai/users-core": "0.1.88",
+        "@jskit-ai/http-runtime": "0.1.78",
+        "@jskit-ai/kernel": "0.1.79",
+        "@jskit-ai/resource-core": "0.1.24",
+        "@jskit-ai/resource-crud-core": "0.1.24",
+        "@jskit-ai/users-core": "0.1.89",
         "dompurify": "^3.3.3",
         "json-rest-schema": "1.x.x",
         "marked": "^17.0.4",

--- a/packages/assistant-core/package.json
+++ b/packages/assistant-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-core",
-  "version": "0.1.54",
+  "version": "0.1.55",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,12 +11,12 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.78",
-    "@jskit-ai/http-runtime": "0.1.77",
-    "@jskit-ai/kernel": "0.1.78",
-    "@jskit-ai/resource-crud-core": "0.1.23",
-    "@jskit-ai/resource-core": "0.1.23",
-    "@jskit-ai/users-core": "0.1.88",
+    "@jskit-ai/database-runtime": "0.1.79",
+    "@jskit-ai/http-runtime": "0.1.78",
+    "@jskit-ai/kernel": "0.1.79",
+    "@jskit-ai/resource-crud-core": "0.1.24",
+    "@jskit-ai/resource-core": "0.1.24",
+    "@jskit-ai/users-core": "0.1.89",
     "dompurify": "^3.3.3",
     "json-rest-schema": "1.x.x",
     "marked": "^17.0.4",

--- a/packages/assistant-runtime/package.descriptor.mjs
+++ b/packages/assistant-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-runtime",
-  version: "0.1.49",
+  version: "0.1.50",
   kind: "runtime",
   description: "Shared assistant runtime with per-surface assistant registration.",
   dependsOn: [
@@ -95,13 +95,13 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/assistant-core": "0.1.54",
-        "@jskit-ai/database-runtime": "0.1.78",
-        "@jskit-ai/http-runtime": "0.1.77",
-        "@jskit-ai/kernel": "0.1.78",
-        "@jskit-ai/shell-web": "0.1.77",
-        "@jskit-ai/users-core": "0.1.88",
-        "@jskit-ai/users-web": "0.1.93"
+        "@jskit-ai/assistant-core": "0.1.55",
+        "@jskit-ai/database-runtime": "0.1.79",
+        "@jskit-ai/http-runtime": "0.1.78",
+        "@jskit-ai/kernel": "0.1.79",
+        "@jskit-ai/shell-web": "0.1.78",
+        "@jskit-ai/users-core": "0.1.89",
+        "@jskit-ai/users-web": "0.1.94"
       },
       dev: {}
     },

--- a/packages/assistant-runtime/package.json
+++ b/packages/assistant-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-runtime",
-  "version": "0.1.49",
+  "version": "0.1.50",
   "type": "module",
   "exports": {
     "./client": "./src/client/index.js",
@@ -8,13 +8,13 @@
     "./server/actionIds": "./src/server/actionIds.js"
   },
   "dependencies": {
-    "@jskit-ai/assistant-core": "0.1.54",
-    "@jskit-ai/database-runtime": "0.1.78",
-    "@jskit-ai/http-runtime": "0.1.77",
-    "@jskit-ai/kernel": "0.1.78",
-    "@jskit-ai/shell-web": "0.1.77",
-    "@jskit-ai/users-core": "0.1.88",
-    "@jskit-ai/users-web": "0.1.93",
+    "@jskit-ai/assistant-core": "0.1.55",
+    "@jskit-ai/database-runtime": "0.1.79",
+    "@jskit-ai/http-runtime": "0.1.78",
+    "@jskit-ai/kernel": "0.1.79",
+    "@jskit-ai/shell-web": "0.1.78",
+    "@jskit-ai/users-core": "0.1.89",
+    "@jskit-ai/users-web": "0.1.94",
     "json-rest-schema": "1.x.x"
   },
   "peerDependencies": {

--- a/packages/assistant/package.descriptor.mjs
+++ b/packages/assistant/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant",
-  version: "0.1.87",
+  version: "0.1.88",
   kind: "generator",
   description: "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
   options: {

--- a/packages/assistant/package.json
+++ b/packages/assistant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant",
-  "version": "0.1.87",
+  "version": "0.1.88",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.78"
+    "@jskit-ai/kernel": "0.1.79"
   }
 }

--- a/packages/auth-core/package.descriptor.mjs
+++ b/packages/auth-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-core",
-  "version": "0.1.77",
+  "version": "0.1.78",
   "kind": "runtime",
   "dependsOn": [
     "@jskit-ai/value-app-config-shared"
@@ -69,7 +69,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.78",
+        "@jskit-ai/kernel": "0.1.79",
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0"

--- a/packages/auth-core/package.json
+++ b/packages/auth-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-core",
-  "version": "0.1.77",
+  "version": "0.1.78",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -46,7 +46,7 @@
     "./shared/commands/authSessionReadCommand": "./src/shared/commands/authSessionReadCommand.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.78",
+    "@jskit-ai/kernel": "0.1.79",
     "@fastify/cookie": "^11.0.2",
     "@fastify/csrf-protection": "^7.1.0",
     "@fastify/rate-limit": "^10.3.0",

--- a/packages/auth-provider-supabase-core/package.descriptor.mjs
+++ b/packages/auth-provider-supabase-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.77",
+  "version": "0.1.78",
   "kind": "runtime",
   "options": {
     "auth-supabase-url": {
@@ -83,8 +83,8 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/auth-core": "0.1.77",
-        "@jskit-ai/kernel": "0.1.78",
+        "@jskit-ai/auth-core": "0.1.78",
+        "@jskit-ai/kernel": "0.1.79",
         "dotenv": "^16.4.5",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0"

--- a/packages/auth-provider-supabase-core/package.json
+++ b/packages/auth-provider-supabase-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.77",
+  "version": "0.1.78",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,8 +12,8 @@
     "./client": "./src/client/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.77",
-    "@jskit-ai/kernel": "0.1.78",
+    "@jskit-ai/auth-core": "0.1.78",
+    "@jskit-ai/kernel": "0.1.79",
     "json-rest-schema": "1.x.x",
     "jose": "^6.1.0",
     "@supabase/supabase-js": "^2.57.4",

--- a/packages/auth-web/package.descriptor.mjs
+++ b/packages/auth-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-web",
-  "version": "0.1.79",
+  "version": "0.1.80",
   "kind": "runtime",
   "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
   "dependsOn": [
@@ -247,10 +247,10 @@ export default Object.freeze({
     "dependencies": {
       "runtime": {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/auth-core": "0.1.77",
-        "@jskit-ai/http-runtime": "0.1.77",
-        "@jskit-ai/kernel": "0.1.78",
-        "@jskit-ai/shell-web": "0.1.77"
+        "@jskit-ai/auth-core": "0.1.78",
+        "@jskit-ai/http-runtime": "0.1.78",
+        "@jskit-ai/kernel": "0.1.79",
+        "@jskit-ai/shell-web": "0.1.78"
       },
       "dev": {}
     },

--- a/packages/auth-web/package.json
+++ b/packages/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-web",
-  "version": "0.1.79",
+  "version": "0.1.80",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -18,11 +18,11 @@
     "./client/runtime/useSignOut": "./src/client/runtime/useSignOut.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.77",
+    "@jskit-ai/auth-core": "0.1.78",
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/kernel": "0.1.78",
-    "@jskit-ai/shell-web": "0.1.77",
-    "@jskit-ai/http-runtime": "0.1.77"
+    "@jskit-ai/kernel": "0.1.79",
+    "@jskit-ai/shell-web": "0.1.78",
+    "@jskit-ai/http-runtime": "0.1.78"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/console-core/package.descriptor.mjs
+++ b/packages/console-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-core",
-  version: "0.1.41",
+  version: "0.1.42",
   kind: "runtime",
   description: "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
   dependsOn: [
@@ -85,12 +85,12 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.77",
-        "@jskit-ai/database-runtime": "0.1.78",
-        "@jskit-ai/http-runtime": "0.1.77",
-        "@jskit-ai/kernel": "0.1.78",
-        "@jskit-ai/resource-crud-core": "0.1.23",
-        "@jskit-ai/users-core": "0.1.88"
+        "@jskit-ai/auth-core": "0.1.78",
+        "@jskit-ai/database-runtime": "0.1.79",
+        "@jskit-ai/http-runtime": "0.1.78",
+        "@jskit-ai/kernel": "0.1.79",
+        "@jskit-ai/resource-crud-core": "0.1.24",
+        "@jskit-ai/users-core": "0.1.89"
       },
       dev: {}
     },

--- a/packages/console-core/package.json
+++ b/packages/console-core/package.json
@@ -1,17 +1,17 @@
 {
   "name": "@jskit-ai/console-core",
-  "version": "0.1.41",
+  "version": "0.1.42",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.77",
-    "@jskit-ai/database-runtime": "0.1.78",
-    "@jskit-ai/http-runtime": "0.1.77",
-    "@jskit-ai/kernel": "0.1.78",
-    "@jskit-ai/resource-crud-core": "0.1.23",
-    "@jskit-ai/users-core": "0.1.88",
+    "@jskit-ai/auth-core": "0.1.78",
+    "@jskit-ai/database-runtime": "0.1.79",
+    "@jskit-ai/http-runtime": "0.1.78",
+    "@jskit-ai/kernel": "0.1.79",
+    "@jskit-ai/resource-crud-core": "0.1.24",
+    "@jskit-ai/users-core": "0.1.89",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/console-web/package.descriptor.mjs
+++ b/packages/console-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-web",
-  version: "0.1.46",
+  version: "0.1.47",
   kind: "runtime",
   description: "Authenticated console surface scaffold and surface policy wiring.",
   dependsOn: [
@@ -103,9 +103,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-web": "0.1.79",
-        "@jskit-ai/console-core": "0.1.41",
-        "@jskit-ai/shell-web": "0.1.77",
+        "@jskit-ai/auth-web": "0.1.80",
+        "@jskit-ai/console-core": "0.1.42",
+        "@jskit-ai/shell-web": "0.1.78",
       },
       dev: {}
     },

--- a/packages/console-web/package.json
+++ b/packages/console-web/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/console-web",
-  "version": "0.1.46",
+  "version": "0.1.47",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-web": "0.1.79",
-    "@jskit-ai/console-core": "0.1.41",
-    "@jskit-ai/shell-web": "0.1.77"
+    "@jskit-ai/auth-web": "0.1.80",
+    "@jskit-ai/console-core": "0.1.42",
+    "@jskit-ai/shell-web": "0.1.78"
   }
 }

--- a/packages/crud-core/package.descriptor.mjs
+++ b/packages/crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-core",
-  version: "0.1.86",
+  version: "0.1.87",
   kind: "runtime",
   description: "Shared CRUD helpers used by CRUD modules.",
   dependsOn: [
@@ -28,7 +28,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/crud-core": "0.1.86"
+        "@jskit-ai/crud-core": "0.1.87"
       },
       dev: {}
     },

--- a/packages/crud-core/package.json
+++ b/packages/crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-core",
-  "version": "0.1.86",
+  "version": "0.1.87",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -27,15 +27,15 @@
     "./server/routeContracts": "./src/server/routeContracts.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.78",
-    "@jskit-ai/http-runtime": "0.1.77",
-    "@jskit-ai/kernel": "0.1.78",
+    "@jskit-ai/database-runtime": "0.1.79",
+    "@jskit-ai/http-runtime": "0.1.78",
+    "@jskit-ai/kernel": "0.1.79",
     "json-rest-schema": "1.x.x",
-    "@jskit-ai/realtime": "0.1.77",
-    "@jskit-ai/resource-crud-core": "0.1.23",
-    "@jskit-ai/shell-web": "0.1.77",
-    "@jskit-ai/users-core": "0.1.88",
-    "@jskit-ai/users-web": "0.1.93"
+    "@jskit-ai/realtime": "0.1.78",
+    "@jskit-ai/resource-crud-core": "0.1.24",
+    "@jskit-ai/shell-web": "0.1.78",
+    "@jskit-ai/users-core": "0.1.89",
+    "@jskit-ai/users-web": "0.1.94"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/crud-server-generator/package.descriptor.mjs
+++ b/packages/crud-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-server-generator",
-  version: "0.1.86",
+  version: "0.1.87",
   kind: "generator",
   description: "CRUD server generator with routes, actions, and persistence scaffolding.",
   options: {
@@ -160,14 +160,14 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.77",
-        "@jskit-ai/crud-core": "0.1.86",
-        "@jskit-ai/database-runtime": "0.1.78",
-        "@jskit-ai/http-runtime": "0.1.77",
-        "@jskit-ai/json-rest-api-core": "0.1.23",
-        "@jskit-ai/kernel": "0.1.78",
-        "@jskit-ai/realtime": "0.1.77",
-        "@jskit-ai/resource-crud-core": "0.1.23",
+        "@jskit-ai/auth-core": "0.1.78",
+        "@jskit-ai/crud-core": "0.1.87",
+        "@jskit-ai/database-runtime": "0.1.79",
+        "@jskit-ai/http-runtime": "0.1.78",
+        "@jskit-ai/json-rest-api-core": "0.1.24",
+        "@jskit-ai/kernel": "0.1.79",
+        "@jskit-ai/realtime": "0.1.78",
+        "@jskit-ai/resource-crud-core": "0.1.24",
         "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}"
       },
       dev: {}

--- a/packages/crud-server-generator/package.json
+++ b/packages/crud-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-server-generator",
-  "version": "0.1.86",
+  "version": "0.1.87",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,12 +13,12 @@
   },
   "dependencies": {
     "@babel/parser": "^7.29.2",
-    "@jskit-ai/crud-core": "0.1.86",
-    "@jskit-ai/database-runtime": "0.1.78",
-    "@jskit-ai/http-runtime": "0.1.77",
-    "@jskit-ai/json-rest-api-core": "0.1.23",
-    "@jskit-ai/kernel": "0.1.78",
-    "@jskit-ai/resource-crud-core": "0.1.23",
+    "@jskit-ai/crud-core": "0.1.87",
+    "@jskit-ai/database-runtime": "0.1.79",
+    "@jskit-ai/http-runtime": "0.1.78",
+    "@jskit-ai/json-rest-api-core": "0.1.24",
+    "@jskit-ai/kernel": "0.1.79",
+    "@jskit-ai/resource-crud-core": "0.1.24",
     "recast": "^0.23.11"
   }
 }

--- a/packages/crud-ui-generator/package.descriptor.mjs
+++ b/packages/crud-ui-generator/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { GENERATED_UI_NAVIGATION_ROLE_OPTION } from "@jskit-ai/kernel/shared/sup
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-ui-generator",
-  version: "0.1.61",
+  version: "0.1.62",
   kind: "generator",
   description: "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
   options: {
@@ -175,7 +175,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.93"
+        "@jskit-ai/users-web": "0.1.94"
       },
       dev: {}
     },

--- a/packages/crud-ui-generator/package.json
+++ b/packages/crud-ui-generator/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@jskit-ai/crud-ui-generator",
-  "version": "0.1.61",
+  "version": "0.1.62",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/crud-core": "0.1.86",
-    "@jskit-ai/kernel": "0.1.78",
-    "@jskit-ai/resource-crud-core": "0.1.23"
+    "@jskit-ai/crud-core": "0.1.87",
+    "@jskit-ai/kernel": "0.1.79",
+    "@jskit-ai/resource-crud-core": "0.1.24"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/database-runtime-mysql/package.descriptor.mjs
+++ b/packages/database-runtime-mysql/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-mysql",
-  version: "0.1.77",
+  version: "0.1.78",
   kind: "runtime",
   options: {
     "db-host": {
@@ -91,7 +91,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.78",
+        "@jskit-ai/database-runtime": "0.1.79",
         "mysql2": "^3.11.2"
       },
       dev: {}

--- a/packages/database-runtime-mysql/package.json
+++ b/packages/database-runtime-mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-mysql",
-  "version": "0.1.77",
+  "version": "0.1.78",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,7 +12,7 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.78",
-    "@jskit-ai/kernel": "0.1.78"
+    "@jskit-ai/database-runtime": "0.1.79",
+    "@jskit-ai/kernel": "0.1.79"
   }
 }

--- a/packages/database-runtime-postgres/package.descriptor.mjs
+++ b/packages/database-runtime-postgres/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-postgres",
-  version: "0.1.77",
+  version: "0.1.78",
   kind: "runtime",
   options: {
     "db-host": {
@@ -91,7 +91,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.78",
+        "@jskit-ai/database-runtime": "0.1.79",
         "pg": "^8.13.1"
       },
       dev: {}

--- a/packages/database-runtime-postgres/package.json
+++ b/packages/database-runtime-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-postgres",
-  "version": "0.1.77",
+  "version": "0.1.78",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,6 +12,6 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.78"
+    "@jskit-ai/database-runtime": "0.1.79"
   }
 }

--- a/packages/database-runtime/package.descriptor.mjs
+++ b/packages/database-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime",
-  version: "0.1.78",
+  version: "0.1.79",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -58,7 +58,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.78",
+        "@jskit-ai/kernel": "0.1.79",
         "dotenv": "^16.4.5",
         "knex": "^3.1.0"
       },

--- a/packages/database-runtime/package.json
+++ b/packages/database-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime",
-  "version": "0.1.78",
+  "version": "0.1.79",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -25,6 +25,6 @@
     "./shared/transactions": "./src/shared/transactions.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.78"
+    "@jskit-ai/kernel": "0.1.79"
   }
 }

--- a/packages/feature-server-generator/package.descriptor.mjs
+++ b/packages/feature-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/feature-server-generator",
-  version: "0.1.20",
+  version: "0.1.21",
   kind: "generator",
   description: "Scaffold substantial non-CRUD server feature packages with provider, actions, service, and optional persistence seams.",
   options: {
@@ -174,7 +174,7 @@ export default Object.freeze({
             equals: "json-rest"
           }
         },
-        "@jskit-ai/kernel": "0.1.78",
+        "@jskit-ai/kernel": "0.1.79",
         "json-rest-schema": "1.x.x",
         "@local/${option:feature-name|kebab}": "file:packages/${option:feature-name|kebab}"
       },

--- a/packages/feature-server-generator/package.json
+++ b/packages/feature-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/feature-server-generator",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "type": "module",
   "scripts": {
     "test": "node --test"

--- a/packages/google-rewarded-core/package.descriptor.mjs
+++ b/packages/google-rewarded-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/google-rewarded-core",
-  version: "0.1.15",
+  version: "0.1.16",
   kind: "runtime",
   description: "Google rewarded workflow runtime plus internal CRUD providers for rules, provider configs, watch sessions, and unlock receipts.",
   dependsOn: [
@@ -128,14 +128,14 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.77",
-        "@jskit-ai/crud-core": "0.1.86",
-        "@jskit-ai/database-runtime": "0.1.78",
-        "@jskit-ai/http-runtime": "0.1.77",
-        "@jskit-ai/json-rest-api-core": "0.1.23",
-        "@jskit-ai/kernel": "0.1.78",
-        "@jskit-ai/resource-crud-core": "0.1.23",
-        "@jskit-ai/workspaces-core": "0.1.54"
+        "@jskit-ai/auth-core": "0.1.78",
+        "@jskit-ai/crud-core": "0.1.87",
+        "@jskit-ai/database-runtime": "0.1.79",
+        "@jskit-ai/http-runtime": "0.1.78",
+        "@jskit-ai/json-rest-api-core": "0.1.24",
+        "@jskit-ai/kernel": "0.1.79",
+        "@jskit-ai/resource-crud-core": "0.1.24",
+        "@jskit-ai/workspaces-core": "0.1.55"
       },
       dev: {}
     },

--- a/packages/google-rewarded-core/package.json
+++ b/packages/google-rewarded-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/google-rewarded-core",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/google-rewarded-web/package.descriptor.mjs
+++ b/packages/google-rewarded-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/google-rewarded-web",
-  version: "0.1.15",
+  version: "0.1.16",
   kind: "runtime",
   description: "Google rewarded client runtime with a fullscreen gate host and GPT orchestration.",
   dependsOn: [
@@ -46,10 +46,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/google-rewarded-core": "0.1.15",
-        "@jskit-ai/http-runtime": "0.1.77",
-        "@jskit-ai/kernel": "0.1.78",
-        "@jskit-ai/shell-web": "0.1.77"
+        "@jskit-ai/google-rewarded-core": "0.1.16",
+        "@jskit-ai/http-runtime": "0.1.78",
+        "@jskit-ai/kernel": "0.1.79",
+        "@jskit-ai/shell-web": "0.1.78"
       },
       dev: {}
     },

--- a/packages/google-rewarded-web/package.json
+++ b/packages/google-rewarded-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/google-rewarded-web",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/http-runtime/package.descriptor.mjs
+++ b/packages/http-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/http-runtime",
-  "version": "0.1.77",
+  "version": "0.1.78",
   "kind": "runtime",
   "dependsOn": [],
   "capabilities": {
@@ -67,7 +67,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.78"
+        "@jskit-ai/kernel": "0.1.79"
       },
       "dev": {}
     },

--- a/packages/http-runtime/package.json
+++ b/packages/http-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/http-runtime",
-  "version": "0.1.77",
+  "version": "0.1.78",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -18,7 +18,7 @@
     "./shared/validators/operationValidation": "./src/shared/validators/operationValidation.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.78",
+    "@jskit-ai/kernel": "0.1.79",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/json-rest-api-core/package.descriptor.mjs
+++ b/packages/json-rest-api-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/json-rest-api-core",
-  version: "0.1.23",
+  version: "0.1.24",
   kind: "runtime",
   description: "Shared internal json-rest-api host runtime for JSKIT server packages.",
   dependsOn: [

--- a/packages/json-rest-api-core/package.json
+++ b/packages/json-rest-api-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/json-rest-api-core",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,6 +11,6 @@
   "dependencies": {
     "hooked-api": "1.x.x",
     "json-rest-api": "1.x.x",
-    "@jskit-ai/kernel": "0.1.78"
+    "@jskit-ai/kernel": "0.1.79"
   }
 }

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/kernel",
-  "version": "0.1.78",
+  "version": "0.1.79",
   "type": "module",
   "dependencies": {
     "json-rest-schema": "1.x.x"

--- a/packages/mobile-capacitor/package.descriptor.mjs
+++ b/packages/mobile-capacitor/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/mobile-capacitor",
-  version: "0.1.15",
+  version: "0.1.16",
   kind: "runtime",
   description: "Thin Capacitor client integration for JSKIT mobile-shell launch routing and auth callback completion.",
   dependsOn: [
@@ -62,8 +62,8 @@ export default Object.freeze({
         "@capacitor/app": "^7.1.0",
         "@capacitor/browser": "^7.0.1",
         "@capacitor/core": "^7.4.3",
-        "@jskit-ai/kernel": "0.1.78",
-        "@jskit-ai/shell-web": "0.1.77"
+        "@jskit-ai/kernel": "0.1.79",
+        "@jskit-ai/shell-web": "0.1.78"
       },
       dev: {
         "@capacitor/cli": "^7.4.3"

--- a/packages/mobile-capacitor/package.json
+++ b/packages/mobile-capacitor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/mobile-capacitor",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,6 +12,6 @@
   },
   "dependencies": {
     "@capacitor/browser": "^7.0.1",
-    "@jskit-ai/kernel": "0.1.78"
+    "@jskit-ai/kernel": "0.1.79"
   }
 }

--- a/packages/realtime/package.descriptor.mjs
+++ b/packages/realtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/realtime",
-  version: "0.1.77",
+  version: "0.1.78",
   kind: "runtime",
   description: "Thin, generic realtime runtime wrappers for socket.io server and client.",
   options: {
@@ -95,7 +95,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.78",
+        "@jskit-ai/kernel": "0.1.79",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/realtime",
-  "version": "0.1.77",
+  "version": "0.1.78",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@socket.io/redis-adapter": "^8.3.0",
-    "@jskit-ai/kernel": "0.1.78",
+    "@jskit-ai/kernel": "0.1.79",
     "redis": "^5.8.2",
     "socket.io": "^4.8.3",
     "socket.io-client": "^4.8.3"

--- a/packages/resource-core/package.descriptor.mjs
+++ b/packages/resource-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/resource-core",
-  version: "0.1.23",
+  version: "0.1.24",
   kind: "runtime",
   description: "Generic resource-definition helpers and schema-definition normalization.",
   dependsOn: [
@@ -22,7 +22,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/resource-core": "0.1.23"
+        "@jskit-ai/resource-core": "0.1.24"
       },
       dev: {}
     },

--- a/packages/resource-core/package.json
+++ b/packages/resource-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/resource-core",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./shared/resource": "./src/shared/resource.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.78"
+    "@jskit-ai/kernel": "0.1.79"
   }
 }

--- a/packages/resource-crud-core/package.descriptor.mjs
+++ b/packages/resource-crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/resource-crud-core",
-  version: "0.1.23",
+  version: "0.1.24",
   kind: "runtime",
   description: "CRUD-specific resource-definition helpers and namespace support.",
   dependsOn: [
@@ -23,7 +23,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/resource-crud-core": "0.1.23"
+        "@jskit-ai/resource-crud-core": "0.1.24"
       },
       dev: {}
     },

--- a/packages/resource-crud-core/package.json
+++ b/packages/resource-crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/resource-crud-core",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./shared/crudResource": "./src/shared/crudResource.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.78",
-    "@jskit-ai/resource-core": "0.1.23"
+    "@jskit-ai/kernel": "0.1.79",
+    "@jskit-ai/resource-core": "0.1.24"
   }
 }

--- a/packages/shell-web/package.descriptor.mjs
+++ b/packages/shell-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/shell-web",
-  version: "0.1.77",
+  version: "0.1.78",
   kind: "runtime",
   description: "Web shell layout runtime with outlet-based placement contributions.",
   dependsOn: [],
@@ -291,7 +291,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/kernel": "0.1.78"
+        "@jskit-ai/kernel": "0.1.79"
       },
       dev: {}
     },

--- a/packages/shell-web/package.json
+++ b/packages/shell-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/shell-web",
-  "version": "0.1.77",
+  "version": "0.1.78",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/kernel": "0.1.78"
+    "@jskit-ai/kernel": "0.1.79"
   },
   "peerDependencies": {
     "pinia": "^3.0.4",

--- a/packages/storage-runtime/package.descriptor.mjs
+++ b/packages/storage-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/storage-runtime",
-  version: "0.1.77",
+  version: "0.1.78",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -50,7 +50,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.78",
+        "@jskit-ai/kernel": "0.1.79",
         "unstorage": "^1.17.3"
       },
       dev: {}

--- a/packages/storage-runtime/package.json
+++ b/packages/storage-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/storage-runtime",
-  "version": "0.1.77",
+  "version": "0.1.78",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./server/providers/StorageRuntimeServiceProvider": "./src/server/providers/StorageRuntimeServiceProvider.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.78",
+    "@jskit-ai/kernel": "0.1.79",
     "unstorage": "^1.17.3"
   }
 }

--- a/packages/ui-generator/package.descriptor.mjs
+++ b/packages/ui-generator/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { GENERATED_UI_NAVIGATION_ROLE_OPTION } from "@jskit-ai/kernel/shared/sup
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/ui-generator",
-  version: "0.1.61",
+  version: "0.1.62",
   kind: "generator",
   description: "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
   options: {
@@ -371,7 +371,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.93"
+        "@jskit-ai/users-web": "0.1.94"
       },
       dev: {}
     },

--- a/packages/ui-generator/package.json
+++ b/packages/ui-generator/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/ui-generator",
-  "version": "0.1.61",
+  "version": "0.1.62",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.78",
-    "@jskit-ai/shell-web": "0.1.77"
+    "@jskit-ai/kernel": "0.1.79",
+    "@jskit-ai/shell-web": "0.1.78"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/uploads-image-web/package.descriptor.mjs
+++ b/packages/uploads-image-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-image-web",
-  version: "0.1.56",
+  version: "0.1.57",
   kind: "runtime",
   description: "Reusable client-side image upload runtime with pre-upload image editing.",
   dependsOn: [
@@ -65,7 +65,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/uploads-runtime": "0.1.56",
+        "@jskit-ai/uploads-runtime": "0.1.57",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-image-web/package.json
+++ b/packages/uploads-image-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-image-web",
-  "version": "0.1.56",
+  "version": "0.1.57",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,7 +13,7 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/uploads-runtime": "0.1.56",
+    "@jskit-ai/uploads-runtime": "0.1.57",
     "@uppy/compressor": "^3.1.0",
     "@uppy/core": "^5.2.0",
     "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-runtime/package.descriptor.mjs
+++ b/packages/uploads-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-runtime",
-  version: "0.1.56",
+  version: "0.1.57",
   kind: "runtime",
   description: "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
   dependsOn: [
@@ -71,7 +71,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.78"
+        "@jskit-ai/kernel": "0.1.79"
       },
       dev: {}
     },

--- a/packages/uploads-runtime/package.json
+++ b/packages/uploads-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-runtime",
-  "version": "0.1.56",
+  "version": "0.1.57",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,6 +16,6 @@
   },
   "dependencies": {
     "@fastify/multipart": "^9.4.0",
-    "@jskit-ai/kernel": "0.1.78"
+    "@jskit-ai/kernel": "0.1.79"
   }
 }

--- a/packages/users-core/package.descriptor.mjs
+++ b/packages/users-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-core",
-  version: "0.1.88",
+  version: "0.1.89",
   kind: "runtime",
   description: "Users/account runtime plus HTTP routes for account features.",
   dependsOn: [
@@ -143,16 +143,16 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.77",
-        "@jskit-ai/crud-core": "0.1.86",
-        "@jskit-ai/database-runtime": "0.1.78",
-        "@jskit-ai/http-runtime": "0.1.77",
-        "@jskit-ai/json-rest-api-core": "0.1.23",
-        "@jskit-ai/kernel": "0.1.78",
-        "@jskit-ai/resource-core": "0.1.23",
-        "@jskit-ai/resource-crud-core": "0.1.23",
+        "@jskit-ai/auth-core": "0.1.78",
+        "@jskit-ai/crud-core": "0.1.87",
+        "@jskit-ai/database-runtime": "0.1.79",
+        "@jskit-ai/http-runtime": "0.1.78",
+        "@jskit-ai/json-rest-api-core": "0.1.24",
+        "@jskit-ai/kernel": "0.1.79",
+        "@jskit-ai/resource-core": "0.1.24",
+        "@jskit-ai/resource-crud-core": "0.1.24",
         "@local/users": "file:packages/users",
-        "@jskit-ai/uploads-runtime": "0.1.56"
+        "@jskit-ai/uploads-runtime": "0.1.57"
       },
       dev: {}
     },

--- a/packages/users-core/package.json
+++ b/packages/users-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-core",
-  "version": "0.1.88",
+  "version": "0.1.89",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,14 +11,14 @@
     "./shared/resources/userSettingsResource": "./src/shared/resources/userSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.77",
-    "@jskit-ai/database-runtime": "0.1.78",
-    "@jskit-ai/http-runtime": "0.1.77",
-    "@jskit-ai/json-rest-api-core": "0.1.23",
-    "@jskit-ai/kernel": "0.1.78",
-    "@jskit-ai/resource-crud-core": "0.1.23",
-    "@jskit-ai/resource-core": "0.1.23",
-    "@jskit-ai/uploads-runtime": "0.1.56",
+    "@jskit-ai/auth-core": "0.1.78",
+    "@jskit-ai/database-runtime": "0.1.79",
+    "@jskit-ai/http-runtime": "0.1.78",
+    "@jskit-ai/json-rest-api-core": "0.1.24",
+    "@jskit-ai/kernel": "0.1.79",
+    "@jskit-ai/resource-crud-core": "0.1.24",
+    "@jskit-ai/resource-core": "0.1.24",
+    "@jskit-ai/uploads-runtime": "0.1.57",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/users-web/package.descriptor.mjs
+++ b/packages/users-web/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { HOME_COG_OUTLET } from "./src/shared/toolsOutletContracts.js";
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-web",
-  version: "0.1.93",
+  version: "0.1.94",
   kind: "runtime",
   description: "Users web module: account/profile UI plus shared users web widgets.",
   dependsOn: [
@@ -278,12 +278,12 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/http-runtime": "0.1.77",
-        "@jskit-ai/realtime": "0.1.77",
-        "@jskit-ai/kernel": "0.1.78",
-        "@jskit-ai/shell-web": "0.1.77",
-        "@jskit-ai/uploads-image-web": "0.1.56",
-        "@jskit-ai/users-core": "0.1.88"
+        "@jskit-ai/http-runtime": "0.1.78",
+        "@jskit-ai/realtime": "0.1.78",
+        "@jskit-ai/kernel": "0.1.79",
+        "@jskit-ai/shell-web": "0.1.78",
+        "@jskit-ai/uploads-image-web": "0.1.57",
+        "@jskit-ai/users-core": "0.1.89"
       },
       dev: {}
     },

--- a/packages/users-web/package.json
+++ b/packages/users-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-web",
-  "version": "0.1.93",
+  "version": "0.1.94",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -44,12 +44,12 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/http-runtime": "0.1.77",
-    "@jskit-ai/kernel": "0.1.78",
-    "@jskit-ai/realtime": "0.1.77",
-    "@jskit-ai/shell-web": "0.1.77",
-    "@jskit-ai/uploads-image-web": "0.1.56",
-    "@jskit-ai/users-core": "0.1.88"
+    "@jskit-ai/http-runtime": "0.1.78",
+    "@jskit-ai/kernel": "0.1.79",
+    "@jskit-ai/realtime": "0.1.78",
+    "@jskit-ai/shell-web": "0.1.78",
+    "@jskit-ai/uploads-image-web": "0.1.57",
+    "@jskit-ai/users-core": "0.1.89"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/workspaces-core/package.descriptor.mjs
+++ b/packages/workspaces-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-core",
-  version: "0.1.54",
+  version: "0.1.55",
   kind: "runtime",
   description: "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
   dependsOn: [
@@ -142,10 +142,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/json-rest-api-core": "0.1.23",
-        "@jskit-ai/resource-core": "0.1.23",
-        "@jskit-ai/resource-crud-core": "0.1.23",
-        "@jskit-ai/users-core": "0.1.88"
+        "@jskit-ai/json-rest-api-core": "0.1.24",
+        "@jskit-ai/resource-core": "0.1.24",
+        "@jskit-ai/resource-crud-core": "0.1.24",
+        "@jskit-ai/users-core": "0.1.89"
       },
       dev: {}
     },

--- a/packages/workspaces-core/package.json
+++ b/packages/workspaces-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-core",
-  "version": "0.1.54",
+  "version": "0.1.55",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -17,14 +17,14 @@
     "./shared/resources/workspaceSettingsResource": "./src/shared/resources/workspaceSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.77",
-    "@jskit-ai/database-runtime": "0.1.78",
-    "@jskit-ai/http-runtime": "0.1.77",
-    "@jskit-ai/json-rest-api-core": "0.1.23",
-    "@jskit-ai/kernel": "0.1.78",
-    "@jskit-ai/resource-crud-core": "0.1.23",
-    "@jskit-ai/resource-core": "0.1.23",
-    "@jskit-ai/users-core": "0.1.88",
+    "@jskit-ai/auth-core": "0.1.78",
+    "@jskit-ai/database-runtime": "0.1.79",
+    "@jskit-ai/http-runtime": "0.1.78",
+    "@jskit-ai/json-rest-api-core": "0.1.24",
+    "@jskit-ai/kernel": "0.1.79",
+    "@jskit-ai/resource-crud-core": "0.1.24",
+    "@jskit-ai/resource-core": "0.1.24",
+    "@jskit-ai/users-core": "0.1.89",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/workspaces-web/package.descriptor.mjs
+++ b/packages/workspaces-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-web",
-  version: "0.1.54",
+  version: "0.1.55",
   kind: "runtime",
   description: "Workspace web module: workspace selector, tools widget, workspace surfaces, and members/settings UI.",
   dependsOn: [
@@ -231,8 +231,8 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/workspaces-core": "0.1.54",
-        "@jskit-ai/users-web": "0.1.93"
+        "@jskit-ai/workspaces-core": "0.1.55",
+        "@jskit-ai/users-web": "0.1.94"
       },
       dev: {}
     },

--- a/packages/workspaces-web/package.json
+++ b/packages/workspaces-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-web",
-  "version": "0.1.54",
+  "version": "0.1.55",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -15,12 +15,12 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/http-runtime": "0.1.77",
-    "@jskit-ai/kernel": "0.1.78",
-    "@jskit-ai/shell-web": "0.1.77",
-    "@jskit-ai/users-core": "0.1.88",
-    "@jskit-ai/users-web": "0.1.93",
-    "@jskit-ai/workspaces-core": "0.1.54"
+    "@jskit-ai/http-runtime": "0.1.78",
+    "@jskit-ai/kernel": "0.1.79",
+    "@jskit-ai/shell-web": "0.1.78",
+    "@jskit-ai/users-core": "0.1.89",
+    "@jskit-ai/users-web": "0.1.94",
+    "@jskit-ai/workspaces-core": "0.1.55"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/tooling/config-eslint/package.json
+++ b/tooling/config-eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/config-eslint",
-  "version": "0.1.77",
+  "version": "0.1.78",
   "description": "Shared flat ESLint presets for JSKIT projects.",
   "type": "module",
   "files": [

--- a/tooling/create-app/package.descriptor.mjs
+++ b/tooling/create-app/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/create-app",
-  "version": "0.1.86",
+  "version": "0.1.87",
   "dependsOn": [],
   "capabilities": {
     "provides": [

--- a/tooling/create-app/package.json
+++ b/tooling/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/create-app",
-  "version": "0.1.86",
+  "version": "0.1.87",
   "description": "Scaffold minimal JSKIT app shells.",
   "type": "module",
   "files": [

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -6,11 +6,11 @@
   "packages": [
     {
       "packageId": "@jskit-ai/assistant",
-      "version": "0.1.87",
+      "version": "0.1.88",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant",
-        "version": "0.1.87",
+        "version": "0.1.88",
         "kind": "generator",
         "description": "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
         "options": {
@@ -347,11 +347,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-core",
-      "version": "0.1.54",
+      "version": "0.1.55",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-core",
-        "version": "0.1.54",
+        "version": "0.1.55",
         "kind": "runtime",
         "description": "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
         "dependsOn": [
@@ -399,11 +399,11 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/http-runtime": "0.1.77",
-              "@jskit-ai/kernel": "0.1.78",
-              "@jskit-ai/resource-core": "0.1.23",
-              "@jskit-ai/resource-crud-core": "0.1.23",
-              "@jskit-ai/users-core": "0.1.88",
+              "@jskit-ai/http-runtime": "0.1.78",
+              "@jskit-ai/kernel": "0.1.79",
+              "@jskit-ai/resource-core": "0.1.24",
+              "@jskit-ai/resource-crud-core": "0.1.24",
+              "@jskit-ai/users-core": "0.1.89",
               "dompurify": "^3.3.3",
               "json-rest-schema": "1.x.x",
               "marked": "^17.0.4",
@@ -422,11 +422,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-runtime",
-      "version": "0.1.49",
+      "version": "0.1.50",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-runtime",
-        "version": "0.1.49",
+        "version": "0.1.50",
         "kind": "runtime",
         "description": "Shared assistant runtime with per-surface assistant registration.",
         "dependsOn": [
@@ -522,13 +522,13 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/assistant-core": "0.1.54",
-              "@jskit-ai/database-runtime": "0.1.78",
-              "@jskit-ai/http-runtime": "0.1.77",
-              "@jskit-ai/kernel": "0.1.78",
-              "@jskit-ai/shell-web": "0.1.77",
-              "@jskit-ai/users-core": "0.1.88",
-              "@jskit-ai/users-web": "0.1.93"
+              "@jskit-ai/assistant-core": "0.1.55",
+              "@jskit-ai/database-runtime": "0.1.79",
+              "@jskit-ai/http-runtime": "0.1.78",
+              "@jskit-ai/kernel": "0.1.79",
+              "@jskit-ai/shell-web": "0.1.78",
+              "@jskit-ai/users-core": "0.1.89",
+              "@jskit-ai/users-web": "0.1.94"
             },
             "dev": {}
           },
@@ -583,11 +583,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-core",
-      "version": "0.1.77",
+      "version": "0.1.78",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-core",
-        "version": "0.1.77",
+        "version": "0.1.78",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/value-app-config-shared"
@@ -655,7 +655,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.78",
+              "@jskit-ai/kernel": "0.1.79",
               "@fastify/cookie": "^11.0.2",
               "@fastify/csrf-protection": "^7.1.0",
               "@fastify/rate-limit": "^10.3.0"
@@ -673,11 +673,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.77",
+      "version": "0.1.78",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-supabase-core",
-        "version": "0.1.77",
+        "version": "0.1.78",
         "kind": "runtime",
         "options": {
           "auth-supabase-url": {
@@ -759,8 +759,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.77",
-              "@jskit-ai/kernel": "0.1.78",
+              "@jskit-ai/auth-core": "0.1.78",
+              "@jskit-ai/kernel": "0.1.79",
               "dotenv": "^16.4.5",
               "@supabase/supabase-js": "^2.57.4",
               "jose": "^6.1.0"
@@ -825,11 +825,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-web",
-      "version": "0.1.79",
+      "version": "0.1.80",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-web",
-        "version": "0.1.79",
+        "version": "0.1.80",
         "kind": "runtime",
         "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
         "dependsOn": [
@@ -1085,10 +1085,10 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/auth-core": "0.1.77",
-              "@jskit-ai/http-runtime": "0.1.77",
-              "@jskit-ai/kernel": "0.1.78",
-              "@jskit-ai/shell-web": "0.1.77"
+              "@jskit-ai/auth-core": "0.1.78",
+              "@jskit-ai/http-runtime": "0.1.78",
+              "@jskit-ai/kernel": "0.1.79",
+              "@jskit-ai/shell-web": "0.1.78"
             },
             "dev": {}
           },
@@ -1167,11 +1167,11 @@
     },
     {
       "packageId": "@jskit-ai/console-core",
-      "version": "0.1.41",
+      "version": "0.1.42",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-core",
-        "version": "0.1.41",
+        "version": "0.1.42",
         "kind": "runtime",
         "description": "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
         "dependsOn": [
@@ -1255,12 +1255,12 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.77",
-              "@jskit-ai/database-runtime": "0.1.78",
-              "@jskit-ai/http-runtime": "0.1.77",
-              "@jskit-ai/kernel": "0.1.78",
-              "@jskit-ai/resource-crud-core": "0.1.23",
-              "@jskit-ai/users-core": "0.1.88"
+              "@jskit-ai/auth-core": "0.1.78",
+              "@jskit-ai/database-runtime": "0.1.79",
+              "@jskit-ai/http-runtime": "0.1.78",
+              "@jskit-ai/kernel": "0.1.79",
+              "@jskit-ai/resource-crud-core": "0.1.24",
+              "@jskit-ai/users-core": "0.1.89"
             },
             "dev": {}
           },
@@ -1285,11 +1285,11 @@
     },
     {
       "packageId": "@jskit-ai/console-web",
-      "version": "0.1.46",
+      "version": "0.1.47",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-web",
-        "version": "0.1.46",
+        "version": "0.1.47",
         "kind": "runtime",
         "description": "Authenticated console surface scaffold and surface policy wiring.",
         "dependsOn": [
@@ -1399,9 +1399,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-web": "0.1.79",
-              "@jskit-ai/console-core": "0.1.41",
-              "@jskit-ai/shell-web": "0.1.77"
+              "@jskit-ai/auth-web": "0.1.80",
+              "@jskit-ai/console-core": "0.1.42",
+              "@jskit-ai/shell-web": "0.1.78"
             },
             "dev": {}
           },
@@ -1508,11 +1508,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-core",
-      "version": "0.1.86",
+      "version": "0.1.87",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-core",
-        "version": "0.1.86",
+        "version": "0.1.87",
         "kind": "runtime",
         "description": "Shared CRUD helpers used by CRUD modules.",
         "dependsOn": [
@@ -1541,7 +1541,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/crud-core": "0.1.86"
+              "@jskit-ai/crud-core": "0.1.87"
             },
             "dev": {}
           },
@@ -1555,11 +1555,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-server-generator",
-      "version": "0.1.86",
+      "version": "0.1.87",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-server-generator",
-        "version": "0.1.86",
+        "version": "0.1.87",
         "kind": "generator",
         "description": "CRUD server generator with routes, actions, and persistence scaffolding.",
         "options": {
@@ -1726,14 +1726,14 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.77",
-              "@jskit-ai/crud-core": "0.1.86",
-              "@jskit-ai/database-runtime": "0.1.78",
-              "@jskit-ai/http-runtime": "0.1.77",
-              "@jskit-ai/json-rest-api-core": "0.1.23",
-              "@jskit-ai/kernel": "0.1.78",
-              "@jskit-ai/realtime": "0.1.77",
-              "@jskit-ai/resource-crud-core": "0.1.23",
+              "@jskit-ai/auth-core": "0.1.78",
+              "@jskit-ai/crud-core": "0.1.87",
+              "@jskit-ai/database-runtime": "0.1.79",
+              "@jskit-ai/http-runtime": "0.1.78",
+              "@jskit-ai/json-rest-api-core": "0.1.24",
+              "@jskit-ai/kernel": "0.1.79",
+              "@jskit-ai/realtime": "0.1.78",
+              "@jskit-ai/resource-crud-core": "0.1.24",
               "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}"
             },
             "dev": {}
@@ -1865,11 +1865,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.61",
+      "version": "0.1.62",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-ui-generator",
-        "version": "0.1.61",
+        "version": "0.1.62",
         "kind": "generator",
         "description": "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
         "options": {
@@ -2068,7 +2068,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.93"
+              "@jskit-ai/users-web": "0.1.94"
             },
             "dev": {}
           },
@@ -2327,11 +2327,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime",
-      "version": "0.1.78",
+      "version": "0.1.79",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime",
-        "version": "0.1.78",
+        "version": "0.1.79",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -2388,7 +2388,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.78",
+              "@jskit-ai/kernel": "0.1.79",
               "dotenv": "^16.4.5",
               "knex": "^3.1.0"
             },
@@ -2423,11 +2423,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.77",
+      "version": "0.1.78",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-mysql",
-        "version": "0.1.77",
+        "version": "0.1.78",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -2517,7 +2517,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.78",
+              "@jskit-ai/database-runtime": "0.1.79",
               "mysql2": "^3.11.2"
             },
             "dev": {}
@@ -2588,11 +2588,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.77",
+      "version": "0.1.78",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-postgres",
-        "version": "0.1.77",
+        "version": "0.1.78",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -2682,7 +2682,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.78",
+              "@jskit-ai/database-runtime": "0.1.79",
               "pg": "^8.13.1"
             },
             "dev": {}
@@ -2753,11 +2753,11 @@
     },
     {
       "packageId": "@jskit-ai/feature-server-generator",
-      "version": "0.1.20",
+      "version": "0.1.21",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/feature-server-generator",
-        "version": "0.1.20",
+        "version": "0.1.21",
         "kind": "generator",
         "description": "Scaffold substantial non-CRUD server feature packages with provider, actions, service, and optional persistence seams.",
         "options": {
@@ -2942,7 +2942,7 @@
                   "equals": "json-rest"
                 }
               },
-              "@jskit-ai/kernel": "0.1.78",
+              "@jskit-ai/kernel": "0.1.79",
               "json-rest-schema": "1.x.x",
               "@local/${option:feature-name|kebab}": "file:packages/${option:feature-name|kebab}"
             },
@@ -3055,11 +3055,11 @@
     },
     {
       "packageId": "@jskit-ai/google-rewarded-core",
-      "version": "0.1.15",
+      "version": "0.1.16",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/google-rewarded-core",
-        "version": "0.1.15",
+        "version": "0.1.16",
         "kind": "runtime",
         "description": "Google rewarded workflow runtime plus internal CRUD providers for rules, provider configs, watch sessions, and unlock receipts.",
         "dependsOn": [
@@ -3186,14 +3186,14 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.77",
-              "@jskit-ai/crud-core": "0.1.86",
-              "@jskit-ai/database-runtime": "0.1.78",
-              "@jskit-ai/http-runtime": "0.1.77",
-              "@jskit-ai/json-rest-api-core": "0.1.23",
-              "@jskit-ai/kernel": "0.1.78",
-              "@jskit-ai/resource-crud-core": "0.1.23",
-              "@jskit-ai/workspaces-core": "0.1.54"
+              "@jskit-ai/auth-core": "0.1.78",
+              "@jskit-ai/crud-core": "0.1.87",
+              "@jskit-ai/database-runtime": "0.1.79",
+              "@jskit-ai/http-runtime": "0.1.78",
+              "@jskit-ai/json-rest-api-core": "0.1.24",
+              "@jskit-ai/kernel": "0.1.79",
+              "@jskit-ai/resource-crud-core": "0.1.24",
+              "@jskit-ai/workspaces-core": "0.1.55"
             },
             "dev": {}
           },
@@ -3245,11 +3245,11 @@
     },
     {
       "packageId": "@jskit-ai/google-rewarded-web",
-      "version": "0.1.15",
+      "version": "0.1.16",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/google-rewarded-web",
-        "version": "0.1.15",
+        "version": "0.1.16",
         "kind": "runtime",
         "description": "Google rewarded client runtime with a fullscreen gate host and GPT orchestration.",
         "dependsOn": [
@@ -3296,10 +3296,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/google-rewarded-core": "0.1.15",
-              "@jskit-ai/http-runtime": "0.1.77",
-              "@jskit-ai/kernel": "0.1.78",
-              "@jskit-ai/shell-web": "0.1.77"
+              "@jskit-ai/google-rewarded-core": "0.1.16",
+              "@jskit-ai/http-runtime": "0.1.78",
+              "@jskit-ai/kernel": "0.1.79",
+              "@jskit-ai/shell-web": "0.1.78"
             },
             "dev": {}
           },
@@ -3317,11 +3317,11 @@
     },
     {
       "packageId": "@jskit-ai/http-runtime",
-      "version": "0.1.77",
+      "version": "0.1.78",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/http-runtime",
-        "version": "0.1.77",
+        "version": "0.1.78",
         "kind": "runtime",
         "dependsOn": [],
         "capabilities": {
@@ -3387,7 +3387,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.78"
+              "@jskit-ai/kernel": "0.1.79"
             },
             "dev": {}
           },
@@ -3401,11 +3401,11 @@
     },
     {
       "packageId": "@jskit-ai/json-rest-api-core",
-      "version": "0.1.23",
+      "version": "0.1.24",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/json-rest-api-core",
-        "version": "0.1.23",
+        "version": "0.1.24",
         "kind": "runtime",
         "description": "Shared internal json-rest-api host runtime for JSKIT server packages.",
         "dependsOn": [
@@ -3465,11 +3465,11 @@
     },
     {
       "packageId": "@jskit-ai/mobile-capacitor",
-      "version": "0.1.15",
+      "version": "0.1.16",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/mobile-capacitor",
-        "version": "0.1.15",
+        "version": "0.1.16",
         "kind": "runtime",
         "description": "Thin Capacitor client integration for JSKIT mobile-shell launch routing and auth callback completion.",
         "dependsOn": [
@@ -3532,8 +3532,8 @@
               "@capacitor/app": "^7.1.0",
               "@capacitor/browser": "^7.0.1",
               "@capacitor/core": "^7.4.3",
-              "@jskit-ai/kernel": "0.1.78",
-              "@jskit-ai/shell-web": "0.1.77"
+              "@jskit-ai/kernel": "0.1.79",
+              "@jskit-ai/shell-web": "0.1.78"
             },
             "dev": {
               "@capacitor/cli": "^7.4.3"
@@ -3585,11 +3585,11 @@
     },
     {
       "packageId": "@jskit-ai/realtime",
-      "version": "0.1.77",
+      "version": "0.1.78",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/realtime",
-        "version": "0.1.77",
+        "version": "0.1.78",
         "kind": "runtime",
         "description": "Thin, generic realtime runtime wrappers for socket.io server and client.",
         "options": {
@@ -3685,7 +3685,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.78",
+              "@jskit-ai/kernel": "0.1.79",
               "@socket.io/redis-adapter": "^8.3.0",
               "redis": "^5.8.2",
               "socket.io": "^4.8.3",
@@ -3734,11 +3734,11 @@
     },
     {
       "packageId": "@jskit-ai/resource-core",
-      "version": "0.1.23",
+      "version": "0.1.24",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/resource-core",
-        "version": "0.1.23",
+        "version": "0.1.24",
         "kind": "runtime",
         "description": "Generic resource-definition helpers and schema-definition normalization.",
         "dependsOn": [
@@ -3761,7 +3761,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/resource-core": "0.1.23"
+              "@jskit-ai/resource-core": "0.1.24"
             },
             "dev": {}
           },
@@ -3776,11 +3776,11 @@
     },
     {
       "packageId": "@jskit-ai/resource-crud-core",
-      "version": "0.1.23",
+      "version": "0.1.24",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/resource-crud-core",
-        "version": "0.1.23",
+        "version": "0.1.24",
         "kind": "runtime",
         "description": "CRUD-specific resource-definition helpers and namespace support.",
         "dependsOn": [
@@ -3804,7 +3804,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/resource-crud-core": "0.1.23"
+              "@jskit-ai/resource-crud-core": "0.1.24"
             },
             "dev": {}
           },
@@ -3819,11 +3819,11 @@
     },
     {
       "packageId": "@jskit-ai/shell-web",
-      "version": "0.1.77",
+      "version": "0.1.78",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/shell-web",
-        "version": "0.1.77",
+        "version": "0.1.78",
         "kind": "runtime",
         "description": "Web shell layout runtime with outlet-based placement contributions.",
         "dependsOn": [],
@@ -4149,7 +4149,7 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/kernel": "0.1.78"
+              "@jskit-ai/kernel": "0.1.79"
             },
             "dev": {}
           },
@@ -4349,11 +4349,11 @@
     },
     {
       "packageId": "@jskit-ai/storage-runtime",
-      "version": "0.1.77",
+      "version": "0.1.78",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/storage-runtime",
-        "version": "0.1.77",
+        "version": "0.1.78",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -4402,7 +4402,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.78",
+              "@jskit-ai/kernel": "0.1.79",
               "unstorage": "^1.17.3"
             },
             "dev": {}
@@ -4418,11 +4418,11 @@
     },
     {
       "packageId": "@jskit-ai/ui-generator",
-      "version": "0.1.61",
+      "version": "0.1.62",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/ui-generator",
-        "version": "0.1.61",
+        "version": "0.1.62",
         "kind": "generator",
         "description": "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
         "options": {
@@ -4855,7 +4855,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.93"
+              "@jskit-ai/users-web": "0.1.94"
             },
             "dev": {}
           },
@@ -4870,11 +4870,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-image-web",
-      "version": "0.1.56",
+      "version": "0.1.57",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-image-web",
-        "version": "0.1.56",
+        "version": "0.1.57",
         "kind": "runtime",
         "description": "Reusable client-side image upload runtime with pre-upload image editing.",
         "dependsOn": [
@@ -4938,7 +4938,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/uploads-runtime": "0.1.56",
+              "@jskit-ai/uploads-runtime": "0.1.57",
               "@uppy/compressor": "^3.1.0",
               "@uppy/core": "^5.2.0",
               "@uppy/dashboard": "^5.1.1",
@@ -4958,11 +4958,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-runtime",
-      "version": "0.1.56",
+      "version": "0.1.57",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-runtime",
-        "version": "0.1.56",
+        "version": "0.1.57",
         "kind": "runtime",
         "description": "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
         "dependsOn": [
@@ -5032,7 +5032,7 @@
           "dependencies": {
             "runtime": {
               "@fastify/multipart": "^9.4.0",
-              "@jskit-ai/kernel": "0.1.78"
+              "@jskit-ai/kernel": "0.1.79"
             },
             "dev": {}
           },
@@ -5047,11 +5047,11 @@
     },
     {
       "packageId": "@jskit-ai/users-core",
-      "version": "0.1.88",
+      "version": "0.1.89",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-core",
-        "version": "0.1.88",
+        "version": "0.1.89",
         "kind": "runtime",
         "description": "Users/account runtime plus HTTP routes for account features.",
         "dependsOn": [
@@ -5192,16 +5192,16 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.77",
-              "@jskit-ai/crud-core": "0.1.86",
-              "@jskit-ai/database-runtime": "0.1.78",
-              "@jskit-ai/http-runtime": "0.1.77",
-              "@jskit-ai/json-rest-api-core": "0.1.23",
-              "@jskit-ai/kernel": "0.1.78",
-              "@jskit-ai/resource-core": "0.1.23",
-              "@jskit-ai/resource-crud-core": "0.1.23",
+              "@jskit-ai/auth-core": "0.1.78",
+              "@jskit-ai/crud-core": "0.1.87",
+              "@jskit-ai/database-runtime": "0.1.79",
+              "@jskit-ai/http-runtime": "0.1.78",
+              "@jskit-ai/json-rest-api-core": "0.1.24",
+              "@jskit-ai/kernel": "0.1.79",
+              "@jskit-ai/resource-core": "0.1.24",
+              "@jskit-ai/resource-crud-core": "0.1.24",
               "@local/users": "file:packages/users",
-              "@jskit-ai/uploads-runtime": "0.1.56"
+              "@jskit-ai/uploads-runtime": "0.1.57"
             },
             "dev": {}
           },
@@ -5418,11 +5418,11 @@
     },
     {
       "packageId": "@jskit-ai/users-web",
-      "version": "0.1.93",
+      "version": "0.1.94",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-web",
-        "version": "0.1.93",
+        "version": "0.1.94",
         "kind": "runtime",
         "description": "Users web module: account/profile UI plus shared users web widgets.",
         "dependsOn": [
@@ -5717,12 +5717,12 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/http-runtime": "0.1.77",
-              "@jskit-ai/realtime": "0.1.77",
-              "@jskit-ai/kernel": "0.1.78",
-              "@jskit-ai/shell-web": "0.1.77",
-              "@jskit-ai/uploads-image-web": "0.1.56",
-              "@jskit-ai/users-core": "0.1.88"
+              "@jskit-ai/http-runtime": "0.1.78",
+              "@jskit-ai/realtime": "0.1.78",
+              "@jskit-ai/kernel": "0.1.79",
+              "@jskit-ai/shell-web": "0.1.78",
+              "@jskit-ai/uploads-image-web": "0.1.57",
+              "@jskit-ai/users-core": "0.1.89"
             },
             "dev": {}
           },
@@ -5891,11 +5891,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-core",
-      "version": "0.1.54",
+      "version": "0.1.55",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-core",
-        "version": "0.1.54",
+        "version": "0.1.55",
         "kind": "runtime",
         "description": "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
         "dependsOn": [
@@ -6036,10 +6036,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/json-rest-api-core": "0.1.23",
-              "@jskit-ai/resource-core": "0.1.23",
-              "@jskit-ai/resource-crud-core": "0.1.23",
-              "@jskit-ai/users-core": "0.1.88"
+              "@jskit-ai/json-rest-api-core": "0.1.24",
+              "@jskit-ai/resource-core": "0.1.24",
+              "@jskit-ai/resource-crud-core": "0.1.24",
+              "@jskit-ai/users-core": "0.1.89"
             },
             "dev": {}
           },
@@ -6211,11 +6211,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-web",
-      "version": "0.1.54",
+      "version": "0.1.55",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-web",
-        "version": "0.1.54",
+        "version": "0.1.55",
         "kind": "runtime",
         "description": "Workspace web module: workspace selector, tools widget, workspace surfaces, and members/settings UI.",
         "dependsOn": [
@@ -6471,8 +6471,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/workspaces-core": "0.1.54",
-              "@jskit-ai/users-web": "0.1.93"
+              "@jskit-ai/workspaces-core": "0.1.55",
+              "@jskit-ai/users-web": "0.1.94"
             },
             "dev": {}
           },

--- a/tooling/jskit-catalog/package.json
+++ b/tooling/jskit-catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-catalog",
-  "version": "0.1.86",
+  "version": "0.1.87",
   "description": "Published metadata catalog for JSKIT package descriptors.",
   "type": "module",
   "files": [

--- a/tooling/jskit-cli/package.json
+++ b/tooling/jskit-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-cli",
-  "version": "0.2.87",
+  "version": "0.2.88",
   "description": "Bundle and package orchestration CLI for JSKIT apps.",
   "type": "module",
   "files": [
@@ -20,9 +20,9 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/jskit-catalog": "0.1.86",
-    "@jskit-ai/kernel": "0.1.78",
-    "@jskit-ai/shell-web": "0.1.77",
+    "@jskit-ai/jskit-catalog": "0.1.87",
+    "@jskit-ai/kernel": "0.1.79",
+    "@jskit-ai/shell-web": "0.1.78",
     "@vue/compiler-sfc": "^3.5.29",
     "ts-morph": "^28.0.0"
   },

--- a/tooling/jskit-cli/src/server/sessionRuntime/constants.js
+++ b/tooling/jskit-cli/src/server/sessionRuntime/constants.js
@@ -147,6 +147,10 @@ const JSKIT_STEP_RESULT_CONTRACT = Object.freeze({
   required: true,
   stepField: "step"
 });
+const MANUAL_JSKIT_STEP_RESULT_CONTRACT = Object.freeze({
+  ...JSKIT_STEP_RESULT_CONTRACT,
+  completionBehavior: "manual_advance"
+});
 const DESLOP_RESULT_CONTRACT = Object.freeze({
   autoResolvePriorities: Object.freeze(["high", "medium"]),
   completionBehavior: "deslop_loop",
@@ -231,7 +235,7 @@ function stepAutomationFor({
 const PLAN_EXECUTION_CODEX_HANDOFF = codexHandoff([], {
   autoInject: true,
   promptActionLabel: "Get Codex to execute plan",
-  responseContract: JSKIT_STEP_RESULT_CONTRACT
+  responseContract: MANUAL_JSKIT_STEP_RESULT_CONTRACT
 });
 const ISSUE_DETAILS_CODEX_HANDOFF = codexHandoff([
   ISSUE_CATEGORY_OUTPUT,
@@ -407,7 +411,7 @@ const STEP_DEFINITIONS = Object.freeze([
   defineStep({
     buttonLabel: "Get Codex to execute plan",
     codex: PLAN_EXECUTION_CODEX_HANDOFF,
-    description: "JSKIT sends the active cycle plan to Codex; Codex implements it; Studio advances when Codex finishes.",
+    description: "JSKIT sends the active cycle plan to Codex; Codex implements it; the user advances after reviewing completion.",
     id: "plan_executed",
     kind: "codex_prompt",
     label: "Plan executed",

--- a/tooling/jskit-cli/src/server/sessionRuntime/responses.js
+++ b/tooling/jskit-cli/src/server/sessionRuntime/responses.js
@@ -731,7 +731,7 @@ function buildCurrentStepAction(stepId, artifacts = {}) {
   })();
   const dynamicDescription = (() => {
     if (step.id === "plan_executed" && planExecutionPrompted && !planExecutionSubmitted) {
-      return "Codex has the execution prompt. Studio advances when Codex finishes.";
+      return "Codex has the execution prompt. Review the result, then use Go to next step when ready.";
     }
     if (step.id === "deep_ui_check_run" && deepUiCheckPrompted) {
       return "Codex has the Deep UI check prompt. Studio advances when Codex finishes.";

--- a/tooling/jskit-cli/test/sessionCommand.test.js
+++ b/tooling/jskit-cli/test/sessionCommand.test.js
@@ -1509,11 +1509,12 @@ test("jskit session accepts issue text from stdin and creates a GitHub issue wit
     });
     assert.equal(executionPrompt.currentStep, "plan_executed");
     assert.equal(executionPrompt.currentStepAction.buttonLabel, "Go to next step");
+    assert.match(executionPrompt.currentStepAction.description, /use Go to next step when ready/);
     assert.deepEqual(executionPrompt.currentStepAction.utilityActions, []);
     assert.equal(executionPrompt.codex.autoInject, true);
     assert.equal(executionPrompt.codex.promptActionLabel, "Get Codex to execute plan");
     assert.deepEqual(executionPrompt.codex.responseContract, {
-      completionBehavior: "auto_advance",
+      completionBehavior: "manual_advance",
       kind: "completion_marker",
       marker: "jskit_step_result",
       missingMarkerBehavior: "resend",


### PR DESCRIPTION
Summary:
- change plan execution Codex handoff to use manual advancement after review
- update Studio action copy and session contract tests for the manual advance flow
- refresh package versions across manifests, descriptors, lockfile, and catalog metadata

Tests:
- Not run locally.