### PR TITLE
Release shell scaffold updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6686,28 +6686,28 @@
     },
     "packages/agent-docs": {
       "name": "@jskit-ai/agent-docs",
-      "version": "0.1.42",
+      "version": "0.1.43",
       "engines": {
         "node": ">=20 <23"
       }
     },
     "packages/assistant": {
       "name": "@jskit-ai/assistant",
-      "version": "0.1.90",
+      "version": "0.1.91",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.81"
+        "@jskit-ai/kernel": "0.1.82"
       }
     },
     "packages/assistant-core": {
       "name": "@jskit-ai/assistant-core",
-      "version": "0.1.57",
+      "version": "0.1.58",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.81",
-        "@jskit-ai/http-runtime": "0.1.80",
-        "@jskit-ai/kernel": "0.1.81",
-        "@jskit-ai/resource-core": "0.1.26",
-        "@jskit-ai/resource-crud-core": "0.1.26",
-        "@jskit-ai/users-core": "0.1.91",
+        "@jskit-ai/database-runtime": "0.1.82",
+        "@jskit-ai/http-runtime": "0.1.81",
+        "@jskit-ai/kernel": "0.1.82",
+        "@jskit-ai/resource-core": "0.1.27",
+        "@jskit-ai/resource-crud-core": "0.1.27",
+        "@jskit-ai/users-core": "0.1.92",
         "dompurify": "^3.3.3",
         "json-rest-schema": "1.x.x",
         "marked": "^17.0.4",
@@ -6720,15 +6720,15 @@
     },
     "packages/assistant-runtime": {
       "name": "@jskit-ai/assistant-runtime",
-      "version": "0.1.52",
+      "version": "0.1.53",
       "dependencies": {
-        "@jskit-ai/assistant-core": "0.1.57",
-        "@jskit-ai/database-runtime": "0.1.81",
-        "@jskit-ai/http-runtime": "0.1.80",
-        "@jskit-ai/kernel": "0.1.81",
-        "@jskit-ai/shell-web": "0.1.80",
-        "@jskit-ai/users-core": "0.1.91",
-        "@jskit-ai/users-web": "0.1.96",
+        "@jskit-ai/assistant-core": "0.1.58",
+        "@jskit-ai/database-runtime": "0.1.82",
+        "@jskit-ai/http-runtime": "0.1.81",
+        "@jskit-ai/kernel": "0.1.82",
+        "@jskit-ai/shell-web": "0.1.81",
+        "@jskit-ai/users-core": "0.1.92",
+        "@jskit-ai/users-web": "0.1.97",
         "json-rest-schema": "1.x.x"
       },
       "peerDependencies": {
@@ -6739,21 +6739,21 @@
     },
     "packages/auth-core": {
       "name": "@jskit-ai/auth-core",
-      "version": "0.1.80",
+      "version": "0.1.81",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0",
-        "@jskit-ai/kernel": "0.1.81",
+        "@jskit-ai/kernel": "0.1.82",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/auth-provider-supabase-core": {
       "name": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.80",
+      "version": "0.1.81",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.80",
-        "@jskit-ai/kernel": "0.1.81",
+        "@jskit-ai/auth-core": "0.1.81",
+        "@jskit-ai/kernel": "0.1.82",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0",
         "json-rest-schema": "1.x.x",
@@ -6762,12 +6762,12 @@
     },
     "packages/auth-web": {
       "name": "@jskit-ai/auth-web",
-      "version": "0.1.82",
+      "version": "0.1.83",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.80",
-        "@jskit-ai/http-runtime": "0.1.80",
-        "@jskit-ai/kernel": "0.1.81",
-        "@jskit-ai/shell-web": "0.1.80",
+        "@jskit-ai/auth-core": "0.1.81",
+        "@jskit-ai/http-runtime": "0.1.81",
+        "@jskit-ai/kernel": "0.1.82",
+        "@jskit-ai/shell-web": "0.1.81",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -6780,38 +6780,38 @@
     },
     "packages/console-core": {
       "name": "@jskit-ai/console-core",
-      "version": "0.1.44",
+      "version": "0.1.45",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.80",
-        "@jskit-ai/database-runtime": "0.1.81",
-        "@jskit-ai/http-runtime": "0.1.80",
-        "@jskit-ai/kernel": "0.1.81",
-        "@jskit-ai/resource-crud-core": "0.1.26",
-        "@jskit-ai/users-core": "0.1.91",
+        "@jskit-ai/auth-core": "0.1.81",
+        "@jskit-ai/database-runtime": "0.1.82",
+        "@jskit-ai/http-runtime": "0.1.81",
+        "@jskit-ai/kernel": "0.1.82",
+        "@jskit-ai/resource-crud-core": "0.1.27",
+        "@jskit-ai/users-core": "0.1.92",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/console-web": {
       "name": "@jskit-ai/console-web",
-      "version": "0.1.49",
+      "version": "0.1.50",
       "dependencies": {
-        "@jskit-ai/auth-web": "0.1.82",
-        "@jskit-ai/console-core": "0.1.44",
-        "@jskit-ai/shell-web": "0.1.80"
+        "@jskit-ai/auth-web": "0.1.83",
+        "@jskit-ai/console-core": "0.1.45",
+        "@jskit-ai/shell-web": "0.1.81"
       }
     },
     "packages/crud-core": {
       "name": "@jskit-ai/crud-core",
-      "version": "0.1.89",
+      "version": "0.1.90",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.81",
-        "@jskit-ai/http-runtime": "0.1.80",
-        "@jskit-ai/kernel": "0.1.81",
-        "@jskit-ai/realtime": "0.1.80",
-        "@jskit-ai/resource-crud-core": "0.1.26",
-        "@jskit-ai/shell-web": "0.1.80",
-        "@jskit-ai/users-core": "0.1.91",
-        "@jskit-ai/users-web": "0.1.96",
+        "@jskit-ai/database-runtime": "0.1.82",
+        "@jskit-ai/http-runtime": "0.1.81",
+        "@jskit-ai/kernel": "0.1.82",
+        "@jskit-ai/realtime": "0.1.81",
+        "@jskit-ai/resource-crud-core": "0.1.27",
+        "@jskit-ai/shell-web": "0.1.81",
+        "@jskit-ai/users-core": "0.1.92",
+        "@jskit-ai/users-web": "0.1.97",
         "json-rest-schema": "1.x.x"
       },
       "peerDependencies": {
@@ -6822,98 +6822,98 @@
     },
     "packages/crud-server-generator": {
       "name": "@jskit-ai/crud-server-generator",
-      "version": "0.1.89",
+      "version": "0.1.90",
       "dependencies": {
         "@babel/parser": "^7.29.2",
-        "@jskit-ai/crud-core": "0.1.89",
-        "@jskit-ai/database-runtime": "0.1.81",
-        "@jskit-ai/http-runtime": "0.1.80",
-        "@jskit-ai/json-rest-api-core": "0.1.26",
-        "@jskit-ai/kernel": "0.1.81",
-        "@jskit-ai/resource-crud-core": "0.1.26",
+        "@jskit-ai/crud-core": "0.1.90",
+        "@jskit-ai/database-runtime": "0.1.82",
+        "@jskit-ai/http-runtime": "0.1.81",
+        "@jskit-ai/json-rest-api-core": "0.1.27",
+        "@jskit-ai/kernel": "0.1.82",
+        "@jskit-ai/resource-crud-core": "0.1.27",
         "recast": "^0.23.11"
       }
     },
     "packages/crud-ui-generator": {
       "name": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.64",
+      "version": "0.1.65",
       "dependencies": {
-        "@jskit-ai/crud-core": "0.1.89",
-        "@jskit-ai/kernel": "0.1.81",
-        "@jskit-ai/resource-crud-core": "0.1.26"
+        "@jskit-ai/crud-core": "0.1.90",
+        "@jskit-ai/kernel": "0.1.82",
+        "@jskit-ai/resource-crud-core": "0.1.27"
       }
     },
     "packages/database-runtime": {
       "name": "@jskit-ai/database-runtime",
-      "version": "0.1.81",
+      "version": "0.1.82",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.81"
+        "@jskit-ai/kernel": "0.1.82"
       }
     },
     "packages/database-runtime-mysql": {
       "name": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.80",
+      "version": "0.1.81",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.81",
-        "@jskit-ai/kernel": "0.1.81"
+        "@jskit-ai/database-runtime": "0.1.82",
+        "@jskit-ai/kernel": "0.1.82"
       }
     },
     "packages/database-runtime-postgres": {
       "name": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.80",
+      "version": "0.1.81",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.81"
+        "@jskit-ai/database-runtime": "0.1.82"
       }
     },
     "packages/feature-server-generator": {
       "name": "@jskit-ai/feature-server-generator",
-      "version": "0.1.23"
+      "version": "0.1.24"
     },
     "packages/google-rewarded-core": {
       "name": "@jskit-ai/google-rewarded-core",
-      "version": "0.1.18"
+      "version": "0.1.19"
     },
     "packages/google-rewarded-web": {
       "name": "@jskit-ai/google-rewarded-web",
-      "version": "0.1.18"
+      "version": "0.1.19"
     },
     "packages/http-runtime": {
       "name": "@jskit-ai/http-runtime",
-      "version": "0.1.80",
+      "version": "0.1.81",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.81",
+        "@jskit-ai/kernel": "0.1.82",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/json-rest-api-core": {
       "name": "@jskit-ai/json-rest-api-core",
-      "version": "0.1.26",
+      "version": "0.1.27",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.81",
+        "@jskit-ai/kernel": "0.1.82",
         "hooked-api": "1.x.x",
         "json-rest-api": "1.x.x"
       }
     },
     "packages/kernel": {
       "name": "@jskit-ai/kernel",
-      "version": "0.1.81",
+      "version": "0.1.82",
       "dependencies": {
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/mobile-capacitor": {
       "name": "@jskit-ai/mobile-capacitor",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "dependencies": {
         "@capacitor/browser": "^7.0.1",
-        "@jskit-ai/kernel": "0.1.81"
+        "@jskit-ai/kernel": "0.1.82"
       }
     },
     "packages/realtime": {
       "name": "@jskit-ai/realtime",
-      "version": "0.1.80",
+      "version": "0.1.81",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.81",
+        "@jskit-ai/kernel": "0.1.82",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",
@@ -6925,24 +6925,24 @@
     },
     "packages/resource-core": {
       "name": "@jskit-ai/resource-core",
-      "version": "0.1.26",
+      "version": "0.1.27",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.81"
+        "@jskit-ai/kernel": "0.1.82"
       }
     },
     "packages/resource-crud-core": {
       "name": "@jskit-ai/resource-crud-core",
-      "version": "0.1.26",
+      "version": "0.1.27",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.81",
-        "@jskit-ai/resource-core": "0.1.26"
+        "@jskit-ai/kernel": "0.1.82",
+        "@jskit-ai/resource-core": "0.1.27"
       }
     },
     "packages/shell-web": {
       "name": "@jskit-ai/shell-web",
-      "version": "0.1.80",
+      "version": "0.1.81",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.81",
+        "@jskit-ai/kernel": "0.1.82",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -6954,25 +6954,25 @@
     },
     "packages/storage-runtime": {
       "name": "@jskit-ai/storage-runtime",
-      "version": "0.1.80",
+      "version": "0.1.81",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.81",
+        "@jskit-ai/kernel": "0.1.82",
         "unstorage": "^1.17.3"
       }
     },
     "packages/ui-generator": {
       "name": "@jskit-ai/ui-generator",
-      "version": "0.1.64",
+      "version": "0.1.65",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.81",
-        "@jskit-ai/shell-web": "0.1.80"
+        "@jskit-ai/kernel": "0.1.82",
+        "@jskit-ai/shell-web": "0.1.81"
       }
     },
     "packages/uploads-image-web": {
       "name": "@jskit-ai/uploads-image-web",
-      "version": "0.1.59",
+      "version": "0.1.60",
       "dependencies": {
-        "@jskit-ai/uploads-runtime": "0.1.59",
+        "@jskit-ai/uploads-runtime": "0.1.60",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",
@@ -6985,37 +6985,37 @@
     },
     "packages/uploads-runtime": {
       "name": "@jskit-ai/uploads-runtime",
-      "version": "0.1.59",
+      "version": "0.1.60",
       "dependencies": {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.81"
+        "@jskit-ai/kernel": "0.1.82"
       }
     },
     "packages/users-core": {
       "name": "@jskit-ai/users-core",
-      "version": "0.1.91",
+      "version": "0.1.92",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.80",
-        "@jskit-ai/database-runtime": "0.1.81",
-        "@jskit-ai/http-runtime": "0.1.80",
-        "@jskit-ai/json-rest-api-core": "0.1.26",
-        "@jskit-ai/kernel": "0.1.81",
-        "@jskit-ai/resource-core": "0.1.26",
-        "@jskit-ai/resource-crud-core": "0.1.26",
-        "@jskit-ai/uploads-runtime": "0.1.59",
+        "@jskit-ai/auth-core": "0.1.81",
+        "@jskit-ai/database-runtime": "0.1.82",
+        "@jskit-ai/http-runtime": "0.1.81",
+        "@jskit-ai/json-rest-api-core": "0.1.27",
+        "@jskit-ai/kernel": "0.1.82",
+        "@jskit-ai/resource-core": "0.1.27",
+        "@jskit-ai/resource-crud-core": "0.1.27",
+        "@jskit-ai/uploads-runtime": "0.1.60",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/users-web": {
       "name": "@jskit-ai/users-web",
-      "version": "0.1.96",
+      "version": "0.1.97",
       "dependencies": {
-        "@jskit-ai/http-runtime": "0.1.80",
-        "@jskit-ai/kernel": "0.1.81",
-        "@jskit-ai/realtime": "0.1.80",
-        "@jskit-ai/shell-web": "0.1.80",
-        "@jskit-ai/uploads-image-web": "0.1.59",
-        "@jskit-ai/users-core": "0.1.91",
+        "@jskit-ai/http-runtime": "0.1.81",
+        "@jskit-ai/kernel": "0.1.82",
+        "@jskit-ai/realtime": "0.1.81",
+        "@jskit-ai/shell-web": "0.1.81",
+        "@jskit-ai/uploads-image-web": "0.1.60",
+        "@jskit-ai/users-core": "0.1.92",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -7027,29 +7027,29 @@
     },
     "packages/workspaces-core": {
       "name": "@jskit-ai/workspaces-core",
-      "version": "0.1.57",
+      "version": "0.1.58",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.80",
-        "@jskit-ai/database-runtime": "0.1.81",
-        "@jskit-ai/http-runtime": "0.1.80",
-        "@jskit-ai/json-rest-api-core": "0.1.26",
-        "@jskit-ai/kernel": "0.1.81",
-        "@jskit-ai/resource-core": "0.1.26",
-        "@jskit-ai/resource-crud-core": "0.1.26",
-        "@jskit-ai/users-core": "0.1.91",
+        "@jskit-ai/auth-core": "0.1.81",
+        "@jskit-ai/database-runtime": "0.1.82",
+        "@jskit-ai/http-runtime": "0.1.81",
+        "@jskit-ai/json-rest-api-core": "0.1.27",
+        "@jskit-ai/kernel": "0.1.82",
+        "@jskit-ai/resource-core": "0.1.27",
+        "@jskit-ai/resource-crud-core": "0.1.27",
+        "@jskit-ai/users-core": "0.1.92",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/workspaces-web": {
       "name": "@jskit-ai/workspaces-web",
-      "version": "0.1.57",
+      "version": "0.1.58",
       "dependencies": {
-        "@jskit-ai/http-runtime": "0.1.80",
-        "@jskit-ai/kernel": "0.1.81",
-        "@jskit-ai/shell-web": "0.1.80",
-        "@jskit-ai/users-core": "0.1.91",
-        "@jskit-ai/users-web": "0.1.96",
-        "@jskit-ai/workspaces-core": "0.1.57",
+        "@jskit-ai/http-runtime": "0.1.81",
+        "@jskit-ai/kernel": "0.1.82",
+        "@jskit-ai/shell-web": "0.1.81",
+        "@jskit-ai/users-core": "0.1.92",
+        "@jskit-ai/users-web": "0.1.97",
+        "@jskit-ai/workspaces-core": "0.1.58",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -7061,7 +7061,7 @@
     },
     "tooling/config-eslint": {
       "name": "@jskit-ai/config-eslint",
-      "version": "0.1.80",
+      "version": "0.1.81",
       "dependencies": {
         "@eslint/js": "^9.39.1",
         "eslint-plugin-vue": "^10.5.1",
@@ -7079,7 +7079,7 @@
     },
     "tooling/create-app": {
       "name": "@jskit-ai/create-app",
-      "version": "0.1.89",
+      "version": "0.1.90",
       "bin": {
         "jskit-create-app": "bin/jskit-create-app.js"
       },
@@ -7089,18 +7089,18 @@
     },
     "tooling/jskit-catalog": {
       "name": "@jskit-ai/jskit-catalog",
-      "version": "0.1.89",
+      "version": "0.1.90",
       "engines": {
         "node": ">=20 <23"
       }
     },
     "tooling/jskit-cli": {
       "name": "@jskit-ai/jskit-cli",
-      "version": "0.2.90",
+      "version": "0.2.91",
       "dependencies": {
-        "@jskit-ai/jskit-catalog": "0.1.89",
-        "@jskit-ai/kernel": "0.1.81",
-        "@jskit-ai/shell-web": "0.1.80",
+        "@jskit-ai/jskit-catalog": "0.1.90",
+        "@jskit-ai/kernel": "0.1.82",
+        "@jskit-ai/shell-web": "0.1.81",
         "@vue/compiler-sfc": "^3.5.29",
         "ts-morph": "^28.0.0"
       },

--- a/packages/agent-docs/guide/agent/app-setup/initial-scaffolding.md
+++ b/packages/agent-docs/guide/agent/app-setup/initial-scaffolding.md
@@ -287,8 +287,6 @@ import { createRouter, createWebHistory } from "vue-router/auto";
 import { routes } from "vue-router/auto-routes";
 import "vuetify/styles";
 import { createVuetify } from "vuetify";
-import * as components from "vuetify/components";
-import * as directives from "vuetify/directives";
 import { aliases as mdiAliases, mdi } from "vuetify/iconsets/mdi-svg";
 import { createSurfaceRuntime } from "@jskit-ai/kernel/shared/surface/runtime";
 import {
@@ -326,8 +324,6 @@ const { router, fallbackRoute } = createShellRouter({
 });
 
 const vuetify = createVuetify({
-  components,
-  directives,
   theme: {
     defaultTheme: "light"
   },
@@ -422,7 +418,7 @@ In the starter app, with only `home`, this is almost boring. It mostly means:
 
 In the plain starter scaffold there are still no package-defined client stores to use yet. Pinia is already there so later packages can add them without changing the app bootstrap. In the next chapters, `shell-web` adds shell stores such as `useShellLayoutStore()`, and `auth-web` later adds `useAuthStore()`.
 
-`createVuetify(...)` is the ordinary UI plugin setup. There is nothing especially JSKIT-specific there; it just makes Vuetify components, directives, theme settings, and icon aliases available to the app before the router is mounted.
+`createVuetify(...)` is the ordinary UI plugin setup. There is nothing especially JSKIT-specific there; it configures theme settings and icon aliases before the router is mounted. Vuetify components are auto-imported by `vite-plugin-vuetify`, so the scaffold does not register the full Vuetify component namespace in the client bundle.
 
 `bootInstalledClientModules` is the extension seam, meaning "this is the point where later-installed JSKIT packages get to join client startup". The confusing part is that it is not a normal file in your app. In `src/main.js` you import it from:
 

--- a/packages/agent-docs/package.json
+++ b/packages/agent-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/agent-docs",
-  "version": "0.1.42",
+  "version": "0.1.43",
   "description": "Distributed JSKIT agent references, prompts, guides, and generated reference maps.",
   "type": "module",
   "files": [

--- a/packages/agent-docs/reference/autogen/packages/users-web.md
+++ b/packages/agent-docs/reference/autogen/packages/users-web.md
@@ -238,7 +238,7 @@ Exports
 
 ### `src/client/composables/records/useView.js`
 Exports
-- `useView({ ownershipFilter = ROUTE_VISIBILITY_WORKSPACE, surfaceId = "", access = "auto", apiSuffix = "", queryKeyFactory = null, viewPermissions = [], readMethod = "GET", readEnabled = true, transport = null, placementSource = "users-web.view", fallbackLoadError = "Unable to load resource.", notFoundStatuses = [404], notFoundMessage = "Record not found.", model, mapLoadedToModel, requestQueryParams = null, recordIdParam = "recordId", routeParams = null, routeRecordId = null, apiUrlTemplate = "", listUrlTemplate = "", editUrlTemplate = "", includeRecordIdInQueryKey = false, realtime = undefined, adapter = null } = {})`
+- `useView({ resource = null, ownershipFilter = ROUTE_VISIBILITY_WORKSPACE, surfaceId = "", access = "auto", apiSuffix = "", queryKeyFactory = null, viewPermissions = [], readMethod = "GET", readEnabled = true, transport = null, placementSource = "users-web.view", fallbackLoadError = "Unable to load resource.", notFoundStatuses = [404], notFoundMessage = "Record not found.", model, mapLoadedToModel, requestQueryParams = null, recordIdParam = "recordId", routeParams = null, routeRecordId = null, apiUrlTemplate = "", listUrlTemplate = "", editUrlTemplate = "", includeRecordIdInQueryKey = false, realtime = undefined, adapter = null } = {})`
 
 ### `src/client/composables/runtime/addEditUiRuntime.js`
 Exports

--- a/packages/agent-docs/reference/autogen/tooling/jskit-cli.md
+++ b/packages/agent-docs/reference/autogen/tooling/jskit-cli.md
@@ -682,6 +682,10 @@ Local functions
 - `resolveStepInputs({ inlineOptions = {}, io = {}, cwd, sessionId })`
 - `normalizeStepOptions(inlineOptions = {})`
 - `resolveListArchiveOption(options = {})`
+- `runSessionStepCommand({ cwd, inlineOptions = {}, io = {}, sessionId })`
+- `runNextSessionStep({ cwd, sessionId })`
+- `runSkipSessionStep({ cwd, inlineOptions = {}, io = {}, sessionId })`
+- `runDeslopSessionStep({ cwd, sessionId })`
 
 ### `src/server/commandHandlers/shared.js`
 Exports
@@ -814,6 +818,7 @@ Exports
 - `STEP_IDS`
 - `STEP_PRECONDITION_NAMES`
 - `abandonSession({ targetRoot = process.cwd(), sessionId } = {})`
+- `advanceSessionStep({ targetRoot = process.cwd(), sessionId } = {})`
 - `adoptDependenciesInstalled({ targetRoot = process.cwd(), sessionId, message = "" } = {})`
 - `adoptCodexThreadId({ targetRoot = process.cwd(), sessionId, codexThreadId } = {})`
 - `buildSessionResponse`
@@ -822,8 +827,6 @@ Exports
 - `createSessionId`
 - `extractIssueTitle(value = "")`
 - `extractIssueText(value = "")`
-- `extractIssueDetails(value = "")`
-- `extractPlanText(value = "")`
 - `inspectSession({ targetRoot = process.cwd(), sessionId } = {})`
 - `inspectSessionDiff({ targetRoot = process.cwd(), sessionId } = {})`
 - `inspectSessionDetails({ targetRoot = process.cwd(), sessionId } = {})`
@@ -834,28 +837,16 @@ Exports
 - `rewindSession({ targetRoot = process.cwd(), sessionId, stepId } = {})`
 - `resolveSessionPaths`
 - `runSessionStep({ targetRoot = process.cwd(), sessionId, options = {} } = {})`
+- `runSessionStepAction({ targetRoot = process.cwd(), sessionId, action, options = {} } = {})`
 Local functions
 - `invalidSessionIdError(sessionId = "")`
 - `invalidSessionIdResponse({ targetRoot, sessionId })`
 - `existingSessionContext({ targetRoot = process.cwd(), sessionId } = {})`
 - `withExistingSession(input, handler)`
 - `extractMarkedText(value = "", marker = "")`
-- `extractMarkedField(value = "", fieldName = "")`
-- `extractIssueCategory(value = "")`
-- `extractUiImpact(value = "")`
-- `extractAgentDecisions(value = "")`
-- `normalizeIssueCategory(value = "")`
-- `normalizeUiImpact(value = "")`
 - `writePromptArtifact(paths, fileName, prompt)`
-- `codexResultPath(paths, stepId)`
-- `codexResponseContractForStep(stepId)`
-- `requireCodexStepResult(paths, stepId, result, preconditions = [], contractOverride = null)`
 - `commandText(command, args = [])`
 - `cycleRootPath(paths, cycle)`
-- `cyclePlanPath(paths, cycle)`
-- `cyclePlanPromptFileName(cycle)`
-- `cyclePlanExecutionPromptFileName(cycle)`
-- `readCurrentPlan(paths)`
 - `commandOutputSummary(output = "")`
 - `appendCommandLog(paths, { args = [], command, cwd = "", kind = "command", result } = {})`
 - `runLoggedCommand(paths, kind, command, args = [], options = {})`
@@ -864,37 +855,33 @@ Local functions
 - `packageScriptCommandForWorktree(worktree, scriptName, { preferredPackageManager = "" } = {})`
 - `sessionPackageScriptEnv(paths, scriptName)`
 - `packageScriptRepairCommand(paths, command, args)`
-- `packageScriptReceiptName(scriptName)`
-- `writeSessionHookReceipt(paths, scriptName, message)`
+- `packageScriptRecordName(scriptName)`
+- `writeSessionHookRecord(paths, scriptName, message)`
 - `runOptionalSessionPackageScript(paths, { failureCode, failureMessage, kind, preferredPackageManager = "", preconditions = [], scriptName, timeout = 1000 * 60 * 10 } = {})`
 - `runSessionFinalizationGuard(paths, preconditions = [])`
 - `runSessionProvisioningHook(paths, { preferredPackageManager = "", preconditions = [] } = {})`
-- `readIssueMetadata(paths)`
-- `writeIssueMetadata(paths, metadata = {})`
 - `readGithubComments(paths)`
 - `writeGithubComments(paths, comments = {})`
 - `commentOnIssueOnce(paths, { bodyFile, issueUrl, purpose })`
-- `appendAgentDecisions(paths, decisions = "")`
-- `appendAgentDecisionsInput(paths, options = {})`
-- `recordIssueInAgentDecisions(paths, issueUrl = "")`
 - `issueMetadataFromUrl(issueUrl = "")`
-- `nextCycleNumber(cycle = "001")`
+- `writeIssueMetadataFiles(paths, { issueTitle = "", issueUrl = "" } = {})`
 - `normalizeArchiveFilter(archive = "active")`
 - `emptySessionDetails(response)`
 - `removeEmptyStaleWorktreeDirectory(paths)`
 - `createWorktree(paths, _options = {}, context = {})`
+- `recordDependencyInstallResult(paths, { message = "Installed Node dependencies in the session worktree.", preconditions = [] } = {})`
 - `parsePackageManager(value = "")`
 - `hasWorktreeFile(worktree, fileName)`
 - `dependencyInstallCommandForWorktree(worktree)`
 - `installDependencies(paths, _options = {}, context = {})`
-- `renderIssuePrompt(paths, options = {})`
-- `draftIssue(paths, options = {})`
+- `issueDefinitionPrompt(userInput, context)`
+- `renderIssuePrompt(paths, options = {}, context = {})`
 - `titleFromIssue(issueText)`
 - `createIssue(paths, _options = {}, context = {})`
-- `renderIssueDetailsPrompt(paths, _options = {}, context = {})`
-- `saveIssueDetails(paths, options = {}, context = {})`
-- `makePlan(paths, options = {}, context = {})`
-- `renderPlanExecutionPrompt(paths, options = {}, context = {})`
+- `submitIssue(paths, _options = {}, context = {})`
+- `renderIssueFilePrompt(paths, context = {})`
+- `makePlan(paths, _options = {}, context = {})`
+- `renderPlanExecutionPrompt(paths, _options = {}, context = {})`
 - `worktreeStatus(worktree)`
 - `untrackedFiles(worktree)`
 - `untrackedFileDiff(worktree, filePath)`
@@ -903,16 +890,16 @@ Local functions
 - `removeSessionRootFile(paths, fileName)`
 - `removePromptArtifact(paths, fileName)`
 - `removeGlobalCodexResult(paths, stepId)`
+- `removeCycleCodexResults(paths, stepId)`
+- `removeCodexResult(paths, stepId)`
 - `removeGithubCommentPurpose(paths, purpose)`
-- `removeIssueDetailsMetadata(paths)`
 - `removeCycleDirectories(paths)`
-- `removeCyclePromptArtifacts(paths)`
-- `cancelAllCycleState(paths)`
-- `targetRequiresCycleReset(stepId)`
+- `removePlanArtifacts(paths)`
+- `removePlanExecutionArtifacts(paths)`
 - `targetIsAllowedRewindStep(stepId)`
 - `deletedStepIdsForRewindTarget(stepId)`
-- `removeReceiptsForDeletedSteps(paths, deletedStepIds)`
-- `cancelDeletedStepArtifacts(paths, deletedStepIds, { cycleReset = false } = {})`
+- `removeStepRecordsForDeletedSteps(paths, deletedStepIds)`
+- `cancelDeletedStepArtifacts(paths, deletedStepIds)`
 - `commitWorktree(paths, { message, allowNoChanges = false } = {})`
 - `uniqueChangedFileList(entries = [])`
 - `changedFilesInWorktree(paths)`
@@ -932,23 +919,34 @@ Local functions
 - `writeReviewPassJson(paths, pass, fileName, payload)`
 - `currentHead(paths)`
 - `renderReviewPrompt(paths)`
-- `acceptReviewChanges(paths, options = {})`
-- `runAutomatedChecks(paths, { stepId, label }, options = {}, context = {})`
+- `renderResolveDeslopPrompt(paths, context = {})`
+- `acceptReviewChanges(paths, options = {}, context = {})`
+- `runAutomatedChecks(paths, { stepId }, _options = {}, context = {})`
 - `writeUiCheckJson(paths, fileName, payload)`
-- `runDeepUiCheck(paths, { stepId, label, phase }, options = {}, context = {})`
+- `runDeepUiCheck(paths, { stepId, phase }, _options = {}, context = {})`
 - `userCheck(paths, options = {})`
 - `readAcceptedChangesCommit(paths)`
 - `commitAcceptedChanges(paths, _options = {}, context = {})`
-- `updateBlueprint(paths, options = {}, context = {})`
+- `updateBlueprint(paths, _options = {}, context = {})`
 - `readPackageJson(root)`
 - `doctorCommandForWorktree(worktree)`
 - `commitLinesSinceBase(paths)`
 - `readCheckSummaries(paths)`
 - `readUiCheckSummaries(paths)`
 - `readReviewPassSummaries(paths)`
-- `createFinalReport(paths, _options = {}, context = {})`
+- `renderPullRequestFilePrompt(paths, context = {})`
+- `createPullRequestFile(paths, _options = {}, context = {})`
 - `issueNumberFromUrl(issueUrl)`
 - `parseJsonObject(value)`
+- `booleanOption(options = {}, ...names)`
+- `skipStepRequested(options = {})`
+- `skipStepReason(options = {}, stepId = "")`
+- `writeJsonFile(filePath, payload)`
+- `writeTextIfMissing(filePath, value)`
+- `writeSkippedIssueDraft(paths, reason)`
+- `writeSkippedReviewPass(paths, reason)`
+- `writeSkippedStepArtifacts(paths, stepId, reason)`
+- `skipCurrentStep(paths, stepId, options = {})`
 - `readPrState(paths, prUrl)`
 - `readCurrentBranchPrState(paths)`
 - `prStateIsMerged(prState)`
@@ -963,12 +961,14 @@ Local functions
 - `updateLocalBaseBranch(paths, baseBranch = "")`
 - `syncMainCheckout(paths, options = {}, context = {})`
 - `updateHelperMapBeforePr(paths)`
-- `createPr(paths)`
-- `closePrWithoutMerge(paths, prUrl, options = {})`
+- `createPr(paths, _options = {}, context = {})`
 - `preparePrMerge(paths, options = {}, context = {})`
 - `finalizePr(paths, options = {}, context = {})`
 - `finishSession(paths)`
 - `runNamedPreconditions(paths, names = [])`
+- `sessionStepError(paths, { code, message, repairCommand = "" } = {})`
+- `createIssueFileAction(paths, options = {}, context = {})`
+- `createGithubIssueAction(paths, options = {}, context = {})`
 
 ### `src/server/sessionRuntime/appReadiness.js`
 Exports
@@ -983,6 +983,7 @@ Exports
 - `SESSION_ID_PATTERN`
 - `SESSION_STATUS`
 - `SESSION_WORKFLOW_VERSION`
+- `DEPENDENCIES_INSTALL_RESULT_FILE`
 - `REVIEW_PASS_LIMIT`
 - `CYCLE_STEP_IDS`
 - `STEP_DEFINITION_BY_ID`
@@ -990,19 +991,21 @@ Exports
 - `STEP_IDS`
 - `STEP_LABEL_BY_ID`
 - `STEP_PRECONDITION_NAMES`
-- `ISSUE_DETAILS_CODEX_HANDOFF`
+- `ISSUE_DEFINITION_CODEX_HANDOFF`
+- `ISSUE_FILE_CODEX_HANDOFF`
+- `PLAN_CODEX_HANDOFF`
 - `PLAN_EXECUTION_CODEX_HANDOFF`
 - `REVIEW_EXECUTION_CODEX_HANDOFF`
+- `RESOLVE_DESLOP_CODEX_HANDOFF`
 - `DEEP_UI_CHECK_CODEX_HANDOFF`
 - `AUTOMATED_CHECK_REPAIR_CODEX_HANDOFF`
 - `BLUEPRINT_CODEX_HANDOFF`
+- `PR_FILE_CODEX_HANDOFF`
 - `PR_MERGE_PREP_CODEX_HANDOFF`
 - `JSKIT_CLI_SHELL_COMMAND`
-- `JSKIT_CLI_SHELL_RULE`
 - `SESSION_STATE_RELATIVE_PATH`
 Local functions
-- `fieldResponseContract(outputDefinitions)`
-- `codexHandoff(outputDefinition, { autoInject = false, promptActionLabel = "", promptIntroText = "", promptWaitingText = "", responseContract = undefined } = {})`
+- `codexHandoff({ promptActionLabel = "", promptIntroText = "", promptWaitingText = "", sendPrompt = false } = {})`
 - `stepAutomationFor({ codex = undefined, id, kind, requiresExplicitRun = false })`
 - `defineStep({ buttonLabel, codex = undefined, description, id, input = INPUT_NONE, kind = "automatic", label, nextCommandTemplate = DEFAULT_NEXT_COMMAND_TEMPLATE, preconditions = [], requiresExplicitRun = false, submitOptions = {}, automation = undefined, utilityActions = [], displayGroupId = "", displayGroupLabel = "" })`
 
@@ -1015,7 +1018,7 @@ Exports
 - `runCommand(command, args = [], { cwd, env = {}, timeout = 30000 } = {})`
 - `runGit(targetRoot, args = [], options = {})`
 - `runGitInWorktree(worktree, args = [], options = {})`
-- `timestampForReceipt(now = new Date())`
+- `timestampForStepRecord(now = new Date())`
 - `writeTextFile(filePath, value)`
 
 ### `src/server/sessionRuntime/paths.js`
@@ -1037,21 +1040,19 @@ Exports
 - `assertAcceptedChangesCommitted(paths)`
 - `assertActiveCycleExists(paths)`
 - `assertActiveCycleUserCheckPassed(paths)`
+- `assertUserCheckPassed(paths)`
 - `assertBlueprintUpdateSatisfied(paths)`
 - `assertDeepUiCheckSatisfied(paths)`
 - `assertDependenciesInstalled(paths)`
-- `assertFinalReportExists(paths)`
+- `assertPullRequestFileExists(paths)`
 - `assertGhAuth(targetRoot)`
 - `assertGitCurrentBranch(targetRoot)`
 - `assertGitRepository(targetRoot)`
 - `assertGithubOrigin(targetRoot)`
-- `assertIssueMetadataExists(paths)`
 - `assertIssueTextExists(paths)`
 - `assertIssueUrlExists(paths)`
 - `assertAutomatedChecksPassed(paths)`
-- `assertIssueDetailsExists(paths)`
 - `assertMainCheckoutSyncSatisfied(paths)`
-- `assertPlanTextExists(paths)`
 - `assertPrUrlExists(paths)`
 - `assertReadyJskitApp(paths)`
 - `assertSessionExists(paths)`
@@ -1063,14 +1064,13 @@ Local functions
 - `jskitCommand(args = "")`
 - `resolveGitCommonDirectory(targetRoot)`
 - `pathExists(filePath)`
-- `assertActiveCycleStepReceipt(paths, { code, id, message, stepId })`
+- `assertActiveCycleStepRecord(paths, { code, id, message, stepId })`
 
 ### `src/server/sessionRuntime/promptRenderer.js`
 Exports
 - `readPromptTemplate(targetRoot, name)`
 - `renderPrompt(paths, templateName, values = {})`
 - `renderTemplate(source, values = {})`
-- `withShellCommandRule(template)`
 
 ### `src/server/sessionRuntime/responses.js`
 Exports
@@ -1084,16 +1084,16 @@ Exports
 - `markStatus(paths, status)`
 - `normalizeReviewPassNumber(value = "")`
 - `readActiveCycle(paths)`
-- `readReceiptSteps(paths)`
+- `readStepRecords(paths)`
 - `readReviewPasses(paths)`
 - `readSessionArtifacts(paths)`
 - `reviewPassDirectoryName(pass = DEFAULT_REVIEW_PASS)`
 - `reviewPassRoot(paths, pass)`
-- `writeActiveCycle(paths, cycle)`
-- `writeCycleReceipt(paths, receiptName, message, { cycle = "" } = {})`
-- `writeReceipt(paths, stepId, message)`
+- `writeCycleStepRecord(paths, recordName, message, { cycle = "" } = {})`
+- `writeStepRecord(paths, stepId, message)`
 Local functions
 - `createWarning({ code, message, repairCommand = "" })`
+- `issueNumberFromUrl(issueUrl = "")`
 - `normalizeStepId(stepId)`
 - `stepIndex(stepId)`
 - `normalizeKnownStepIds(stepIds = [])`
@@ -1104,9 +1104,6 @@ Local functions
 - `readWorkflowVersion(paths)`
 - `cycleStepsRoot(paths, cycle)`
 - `cycleRoot(paths, cycle)`
-- `cyclePlanPath(paths, cycle)`
-- `cyclePlanPromptFileName(cycle)`
-- `cyclePlanExecutionPromptFileName(cycle)`
 - `parseJsonFileIfExists(filePath)`
 - `readReviewPassNumbers(paths)`
 - `readReviewPassInfo(paths, pass)`
@@ -1114,7 +1111,6 @@ Local functions
 - `latestReviewPassIsPrompted(artifacts = {})`
 - `readPromptFromAbsolutePath(filePath = "")`
 - `readReviewPromptForStep(paths, artifacts = {})`
-- `promptArtifactForStep(paths, stepId)`
 - `readPromptForStep(paths, stepId, artifacts = {})`
 - `readStepFileNames(stepsRoot)`
 - `readCompletedSteps(paths)`
@@ -1132,14 +1128,14 @@ Local functions
 - `stepRepeatabilityContract(stepId)`
 - `publicStepDefinition(step, index)`
 - `stepIsRetryableWhenBlocked(stepId)`
-- `stepIsConditional(stepId)`
-- `activeCycleInfoFromArtifacts(artifacts = {})`
 - `uiCheckPromptedForStep(artifacts = {}, stepId = "")`
 - `skipReasonForStep(stepId, artifacts = {})`
 - `buildCurrentStepAction(stepId, artifacts = {})`
 - `rawCodexHandoff(stepId, artifacts = {})`
 - `buildCodexHandoff(stepId, artifacts = {})`
-- `buildNextCommand(sessionId, stepId)`
+- `stepCanExposeNextCommand(stepId, artifacts = {})`
+- `buildNextCommand(sessionId, stepId, artifacts = {})`
+- `buildStepActionCommands(sessionId, stepId, artifacts = {})`
 
 ### `src/server/sessionRuntime/worktrees.js`
 Exports

--- a/packages/agent-docs/site/guide/app-setup/initial-scaffolding.md
+++ b/packages/agent-docs/site/guide/app-setup/initial-scaffolding.md
@@ -303,8 +303,6 @@ import { createRouter, createWebHistory } from "vue-router/auto";
 import { routes } from "vue-router/auto-routes";
 import "vuetify/styles";
 import { createVuetify } from "vuetify";
-import * as components from "vuetify/components";
-import * as directives from "vuetify/directives";
 import { aliases as mdiAliases, mdi } from "vuetify/iconsets/mdi-svg";
 import { createSurfaceRuntime } from "@jskit-ai/kernel/shared/surface/runtime";
 import {
@@ -342,8 +340,6 @@ const { router, fallbackRoute } = createShellRouter({
 });
 
 const vuetify = createVuetify({
-  components,
-  directives,
   theme: {
     defaultTheme: "light"
   },
@@ -438,7 +434,7 @@ In the starter app, with only `home`, this is almost boring. It mostly means:
 
 In the plain starter scaffold there are still no package-defined client stores to use yet. Pinia is already there so later packages can add them without changing the app bootstrap. In the next chapters, `shell-web` adds shell stores such as `useShellLayoutStore()`, and `auth-web` later adds `useAuthStore()`.
 
-`createVuetify(...)` is the ordinary UI plugin setup. There is nothing especially JSKIT-specific there; it just makes Vuetify components, directives, theme settings, and icon aliases available to the app before the router is mounted.
+`createVuetify(...)` is the ordinary UI plugin setup. There is nothing especially JSKIT-specific there; it configures theme settings and icon aliases before the router is mounted. Vuetify components are auto-imported by `vite-plugin-vuetify`, so the scaffold does not register the full Vuetify component namespace in the client bundle.
 
 `bootInstalledClientModules` is the extension seam, meaning "this is the point where later-installed JSKIT packages get to join client startup". The confusing part is that it is not a normal file in your app. In `src/main.js` you import it from:
 

--- a/packages/assistant-core/package.descriptor.mjs
+++ b/packages/assistant-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-core",
-  version: "0.1.57",
+  version: "0.1.58",
   kind: "runtime",
   description: "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
   dependsOn: [
@@ -47,11 +47,11 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/http-runtime": "0.1.80",
-        "@jskit-ai/kernel": "0.1.81",
-        "@jskit-ai/resource-core": "0.1.26",
-        "@jskit-ai/resource-crud-core": "0.1.26",
-        "@jskit-ai/users-core": "0.1.91",
+        "@jskit-ai/http-runtime": "0.1.81",
+        "@jskit-ai/kernel": "0.1.82",
+        "@jskit-ai/resource-core": "0.1.27",
+        "@jskit-ai/resource-crud-core": "0.1.27",
+        "@jskit-ai/users-core": "0.1.92",
         "dompurify": "^3.3.3",
         "json-rest-schema": "1.x.x",
         "marked": "^17.0.4",

--- a/packages/assistant-core/package.json
+++ b/packages/assistant-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-core",
-  "version": "0.1.57",
+  "version": "0.1.58",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,12 +11,12 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.81",
-    "@jskit-ai/http-runtime": "0.1.80",
-    "@jskit-ai/kernel": "0.1.81",
-    "@jskit-ai/resource-crud-core": "0.1.26",
-    "@jskit-ai/resource-core": "0.1.26",
-    "@jskit-ai/users-core": "0.1.91",
+    "@jskit-ai/database-runtime": "0.1.82",
+    "@jskit-ai/http-runtime": "0.1.81",
+    "@jskit-ai/kernel": "0.1.82",
+    "@jskit-ai/resource-crud-core": "0.1.27",
+    "@jskit-ai/resource-core": "0.1.27",
+    "@jskit-ai/users-core": "0.1.92",
     "dompurify": "^3.3.3",
     "json-rest-schema": "1.x.x",
     "marked": "^17.0.4",

--- a/packages/assistant-runtime/package.descriptor.mjs
+++ b/packages/assistant-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-runtime",
-  version: "0.1.52",
+  version: "0.1.53",
   kind: "runtime",
   description: "Shared assistant runtime with per-surface assistant registration.",
   dependsOn: [
@@ -95,13 +95,13 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/assistant-core": "0.1.57",
-        "@jskit-ai/database-runtime": "0.1.81",
-        "@jskit-ai/http-runtime": "0.1.80",
-        "@jskit-ai/kernel": "0.1.81",
-        "@jskit-ai/shell-web": "0.1.80",
-        "@jskit-ai/users-core": "0.1.91",
-        "@jskit-ai/users-web": "0.1.96"
+        "@jskit-ai/assistant-core": "0.1.58",
+        "@jskit-ai/database-runtime": "0.1.82",
+        "@jskit-ai/http-runtime": "0.1.81",
+        "@jskit-ai/kernel": "0.1.82",
+        "@jskit-ai/shell-web": "0.1.81",
+        "@jskit-ai/users-core": "0.1.92",
+        "@jskit-ai/users-web": "0.1.97"
       },
       dev: {}
     },

--- a/packages/assistant-runtime/package.json
+++ b/packages/assistant-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-runtime",
-  "version": "0.1.52",
+  "version": "0.1.53",
   "type": "module",
   "exports": {
     "./client": "./src/client/index.js",
@@ -8,13 +8,13 @@
     "./server/actionIds": "./src/server/actionIds.js"
   },
   "dependencies": {
-    "@jskit-ai/assistant-core": "0.1.57",
-    "@jskit-ai/database-runtime": "0.1.81",
-    "@jskit-ai/http-runtime": "0.1.80",
-    "@jskit-ai/kernel": "0.1.81",
-    "@jskit-ai/shell-web": "0.1.80",
-    "@jskit-ai/users-core": "0.1.91",
-    "@jskit-ai/users-web": "0.1.96",
+    "@jskit-ai/assistant-core": "0.1.58",
+    "@jskit-ai/database-runtime": "0.1.82",
+    "@jskit-ai/http-runtime": "0.1.81",
+    "@jskit-ai/kernel": "0.1.82",
+    "@jskit-ai/shell-web": "0.1.81",
+    "@jskit-ai/users-core": "0.1.92",
+    "@jskit-ai/users-web": "0.1.97",
     "json-rest-schema": "1.x.x"
   },
   "peerDependencies": {

--- a/packages/assistant/package.descriptor.mjs
+++ b/packages/assistant/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant",
-  version: "0.1.90",
+  version: "0.1.91",
   kind: "generator",
   description: "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
   options: {

--- a/packages/assistant/package.json
+++ b/packages/assistant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant",
-  "version": "0.1.90",
+  "version": "0.1.91",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.81"
+    "@jskit-ai/kernel": "0.1.82"
   }
 }

--- a/packages/auth-core/package.descriptor.mjs
+++ b/packages/auth-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-core",
-  "version": "0.1.80",
+  "version": "0.1.81",
   "kind": "runtime",
   "dependsOn": [
     "@jskit-ai/value-app-config-shared"
@@ -69,7 +69,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.81",
+        "@jskit-ai/kernel": "0.1.82",
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0"

--- a/packages/auth-core/package.json
+++ b/packages/auth-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-core",
-  "version": "0.1.80",
+  "version": "0.1.81",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -46,7 +46,7 @@
     "./shared/commands/authSessionReadCommand": "./src/shared/commands/authSessionReadCommand.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.81",
+    "@jskit-ai/kernel": "0.1.82",
     "@fastify/cookie": "^11.0.2",
     "@fastify/csrf-protection": "^7.1.0",
     "@fastify/rate-limit": "^10.3.0",

--- a/packages/auth-provider-supabase-core/package.descriptor.mjs
+++ b/packages/auth-provider-supabase-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.80",
+  "version": "0.1.81",
   "kind": "runtime",
   "options": {
     "auth-supabase-url": {
@@ -83,8 +83,8 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/auth-core": "0.1.80",
-        "@jskit-ai/kernel": "0.1.81",
+        "@jskit-ai/auth-core": "0.1.81",
+        "@jskit-ai/kernel": "0.1.82",
         "dotenv": "^16.4.5",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0"

--- a/packages/auth-provider-supabase-core/package.json
+++ b/packages/auth-provider-supabase-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.80",
+  "version": "0.1.81",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,8 +12,8 @@
     "./client": "./src/client/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.80",
-    "@jskit-ai/kernel": "0.1.81",
+    "@jskit-ai/auth-core": "0.1.81",
+    "@jskit-ai/kernel": "0.1.82",
     "json-rest-schema": "1.x.x",
     "jose": "^6.1.0",
     "@supabase/supabase-js": "^2.57.4",

--- a/packages/auth-web/package.descriptor.mjs
+++ b/packages/auth-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-web",
-  "version": "0.1.82",
+  "version": "0.1.83",
   "kind": "runtime",
   "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
   "dependsOn": [
@@ -247,10 +247,10 @@ export default Object.freeze({
     "dependencies": {
       "runtime": {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/auth-core": "0.1.80",
-        "@jskit-ai/http-runtime": "0.1.80",
-        "@jskit-ai/kernel": "0.1.81",
-        "@jskit-ai/shell-web": "0.1.80"
+        "@jskit-ai/auth-core": "0.1.81",
+        "@jskit-ai/http-runtime": "0.1.81",
+        "@jskit-ai/kernel": "0.1.82",
+        "@jskit-ai/shell-web": "0.1.81"
       },
       "dev": {}
     },

--- a/packages/auth-web/package.json
+++ b/packages/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-web",
-  "version": "0.1.82",
+  "version": "0.1.83",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -18,11 +18,11 @@
     "./client/runtime/useSignOut": "./src/client/runtime/useSignOut.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.80",
+    "@jskit-ai/auth-core": "0.1.81",
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/kernel": "0.1.81",
-    "@jskit-ai/shell-web": "0.1.80",
-    "@jskit-ai/http-runtime": "0.1.80"
+    "@jskit-ai/kernel": "0.1.82",
+    "@jskit-ai/shell-web": "0.1.81",
+    "@jskit-ai/http-runtime": "0.1.81"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/console-core/package.descriptor.mjs
+++ b/packages/console-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-core",
-  version: "0.1.44",
+  version: "0.1.45",
   kind: "runtime",
   description: "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
   dependsOn: [
@@ -85,12 +85,12 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.80",
-        "@jskit-ai/database-runtime": "0.1.81",
-        "@jskit-ai/http-runtime": "0.1.80",
-        "@jskit-ai/kernel": "0.1.81",
-        "@jskit-ai/resource-crud-core": "0.1.26",
-        "@jskit-ai/users-core": "0.1.91"
+        "@jskit-ai/auth-core": "0.1.81",
+        "@jskit-ai/database-runtime": "0.1.82",
+        "@jskit-ai/http-runtime": "0.1.81",
+        "@jskit-ai/kernel": "0.1.82",
+        "@jskit-ai/resource-crud-core": "0.1.27",
+        "@jskit-ai/users-core": "0.1.92"
       },
       dev: {}
     },

--- a/packages/console-core/package.json
+++ b/packages/console-core/package.json
@@ -1,17 +1,17 @@
 {
   "name": "@jskit-ai/console-core",
-  "version": "0.1.44",
+  "version": "0.1.45",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.80",
-    "@jskit-ai/database-runtime": "0.1.81",
-    "@jskit-ai/http-runtime": "0.1.80",
-    "@jskit-ai/kernel": "0.1.81",
-    "@jskit-ai/resource-crud-core": "0.1.26",
-    "@jskit-ai/users-core": "0.1.91",
+    "@jskit-ai/auth-core": "0.1.81",
+    "@jskit-ai/database-runtime": "0.1.82",
+    "@jskit-ai/http-runtime": "0.1.81",
+    "@jskit-ai/kernel": "0.1.82",
+    "@jskit-ai/resource-crud-core": "0.1.27",
+    "@jskit-ai/users-core": "0.1.92",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/console-web/package.descriptor.mjs
+++ b/packages/console-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-web",
-  version: "0.1.49",
+  version: "0.1.50",
   kind: "runtime",
   description: "Authenticated console surface scaffold and surface policy wiring.",
   dependsOn: [
@@ -103,9 +103,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-web": "0.1.82",
-        "@jskit-ai/console-core": "0.1.44",
-        "@jskit-ai/shell-web": "0.1.80",
+        "@jskit-ai/auth-web": "0.1.83",
+        "@jskit-ai/console-core": "0.1.45",
+        "@jskit-ai/shell-web": "0.1.81",
       },
       dev: {}
     },

--- a/packages/console-web/package.json
+++ b/packages/console-web/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/console-web",
-  "version": "0.1.49",
+  "version": "0.1.50",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-web": "0.1.82",
-    "@jskit-ai/console-core": "0.1.44",
-    "@jskit-ai/shell-web": "0.1.80"
+    "@jskit-ai/auth-web": "0.1.83",
+    "@jskit-ai/console-core": "0.1.45",
+    "@jskit-ai/shell-web": "0.1.81"
   }
 }

--- a/packages/crud-core/package.descriptor.mjs
+++ b/packages/crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-core",
-  version: "0.1.89",
+  version: "0.1.90",
   kind: "runtime",
   description: "Shared CRUD helpers used by CRUD modules.",
   dependsOn: [
@@ -28,7 +28,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/crud-core": "0.1.89"
+        "@jskit-ai/crud-core": "0.1.90"
       },
       dev: {}
     },

--- a/packages/crud-core/package.json
+++ b/packages/crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-core",
-  "version": "0.1.89",
+  "version": "0.1.90",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -27,15 +27,15 @@
     "./server/routeContracts": "./src/server/routeContracts.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.81",
-    "@jskit-ai/http-runtime": "0.1.80",
-    "@jskit-ai/kernel": "0.1.81",
+    "@jskit-ai/database-runtime": "0.1.82",
+    "@jskit-ai/http-runtime": "0.1.81",
+    "@jskit-ai/kernel": "0.1.82",
     "json-rest-schema": "1.x.x",
-    "@jskit-ai/realtime": "0.1.80",
-    "@jskit-ai/resource-crud-core": "0.1.26",
-    "@jskit-ai/shell-web": "0.1.80",
-    "@jskit-ai/users-core": "0.1.91",
-    "@jskit-ai/users-web": "0.1.96"
+    "@jskit-ai/realtime": "0.1.81",
+    "@jskit-ai/resource-crud-core": "0.1.27",
+    "@jskit-ai/shell-web": "0.1.81",
+    "@jskit-ai/users-core": "0.1.92",
+    "@jskit-ai/users-web": "0.1.97"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/crud-server-generator/package.descriptor.mjs
+++ b/packages/crud-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-server-generator",
-  version: "0.1.89",
+  version: "0.1.90",
   kind: "generator",
   description: "CRUD server generator with routes, actions, and persistence scaffolding.",
   options: {
@@ -160,14 +160,14 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.80",
-        "@jskit-ai/crud-core": "0.1.89",
-        "@jskit-ai/database-runtime": "0.1.81",
-        "@jskit-ai/http-runtime": "0.1.80",
-        "@jskit-ai/json-rest-api-core": "0.1.26",
-        "@jskit-ai/kernel": "0.1.81",
-        "@jskit-ai/realtime": "0.1.80",
-        "@jskit-ai/resource-crud-core": "0.1.26",
+        "@jskit-ai/auth-core": "0.1.81",
+        "@jskit-ai/crud-core": "0.1.90",
+        "@jskit-ai/database-runtime": "0.1.82",
+        "@jskit-ai/http-runtime": "0.1.81",
+        "@jskit-ai/json-rest-api-core": "0.1.27",
+        "@jskit-ai/kernel": "0.1.82",
+        "@jskit-ai/realtime": "0.1.81",
+        "@jskit-ai/resource-crud-core": "0.1.27",
         "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}"
       },
       dev: {}

--- a/packages/crud-server-generator/package.json
+++ b/packages/crud-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-server-generator",
-  "version": "0.1.89",
+  "version": "0.1.90",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,12 +13,12 @@
   },
   "dependencies": {
     "@babel/parser": "^7.29.2",
-    "@jskit-ai/crud-core": "0.1.89",
-    "@jskit-ai/database-runtime": "0.1.81",
-    "@jskit-ai/http-runtime": "0.1.80",
-    "@jskit-ai/json-rest-api-core": "0.1.26",
-    "@jskit-ai/kernel": "0.1.81",
-    "@jskit-ai/resource-crud-core": "0.1.26",
+    "@jskit-ai/crud-core": "0.1.90",
+    "@jskit-ai/database-runtime": "0.1.82",
+    "@jskit-ai/http-runtime": "0.1.81",
+    "@jskit-ai/json-rest-api-core": "0.1.27",
+    "@jskit-ai/kernel": "0.1.82",
+    "@jskit-ai/resource-crud-core": "0.1.27",
     "recast": "^0.23.11"
   }
 }

--- a/packages/crud-ui-generator/package.descriptor.mjs
+++ b/packages/crud-ui-generator/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { GENERATED_UI_NAVIGATION_ROLE_OPTION } from "@jskit-ai/kernel/shared/sup
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-ui-generator",
-  version: "0.1.64",
+  version: "0.1.65",
   kind: "generator",
   description: "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
   options: {
@@ -175,7 +175,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.96"
+        "@jskit-ai/users-web": "0.1.97"
       },
       dev: {}
     },

--- a/packages/crud-ui-generator/package.json
+++ b/packages/crud-ui-generator/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@jskit-ai/crud-ui-generator",
-  "version": "0.1.64",
+  "version": "0.1.65",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/crud-core": "0.1.89",
-    "@jskit-ai/kernel": "0.1.81",
-    "@jskit-ai/resource-crud-core": "0.1.26"
+    "@jskit-ai/crud-core": "0.1.90",
+    "@jskit-ai/kernel": "0.1.82",
+    "@jskit-ai/resource-crud-core": "0.1.27"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/database-runtime-mysql/package.descriptor.mjs
+++ b/packages/database-runtime-mysql/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-mysql",
-  version: "0.1.80",
+  version: "0.1.81",
   kind: "runtime",
   options: {
     "db-host": {
@@ -91,7 +91,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.81",
+        "@jskit-ai/database-runtime": "0.1.82",
         "mysql2": "^3.11.2"
       },
       dev: {}

--- a/packages/database-runtime-mysql/package.json
+++ b/packages/database-runtime-mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-mysql",
-  "version": "0.1.80",
+  "version": "0.1.81",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,7 +12,7 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.81",
-    "@jskit-ai/kernel": "0.1.81"
+    "@jskit-ai/database-runtime": "0.1.82",
+    "@jskit-ai/kernel": "0.1.82"
   }
 }

--- a/packages/database-runtime-postgres/package.descriptor.mjs
+++ b/packages/database-runtime-postgres/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-postgres",
-  version: "0.1.80",
+  version: "0.1.81",
   kind: "runtime",
   options: {
     "db-host": {
@@ -91,7 +91,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.81",
+        "@jskit-ai/database-runtime": "0.1.82",
         "pg": "^8.13.1"
       },
       dev: {}

--- a/packages/database-runtime-postgres/package.json
+++ b/packages/database-runtime-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-postgres",
-  "version": "0.1.80",
+  "version": "0.1.81",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,6 +12,6 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.81"
+    "@jskit-ai/database-runtime": "0.1.82"
   }
 }

--- a/packages/database-runtime/package.descriptor.mjs
+++ b/packages/database-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime",
-  version: "0.1.81",
+  version: "0.1.82",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -58,7 +58,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.81",
+        "@jskit-ai/kernel": "0.1.82",
         "dotenv": "^16.4.5",
         "knex": "^3.1.0"
       },

--- a/packages/database-runtime/package.json
+++ b/packages/database-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime",
-  "version": "0.1.81",
+  "version": "0.1.82",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -25,6 +25,6 @@
     "./shared/transactions": "./src/shared/transactions.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.81"
+    "@jskit-ai/kernel": "0.1.82"
   }
 }

--- a/packages/feature-server-generator/package.descriptor.mjs
+++ b/packages/feature-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/feature-server-generator",
-  version: "0.1.23",
+  version: "0.1.24",
   kind: "generator",
   description: "Scaffold substantial non-CRUD server feature packages with provider, actions, service, and optional persistence seams.",
   options: {
@@ -174,7 +174,7 @@ export default Object.freeze({
             equals: "json-rest"
           }
         },
-        "@jskit-ai/kernel": "0.1.81",
+        "@jskit-ai/kernel": "0.1.82",
         "json-rest-schema": "1.x.x",
         "@local/${option:feature-name|kebab}": "file:packages/${option:feature-name|kebab}"
       },

--- a/packages/feature-server-generator/package.json
+++ b/packages/feature-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/feature-server-generator",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "type": "module",
   "scripts": {
     "test": "node --test"

--- a/packages/google-rewarded-core/package.descriptor.mjs
+++ b/packages/google-rewarded-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/google-rewarded-core",
-  version: "0.1.18",
+  version: "0.1.19",
   kind: "runtime",
   description: "Google rewarded workflow runtime plus internal CRUD providers for rules, provider configs, watch sessions, and unlock receipts.",
   dependsOn: [
@@ -128,14 +128,14 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.80",
-        "@jskit-ai/crud-core": "0.1.89",
-        "@jskit-ai/database-runtime": "0.1.81",
-        "@jskit-ai/http-runtime": "0.1.80",
-        "@jskit-ai/json-rest-api-core": "0.1.26",
-        "@jskit-ai/kernel": "0.1.81",
-        "@jskit-ai/resource-crud-core": "0.1.26",
-        "@jskit-ai/workspaces-core": "0.1.57"
+        "@jskit-ai/auth-core": "0.1.81",
+        "@jskit-ai/crud-core": "0.1.90",
+        "@jskit-ai/database-runtime": "0.1.82",
+        "@jskit-ai/http-runtime": "0.1.81",
+        "@jskit-ai/json-rest-api-core": "0.1.27",
+        "@jskit-ai/kernel": "0.1.82",
+        "@jskit-ai/resource-crud-core": "0.1.27",
+        "@jskit-ai/workspaces-core": "0.1.58"
       },
       dev: {}
     },

--- a/packages/google-rewarded-core/package.json
+++ b/packages/google-rewarded-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/google-rewarded-core",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/google-rewarded-web/package.descriptor.mjs
+++ b/packages/google-rewarded-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/google-rewarded-web",
-  version: "0.1.18",
+  version: "0.1.19",
   kind: "runtime",
   description: "Google rewarded client runtime with a fullscreen gate host and GPT orchestration.",
   dependsOn: [
@@ -46,10 +46,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/google-rewarded-core": "0.1.18",
-        "@jskit-ai/http-runtime": "0.1.80",
-        "@jskit-ai/kernel": "0.1.81",
-        "@jskit-ai/shell-web": "0.1.80"
+        "@jskit-ai/google-rewarded-core": "0.1.19",
+        "@jskit-ai/http-runtime": "0.1.81",
+        "@jskit-ai/kernel": "0.1.82",
+        "@jskit-ai/shell-web": "0.1.81"
       },
       dev: {}
     },

--- a/packages/google-rewarded-web/package.json
+++ b/packages/google-rewarded-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/google-rewarded-web",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/http-runtime/package.descriptor.mjs
+++ b/packages/http-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/http-runtime",
-  "version": "0.1.80",
+  "version": "0.1.81",
   "kind": "runtime",
   "dependsOn": [],
   "capabilities": {
@@ -67,7 +67,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.81"
+        "@jskit-ai/kernel": "0.1.82"
       },
       "dev": {}
     },

--- a/packages/http-runtime/package.json
+++ b/packages/http-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/http-runtime",
-  "version": "0.1.80",
+  "version": "0.1.81",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -18,7 +18,7 @@
     "./shared/validators/operationValidation": "./src/shared/validators/operationValidation.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.81",
+    "@jskit-ai/kernel": "0.1.82",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/json-rest-api-core/package.descriptor.mjs
+++ b/packages/json-rest-api-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/json-rest-api-core",
-  version: "0.1.26",
+  version: "0.1.27",
   kind: "runtime",
   description: "Shared internal json-rest-api host runtime for JSKIT server packages.",
   dependsOn: [

--- a/packages/json-rest-api-core/package.json
+++ b/packages/json-rest-api-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/json-rest-api-core",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,6 +11,6 @@
   "dependencies": {
     "hooked-api": "1.x.x",
     "json-rest-api": "1.x.x",
-    "@jskit-ai/kernel": "0.1.81"
+    "@jskit-ai/kernel": "0.1.82"
   }
 }

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/kernel",
-  "version": "0.1.81",
+  "version": "0.1.82",
   "type": "module",
   "dependencies": {
     "json-rest-schema": "1.x.x"

--- a/packages/mobile-capacitor/package.descriptor.mjs
+++ b/packages/mobile-capacitor/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/mobile-capacitor",
-  version: "0.1.18",
+  version: "0.1.19",
   kind: "runtime",
   description: "Thin Capacitor client integration for JSKIT mobile-shell launch routing and auth callback completion.",
   dependsOn: [
@@ -62,8 +62,8 @@ export default Object.freeze({
         "@capacitor/app": "^7.1.0",
         "@capacitor/browser": "^7.0.1",
         "@capacitor/core": "^7.4.3",
-        "@jskit-ai/kernel": "0.1.81",
-        "@jskit-ai/shell-web": "0.1.80"
+        "@jskit-ai/kernel": "0.1.82",
+        "@jskit-ai/shell-web": "0.1.81"
       },
       dev: {
         "@capacitor/cli": "^7.4.3"

--- a/packages/mobile-capacitor/package.json
+++ b/packages/mobile-capacitor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/mobile-capacitor",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,6 +12,6 @@
   },
   "dependencies": {
     "@capacitor/browser": "^7.0.1",
-    "@jskit-ai/kernel": "0.1.81"
+    "@jskit-ai/kernel": "0.1.82"
   }
 }

--- a/packages/realtime/package.descriptor.mjs
+++ b/packages/realtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/realtime",
-  version: "0.1.80",
+  version: "0.1.81",
   kind: "runtime",
   description: "Thin, generic realtime runtime wrappers for socket.io server and client.",
   options: {
@@ -95,7 +95,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.81",
+        "@jskit-ai/kernel": "0.1.82",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/realtime",
-  "version": "0.1.80",
+  "version": "0.1.81",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@socket.io/redis-adapter": "^8.3.0",
-    "@jskit-ai/kernel": "0.1.81",
+    "@jskit-ai/kernel": "0.1.82",
     "redis": "^5.8.2",
     "socket.io": "^4.8.3",
     "socket.io-client": "^4.8.3"

--- a/packages/resource-core/package.descriptor.mjs
+++ b/packages/resource-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/resource-core",
-  version: "0.1.26",
+  version: "0.1.27",
   kind: "runtime",
   description: "Generic resource-definition helpers and schema-definition normalization.",
   dependsOn: [
@@ -22,7 +22,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/resource-core": "0.1.26"
+        "@jskit-ai/resource-core": "0.1.27"
       },
       dev: {}
     },

--- a/packages/resource-core/package.json
+++ b/packages/resource-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/resource-core",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./shared/resource": "./src/shared/resource.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.81"
+    "@jskit-ai/kernel": "0.1.82"
   }
 }

--- a/packages/resource-crud-core/package.descriptor.mjs
+++ b/packages/resource-crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/resource-crud-core",
-  version: "0.1.26",
+  version: "0.1.27",
   kind: "runtime",
   description: "CRUD-specific resource-definition helpers and namespace support.",
   dependsOn: [
@@ -23,7 +23,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/resource-crud-core": "0.1.26"
+        "@jskit-ai/resource-crud-core": "0.1.27"
       },
       dev: {}
     },

--- a/packages/resource-crud-core/package.json
+++ b/packages/resource-crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/resource-crud-core",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./shared/crudResource": "./src/shared/crudResource.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.81",
-    "@jskit-ai/resource-core": "0.1.26"
+    "@jskit-ai/kernel": "0.1.82",
+    "@jskit-ai/resource-core": "0.1.27"
   }
 }

--- a/packages/shell-web/package.descriptor.mjs
+++ b/packages/shell-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/shell-web",
-  version: "0.1.80",
+  version: "0.1.81",
   kind: "runtime",
   description: "Web shell layout runtime with outlet-based placement contributions.",
   dependsOn: [],
@@ -291,7 +291,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/kernel": "0.1.81"
+        "@jskit-ai/kernel": "0.1.82"
       },
       dev: {}
     },

