### PR TITLE
Include blueprint updates in accepted changes commit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6686,28 +6686,28 @@
     },
     "packages/agent-docs": {
       "name": "@jskit-ai/agent-docs",
-      "version": "0.1.40",
+      "version": "0.1.41",
       "engines": {
         "node": ">=20 <23"
       }
     },
     "packages/assistant": {
       "name": "@jskit-ai/assistant",
-      "version": "0.1.88",
+      "version": "0.1.89",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.79"
+        "@jskit-ai/kernel": "0.1.80"
       }
     },
     "packages/assistant-core": {
       "name": "@jskit-ai/assistant-core",
-      "version": "0.1.55",
+      "version": "0.1.56",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.79",
-        "@jskit-ai/http-runtime": "0.1.78",
-        "@jskit-ai/kernel": "0.1.79",
-        "@jskit-ai/resource-core": "0.1.24",
-        "@jskit-ai/resource-crud-core": "0.1.24",
-        "@jskit-ai/users-core": "0.1.89",
+        "@jskit-ai/database-runtime": "0.1.80",
+        "@jskit-ai/http-runtime": "0.1.79",
+        "@jskit-ai/kernel": "0.1.80",
+        "@jskit-ai/resource-core": "0.1.25",
+        "@jskit-ai/resource-crud-core": "0.1.25",
+        "@jskit-ai/users-core": "0.1.90",
         "dompurify": "^3.3.3",
         "json-rest-schema": "1.x.x",
         "marked": "^17.0.4",
@@ -6720,15 +6720,15 @@
     },
     "packages/assistant-runtime": {
       "name": "@jskit-ai/assistant-runtime",
-      "version": "0.1.50",
+      "version": "0.1.51",
       "dependencies": {
-        "@jskit-ai/assistant-core": "0.1.55",
-        "@jskit-ai/database-runtime": "0.1.79",
-        "@jskit-ai/http-runtime": "0.1.78",
-        "@jskit-ai/kernel": "0.1.79",
-        "@jskit-ai/shell-web": "0.1.78",
-        "@jskit-ai/users-core": "0.1.89",
-        "@jskit-ai/users-web": "0.1.94",
+        "@jskit-ai/assistant-core": "0.1.56",
+        "@jskit-ai/database-runtime": "0.1.80",
+        "@jskit-ai/http-runtime": "0.1.79",
+        "@jskit-ai/kernel": "0.1.80",
+        "@jskit-ai/shell-web": "0.1.79",
+        "@jskit-ai/users-core": "0.1.90",
+        "@jskit-ai/users-web": "0.1.95",
         "json-rest-schema": "1.x.x"
       },
       "peerDependencies": {
@@ -6739,21 +6739,21 @@
     },
     "packages/auth-core": {
       "name": "@jskit-ai/auth-core",
-      "version": "0.1.78",
+      "version": "0.1.79",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0",
-        "@jskit-ai/kernel": "0.1.79",
+        "@jskit-ai/kernel": "0.1.80",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/auth-provider-supabase-core": {
       "name": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.78",
+      "version": "0.1.79",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.78",
-        "@jskit-ai/kernel": "0.1.79",
+        "@jskit-ai/auth-core": "0.1.79",
+        "@jskit-ai/kernel": "0.1.80",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0",
         "json-rest-schema": "1.x.x",
@@ -6762,12 +6762,12 @@
     },
     "packages/auth-web": {
       "name": "@jskit-ai/auth-web",
-      "version": "0.1.80",
+      "version": "0.1.81",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.78",
-        "@jskit-ai/http-runtime": "0.1.78",
-        "@jskit-ai/kernel": "0.1.79",
-        "@jskit-ai/shell-web": "0.1.78",
+        "@jskit-ai/auth-core": "0.1.79",
+        "@jskit-ai/http-runtime": "0.1.79",
+        "@jskit-ai/kernel": "0.1.80",
+        "@jskit-ai/shell-web": "0.1.79",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -6780,38 +6780,38 @@
     },
     "packages/console-core": {
       "name": "@jskit-ai/console-core",
-      "version": "0.1.42",
+      "version": "0.1.43",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.78",
-        "@jskit-ai/database-runtime": "0.1.79",
-        "@jskit-ai/http-runtime": "0.1.78",
-        "@jskit-ai/kernel": "0.1.79",
-        "@jskit-ai/resource-crud-core": "0.1.24",
-        "@jskit-ai/users-core": "0.1.89",
+        "@jskit-ai/auth-core": "0.1.79",
+        "@jskit-ai/database-runtime": "0.1.80",
+        "@jskit-ai/http-runtime": "0.1.79",
+        "@jskit-ai/kernel": "0.1.80",
+        "@jskit-ai/resource-crud-core": "0.1.25",
+        "@jskit-ai/users-core": "0.1.90",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/console-web": {
       "name": "@jskit-ai/console-web",
-      "version": "0.1.47",
+      "version": "0.1.48",
       "dependencies": {
-        "@jskit-ai/auth-web": "0.1.80",
-        "@jskit-ai/console-core": "0.1.42",
-        "@jskit-ai/shell-web": "0.1.78"
+        "@jskit-ai/auth-web": "0.1.81",
+        "@jskit-ai/console-core": "0.1.43",
+        "@jskit-ai/shell-web": "0.1.79"
       }
     },
     "packages/crud-core": {
       "name": "@jskit-ai/crud-core",
-      "version": "0.1.87",
+      "version": "0.1.88",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.79",
-        "@jskit-ai/http-runtime": "0.1.78",
-        "@jskit-ai/kernel": "0.1.79",
-        "@jskit-ai/realtime": "0.1.78",
-        "@jskit-ai/resource-crud-core": "0.1.24",
-        "@jskit-ai/shell-web": "0.1.78",
-        "@jskit-ai/users-core": "0.1.89",
-        "@jskit-ai/users-web": "0.1.94",
+        "@jskit-ai/database-runtime": "0.1.80",
+        "@jskit-ai/http-runtime": "0.1.79",
+        "@jskit-ai/kernel": "0.1.80",
+        "@jskit-ai/realtime": "0.1.79",
+        "@jskit-ai/resource-crud-core": "0.1.25",
+        "@jskit-ai/shell-web": "0.1.79",
+        "@jskit-ai/users-core": "0.1.90",
+        "@jskit-ai/users-web": "0.1.95",
         "json-rest-schema": "1.x.x"
       },
       "peerDependencies": {
@@ -6822,98 +6822,98 @@
     },
     "packages/crud-server-generator": {
       "name": "@jskit-ai/crud-server-generator",
-      "version": "0.1.87",
+      "version": "0.1.88",
       "dependencies": {
         "@babel/parser": "^7.29.2",
-        "@jskit-ai/crud-core": "0.1.87",
-        "@jskit-ai/database-runtime": "0.1.79",
-        "@jskit-ai/http-runtime": "0.1.78",
-        "@jskit-ai/json-rest-api-core": "0.1.24",
-        "@jskit-ai/kernel": "0.1.79",
-        "@jskit-ai/resource-crud-core": "0.1.24",
+        "@jskit-ai/crud-core": "0.1.88",
+        "@jskit-ai/database-runtime": "0.1.80",
+        "@jskit-ai/http-runtime": "0.1.79",
+        "@jskit-ai/json-rest-api-core": "0.1.25",
+        "@jskit-ai/kernel": "0.1.80",
+        "@jskit-ai/resource-crud-core": "0.1.25",
         "recast": "^0.23.11"
       }
     },
     "packages/crud-ui-generator": {
       "name": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.62",
+      "version": "0.1.63",
       "dependencies": {
-        "@jskit-ai/crud-core": "0.1.87",
-        "@jskit-ai/kernel": "0.1.79",
-        "@jskit-ai/resource-crud-core": "0.1.24"
+        "@jskit-ai/crud-core": "0.1.88",
+        "@jskit-ai/kernel": "0.1.80",
+        "@jskit-ai/resource-crud-core": "0.1.25"
       }
     },
     "packages/database-runtime": {
       "name": "@jskit-ai/database-runtime",
-      "version": "0.1.79",
+      "version": "0.1.80",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.79"
+        "@jskit-ai/kernel": "0.1.80"
       }
     },
     "packages/database-runtime-mysql": {
       "name": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.78",
+      "version": "0.1.79",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.79",
-        "@jskit-ai/kernel": "0.1.79"
+        "@jskit-ai/database-runtime": "0.1.80",
+        "@jskit-ai/kernel": "0.1.80"
       }
     },
     "packages/database-runtime-postgres": {
       "name": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.78",
+      "version": "0.1.79",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.79"
+        "@jskit-ai/database-runtime": "0.1.80"
       }
     },
     "packages/feature-server-generator": {
       "name": "@jskit-ai/feature-server-generator",
-      "version": "0.1.21"
+      "version": "0.1.22"
     },
     "packages/google-rewarded-core": {
       "name": "@jskit-ai/google-rewarded-core",
-      "version": "0.1.16"
+      "version": "0.1.17"
     },
     "packages/google-rewarded-web": {
       "name": "@jskit-ai/google-rewarded-web",
-      "version": "0.1.16"
+      "version": "0.1.17"
     },
     "packages/http-runtime": {
       "name": "@jskit-ai/http-runtime",
-      "version": "0.1.78",
+      "version": "0.1.79",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.79",
+        "@jskit-ai/kernel": "0.1.80",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/json-rest-api-core": {
       "name": "@jskit-ai/json-rest-api-core",
-      "version": "0.1.24",
+      "version": "0.1.25",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.79",
+        "@jskit-ai/kernel": "0.1.80",
         "hooked-api": "1.x.x",
         "json-rest-api": "1.x.x"
       }
     },
     "packages/kernel": {
       "name": "@jskit-ai/kernel",
-      "version": "0.1.79",
+      "version": "0.1.80",
       "dependencies": {
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/mobile-capacitor": {
       "name": "@jskit-ai/mobile-capacitor",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "dependencies": {
         "@capacitor/browser": "^7.0.1",
-        "@jskit-ai/kernel": "0.1.79"
+        "@jskit-ai/kernel": "0.1.80"
       }
     },
     "packages/realtime": {
       "name": "@jskit-ai/realtime",
-      "version": "0.1.78",
+      "version": "0.1.79",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.79",
+        "@jskit-ai/kernel": "0.1.80",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",
@@ -6925,24 +6925,24 @@
     },
     "packages/resource-core": {
       "name": "@jskit-ai/resource-core",
-      "version": "0.1.24",
+      "version": "0.1.25",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.79"
+        "@jskit-ai/kernel": "0.1.80"
       }
     },
     "packages/resource-crud-core": {
       "name": "@jskit-ai/resource-crud-core",
-      "version": "0.1.24",
+      "version": "0.1.25",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.79",
-        "@jskit-ai/resource-core": "0.1.24"
+        "@jskit-ai/kernel": "0.1.80",
+        "@jskit-ai/resource-core": "0.1.25"
       }
     },
     "packages/shell-web": {
       "name": "@jskit-ai/shell-web",
-      "version": "0.1.78",
+      "version": "0.1.79",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.79",
+        "@jskit-ai/kernel": "0.1.80",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -6954,25 +6954,25 @@
     },
     "packages/storage-runtime": {
       "name": "@jskit-ai/storage-runtime",
-      "version": "0.1.78",
+      "version": "0.1.79",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.79",
+        "@jskit-ai/kernel": "0.1.80",
         "unstorage": "^1.17.3"
       }
     },
     "packages/ui-generator": {
       "name": "@jskit-ai/ui-generator",
-      "version": "0.1.62",
+      "version": "0.1.63",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.79",
-        "@jskit-ai/shell-web": "0.1.78"
+        "@jskit-ai/kernel": "0.1.80",
+        "@jskit-ai/shell-web": "0.1.79"
       }
     },
     "packages/uploads-image-web": {
       "name": "@jskit-ai/uploads-image-web",
-      "version": "0.1.57",
+      "version": "0.1.58",
       "dependencies": {
-        "@jskit-ai/uploads-runtime": "0.1.57",
+        "@jskit-ai/uploads-runtime": "0.1.58",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",
@@ -6985,37 +6985,37 @@
     },
     "packages/uploads-runtime": {
       "name": "@jskit-ai/uploads-runtime",
-      "version": "0.1.57",
+      "version": "0.1.58",
       "dependencies": {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.79"
+        "@jskit-ai/kernel": "0.1.80"
       }
     },
     "packages/users-core": {
       "name": "@jskit-ai/users-core",
-      "version": "0.1.89",
+      "version": "0.1.90",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.78",
-        "@jskit-ai/database-runtime": "0.1.79",
-        "@jskit-ai/http-runtime": "0.1.78",
-        "@jskit-ai/json-rest-api-core": "0.1.24",
-        "@jskit-ai/kernel": "0.1.79",
-        "@jskit-ai/resource-core": "0.1.24",
-        "@jskit-ai/resource-crud-core": "0.1.24",
-        "@jskit-ai/uploads-runtime": "0.1.57",
+        "@jskit-ai/auth-core": "0.1.79",
+        "@jskit-ai/database-runtime": "0.1.80",
+        "@jskit-ai/http-runtime": "0.1.79",
+        "@jskit-ai/json-rest-api-core": "0.1.25",
+        "@jskit-ai/kernel": "0.1.80",
+        "@jskit-ai/resource-core": "0.1.25",
+        "@jskit-ai/resource-crud-core": "0.1.25",
+        "@jskit-ai/uploads-runtime": "0.1.58",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/users-web": {
       "name": "@jskit-ai/users-web",
-      "version": "0.1.94",
+      "version": "0.1.95",
       "dependencies": {
-        "@jskit-ai/http-runtime": "0.1.78",
-        "@jskit-ai/kernel": "0.1.79",
-        "@jskit-ai/realtime": "0.1.78",
-        "@jskit-ai/shell-web": "0.1.78",
-        "@jskit-ai/uploads-image-web": "0.1.57",
-        "@jskit-ai/users-core": "0.1.89",
+        "@jskit-ai/http-runtime": "0.1.79",
+        "@jskit-ai/kernel": "0.1.80",
+        "@jskit-ai/realtime": "0.1.79",
+        "@jskit-ai/shell-web": "0.1.79",
+        "@jskit-ai/uploads-image-web": "0.1.58",
+        "@jskit-ai/users-core": "0.1.90",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -7027,29 +7027,29 @@
     },
     "packages/workspaces-core": {
       "name": "@jskit-ai/workspaces-core",
-      "version": "0.1.55",
+      "version": "0.1.56",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.78",
-        "@jskit-ai/database-runtime": "0.1.79",
-        "@jskit-ai/http-runtime": "0.1.78",
-        "@jskit-ai/json-rest-api-core": "0.1.24",
-        "@jskit-ai/kernel": "0.1.79",
-        "@jskit-ai/resource-core": "0.1.24",
-        "@jskit-ai/resource-crud-core": "0.1.24",
-        "@jskit-ai/users-core": "0.1.89",
+        "@jskit-ai/auth-core": "0.1.79",
+        "@jskit-ai/database-runtime": "0.1.80",
+        "@jskit-ai/http-runtime": "0.1.79",
+        "@jskit-ai/json-rest-api-core": "0.1.25",
+        "@jskit-ai/kernel": "0.1.80",
+        "@jskit-ai/resource-core": "0.1.25",
+        "@jskit-ai/resource-crud-core": "0.1.25",
+        "@jskit-ai/users-core": "0.1.90",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/workspaces-web": {
       "name": "@jskit-ai/workspaces-web",
-      "version": "0.1.55",
+      "version": "0.1.56",
       "dependencies": {
-        "@jskit-ai/http-runtime": "0.1.78",
-        "@jskit-ai/kernel": "0.1.79",
-        "@jskit-ai/shell-web": "0.1.78",
-        "@jskit-ai/users-core": "0.1.89",
-        "@jskit-ai/users-web": "0.1.94",
-        "@jskit-ai/workspaces-core": "0.1.55",
+        "@jskit-ai/http-runtime": "0.1.79",
+        "@jskit-ai/kernel": "0.1.80",
+        "@jskit-ai/shell-web": "0.1.79",
+        "@jskit-ai/users-core": "0.1.90",
+        "@jskit-ai/users-web": "0.1.95",
+        "@jskit-ai/workspaces-core": "0.1.56",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -7061,7 +7061,7 @@
     },
     "tooling/config-eslint": {
       "name": "@jskit-ai/config-eslint",
-      "version": "0.1.78",
+      "version": "0.1.79",
       "dependencies": {
         "@eslint/js": "^9.39.1",
         "eslint-plugin-vue": "^10.5.1",
@@ -7079,7 +7079,7 @@
     },
     "tooling/create-app": {
       "name": "@jskit-ai/create-app",
-      "version": "0.1.87",
+      "version": "0.1.88",
       "bin": {
         "jskit-create-app": "bin/jskit-create-app.js"
       },
@@ -7089,18 +7089,18 @@
     },
     "tooling/jskit-catalog": {
       "name": "@jskit-ai/jskit-catalog",
-      "version": "0.1.87",
+      "version": "0.1.88",
       "engines": {
         "node": ">=20 <23"
       }
     },
     "tooling/jskit-cli": {
       "name": "@jskit-ai/jskit-cli",
-      "version": "0.2.88",
+      "version": "0.2.89",
       "dependencies": {
-        "@jskit-ai/jskit-catalog": "0.1.87",
-        "@jskit-ai/kernel": "0.1.79",
-        "@jskit-ai/shell-web": "0.1.78",
+        "@jskit-ai/jskit-catalog": "0.1.88",
+        "@jskit-ai/kernel": "0.1.80",
+        "@jskit-ai/shell-web": "0.1.79",
         "@vue/compiler-sfc": "^3.5.29",
         "ts-morph": "^28.0.0"
       },

--- a/packages/agent-docs/package.json
+++ b/packages/agent-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/agent-docs",
-  "version": "0.1.40",
+  "version": "0.1.41",
   "description": "Distributed JSKIT agent references, prompts, guides, and generated reference maps.",
   "type": "module",
   "files": [

--- a/packages/agent-docs/reference/autogen/tooling/jskit-cli.md
+++ b/packages/agent-docs/reference/autogen/tooling/jskit-cli.md
@@ -916,6 +916,14 @@ Local functions
 - `commitWorktree(paths, { message, allowNoChanges = false } = {})`
 - `uniqueChangedFileList(entries = [])`
 - `changedFilesInWorktree(paths)`
+- `blueprintBaselinePath(paths)`
+- `isBlueprintRelativePath(filePath = "")`
+- `nonBlueprintChangedFiles(files = [])`
+- `hashWorktreeFile(paths, filePath)`
+- `buildDirtyFileSnapshot(paths, files = [])`
+- `writeBlueprintBaseline(paths)`
+- `readBlueprintBaseline(paths)`
+- `unexpectedBlueprintStepChanges(paths, changedFiles = [])`
 - `changedFilesSinceBase(paths)`
 - `nextReviewPassNumber(pass = "")`
 - `readCurrentReviewPass(paths)`
@@ -1067,7 +1075,7 @@ Exports
 ### `src/server/sessionRuntime/responses.js`
 Exports
 - `buildSessionErrorResponse({ targetRoot = process.cwd(), sessionId = "", code, message, repairCommand = "", status = SESSION_STATUS.BLOCKED, preconditions = [], errors = undefined } = {})`
-- `buildSessionResponse(paths, { codex = undefined, ok = true, errors = [], preconditions = [], prompt = undefined, status = undefined } = {})`
+- `buildSessionResponse(paths, { codex = undefined, ok = true, errors = [], preconditions = [], prompt = undefined, status = undefined, warnings = [] } = {})`
 - `buildStepDefinitions()`
 - `createError({ code, message, repairCommand = "" })`
 - `createPrecondition({ id, ok, message })`
@@ -1085,6 +1093,7 @@ Exports
 - `writeCycleReceipt(paths, receiptName, message, { cycle = "" } = {})`
 - `writeReceipt(paths, stepId, message)`
 Local functions
+- `createWarning({ code, message, repairCommand = "" })`
 - `normalizeStepId(stepId)`
 - `stepIndex(stepId)`
 - `normalizeKnownStepIds(stepIds = [])`
@@ -1117,6 +1126,8 @@ Local functions
 - `readWorktreeStatus(paths, worktreeReady)`
 - `resolveNextStep(completedSteps = [])`
 - `cloneContractValue(value)`
+- `normalizeWarning(warning)`
+- `mergeWarnings(...warningLists)`
 - `publicCodexContract(codex = null)`
 - `stepRepeatabilityContract(stepId)`
 - `publicStepDefinition(step, index)`

--- a/packages/assistant-core/package.descriptor.mjs
+++ b/packages/assistant-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-core",
-  version: "0.1.55",
+  version: "0.1.56",
   kind: "runtime",
   description: "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
   dependsOn: [
@@ -47,11 +47,11 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/http-runtime": "0.1.78",
-        "@jskit-ai/kernel": "0.1.79",
-        "@jskit-ai/resource-core": "0.1.24",
-        "@jskit-ai/resource-crud-core": "0.1.24",
-        "@jskit-ai/users-core": "0.1.89",
+        "@jskit-ai/http-runtime": "0.1.79",
+        "@jskit-ai/kernel": "0.1.80",
+        "@jskit-ai/resource-core": "0.1.25",
+        "@jskit-ai/resource-crud-core": "0.1.25",
+        "@jskit-ai/users-core": "0.1.90",
         "dompurify": "^3.3.3",
         "json-rest-schema": "1.x.x",
         "marked": "^17.0.4",

--- a/packages/assistant-core/package.json
+++ b/packages/assistant-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-core",
-  "version": "0.1.55",
+  "version": "0.1.56",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,12 +11,12 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.79",
-    "@jskit-ai/http-runtime": "0.1.78",
-    "@jskit-ai/kernel": "0.1.79",
-    "@jskit-ai/resource-crud-core": "0.1.24",
-    "@jskit-ai/resource-core": "0.1.24",
-    "@jskit-ai/users-core": "0.1.89",
+    "@jskit-ai/database-runtime": "0.1.80",
+    "@jskit-ai/http-runtime": "0.1.79",
+    "@jskit-ai/kernel": "0.1.80",
+    "@jskit-ai/resource-crud-core": "0.1.25",
+    "@jskit-ai/resource-core": "0.1.25",
+    "@jskit-ai/users-core": "0.1.90",
     "dompurify": "^3.3.3",
     "json-rest-schema": "1.x.x",
     "marked": "^17.0.4",

--- a/packages/assistant-runtime/package.descriptor.mjs
+++ b/packages/assistant-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-runtime",
-  version: "0.1.50",
+  version: "0.1.51",
   kind: "runtime",
   description: "Shared assistant runtime with per-surface assistant registration.",
   dependsOn: [
@@ -95,13 +95,13 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/assistant-core": "0.1.55",
-        "@jskit-ai/database-runtime": "0.1.79",
-        "@jskit-ai/http-runtime": "0.1.78",
-        "@jskit-ai/kernel": "0.1.79",
-        "@jskit-ai/shell-web": "0.1.78",
-        "@jskit-ai/users-core": "0.1.89",
-        "@jskit-ai/users-web": "0.1.94"
+        "@jskit-ai/assistant-core": "0.1.56",
+        "@jskit-ai/database-runtime": "0.1.80",
+        "@jskit-ai/http-runtime": "0.1.79",
+        "@jskit-ai/kernel": "0.1.80",
+        "@jskit-ai/shell-web": "0.1.79",
+        "@jskit-ai/users-core": "0.1.90",
+        "@jskit-ai/users-web": "0.1.95"
       },
       dev: {}
     },

--- a/packages/assistant-runtime/package.json
+++ b/packages/assistant-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-runtime",
-  "version": "0.1.50",
+  "version": "0.1.51",
   "type": "module",
   "exports": {
     "./client": "./src/client/index.js",
@@ -8,13 +8,13 @@
     "./server/actionIds": "./src/server/actionIds.js"
   },
   "dependencies": {
-    "@jskit-ai/assistant-core": "0.1.55",
-    "@jskit-ai/database-runtime": "0.1.79",
-    "@jskit-ai/http-runtime": "0.1.78",
-    "@jskit-ai/kernel": "0.1.79",
-    "@jskit-ai/shell-web": "0.1.78",
-    "@jskit-ai/users-core": "0.1.89",
-    "@jskit-ai/users-web": "0.1.94",
+    "@jskit-ai/assistant-core": "0.1.56",
+    "@jskit-ai/database-runtime": "0.1.80",
+    "@jskit-ai/http-runtime": "0.1.79",
+    "@jskit-ai/kernel": "0.1.80",
+    "@jskit-ai/shell-web": "0.1.79",
+    "@jskit-ai/users-core": "0.1.90",
+    "@jskit-ai/users-web": "0.1.95",
     "json-rest-schema": "1.x.x"
   },
   "peerDependencies": {

--- a/packages/assistant/package.descriptor.mjs
+++ b/packages/assistant/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant",
-  version: "0.1.88",
+  version: "0.1.89",
   kind: "generator",
   description: "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
   options: {

--- a/packages/assistant/package.json
+++ b/packages/assistant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant",
-  "version": "0.1.88",
+  "version": "0.1.89",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.79"
+    "@jskit-ai/kernel": "0.1.80"
   }
 }

--- a/packages/auth-core/package.descriptor.mjs
+++ b/packages/auth-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-core",
-  "version": "0.1.78",
+  "version": "0.1.79",
   "kind": "runtime",
   "dependsOn": [
     "@jskit-ai/value-app-config-shared"
@@ -69,7 +69,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.79",
+        "@jskit-ai/kernel": "0.1.80",
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0"

--- a/packages/auth-core/package.json
+++ b/packages/auth-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-core",
-  "version": "0.1.78",
+  "version": "0.1.79",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -46,7 +46,7 @@
     "./shared/commands/authSessionReadCommand": "./src/shared/commands/authSessionReadCommand.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.79",
+    "@jskit-ai/kernel": "0.1.80",
     "@fastify/cookie": "^11.0.2",
     "@fastify/csrf-protection": "^7.1.0",
     "@fastify/rate-limit": "^10.3.0",

--- a/packages/auth-provider-supabase-core/package.descriptor.mjs
+++ b/packages/auth-provider-supabase-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.78",
+  "version": "0.1.79",
   "kind": "runtime",
   "options": {
     "auth-supabase-url": {
@@ -83,8 +83,8 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/auth-core": "0.1.78",
-        "@jskit-ai/kernel": "0.1.79",
+        "@jskit-ai/auth-core": "0.1.79",
+        "@jskit-ai/kernel": "0.1.80",
         "dotenv": "^16.4.5",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0"

--- a/packages/auth-provider-supabase-core/package.json
+++ b/packages/auth-provider-supabase-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.78",
+  "version": "0.1.79",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,8 +12,8 @@
     "./client": "./src/client/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.78",
-    "@jskit-ai/kernel": "0.1.79",
+    "@jskit-ai/auth-core": "0.1.79",
+    "@jskit-ai/kernel": "0.1.80",
     "json-rest-schema": "1.x.x",
     "jose": "^6.1.0",
     "@supabase/supabase-js": "^2.57.4",

--- a/packages/auth-web/package.descriptor.mjs
+++ b/packages/auth-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-web",
-  "version": "0.1.80",
+  "version": "0.1.81",
   "kind": "runtime",
   "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
   "dependsOn": [
@@ -247,10 +247,10 @@ export default Object.freeze({
     "dependencies": {
       "runtime": {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/auth-core": "0.1.78",
-        "@jskit-ai/http-runtime": "0.1.78",
-        "@jskit-ai/kernel": "0.1.79",
-        "@jskit-ai/shell-web": "0.1.78"
+        "@jskit-ai/auth-core": "0.1.79",
+        "@jskit-ai/http-runtime": "0.1.79",
+        "@jskit-ai/kernel": "0.1.80",
+        "@jskit-ai/shell-web": "0.1.79"
       },
       "dev": {}
     },

--- a/packages/auth-web/package.json
+++ b/packages/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-web",
-  "version": "0.1.80",
+  "version": "0.1.81",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -18,11 +18,11 @@
     "./client/runtime/useSignOut": "./src/client/runtime/useSignOut.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.78",
+    "@jskit-ai/auth-core": "0.1.79",
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/kernel": "0.1.79",
-    "@jskit-ai/shell-web": "0.1.78",
-    "@jskit-ai/http-runtime": "0.1.78"
+    "@jskit-ai/kernel": "0.1.80",
+    "@jskit-ai/shell-web": "0.1.79",
+    "@jskit-ai/http-runtime": "0.1.79"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/console-core/package.descriptor.mjs
+++ b/packages/console-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-core",
-  version: "0.1.42",
+  version: "0.1.43",
   kind: "runtime",
   description: "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
   dependsOn: [
@@ -85,12 +85,12 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.78",
-        "@jskit-ai/database-runtime": "0.1.79",
-        "@jskit-ai/http-runtime": "0.1.78",
-        "@jskit-ai/kernel": "0.1.79",
-        "@jskit-ai/resource-crud-core": "0.1.24",
-        "@jskit-ai/users-core": "0.1.89"
+        "@jskit-ai/auth-core": "0.1.79",
+        "@jskit-ai/database-runtime": "0.1.80",
+        "@jskit-ai/http-runtime": "0.1.79",
+        "@jskit-ai/kernel": "0.1.80",
+        "@jskit-ai/resource-crud-core": "0.1.25",
+        "@jskit-ai/users-core": "0.1.90"
       },
       dev: {}
     },

--- a/packages/console-core/package.json
+++ b/packages/console-core/package.json
@@ -1,17 +1,17 @@
 {
   "name": "@jskit-ai/console-core",
-  "version": "0.1.42",
+  "version": "0.1.43",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.78",
-    "@jskit-ai/database-runtime": "0.1.79",
-    "@jskit-ai/http-runtime": "0.1.78",
-    "@jskit-ai/kernel": "0.1.79",
-    "@jskit-ai/resource-crud-core": "0.1.24",
-    "@jskit-ai/users-core": "0.1.89",
+    "@jskit-ai/auth-core": "0.1.79",
+    "@jskit-ai/database-runtime": "0.1.80",
+    "@jskit-ai/http-runtime": "0.1.79",
+    "@jskit-ai/kernel": "0.1.80",
+    "@jskit-ai/resource-crud-core": "0.1.25",
+    "@jskit-ai/users-core": "0.1.90",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/console-web/package.descriptor.mjs
+++ b/packages/console-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-web",
-  version: "0.1.47",
+  version: "0.1.48",
   kind: "runtime",
   description: "Authenticated console surface scaffold and surface policy wiring.",
   dependsOn: [
@@ -103,9 +103,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-web": "0.1.80",
-        "@jskit-ai/console-core": "0.1.42",
-        "@jskit-ai/shell-web": "0.1.78",
+        "@jskit-ai/auth-web": "0.1.81",
+        "@jskit-ai/console-core": "0.1.43",
+        "@jskit-ai/shell-web": "0.1.79",
       },
       dev: {}
     },

--- a/packages/console-web/package.json
+++ b/packages/console-web/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/console-web",
-  "version": "0.1.47",
+  "version": "0.1.48",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-web": "0.1.80",
-    "@jskit-ai/console-core": "0.1.42",
-    "@jskit-ai/shell-web": "0.1.78"
+    "@jskit-ai/auth-web": "0.1.81",
+    "@jskit-ai/console-core": "0.1.43",
+    "@jskit-ai/shell-web": "0.1.79"
   }
 }

--- a/packages/crud-core/package.descriptor.mjs
+++ b/packages/crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-core",
-  version: "0.1.87",
+  version: "0.1.88",
   kind: "runtime",
   description: "Shared CRUD helpers used by CRUD modules.",
   dependsOn: [
@@ -28,7 +28,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/crud-core": "0.1.87"
+        "@jskit-ai/crud-core": "0.1.88"
       },
       dev: {}
     },

--- a/packages/crud-core/package.json
+++ b/packages/crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-core",
-  "version": "0.1.87",
+  "version": "0.1.88",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -27,15 +27,15 @@
     "./server/routeContracts": "./src/server/routeContracts.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.79",
-    "@jskit-ai/http-runtime": "0.1.78",
-    "@jskit-ai/kernel": "0.1.79",
+    "@jskit-ai/database-runtime": "0.1.80",
+    "@jskit-ai/http-runtime": "0.1.79",
+    "@jskit-ai/kernel": "0.1.80",
     "json-rest-schema": "1.x.x",
-    "@jskit-ai/realtime": "0.1.78",
-    "@jskit-ai/resource-crud-core": "0.1.24",
-    "@jskit-ai/shell-web": "0.1.78",
-    "@jskit-ai/users-core": "0.1.89",
-    "@jskit-ai/users-web": "0.1.94"
+    "@jskit-ai/realtime": "0.1.79",
+    "@jskit-ai/resource-crud-core": "0.1.25",
+    "@jskit-ai/shell-web": "0.1.79",
+    "@jskit-ai/users-core": "0.1.90",
+    "@jskit-ai/users-web": "0.1.95"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/crud-server-generator/package.descriptor.mjs
+++ b/packages/crud-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-server-generator",
-  version: "0.1.87",
+  version: "0.1.88",
   kind: "generator",
   description: "CRUD server generator with routes, actions, and persistence scaffolding.",
   options: {
@@ -160,14 +160,14 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.78",
-        "@jskit-ai/crud-core": "0.1.87",
-        "@jskit-ai/database-runtime": "0.1.79",
-        "@jskit-ai/http-runtime": "0.1.78",
-        "@jskit-ai/json-rest-api-core": "0.1.24",
-        "@jskit-ai/kernel": "0.1.79",
-        "@jskit-ai/realtime": "0.1.78",
-        "@jskit-ai/resource-crud-core": "0.1.24",
+        "@jskit-ai/auth-core": "0.1.79",
+        "@jskit-ai/crud-core": "0.1.88",
+        "@jskit-ai/database-runtime": "0.1.80",
+        "@jskit-ai/http-runtime": "0.1.79",
+        "@jskit-ai/json-rest-api-core": "0.1.25",
+        "@jskit-ai/kernel": "0.1.80",
+        "@jskit-ai/realtime": "0.1.79",
+        "@jskit-ai/resource-crud-core": "0.1.25",
         "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}"
       },
       dev: {}

--- a/packages/crud-server-generator/package.json
+++ b/packages/crud-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-server-generator",
-  "version": "0.1.87",
+  "version": "0.1.88",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,12 +13,12 @@
   },
   "dependencies": {
     "@babel/parser": "^7.29.2",
-    "@jskit-ai/crud-core": "0.1.87",
-    "@jskit-ai/database-runtime": "0.1.79",
-    "@jskit-ai/http-runtime": "0.1.78",
-    "@jskit-ai/json-rest-api-core": "0.1.24",
-    "@jskit-ai/kernel": "0.1.79",
-    "@jskit-ai/resource-crud-core": "0.1.24",
+    "@jskit-ai/crud-core": "0.1.88",
+    "@jskit-ai/database-runtime": "0.1.80",
+    "@jskit-ai/http-runtime": "0.1.79",
+    "@jskit-ai/json-rest-api-core": "0.1.25",
+    "@jskit-ai/kernel": "0.1.80",
+    "@jskit-ai/resource-crud-core": "0.1.25",
     "recast": "^0.23.11"
   }
 }

--- a/packages/crud-ui-generator/package.descriptor.mjs
+++ b/packages/crud-ui-generator/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { GENERATED_UI_NAVIGATION_ROLE_OPTION } from "@jskit-ai/kernel/shared/sup
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-ui-generator",
-  version: "0.1.62",
+  version: "0.1.63",
   kind: "generator",
   description: "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
   options: {
@@ -175,7 +175,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.94"
+        "@jskit-ai/users-web": "0.1.95"
       },
       dev: {}
     },

--- a/packages/crud-ui-generator/package.json
+++ b/packages/crud-ui-generator/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@jskit-ai/crud-ui-generator",
-  "version": "0.1.62",
+  "version": "0.1.63",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/crud-core": "0.1.87",
-    "@jskit-ai/kernel": "0.1.79",
-    "@jskit-ai/resource-crud-core": "0.1.24"
+    "@jskit-ai/crud-core": "0.1.88",
+    "@jskit-ai/kernel": "0.1.80",
+    "@jskit-ai/resource-crud-core": "0.1.25"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/database-runtime-mysql/package.descriptor.mjs
+++ b/packages/database-runtime-mysql/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-mysql",
-  version: "0.1.78",
+  version: "0.1.79",
   kind: "runtime",
   options: {
     "db-host": {
@@ -91,7 +91,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.79",
+        "@jskit-ai/database-runtime": "0.1.80",
         "mysql2": "^3.11.2"
       },
       dev: {}

--- a/packages/database-runtime-mysql/package.json
+++ b/packages/database-runtime-mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-mysql",
-  "version": "0.1.78",
+  "version": "0.1.79",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,7 +12,7 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.79",
-    "@jskit-ai/kernel": "0.1.79"
+    "@jskit-ai/database-runtime": "0.1.80",
+    "@jskit-ai/kernel": "0.1.80"
   }
 }

--- a/packages/database-runtime-postgres/package.descriptor.mjs
+++ b/packages/database-runtime-postgres/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-postgres",
-  version: "0.1.78",
+  version: "0.1.79",
   kind: "runtime",
   options: {
     "db-host": {
@@ -91,7 +91,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.79",
+        "@jskit-ai/database-runtime": "0.1.80",
         "pg": "^8.13.1"
       },
       dev: {}

--- a/packages/database-runtime-postgres/package.json
+++ b/packages/database-runtime-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-postgres",
-  "version": "0.1.78",
+  "version": "0.1.79",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,6 +12,6 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.79"
+    "@jskit-ai/database-runtime": "0.1.80"
   }
 }

--- a/packages/database-runtime/package.descriptor.mjs
+++ b/packages/database-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime",
-  version: "0.1.79",
+  version: "0.1.80",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -58,7 +58,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.79",
+        "@jskit-ai/kernel": "0.1.80",
         "dotenv": "^16.4.5",
         "knex": "^3.1.0"
       },

--- a/packages/database-runtime/package.json
+++ b/packages/database-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime",
-  "version": "0.1.79",
+  "version": "0.1.80",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -25,6 +25,6 @@
     "./shared/transactions": "./src/shared/transactions.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.79"
+    "@jskit-ai/kernel": "0.1.80"
   }
 }

--- a/packages/feature-server-generator/package.descriptor.mjs
+++ b/packages/feature-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/feature-server-generator",
-  version: "0.1.21",
+  version: "0.1.22",
   kind: "generator",
   description: "Scaffold substantial non-CRUD server feature packages with provider, actions, service, and optional persistence seams.",
   options: {
@@ -174,7 +174,7 @@ export default Object.freeze({
             equals: "json-rest"
           }
         },
-        "@jskit-ai/kernel": "0.1.79",
+        "@jskit-ai/kernel": "0.1.80",
         "json-rest-schema": "1.x.x",
         "@local/${option:feature-name|kebab}": "file:packages/${option:feature-name|kebab}"
       },

--- a/packages/feature-server-generator/package.json
+++ b/packages/feature-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/feature-server-generator",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "type": "module",
   "scripts": {
     "test": "node --test"

--- a/packages/google-rewarded-core/package.descriptor.mjs
+++ b/packages/google-rewarded-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/google-rewarded-core",
-  version: "0.1.16",
+  version: "0.1.17",
   kind: "runtime",
   description: "Google rewarded workflow runtime plus internal CRUD providers for rules, provider configs, watch sessions, and unlock receipts.",
   dependsOn: [
@@ -128,14 +128,14 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.78",
-        "@jskit-ai/crud-core": "0.1.87",
-        "@jskit-ai/database-runtime": "0.1.79",
-        "@jskit-ai/http-runtime": "0.1.78",
-        "@jskit-ai/json-rest-api-core": "0.1.24",
-        "@jskit-ai/kernel": "0.1.79",
-        "@jskit-ai/resource-crud-core": "0.1.24",
-        "@jskit-ai/workspaces-core": "0.1.55"
+        "@jskit-ai/auth-core": "0.1.79",
+        "@jskit-ai/crud-core": "0.1.88",
+        "@jskit-ai/database-runtime": "0.1.80",
+        "@jskit-ai/http-runtime": "0.1.79",
+        "@jskit-ai/json-rest-api-core": "0.1.25",
+        "@jskit-ai/kernel": "0.1.80",
+        "@jskit-ai/resource-crud-core": "0.1.25",
+        "@jskit-ai/workspaces-core": "0.1.56"
       },
       dev: {}
     },