--- a/packages/shell-web/package.json
+++ b/packages/shell-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/shell-web",
-  "version": "0.1.80",
+  "version": "0.1.81",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/kernel": "0.1.81"
+    "@jskit-ai/kernel": "0.1.82"
   },
   "peerDependencies": {
     "pinia": "^3.0.4",

--- a/packages/shell-web/src/client/lib/menuIcons.js
+++ b/packages/shell-web/src/client/lib/menuIcons.js
@@ -1,4 +1,3 @@
-import * as mdiIcons from "@mdi/js";
 import {
   mdiAccountCircleOutline,
   mdiAccountCogOutline,
@@ -27,6 +26,24 @@ const SURFACE_SWITCH_ICON_BY_ID = Object.freeze({
   console: mdiConsoleNetworkOutline
 });
 
+const SUPPORTED_EXPLICIT_MDI_ICON_BY_NAME = Object.freeze({
+  "mdi-account-circle-outline": mdiAccountCircleOutline,
+  "mdi-account-cog-outline": mdiAccountCogOutline,
+  "mdi-account-group-outline": mdiAccountGroupOutline,
+  "mdi-arrow-right-circle-outline": mdiArrowRightCircleOutline,
+  "mdi-clipboard-list-outline": mdiClipboardListOutline,
+  "mdi-cog-outline": mdiCogOutline,
+  "mdi-console-network-outline": mdiConsoleNetworkOutline,
+  "mdi-folder-outline": mdiFolderOutline,
+  "mdi-home-variant-outline": mdiHomeVariantOutline,
+  "mdi-login": mdiLogin,
+  "mdi-logout": mdiLogout,
+  "mdi-robot-outline": mdiRobotOutline,
+  "mdi-shield-crown-outline": mdiShieldCrownOutline,
+  "mdi-view-dashboard-outline": mdiViewDashboardOutline,
+  "mdi-view-list-outline": mdiViewListOutline
+});
+
 function resolveExplicitIconValue(explicitIcon = "") {
   const normalizedExplicitIcon = normalizeText(explicitIcon);
   if (!normalizedExplicitIcon) {
@@ -37,13 +54,7 @@ function resolveExplicitIconValue(explicitIcon = "") {
     return normalizedExplicitIcon;
   }
 
-  const iconKey = normalizedExplicitIcon
-    .slice("mdi-".length)
-    .split("-")
-    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
-    .join("");
-  const exportName = `mdi${iconKey}`;
-  const resolvedIcon = mdiIcons[exportName];
+  const resolvedIcon = SUPPORTED_EXPLICIT_MDI_ICON_BY_NAME[normalizedExplicitIcon];
   return typeof resolvedIcon === "string" && resolvedIcon ? resolvedIcon : normalizedExplicitIcon;
 }
 

--- a/packages/shell-web/test/menuIcons.test.js
+++ b/packages/shell-web/test/menuIcons.test.js
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import test from "node:test";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import {
+  mdiCogOutline,
+  mdiConsoleNetworkOutline,
+  mdiViewListOutline
+} from "@mdi/js";
+import {
+  resolveMenuLinkIcon,
+  resolveSurfaceSwitchIcon
+} from "../src/client/lib/menuIcons.js";
+
+const TEST_DIRECTORY = path.dirname(fileURLToPath(import.meta.url));
+const PACKAGE_DIR = path.resolve(TEST_DIRECTORY, "..");
+
+test("shell-web resolves supported explicit mdi metadata icons from a finite map", () => {
+  assert.equal(resolveMenuLinkIcon({ icon: "mdi-view-list-outline" }), mdiViewListOutline);
+  assert.equal(resolveMenuLinkIcon({ icon: "mdi-cog-outline" }), mdiCogOutline);
+  assert.equal(
+    resolveSurfaceSwitchIcon("home", "mdi-console-network-outline"),
+    mdiConsoleNetworkOutline
+  );
+});
+
+test("shell-web leaves unknown explicit mdi metadata icons unchanged", () => {
+  assert.equal(resolveMenuLinkIcon({ icon: "mdi-not-a-real-supported-icon" }), "mdi-not-a-real-supported-icon");
+});
+
+test("shell-web menu icon resolution does not import the full mdi namespace", async () => {
+  const source = await readFile(path.join(PACKAGE_DIR, "src", "client", "lib", "menuIcons.js"), "utf8");
+
+  assert.doesNotMatch(source, /import\s+\*\s+as\s+mdiIcons\s+from\s+["']@mdi\/js["']/);
+  assert.doesNotMatch(source, /mdiIcons\[/);
+});

--- a/packages/storage-runtime/package.descriptor.mjs
+++ b/packages/storage-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/storage-runtime",
-  version: "0.1.80",
+  version: "0.1.81",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -50,7 +50,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.81",
+        "@jskit-ai/kernel": "0.1.82",
         "unstorage": "^1.17.3"
       },
       dev: {}

--- a/packages/storage-runtime/package.json
+++ b/packages/storage-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/storage-runtime",
-  "version": "0.1.80",
+  "version": "0.1.81",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./server/providers/StorageRuntimeServiceProvider": "./src/server/providers/StorageRuntimeServiceProvider.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.81",
+    "@jskit-ai/kernel": "0.1.82",
     "unstorage": "^1.17.3"
   }
 }

--- a/packages/ui-generator/package.descriptor.mjs
+++ b/packages/ui-generator/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { GENERATED_UI_NAVIGATION_ROLE_OPTION } from "@jskit-ai/kernel/shared/sup
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/ui-generator",
-  version: "0.1.64",
+  version: "0.1.65",
   kind: "generator",
   description: "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
   options: {
@@ -371,7 +371,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.96"
+        "@jskit-ai/users-web": "0.1.97"
       },
       dev: {}
     },

--- a/packages/ui-generator/package.json
+++ b/packages/ui-generator/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/ui-generator",
-  "version": "0.1.64",
+  "version": "0.1.65",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.81",
-    "@jskit-ai/shell-web": "0.1.80"
+    "@jskit-ai/kernel": "0.1.82",
+    "@jskit-ai/shell-web": "0.1.81"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/uploads-image-web/package.descriptor.mjs
+++ b/packages/uploads-image-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-image-web",
-  version: "0.1.59",
+  version: "0.1.60",
   kind: "runtime",
   description: "Reusable client-side image upload runtime with pre-upload image editing.",
   dependsOn: [
@@ -65,7 +65,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/uploads-runtime": "0.1.59",
+        "@jskit-ai/uploads-runtime": "0.1.60",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-image-web/package.json
+++ b/packages/uploads-image-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-image-web",
-  "version": "0.1.59",
+  "version": "0.1.60",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,7 +13,7 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/uploads-runtime": "0.1.59",
+    "@jskit-ai/uploads-runtime": "0.1.60",
     "@uppy/compressor": "^3.1.0",
     "@uppy/core": "^5.2.0",
     "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-runtime/package.descriptor.mjs
+++ b/packages/uploads-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-runtime",
-  version: "0.1.59",
+  version: "0.1.60",
   kind: "runtime",
   description: "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
   dependsOn: [
@@ -71,7 +71,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.81"
+        "@jskit-ai/kernel": "0.1.82"
       },
       dev: {}
     },

--- a/packages/uploads-runtime/package.json
+++ b/packages/uploads-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-runtime",
-  "version": "0.1.59",
+  "version": "0.1.60",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,6 +16,6 @@
   },
   "dependencies": {
     "@fastify/multipart": "^9.4.0",
-    "@jskit-ai/kernel": "0.1.81"
+    "@jskit-ai/kernel": "0.1.82"
   }
 }