--- a/packages/google-rewarded-core/package.json
+++ b/packages/google-rewarded-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/google-rewarded-core",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/google-rewarded-web/package.descriptor.mjs
+++ b/packages/google-rewarded-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/google-rewarded-web",
-  version: "0.1.16",
+  version: "0.1.17",
   kind: "runtime",
   description: "Google rewarded client runtime with a fullscreen gate host and GPT orchestration.",
   dependsOn: [
@@ -46,10 +46,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/google-rewarded-core": "0.1.16",
-        "@jskit-ai/http-runtime": "0.1.78",
-        "@jskit-ai/kernel": "0.1.79",
-        "@jskit-ai/shell-web": "0.1.78"
+        "@jskit-ai/google-rewarded-core": "0.1.17",
+        "@jskit-ai/http-runtime": "0.1.79",
+        "@jskit-ai/kernel": "0.1.80",
+        "@jskit-ai/shell-web": "0.1.79"
       },
       dev: {}
     },

--- a/packages/google-rewarded-web/package.json
+++ b/packages/google-rewarded-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/google-rewarded-web",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/http-runtime/package.descriptor.mjs
+++ b/packages/http-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/http-runtime",
-  "version": "0.1.78",
+  "version": "0.1.79",
   "kind": "runtime",
   "dependsOn": [],
   "capabilities": {
@@ -67,7 +67,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.79"
+        "@jskit-ai/kernel": "0.1.80"
       },
       "dev": {}
     },

--- a/packages/http-runtime/package.json
+++ b/packages/http-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/http-runtime",
-  "version": "0.1.78",
+  "version": "0.1.79",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -18,7 +18,7 @@
     "./shared/validators/operationValidation": "./src/shared/validators/operationValidation.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.79",
+    "@jskit-ai/kernel": "0.1.80",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/json-rest-api-core/package.descriptor.mjs
+++ b/packages/json-rest-api-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/json-rest-api-core",
-  version: "0.1.24",
+  version: "0.1.25",
   kind: "runtime",
   description: "Shared internal json-rest-api host runtime for JSKIT server packages.",
   dependsOn: [

--- a/packages/json-rest-api-core/package.json
+++ b/packages/json-rest-api-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/json-rest-api-core",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,6 +11,6 @@
   "dependencies": {
     "hooked-api": "1.x.x",
     "json-rest-api": "1.x.x",
-    "@jskit-ai/kernel": "0.1.79"
+    "@jskit-ai/kernel": "0.1.80"
   }
 }

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/kernel",
-  "version": "0.1.79",
+  "version": "0.1.80",
   "type": "module",
   "dependencies": {
     "json-rest-schema": "1.x.x"

--- a/packages/mobile-capacitor/package.descriptor.mjs
+++ b/packages/mobile-capacitor/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/mobile-capacitor",
-  version: "0.1.16",
+  version: "0.1.17",
   kind: "runtime",
   description: "Thin Capacitor client integration for JSKIT mobile-shell launch routing and auth callback completion.",
   dependsOn: [
@@ -62,8 +62,8 @@ export default Object.freeze({
         "@capacitor/app": "^7.1.0",
         "@capacitor/browser": "^7.0.1",
         "@capacitor/core": "^7.4.3",
-        "@jskit-ai/kernel": "0.1.79",
-        "@jskit-ai/shell-web": "0.1.78"
+        "@jskit-ai/kernel": "0.1.80",
+        "@jskit-ai/shell-web": "0.1.79"
       },
       dev: {
         "@capacitor/cli": "^7.4.3"

--- a/packages/mobile-capacitor/package.json
+++ b/packages/mobile-capacitor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/mobile-capacitor",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,6 +12,6 @@
   },
   "dependencies": {
     "@capacitor/browser": "^7.0.1",
-    "@jskit-ai/kernel": "0.1.79"
+    "@jskit-ai/kernel": "0.1.80"
   }
 }

--- a/packages/realtime/package.descriptor.mjs
+++ b/packages/realtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/realtime",
-  version: "0.1.78",
+  version: "0.1.79",
   kind: "runtime",
   description: "Thin, generic realtime runtime wrappers for socket.io server and client.",
   options: {
@@ -95,7 +95,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.79",
+        "@jskit-ai/kernel": "0.1.80",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/realtime",
-  "version": "0.1.78",
+  "version": "0.1.79",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@socket.io/redis-adapter": "^8.3.0",
-    "@jskit-ai/kernel": "0.1.79",
+    "@jskit-ai/kernel": "0.1.80",
     "redis": "^5.8.2",
     "socket.io": "^4.8.3",
     "socket.io-client": "^4.8.3"

--- a/packages/resource-core/package.descriptor.mjs
+++ b/packages/resource-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/resource-core",
-  version: "0.1.24",
+  version: "0.1.25",
   kind: "runtime",
   description: "Generic resource-definition helpers and schema-definition normalization.",
   dependsOn: [
@@ -22,7 +22,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/resource-core": "0.1.24"
+        "@jskit-ai/resource-core": "0.1.25"
       },
       dev: {}
     },

--- a/packages/resource-core/package.json
+++ b/packages/resource-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/resource-core",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./shared/resource": "./src/shared/resource.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.79"
+    "@jskit-ai/kernel": "0.1.80"
   }
 }

--- a/packages/resource-crud-core/package.descriptor.mjs
+++ b/packages/resource-crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/resource-crud-core",
-  version: "0.1.24",
+  version: "0.1.25",
   kind: "runtime",
   description: "CRUD-specific resource-definition helpers and namespace support.",
   dependsOn: [
@@ -23,7 +23,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/resource-crud-core": "0.1.24"
+        "@jskit-ai/resource-crud-core": "0.1.25"
       },
       dev: {}
     },

--- a/packages/resource-crud-core/package.json
+++ b/packages/resource-crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/resource-crud-core",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./shared/crudResource": "./src/shared/crudResource.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.79",
-    "@jskit-ai/resource-core": "0.1.24"
+    "@jskit-ai/kernel": "0.1.80",
+    "@jskit-ai/resource-core": "0.1.25"
   }
 }

--- a/packages/shell-web/package.descriptor.mjs
+++ b/packages/shell-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/shell-web",
-  version: "0.1.78",
+  version: "0.1.79",
   kind: "runtime",
   description: "Web shell layout runtime with outlet-based placement contributions.",
   dependsOn: [],
@@ -291,7 +291,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/kernel": "0.1.79"
+        "@jskit-ai/kernel": "0.1.80"
       },
       dev: {}
     },

--- a/packages/shell-web/package.json
+++ b/packages/shell-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/shell-web",
-  "version": "0.1.78",
+  "version": "0.1.79",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/kernel": "0.1.79"
+    "@jskit-ai/kernel": "0.1.80"
   },
   "peerDependencies": {
     "pinia": "^3.0.4",

--- a/packages/storage-runtime/package.descriptor.mjs
+++ b/packages/storage-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/storage-runtime",
-  version: "0.1.78",
+  version: "0.1.79",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -50,7 +50,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.79",
+        "@jskit-ai/kernel": "0.1.80",
         "unstorage": "^1.17.3"
       },
       dev: {}

--- a/packages/storage-runtime/package.json
+++ b/packages/storage-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/storage-runtime",
-  "version": "0.1.78",
+  "version": "0.1.79",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./server/providers/StorageRuntimeServiceProvider": "./src/server/providers/StorageRuntimeServiceProvider.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.79",
+    "@jskit-ai/kernel": "0.1.80",
     "unstorage": "^1.17.3"
   }
 }

--- a/packages/ui-generator/package.descriptor.mjs
+++ b/packages/ui-generator/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { GENERATED_UI_NAVIGATION_ROLE_OPTION } from "@jskit-ai/kernel/shared/sup
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/ui-generator",
-  version: "0.1.62",
+  version: "0.1.63",
   kind: "generator",
   description: "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
   options: {
@@ -371,7 +371,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.94"
+        "@jskit-ai/users-web": "0.1.95"
       },
       dev: {}
     },

--- a/packages/ui-generator/package.json
+++ b/packages/ui-generator/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/ui-generator",
-  "version": "0.1.62",
+  "version": "0.1.63",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.79",
-    "@jskit-ai/shell-web": "0.1.78"
+    "@jskit-ai/kernel": "0.1.80",
+    "@jskit-ai/shell-web": "0.1.79"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/uploads-image-web/package.descriptor.mjs
+++ b/packages/uploads-image-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-image-web",
-  version: "0.1.57",
+  version: "0.1.58",
   kind: "runtime",
   description: "Reusable client-side image upload runtime with pre-upload image editing.",
   dependsOn: [
@@ -65,7 +65,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/uploads-runtime": "0.1.57",
+        "@jskit-ai/uploads-runtime": "0.1.58",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-image-web/package.json
+++ b/packages/uploads-image-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-image-web",
-  "version": "0.1.57",
+  "version": "0.1.58",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,7 +13,7 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/uploads-runtime": "0.1.57",
+    "@jskit-ai/uploads-runtime": "0.1.58",
     "@uppy/compressor": "^3.1.0",
     "@uppy/core": "^5.2.0",
     "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-runtime/package.descriptor.mjs
+++ b/packages/uploads-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-runtime",
-  version: "0.1.57",
+  version: "0.1.58",
   kind: "runtime",
   description: "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
   dependsOn: [
@@ -71,7 +71,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.79"
+        "@jskit-ai/kernel": "0.1.80"
       },
       dev: {}
     },

--- a/packages/uploads-runtime/package.json
+++ b/packages/uploads-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-runtime",
-  "version": "0.1.57",
+  "version": "0.1.58",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,6 +16,6 @@
   },
   "dependencies": {
     "@fastify/multipart": "^9.4.0",
-    "@jskit-ai/kernel": "0.1.79"
+    "@jskit-ai/kernel": "0.1.80"
   }
 }

--- a/packages/users-core/package.descriptor.mjs
+++ b/packages/users-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-core",
-  version: "0.1.89",
+  version: "0.1.90",
   kind: "runtime",
   description: "Users/account runtime plus HTTP routes for account features.",
   dependsOn: [
@@ -143,16 +143,16 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.78",
-        "@jskit-ai/crud-core": "0.1.87",
-        "@jskit-ai/database-runtime": "0.1.79",
-        "@jskit-ai/http-runtime": "0.1.78",
-        "@jskit-ai/json-rest-api-core": "0.1.24",
-        "@jskit-ai/kernel": "0.1.79",
-        "@jskit-ai/resource-core": "0.1.24",
-        "@jskit-ai/resource-crud-core": "0.1.24",
+        "@jskit-ai/auth-core": "0.1.79",
+        "@jskit-ai/crud-core": "0.1.88",
+        "@jskit-ai/database-runtime": "0.1.80",
+        "@jskit-ai/http-runtime": "0.1.79",
+        "@jskit-ai/json-rest-api-core": "0.1.25",
+        "@jskit-ai/kernel": "0.1.80",
+        "@jskit-ai/resource-core": "0.1.25",
+        "@jskit-ai/resource-crud-core": "0.1.25",
         "@local/users": "file:packages/users",
-        "@jskit-ai/uploads-runtime": "0.1.57"
+        "@jskit-ai/uploads-runtime": "0.1.58"
       },
       dev: {}
     },

--- a/packages/users-core/package.json
+++ b/packages/users-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-core",
-  "version": "0.1.89",
+  "version": "0.1.90",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,14 +11,14 @@
     "./shared/resources/userSettingsResource": "./src/shared/resources/userSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.78",
-    "@jskit-ai/database-runtime": "0.1.79",
-    "@jskit-ai/http-runtime": "0.1.78",
-    "@jskit-ai/json-rest-api-core": "0.1.24",
-    "@jskit-ai/kernel": "0.1.79",
-    "@jskit-ai/resource-crud-core": "0.1.24",
-    "@jskit-ai/resource-core": "0.1.24",
-    "@jskit-ai/uploads-runtime": "0.1.57",
+    "@jskit-ai/auth-core": "0.1.79",
+    "@jskit-ai/database-runtime": "0.1.80",
+    "@jskit-ai/http-runtime": "0.1.79",
+    "@jskit-ai/json-rest-api-core": "0.1.25",
+    "@jskit-ai/kernel": "0.1.80",
+    "@jskit-ai/resource-crud-core": "0.1.25",
+    "@jskit-ai/resource-core": "0.1.25",
+    "@jskit-ai/uploads-runtime": "0.1.58",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/users-web/package.descriptor.mjs
+++ b/packages/users-web/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { HOME_COG_OUTLET } from "./src/shared/toolsOutletContracts.js";
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-web",
-  version: "0.1.94",
+  version: "0.1.95",
   kind: "runtime",
   description: "Users web module: account/profile UI plus shared users web widgets.",
   dependsOn: [
@@ -278,12 +278,12 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/http-runtime": "0.1.78",
-        "@jskit-ai/realtime": "0.1.78",
-        "@jskit-ai/kernel": "0.1.79",
-        "@jskit-ai/shell-web": "0.1.78",
-        "@jskit-ai/uploads-image-web": "0.1.57",
-        "@jskit-ai/users-core": "0.1.89"
+        "@jskit-ai/http-runtime": "0.1.79",
+        "@jskit-ai/realtime": "0.1.79",
+        "@jskit-ai/kernel": "0.1.80",
+        "@jskit-ai/shell-web": "0.1.79",
+        "@jskit-ai/uploads-image-web": "0.1.58",
+        "@jskit-ai/users-core": "0.1.90"
       },
       dev: {}
     },