--- a/packages/users-core/package.descriptor.mjs
+++ b/packages/users-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-core",
-  version: "0.1.91",
+  version: "0.1.92",
   kind: "runtime",
   description: "Users/account runtime plus HTTP routes for account features.",
   dependsOn: [
@@ -143,16 +143,16 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.80",
-        "@jskit-ai/crud-core": "0.1.89",
-        "@jskit-ai/database-runtime": "0.1.81",
-        "@jskit-ai/http-runtime": "0.1.80",
-        "@jskit-ai/json-rest-api-core": "0.1.26",
-        "@jskit-ai/kernel": "0.1.81",
-        "@jskit-ai/resource-core": "0.1.26",
-        "@jskit-ai/resource-crud-core": "0.1.26",
+        "@jskit-ai/auth-core": "0.1.81",
+        "@jskit-ai/crud-core": "0.1.90",
+        "@jskit-ai/database-runtime": "0.1.82",
+        "@jskit-ai/http-runtime": "0.1.81",
+        "@jskit-ai/json-rest-api-core": "0.1.27",
+        "@jskit-ai/kernel": "0.1.82",
+        "@jskit-ai/resource-core": "0.1.27",
+        "@jskit-ai/resource-crud-core": "0.1.27",
         "@local/users": "file:packages/users",
-        "@jskit-ai/uploads-runtime": "0.1.59"
+        "@jskit-ai/uploads-runtime": "0.1.60"
       },
       dev: {}
     },