--- a/packages/users-web/package.json
+++ b/packages/users-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-web",
-  "version": "0.1.94",
+  "version": "0.1.95",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -44,12 +44,12 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/http-runtime": "0.1.78",
-    "@jskit-ai/kernel": "0.1.79",
-    "@jskit-ai/realtime": "0.1.78",
-    "@jskit-ai/shell-web": "0.1.78",
-    "@jskit-ai/uploads-image-web": "0.1.57",
-    "@jskit-ai/users-core": "0.1.89"
+    "@jskit-ai/http-runtime": "0.1.79",
+    "@jskit-ai/kernel": "0.1.80",
+    "@jskit-ai/realtime": "0.1.79",
+    "@jskit-ai/shell-web": "0.1.79",
+    "@jskit-ai/uploads-image-web": "0.1.58",
+    "@jskit-ai/users-core": "0.1.90"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/workspaces-core/package.descriptor.mjs
+++ b/packages/workspaces-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-core",
-  version: "0.1.55",
+  version: "0.1.56",
   kind: "runtime",
   description: "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
   dependsOn: [
@@ -142,10 +142,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/json-rest-api-core": "0.1.24",
-        "@jskit-ai/resource-core": "0.1.24",
-        "@jskit-ai/resource-crud-core": "0.1.24",
-        "@jskit-ai/users-core": "0.1.89"
+        "@jskit-ai/json-rest-api-core": "0.1.25",
+        "@jskit-ai/resource-core": "0.1.25",
+        "@jskit-ai/resource-crud-core": "0.1.25",
+        "@jskit-ai/users-core": "0.1.90"
       },
       dev: {}
     },

--- a/packages/workspaces-core/package.json
+++ b/packages/workspaces-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-core",
-  "version": "0.1.55",
+  "version": "0.1.56",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -17,14 +17,14 @@
     "./shared/resources/workspaceSettingsResource": "./src/shared/resources/workspaceSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.78",
-    "@jskit-ai/database-runtime": "0.1.79",
-    "@jskit-ai/http-runtime": "0.1.78",
-    "@jskit-ai/json-rest-api-core": "0.1.24",
-    "@jskit-ai/kernel": "0.1.79",
-    "@jskit-ai/resource-crud-core": "0.1.24",
-    "@jskit-ai/resource-core": "0.1.24",
-    "@jskit-ai/users-core": "0.1.89",
+    "@jskit-ai/auth-core": "0.1.79",
+    "@jskit-ai/database-runtime": "0.1.80",
+    "@jskit-ai/http-runtime": "0.1.79",
+    "@jskit-ai/json-rest-api-core": "0.1.25",
+    "@jskit-ai/kernel": "0.1.80",
+    "@jskit-ai/resource-crud-core": "0.1.25",
+    "@jskit-ai/resource-core": "0.1.25",
+    "@jskit-ai/users-core": "0.1.90",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/workspaces-web/package.descriptor.mjs
+++ b/packages/workspaces-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-web",
-  version: "0.1.55",
+  version: "0.1.56",
   kind: "runtime",
   description: "Workspace web module: workspace selector, tools widget, workspace surfaces, and members/settings UI.",
   dependsOn: [
@@ -231,8 +231,8 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/workspaces-core": "0.1.55",
-        "@jskit-ai/users-web": "0.1.94"
+        "@jskit-ai/workspaces-core": "0.1.56",
+        "@jskit-ai/users-web": "0.1.95"
       },
       dev: {}
     },

--- a/packages/workspaces-web/package.json
+++ b/packages/workspaces-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-web",
-  "version": "0.1.55",
+  "version": "0.1.56",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -15,12 +15,12 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/http-runtime": "0.1.78",
-    "@jskit-ai/kernel": "0.1.79",
-    "@jskit-ai/shell-web": "0.1.78",
-    "@jskit-ai/users-core": "0.1.89",
-    "@jskit-ai/users-web": "0.1.94",
-    "@jskit-ai/workspaces-core": "0.1.55"
+    "@jskit-ai/http-runtime": "0.1.79",
+    "@jskit-ai/kernel": "0.1.80",
+    "@jskit-ai/shell-web": "0.1.79",
+    "@jskit-ai/users-core": "0.1.90",
+    "@jskit-ai/users-web": "0.1.95",
+    "@jskit-ai/workspaces-core": "0.1.56"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/tooling/config-eslint/package.json
+++ b/tooling/config-eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/config-eslint",
-  "version": "0.1.78",
+  "version": "0.1.79",
   "description": "Shared flat ESLint presets for JSKIT projects.",
   "type": "module",
   "files": [

--- a/tooling/create-app/package.descriptor.mjs
+++ b/tooling/create-app/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/create-app",
-  "version": "0.1.87",
+  "version": "0.1.88",
   "dependsOn": [],
   "capabilities": {
     "provides": [

--- a/tooling/create-app/package.json
+++ b/tooling/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/create-app",
-  "version": "0.1.87",
+  "version": "0.1.88",
   "description": "Scaffold minimal JSKIT app shells.",
   "type": "module",
   "files": [

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -6,11 +6,11 @@
   "packages": [
     {
       "packageId": "@jskit-ai/assistant",
-      "version": "0.1.88",
+      "version": "0.1.89",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant",
-        "version": "0.1.88",
+        "version": "0.1.89",
         "kind": "generator",
         "description": "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
         "options": {
@@ -347,11 +347,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-core",
-      "version": "0.1.55",
+      "version": "0.1.56",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-core",
-        "version": "0.1.55",
+        "version": "0.1.56",
         "kind": "runtime",
         "description": "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
         "dependsOn": [
@@ -399,11 +399,11 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/http-runtime": "0.1.78",
-              "@jskit-ai/kernel": "0.1.79",
-              "@jskit-ai/resource-core": "0.1.24",
-              "@jskit-ai/resource-crud-core": "0.1.24",
-              "@jskit-ai/users-core": "0.1.89",
+              "@jskit-ai/http-runtime": "0.1.79",
+              "@jskit-ai/kernel": "0.1.80",
+              "@jskit-ai/resource-core": "0.1.25",
+              "@jskit-ai/resource-crud-core": "0.1.25",
+              "@jskit-ai/users-core": "0.1.90",
               "dompurify": "^3.3.3",
               "json-rest-schema": "1.x.x",
               "marked": "^17.0.4",
@@ -422,11 +422,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-runtime",
-      "version": "0.1.50",
+      "version": "0.1.51",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-runtime",
-        "version": "0.1.50",
+        "version": "0.1.51",
         "kind": "runtime",
         "description": "Shared assistant runtime with per-surface assistant registration.",
         "dependsOn": [
@@ -522,13 +522,13 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/assistant-core": "0.1.55",
-              "@jskit-ai/database-runtime": "0.1.79",
-              "@jskit-ai/http-runtime": "0.1.78",
-              "@jskit-ai/kernel": "0.1.79",
-              "@jskit-ai/shell-web": "0.1.78",
-              "@jskit-ai/users-core": "0.1.89",
-              "@jskit-ai/users-web": "0.1.94"
+              "@jskit-ai/assistant-core": "0.1.56",
+              "@jskit-ai/database-runtime": "0.1.80",
+              "@jskit-ai/http-runtime": "0.1.79",
+              "@jskit-ai/kernel": "0.1.80",
+              "@jskit-ai/shell-web": "0.1.79",
+              "@jskit-ai/users-core": "0.1.90",
+              "@jskit-ai/users-web": "0.1.95"
             },
             "dev": {}
           },
@@ -583,11 +583,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-core",
-      "version": "0.1.78",
+      "version": "0.1.79",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-core",
-        "version": "0.1.78",
+        "version": "0.1.79",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/value-app-config-shared"
@@ -655,7 +655,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.79",
+              "@jskit-ai/kernel": "0.1.80",
               "@fastify/cookie": "^11.0.2",
               "@fastify/csrf-protection": "^7.1.0",
               "@fastify/rate-limit": "^10.3.0"
@@ -673,11 +673,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.78",
+      "version": "0.1.79",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-supabase-core",
-        "version": "0.1.78",
+        "version": "0.1.79",
         "kind": "runtime",
         "options": {
           "auth-supabase-url": {
@@ -759,8 +759,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.78",
-              "@jskit-ai/kernel": "0.1.79",
+              "@jskit-ai/auth-core": "0.1.79",
+              "@jskit-ai/kernel": "0.1.80",
               "dotenv": "^16.4.5",
               "@supabase/supabase-js": "^2.57.4",
               "jose": "^6.1.0"
@@ -825,11 +825,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-web",
-      "version": "0.1.80",
+      "version": "0.1.81",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-web",
-        "version": "0.1.80",
+        "version": "0.1.81",
         "kind": "runtime",
         "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
         "dependsOn": [
@@ -1085,10 +1085,10 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/auth-core": "0.1.78",
-              "@jskit-ai/http-runtime": "0.1.78",
-              "@jskit-ai/kernel": "0.1.79",
-              "@jskit-ai/shell-web": "0.1.78"
+              "@jskit-ai/auth-core": "0.1.79",
+              "@jskit-ai/http-runtime": "0.1.79",
+              "@jskit-ai/kernel": "0.1.80",
+              "@jskit-ai/shell-web": "0.1.79"
             },
             "dev": {}
           },
@@ -1167,11 +1167,11 @@
     },
     {
       "packageId": "@jskit-ai/console-core",
-      "version": "0.1.42",
+      "version": "0.1.43",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-core",
-        "version": "0.1.42",
+        "version": "0.1.43",
         "kind": "runtime",
         "description": "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
         "dependsOn": [
@@ -1255,12 +1255,12 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.78",
-              "@jskit-ai/database-runtime": "0.1.79",
-              "@jskit-ai/http-runtime": "0.1.78",
-              "@jskit-ai/kernel": "0.1.79",
-              "@jskit-ai/resource-crud-core": "0.1.24",
-              "@jskit-ai/users-core": "0.1.89"
+              "@jskit-ai/auth-core": "0.1.79",
+              "@jskit-ai/database-runtime": "0.1.80",
+              "@jskit-ai/http-runtime": "0.1.79",
+              "@jskit-ai/kernel": "0.1.80",
+              "@jskit-ai/resource-crud-core": "0.1.25",
+              "@jskit-ai/users-core": "0.1.90"
             },
             "dev": {}
           },
@@ -1285,11 +1285,11 @@
     },
     {
       "packageId": "@jskit-ai/console-web",
-      "version": "0.1.47",
+      "version": "0.1.48",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-web",
-        "version": "0.1.47",
+        "version": "0.1.48",
         "kind": "runtime",
         "description": "Authenticated console surface scaffold and surface policy wiring.",
         "dependsOn": [
@@ -1399,9 +1399,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-web": "0.1.80",
-              "@jskit-ai/console-core": "0.1.42",
-              "@jskit-ai/shell-web": "0.1.78"
+              "@jskit-ai/auth-web": "0.1.81",
+              "@jskit-ai/console-core": "0.1.43",
+              "@jskit-ai/shell-web": "0.1.79"
             },
             "dev": {}
           },
@@ -1508,11 +1508,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-core",
-      "version": "0.1.87",
+      "version": "0.1.88",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-core",
-        "version": "0.1.87",
+        "version": "0.1.88",
         "kind": "runtime",
         "description": "Shared CRUD helpers used by CRUD modules.",
         "dependsOn": [
@@ -1541,7 +1541,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/crud-core": "0.1.87"
+              "@jskit-ai/crud-core": "0.1.88"
             },
             "dev": {}
           },
@@ -1555,11 +1555,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-server-generator",
-      "version": "0.1.87",
+      "version": "0.1.88",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-server-generator",
-        "version": "0.1.87",
+        "version": "0.1.88",
         "kind": "generator",
         "description": "CRUD server generator with routes, actions, and persistence scaffolding.",
         "options": {
@@ -1726,14 +1726,14 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.78",
-              "@jskit-ai/crud-core": "0.1.87",
-              "@jskit-ai/database-runtime": "0.1.79",
-              "@jskit-ai/http-runtime": "0.1.78",
-              "@jskit-ai/json-rest-api-core": "0.1.24",
-              "@jskit-ai/kernel": "0.1.79",
-              "@jskit-ai/realtime": "0.1.78",
-              "@jskit-ai/resource-crud-core": "0.1.24",
+              "@jskit-ai/auth-core": "0.1.79",
+              "@jskit-ai/crud-core": "0.1.88",
+              "@jskit-ai/database-runtime": "0.1.80",
+              "@jskit-ai/http-runtime": "0.1.79",
+              "@jskit-ai/json-rest-api-core": "0.1.25",
+              "@jskit-ai/kernel": "0.1.80",
+              "@jskit-ai/realtime": "0.1.79",
+              "@jskit-ai/resource-crud-core": "0.1.25",
               "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}"
             },
             "dev": {}
@@ -1865,11 +1865,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.62",
+      "version": "0.1.63",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-ui-generator",
-        "version": "0.1.62",
+        "version": "0.1.63",
         "kind": "generator",
         "description": "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
         "options": {
@@ -2068,7 +2068,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.94"
+              "@jskit-ai/users-web": "0.1.95"
             },
             "dev": {}
           },
@@ -2327,11 +2327,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime",
-      "version": "0.1.79",
+      "version": "0.1.80",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime",
-        "version": "0.1.79",
+        "version": "0.1.80",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -2388,7 +2388,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.79",
+              "@jskit-ai/kernel": "0.1.80",
               "dotenv": "^16.4.5",
               "knex": "^3.1.0"
             },
@@ -2423,11 +2423,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.78",
+      "version": "0.1.79",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-mysql",
-        "version": "0.1.78",
+        "version": "0.1.79",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -2517,7 +2517,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.79",
+              "@jskit-ai/database-runtime": "0.1.80",
               "mysql2": "^3.11.2"
             },
             "dev": {}
@@ -2588,11 +2588,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.78",
+      "version": "0.1.79",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-postgres",
-        "version": "0.1.78",
+        "version": "0.1.79",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -2682,7 +2682,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.79",
+              "@jskit-ai/database-runtime": "0.1.80",
               "pg": "^8.13.1"
             },
             "dev": {}
@@ -2753,11 +2753,11 @@
     },
     {
       "packageId": "@jskit-ai/feature-server-generator",
-      "version": "0.1.21",
+      "version": "0.1.22",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/feature-server-generator",
-        "version": "0.1.21",
+        "version": "0.1.22",
         "kind": "generator",
         "description": "Scaffold substantial non-CRUD server feature packages with provider, actions, service, and optional persistence seams.",
         "options": {
@@ -2942,7 +2942,7 @@
                   "equals": "json-rest"
                 }
               },