--- a/packages/users-core/package.json
+++ b/packages/users-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-core",
-  "version": "0.1.91",
+  "version": "0.1.92",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,14 +11,14 @@
     "./shared/resources/userSettingsResource": "./src/shared/resources/userSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.80",
-    "@jskit-ai/database-runtime": "0.1.81",
-    "@jskit-ai/http-runtime": "0.1.80",
-    "@jskit-ai/json-rest-api-core": "0.1.26",
-    "@jskit-ai/kernel": "0.1.81",
-    "@jskit-ai/resource-crud-core": "0.1.26",
-    "@jskit-ai/resource-core": "0.1.26",
-    "@jskit-ai/uploads-runtime": "0.1.59",
+    "@jskit-ai/auth-core": "0.1.81",
+    "@jskit-ai/database-runtime": "0.1.82",
+    "@jskit-ai/http-runtime": "0.1.81",
+    "@jskit-ai/json-rest-api-core": "0.1.27",
+    "@jskit-ai/kernel": "0.1.82",
+    "@jskit-ai/resource-crud-core": "0.1.27",
+    "@jskit-ai/resource-core": "0.1.27",
+    "@jskit-ai/uploads-runtime": "0.1.60",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/users-web/package.descriptor.mjs
+++ b/packages/users-web/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { HOME_COG_OUTLET } from "./src/shared/toolsOutletContracts.js";
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-web",
-  version: "0.1.96",
+  version: "0.1.97",
   kind: "runtime",
   description: "Users web module: account/profile UI plus shared users web widgets.",
   dependsOn: [
@@ -278,12 +278,12 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/http-runtime": "0.1.80",
-        "@jskit-ai/realtime": "0.1.80",
-        "@jskit-ai/kernel": "0.1.81",
-        "@jskit-ai/shell-web": "0.1.80",
-        "@jskit-ai/uploads-image-web": "0.1.59",
-        "@jskit-ai/users-core": "0.1.91"
+        "@jskit-ai/http-runtime": "0.1.81",
+        "@jskit-ai/realtime": "0.1.81",
+        "@jskit-ai/kernel": "0.1.82",
+        "@jskit-ai/shell-web": "0.1.81",
+        "@jskit-ai/uploads-image-web": "0.1.60",
+        "@jskit-ai/users-core": "0.1.92"
       },
       dev: {}
     },

--- a/packages/users-web/package.json
+++ b/packages/users-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-web",
-  "version": "0.1.96",
+  "version": "0.1.97",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -44,12 +44,12 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/http-runtime": "0.1.80",
-    "@jskit-ai/kernel": "0.1.81",
-    "@jskit-ai/realtime": "0.1.80",
-    "@jskit-ai/shell-web": "0.1.80",
-    "@jskit-ai/uploads-image-web": "0.1.59",
-    "@jskit-ai/users-core": "0.1.91"
+    "@jskit-ai/http-runtime": "0.1.81",
+    "@jskit-ai/kernel": "0.1.82",
+    "@jskit-ai/realtime": "0.1.81",
+    "@jskit-ai/shell-web": "0.1.81",
+    "@jskit-ai/uploads-image-web": "0.1.60",
+    "@jskit-ai/users-core": "0.1.92"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/workspaces-core/package.descriptor.mjs
+++ b/packages/workspaces-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-core",
-  version: "0.1.57",
+  version: "0.1.58",
   kind: "runtime",
   description: "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
   dependsOn: [
@@ -142,10 +142,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/json-rest-api-core": "0.1.26",
-        "@jskit-ai/resource-core": "0.1.26",
-        "@jskit-ai/resource-crud-core": "0.1.26",
-        "@jskit-ai/users-core": "0.1.91"
+        "@jskit-ai/json-rest-api-core": "0.1.27",
+        "@jskit-ai/resource-core": "0.1.27",
+        "@jskit-ai/resource-crud-core": "0.1.27",
+        "@jskit-ai/users-core": "0.1.92"
       },
       dev: {}
     },