-              "@jskit-ai/kernel": "0.1.79",
+              "@jskit-ai/kernel": "0.1.80",
               "json-rest-schema": "1.x.x",
               "@local/${option:feature-name|kebab}": "file:packages/${option:feature-name|kebab}"
             },
@@ -3055,11 +3055,11 @@
     },
     {
       "packageId": "@jskit-ai/google-rewarded-core",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/google-rewarded-core",
-        "version": "0.1.16",
+        "version": "0.1.17",
         "kind": "runtime",
         "description": "Google rewarded workflow runtime plus internal CRUD providers for rules, provider configs, watch sessions, and unlock receipts.",
         "dependsOn": [
@@ -3186,14 +3186,14 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.78",
-              "@jskit-ai/crud-core": "0.1.87",
-              "@jskit-ai/database-runtime": "0.1.79",
-              "@jskit-ai/http-runtime": "0.1.78",
-              "@jskit-ai/json-rest-api-core": "0.1.24",
-              "@jskit-ai/kernel": "0.1.79",
-              "@jskit-ai/resource-crud-core": "0.1.24",
-              "@jskit-ai/workspaces-core": "0.1.55"
+              "@jskit-ai/auth-core": "0.1.79",
+              "@jskit-ai/crud-core": "0.1.88",
+              "@jskit-ai/database-runtime": "0.1.80",
+              "@jskit-ai/http-runtime": "0.1.79",
+              "@jskit-ai/json-rest-api-core": "0.1.25",
+              "@jskit-ai/kernel": "0.1.80",
+              "@jskit-ai/resource-crud-core": "0.1.25",
+              "@jskit-ai/workspaces-core": "0.1.56"
             },
             "dev": {}
           },
@@ -3245,11 +3245,11 @@
     },
     {
       "packageId": "@jskit-ai/google-rewarded-web",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/google-rewarded-web",
-        "version": "0.1.16",
+        "version": "0.1.17",
         "kind": "runtime",
         "description": "Google rewarded client runtime with a fullscreen gate host and GPT orchestration.",
         "dependsOn": [
@@ -3296,10 +3296,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/google-rewarded-core": "0.1.16",
-              "@jskit-ai/http-runtime": "0.1.78",
-              "@jskit-ai/kernel": "0.1.79",
-              "@jskit-ai/shell-web": "0.1.78"
+              "@jskit-ai/google-rewarded-core": "0.1.17",
+              "@jskit-ai/http-runtime": "0.1.79",
+              "@jskit-ai/kernel": "0.1.80",
+              "@jskit-ai/shell-web": "0.1.79"
             },
             "dev": {}
           },
@@ -3317,11 +3317,11 @@
     },
     {
       "packageId": "@jskit-ai/http-runtime",
-      "version": "0.1.78",
+      "version": "0.1.79",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/http-runtime",
-        "version": "0.1.78",
+        "version": "0.1.79",
         "kind": "runtime",
         "dependsOn": [],
         "capabilities": {
@@ -3387,7 +3387,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.79"
+              "@jskit-ai/kernel": "0.1.80"
             },
             "dev": {}
           },
@@ -3401,11 +3401,11 @@
     },
     {
       "packageId": "@jskit-ai/json-rest-api-core",
-      "version": "0.1.24",
+      "version": "0.1.25",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/json-rest-api-core",
-        "version": "0.1.24",
+        "version": "0.1.25",
         "kind": "runtime",
         "description": "Shared internal json-rest-api host runtime for JSKIT server packages.",
         "dependsOn": [
@@ -3465,11 +3465,11 @@
     },
     {
       "packageId": "@jskit-ai/mobile-capacitor",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/mobile-capacitor",
-        "version": "0.1.16",
+        "version": "0.1.17",
         "kind": "runtime",
         "description": "Thin Capacitor client integration for JSKIT mobile-shell launch routing and auth callback completion.",
         "dependsOn": [
@@ -3532,8 +3532,8 @@
               "@capacitor/app": "^7.1.0",
               "@capacitor/browser": "^7.0.1",
               "@capacitor/core": "^7.4.3",
-              "@jskit-ai/kernel": "0.1.79",
-              "@jskit-ai/shell-web": "0.1.78"
+              "@jskit-ai/kernel": "0.1.80",
+              "@jskit-ai/shell-web": "0.1.79"
             },
             "dev": {
               "@capacitor/cli": "^7.4.3"
@@ -3585,11 +3585,11 @@
     },
     {
       "packageId": "@jskit-ai/realtime",
-      "version": "0.1.78",
+      "version": "0.1.79",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/realtime",
-        "version": "0.1.78",
+        "version": "0.1.79",
         "kind": "runtime",
         "description": "Thin, generic realtime runtime wrappers for socket.io server and client.",
         "options": {
@@ -3685,7 +3685,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.79",
+              "@jskit-ai/kernel": "0.1.80",
               "@socket.io/redis-adapter": "^8.3.0",
               "redis": "^5.8.2",
               "socket.io": "^4.8.3",
@@ -3734,11 +3734,11 @@
     },
     {
       "packageId": "@jskit-ai/resource-core",
-      "version": "0.1.24",
+      "version": "0.1.25",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/resource-core",
-        "version": "0.1.24",
+        "version": "0.1.25",
         "kind": "runtime",
         "description": "Generic resource-definition helpers and schema-definition normalization.",
         "dependsOn": [
@@ -3761,7 +3761,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/resource-core": "0.1.24"
+              "@jskit-ai/resource-core": "0.1.25"
             },
             "dev": {}
           },
@@ -3776,11 +3776,11 @@
     },
     {
       "packageId": "@jskit-ai/resource-crud-core",
-      "version": "0.1.24",
+      "version": "0.1.25",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/resource-crud-core",
-        "version": "0.1.24",
+        "version": "0.1.25",
         "kind": "runtime",
         "description": "CRUD-specific resource-definition helpers and namespace support.",
         "dependsOn": [
@@ -3804,7 +3804,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/resource-crud-core": "0.1.24"
+              "@jskit-ai/resource-crud-core": "0.1.25"
             },
             "dev": {}
           },
@@ -3819,11 +3819,11 @@
     },
     {
       "packageId": "@jskit-ai/shell-web",
-      "version": "0.1.78",
+      "version": "0.1.79",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/shell-web",
-        "version": "0.1.78",
+        "version": "0.1.79",
         "kind": "runtime",
         "description": "Web shell layout runtime with outlet-based placement contributions.",
         "dependsOn": [],
@@ -4149,7 +4149,7 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/kernel": "0.1.79"
+              "@jskit-ai/kernel": "0.1.80"
             },
             "dev": {}
           },
@@ -4349,11 +4349,11 @@
     },
     {
       "packageId": "@jskit-ai/storage-runtime",
-      "version": "0.1.78",
+      "version": "0.1.79",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/storage-runtime",
-        "version": "0.1.78",
+        "version": "0.1.79",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -4402,7 +4402,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.79",
+              "@jskit-ai/kernel": "0.1.80",
               "unstorage": "^1.17.3"
             },
             "dev": {}
@@ -4418,11 +4418,11 @@
     },
     {
       "packageId": "@jskit-ai/ui-generator",
-      "version": "0.1.62",
+      "version": "0.1.63",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/ui-generator",
-        "version": "0.1.62",
+        "version": "0.1.63",
         "kind": "generator",
         "description": "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
         "options": {
@@ -4855,7 +4855,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.94"
+              "@jskit-ai/users-web": "0.1.95"
             },
             "dev": {}
           },
@@ -4870,11 +4870,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-image-web",
-      "version": "0.1.57",
+      "version": "0.1.58",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-image-web",
-        "version": "0.1.57",
+        "version": "0.1.58",
         "kind": "runtime",
         "description": "Reusable client-side image upload runtime with pre-upload image editing.",
         "dependsOn": [
@@ -4938,7 +4938,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/uploads-runtime": "0.1.57",
+              "@jskit-ai/uploads-runtime": "0.1.58",
               "@uppy/compressor": "^3.1.0",
               "@uppy/core": "^5.2.0",
               "@uppy/dashboard": "^5.1.1",
@@ -4958,11 +4958,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-runtime",
-      "version": "0.1.57",
+      "version": "0.1.58",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-runtime",
-        "version": "0.1.57",
+        "version": "0.1.58",
         "kind": "runtime",
         "description": "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
         "dependsOn": [
@@ -5032,7 +5032,7 @@
           "dependencies": {
             "runtime": {
               "@fastify/multipart": "^9.4.0",
-              "@jskit-ai/kernel": "0.1.79"
+              "@jskit-ai/kernel": "0.1.80"
             },
             "dev": {}
           },
@@ -5047,11 +5047,11 @@
     },
     {
       "packageId": "@jskit-ai/users-core",
-      "version": "0.1.89",
+      "version": "0.1.90",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-core",
-        "version": "0.1.89",
+        "version": "0.1.90",
         "kind": "runtime",
         "description": "Users/account runtime plus HTTP routes for account features.",
         "dependsOn": [
@@ -5192,16 +5192,16 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.78",
-              "@jskit-ai/crud-core": "0.1.87",
-              "@jskit-ai/database-runtime": "0.1.79",
-              "@jskit-ai/http-runtime": "0.1.78",
-              "@jskit-ai/json-rest-api-core": "0.1.24",
-              "@jskit-ai/kernel": "0.1.79",
-              "@jskit-ai/resource-core": "0.1.24",
-              "@jskit-ai/resource-crud-core": "0.1.24",
+              "@jskit-ai/auth-core": "0.1.79",
+              "@jskit-ai/crud-core": "0.1.88",
+              "@jskit-ai/database-runtime": "0.1.80",
+              "@jskit-ai/http-runtime": "0.1.79",
+              "@jskit-ai/json-rest-api-core": "0.1.25",
+              "@jskit-ai/kernel": "0.1.80",
+              "@jskit-ai/resource-core": "0.1.25",
+              "@jskit-ai/resource-crud-core": "0.1.25",
               "@local/users": "file:packages/users",
-              "@jskit-ai/uploads-runtime": "0.1.57"
+              "@jskit-ai/uploads-runtime": "0.1.58"
             },
             "dev": {}
           },
@@ -5418,11 +5418,11 @@
     },
     {
       "packageId": "@jskit-ai/users-web",
-      "version": "0.1.94",
+      "version": "0.1.95",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-web",
-        "version": "0.1.94",
+        "version": "0.1.95",
         "kind": "runtime",
         "description": "Users web module: account/profile UI plus shared users web widgets.",
         "dependsOn": [
@@ -5717,12 +5717,12 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/http-runtime": "0.1.78",
-              "@jskit-ai/realtime": "0.1.78",
-              "@jskit-ai/kernel": "0.1.79",
-              "@jskit-ai/shell-web": "0.1.78",
-              "@jskit-ai/uploads-image-web": "0.1.57",
-              "@jskit-ai/users-core": "0.1.89"
+              "@jskit-ai/http-runtime": "0.1.79",
+              "@jskit-ai/realtime": "0.1.79",
+              "@jskit-ai/kernel": "0.1.80",
+              "@jskit-ai/shell-web": "0.1.79",
+              "@jskit-ai/uploads-image-web": "0.1.58",
+              "@jskit-ai/users-core": "0.1.90"
             },
             "dev": {}
           },
@@ -5891,11 +5891,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-core",
-      "version": "0.1.55",
+      "version": "0.1.56",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-core",
-        "version": "0.1.55",
+        "version": "0.1.56",
         "kind": "runtime",
         "description": "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
         "dependsOn": [
@@ -6036,10 +6036,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/json-rest-api-core": "0.1.24",
-              "@jskit-ai/resource-core": "0.1.24",
-              "@jskit-ai/resource-crud-core": "0.1.24",
-              "@jskit-ai/users-core": "0.1.89"
+              "@jskit-ai/json-rest-api-core": "0.1.25",
+              "@jskit-ai/resource-core": "0.1.25",
+              "@jskit-ai/resource-crud-core": "0.1.25",
+              "@jskit-ai/users-core": "0.1.90"
             },
             "dev": {}
           },