--- a/packages/workspaces-core/package.json
+++ b/packages/workspaces-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-core",
-  "version": "0.1.57",
+  "version": "0.1.58",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -17,14 +17,14 @@
     "./shared/resources/workspaceSettingsResource": "./src/shared/resources/workspaceSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.80",
-    "@jskit-ai/database-runtime": "0.1.81",
-    "@jskit-ai/http-runtime": "0.1.80",
-    "@jskit-ai/json-rest-api-core": "0.1.26",
-    "@jskit-ai/kernel": "0.1.81",
-    "@jskit-ai/resource-crud-core": "0.1.26",
-    "@jskit-ai/resource-core": "0.1.26",
-    "@jskit-ai/users-core": "0.1.91",
+    "@jskit-ai/auth-core": "0.1.81",
+    "@jskit-ai/database-runtime": "0.1.82",
+    "@jskit-ai/http-runtime": "0.1.81",
+    "@jskit-ai/json-rest-api-core": "0.1.27",
+    "@jskit-ai/kernel": "0.1.82",
+    "@jskit-ai/resource-crud-core": "0.1.27",
+    "@jskit-ai/resource-core": "0.1.27",
+    "@jskit-ai/users-core": "0.1.92",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/workspaces-web/package.descriptor.mjs
+++ b/packages/workspaces-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-web",
-  version: "0.1.57",
+  version: "0.1.58",
   kind: "runtime",
   description: "Workspace web module: workspace selector, tools widget, workspace surfaces, and members/settings UI.",
   dependsOn: [
@@ -231,8 +231,8 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/workspaces-core": "0.1.57",
-        "@jskit-ai/users-web": "0.1.96"
+        "@jskit-ai/workspaces-core": "0.1.58",
+        "@jskit-ai/users-web": "0.1.97"
       },
       dev: {}
     },