@@ -6211,11 +6211,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-web",
-      "version": "0.1.55",
+      "version": "0.1.56",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-web",
-        "version": "0.1.55",
+        "version": "0.1.56",
         "kind": "runtime",
         "description": "Workspace web module: workspace selector, tools widget, workspace surfaces, and members/settings UI.",
         "dependsOn": [
@@ -6471,8 +6471,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/workspaces-core": "0.1.55",
-              "@jskit-ai/users-web": "0.1.94"
+              "@jskit-ai/workspaces-core": "0.1.56",
+              "@jskit-ai/users-web": "0.1.95"
             },
             "dev": {}
           },

--- a/tooling/jskit-catalog/package.json
+++ b/tooling/jskit-catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-catalog",
-  "version": "0.1.87",
+  "version": "0.1.88",
   "description": "Published metadata catalog for JSKIT package descriptors.",
   "type": "module",
   "files": [

--- a/tooling/jskit-cli/package.json
+++ b/tooling/jskit-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-cli",
-  "version": "0.2.88",
+  "version": "0.2.89",
   "description": "Bundle and package orchestration CLI for JSKIT apps.",
   "type": "module",
   "files": [
@@ -20,9 +20,9 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/jskit-catalog": "0.1.87",
-    "@jskit-ai/kernel": "0.1.79",
-    "@jskit-ai/shell-web": "0.1.78",
+    "@jskit-ai/jskit-catalog": "0.1.88",
+    "@jskit-ai/kernel": "0.1.80",
+    "@jskit-ai/shell-web": "0.1.79",
     "@vue/compiler-sfc": "^3.5.29",
     "ts-morph": "^28.0.0"
   },

--- a/tooling/jskit-cli/src/server/sessionRuntime.js
+++ b/tooling/jskit-cli/src/server/sessionRuntime.js
@@ -1,4 +1,7 @@
 import {
+  createHash
+} from "node:crypto";
+import {
   appendFile,
   mkdir,
   readFile,
@@ -1581,6 +1584,7 @@ const STEP_CANCELERS = Object.freeze({
   blueprint_updated: async (paths) => {
     await Promise.all([
       removePromptArtifact(paths, "update_blueprint.md"),
+      removeSessionRootFile(paths, BLUEPRINT_BASELINE_FILE),
       removeGlobalCodexResult(paths, "blueprint_updated")
     ]);
   },
@@ -1828,6 +1832,79 @@ async function changedFilesInWorktree(paths) {
     trackedResult.ok ? trackedResult.stdout : "",
     untrackedResult.ok ? untrackedResult.stdout : ""
   ]);
+}
+
+const BLUEPRINT_RELATIVE_PATH = ".jskit/APP_BLUEPRINT.md";
+const BLUEPRINT_BASELINE_FILE = "blueprint_update_baseline.json";
+
+function blueprintBaselinePath(paths) {
+  return path.join(paths.sessionRoot, BLUEPRINT_BASELINE_FILE);
+}
+
+function isBlueprintRelativePath(filePath = "") {
+  return normalizeText(filePath) === BLUEPRINT_RELATIVE_PATH;
+}
+
+function nonBlueprintChangedFiles(files = []) {
+  return files.filter((file) => !isBlueprintRelativePath(file));
+}
+
+async function hashWorktreeFile(paths, filePath) {
+  try {
+    const buffer = await readFile(path.join(paths.worktree, filePath));
+    return createHash("sha256").update(buffer).digest("hex");
+  } catch {
+    return "missing";
+  }
+}
+
+async function buildDirtyFileSnapshot(paths, files = []) {
+  const entries = await Promise.all(nonBlueprintChangedFiles(files).map(async (file) => [
+    file,
+    await hashWorktreeFile(paths, file)
+  ]));
+  return Object.fromEntries(entries);
+}
+
+async function writeBlueprintBaseline(paths) {
+  const changedFiles = await changedFilesInWorktree(paths);
+  const snapshot = await buildDirtyFileSnapshot(paths, changedFiles);
+  const payload = {
+    changedFiles: Object.keys(snapshot).sort((left, right) => left.localeCompare(right)),
+    files: snapshot,
+    recordedAt: timestampForReceipt()
+  };
+  await writeTextFile(blueprintBaselinePath(paths), `${JSON.stringify(payload, null, 2)}\n`);
+  return payload;
+}
+
+async function readBlueprintBaseline(paths) {
+  return parseJsonObject(await readTextIfExists(blueprintBaselinePath(paths))) || null;
+}
+
+async function unexpectedBlueprintStepChanges(paths, changedFiles = []) {
+  const baseline = await readBlueprintBaseline(paths);
+  if (!baseline?.files || typeof baseline.files !== "object" || Array.isArray(baseline.files)) {
+    return nonBlueprintChangedFiles(changedFiles);
+  }
+  const baselineFiles = baseline.files;
+  const currentFiles = new Set(nonBlueprintChangedFiles(changedFiles));
+  const candidates = new Set([
+    ...Object.keys(baselineFiles),
+    ...currentFiles
+  ]);
+  const unexpected = [];
+  for (const file of [...candidates].sort((left, right) => left.localeCompare(right))) {
+    if (!Object.prototype.hasOwnProperty.call(baselineFiles, file)) {
+      unexpected.push(file);
+      continue;
+    }
+    const currentHash = await hashWorktreeFile(paths, file);
+    if (currentHash !== baselineFiles[file]) {
+      unexpected.push(file);
+    }
+  }
+  return unexpected;
 }
 
 async function changedFilesSinceBase(paths) {
@@ -2178,17 +2255,10 @@ async function commitAcceptedChanges(paths, _options = {}, context = {}) {
 
   if (!commitInfo?.commit) {
     const result = await commitWorktree(paths, {
+      allowNoChanges: true,
       message: `Implement JSKIT session ${paths.sessionId}`
     });
     if (!result.ok) {
-      if (result.output === "No changes found.") {
-        return failSession(paths, {
-          code: "accepted_changes_missing",
-          message: "No accepted worktree changes found to commit.",
-          repairCommand: `git -C ${paths.worktree} status --short`,
-          preconditions
-        });
-      }
       return failSession(paths, {
         code: "accepted_changes_commit_failed",
         message: result.output || "Failed to commit accepted changes.",
@@ -2199,15 +2269,30 @@ async function commitAcceptedChanges(paths, _options = {}, context = {}) {
     commitInfo = {
       changedFiles: result.changedFiles || [],
       commit: await currentHead(paths),
-      committedAt: timestampForReceipt()
+      committedAt: timestampForReceipt(),
+      noChanges: (result.changedFiles || []).length < 1
     };
     await writeTextFile(path.join(paths.sessionRoot, "changes_committed.json"), `${JSON.stringify(commitInfo, null, 2)}\n`);
   }
 
-  await writeReceipt(paths, "changes_committed", `Committed accepted changes at ${commitInfo.commit || "unknown"}.`);
+  const warnings = [];
+  if (commitInfo.noChanges === true) {
+    warnings.push({
+      code: "accepted_changes_noop",
+      message: "No accepted worktree changes were found; continuing without a new commit."
+    });
+  }
+  await writeReceipt(
+    paths,
+    "changes_committed",
+    commitInfo.noChanges === true
+      ? "No accepted worktree changes were found; continued without a new commit."
+      : `Committed accepted changes at ${commitInfo.commit || "unknown"}.`
+  );
   await markStatus(paths, SESSION_STATUS.RUNNING);
   return buildSessionResponse(paths, {
-    preconditions
+    preconditions,
+    warnings
   });
 }
 
@@ -2220,7 +2305,7 @@ async function updateBlueprint(paths, options = {}, context = {}) {
   const { planPath } = await readCurrentPlan(paths);
   const issueDetailsPath = path.join(paths.sessionRoot, "issue_details.md");
   const agentDecisionsPath = path.join(paths.sessionRoot, "agent_decisions.md");
-  const blueprintPath = path.join(paths.worktree, ".jskit", "APP_BLUEPRINT.md");
+  const blueprintPath = path.join(paths.worktree, BLUEPRINT_RELATIVE_PATH);
   const blueprintPromptPath = path.join(paths.sessionRoot, "prompts", "update_blueprint.md");
 
   if (await fileExists(blueprintPromptPath)) {
@@ -2229,11 +2314,11 @@ async function updateBlueprint(paths, options = {}, context = {}) {
       return codexResultFailure;
     }
     const changedFiles = await changedFilesInWorktree(paths);
-    const unexpectedChanges = changedFiles.filter((file) => file !== ".jskit/APP_BLUEPRINT.md");
+    const unexpectedChanges = await unexpectedBlueprintStepChanges(paths, changedFiles);
     if (unexpectedChanges.length > 0) {
       return failSession(paths, {
         code: "blueprint_unexpected_changes",
-        message: `The blueprint step changed files outside .jskit/APP_BLUEPRINT.md: ${unexpectedChanges.join(", ")}`,
+        message: `The blueprint step changed files outside ${BLUEPRINT_RELATIVE_PATH}: ${unexpectedChanges.join(", ")}`,
         repairCommand: `git -C ${paths.worktree} status --short`,
         preconditions
       });
@@ -2249,30 +2334,8 @@ async function updateBlueprint(paths, options = {}, context = {}) {
       });
     }
 
-    if (changedFiles.includes(".jskit/APP_BLUEPRINT.md")) {
-      const addResult = await runGitInWorktree(paths.worktree, ["add", ".jskit/APP_BLUEPRINT.md"], {
-        timeout: 15000
-      });
-      if (!addResult.ok) {
-        return failSession(paths, {
-          code: "blueprint_stage_failed",
-          message: addResult.output || "Failed to stage app blueprint update.",
-          repairCommand: `git -C ${paths.worktree} add .jskit/APP_BLUEPRINT.md`,
-          preconditions
-        });
-      }
-      const commitResult = await runGitInWorktree(paths.worktree, ["commit", "-m", `Update app blueprint for ${paths.sessionId}`], {
-        timeout: 1000 * 60
-      });
-      if (!commitResult.ok) {
-        return failSession(paths, {
-          code: "blueprint_commit_failed",
-          message: commitResult.output || "Failed to commit app blueprint update.",
-          repairCommand: `git -C ${paths.worktree} status --short`,
-          preconditions
-        });
-      }
-      await writeReceipt(paths, "blueprint_updated", "Codex updated and JSKIT committed the app blueprint.");
+    if (changedFiles.includes(BLUEPRINT_RELATIVE_PATH)) {
+      await writeReceipt(paths, "blueprint_updated", "Codex updated the app blueprint; JSKIT will include it in the accepted changes commit.");
     } else {
       await writeReceipt(paths, "blueprint_updated", "Codex reviewed the app blueprint; no blueprint changes were needed.");
     }
@@ -2283,6 +2346,7 @@ async function updateBlueprint(paths, options = {}, context = {}) {
     });
   }
 
+  await writeBlueprintBaseline(paths);
   const prompt = await renderPrompt(paths, "update_blueprint.md", {
     agent_decisions_file: agentDecisionsPath,
     app_blueprint_file: blueprintPath,

--- a/tooling/jskit-cli/src/server/sessionRuntime/constants.js
+++ b/tooling/jskit-cli/src/server/sessionRuntime/constants.js
@@ -478,27 +478,27 @@ const STEP_DEFINITIONS = Object.freeze([
     ])
   }),
   defineStep({
-    buttonLabel: "Commit accepted changes",
-    description: "JSKIT commits the user-accepted session changes in the session worktree.",
-    id: "changes_committed",
-    label: "Changes committed",
-    preconditions: ["session_exists", "worktree_exists", "dependencies_installed", "ready_jskit_app", "issue_metadata_exists", "issue_url_exists", "github_auth", "active_cycle_exists", "automated_checks_passed", "deep_ui_check_satisfied", "active_cycle_user_check_passed"]
-  }),
-  defineStep({
     buttonLabel: "Update blueprint",
     codex: BLUEPRINT_CODEX_HANDOFF,
-    description: "JSKIT asks Codex to update durable app memory from the accepted work; Codex edits .jskit/APP_BLUEPRINT.md; JSKIT records and commits the update.",
+    description: "JSKIT asks Codex to update durable app memory from the accepted work; Codex edits .jskit/APP_BLUEPRINT.md; JSKIT records the update for the accepted-work commit.",
     id: "blueprint_updated",
     kind: "codex_prompt",
     label: "Blueprint updated",
-    preconditions: ["session_exists", "worktree_exists", "dependencies_installed", "ready_jskit_app", "issue_metadata_exists", "active_cycle_exists", "automated_checks_passed", "deep_ui_check_satisfied", "active_cycle_user_check_passed", "accepted_changes_committed"]
+    preconditions: ["session_exists", "worktree_exists", "dependencies_installed", "ready_jskit_app", "issue_metadata_exists", "active_cycle_exists", "automated_checks_passed", "deep_ui_check_satisfied", "active_cycle_user_check_passed"]
+  }),
+  defineStep({
+    buttonLabel: "Commit accepted changes",
+    description: "JSKIT commits the accepted session changes, including durable app memory updates, in the session worktree.",
+    id: "changes_committed",
+    label: "Changes committed",
+    preconditions: ["session_exists", "worktree_exists", "dependencies_installed", "ready_jskit_app", "issue_metadata_exists", "issue_url_exists", "github_auth", "active_cycle_exists", "automated_checks_passed", "deep_ui_check_satisfied", "active_cycle_user_check_passed", "blueprint_update_satisfied"]
   }),
   defineStep({
     buttonLabel: "Create final report",
     description: "JSKIT creates the deterministic final session report and comments it on the GitHub issue.",
     id: "final_report_created",
     label: "Final report created",
-    preconditions: ["session_exists", "worktree_exists", "dependencies_installed", "ready_jskit_app", "issue_metadata_exists", "active_cycle_exists", "automated_checks_passed", "deep_ui_check_satisfied", "active_cycle_user_check_passed", "accepted_changes_committed", "blueprint_update_satisfied"]
+    preconditions: ["session_exists", "worktree_exists", "dependencies_installed", "ready_jskit_app", "issue_metadata_exists", "active_cycle_exists", "automated_checks_passed", "deep_ui_check_satisfied", "active_cycle_user_check_passed", "blueprint_update_satisfied", "accepted_changes_committed"]
   }),
   defineStep({
     buttonLabel: "Push branch and create PR",

--- a/tooling/jskit-cli/src/server/sessionRuntime/preconditions.js
+++ b/tooling/jskit-cli/src/server/sessionRuntime/preconditions.js
@@ -379,7 +379,7 @@ async function assertAcceptedChangesCommitted(paths) {
     ok: false,
     error: createError({
       code: "accepted_changes_not_committed",
-      message: "Accepted changes must be committed before app memory and finalization steps continue.",
+      message: "Accepted changes must be committed before finalization steps continue.",
       repairCommand: jskitCommand(`session ${paths.sessionId} step`)
     }),
     precondition: createPrecondition({

--- a/tooling/jskit-cli/src/server/sessionRuntime/responses.js
+++ b/tooling/jskit-cli/src/server/sessionRuntime/responses.js
@@ -56,6 +56,19 @@ function createPrecondition({
   });
 }
 
+function createWarning({
+  code,
+  message,
+  repairCommand = ""
+}) {
+  return createError({ code, message, repairCommand });
+}
+
+const ACCEPTED_CHANGES_NOOP_WARNING = createWarning({
+  code: "accepted_changes_noop",
+  message: "No accepted worktree changes were found; continuing without a new commit."
+});
+
 function normalizeStepId(stepId) {
   return normalizeText(stepId);
 }
@@ -530,6 +543,43 @@ function cloneContractValue(value) {
   );
 }
 
+function normalizeWarning(warning) {
+  if (typeof warning === "string") {
+    return createWarning({
+      code: "session_warning",
+      message: warning
+    });
+  }
+  if (!warning || typeof warning !== "object" || Array.isArray(warning)) {
+    return null;
+  }
+  return createWarning({
+    code: warning.code || "session_warning",
+    message: warning.message || "",
+    repairCommand: warning.repairCommand || ""
+  });
+}
+
+function mergeWarnings(...warningLists) {
+  const merged = [];
+  const seen = new Set();
+  for (const warnings of warningLists) {
+    for (const warning of Array.isArray(warnings) ? warnings : []) {
+      const normalized = normalizeWarning(warning);
+      if (!normalized?.message) {
+        continue;
+      }
+      const key = `${normalized.code}\n${normalized.message}`;
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      merged.push(normalized);
+    }
+  }
+  return merged;
+}
+
 async function publicCodexContract(codex = null) {
   if (!codex || typeof codex !== "object" || Array.isArray(codex)) {
     return null;
@@ -814,7 +864,8 @@ async function readSessionArtifacts(paths) {
     issueMetadataText,
     planExecutionReceipt,
     prOutcomeText,
-    mainCheckoutSyncText
+    mainCheckoutSyncText,
+    changesCommittedText
   ] = await Promise.all([
     readTrimmedFile(path.join(paths.sessionRoot, "status")),
     readTrimmedFile(path.join(paths.sessionRoot, "current_step")),
@@ -834,7 +885,8 @@ async function readSessionArtifacts(paths) {
     readTextIfExists(path.join(paths.sessionRoot, "issue_metadata.json")),
     readTextIfExists(path.join(cycleStepsRoot(paths, activeCycle), "plan_executed")),
     readTextIfExists(path.join(paths.sessionRoot, "pr_outcome.json")),
-    readTextIfExists(path.join(paths.sessionRoot, "main_checkout_sync.json"))
+    readTextIfExists(path.join(paths.sessionRoot, "main_checkout_sync.json")),
+    readTextIfExists(path.join(paths.sessionRoot, "changes_committed.json"))
   ]);
   let issueMetadata = null;
   if (issueMetadataText) {
@@ -871,6 +923,18 @@ async function readSessionArtifacts(paths) {
       mainCheckoutSync = null;
     }
   }
+  let acceptedChangesCommit = null;
+  if (changesCommittedText) {
+    try {
+      const parsed = JSON.parse(changesCommittedText);
+      acceptedChangesCommit = parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : null;
+    } catch {
+      acceptedChangesCommit = null;
+    }
+  }
+  const warnings = acceptedChangesCommit?.noChanges === true
+    ? [ACCEPTED_CHANGES_NOOP_WARNING]
+    : [];
   const cycles = await readCycles(paths, activeCycle);
   const checks = await readStructuredChecks(paths);
   const uiChecks = await readStructuredUiChecks(paths);
@@ -960,6 +1024,7 @@ async function readSessionArtifacts(paths) {
     finalReportText: finalReportText.trim(),
     prompt: prompt.trim(),
     status: status || SESSION_STATUS.PENDING,
+    warnings,
     workflowVersion,
     worktreeReady,
     worktreeStatus
@@ -980,7 +1045,8 @@ async function buildSessionResponse(paths, {
   errors = [],
   preconditions = [],
   prompt = undefined,
-  status = undefined
+  status = undefined,
+  warnings = []
 } = {}) {
   const responsePaths = paths.sessionId ? await pathsForExistingSession(paths) : paths;
   const artifacts = responsePaths.sessionRoot ? await readSessionArtifacts(responsePaths) : {};
@@ -1039,6 +1105,7 @@ async function buildSessionResponse(paths, {
           message: `Session ${paths.sessionId || ""} uses workflow version ${artifacts.workflowVersion || "missing"}, but this JSKIT runtime expects ${SESSION_WORKFLOW_VERSION}.`
         })
       ],
+      warnings: [],
       archive: responsePaths.archive || "active",
       sessionRoot: responsePaths.sessionRoot || "",
       worktree: paths.worktree || "",
@@ -1052,6 +1119,7 @@ async function buildSessionResponse(paths, {
   const responsePrompt = typeof prompt === "string"
     ? prompt
     : stepCanExposeStoredPrompt(currentStep) ? artifacts.prompt || "" : "";
+  const responseWarnings = mergeWarnings(artifacts.warnings || [], warnings);
 
   return {
     ok: ok === true,
@@ -1101,6 +1169,7 @@ async function buildSessionResponse(paths, {
     mainCheckoutSync: cloneContractValue(artifacts.mainCheckoutSync || null),
     preconditions,
     errors,
+    warnings: responseWarnings,
     archive: responsePaths.archive || (resolvedStatus === SESSION_STATUS.FINISHED ? "completed" : resolvedStatus === SESSION_STATUS.ABANDONED ? "abandoned" : "active"),
     sessionRoot: responsePaths.sessionRoot || "",
     worktree: paths.worktree || "",
@@ -1179,6 +1248,7 @@ function buildSessionErrorResponse({
     prOutcome: null,
     preconditions,
     errors: errorList,
+    warnings: [],
     archive: "",
     sessionRoot: "",
     worktree: "",

--- a/tooling/jskit-cli/test/sessionCommand.test.js
+++ b/tooling/jskit-cli/test/sessionCommand.test.js
@@ -2467,9 +2467,9 @@ test("blueprint update step renders a Codex prompt then records the edited bluep
       args: codexResultArgs(),
       input: codexStepResult("blueprint_updated")
     });
-    assert.equal(changed.currentStep, "final_report_created");
-    assert.match(runGit(changedWorktree.worktree, ["log", "--oneline", "--max-count=1"]), /Update app blueprint/);
-    assert.match(await readFile(path.join(changedSession.sessionRoot, "steps", "blueprint_updated"), "utf8"), /committed the app blueprint/);
+    assert.equal(changed.currentStep, "changes_committed");
+    assert.match(runGit(changedWorktree.worktree, ["status", "--porcelain=v1"]), /\.jskit\/APP_BLUEPRINT\.md/);
+    assert.match(await readFile(path.join(changedSession.sessionRoot, "steps", "blueprint_updated"), "utf8"), /include it in the accepted changes commit/);
 
     const unchangedRoot = path.join(cwd, "unchanged");
     await createGitApp(unchangedRoot);
@@ -2492,12 +2492,28 @@ test("blueprint update step renders a Codex prompt then records the edited bluep
       args: codexResultArgs(),
       input: codexStepResult("blueprint_updated")
     });
-    assert.equal(unchanged.currentStep, "final_report_created");
+    assert.equal(unchanged.currentStep, "changes_committed");
     assert.equal(runGit(unchangedWorktree.worktree, ["status", "--porcelain=v1"]), "");
     assert.match(
       await readFile(path.join(unchangedSession.sessionRoot, "steps", "blueprint_updated"), "utf8"),
       /no blueprint changes were needed/
     );
+    const binDir = path.join(cwd, "bin-blueprint-noop");
+    const logPath = path.join(cwd, "blueprint-noop-commands.log");
+    await installFakeGh(binDir, logPath);
+    const noopCommit = runSessionStepJson(unchangedRoot, unchangedSession.sessionId, {
+      env: {
+        PATH: `${binDir}:${process.env.PATH}`
+      }
+    });
+    assert.equal(noopCommit.currentStep, "final_report_created");
+    assert.equal(noopCommit.warnings[0].code, "accepted_changes_noop");
+    assert.match(await readFile(path.join(unchangedSession.sessionRoot, "changes_committed.json"), "utf8"), /"noChanges": true/);
+    const reloadedNoopCommit = parseJsonResult(runCli({
+      cwd: unchangedRoot,
+      args: ["session", unchangedSession.sessionId, "--json"]
+    }));
+    assert.equal(reloadedNoopCommit.warnings[0].code, "accepted_changes_noop");
 
     const unexpectedRoot = path.join(cwd, "unexpected");
     await createGitApp(unexpectedRoot);
@@ -2684,14 +2700,7 @@ test("jskit session can execute review loop, PR, merge, cleanup, and finish", as
       args: ["--user-check", "passed"],
       env
     });
-    assert.equal(userChecked.currentStep, "changes_committed");
-
-    const committed = runSessionStepJson(appRoot, created.sessionId, { env });
-    assert.equal(committed.currentStep, "blueprint_updated");
-    assert.ok(committed.completedSteps.includes("changes_committed"));
-    assert.equal(committed.githubComments.accepted_changes_committed, undefined);
-    assert.match(await readFile(path.join(committed.sessionRoot, "changes_committed.json"), "utf8"), /"commit":/u);
-    await assert.rejects(access(path.join(committed.sessionRoot, "changes_committed.md")));
+    assert.equal(userChecked.currentStep, "blueprint_updated");
 
     const blueprintPrompt = runSessionStepJson(appRoot, created.sessionId, { env });
     assert.equal(blueprintPrompt.currentStep, "blueprint_updated");
@@ -2702,8 +2711,15 @@ test("jskit session can execute review loop, PR, merge, cleanup, and finish", as
       env,
       input: codexStepResult("blueprint_updated")
     });
-    assert.equal(blueprintUpdated.currentStep, "final_report_created");
+    assert.equal(blueprintUpdated.currentStep, "changes_committed");
     assert.match(await readFile(path.join(inspect.worktree, ".jskit", "APP_BLUEPRINT.md"), "utf8"), /Session Test App/);
+
+    const committed = runSessionStepJson(appRoot, created.sessionId, { env });
+    assert.equal(committed.currentStep, "final_report_created");
+    assert.ok(committed.completedSteps.includes("changes_committed"));
+    assert.equal(committed.githubComments.accepted_changes_committed, undefined);
+    assert.match(await readFile(path.join(committed.sessionRoot, "changes_committed.json"), "utf8"), /"commit":/u);
+    await assert.rejects(access(path.join(committed.sessionRoot, "changes_committed.md")));
 
     const finalReport = runSessionStepJson(appRoot, created.sessionId, { env });
     assert.equal(finalReport.currentStep, "pr_created");
@@ -2714,7 +2730,7 @@ test("jskit session can execute review loop, PR, merge, cleanup, and finish", as
     assert.match(finalReport.finalReportText, /## Command Log/);
     assert.match(finalReport.finalReportText, /## Remaining Unverified Gaps/);
     assert.match(finalReport.finalReportText, /## Decisions/);
-    assert.match(finalReport.finalReportText, /Codex updated and JSKIT committed the app blueprint/);
+    assert.match(finalReport.finalReportText, /Codex updated the app blueprint/);
     assert.equal(finalReport.githubComments.final_report.purpose, "final_report");
     const pr = runSessionStepJson(appRoot, created.sessionId, { env });
     assert.equal(pr.prUrl, "https://github.com/example/repo/pull/456");


### PR DESCRIPTION
Summary:
- include app blueprint updates in the accepted changes commit instead of committing them separately
- preserve and report no-op accepted-change commits as warnings
- refresh package versions and generated CLI reference metadata included in the current change set

Tests:
- Not run locally per request.