--- a/packages/workspaces-web/package.json
+++ b/packages/workspaces-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-web",
-  "version": "0.1.57",
+  "version": "0.1.58",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -15,12 +15,12 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/http-runtime": "0.1.80",
-    "@jskit-ai/kernel": "0.1.81",
-    "@jskit-ai/shell-web": "0.1.80",
-    "@jskit-ai/users-core": "0.1.91",
-    "@jskit-ai/users-web": "0.1.96",
-    "@jskit-ai/workspaces-core": "0.1.57"
+    "@jskit-ai/http-runtime": "0.1.81",
+    "@jskit-ai/kernel": "0.1.82",
+    "@jskit-ai/shell-web": "0.1.81",
+    "@jskit-ai/users-core": "0.1.92",
+    "@jskit-ai/users-web": "0.1.97",
+    "@jskit-ai/workspaces-core": "0.1.58"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/tooling/config-eslint/package.json
+++ b/tooling/config-eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/config-eslint",
-  "version": "0.1.80",
+  "version": "0.1.81",
   "description": "Shared flat ESLint presets for JSKIT projects.",
   "type": "module",
   "files": [

--- a/tooling/create-app/package.descriptor.mjs
+++ b/tooling/create-app/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/create-app",
-  "version": "0.1.89",
+  "version": "0.1.90",
   "dependsOn": [],
   "capabilities": {
     "provides": [

--- a/tooling/create-app/package.json
+++ b/tooling/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/create-app",
-  "version": "0.1.89",
+  "version": "0.1.90",
   "description": "Scaffold minimal JSKIT app shells.",
   "type": "module",
   "files": [

--- a/tooling/create-app/templates/base-shell/package.json
+++ b/tooling/create-app/templates/base-shell/package.json
@@ -49,6 +49,7 @@
     "@vitejs/plugin-vue": "^5.2.1",
     "eslint": "^9.39.1",
     "vite": "^6.1.0",
+    "vite-plugin-vuetify": "^2.1.3",
     "vitest": "^4.0.18"
   }
 }

--- a/tooling/create-app/templates/base-shell/src/main.js
+++ b/tooling/create-app/templates/base-shell/src/main.js
@@ -5,8 +5,6 @@ import { createRouter, createWebHistory } from "vue-router/auto";
 import { routes } from "vue-router/auto-routes";
 import "vuetify/styles";
 import { createVuetify } from "vuetify";
-import * as components from "vuetify/components";
-import * as directives from "vuetify/directives";
 import { aliases as mdiAliases, mdi } from "vuetify/iconsets/mdi-svg";
 import App from "./App.vue";
 import NotFoundView from "./views/NotFound.vue";
@@ -44,8 +42,6 @@ const { router, fallbackRoute } = createShellRouter({
 });
 
 const vuetify = createVuetify({
-  components,
-  directives,
   theme: {
     defaultTheme: "light"
   },

--- a/tooling/create-app/templates/base-shell/vite.config.mjs
+++ b/tooling/create-app/templates/base-shell/vite.config.mjs
@@ -1,6 +1,7 @@
 import { fileURLToPath, URL } from "node:url";
 import { defineConfig } from "vite";
 import vue from "@vitejs/plugin-vue";
+import vuetify from "vite-plugin-vuetify";
 import VueRouter from "vue-router/vite";
 import { createJskitClientBootstrapPlugin } from "@jskit-ai/kernel/client/vite";
 import { loadViteDevProxyEntries, toPositiveInt } from "./vite.shared.mjs";
@@ -41,6 +42,9 @@ export default defineConfig({
       // beforeWriteFiles: reparentNestedChildrenToIndexOwners
     }),
     vue(),
+    vuetify({
+      autoImport: true
+    }),
     {
       name: "jskit-client-entry",
       transformIndexHtml(source) {

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -6,11 +6,11 @@
   "packages": [
     {
       "packageId": "@jskit-ai/assistant",
-      "version": "0.1.90",
+      "version": "0.1.91",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant",
-        "version": "0.1.90",
+        "version": "0.1.91",
         "kind": "generator",
         "description": "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
         "options": {
@@ -347,11 +347,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-core",
-      "version": "0.1.57",
+      "version": "0.1.58",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-core",
-        "version": "0.1.57",
+        "version": "0.1.58",
         "kind": "runtime",
         "description": "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
         "dependsOn": [
@@ -399,11 +399,11 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/http-runtime": "0.1.80",
-              "@jskit-ai/kernel": "0.1.81",
-              "@jskit-ai/resource-core": "0.1.26",
-              "@jskit-ai/resource-crud-core": "0.1.26",
-              "@jskit-ai/users-core": "0.1.91",
+              "@jskit-ai/http-runtime": "0.1.81",
+              "@jskit-ai/kernel": "0.1.82",
+              "@jskit-ai/resource-core": "0.1.27",
+              "@jskit-ai/resource-crud-core": "0.1.27",
+              "@jskit-ai/users-core": "0.1.92",
               "dompurify": "^3.3.3",
               "json-rest-schema": "1.x.x",
               "marked": "^17.0.4",
@@ -422,11 +422,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-runtime",
-      "version": "0.1.52",
+      "version": "0.1.53",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-runtime",
-        "version": "0.1.52",
+        "version": "0.1.53",
         "kind": "runtime",
         "description": "Shared assistant runtime with per-surface assistant registration.",
         "dependsOn": [
@@ -522,13 +522,13 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/assistant-core": "0.1.57",
-              "@jskit-ai/database-runtime": "0.1.81",
-              "@jskit-ai/http-runtime": "0.1.80",
-              "@jskit-ai/kernel": "0.1.81",
-              "@jskit-ai/shell-web": "0.1.80",
-              "@jskit-ai/users-core": "0.1.91",
-              "@jskit-ai/users-web": "0.1.96"
+              "@jskit-ai/assistant-core": "0.1.58",
+              "@jskit-ai/database-runtime": "0.1.82",
+              "@jskit-ai/http-runtime": "0.1.81",
+              "@jskit-ai/kernel": "0.1.82",
+              "@jskit-ai/shell-web": "0.1.81",
+              "@jskit-ai/users-core": "0.1.92",
+              "@jskit-ai/users-web": "0.1.97"
             },
             "dev": {}
           },
@@ -583,11 +583,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-core",
-      "version": "0.1.80",
+      "version": "0.1.81",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-core",
-        "version": "0.1.80",
+        "version": "0.1.81",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/value-app-config-shared"
@@ -655,7 +655,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.81",
+              "@jskit-ai/kernel": "0.1.82",
               "@fastify/cookie": "^11.0.2",
               "@fastify/csrf-protection": "^7.1.0",
               "@fastify/rate-limit": "^10.3.0"
@@ -673,11 +673,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.80",
+      "version": "0.1.81",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-supabase-core",
-        "version": "0.1.80",
+        "version": "0.1.81",
         "kind": "runtime",
         "options": {
           "auth-supabase-url": {
@@ -759,8 +759,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.80",
-              "@jskit-ai/kernel": "0.1.81",
+              "@jskit-ai/auth-core": "0.1.81",
+              "@jskit-ai/kernel": "0.1.82",
               "dotenv": "^16.4.5",
               "@supabase/supabase-js": "^2.57.4",
               "jose": "^6.1.0"
@@ -825,11 +825,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-web",
-      "version": "0.1.82",
+      "version": "0.1.83",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-web",
-        "version": "0.1.82",
+        "version": "0.1.83",
         "kind": "runtime",
         "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
         "dependsOn": [
@@ -1085,10 +1085,10 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/auth-core": "0.1.80",
-              "@jskit-ai/http-runtime": "0.1.80",
-              "@jskit-ai/kernel": "0.1.81",
-              "@jskit-ai/shell-web": "0.1.80"
+              "@jskit-ai/auth-core": "0.1.81",
+              "@jskit-ai/http-runtime": "0.1.81",
+              "@jskit-ai/kernel": "0.1.82",
+              "@jskit-ai/shell-web": "0.1.81"
             },
             "dev": {}
           },
@@ -1167,11 +1167,11 @@
     },
     {
       "packageId": "@jskit-ai/console-core",
-      "version": "0.1.44",
+      "version": "0.1.45",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-core",
-        "version": "0.1.44",
+        "version": "0.1.45",
         "kind": "runtime",
         "description": "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
         "dependsOn": [
@@ -1255,12 +1255,12 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.80",
-              "@jskit-ai/database-runtime": "0.1.81",
-              "@jskit-ai/http-runtime": "0.1.80",
-              "@jskit-ai/kernel": "0.1.81",
-              "@jskit-ai/resource-crud-core": "0.1.26",
-              "@jskit-ai/users-core": "0.1.91"
+              "@jskit-ai/auth-core": "0.1.81",
+              "@jskit-ai/database-runtime": "0.1.82",
+              "@jskit-ai/http-runtime": "0.1.81",
+              "@jskit-ai/kernel": "0.1.82",
+              "@jskit-ai/resource-crud-core": "0.1.27",
+              "@jskit-ai/users-core": "0.1.92"
             },
             "dev": {}
           },
@@ -1285,11 +1285,11 @@
     },
     {
       "packageId": "@jskit-ai/console-web",
-      "version": "0.1.49",
+      "version": "0.1.50",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-web",
-        "version": "0.1.49",
+        "version": "0.1.50",
         "kind": "runtime",
         "description": "Authenticated console surface scaffold and surface policy wiring.",
         "dependsOn": [
@@ -1399,9 +1399,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-web": "0.1.82",
-              "@jskit-ai/console-core": "0.1.44",
-              "@jskit-ai/shell-web": "0.1.80"
+              "@jskit-ai/auth-web": "0.1.83",
+              "@jskit-ai/console-core": "0.1.45",
+              "@jskit-ai/shell-web": "0.1.81"
             },
             "dev": {}
           },
@@ -1508,11 +1508,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-core",
-      "version": "0.1.89",
+      "version": "0.1.90",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-core",
-        "version": "0.1.89",
+        "version": "0.1.90",
         "kind": "runtime",
         "description": "Shared CRUD helpers used by CRUD modules.",
         "dependsOn": [
@@ -1541,7 +1541,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/crud-core": "0.1.89"
+              "@jskit-ai/crud-core": "0.1.90"
             },
             "dev": {}
           },
@@ -1555,11 +1555,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-server-generator",
-      "version": "0.1.89",
+      "version": "0.1.90",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-server-generator",
-        "version": "0.1.89",
+        "version": "0.1.90",
         "kind": "generator",
         "description": "CRUD server generator with routes, actions, and persistence scaffolding.",
         "options": {
@@ -1726,14 +1726,14 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.80",
-              "@jskit-ai/crud-core": "0.1.89",
-              "@jskit-ai/database-runtime": "0.1.81",
-              "@jskit-ai/http-runtime": "0.1.80",
-              "@jskit-ai/json-rest-api-core": "0.1.26",
-              "@jskit-ai/kernel": "0.1.81",
-              "@jskit-ai/realtime": "0.1.80",
-              "@jskit-ai/resource-crud-core": "0.1.26",
+              "@jskit-ai/auth-core": "0.1.81",
+              "@jskit-ai/crud-core": "0.1.90",
+              "@jskit-ai/database-runtime": "0.1.82",
+              "@jskit-ai/http-runtime": "0.1.81",
+              "@jskit-ai/json-rest-api-core": "0.1.27",
+              "@jskit-ai/kernel": "0.1.82",
+              "@jskit-ai/realtime": "0.1.81",
+              "@jskit-ai/resource-crud-core": "0.1.27",
               "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}"
             },
             "dev": {}
@@ -1865,11 +1865,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.64",
+      "version": "0.1.65",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-ui-generator",
-        "version": "0.1.64",
+        "version": "0.1.65",
         "kind": "generator",
         "description": "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
         "options": {
@@ -2068,7 +2068,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.96"
+              "@jskit-ai/users-web": "0.1.97"
             },
             "dev": {}
           },
@@ -2327,11 +2327,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime",
-      "version": "0.1.81",
+      "version": "0.1.82",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime",
-        "version": "0.1.81",
+        "version": "0.1.82",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -2388,7 +2388,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.81",
+              "@jskit-ai/kernel": "0.1.82",
               "dotenv": "^16.4.5",
               "knex": "^3.1.0"
             },
@@ -2423,11 +2423,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.80",
+      "version": "0.1.81",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-mysql",
-        "version": "0.1.80",
+        "version": "0.1.81",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -2517,7 +2517,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.81",
+              "@jskit-ai/database-runtime": "0.1.82",
               "mysql2": "^3.11.2"
             },
             "dev": {}
@@ -2588,11 +2588,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.80",
+      "version": "0.1.81",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-postgres",
-        "version": "0.1.80",
+        "version": "0.1.81",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -2682,7 +2682,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.81",
+              "@jskit-ai/database-runtime": "0.1.82",
               "pg": "^8.13.1"
             },
             "dev": {}
@@ -2753,11 +2753,11 @@
     },
     {
       "packageId": "@jskit-ai/feature-server-generator",
-      "version": "0.1.23",
+      "version": "0.1.24",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/feature-server-generator",
-        "version": "0.1.23",
+        "version": "0.1.24",
         "kind": "generator",
         "description": "Scaffold substantial non-CRUD server feature packages with provider, actions, service, and optional persistence seams.",
         "options": {
@@ -2942,7 +2942,7 @@
                   "equals": "json-rest"
                 }
               },
-              "@jskit-ai/kernel": "0.1.81",
+              "@jskit-ai/kernel": "0.1.82",
               "json-rest-schema": "1.x.x",
               "@local/${option:feature-name|kebab}": "file:packages/${option:feature-name|kebab}"
             },
@@ -3055,11 +3055,11 @@
     },
     {
       "packageId": "@jskit-ai/google-rewarded-core",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/google-rewarded-core",
-        "version": "0.1.18",
+        "version": "0.1.19",
         "kind": "runtime",
         "description": "Google rewarded workflow runtime plus internal CRUD providers for rules, provider configs, watch sessions, and unlock receipts.",
         "dependsOn": [
@@ -3186,14 +3186,14 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.80",
-              "@jskit-ai/crud-core": "0.1.89",
-              "@jskit-ai/database-runtime": "0.1.81",
-              "@jskit-ai/http-runtime": "0.1.80",
-              "@jskit-ai/json-rest-api-core": "0.1.26",
-              "@jskit-ai/kernel": "0.1.81",
-              "@jskit-ai/resource-crud-core": "0.1.26",
-              "@jskit-ai/workspaces-core": "0.1.57"
+              "@jskit-ai/auth-core": "0.1.81",
+              "@jskit-ai/crud-core": "0.1.90",
+              "@jskit-ai/database-runtime": "0.1.82",
+              "@jskit-ai/http-runtime": "0.1.81",
+              "@jskit-ai/json-rest-api-core": "0.1.27",
+              "@jskit-ai/kernel": "0.1.82",
+              "@jskit-ai/resource-crud-core": "0.1.27",
+              "@jskit-ai/workspaces-core": "0.1.58"
             },
             "dev": {}
           },
@@ -3245,11 +3245,11 @@
     },
     {
       "packageId": "@jskit-ai/google-rewarded-web",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/google-rewarded-web",
-        "version": "0.1.18",
+        "version": "0.1.19",
         "kind": "runtime",
         "description": "Google rewarded client runtime with a fullscreen gate host and GPT orchestration.",
         "dependsOn": [
@@ -3296,10 +3296,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/google-rewarded-core": "0.1.18",
-              "@jskit-ai/http-runtime": "0.1.80",
-              "@jskit-ai/kernel": "0.1.81",
-              "@jskit-ai/shell-web": "0.1.80"
+              "@jskit-ai/google-rewarded-core": "0.1.19",
+              "@jskit-ai/http-runtime": "0.1.81",
+              "@jskit-ai/kernel": "0.1.82",
+              "@jskit-ai/shell-web": "0.1.81"
             },
             "dev": {}
           },
@@ -3317,11 +3317,11 @@
     },
     {
       "packageId": "@jskit-ai/http-runtime",
-      "version": "0.1.80",
+      "version": "0.1.81",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/http-runtime",
-        "version": "0.1.80",
+        "version": "0.1.81",
         "kind": "runtime",
         "dependsOn": [],
         "capabilities": {
@@ -3387,7 +3387,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.81"
+              "@jskit-ai/kernel": "0.1.82"
             },
             "dev": {}
           },
@@ -3401,11 +3401,11 @@
     },
     {
       "packageId": "@jskit-ai/json-rest-api-core",
-      "version": "0.1.26",
+      "version": "0.1.27",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/json-rest-api-core",
-        "version": "0.1.26",
+        "version": "0.1.27",
         "kind": "runtime",
         "description": "Shared internal json-rest-api host runtime for JSKIT server packages.",
         "dependsOn": [
@@ -3465,11 +3465,11 @@
     },
     {
       "packageId": "@jskit-ai/mobile-capacitor",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/mobile-capacitor",
-        "version": "0.1.18",
+        "version": "0.1.19",
         "kind": "runtime",
         "description": "Thin Capacitor client integration for JSKIT mobile-shell launch routing and auth callback completion.",
         "dependsOn": [
@@ -3532,8 +3532,8 @@
               "@capacitor/app": "^7.1.0",
               "@capacitor/browser": "^7.0.1",
               "@capacitor/core": "^7.4.3",
-              "@jskit-ai/kernel": "0.1.81",
-              "@jskit-ai/shell-web": "0.1.80"
+              "@jskit-ai/kernel": "0.1.82",
+              "@jskit-ai/shell-web": "0.1.81"
             },
             "dev": {
               "@capacitor/cli": "^7.4.3"
@@ -3585,11 +3585,11 @@
     },
     {
       "packageId": "@jskit-ai/realtime",
-      "version": "0.1.80",
+      "version": "0.1.81",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/realtime",
-        "version": "0.1.80",
+        "version": "0.1.81",
         "kind": "runtime",
         "description": "Thin, generic realtime runtime wrappers for socket.io server and client.",
         "options": {
@@ -3685,7 +3685,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.81",
+              "@jskit-ai/kernel": "0.1.82",
               "@socket.io/redis-adapter": "^8.3.0",
               "redis": "^5.8.2",
               "socket.io": "^4.8.3",
@@ -3734,11 +3734,11 @@
     },
     {
       "packageId": "@jskit-ai/resource-core",
-      "version": "0.1.26",
+      "version": "0.1.27",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/resource-core",
-        "version": "0.1.26",
+        "version": "0.1.27",
         "kind": "runtime",
         "description": "Generic resource-definition helpers and schema-definition normalization.",
         "dependsOn": [
@@ -3761,7 +3761,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/resource-core": "0.1.26"
+              "@jskit-ai/resource-core": "0.1.27"
             },
             "dev": {}
           },
@@ -3776,11 +3776,11 @@
     },
     {
       "packageId": "@jskit-ai/resource-crud-core",
-      "version": "0.1.26",
+      "version": "0.1.27",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/resource-crud-core",
-        "version": "0.1.26",
+        "version": "0.1.27",
         "kind": "runtime",
         "description": "CRUD-specific resource-definition helpers and namespace support.",
         "dependsOn": [
@@ -3804,7 +3804,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/resource-crud-core": "0.1.26"
+              "@jskit-ai/resource-crud-core": "0.1.27"
             },
             "dev": {}
           },
@@ -3819,11 +3819,11 @@
     },
     {
       "packageId": "@jskit-ai/shell-web",
-      "version": "0.1.80",
+      "version": "0.1.81",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/shell-web",
-        "version": "0.1.80",
+        "version": "0.1.81",
         "kind": "runtime",
         "description": "Web shell layout runtime with outlet-based placement contributions.",
         "dependsOn": [],
@@ -4149,7 +4149,7 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/kernel": "0.1.81"
+              "@jskit-ai/kernel": "0.1.82"
             },
             "dev": {}
           },
@@ -4349,11 +4349,11 @@
     },
     {
       "packageId": "@jskit-ai/storage-runtime",
-      "version": "0.1.80",
+      "version": "0.1.81",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/storage-runtime",
-        "version": "0.1.80",
+        "version": "0.1.81",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -4402,7 +4402,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.81",
+              "@jskit-ai/kernel": "0.1.82",
               "unstorage": "^1.17.3"
             },
             "dev": {}
@@ -4418,11 +4418,11 @@
     },
     {
       "packageId": "@jskit-ai/ui-generator",
-      "version": "0.1.64",
+      "version": "0.1.65",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/ui-generator",
-        "version": "0.1.64",
+        "version": "0.1.65",
         "kind": "generator",
         "description": "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
         "options": {
@@ -4855,7 +4855,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.96"
+              "@jskit-ai/users-web": "0.1.97"
             },
             "dev": {}
           },
@@ -4870,11 +4870,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-image-web",
-      "version": "0.1.59",
+      "version": "0.1.60",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-image-web",
-        "version": "0.1.59",
+        "version": "0.1.60",
         "kind": "runtime",
         "description": "Reusable client-side image upload runtime with pre-upload image editing.",
         "dependsOn": [
@@ -4938,7 +4938,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/uploads-runtime": "0.1.59",
+              "@jskit-ai/uploads-runtime": "0.1.60",
               "@uppy/compressor": "^3.1.0",
               "@uppy/core": "^5.2.0",
               "@uppy/dashboard": "^5.1.1",
@@ -4958,11 +4958,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-runtime",
-      "version": "0.1.59",
+      "version": "0.1.60",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-runtime",
-        "version": "0.1.59",
+        "version": "0.1.60",
         "kind": "runtime",
         "description": "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
         "dependsOn": [
@@ -5032,7 +5032,7 @@
           "dependencies": {
             "runtime": {
               "@fastify/multipart": "^9.4.0",
-              "@jskit-ai/kernel": "0.1.81"
+              "@jskit-ai/kernel": "0.1.82"
             },
             "dev": {}
           },
@@ -5047,11 +5047,11 @@
     },
     {
       "packageId": "@jskit-ai/users-core",
-      "version": "0.1.91",
+      "version": "0.1.92",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-core",
-        "version": "0.1.91",
+        "version": "0.1.92",
         "kind": "runtime",
         "description": "Users/account runtime plus HTTP routes for account features.",
         "dependsOn": [
@@ -5192,16 +5192,16 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.80",
-              "@jskit-ai/crud-core": "0.1.89",
-              "@jskit-ai/database-runtime": "0.1.81",
-              "@jskit-ai/http-runtime": "0.1.80",
-              "@jskit-ai/json-rest-api-core": "0.1.26",
-              "@jskit-ai/kernel": "0.1.81",
-              "@jskit-ai/resource-core": "0.1.26",
-              "@jskit-ai/resource-crud-core": "0.1.26",
+              "@jskit-ai/auth-core": "0.1.81",
+              "@jskit-ai/crud-core": "0.1.90",
+              "@jskit-ai/database-runtime": "0.1.82",
+              "@jskit-ai/http-runtime": "0.1.81",
+              "@jskit-ai/json-rest-api-core": "0.1.27",
+              "@jskit-ai/kernel": "0.1.82",
+              "@jskit-ai/resource-core": "0.1.27",
+              "@jskit-ai/resource-crud-core": "0.1.27",
               "@local/users": "file:packages/users",
-              "@jskit-ai/uploads-runtime": "0.1.59"
+              "@jskit-ai/uploads-runtime": "0.1.60"
             },
             "dev": {}
           },
@@ -5418,11 +5418,11 @@
     },
     {
       "packageId": "@jskit-ai/users-web",
-      "version": "0.1.96",
+      "version": "0.1.97",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-web",
-        "version": "0.1.96",
+        "version": "0.1.97",
         "kind": "runtime",
         "description": "Users web module: account/profile UI plus shared users web widgets.",
         "dependsOn": [
@@ -5717,12 +5717,12 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/http-runtime": "0.1.80",
-              "@jskit-ai/realtime": "0.1.80",
-              "@jskit-ai/kernel": "0.1.81",
-              "@jskit-ai/shell-web": "0.1.80",
-              "@jskit-ai/uploads-image-web": "0.1.59",
-              "@jskit-ai/users-core": "0.1.91"
+              "@jskit-ai/http-runtime": "0.1.81",
+              "@jskit-ai/realtime": "0.1.81",
+              "@jskit-ai/kernel": "0.1.82",
+              "@jskit-ai/shell-web": "0.1.81",
+              "@jskit-ai/uploads-image-web": "0.1.60",
+              "@jskit-ai/users-core": "0.1.92"
             },
             "dev": {}
           },
@@ -5891,11 +5891,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-core",
-      "version": "0.1.57",
+      "version": "0.1.58",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-core",
-        "version": "0.1.57",
+        "version": "0.1.58",
         "kind": "runtime",
         "description": "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
         "dependsOn": [
@@ -6036,10 +6036,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/json-rest-api-core": "0.1.26",
-              "@jskit-ai/resource-core": "0.1.26",
-              "@jskit-ai/resource-crud-core": "0.1.26",
-              "@jskit-ai/users-core": "0.1.91"
+              "@jskit-ai/json-rest-api-core": "0.1.27",
+              "@jskit-ai/resource-core": "0.1.27",
+              "@jskit-ai/resource-crud-core": "0.1.27",
+              "@jskit-ai/users-core": "0.1.92"
             },
             "dev": {}
           },
@@ -6211,11 +6211,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-web",
-      "version": "0.1.57",
+      "version": "0.1.58",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-web",
-        "version": "0.1.57",
+        "version": "0.1.58",
         "kind": "runtime",
         "description": "Workspace web module: workspace selector, tools widget, workspace surfaces, and members/settings UI.",
         "dependsOn": [
@@ -6471,8 +6471,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/workspaces-core": "0.1.57",
-              "@jskit-ai/users-web": "0.1.96"
+              "@jskit-ai/workspaces-core": "0.1.58",
+              "@jskit-ai/users-web": "0.1.97"
             },
             "dev": {}
           },

--- a/tooling/jskit-catalog/package.json
+++ b/tooling/jskit-catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-catalog",
-  "version": "0.1.89",
+  "version": "0.1.90",
   "description": "Published metadata catalog for JSKIT package descriptors.",
   "type": "module",
   "files": [

--- a/tooling/jskit-cli/package.json
+++ b/tooling/jskit-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-cli",
-  "version": "0.2.90",
+  "version": "0.2.91",
   "description": "Bundle and package orchestration CLI for JSKIT apps.",
   "type": "module",
   "files": [
@@ -20,9 +20,9 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/jskit-catalog": "0.1.89",
-    "@jskit-ai/kernel": "0.1.81",
-    "@jskit-ai/shell-web": "0.1.80",
+    "@jskit-ai/jskit-catalog": "0.1.90",
+    "@jskit-ai/kernel": "0.1.82",
+    "@jskit-ai/shell-web": "0.1.81",
     "@vue/compiler-sfc": "^3.5.29",
     "ts-morph": "^28.0.0"
   },


### PR DESCRIPTION
## Summary
- constrain shell-web explicit MDI icon resolution to supported named imports
- switch the base shell scaffold to vite-plugin-vuetify auto imports
- refresh generated docs, package versions, lockfile, and catalog metadata

## Verification
- Not run per request.