### PR TITLE
Support CRUD collection relationship serialization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6686,28 +6686,28 @@
     },
     "packages/agent-docs": {
       "name": "@jskit-ai/agent-docs",
-      "version": "0.1.44",
+      "version": "0.1.45",
       "engines": {
         "node": ">=20 <23"
       }
     },
     "packages/assistant": {
       "name": "@jskit-ai/assistant",
-      "version": "0.1.92",
+      "version": "0.1.93",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.83"
+        "@jskit-ai/kernel": "0.1.84"
       }
     },
     "packages/assistant-core": {
       "name": "@jskit-ai/assistant-core",
-      "version": "0.1.59",
+      "version": "0.1.60",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.83",
-        "@jskit-ai/http-runtime": "0.1.82",
-        "@jskit-ai/kernel": "0.1.83",
-        "@jskit-ai/resource-core": "0.1.28",
-        "@jskit-ai/resource-crud-core": "0.1.28",
-        "@jskit-ai/users-core": "0.1.93",
+        "@jskit-ai/database-runtime": "0.1.84",
+        "@jskit-ai/http-runtime": "0.1.83",
+        "@jskit-ai/kernel": "0.1.84",
+        "@jskit-ai/resource-core": "0.1.29",
+        "@jskit-ai/resource-crud-core": "0.1.29",
+        "@jskit-ai/users-core": "0.1.94",
         "dompurify": "^3.3.3",
         "json-rest-schema": "1.x.x",
         "marked": "^17.0.4",
@@ -6720,15 +6720,15 @@
     },
     "packages/assistant-runtime": {
       "name": "@jskit-ai/assistant-runtime",
-      "version": "0.1.54",
+      "version": "0.1.55",
       "dependencies": {
-        "@jskit-ai/assistant-core": "0.1.59",
-        "@jskit-ai/database-runtime": "0.1.83",
-        "@jskit-ai/http-runtime": "0.1.82",
-        "@jskit-ai/kernel": "0.1.83",
-        "@jskit-ai/shell-web": "0.1.82",
-        "@jskit-ai/users-core": "0.1.93",
-        "@jskit-ai/users-web": "0.1.98",
+        "@jskit-ai/assistant-core": "0.1.60",
+        "@jskit-ai/database-runtime": "0.1.84",
+        "@jskit-ai/http-runtime": "0.1.83",
+        "@jskit-ai/kernel": "0.1.84",
+        "@jskit-ai/shell-web": "0.1.83",
+        "@jskit-ai/users-core": "0.1.94",
+        "@jskit-ai/users-web": "0.1.99",
         "json-rest-schema": "1.x.x"
       },
       "peerDependencies": {
@@ -6739,21 +6739,21 @@
     },
     "packages/auth-core": {
       "name": "@jskit-ai/auth-core",
-      "version": "0.1.82",
+      "version": "0.1.83",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0",
-        "@jskit-ai/kernel": "0.1.83",
+        "@jskit-ai/kernel": "0.1.84",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/auth-provider-supabase-core": {
       "name": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.82",
+      "version": "0.1.83",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.82",
-        "@jskit-ai/kernel": "0.1.83",
+        "@jskit-ai/auth-core": "0.1.83",
+        "@jskit-ai/kernel": "0.1.84",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0",
         "json-rest-schema": "1.x.x",
@@ -6762,12 +6762,12 @@
     },
     "packages/auth-web": {
       "name": "@jskit-ai/auth-web",
-      "version": "0.1.84",
+      "version": "0.1.85",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.82",
-        "@jskit-ai/http-runtime": "0.1.82",
-        "@jskit-ai/kernel": "0.1.83",
-        "@jskit-ai/shell-web": "0.1.82",
+        "@jskit-ai/auth-core": "0.1.83",
+        "@jskit-ai/http-runtime": "0.1.83",
+        "@jskit-ai/kernel": "0.1.84",
+        "@jskit-ai/shell-web": "0.1.83",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -6780,38 +6780,38 @@
     },
     "packages/console-core": {
       "name": "@jskit-ai/console-core",
-      "version": "0.1.46",
+      "version": "0.1.47",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.82",
-        "@jskit-ai/database-runtime": "0.1.83",
-        "@jskit-ai/http-runtime": "0.1.82",
-        "@jskit-ai/kernel": "0.1.83",
-        "@jskit-ai/resource-crud-core": "0.1.28",
-        "@jskit-ai/users-core": "0.1.93",
+        "@jskit-ai/auth-core": "0.1.83",
+        "@jskit-ai/database-runtime": "0.1.84",
+        "@jskit-ai/http-runtime": "0.1.83",
+        "@jskit-ai/kernel": "0.1.84",
+        "@jskit-ai/resource-crud-core": "0.1.29",
+        "@jskit-ai/users-core": "0.1.94",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/console-web": {
       "name": "@jskit-ai/console-web",
-      "version": "0.1.51",
+      "version": "0.1.52",
       "dependencies": {
-        "@jskit-ai/auth-web": "0.1.84",
-        "@jskit-ai/console-core": "0.1.46",
-        "@jskit-ai/shell-web": "0.1.82"
+        "@jskit-ai/auth-web": "0.1.85",
+        "@jskit-ai/console-core": "0.1.47",
+        "@jskit-ai/shell-web": "0.1.83"
       }
     },
     "packages/crud-core": {
       "name": "@jskit-ai/crud-core",
-      "version": "0.1.91",
+      "version": "0.1.92",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.83",
-        "@jskit-ai/http-runtime": "0.1.82",
-        "@jskit-ai/kernel": "0.1.83",
-        "@jskit-ai/realtime": "0.1.82",
-        "@jskit-ai/resource-crud-core": "0.1.28",
-        "@jskit-ai/shell-web": "0.1.82",
-        "@jskit-ai/users-core": "0.1.93",
-        "@jskit-ai/users-web": "0.1.98",
+        "@jskit-ai/database-runtime": "0.1.84",
+        "@jskit-ai/http-runtime": "0.1.83",
+        "@jskit-ai/kernel": "0.1.84",
+        "@jskit-ai/realtime": "0.1.83",
+        "@jskit-ai/resource-crud-core": "0.1.29",
+        "@jskit-ai/shell-web": "0.1.83",
+        "@jskit-ai/users-core": "0.1.94",
+        "@jskit-ai/users-web": "0.1.99",
         "json-rest-schema": "1.x.x"
       },
       "peerDependencies": {
@@ -6822,98 +6822,98 @@
     },
     "packages/crud-server-generator": {
       "name": "@jskit-ai/crud-server-generator",
-      "version": "0.1.91",
+      "version": "0.1.92",
       "dependencies": {
         "@babel/parser": "^7.29.2",
-        "@jskit-ai/crud-core": "0.1.91",
-        "@jskit-ai/database-runtime": "0.1.83",
-        "@jskit-ai/http-runtime": "0.1.82",
-        "@jskit-ai/json-rest-api-core": "0.1.28",
-        "@jskit-ai/kernel": "0.1.83",
-        "@jskit-ai/resource-crud-core": "0.1.28",
+        "@jskit-ai/crud-core": "0.1.92",
+        "@jskit-ai/database-runtime": "0.1.84",
+        "@jskit-ai/http-runtime": "0.1.83",
+        "@jskit-ai/json-rest-api-core": "0.1.29",
+        "@jskit-ai/kernel": "0.1.84",
+        "@jskit-ai/resource-crud-core": "0.1.29",
         "recast": "^0.23.11"
       }
     },
     "packages/crud-ui-generator": {
       "name": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.66",
+      "version": "0.1.67",
       "dependencies": {
-        "@jskit-ai/crud-core": "0.1.91",
-        "@jskit-ai/kernel": "0.1.83",
-        "@jskit-ai/resource-crud-core": "0.1.28"
+        "@jskit-ai/crud-core": "0.1.92",
+        "@jskit-ai/kernel": "0.1.84",
+        "@jskit-ai/resource-crud-core": "0.1.29"
       }
     },
     "packages/database-runtime": {
       "name": "@jskit-ai/database-runtime",
-      "version": "0.1.83",
+      "version": "0.1.84",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.83"
+        "@jskit-ai/kernel": "0.1.84"
       }
     },
     "packages/database-runtime-mysql": {
       "name": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.82",
+      "version": "0.1.83",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.83",
-        "@jskit-ai/kernel": "0.1.83"
+        "@jskit-ai/database-runtime": "0.1.84",
+        "@jskit-ai/kernel": "0.1.84"
       }
     },
     "packages/database-runtime-postgres": {
       "name": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.82",
+      "version": "0.1.83",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.83"
+        "@jskit-ai/database-runtime": "0.1.84"
       }
     },
     "packages/feature-server-generator": {
       "name": "@jskit-ai/feature-server-generator",
-      "version": "0.1.25"
+      "version": "0.1.26"
     },
     "packages/google-rewarded-core": {
       "name": "@jskit-ai/google-rewarded-core",
-      "version": "0.1.20"
+      "version": "0.1.21"
     },
     "packages/google-rewarded-web": {
       "name": "@jskit-ai/google-rewarded-web",
-      "version": "0.1.20"
+      "version": "0.1.21"
     },
     "packages/http-runtime": {
       "name": "@jskit-ai/http-runtime",
-      "version": "0.1.82",
+      "version": "0.1.83",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.83",
+        "@jskit-ai/kernel": "0.1.84",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/json-rest-api-core": {
       "name": "@jskit-ai/json-rest-api-core",
-      "version": "0.1.28",
+      "version": "0.1.29",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.83",
+        "@jskit-ai/kernel": "0.1.84",
         "hooked-api": "1.x.x",
         "json-rest-api": "1.x.x"
       }
     },
     "packages/kernel": {
       "name": "@jskit-ai/kernel",
-      "version": "0.1.83",
+      "version": "0.1.84",
       "dependencies": {
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/mobile-capacitor": {
       "name": "@jskit-ai/mobile-capacitor",
-      "version": "0.1.20",
+      "version": "0.1.21",
       "dependencies": {
         "@capacitor/browser": "^7.0.1",
-        "@jskit-ai/kernel": "0.1.83"
+        "@jskit-ai/kernel": "0.1.84"
       }
     },
     "packages/realtime": {
       "name": "@jskit-ai/realtime",
-      "version": "0.1.82",
+      "version": "0.1.83",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.83",
+        "@jskit-ai/kernel": "0.1.84",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",
@@ -6925,24 +6925,24 @@
     },
     "packages/resource-core": {
       "name": "@jskit-ai/resource-core",
-      "version": "0.1.28",
+      "version": "0.1.29",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.83"
+        "@jskit-ai/kernel": "0.1.84"
       }
     },
     "packages/resource-crud-core": {
       "name": "@jskit-ai/resource-crud-core",
-      "version": "0.1.28",
+      "version": "0.1.29",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.83",
-        "@jskit-ai/resource-core": "0.1.28"
+        "@jskit-ai/kernel": "0.1.84",
+        "@jskit-ai/resource-core": "0.1.29"
       }
     },
     "packages/shell-web": {
       "name": "@jskit-ai/shell-web",
-      "version": "0.1.82",
+      "version": "0.1.83",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.83",
+        "@jskit-ai/kernel": "0.1.84",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -6954,25 +6954,25 @@
     },
     "packages/storage-runtime": {
       "name": "@jskit-ai/storage-runtime",
-      "version": "0.1.82",
+      "version": "0.1.83",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.83",
+        "@jskit-ai/kernel": "0.1.84",
         "unstorage": "^1.17.3"
       }
     },
     "packages/ui-generator": {
       "name": "@jskit-ai/ui-generator",
-      "version": "0.1.66",
+      "version": "0.1.67",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.83",
-        "@jskit-ai/shell-web": "0.1.82"
+        "@jskit-ai/kernel": "0.1.84",
+        "@jskit-ai/shell-web": "0.1.83"
       }
     },
     "packages/uploads-image-web": {
       "name": "@jskit-ai/uploads-image-web",
-      "version": "0.1.61",
+      "version": "0.1.62",
       "dependencies": {
-        "@jskit-ai/uploads-runtime": "0.1.61",
+        "@jskit-ai/uploads-runtime": "0.1.62",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",
@@ -6985,37 +6985,37 @@
     },
     "packages/uploads-runtime": {
       "name": "@jskit-ai/uploads-runtime",
-      "version": "0.1.61",
+      "version": "0.1.62",
       "dependencies": {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.83"
+        "@jskit-ai/kernel": "0.1.84"
       }
     },
     "packages/users-core": {
       "name": "@jskit-ai/users-core",
-      "version": "0.1.93",
+      "version": "0.1.94",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.82",
-        "@jskit-ai/database-runtime": "0.1.83",
-        "@jskit-ai/http-runtime": "0.1.82",
-        "@jskit-ai/json-rest-api-core": "0.1.28",
-        "@jskit-ai/kernel": "0.1.83",
-        "@jskit-ai/resource-core": "0.1.28",
-        "@jskit-ai/resource-crud-core": "0.1.28",
-        "@jskit-ai/uploads-runtime": "0.1.61",
+        "@jskit-ai/auth-core": "0.1.83",
+        "@jskit-ai/database-runtime": "0.1.84",
+        "@jskit-ai/http-runtime": "0.1.83",
+        "@jskit-ai/json-rest-api-core": "0.1.29",
+        "@jskit-ai/kernel": "0.1.84",
+        "@jskit-ai/resource-core": "0.1.29",
+        "@jskit-ai/resource-crud-core": "0.1.29",
+        "@jskit-ai/uploads-runtime": "0.1.62",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/users-web": {
       "name": "@jskit-ai/users-web",
-      "version": "0.1.98",
+      "version": "0.1.99",
       "dependencies": {
-        "@jskit-ai/http-runtime": "0.1.82",
-        "@jskit-ai/kernel": "0.1.83",
-        "@jskit-ai/realtime": "0.1.82",
-        "@jskit-ai/shell-web": "0.1.82",
-        "@jskit-ai/uploads-image-web": "0.1.61",
-        "@jskit-ai/users-core": "0.1.93",
+        "@jskit-ai/http-runtime": "0.1.83",
+        "@jskit-ai/kernel": "0.1.84",
+        "@jskit-ai/realtime": "0.1.83",
+        "@jskit-ai/shell-web": "0.1.83",
+        "@jskit-ai/uploads-image-web": "0.1.62",
+        "@jskit-ai/users-core": "0.1.94",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -7027,29 +7027,29 @@
     },
     "packages/workspaces-core": {
       "name": "@jskit-ai/workspaces-core",
-      "version": "0.1.59",
+      "version": "0.1.60",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.82",
-        "@jskit-ai/database-runtime": "0.1.83",
-        "@jskit-ai/http-runtime": "0.1.82",
-        "@jskit-ai/json-rest-api-core": "0.1.28",
-        "@jskit-ai/kernel": "0.1.83",
-        "@jskit-ai/resource-core": "0.1.28",
-        "@jskit-ai/resource-crud-core": "0.1.28",
-        "@jskit-ai/users-core": "0.1.93",
+        "@jskit-ai/auth-core": "0.1.83",
+        "@jskit-ai/database-runtime": "0.1.84",
+        "@jskit-ai/http-runtime": "0.1.83",
+        "@jskit-ai/json-rest-api-core": "0.1.29",
+        "@jskit-ai/kernel": "0.1.84",
+        "@jskit-ai/resource-core": "0.1.29",
+        "@jskit-ai/resource-crud-core": "0.1.29",
+        "@jskit-ai/users-core": "0.1.94",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/workspaces-web": {
       "name": "@jskit-ai/workspaces-web",
-      "version": "0.1.59",
+      "version": "0.1.60",
       "dependencies": {
-        "@jskit-ai/http-runtime": "0.1.82",
-        "@jskit-ai/kernel": "0.1.83",
-        "@jskit-ai/shell-web": "0.1.82",
-        "@jskit-ai/users-core": "0.1.93",
-        "@jskit-ai/users-web": "0.1.98",
-        "@jskit-ai/workspaces-core": "0.1.59",
+        "@jskit-ai/http-runtime": "0.1.83",
+        "@jskit-ai/kernel": "0.1.84",
+        "@jskit-ai/shell-web": "0.1.83",
+        "@jskit-ai/users-core": "0.1.94",
+        "@jskit-ai/users-web": "0.1.99",
+        "@jskit-ai/workspaces-core": "0.1.60",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -7061,7 +7061,7 @@
     },
     "tooling/config-eslint": {
       "name": "@jskit-ai/config-eslint",
-      "version": "0.1.82",
+      "version": "0.1.83",
       "dependencies": {
         "@eslint/js": "^9.39.1",
         "eslint-plugin-vue": "^10.5.1",
@@ -7079,7 +7079,7 @@
     },
     "tooling/create-app": {
       "name": "@jskit-ai/create-app",
-      "version": "0.1.91",
+      "version": "0.1.92",
       "bin": {
         "jskit-create-app": "bin/jskit-create-app.js"
       },
@@ -7089,18 +7089,18 @@
     },
     "tooling/jskit-catalog": {
       "name": "@jskit-ai/jskit-catalog",
-      "version": "0.1.91",
+      "version": "0.1.92",
       "engines": {
         "node": ">=20 <23"
       }
     },
     "tooling/jskit-cli": {
       "name": "@jskit-ai/jskit-cli",
-      "version": "0.2.93",
+      "version": "0.2.97",
       "dependencies": {
-        "@jskit-ai/jskit-catalog": "0.1.91",
-        "@jskit-ai/kernel": "0.1.83",
-        "@jskit-ai/shell-web": "0.1.82",
+        "@jskit-ai/jskit-catalog": "0.1.92",
+        "@jskit-ai/kernel": "0.1.84",
+        "@jskit-ai/shell-web": "0.1.83",
         "@vue/compiler-sfc": "^3.5.29",
         "ts-morph": "^28.0.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -6686,28 +6686,28 @@
     },
     "packages/agent-docs": {
       "name": "@jskit-ai/agent-docs",
-      "version": "0.1.45",
+      "version": "0.1.46",
       "engines": {
         "node": ">=20 <23"
       }
     },
     "packages/assistant": {
       "name": "@jskit-ai/assistant",
-      "version": "0.1.93",
+      "version": "0.1.94",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.84"
+        "@jskit-ai/kernel": "0.1.85"
       }
     },
     "packages/assistant-core": {
       "name": "@jskit-ai/assistant-core",
-      "version": "0.1.60",
+      "version": "0.1.61",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.84",
-        "@jskit-ai/http-runtime": "0.1.83",
-        "@jskit-ai/kernel": "0.1.84",
-        "@jskit-ai/resource-core": "0.1.29",
-        "@jskit-ai/resource-crud-core": "0.1.29",
-        "@jskit-ai/users-core": "0.1.94",
+        "@jskit-ai/database-runtime": "0.1.85",
+        "@jskit-ai/http-runtime": "0.1.84",
+        "@jskit-ai/kernel": "0.1.85",
+        "@jskit-ai/resource-core": "0.1.30",
+        "@jskit-ai/resource-crud-core": "0.1.30",
+        "@jskit-ai/users-core": "0.1.95",
         "dompurify": "^3.3.3",
         "json-rest-schema": "1.x.x",
         "marked": "^17.0.4",
@@ -6720,15 +6720,15 @@
     },
     "packages/assistant-runtime": {
       "name": "@jskit-ai/assistant-runtime",
-      "version": "0.1.55",
+      "version": "0.1.56",
       "dependencies": {
-        "@jskit-ai/assistant-core": "0.1.60",
-        "@jskit-ai/database-runtime": "0.1.84",
-        "@jskit-ai/http-runtime": "0.1.83",
-        "@jskit-ai/kernel": "0.1.84",
-        "@jskit-ai/shell-web": "0.1.83",
-        "@jskit-ai/users-core": "0.1.94",
-        "@jskit-ai/users-web": "0.1.99",
+        "@jskit-ai/assistant-core": "0.1.61",
+        "@jskit-ai/database-runtime": "0.1.85",
+        "@jskit-ai/http-runtime": "0.1.84",
+        "@jskit-ai/kernel": "0.1.85",
+        "@jskit-ai/shell-web": "0.1.84",
+        "@jskit-ai/users-core": "0.1.95",
+        "@jskit-ai/users-web": "0.1.100",
         "json-rest-schema": "1.x.x"
       },
       "peerDependencies": {
@@ -6739,21 +6739,21 @@
     },
     "packages/auth-core": {
       "name": "@jskit-ai/auth-core",
-      "version": "0.1.83",
+      "version": "0.1.84",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0",
-        "@jskit-ai/kernel": "0.1.84",
+        "@jskit-ai/kernel": "0.1.85",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/auth-provider-supabase-core": {
       "name": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.83",
+      "version": "0.1.84",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.83",
-        "@jskit-ai/kernel": "0.1.84",
+        "@jskit-ai/auth-core": "0.1.84",
+        "@jskit-ai/kernel": "0.1.85",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0",
         "json-rest-schema": "1.x.x",
@@ -6762,12 +6762,12 @@
     },
     "packages/auth-web": {
       "name": "@jskit-ai/auth-web",
-      "version": "0.1.85",
+      "version": "0.1.86",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.83",
-        "@jskit-ai/http-runtime": "0.1.83",
-        "@jskit-ai/kernel": "0.1.84",
-        "@jskit-ai/shell-web": "0.1.83",
+        "@jskit-ai/auth-core": "0.1.84",
+        "@jskit-ai/http-runtime": "0.1.84",
+        "@jskit-ai/kernel": "0.1.85",
+        "@jskit-ai/shell-web": "0.1.84",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -6780,38 +6780,38 @@
     },
     "packages/console-core": {
       "name": "@jskit-ai/console-core",
-      "version": "0.1.47",
+      "version": "0.1.48",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.83",
-        "@jskit-ai/database-runtime": "0.1.84",
-        "@jskit-ai/http-runtime": "0.1.83",
-        "@jskit-ai/kernel": "0.1.84",
-        "@jskit-ai/resource-crud-core": "0.1.29",
-        "@jskit-ai/users-core": "0.1.94",
+        "@jskit-ai/auth-core": "0.1.84",
+        "@jskit-ai/database-runtime": "0.1.85",
+        "@jskit-ai/http-runtime": "0.1.84",
+        "@jskit-ai/kernel": "0.1.85",
+        "@jskit-ai/resource-crud-core": "0.1.30",
+        "@jskit-ai/users-core": "0.1.95",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/console-web": {
       "name": "@jskit-ai/console-web",
-      "version": "0.1.52",
+      "version": "0.1.53",
       "dependencies": {
-        "@jskit-ai/auth-web": "0.1.85",
-        "@jskit-ai/console-core": "0.1.47",
-        "@jskit-ai/shell-web": "0.1.83"
+        "@jskit-ai/auth-web": "0.1.86",
+        "@jskit-ai/console-core": "0.1.48",
+        "@jskit-ai/shell-web": "0.1.84"
       }
     },
     "packages/crud-core": {
       "name": "@jskit-ai/crud-core",
-      "version": "0.1.92",
+      "version": "0.1.93",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.84",
-        "@jskit-ai/http-runtime": "0.1.83",
-        "@jskit-ai/kernel": "0.1.84",
-        "@jskit-ai/realtime": "0.1.83",
-        "@jskit-ai/resource-crud-core": "0.1.29",
-        "@jskit-ai/shell-web": "0.1.83",
-        "@jskit-ai/users-core": "0.1.94",
-        "@jskit-ai/users-web": "0.1.99",
+        "@jskit-ai/database-runtime": "0.1.85",
+        "@jskit-ai/http-runtime": "0.1.84",
+        "@jskit-ai/kernel": "0.1.85",
+        "@jskit-ai/realtime": "0.1.84",
+        "@jskit-ai/resource-crud-core": "0.1.30",
+        "@jskit-ai/shell-web": "0.1.84",
+        "@jskit-ai/users-core": "0.1.95",
+        "@jskit-ai/users-web": "0.1.100",
         "json-rest-schema": "1.x.x"
       },
       "peerDependencies": {
@@ -6822,98 +6822,98 @@
     },
     "packages/crud-server-generator": {
       "name": "@jskit-ai/crud-server-generator",
-      "version": "0.1.92",
+      "version": "0.1.93",
       "dependencies": {
         "@babel/parser": "^7.29.2",
-        "@jskit-ai/crud-core": "0.1.92",
-        "@jskit-ai/database-runtime": "0.1.84",
-        "@jskit-ai/http-runtime": "0.1.83",
-        "@jskit-ai/json-rest-api-core": "0.1.29",
-        "@jskit-ai/kernel": "0.1.84",
-        "@jskit-ai/resource-crud-core": "0.1.29",
+        "@jskit-ai/crud-core": "0.1.93",
+        "@jskit-ai/database-runtime": "0.1.85",
+        "@jskit-ai/http-runtime": "0.1.84",
+        "@jskit-ai/json-rest-api-core": "0.1.30",
+        "@jskit-ai/kernel": "0.1.85",
+        "@jskit-ai/resource-crud-core": "0.1.30",
         "recast": "^0.23.11"
       }
     },
     "packages/crud-ui-generator": {
       "name": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.67",
+      "version": "0.1.68",
       "dependencies": {
-        "@jskit-ai/crud-core": "0.1.92",
-        "@jskit-ai/kernel": "0.1.84",
-        "@jskit-ai/resource-crud-core": "0.1.29"
+        "@jskit-ai/crud-core": "0.1.93",
+        "@jskit-ai/kernel": "0.1.85",
+        "@jskit-ai/resource-crud-core": "0.1.30"
       }
     },
     "packages/database-runtime": {
       "name": "@jskit-ai/database-runtime",
-      "version": "0.1.84",
+      "version": "0.1.85",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.84"
+        "@jskit-ai/kernel": "0.1.85"
       }
     },
     "packages/database-runtime-mysql": {
       "name": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.83",
+      "version": "0.1.84",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.84",
-        "@jskit-ai/kernel": "0.1.84"
+        "@jskit-ai/database-runtime": "0.1.85",
+        "@jskit-ai/kernel": "0.1.85"
       }
     },
     "packages/database-runtime-postgres": {
       "name": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.83",
+      "version": "0.1.84",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.84"
+        "@jskit-ai/database-runtime": "0.1.85"
       }
     },
     "packages/feature-server-generator": {
       "name": "@jskit-ai/feature-server-generator",
-      "version": "0.1.26"
+      "version": "0.1.27"
     },
     "packages/google-rewarded-core": {
       "name": "@jskit-ai/google-rewarded-core",
-      "version": "0.1.21"
+      "version": "0.1.22"
     },
     "packages/google-rewarded-web": {
       "name": "@jskit-ai/google-rewarded-web",
-      "version": "0.1.21"
+      "version": "0.1.22"
     },
     "packages/http-runtime": {
       "name": "@jskit-ai/http-runtime",
-      "version": "0.1.83",
+      "version": "0.1.84",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.84",
+        "@jskit-ai/kernel": "0.1.85",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/json-rest-api-core": {
       "name": "@jskit-ai/json-rest-api-core",
-      "version": "0.1.29",
+      "version": "0.1.30",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.84",
+        "@jskit-ai/kernel": "0.1.85",
         "hooked-api": "1.x.x",
         "json-rest-api": "1.x.x"
       }
     },
     "packages/kernel": {
       "name": "@jskit-ai/kernel",
-      "version": "0.1.84",
+      "version": "0.1.85",
       "dependencies": {
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/mobile-capacitor": {
       "name": "@jskit-ai/mobile-capacitor",
-      "version": "0.1.21",
+      "version": "0.1.22",
       "dependencies": {
         "@capacitor/browser": "^7.0.1",
-        "@jskit-ai/kernel": "0.1.84"
+        "@jskit-ai/kernel": "0.1.85"
       }
     },
     "packages/realtime": {
       "name": "@jskit-ai/realtime",
-      "version": "0.1.83",
+      "version": "0.1.84",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.84",
+        "@jskit-ai/kernel": "0.1.85",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",
@@ -6925,24 +6925,24 @@
     },
     "packages/resource-core": {
       "name": "@jskit-ai/resource-core",
-      "version": "0.1.29",
+      "version": "0.1.30",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.84"
+        "@jskit-ai/kernel": "0.1.85"
       }
     },
     "packages/resource-crud-core": {
       "name": "@jskit-ai/resource-crud-core",
-      "version": "0.1.29",
+      "version": "0.1.30",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.84",
-        "@jskit-ai/resource-core": "0.1.29"
+        "@jskit-ai/kernel": "0.1.85",
+        "@jskit-ai/resource-core": "0.1.30"
       }
     },
     "packages/shell-web": {
       "name": "@jskit-ai/shell-web",
-      "version": "0.1.83",
+      "version": "0.1.84",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.84",
+        "@jskit-ai/kernel": "0.1.85",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -6954,25 +6954,25 @@
     },
     "packages/storage-runtime": {
       "name": "@jskit-ai/storage-runtime",
-      "version": "0.1.83",
+      "version": "0.1.84",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.84",
+        "@jskit-ai/kernel": "0.1.85",
         "unstorage": "^1.17.3"
       }
     },
     "packages/ui-generator": {
       "name": "@jskit-ai/ui-generator",
-      "version": "0.1.67",
+      "version": "0.1.68",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.84",
-        "@jskit-ai/shell-web": "0.1.83"
+        "@jskit-ai/kernel": "0.1.85",
+        "@jskit-ai/shell-web": "0.1.84"
       }
     },
     "packages/uploads-image-web": {
       "name": "@jskit-ai/uploads-image-web",
-      "version": "0.1.62",
+      "version": "0.1.63",
       "dependencies": {
-        "@jskit-ai/uploads-runtime": "0.1.62",
+        "@jskit-ai/uploads-runtime": "0.1.63",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",
@@ -6985,37 +6985,37 @@
     },
     "packages/uploads-runtime": {
       "name": "@jskit-ai/uploads-runtime",
-      "version": "0.1.62",
+      "version": "0.1.63",
       "dependencies": {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.84"
+        "@jskit-ai/kernel": "0.1.85"
       }
     },
     "packages/users-core": {
       "name": "@jskit-ai/users-core",
-      "version": "0.1.94",
+      "version": "0.1.95",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.83",
-        "@jskit-ai/database-runtime": "0.1.84",
-        "@jskit-ai/http-runtime": "0.1.83",
-        "@jskit-ai/json-rest-api-core": "0.1.29",
-        "@jskit-ai/kernel": "0.1.84",
-        "@jskit-ai/resource-core": "0.1.29",
-        "@jskit-ai/resource-crud-core": "0.1.29",
-        "@jskit-ai/uploads-runtime": "0.1.62",
+        "@jskit-ai/auth-core": "0.1.84",
+        "@jskit-ai/database-runtime": "0.1.85",
+        "@jskit-ai/http-runtime": "0.1.84",
+        "@jskit-ai/json-rest-api-core": "0.1.30",
+        "@jskit-ai/kernel": "0.1.85",
+        "@jskit-ai/resource-core": "0.1.30",
+        "@jskit-ai/resource-crud-core": "0.1.30",
+        "@jskit-ai/uploads-runtime": "0.1.63",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/users-web": {
       "name": "@jskit-ai/users-web",
-      "version": "0.1.99",
+      "version": "0.1.100",
       "dependencies": {
-        "@jskit-ai/http-runtime": "0.1.83",
-        "@jskit-ai/kernel": "0.1.84",
-        "@jskit-ai/realtime": "0.1.83",
-        "@jskit-ai/shell-web": "0.1.83",
-        "@jskit-ai/uploads-image-web": "0.1.62",
-        "@jskit-ai/users-core": "0.1.94",
+        "@jskit-ai/http-runtime": "0.1.84",
+        "@jskit-ai/kernel": "0.1.85",
+        "@jskit-ai/realtime": "0.1.84",
+        "@jskit-ai/shell-web": "0.1.84",
+        "@jskit-ai/uploads-image-web": "0.1.63",
+        "@jskit-ai/users-core": "0.1.95",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -7027,29 +7027,29 @@
     },
     "packages/workspaces-core": {
       "name": "@jskit-ai/workspaces-core",
-      "version": "0.1.60",
+      "version": "0.1.61",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.83",
-        "@jskit-ai/database-runtime": "0.1.84",
-        "@jskit-ai/http-runtime": "0.1.83",
-        "@jskit-ai/json-rest-api-core": "0.1.29",
-        "@jskit-ai/kernel": "0.1.84",
-        "@jskit-ai/resource-core": "0.1.29",
-        "@jskit-ai/resource-crud-core": "0.1.29",
-        "@jskit-ai/users-core": "0.1.94",
+        "@jskit-ai/auth-core": "0.1.84",
+        "@jskit-ai/database-runtime": "0.1.85",
+        "@jskit-ai/http-runtime": "0.1.84",
+        "@jskit-ai/json-rest-api-core": "0.1.30",
+        "@jskit-ai/kernel": "0.1.85",
+        "@jskit-ai/resource-core": "0.1.30",
+        "@jskit-ai/resource-crud-core": "0.1.30",
+        "@jskit-ai/users-core": "0.1.95",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/workspaces-web": {
       "name": "@jskit-ai/workspaces-web",
-      "version": "0.1.60",
+      "version": "0.1.61",
       "dependencies": {
-        "@jskit-ai/http-runtime": "0.1.83",
-        "@jskit-ai/kernel": "0.1.84",
-        "@jskit-ai/shell-web": "0.1.83",
-        "@jskit-ai/users-core": "0.1.94",
-        "@jskit-ai/users-web": "0.1.99",
-        "@jskit-ai/workspaces-core": "0.1.60",
+        "@jskit-ai/http-runtime": "0.1.84",
+        "@jskit-ai/kernel": "0.1.85",
+        "@jskit-ai/shell-web": "0.1.84",
+        "@jskit-ai/users-core": "0.1.95",
+        "@jskit-ai/users-web": "0.1.100",
+        "@jskit-ai/workspaces-core": "0.1.61",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -7061,7 +7061,7 @@
     },
     "tooling/config-eslint": {
       "name": "@jskit-ai/config-eslint",
-      "version": "0.1.83",
+      "version": "0.1.84",
       "dependencies": {
         "@eslint/js": "^9.39.1",
         "eslint-plugin-vue": "^10.5.1",
@@ -7079,7 +7079,7 @@
     },
     "tooling/create-app": {
       "name": "@jskit-ai/create-app",
-      "version": "0.1.92",
+      "version": "0.1.93",
       "bin": {
         "jskit-create-app": "bin/jskit-create-app.js"
       },
@@ -7089,18 +7089,18 @@
     },
     "tooling/jskit-catalog": {
       "name": "@jskit-ai/jskit-catalog",
-      "version": "0.1.92",
+      "version": "0.1.93",
       "engines": {
         "node": ">=20 <23"
       }
     },
     "tooling/jskit-cli": {
       "name": "@jskit-ai/jskit-cli",
-      "version": "0.2.97",
+      "version": "0.2.98",
       "dependencies": {
-        "@jskit-ai/jskit-catalog": "0.1.92",
-        "@jskit-ai/kernel": "0.1.84",
-        "@jskit-ai/shell-web": "0.1.83",
+        "@jskit-ai/jskit-catalog": "0.1.93",
+        "@jskit-ai/kernel": "0.1.85",
+        "@jskit-ai/shell-web": "0.1.84",
         "@vue/compiler-sfc": "^3.5.29",
         "ts-morph": "^28.0.0"
       },

--- a/packages/agent-docs/package.json
+++ b/packages/agent-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/agent-docs",
-  "version": "0.1.45",
+  "version": "0.1.46",
   "description": "Distributed JSKIT agent references, prompts, guides, and generated reference maps.",
   "type": "module",
   "files": [

--- a/packages/agent-docs/reference/autogen/KERNEL_MAP.md
+++ b/packages/agent-docs/reference/autogen/KERNEL_MAP.md
@@ -106,6 +106,7 @@ Exports
 - `normalizeCrudLookupApiPath(value = "")`
 - `normalizeCrudLookupNamespace(value = "")`
 - `resolveCrudLookupApiPathFromNamespace(value = "")`
+- `resolveCrudResourceScopeName(value = "")`
 - `normalizeCrudLookupContainerKey(value, { defaultValue = DEFAULT_CRUD_LOOKUP_CONTAINER_KEY, context = "crud lookup container key" } = {})`
 - `resolveCrudLookupContainerKey(resource = {}, options = {})`
 - `resolveCrudLookupFieldKeys(resource = {}, { allowKeys = [] } = {})`

--- a/packages/agent-docs/reference/autogen/packages/crud-core.md
+++ b/packages/agent-docs/reference/autogen/packages/crud-core.md
@@ -300,13 +300,19 @@ Local functions
 - `isRecord(value)`
 - `resolveSchemaFieldDefinitions(definition = null)`
 - `resolveJsonApiRelationshipEntries(definition = null)`
+- `readOwnValue(source = {}, key = "")`
+- `resolveLookupContainer(record = {}, lookupContainerKey = "")`
+- `resolveRelationshipValueSource(record = {}, entry = {}, { lookupContainerKey = "", preferLookup = false } = {})`
+- `normalizeLookupId(value)`
+- `normalizeRelationshipIdentifierId(value = null)`
+- `createRelationshipIdentifier(entry = {}, value = null)`
 - `createRecordAttributesResolver(definition = null, { excludeKeys = [] } = {})`
-- `createRecordRelationshipsResolver(definition = null)`
+- `createRecordRelationshipsResolver(definition = null, { lookupContainerKey = "" } = {})`
 - `createRequestRelationshipMapper(definition = null)`
 - `resolveOutputAttributeExcludeKeys(resource = {})`
 - `resolveLookupContainerKey(resource = {})`
-- `normalizeLookupId(value)`
 - `normalizeIncludedLookupRecord(source = null, fallbackId = null)`
+- `appendIncludedRelationshipResource({ included = [], seen = new Set(), entry = {}, lookupRecord = null, fallbackId = null } = {})`
 - `createLookupIncludedResolver(definition = null, { lookupContainerKey = "" } = {})`
 
 ### `src/server/serviceEvents.js`

--- a/packages/agent-docs/reference/autogen/packages/http-runtime.md
+++ b/packages/agent-docs/reference/autogen/packages/http-runtime.md
@@ -282,7 +282,7 @@ Local functions
 - `resolveRouteTypes(value = {})`
 - `resolveEmbeddedAttributesTransportSchema(definition, { context = "JSON:API resource", defaultMode = "replace", removeId = false, removeKeys = [] } = {})`
 - `normalizeRelationshipSchemaEntries(entries = [])`
-- `createJsonApiRelationshipDataSchema(relationshipType = "", { nullable = false } = {})`
+- `createJsonApiRelationshipDataSchema(relationshipType = "", { many = false, nullable = false } = {})`
 - `createJsonApiRelationshipsTransportSchema(entries = [], { includeRequired = false } = {})`
 - `createJsonApiMetaSuccessTransportSchema({ meta } = {})`
 - `defaultRecordTypeResolver(type)`

--- a/packages/agent-docs/reference/autogen/packages/json-rest-api-core.md
+++ b/packages/agent-docs/reference/autogen/packages/json-rest-api-core.md
@@ -42,6 +42,7 @@ Local functions
 - `normalizeJsonRestText(value, { fallback = "" } = {})`
 - `normalizeJsonRestObject(value)`
 - `normalizeJsonRestList(value)`
+- `resolveJsonRestCollectionRelationships(resource = {})`
 - `extractJsonApiInputRelationships(attributes = {}, resource = null, relationships = null)`
 
 ### root

--- a/packages/agent-docs/reference/autogen/packages/kernel.md
+++ b/packages/agent-docs/reference/autogen/packages/kernel.md
@@ -270,6 +270,7 @@ Exports
 - `normalizeCrudLookupApiPath(value = "")`
 - `normalizeCrudLookupNamespace(value = "")`
 - `resolveCrudLookupApiPathFromNamespace(value = "")`
+- `resolveCrudResourceScopeName(value = "")`
 - `normalizeCrudLookupContainerKey(value, { defaultValue = DEFAULT_CRUD_LOOKUP_CONTAINER_KEY, context = "crud lookup container key" } = {})`
 - `resolveCrudLookupContainerKey(resource = {}, options = {})`
 - `resolveCrudLookupFieldKeys(resource = {}, { allowKeys = [] } = {})`
@@ -1532,5 +1533,6 @@ Exports
 - `loadInstalledPackageDescriptor({ appRoot, packageId, installedPackageState, required = false })`
 - `resolveDescriptorPathForInstalledPackage({ appRoot, packageId, installedPackageState, required = false })`
 Local functions
+- `resolveNodeModulesDescriptorCandidatePaths({ appRoot, packageId })`
 - `resolveDescriptorCandidatePaths({ appRoot, packageId, installedPackageState })`
 - `normalizeDescriptorPayload(descriptorModule)`

--- a/packages/agent-docs/reference/autogen/tooling/jskit-cli.md
+++ b/packages/agent-docs/reference/autogen/tooling/jskit-cli.md
@@ -770,24 +770,34 @@ Local functions
 Exports
 - `HELPER_MAP_JSON_RELATIVE_PATH`
 - `HELPER_MAP_MARKDOWN_RELATIVE_PATH`
-- `buildHelperMap({ targetRoot })`
+- `buildHelperMap({ targetRoot, previousMap = null })`
 - `readHelperMap({ targetRoot })`
 - `updateHelperMap({ targetRoot })`
 Local functions
 - `pathExists(filePath)`
 - `readJsonFile(filePath)`
+- `readFileHash(filePath)`
 - `normalizePackageDependencies(packageJson = {})`
 - `classifySymbol(name = "")`
 - `createExportAnalysisProject()`
-- `kindFromDeclaration(declaration, exportName = "")`
 - `addSymbol(symbols, symbol)`
+- `compilerNodeHasModifier(node, modifierKind)`
+- `exportedDeclarationName(node)`
+- `addExportedDeclarationSymbol(symbols, node, kind = "export")`
+- `bindingNameTexts(bindingName, names = [])`
+- `addVariableStatementExports(symbols, statement)`
+- `addNamedExportSymbols(symbols, exportClause)`
 - `extractExportedSymbols(sourceFile)`
 - `extractVueScriptSource(source = "", filePath = "")`
 - `addCodeFileToProject(project, file)`
 - `walkCodeFiles(rootPath, relativeRoot = "")`
 - `collectAppExports(targetRoot)`
 - `flattenPackageExports(exportsField)`
-- `collectJskitPackageExports(targetRoot, packageJson = {})`
+- `packageExportTargetRecords(packageRoot, exportTargets = [])`
+- `packageExportFingerprint({ installedPackageJson = {}, packageName = "", targetRecords = [] } = {})`
+- `cachedPackageExports(previousPackagesByName = new Map(), packageName = "", fingerprint = "")`
+- `previousPackageMap(previousMap = null)`
+- `collectJskitPackageExports(targetRoot, packageJson = {}, previousMap = null)`
 - `renderExportList(symbols = [])`
 - `renderHelperMapMarkdown(map)`
 

--- a/packages/assistant-core/package.descriptor.mjs
+++ b/packages/assistant-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-core",
-  version: "0.1.60",
+  version: "0.1.61",
   kind: "runtime",
   description: "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
   dependsOn: [
@@ -47,11 +47,11 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/http-runtime": "0.1.83",
-        "@jskit-ai/kernel": "0.1.84",
-        "@jskit-ai/resource-core": "0.1.29",
-        "@jskit-ai/resource-crud-core": "0.1.29",
-        "@jskit-ai/users-core": "0.1.94",
+        "@jskit-ai/http-runtime": "0.1.84",
+        "@jskit-ai/kernel": "0.1.85",
+        "@jskit-ai/resource-core": "0.1.30",
+        "@jskit-ai/resource-crud-core": "0.1.30",
+        "@jskit-ai/users-core": "0.1.95",
         "dompurify": "^3.3.3",
         "json-rest-schema": "1.x.x",
         "marked": "^17.0.4",

--- a/packages/assistant-core/package.descriptor.mjs
+++ b/packages/assistant-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-core",
-  version: "0.1.59",
+  version: "0.1.60",
   kind: "runtime",
   description: "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
   dependsOn: [
@@ -47,11 +47,11 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/http-runtime": "0.1.82",
-        "@jskit-ai/kernel": "0.1.83",
-        "@jskit-ai/resource-core": "0.1.28",
-        "@jskit-ai/resource-crud-core": "0.1.28",
-        "@jskit-ai/users-core": "0.1.93",
+        "@jskit-ai/http-runtime": "0.1.83",
+        "@jskit-ai/kernel": "0.1.84",
+        "@jskit-ai/resource-core": "0.1.29",
+        "@jskit-ai/resource-crud-core": "0.1.29",
+        "@jskit-ai/users-core": "0.1.94",
         "dompurify": "^3.3.3",
         "json-rest-schema": "1.x.x",
         "marked": "^17.0.4",

--- a/packages/assistant-core/package.json
+++ b/packages/assistant-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-core",
-  "version": "0.1.60",
+  "version": "0.1.61",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,12 +11,12 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.84",
-    "@jskit-ai/http-runtime": "0.1.83",
-    "@jskit-ai/kernel": "0.1.84",
-    "@jskit-ai/resource-crud-core": "0.1.29",
-    "@jskit-ai/resource-core": "0.1.29",
-    "@jskit-ai/users-core": "0.1.94",
+    "@jskit-ai/database-runtime": "0.1.85",
+    "@jskit-ai/http-runtime": "0.1.84",
+    "@jskit-ai/kernel": "0.1.85",
+    "@jskit-ai/resource-crud-core": "0.1.30",
+    "@jskit-ai/resource-core": "0.1.30",
+    "@jskit-ai/users-core": "0.1.95",
     "dompurify": "^3.3.3",
     "json-rest-schema": "1.x.x",
     "marked": "^17.0.4",

--- a/packages/assistant-core/package.json
+++ b/packages/assistant-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-core",
-  "version": "0.1.59",
+  "version": "0.1.60",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,12 +11,12 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.83",
-    "@jskit-ai/http-runtime": "0.1.82",
-    "@jskit-ai/kernel": "0.1.83",
-    "@jskit-ai/resource-crud-core": "0.1.28",
-    "@jskit-ai/resource-core": "0.1.28",
-    "@jskit-ai/users-core": "0.1.93",
+    "@jskit-ai/database-runtime": "0.1.84",
+    "@jskit-ai/http-runtime": "0.1.83",
+    "@jskit-ai/kernel": "0.1.84",
+    "@jskit-ai/resource-crud-core": "0.1.29",
+    "@jskit-ai/resource-core": "0.1.29",
+    "@jskit-ai/users-core": "0.1.94",
     "dompurify": "^3.3.3",
     "json-rest-schema": "1.x.x",
     "marked": "^17.0.4",

--- a/packages/assistant-runtime/package.descriptor.mjs
+++ b/packages/assistant-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-runtime",
-  version: "0.1.54",
+  version: "0.1.55",
   kind: "runtime",
   description: "Shared assistant runtime with per-surface assistant registration.",
   dependsOn: [
@@ -95,13 +95,13 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/assistant-core": "0.1.59",
-        "@jskit-ai/database-runtime": "0.1.83",
-        "@jskit-ai/http-runtime": "0.1.82",
-        "@jskit-ai/kernel": "0.1.83",
-        "@jskit-ai/shell-web": "0.1.82",
-        "@jskit-ai/users-core": "0.1.93",
-        "@jskit-ai/users-web": "0.1.98"
+        "@jskit-ai/assistant-core": "0.1.60",
+        "@jskit-ai/database-runtime": "0.1.84",
+        "@jskit-ai/http-runtime": "0.1.83",
+        "@jskit-ai/kernel": "0.1.84",
+        "@jskit-ai/shell-web": "0.1.83",
+        "@jskit-ai/users-core": "0.1.94",
+        "@jskit-ai/users-web": "0.1.99"
       },
       dev: {}
     },

--- a/packages/assistant-runtime/package.descriptor.mjs
+++ b/packages/assistant-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-runtime",
-  version: "0.1.55",
+  version: "0.1.56",
   kind: "runtime",
   description: "Shared assistant runtime with per-surface assistant registration.",
   dependsOn: [
@@ -95,13 +95,13 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/assistant-core": "0.1.60",
-        "@jskit-ai/database-runtime": "0.1.84",
-        "@jskit-ai/http-runtime": "0.1.83",
-        "@jskit-ai/kernel": "0.1.84",
-        "@jskit-ai/shell-web": "0.1.83",
-        "@jskit-ai/users-core": "0.1.94",
-        "@jskit-ai/users-web": "0.1.99"
+        "@jskit-ai/assistant-core": "0.1.61",
+        "@jskit-ai/database-runtime": "0.1.85",
+        "@jskit-ai/http-runtime": "0.1.84",
+        "@jskit-ai/kernel": "0.1.85",
+        "@jskit-ai/shell-web": "0.1.84",
+        "@jskit-ai/users-core": "0.1.95",
+        "@jskit-ai/users-web": "0.1.100"
       },
       dev: {}
     },

--- a/packages/assistant-runtime/package.json
+++ b/packages/assistant-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-runtime",
-  "version": "0.1.55",
+  "version": "0.1.56",
   "type": "module",
   "exports": {
     "./client": "./src/client/index.js",
@@ -8,13 +8,13 @@
     "./server/actionIds": "./src/server/actionIds.js"
   },
   "dependencies": {
-    "@jskit-ai/assistant-core": "0.1.60",
-    "@jskit-ai/database-runtime": "0.1.84",
-    "@jskit-ai/http-runtime": "0.1.83",
-    "@jskit-ai/kernel": "0.1.84",
-    "@jskit-ai/shell-web": "0.1.83",
-    "@jskit-ai/users-core": "0.1.94",
-    "@jskit-ai/users-web": "0.1.99",
+    "@jskit-ai/assistant-core": "0.1.61",
+    "@jskit-ai/database-runtime": "0.1.85",
+    "@jskit-ai/http-runtime": "0.1.84",
+    "@jskit-ai/kernel": "0.1.85",
+    "@jskit-ai/shell-web": "0.1.84",
+    "@jskit-ai/users-core": "0.1.95",
+    "@jskit-ai/users-web": "0.1.100",
     "json-rest-schema": "1.x.x"
   },
   "peerDependencies": {

--- a/packages/assistant-runtime/package.json
+++ b/packages/assistant-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-runtime",
-  "version": "0.1.54",
+  "version": "0.1.55",
   "type": "module",
   "exports": {
     "./client": "./src/client/index.js",
@@ -8,13 +8,13 @@
     "./server/actionIds": "./src/server/actionIds.js"
   },
   "dependencies": {
-    "@jskit-ai/assistant-core": "0.1.59",
-    "@jskit-ai/database-runtime": "0.1.83",
-    "@jskit-ai/http-runtime": "0.1.82",
-    "@jskit-ai/kernel": "0.1.83",
-    "@jskit-ai/shell-web": "0.1.82",
-    "@jskit-ai/users-core": "0.1.93",
-    "@jskit-ai/users-web": "0.1.98",
+    "@jskit-ai/assistant-core": "0.1.60",
+    "@jskit-ai/database-runtime": "0.1.84",
+    "@jskit-ai/http-runtime": "0.1.83",
+    "@jskit-ai/kernel": "0.1.84",
+    "@jskit-ai/shell-web": "0.1.83",
+    "@jskit-ai/users-core": "0.1.94",
+    "@jskit-ai/users-web": "0.1.99",
     "json-rest-schema": "1.x.x"
   },
   "peerDependencies": {

--- a/packages/assistant/package.descriptor.mjs
+++ b/packages/assistant/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant",
-  version: "0.1.93",
+  version: "0.1.94",
   kind: "generator",
   description: "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
   options: {

--- a/packages/assistant/package.descriptor.mjs
+++ b/packages/assistant/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant",
-  version: "0.1.92",
+  version: "0.1.93",
   kind: "generator",
   description: "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
   options: {

--- a/packages/assistant/package.json
+++ b/packages/assistant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant",
-  "version": "0.1.93",
+  "version": "0.1.94",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.84"
+    "@jskit-ai/kernel": "0.1.85"
   }
 }

--- a/packages/assistant/package.json
+++ b/packages/assistant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant",
-  "version": "0.1.92",
+  "version": "0.1.93",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.83"
+    "@jskit-ai/kernel": "0.1.84"
   }
 }

--- a/packages/auth-core/package.descriptor.mjs
+++ b/packages/auth-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-core",
-  "version": "0.1.82",
+  "version": "0.1.83",
   "kind": "runtime",
   "dependsOn": [
     "@jskit-ai/value-app-config-shared"
@@ -69,7 +69,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.83",
+        "@jskit-ai/kernel": "0.1.84",
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0"

--- a/packages/auth-core/package.descriptor.mjs
+++ b/packages/auth-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-core",
-  "version": "0.1.83",
+  "version": "0.1.84",
   "kind": "runtime",
   "dependsOn": [
     "@jskit-ai/value-app-config-shared"
@@ -69,7 +69,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.84",
+        "@jskit-ai/kernel": "0.1.85",
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0"

--- a/packages/auth-core/package.json
+++ b/packages/auth-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-core",
-  "version": "0.1.83",
+  "version": "0.1.84",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -46,7 +46,7 @@
     "./shared/commands/authSessionReadCommand": "./src/shared/commands/authSessionReadCommand.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.84",
+    "@jskit-ai/kernel": "0.1.85",
     "@fastify/cookie": "^11.0.2",
     "@fastify/csrf-protection": "^7.1.0",
     "@fastify/rate-limit": "^10.3.0",

--- a/packages/auth-core/package.json
+++ b/packages/auth-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-core",
-  "version": "0.1.82",
+  "version": "0.1.83",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -46,7 +46,7 @@
     "./shared/commands/authSessionReadCommand": "./src/shared/commands/authSessionReadCommand.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.83",
+    "@jskit-ai/kernel": "0.1.84",
     "@fastify/cookie": "^11.0.2",
     "@fastify/csrf-protection": "^7.1.0",
     "@fastify/rate-limit": "^10.3.0",

--- a/packages/auth-provider-supabase-core/package.descriptor.mjs
+++ b/packages/auth-provider-supabase-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.82",
+  "version": "0.1.83",
   "kind": "runtime",
   "options": {
     "auth-supabase-url": {
@@ -83,8 +83,8 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/auth-core": "0.1.82",
-        "@jskit-ai/kernel": "0.1.83",
+        "@jskit-ai/auth-core": "0.1.83",
+        "@jskit-ai/kernel": "0.1.84",
         "dotenv": "^16.4.5",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0"

--- a/packages/auth-provider-supabase-core/package.descriptor.mjs
+++ b/packages/auth-provider-supabase-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.83",
+  "version": "0.1.84",
   "kind": "runtime",
   "options": {
     "auth-supabase-url": {
@@ -83,8 +83,8 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/auth-core": "0.1.83",
-        "@jskit-ai/kernel": "0.1.84",
+        "@jskit-ai/auth-core": "0.1.84",
+        "@jskit-ai/kernel": "0.1.85",
         "dotenv": "^16.4.5",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0"

--- a/packages/auth-provider-supabase-core/package.json
+++ b/packages/auth-provider-supabase-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.82",
+  "version": "0.1.83",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,8 +12,8 @@
     "./client": "./src/client/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.82",
-    "@jskit-ai/kernel": "0.1.83",
+    "@jskit-ai/auth-core": "0.1.83",
+    "@jskit-ai/kernel": "0.1.84",
     "json-rest-schema": "1.x.x",
     "jose": "^6.1.0",
     "@supabase/supabase-js": "^2.57.4",

--- a/packages/auth-provider-supabase-core/package.json
+++ b/packages/auth-provider-supabase-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.83",
+  "version": "0.1.84",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,8 +12,8 @@
     "./client": "./src/client/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.83",
-    "@jskit-ai/kernel": "0.1.84",
+    "@jskit-ai/auth-core": "0.1.84",
+    "@jskit-ai/kernel": "0.1.85",
     "json-rest-schema": "1.x.x",
     "jose": "^6.1.0",
     "@supabase/supabase-js": "^2.57.4",

--- a/packages/auth-web/package.descriptor.mjs
+++ b/packages/auth-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-web",
-  "version": "0.1.85",
+  "version": "0.1.86",
   "kind": "runtime",
   "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
   "dependsOn": [
@@ -247,10 +247,10 @@ export default Object.freeze({
     "dependencies": {
       "runtime": {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/auth-core": "0.1.83",
-        "@jskit-ai/http-runtime": "0.1.83",
-        "@jskit-ai/kernel": "0.1.84",
-        "@jskit-ai/shell-web": "0.1.83"
+        "@jskit-ai/auth-core": "0.1.84",
+        "@jskit-ai/http-runtime": "0.1.84",
+        "@jskit-ai/kernel": "0.1.85",
+        "@jskit-ai/shell-web": "0.1.84"
       },
       "dev": {}
     },

--- a/packages/auth-web/package.descriptor.mjs
+++ b/packages/auth-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-web",
-  "version": "0.1.84",
+  "version": "0.1.85",
   "kind": "runtime",
   "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
   "dependsOn": [
@@ -247,10 +247,10 @@ export default Object.freeze({
     "dependencies": {
       "runtime": {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/auth-core": "0.1.82",
-        "@jskit-ai/http-runtime": "0.1.82",
-        "@jskit-ai/kernel": "0.1.83",
-        "@jskit-ai/shell-web": "0.1.82"
+        "@jskit-ai/auth-core": "0.1.83",
+        "@jskit-ai/http-runtime": "0.1.83",
+        "@jskit-ai/kernel": "0.1.84",
+        "@jskit-ai/shell-web": "0.1.83"
       },
       "dev": {}
     },

--- a/packages/auth-web/package.json
+++ b/packages/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-web",
-  "version": "0.1.84",
+  "version": "0.1.85",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -18,11 +18,11 @@
     "./client/runtime/useSignOut": "./src/client/runtime/useSignOut.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.82",
+    "@jskit-ai/auth-core": "0.1.83",
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/kernel": "0.1.83",
-    "@jskit-ai/shell-web": "0.1.82",
-    "@jskit-ai/http-runtime": "0.1.82"
+    "@jskit-ai/kernel": "0.1.84",
+    "@jskit-ai/shell-web": "0.1.83",
+    "@jskit-ai/http-runtime": "0.1.83"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/auth-web/package.json
+++ b/packages/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-web",
-  "version": "0.1.85",
+  "version": "0.1.86",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -18,11 +18,11 @@
     "./client/runtime/useSignOut": "./src/client/runtime/useSignOut.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.83",
+    "@jskit-ai/auth-core": "0.1.84",
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/kernel": "0.1.84",
-    "@jskit-ai/shell-web": "0.1.83",
-    "@jskit-ai/http-runtime": "0.1.83"
+    "@jskit-ai/kernel": "0.1.85",
+    "@jskit-ai/shell-web": "0.1.84",
+    "@jskit-ai/http-runtime": "0.1.84"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/console-core/package.descriptor.mjs
+++ b/packages/console-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-core",
-  version: "0.1.46",
+  version: "0.1.47",
   kind: "runtime",
   description: "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
   dependsOn: [
@@ -85,12 +85,12 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.82",
-        "@jskit-ai/database-runtime": "0.1.83",
-        "@jskit-ai/http-runtime": "0.1.82",
-        "@jskit-ai/kernel": "0.1.83",
-        "@jskit-ai/resource-crud-core": "0.1.28",
-        "@jskit-ai/users-core": "0.1.93"
+        "@jskit-ai/auth-core": "0.1.83",
+        "@jskit-ai/database-runtime": "0.1.84",
+        "@jskit-ai/http-runtime": "0.1.83",
+        "@jskit-ai/kernel": "0.1.84",
+        "@jskit-ai/resource-crud-core": "0.1.29",
+        "@jskit-ai/users-core": "0.1.94"
       },
       dev: {}
     },

--- a/packages/console-core/package.descriptor.mjs
+++ b/packages/console-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-core",
-  version: "0.1.47",
+  version: "0.1.48",
   kind: "runtime",
   description: "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
   dependsOn: [
@@ -85,12 +85,12 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.83",
-        "@jskit-ai/database-runtime": "0.1.84",
-        "@jskit-ai/http-runtime": "0.1.83",
-        "@jskit-ai/kernel": "0.1.84",
-        "@jskit-ai/resource-crud-core": "0.1.29",
-        "@jskit-ai/users-core": "0.1.94"
+        "@jskit-ai/auth-core": "0.1.84",
+        "@jskit-ai/database-runtime": "0.1.85",
+        "@jskit-ai/http-runtime": "0.1.84",
+        "@jskit-ai/kernel": "0.1.85",
+        "@jskit-ai/resource-crud-core": "0.1.30",
+        "@jskit-ai/users-core": "0.1.95"
       },
       dev: {}
     },

--- a/packages/console-core/package.json
+++ b/packages/console-core/package.json
@@ -1,17 +1,17 @@
 {
   "name": "@jskit-ai/console-core",
-  "version": "0.1.46",
+  "version": "0.1.47",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.82",
-    "@jskit-ai/database-runtime": "0.1.83",
-    "@jskit-ai/http-runtime": "0.1.82",
-    "@jskit-ai/kernel": "0.1.83",
-    "@jskit-ai/resource-crud-core": "0.1.28",
-    "@jskit-ai/users-core": "0.1.93",
+    "@jskit-ai/auth-core": "0.1.83",
+    "@jskit-ai/database-runtime": "0.1.84",
+    "@jskit-ai/http-runtime": "0.1.83",
+    "@jskit-ai/kernel": "0.1.84",
+    "@jskit-ai/resource-crud-core": "0.1.29",
+    "@jskit-ai/users-core": "0.1.94",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/console-core/package.json
+++ b/packages/console-core/package.json
@@ -1,17 +1,17 @@
 {
   "name": "@jskit-ai/console-core",
-  "version": "0.1.47",
+  "version": "0.1.48",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.83",
-    "@jskit-ai/database-runtime": "0.1.84",
-    "@jskit-ai/http-runtime": "0.1.83",
-    "@jskit-ai/kernel": "0.1.84",
-    "@jskit-ai/resource-crud-core": "0.1.29",
-    "@jskit-ai/users-core": "0.1.94",
+    "@jskit-ai/auth-core": "0.1.84",
+    "@jskit-ai/database-runtime": "0.1.85",
+    "@jskit-ai/http-runtime": "0.1.84",
+    "@jskit-ai/kernel": "0.1.85",
+    "@jskit-ai/resource-crud-core": "0.1.30",
+    "@jskit-ai/users-core": "0.1.95",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/console-web/package.descriptor.mjs
+++ b/packages/console-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-web",
-  version: "0.1.52",
+  version: "0.1.53",
   kind: "runtime",
   description: "Authenticated console surface scaffold and surface policy wiring.",
   dependsOn: [
@@ -103,9 +103,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-web": "0.1.85",
-        "@jskit-ai/console-core": "0.1.47",
-        "@jskit-ai/shell-web": "0.1.83",
+        "@jskit-ai/auth-web": "0.1.86",
+        "@jskit-ai/console-core": "0.1.48",
+        "@jskit-ai/shell-web": "0.1.84",
       },
       dev: {}
     },

--- a/packages/console-web/package.descriptor.mjs
+++ b/packages/console-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-web",
-  version: "0.1.51",
+  version: "0.1.52",
   kind: "runtime",
   description: "Authenticated console surface scaffold and surface policy wiring.",
   dependsOn: [
@@ -103,9 +103,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-web": "0.1.84",
-        "@jskit-ai/console-core": "0.1.46",
-        "@jskit-ai/shell-web": "0.1.82",
+        "@jskit-ai/auth-web": "0.1.85",
+        "@jskit-ai/console-core": "0.1.47",
+        "@jskit-ai/shell-web": "0.1.83",
       },
       dev: {}
     },

--- a/packages/console-web/package.json
+++ b/packages/console-web/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/console-web",
-  "version": "0.1.52",
+  "version": "0.1.53",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-web": "0.1.85",
-    "@jskit-ai/console-core": "0.1.47",
-    "@jskit-ai/shell-web": "0.1.83"
+    "@jskit-ai/auth-web": "0.1.86",
+    "@jskit-ai/console-core": "0.1.48",
+    "@jskit-ai/shell-web": "0.1.84"
   }
 }

--- a/packages/console-web/package.json
+++ b/packages/console-web/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/console-web",
-  "version": "0.1.51",
+  "version": "0.1.52",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-web": "0.1.84",
-    "@jskit-ai/console-core": "0.1.46",
-    "@jskit-ai/shell-web": "0.1.82"
+    "@jskit-ai/auth-web": "0.1.85",
+    "@jskit-ai/console-core": "0.1.47",
+    "@jskit-ai/shell-web": "0.1.83"
   }
 }

--- a/packages/crud-core/package.descriptor.mjs
+++ b/packages/crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-core",
-  version: "0.1.92",
+  version: "0.1.93",
   kind: "runtime",
   description: "Shared CRUD helpers used by CRUD modules.",
   dependsOn: [
@@ -28,7 +28,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/crud-core": "0.1.92"
+        "@jskit-ai/crud-core": "0.1.93"
       },
       dev: {}
     },

--- a/packages/crud-core/package.descriptor.mjs
+++ b/packages/crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-core",
-  version: "0.1.91",
+  version: "0.1.92",
   kind: "runtime",
   description: "Shared CRUD helpers used by CRUD modules.",
   dependsOn: [
@@ -28,7 +28,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/crud-core": "0.1.91"
+        "@jskit-ai/crud-core": "0.1.92"
       },
       dev: {}
     },

--- a/packages/crud-core/package.json
+++ b/packages/crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-core",
-  "version": "0.1.92",
+  "version": "0.1.93",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -27,15 +27,15 @@
     "./server/routeContracts": "./src/server/routeContracts.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.84",
-    "@jskit-ai/http-runtime": "0.1.83",
-    "@jskit-ai/kernel": "0.1.84",
+    "@jskit-ai/database-runtime": "0.1.85",
+    "@jskit-ai/http-runtime": "0.1.84",
+    "@jskit-ai/kernel": "0.1.85",
     "json-rest-schema": "1.x.x",
-    "@jskit-ai/realtime": "0.1.83",
-    "@jskit-ai/resource-crud-core": "0.1.29",
-    "@jskit-ai/shell-web": "0.1.83",
-    "@jskit-ai/users-core": "0.1.94",
-    "@jskit-ai/users-web": "0.1.99"
+    "@jskit-ai/realtime": "0.1.84",
+    "@jskit-ai/resource-crud-core": "0.1.30",
+    "@jskit-ai/shell-web": "0.1.84",
+    "@jskit-ai/users-core": "0.1.95",
+    "@jskit-ai/users-web": "0.1.100"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/crud-core/package.json
+++ b/packages/crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-core",
-  "version": "0.1.91",
+  "version": "0.1.92",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -27,15 +27,15 @@
     "./server/routeContracts": "./src/server/routeContracts.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.83",
-    "@jskit-ai/http-runtime": "0.1.82",
-    "@jskit-ai/kernel": "0.1.83",
+    "@jskit-ai/database-runtime": "0.1.84",
+    "@jskit-ai/http-runtime": "0.1.83",
+    "@jskit-ai/kernel": "0.1.84",
     "json-rest-schema": "1.x.x",
-    "@jskit-ai/realtime": "0.1.82",
-    "@jskit-ai/resource-crud-core": "0.1.28",
-    "@jskit-ai/shell-web": "0.1.82",
-    "@jskit-ai/users-core": "0.1.93",
-    "@jskit-ai/users-web": "0.1.98"
+    "@jskit-ai/realtime": "0.1.83",
+    "@jskit-ai/resource-crud-core": "0.1.29",
+    "@jskit-ai/shell-web": "0.1.83",
+    "@jskit-ai/users-core": "0.1.94",
+    "@jskit-ai/users-web": "0.1.99"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/crud-core/src/server/routeContracts.js
+++ b/packages/crud-core/src/server/routeContracts.js
@@ -6,6 +6,7 @@ import {
   composeSchemaDefinitions,
   recordIdParamsValidator
 } from "@jskit-ai/kernel/shared/validators";
+import { resolveCrudResourceScopeName } from "@jskit-ai/kernel/shared/support/crudLookup";
 import {
   createCrudCursorPaginationQueryValidator,
   listSearchQueryValidator as defaultListSearchQueryValidator,
@@ -33,25 +34,127 @@ function resolveJsonApiRelationshipEntries(definition = null) {
   for (const [fieldKey, fieldDefinition] of Object.entries(resolveSchemaFieldDefinitions(definition))) {
     const normalizedFieldDefinition = isRecord(fieldDefinition) ? fieldDefinition : {};
     const relationshipType = String(normalizedFieldDefinition.belongsTo || "").trim();
-    if (!relationshipType) {
+    if (relationshipType) {
+      const relationshipName = String(normalizedFieldDefinition.as || fieldKey || "").trim();
+      if (!relationshipName) {
+        continue;
+      }
+
+      entries.push(Object.freeze({
+        attributeKey: fieldKey,
+        relationshipName,
+        relationshipType,
+        required: normalizedFieldDefinition.required === true,
+        nullable: normalizedFieldDefinition.nullable === true
+      }));
       continue;
     }
 
-    const relationshipName = String(normalizedFieldDefinition.as || fieldKey || "").trim();
-    if (!relationshipName) {
+    const relation = isRecord(normalizedFieldDefinition.relation)
+      ? normalizedFieldDefinition.relation
+      : {};
+    if (String(relation.kind || "").trim().toLowerCase() !== "collection") {
+      continue;
+    }
+
+    const collectionRelationshipType = resolveCrudResourceScopeName(
+      relation.target || relation.targetResource || relation.namespace || relation.apiPath
+    );
+    if (!collectionRelationshipType) {
+      continue;
+    }
+
+    const collectionRelationshipName = String(
+      relation.as || normalizedFieldDefinition.as || fieldKey || ""
+    ).trim();
+    if (!collectionRelationshipName) {
       continue;
     }
 
     entries.push(Object.freeze({
       attributeKey: fieldKey,
-      relationshipName,
-      relationshipType,
+      relationshipName: collectionRelationshipName,
+      relationshipType: collectionRelationshipType,
+      many: true,
       required: normalizedFieldDefinition.required === true,
       nullable: normalizedFieldDefinition.nullable === true
     }));
   }
 
   return Object.freeze(entries);
+}
+
+function readOwnValue(source = {}, key = "") {
+  if (isRecord(source) && Object.hasOwn(source, key)) {
+    return {
+      found: true,
+      value: source[key]
+    };
+  }
+
+  return {
+    found: false,
+    value: undefined
+  };
+}
+
+function resolveLookupContainer(record = {}, lookupContainerKey = "") {
+  const normalizedLookupContainerKey = String(lookupContainerKey || "").trim();
+  if (!normalizedLookupContainerKey || !isRecord(record?.[normalizedLookupContainerKey])) {
+    return {};
+  }
+
+  return record[normalizedLookupContainerKey];
+}
+
+function resolveRelationshipValueSource(record = {}, entry = {}, {
+  lookupContainerKey = "",
+  preferLookup = false
+} = {}) {
+  const lookups = resolveLookupContainer(record, lookupContainerKey);
+  const lookupValueByAttributeKey = readOwnValue(lookups, entry.attributeKey);
+  const lookupValue = lookupValueByAttributeKey.found
+    ? lookupValueByAttributeKey
+    : readOwnValue(lookups, entry.relationshipName);
+  const recordValue = readOwnValue(record, entry.attributeKey);
+
+  if (preferLookup) {
+    return lookupValue.found ? lookupValue : recordValue;
+  }
+
+  return recordValue.found ? recordValue : lookupValue;
+}
+
+function normalizeLookupId(value) {
+  if (value == null) {
+    return null;
+  }
+
+  const normalized = String(value).trim();
+  return normalized || null;
+}
+
+function normalizeRelationshipIdentifierId(value = null) {
+  if (isRecord(value)) {
+    if (isRecord(value.data)) {
+      return normalizeLookupId(value.data.id);
+    }
+    return normalizeLookupId(value.id);
+  }
+
+  return normalizeLookupId(value);
+}
+
+function createRelationshipIdentifier(entry = {}, value = null) {
+  const id = normalizeRelationshipIdentifierId(value);
+  if (!id) {
+    return null;
+  }
+
+  return {
+    type: entry.relationshipType,
+    id
+  };
 }
 
 function createRecordAttributesResolver(definition = null, {
@@ -91,7 +194,9 @@ function createRecordAttributesResolver(definition = null, {
   };
 }
 
-function createRecordRelationshipsResolver(definition = null) {
+function createRecordRelationshipsResolver(definition = null, {
+  lookupContainerKey = ""
+} = {}) {
   const relationshipEntries = resolveJsonApiRelationshipEntries(definition);
   if (relationshipEntries.length < 1) {
     return null;
@@ -105,18 +210,27 @@ function createRecordRelationshipsResolver(definition = null) {
     const relationships = {};
 
     for (const entry of relationshipEntries) {
-      if (!Object.hasOwn(record, entry.attributeKey)) {
+      const relationshipSource = resolveRelationshipValueSource(record, entry, {
+        lookupContainerKey,
+        preferLookup: entry.many === true
+      });
+      if (!relationshipSource.found) {
         continue;
       }
 
-      const value = record[entry.attributeKey];
+      const value = relationshipSource.value;
+      if (entry.many === true) {
+        const items = Array.isArray(value) ? value : [];
+        relationships[entry.relationshipName] = {
+          data: items
+            .map((item) => createRelationshipIdentifier(entry, item))
+            .filter(Boolean)
+        };
+        continue;
+      }
+
       relationships[entry.relationshipName] = {
-        data: value == null || (typeof value === "string" && value.trim() === "")
-          ? null
-          : {
-              type: entry.relationshipType,
-              id: String(value)
-            }
+        data: createRelationshipIdentifier(entry, value)
       };
     }
 
@@ -145,7 +259,16 @@ function createRequestRelationshipMapper(definition = null) {
       const data = relationship.data;
 
       if (data == null) {
-        mapped[entry.attributeKey] = null;
+        mapped[entry.attributeKey] = entry.many === true ? [] : null;
+        continue;
+      }
+
+      if (entry.many === true) {
+        mapped[entry.attributeKey] = Array.isArray(data)
+          ? data
+              .map((item) => normalizeRelationshipIdentifierId(item))
+              .filter(Boolean)
+          : [];
         continue;
       }
 
@@ -165,15 +288,6 @@ function resolveOutputAttributeExcludeKeys(resource = {}) {
 
 function resolveLookupContainerKey(resource = {}) {
   return String(resource?.contract?.lookup?.containerKey || "").trim();
-}
-
-function normalizeLookupId(value) {
-  if (value == null) {
-    return null;
-  }
-
-  const normalized = String(value).trim();
-  return normalized || null;
 }
 
 function normalizeIncludedLookupRecord(source = null, fallbackId = null) {
@@ -224,6 +338,41 @@ function normalizeIncludedLookupRecord(source = null, fallbackId = null) {
   };
 }
 
+function appendIncludedRelationshipResource({
+  included = [],
+  seen = new Set(),
+  entry = {},
+  lookupRecord = null,
+  fallbackId = null
+} = {}) {
+  const normalizedLookupRecord = normalizeIncludedLookupRecord(lookupRecord, fallbackId);
+  const includedId = normalizeLookupId(normalizedLookupRecord?.id ?? fallbackId);
+  if (!normalizedLookupRecord || !includedId) {
+    return;
+  }
+
+  const resourceKey = `${entry.relationshipType}:${includedId}`;
+  if (seen.has(resourceKey)) {
+    return;
+  }
+  seen.add(resourceKey);
+
+  const attributes = {
+    ...normalizedLookupRecord
+  };
+  delete attributes.id;
+  delete attributes.type;
+  delete attributes.relationships;
+  delete attributes.links;
+  delete attributes.meta;
+
+  included.push(createJsonApiResourceObject({
+    type: entry.relationshipType,
+    id: includedId,
+    attributes
+  }));
+}
+
 function createLookupIncludedResolver(definition = null, {
   lookupContainerKey = ""
 } = {}) {
@@ -254,36 +403,33 @@ function createLookupIncludedResolver(definition = null, {
         : {};
 
       for (const entry of relationshipEntries) {
+        if (entry.many === true) {
+          const relationshipSource = resolveRelationshipValueSource(record, entry, {
+            lookupContainerKey: normalizedLookupContainerKey,
+            preferLookup: true
+          });
+          const lookupRecords = Array.isArray(relationshipSource.value) ? relationshipSource.value : [];
+          for (const lookupRecord of lookupRecords) {
+            appendIncludedRelationshipResource({
+              included,
+              seen,
+              entry,
+              lookupRecord,
+              fallbackId: lookupRecord?.id
+            });
+          }
+          continue;
+        }
+
         const relationshipId = normalizeLookupId(record[entry.attributeKey]);
-        const lookupRecord = normalizeIncludedLookupRecord(
-          sourceLookups[entry.attributeKey] ?? sourceLookups[entry.relationshipName],
-          relationshipId
-        );
-        const includedId = normalizeLookupId(lookupRecord?.id ?? relationshipId);
-        if (!lookupRecord || !includedId) {
-          continue;
-        }
-
-        const resourceKey = `${entry.relationshipType}:${includedId}`;
-        if (seen.has(resourceKey)) {
-          continue;
-        }
-        seen.add(resourceKey);
-
-        const attributes = {
-          ...lookupRecord
-        };
-        delete attributes.id;
-        delete attributes.type;
-        delete attributes.relationships;
-        delete attributes.links;
-        delete attributes.meta;
-
-        included.push(createJsonApiResourceObject({
-          type: entry.relationshipType,
-          id: includedId,
-          attributes
-        }));
+        const lookupRecord = sourceLookups[entry.attributeKey] ?? sourceLookups[entry.relationshipName];
+        appendIncludedRelationshipResource({
+          included,
+          seen,
+          entry,
+          lookupRecord,
+          fallbackId: relationshipId
+        });
       }
     }
 
@@ -329,15 +475,21 @@ function createCrudJsonApiRouteContracts({
   const viewRecordAttributes = createRecordAttributesResolver(viewOutput, {
     excludeKeys: outputAttributeExcludeKeys
   });
-  const viewRecordRelationships = createRecordRelationshipsResolver(viewOutput);
+  const viewRecordRelationships = createRecordRelationshipsResolver(viewOutput, {
+    lookupContainerKey
+  });
   const createRecordAttributes = createRecordAttributesResolver(createOutput, {
     excludeKeys: outputAttributeExcludeKeys
   });
-  const createRecordRelationships = createRecordRelationshipsResolver(createOutput);
+  const createRecordRelationships = createRecordRelationshipsResolver(createOutput, {
+    lookupContainerKey
+  });
   const patchRecordAttributes = createRecordAttributesResolver(patchOutput, {
     excludeKeys: outputAttributeExcludeKeys
   });
-  const patchRecordRelationships = createRecordRelationshipsResolver(patchOutput);
+  const patchRecordRelationships = createRecordRelationshipsResolver(patchOutput, {
+    lookupContainerKey
+  });
   const createRequestRelationships = createRequestRelationshipMapper(createBody);
   const patchRequestRelationships = createRequestRelationshipMapper(patchBody);
   const viewIncluded = createLookupIncludedResolver(viewOutput, {

--- a/packages/crud-core/test/routeContracts.test.js
+++ b/packages/crud-core/test/routeContracts.test.js
@@ -244,6 +244,26 @@ test("createCrudJsonApiRouteContracts builds default CRUD JSON:API contracts", a
     }
   ]);
 
+  const lookupOnlyRelationshipDocument = contracts.viewRouteContract.transport.response(returnJsonApiData({
+    id: "contact-3",
+    name: "Charlie",
+    lookups: {
+      owner: {
+        id: "user-8",
+        name: "User Eight"
+      }
+    }
+  }));
+
+  assert.deepEqual(lookupOnlyRelationshipDocument.data.relationships, {
+    owner: {
+      data: {
+        type: "userProfiles",
+        id: "user-8"
+      }
+    }
+  });
+
   const listResponseDocument = contracts.listRouteContract.transport.response(returnJsonApiData({
     items: [
       {
@@ -282,6 +302,112 @@ test("createCrudJsonApiRouteContracts builds default CRUD JSON:API contracts", a
       }
     }
   ]);
+});
+
+test("createCrudJsonApiRouteContracts serializes collection relationships from hydrated lookups", () => {
+  const output = createSchemaDefinition({
+    id: {
+      type: "string",
+      required: true
+    },
+    name: {
+      type: "string",
+      required: true
+    },
+    pets: {
+      type: "array",
+      required: false,
+      relation: {
+        kind: "collection",
+        namespace: "pets",
+        foreignKey: "contactId"
+      }
+    },
+    lookups: {
+      type: "object",
+      required: false
+    }
+  }, "replace");
+  const body = createSchemaDefinition({
+    name: {
+      type: "string",
+      required: true
+    }
+  }, "create");
+  const contracts = createCrudJsonApiRouteContracts({
+    resource: {
+      namespace: "contacts",
+      contract: {
+        lookup: {
+          containerKey: "lookups"
+        }
+      },
+      operations: {
+        view: { output },
+        create: { body, output },
+        patch: { body, output }
+      }
+    }
+  });
+
+  const responseDocument = contracts.viewRouteContract.transport.response(returnJsonApiData({
+    id: "contact-1",
+    name: "Alice",
+    lookups: {
+      pets: [
+        {
+          id: "pet-1",
+          name: "Ada",
+          contactId: "contact-1"
+        },
+        {
+          id: "pet-2",
+          name: "Bert",
+          contactId: "contact-1"
+        }
+      ]
+    }
+  }));
+  const resourceSchema = contracts.viewRouteContract.responses[200].transportSchema.definitions.contactsSuccessResource;
+  const relationshipDataSchema = resourceSchema.properties.relationships.properties.pets.properties.data;
+
+  assert.deepEqual(responseDocument.data.attributes, {
+    name: "Alice"
+  });
+  assert.deepEqual(responseDocument.data.relationships, {
+    pets: {
+      data: [
+        {
+          type: "pets",
+          id: "pet-1"
+        },
+        {
+          type: "pets",
+          id: "pet-2"
+        }
+      ]
+    }
+  });
+  assert.deepEqual(responseDocument.included, [
+    {
+      type: "pets",
+      id: "pet-1",
+      attributes: {
+        name: "Ada",
+        contactId: "contact-1"
+      }
+    },
+    {
+      type: "pets",
+      id: "pet-2",
+      attributes: {
+        name: "Bert",
+        contactId: "contact-1"
+      }
+    }
+  ]);
+  assert.equal(relationshipDataSchema.anyOf[0].type, "array");
+  assert.equal(relationshipDataSchema.anyOf[0].items.properties.type.const, "pets");
 });
 
 test("createCrudJsonApiRouteContracts falls back to recordId params when no route params validator is provided", () => {

--- a/packages/crud-server-generator/package.descriptor.mjs
+++ b/packages/crud-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-server-generator",
-  version: "0.1.92",
+  version: "0.1.93",
   kind: "generator",
   description: "CRUD server generator with routes, actions, and persistence scaffolding.",
   options: {
@@ -160,14 +160,14 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.83",
-        "@jskit-ai/crud-core": "0.1.92",
-        "@jskit-ai/database-runtime": "0.1.84",
-        "@jskit-ai/http-runtime": "0.1.83",
-        "@jskit-ai/json-rest-api-core": "0.1.29",
-        "@jskit-ai/kernel": "0.1.84",
-        "@jskit-ai/realtime": "0.1.83",
-        "@jskit-ai/resource-crud-core": "0.1.29",
+        "@jskit-ai/auth-core": "0.1.84",
+        "@jskit-ai/crud-core": "0.1.93",
+        "@jskit-ai/database-runtime": "0.1.85",
+        "@jskit-ai/http-runtime": "0.1.84",
+        "@jskit-ai/json-rest-api-core": "0.1.30",
+        "@jskit-ai/kernel": "0.1.85",
+        "@jskit-ai/realtime": "0.1.84",
+        "@jskit-ai/resource-crud-core": "0.1.30",
         "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}"
       },
       dev: {}

--- a/packages/crud-server-generator/package.descriptor.mjs
+++ b/packages/crud-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-server-generator",
-  version: "0.1.91",
+  version: "0.1.92",
   kind: "generator",
   description: "CRUD server generator with routes, actions, and persistence scaffolding.",
   options: {
@@ -160,14 +160,14 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.82",
-        "@jskit-ai/crud-core": "0.1.91",
-        "@jskit-ai/database-runtime": "0.1.83",
-        "@jskit-ai/http-runtime": "0.1.82",
-        "@jskit-ai/json-rest-api-core": "0.1.28",
-        "@jskit-ai/kernel": "0.1.83",
-        "@jskit-ai/realtime": "0.1.82",
-        "@jskit-ai/resource-crud-core": "0.1.28",
+        "@jskit-ai/auth-core": "0.1.83",
+        "@jskit-ai/crud-core": "0.1.92",
+        "@jskit-ai/database-runtime": "0.1.84",
+        "@jskit-ai/http-runtime": "0.1.83",
+        "@jskit-ai/json-rest-api-core": "0.1.29",
+        "@jskit-ai/kernel": "0.1.84",
+        "@jskit-ai/realtime": "0.1.83",
+        "@jskit-ai/resource-crud-core": "0.1.29",
         "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}"
       },
       dev: {}

--- a/packages/crud-server-generator/package.json
+++ b/packages/crud-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-server-generator",
-  "version": "0.1.92",
+  "version": "0.1.93",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,12 +13,12 @@
   },
   "dependencies": {
     "@babel/parser": "^7.29.2",
-    "@jskit-ai/crud-core": "0.1.92",
-    "@jskit-ai/database-runtime": "0.1.84",
-    "@jskit-ai/http-runtime": "0.1.83",
-    "@jskit-ai/json-rest-api-core": "0.1.29",
-    "@jskit-ai/kernel": "0.1.84",
-    "@jskit-ai/resource-crud-core": "0.1.29",
+    "@jskit-ai/crud-core": "0.1.93",
+    "@jskit-ai/database-runtime": "0.1.85",
+    "@jskit-ai/http-runtime": "0.1.84",
+    "@jskit-ai/json-rest-api-core": "0.1.30",
+    "@jskit-ai/kernel": "0.1.85",
+    "@jskit-ai/resource-crud-core": "0.1.30",
     "recast": "^0.23.11"
   }
 }

--- a/packages/crud-server-generator/package.json
+++ b/packages/crud-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-server-generator",
-  "version": "0.1.91",
+  "version": "0.1.92",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,12 +13,12 @@
   },
   "dependencies": {
     "@babel/parser": "^7.29.2",
-    "@jskit-ai/crud-core": "0.1.91",
-    "@jskit-ai/database-runtime": "0.1.83",
-    "@jskit-ai/http-runtime": "0.1.82",
-    "@jskit-ai/json-rest-api-core": "0.1.28",
-    "@jskit-ai/kernel": "0.1.83",
-    "@jskit-ai/resource-crud-core": "0.1.28",
+    "@jskit-ai/crud-core": "0.1.92",
+    "@jskit-ai/database-runtime": "0.1.84",
+    "@jskit-ai/http-runtime": "0.1.83",
+    "@jskit-ai/json-rest-api-core": "0.1.29",
+    "@jskit-ai/kernel": "0.1.84",
+    "@jskit-ai/resource-crud-core": "0.1.29",
     "recast": "^0.23.11"
   }
 }

--- a/packages/crud-server-generator/src/server/buildTemplateContext.js
+++ b/packages/crud-server-generator/src/server/buildTemplateContext.js
@@ -16,7 +16,10 @@ import {
   resolveRequiredAppRoot
 } from "@jskit-ai/kernel/server/support";
 import { normalizeBoolean } from "@jskit-ai/kernel/shared/support/normalize";
-import { normalizeCrudLookupNamespace } from "@jskit-ai/kernel/shared/support/crudLookup";
+import {
+  normalizeCrudLookupNamespace,
+  resolveCrudResourceScopeName
+} from "@jskit-ai/kernel/shared/support/crudLookup";
 import { toCamelCase, toSnakeCase } from "@jskit-ai/kernel/shared/support/stringCase";
 import descriptor from "../../package.descriptor.mjs";
 
@@ -885,12 +888,7 @@ function renderCanonicalResourceSchemaPropertyLines(columns = [], { fieldContrac
 }
 
 function resolveJsonRestRelationshipScopeName(fieldContractEntry = null) {
-  const namespace = normalizeText(fieldContractEntry?.relation?.namespace);
-  if (!namespace) {
-    return "";
-  }
-
-  return toCamelCase(namespace.replace(/\//g, "-"));
+  return resolveCrudResourceScopeName(fieldContractEntry?.relation?.namespace);
 }
 
 function resolveJsonRestRelationshipAlias(column = null) {
@@ -1967,7 +1965,7 @@ function buildReplacementsFromSnapshot({
     __JSKIT_CRUD_RESOURCE_SEARCH_SCHEMA_LINES__: resourceSearchSchemaLines,
     __JSKIT_CRUD_RESOURCE_DEFAULT_SORT__: resourceDefaultSortLiteral,
     __JSKIT_CRUD_RESOURCE_AUTOFILTER__: JSON.stringify(resolvedOwnershipFilter),
-    __JSKIT_CRUD_JSONREST_SCOPE_NAME__: JSON.stringify(toCamelCase(namespace)),
+    __JSKIT_CRUD_JSONREST_SCOPE_NAME__: JSON.stringify(resolveCrudResourceScopeName(namespace)),
     __JSKIT_CRUD_JSONREST_AUTOFILTER__: JSON.stringify(resolvedOwnershipFilter),
     __JSKIT_CRUD_JSONREST_SEARCH_SCHEMA_LINES__: jsonRestSearchSchemaLines,
     __JSKIT_CRUD_JSONREST_SCHEMA_PROPERTIES__: jsonRestSchemaPropertyLines,

--- a/packages/crud-ui-generator/package.descriptor.mjs
+++ b/packages/crud-ui-generator/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { GENERATED_UI_NAVIGATION_ROLE_OPTION } from "@jskit-ai/kernel/shared/sup
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-ui-generator",
-  version: "0.1.67",
+  version: "0.1.68",
   kind: "generator",
   description: "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
   options: {
@@ -175,7 +175,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.99"
+        "@jskit-ai/users-web": "0.1.100"
       },
       dev: {}
     },

--- a/packages/crud-ui-generator/package.descriptor.mjs
+++ b/packages/crud-ui-generator/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { GENERATED_UI_NAVIGATION_ROLE_OPTION } from "@jskit-ai/kernel/shared/sup
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-ui-generator",
-  version: "0.1.66",
+  version: "0.1.67",
   kind: "generator",
   description: "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
   options: {
@@ -175,7 +175,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.98"
+        "@jskit-ai/users-web": "0.1.99"
       },
       dev: {}
     },

--- a/packages/crud-ui-generator/package.json
+++ b/packages/crud-ui-generator/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@jskit-ai/crud-ui-generator",
-  "version": "0.1.66",
+  "version": "0.1.67",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/crud-core": "0.1.91",
-    "@jskit-ai/kernel": "0.1.83",
-    "@jskit-ai/resource-crud-core": "0.1.28"
+    "@jskit-ai/crud-core": "0.1.92",
+    "@jskit-ai/kernel": "0.1.84",
+    "@jskit-ai/resource-crud-core": "0.1.29"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/crud-ui-generator/package.json
+++ b/packages/crud-ui-generator/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@jskit-ai/crud-ui-generator",
-  "version": "0.1.67",
+  "version": "0.1.68",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/crud-core": "0.1.92",
-    "@jskit-ai/kernel": "0.1.84",
-    "@jskit-ai/resource-crud-core": "0.1.29"
+    "@jskit-ai/crud-core": "0.1.93",
+    "@jskit-ai/kernel": "0.1.85",
+    "@jskit-ai/resource-crud-core": "0.1.30"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/database-runtime-mysql/package.descriptor.mjs
+++ b/packages/database-runtime-mysql/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-mysql",
-  version: "0.1.82",
+  version: "0.1.83",
   kind: "runtime",
   options: {
     "db-host": {
@@ -91,7 +91,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.83",
+        "@jskit-ai/database-runtime": "0.1.84",
         "mysql2": "^3.11.2"
       },
       dev: {}

--- a/packages/database-runtime-mysql/package.descriptor.mjs
+++ b/packages/database-runtime-mysql/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-mysql",
-  version: "0.1.83",
+  version: "0.1.84",
   kind: "runtime",
   options: {
     "db-host": {
@@ -91,7 +91,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.84",
+        "@jskit-ai/database-runtime": "0.1.85",
         "mysql2": "^3.11.2"
       },
       dev: {}

--- a/packages/database-runtime-mysql/package.json
+++ b/packages/database-runtime-mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-mysql",
-  "version": "0.1.82",
+  "version": "0.1.83",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,7 +12,7 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.83",
-    "@jskit-ai/kernel": "0.1.83"
+    "@jskit-ai/database-runtime": "0.1.84",
+    "@jskit-ai/kernel": "0.1.84"
   }
 }

--- a/packages/database-runtime-mysql/package.json
+++ b/packages/database-runtime-mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-mysql",
-  "version": "0.1.83",
+  "version": "0.1.84",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,7 +12,7 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.84",
-    "@jskit-ai/kernel": "0.1.84"
+    "@jskit-ai/database-runtime": "0.1.85",
+    "@jskit-ai/kernel": "0.1.85"
   }
 }

--- a/packages/database-runtime-postgres/package.descriptor.mjs
+++ b/packages/database-runtime-postgres/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-postgres",
-  version: "0.1.82",
+  version: "0.1.83",
   kind: "runtime",
   options: {
     "db-host": {
@@ -91,7 +91,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.83",
+        "@jskit-ai/database-runtime": "0.1.84",
         "pg": "^8.13.1"
       },
       dev: {}

--- a/packages/database-runtime-postgres/package.descriptor.mjs
+++ b/packages/database-runtime-postgres/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-postgres",
-  version: "0.1.83",
+  version: "0.1.84",
   kind: "runtime",
   options: {
     "db-host": {
@@ -91,7 +91,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.84",
+        "@jskit-ai/database-runtime": "0.1.85",
         "pg": "^8.13.1"
       },
       dev: {}

--- a/packages/database-runtime-postgres/package.json
+++ b/packages/database-runtime-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-postgres",
-  "version": "0.1.83",
+  "version": "0.1.84",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,6 +12,6 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.84"
+    "@jskit-ai/database-runtime": "0.1.85"
   }
 }

--- a/packages/database-runtime-postgres/package.json
+++ b/packages/database-runtime-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-postgres",
-  "version": "0.1.82",
+  "version": "0.1.83",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,6 +12,6 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.83"
+    "@jskit-ai/database-runtime": "0.1.84"
   }
 }

--- a/packages/database-runtime/package.descriptor.mjs
+++ b/packages/database-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime",
-  version: "0.1.84",
+  version: "0.1.85",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -58,7 +58,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.84",
+        "@jskit-ai/kernel": "0.1.85",
         "dotenv": "^16.4.5",
         "knex": "^3.1.0"
       },

--- a/packages/database-runtime/package.descriptor.mjs
+++ b/packages/database-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime",
-  version: "0.1.83",
+  version: "0.1.84",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -58,7 +58,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.83",
+        "@jskit-ai/kernel": "0.1.84",
         "dotenv": "^16.4.5",
         "knex": "^3.1.0"
       },

--- a/packages/database-runtime/package.json
+++ b/packages/database-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime",
-  "version": "0.1.84",
+  "version": "0.1.85",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -25,6 +25,6 @@
     "./shared/transactions": "./src/shared/transactions.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.84"
+    "@jskit-ai/kernel": "0.1.85"
   }
 }

--- a/packages/database-runtime/package.json
+++ b/packages/database-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime",
-  "version": "0.1.83",
+  "version": "0.1.84",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -25,6 +25,6 @@
     "./shared/transactions": "./src/shared/transactions.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.83"
+    "@jskit-ai/kernel": "0.1.84"
   }
 }

--- a/packages/feature-server-generator/package.descriptor.mjs
+++ b/packages/feature-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/feature-server-generator",
-  version: "0.1.26",
+  version: "0.1.27",
   kind: "generator",
   description: "Scaffold substantial non-CRUD server feature packages with provider, actions, service, and optional persistence seams.",
   options: {
@@ -174,7 +174,7 @@ export default Object.freeze({
             equals: "json-rest"
           }
         },
-        "@jskit-ai/kernel": "0.1.84",
+        "@jskit-ai/kernel": "0.1.85",
         "json-rest-schema": "1.x.x",
         "@local/${option:feature-name|kebab}": "file:packages/${option:feature-name|kebab}"
       },

--- a/packages/feature-server-generator/package.descriptor.mjs
+++ b/packages/feature-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/feature-server-generator",
-  version: "0.1.25",
+  version: "0.1.26",
   kind: "generator",
   description: "Scaffold substantial non-CRUD server feature packages with provider, actions, service, and optional persistence seams.",
   options: {
@@ -174,7 +174,7 @@ export default Object.freeze({
             equals: "json-rest"
           }
         },
-        "@jskit-ai/kernel": "0.1.83",
+        "@jskit-ai/kernel": "0.1.84",
         "json-rest-schema": "1.x.x",
         "@local/${option:feature-name|kebab}": "file:packages/${option:feature-name|kebab}"
       },

--- a/packages/feature-server-generator/package.json
+++ b/packages/feature-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/feature-server-generator",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "type": "module",
   "scripts": {
     "test": "node --test"

--- a/packages/feature-server-generator/package.json
+++ b/packages/feature-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/feature-server-generator",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "type": "module",
   "scripts": {
     "test": "node --test"

--- a/packages/google-rewarded-core/package.descriptor.mjs
+++ b/packages/google-rewarded-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/google-rewarded-core",
-  version: "0.1.20",
+  version: "0.1.21",
   kind: "runtime",
   description: "Google rewarded workflow runtime plus internal CRUD providers for rules, provider configs, watch sessions, and unlock receipts.",
   dependsOn: [
@@ -128,14 +128,14 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.82",
-        "@jskit-ai/crud-core": "0.1.91",
-        "@jskit-ai/database-runtime": "0.1.83",
-        "@jskit-ai/http-runtime": "0.1.82",
-        "@jskit-ai/json-rest-api-core": "0.1.28",
-        "@jskit-ai/kernel": "0.1.83",
-        "@jskit-ai/resource-crud-core": "0.1.28",
-        "@jskit-ai/workspaces-core": "0.1.59"
+        "@jskit-ai/auth-core": "0.1.83",
+        "@jskit-ai/crud-core": "0.1.92",
+        "@jskit-ai/database-runtime": "0.1.84",
+        "@jskit-ai/http-runtime": "0.1.83",
+        "@jskit-ai/json-rest-api-core": "0.1.29",
+        "@jskit-ai/kernel": "0.1.84",
+        "@jskit-ai/resource-crud-core": "0.1.29",
+        "@jskit-ai/workspaces-core": "0.1.60"
       },
       dev: {}
     },

--- a/packages/google-rewarded-core/package.descriptor.mjs
+++ b/packages/google-rewarded-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/google-rewarded-core",
-  version: "0.1.21",
+  version: "0.1.22",
   kind: "runtime",
   description: "Google rewarded workflow runtime plus internal CRUD providers for rules, provider configs, watch sessions, and unlock receipts.",
   dependsOn: [
@@ -128,14 +128,14 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.83",
-        "@jskit-ai/crud-core": "0.1.92",
-        "@jskit-ai/database-runtime": "0.1.84",
-        "@jskit-ai/http-runtime": "0.1.83",
-        "@jskit-ai/json-rest-api-core": "0.1.29",
-        "@jskit-ai/kernel": "0.1.84",
-        "@jskit-ai/resource-crud-core": "0.1.29",
-        "@jskit-ai/workspaces-core": "0.1.60"
+        "@jskit-ai/auth-core": "0.1.84",
+        "@jskit-ai/crud-core": "0.1.93",
+        "@jskit-ai/database-runtime": "0.1.85",
+        "@jskit-ai/http-runtime": "0.1.84",
+        "@jskit-ai/json-rest-api-core": "0.1.30",
+        "@jskit-ai/kernel": "0.1.85",
+        "@jskit-ai/resource-crud-core": "0.1.30",
+        "@jskit-ai/workspaces-core": "0.1.61"
       },
       dev: {}
     },

--- a/packages/google-rewarded-core/package.json
+++ b/packages/google-rewarded-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/google-rewarded-core",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/google-rewarded-core/package.json
+++ b/packages/google-rewarded-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/google-rewarded-core",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/google-rewarded-web/package.descriptor.mjs
+++ b/packages/google-rewarded-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/google-rewarded-web",
-  version: "0.1.20",
+  version: "0.1.21",
   kind: "runtime",
   description: "Google rewarded client runtime with a fullscreen gate host and GPT orchestration.",
   dependsOn: [
@@ -46,10 +46,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/google-rewarded-core": "0.1.20",
-        "@jskit-ai/http-runtime": "0.1.82",
-        "@jskit-ai/kernel": "0.1.83",
-        "@jskit-ai/shell-web": "0.1.82"
+        "@jskit-ai/google-rewarded-core": "0.1.21",
+        "@jskit-ai/http-runtime": "0.1.83",
+        "@jskit-ai/kernel": "0.1.84",
+        "@jskit-ai/shell-web": "0.1.83"
       },
       dev: {}
     },

--- a/packages/google-rewarded-web/package.descriptor.mjs
+++ b/packages/google-rewarded-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/google-rewarded-web",
-  version: "0.1.21",
+  version: "0.1.22",
   kind: "runtime",
   description: "Google rewarded client runtime with a fullscreen gate host and GPT orchestration.",
   dependsOn: [
@@ -46,10 +46,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/google-rewarded-core": "0.1.21",
-        "@jskit-ai/http-runtime": "0.1.83",
-        "@jskit-ai/kernel": "0.1.84",
-        "@jskit-ai/shell-web": "0.1.83"
+        "@jskit-ai/google-rewarded-core": "0.1.22",
+        "@jskit-ai/http-runtime": "0.1.84",
+        "@jskit-ai/kernel": "0.1.85",
+        "@jskit-ai/shell-web": "0.1.84"
       },
       dev: {}
     },

--- a/packages/google-rewarded-web/package.json
+++ b/packages/google-rewarded-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/google-rewarded-web",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/google-rewarded-web/package.json
+++ b/packages/google-rewarded-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/google-rewarded-web",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/http-runtime/package.descriptor.mjs
+++ b/packages/http-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/http-runtime",
-  "version": "0.1.82",
+  "version": "0.1.83",
   "kind": "runtime",
   "dependsOn": [],
   "capabilities": {
@@ -67,7 +67,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.83"
+        "@jskit-ai/kernel": "0.1.84"
       },
       "dev": {}
     },

--- a/packages/http-runtime/package.descriptor.mjs
+++ b/packages/http-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/http-runtime",
-  "version": "0.1.83",
+  "version": "0.1.84",
   "kind": "runtime",
   "dependsOn": [],
   "capabilities": {
@@ -67,7 +67,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.84"
+        "@jskit-ai/kernel": "0.1.85"
       },
       "dev": {}
     },

--- a/packages/http-runtime/package.json
+++ b/packages/http-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/http-runtime",
-  "version": "0.1.83",
+  "version": "0.1.84",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -18,7 +18,7 @@
     "./shared/validators/operationValidation": "./src/shared/validators/operationValidation.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.84",
+    "@jskit-ai/kernel": "0.1.85",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/http-runtime/package.json
+++ b/packages/http-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/http-runtime",
-  "version": "0.1.82",
+  "version": "0.1.83",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -18,7 +18,7 @@
     "./shared/validators/operationValidation": "./src/shared/validators/operationValidation.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.83",
+    "@jskit-ai/kernel": "0.1.84",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/http-runtime/src/shared/validators/jsonApiRouteTransport.js
+++ b/packages/http-runtime/src/shared/validators/jsonApiRouteTransport.js
@@ -247,6 +247,7 @@ function normalizeRelationshipSchemaEntries(entries = []) {
       relationshipName,
       relationshipType,
       attributeKey,
+      many: source.many === true,
       required: source.required === true,
       nullable: source.nullable === true
     }));
@@ -256,6 +257,7 @@ function normalizeRelationshipSchemaEntries(entries = []) {
 }
 
 function createJsonApiRelationshipDataSchema(relationshipType = "", {
+  many = false,
   nullable = false
 } = {}) {
   const normalizedRelationshipType = normalizeText(relationshipType);
@@ -270,14 +272,20 @@ function createJsonApiRelationshipDataSchema(relationshipType = "", {
         }
       }
     : JSON_API_RESOURCE_IDENTIFIER_SCHEMA;
+  const linkageSchema = many
+    ? {
+        type: "array",
+        items: resourceIdentifierSchema
+      }
+    : resourceIdentifierSchema;
 
   return {
     anyOf: nullable
       ? [
-          resourceIdentifierSchema,
+          linkageSchema,
           { type: "null" }
         ]
-      : [resourceIdentifierSchema]
+      : [linkageSchema]
   };
 }
 
@@ -299,6 +307,7 @@ function createJsonApiRelationshipsTransportSchema(entries = [], {
       required: ["data"],
       properties: {
         data: createJsonApiRelationshipDataSchema(entry.relationshipType, {
+          many: entry.many,
           nullable: entry.nullable
         })
       }

--- a/packages/http-runtime/test/jsonApiRouteTransport.test.js
+++ b/packages/http-runtime/test/jsonApiRouteTransport.test.js
@@ -372,6 +372,50 @@ test("createJsonApiResourceRouteContract models explicit relationship-backed out
   assert.ok(Object.hasOwn(contract.responses["200"].transportSchema.properties, "included"));
 });
 
+test("createJsonApiResourceRouteContract models to-many relationship output fields", () => {
+  const contract = createJsonApiResourceRouteContract({
+    responseType: "contacts",
+    output: {
+      schema: createSchema({
+        id: {
+          type: "string",
+          required: true,
+          minLength: 1
+        },
+        name: {
+          type: "string",
+          required: true,
+          minLength: 1
+        },
+        pets: {
+          type: "array",
+          required: false
+        }
+      }),
+      mode: "replace"
+    },
+    outputKind: "record",
+    outputRelationshipEntries: [
+      {
+        attributeKey: "pets",
+        relationshipName: "pets",
+        relationshipType: "pets",
+        many: true
+      }
+    ]
+  });
+
+  const resourceSchema = contract.responses["200"].transportSchema.definitions.contactsSuccessResource;
+  const attributesSchemaRef = resourceSchema.properties.attributes.allOf[0].$ref;
+  const attributesSchemaName = attributesSchemaRef.replace("#/definitions/", "");
+  const attributesSchema = contract.responses["200"].transportSchema.definitions[attributesSchemaName];
+  const relationshipDataSchema = resourceSchema.properties.relationships.properties.pets.properties.data;
+
+  assert.equal(Object.hasOwn(attributesSchema.properties, "pets"), false);
+  assert.equal(relationshipDataSchema.anyOf[0].type, "array");
+  assert.equal(relationshipDataSchema.anyOf[0].items.properties.type.const, "pets");
+});
+
 test("createJsonApiResourceRouteTransport wraps tagged meta results for meta routes", () => {
   const contract = createJsonApiResourceRouteContract({
     requestType: "password-changes",

--- a/packages/json-rest-api-core/package.descriptor.mjs
+++ b/packages/json-rest-api-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/json-rest-api-core",
-  version: "0.1.29",
+  version: "0.1.30",
   kind: "runtime",
   description: "Shared internal json-rest-api host runtime for JSKIT server packages.",
   dependsOn: [

--- a/packages/json-rest-api-core/package.descriptor.mjs
+++ b/packages/json-rest-api-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/json-rest-api-core",
-  version: "0.1.28",
+  version: "0.1.29",
   kind: "runtime",
   description: "Shared internal json-rest-api host runtime for JSKIT server packages.",
   dependsOn: [

--- a/packages/json-rest-api-core/package.json
+++ b/packages/json-rest-api-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/json-rest-api-core",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,6 +11,6 @@
   "dependencies": {
     "hooked-api": "1.x.x",
     "json-rest-api": "1.x.x",
-    "@jskit-ai/kernel": "0.1.83"
+    "@jskit-ai/kernel": "0.1.84"
   }
 }

--- a/packages/json-rest-api-core/package.json
+++ b/packages/json-rest-api-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/json-rest-api-core",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,6 +11,6 @@
   "dependencies": {
     "hooked-api": "1.x.x",
     "json-rest-api": "1.x.x",
-    "@jskit-ai/kernel": "0.1.84"
+    "@jskit-ai/kernel": "0.1.85"
   }
 }

--- a/packages/json-rest-api-core/src/server/jsonRestApiHost.js
+++ b/packages/json-rest-api-core/src/server/jsonRestApiHost.js
@@ -1,6 +1,7 @@
 import { Api } from "hooked-api";
 import { AutoFilterPlugin, RestApiKnexPlugin, RestApiPlugin } from "json-rest-api";
 import { normalizeRecordId } from "@jskit-ai/kernel/shared/support/normalize";
+import { resolveCrudResourceScopeName } from "@jskit-ai/kernel/shared/support/crudLookup";
 
 const INTERNAL_JSON_REST_API = "internal.json-rest-api";
 
@@ -79,6 +80,12 @@ function cloneJsonRestResourceValue(value, { writeSerializers = {} } = {}) {
       delete next.storage.writeSerializer;
     }
   }
+  if (
+    isPlainJsonRestObject(next.relation) &&
+    normalizeJsonRestText(next.relation.kind).toLowerCase() === "collection"
+  ) {
+    next.virtual = true;
+  }
 
   return next;
 }
@@ -142,6 +149,38 @@ function normalizeJsonRestList(value) {
     .split(",")
     .map((entry) => normalizeJsonRestText(entry))
     .filter(Boolean);
+}
+
+function resolveJsonRestCollectionRelationships(resource = {}) {
+  const resourceSchema = normalizeJsonRestObject(resource?.schema);
+  const relationships = {};
+
+  for (const [fieldName, fieldDefinition] of Object.entries(resourceSchema)) {
+    const normalizedFieldDefinition = normalizeJsonRestObject(fieldDefinition);
+    const relation = normalizeJsonRestObject(normalizedFieldDefinition.relation);
+    if (normalizeJsonRestText(relation.kind).toLowerCase() !== "collection") {
+      continue;
+    }
+
+    const relationshipName = normalizeJsonRestText(relation.as || normalizedFieldDefinition.as, {
+      fallback: fieldName
+    });
+    const target = resolveCrudResourceScopeName(
+      relation.target || relation.targetResource || relation.namespace || relation.apiPath
+    );
+    const foreignKey = normalizeJsonRestText(relation.foreignKey);
+    if (!relationshipName || !target || !foreignKey) {
+      continue;
+    }
+
+    relationships[relationshipName] = {
+      type: "hasMany",
+      target,
+      foreignKey
+    };
+  }
+
+  return relationships;
 }
 
 function buildJsonRestQueryParams(resourceType = "", query = {}, { include = undefined } = {}) {
@@ -292,6 +331,23 @@ function createJsonRestResourceScopeOptions(resource = {}, { writeSerializers = 
   const scopeOptions = cloneJsonRestResourceValue(resource, {
     writeSerializers: normalizeJsonRestObject(writeSerializers)
   });
+  const collectionRelationships = resolveJsonRestCollectionRelationships(scopeOptions);
+  if (Object.keys(collectionRelationships).length > 0) {
+    if (
+      scopeOptions.relationships !== undefined &&
+      scopeOptions.relationships !== null &&
+      !isPlainJsonRestObject(scopeOptions.relationships)
+    ) {
+      throw new TypeError(
+        "json-rest-api resource relationships must be an object when collection relations are derived."
+      );
+    }
+
+    scopeOptions.relationships = {
+      ...collectionRelationships,
+      ...normalizeJsonRestObject(scopeOptions.relationships)
+    };
+  }
 
   if (typeof normalizeId === "function") {
     scopeOptions.normalizeId = normalizeId;

--- a/packages/json-rest-api-core/test/entrypoints.boundary.test.js
+++ b/packages/json-rest-api-core/test/entrypoints.boundary.test.js
@@ -290,6 +290,26 @@ test("createJsonRestResourceScopeOptions clones canonical resource metadata and 
             required: false
           })
         })
+      }),
+      pets: Object.freeze({
+        type: "array",
+        relation: Object.freeze({
+          kind: "collection",
+          namespace: "pets",
+          foreignKey: "contactId"
+        }),
+        operations: Object.freeze({
+          output: Object.freeze({
+            required: false
+          })
+        })
+      })
+    }),
+    relationships: Object.freeze({
+      auditEvents: Object.freeze({
+        type: "hasMany",
+        target: "auditEvents",
+        foreignKey: "contactId"
       })
     }),
     operations: Object.freeze({
@@ -314,10 +334,23 @@ test("createJsonRestResourceScopeOptions clones canonical resource metadata and 
   assert.equal(result.schema.createdAt.storage.serialize(null), null);
   assert.equal(result.schema.createdAt.storage.writeSerializer, undefined);
   assert.equal(result.schema.bookingSteps.virtual, true);
+  assert.equal(result.schema.pets.virtual, true);
   assert.equal(result.normalizeId, normalizeId);
   assert.equal(result.schema.name.maxLength, 190);
   assert.equal(result.schema.name.operations.output.required, true);
   assert.equal(result.operations.view.method, "GET");
+  assert.deepEqual(result.relationships, {
+    pets: {
+      type: "hasMany",
+      target: "pets",
+      foreignKey: "contactId"
+    },
+    auditEvents: {
+      type: "hasMany",
+      target: "auditEvents",
+      foreignKey: "contactId"
+    }
+  });
 
   result.schema.createdAt.indexed = true;
   assert.equal(source.schema.createdAt.indexed, undefined);

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/kernel",
-  "version": "0.1.84",
+  "version": "0.1.85",
   "type": "module",
   "dependencies": {
     "json-rest-schema": "1.x.x"

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/kernel",
-  "version": "0.1.83",
+  "version": "0.1.84",
   "type": "module",
   "dependencies": {
     "json-rest-schema": "1.x.x"

--- a/packages/kernel/shared/support/crudLookup.js
+++ b/packages/kernel/shared/support/crudLookup.js
@@ -1,4 +1,5 @@
 import { normalizeText } from "./normalize.js";
+import { toCamelCase } from "./stringCase.js";
 import { normalizePathname } from "../surface/paths.js";
 import {
   buildCrudFieldContractMap,
@@ -32,6 +33,15 @@ function resolveCrudLookupApiPathFromNamespace(value = "") {
   }
 
   return `/${normalizedNamespace}`;
+}
+
+function resolveCrudResourceScopeName(value = "") {
+  const normalizedNamespace = normalizeCrudLookupNamespace(value);
+  if (!normalizedNamespace) {
+    return "";
+  }
+
+  return toCamelCase(normalizedNamespace.replace(/\//g, "-"));
 }
 
 function normalizeCrudLookupContainerKey(
@@ -170,6 +180,7 @@ export {
   normalizeCrudLookupApiPath,
   normalizeCrudLookupNamespace,
   resolveCrudLookupApiPathFromNamespace,
+  resolveCrudResourceScopeName,
   normalizeCrudLookupContainerKey,
   resolveCrudLookupContainerKey,
   resolveCrudLookupFieldKeys,

--- a/packages/kernel/shared/support/crudLookup.test.js
+++ b/packages/kernel/shared/support/crudLookup.test.js
@@ -6,6 +6,7 @@ import {
   normalizeCrudLookupApiPath,
   normalizeCrudLookupNamespace,
   resolveCrudLookupApiPathFromNamespace,
+  resolveCrudResourceScopeName,
   normalizeCrudLookupContainerKey,
   resolveCrudLookupContainerKey,
   resolveCrudParentFilterKeys,
@@ -58,6 +59,13 @@ test("resolveCrudLookupApiPathFromNamespace maps namespace to api path", () => {
   assert.equal(resolveCrudLookupApiPathFromNamespace("vets"), "/vets");
   assert.equal(resolveCrudLookupApiPathFromNamespace("/customer-categories"), "/customer-categories");
   assert.equal(resolveCrudLookupApiPathFromNamespace(""), "");
+});
+
+test("resolveCrudResourceScopeName maps namespace and api path values to json-rest-api scope names", () => {
+  assert.equal(resolveCrudResourceScopeName("pets"), "pets");
+  assert.equal(resolveCrudResourceScopeName("/customer-categories"), "customerCategories");
+  assert.equal(resolveCrudResourceScopeName("/workspace/pets"), "workspacePets");
+  assert.equal(resolveCrudResourceScopeName(""), "");
 });
 
 test("normalizeCrudLookupContainerKey defaults to canonical value", () => {

--- a/packages/mobile-capacitor/package.descriptor.mjs
+++ b/packages/mobile-capacitor/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/mobile-capacitor",
-  version: "0.1.21",
+  version: "0.1.22",
   kind: "runtime",
   description: "Thin Capacitor client integration for JSKIT mobile-shell launch routing and auth callback completion.",
   dependsOn: [
@@ -62,8 +62,8 @@ export default Object.freeze({
         "@capacitor/app": "^7.1.0",
         "@capacitor/browser": "^7.0.1",
         "@capacitor/core": "^7.4.3",
-        "@jskit-ai/kernel": "0.1.84",
-        "@jskit-ai/shell-web": "0.1.83"
+        "@jskit-ai/kernel": "0.1.85",
+        "@jskit-ai/shell-web": "0.1.84"
       },
       dev: {
         "@capacitor/cli": "^7.4.3"

--- a/packages/mobile-capacitor/package.descriptor.mjs
+++ b/packages/mobile-capacitor/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/mobile-capacitor",
-  version: "0.1.20",
+  version: "0.1.21",
   kind: "runtime",
   description: "Thin Capacitor client integration for JSKIT mobile-shell launch routing and auth callback completion.",
   dependsOn: [
@@ -62,8 +62,8 @@ export default Object.freeze({
         "@capacitor/app": "^7.1.0",
         "@capacitor/browser": "^7.0.1",
         "@capacitor/core": "^7.4.3",
-        "@jskit-ai/kernel": "0.1.83",
-        "@jskit-ai/shell-web": "0.1.82"
+        "@jskit-ai/kernel": "0.1.84",
+        "@jskit-ai/shell-web": "0.1.83"
       },
       dev: {
         "@capacitor/cli": "^7.4.3"

--- a/packages/mobile-capacitor/package.json
+++ b/packages/mobile-capacitor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/mobile-capacitor",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,6 +12,6 @@
   },
   "dependencies": {
     "@capacitor/browser": "^7.0.1",
-    "@jskit-ai/kernel": "0.1.83"
+    "@jskit-ai/kernel": "0.1.84"
   }
 }

--- a/packages/mobile-capacitor/package.json
+++ b/packages/mobile-capacitor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/mobile-capacitor",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,6 +12,6 @@
   },
   "dependencies": {
     "@capacitor/browser": "^7.0.1",
-    "@jskit-ai/kernel": "0.1.84"
+    "@jskit-ai/kernel": "0.1.85"
   }
 }

--- a/packages/realtime/package.descriptor.mjs
+++ b/packages/realtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/realtime",
-  version: "0.1.82",
+  version: "0.1.83",
   kind: "runtime",
   description: "Thin, generic realtime runtime wrappers for socket.io server and client.",
   options: {
@@ -95,7 +95,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.83",
+        "@jskit-ai/kernel": "0.1.84",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",

--- a/packages/realtime/package.descriptor.mjs
+++ b/packages/realtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/realtime",
-  version: "0.1.83",
+  version: "0.1.84",
   kind: "runtime",
   description: "Thin, generic realtime runtime wrappers for socket.io server and client.",
   options: {
@@ -95,7 +95,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.84",
+        "@jskit-ai/kernel": "0.1.85",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/realtime",
-  "version": "0.1.83",
+  "version": "0.1.84",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@socket.io/redis-adapter": "^8.3.0",
-    "@jskit-ai/kernel": "0.1.84",
+    "@jskit-ai/kernel": "0.1.85",
     "redis": "^5.8.2",
     "socket.io": "^4.8.3",
     "socket.io-client": "^4.8.3"

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/realtime",
-  "version": "0.1.82",
+  "version": "0.1.83",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@socket.io/redis-adapter": "^8.3.0",
-    "@jskit-ai/kernel": "0.1.83",
+    "@jskit-ai/kernel": "0.1.84",
     "redis": "^5.8.2",
     "socket.io": "^4.8.3",
     "socket.io-client": "^4.8.3"

--- a/packages/resource-core/package.descriptor.mjs
+++ b/packages/resource-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/resource-core",
-  version: "0.1.29",
+  version: "0.1.30",
   kind: "runtime",
   description: "Generic resource-definition helpers and schema-definition normalization.",
   dependsOn: [
@@ -22,7 +22,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/resource-core": "0.1.29"
+        "@jskit-ai/resource-core": "0.1.30"
       },
       dev: {}
     },

--- a/packages/resource-core/package.descriptor.mjs
+++ b/packages/resource-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/resource-core",
-  version: "0.1.28",
+  version: "0.1.29",
   kind: "runtime",
   description: "Generic resource-definition helpers and schema-definition normalization.",
   dependsOn: [
@@ -22,7 +22,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/resource-core": "0.1.28"
+        "@jskit-ai/resource-core": "0.1.29"
       },
       dev: {}
     },

--- a/packages/resource-core/package.json
+++ b/packages/resource-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/resource-core",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./shared/resource": "./src/shared/resource.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.83"
+    "@jskit-ai/kernel": "0.1.84"
   }
 }

--- a/packages/resource-core/package.json
+++ b/packages/resource-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/resource-core",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./shared/resource": "./src/shared/resource.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.84"
+    "@jskit-ai/kernel": "0.1.85"
   }
 }

--- a/packages/resource-crud-core/package.descriptor.mjs
+++ b/packages/resource-crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/resource-crud-core",
-  version: "0.1.29",
+  version: "0.1.30",
   kind: "runtime",
   description: "CRUD-specific resource-definition helpers and namespace support.",
   dependsOn: [
@@ -23,7 +23,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/resource-crud-core": "0.1.29"
+        "@jskit-ai/resource-crud-core": "0.1.30"
       },
       dev: {}
     },

--- a/packages/resource-crud-core/package.descriptor.mjs
+++ b/packages/resource-crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/resource-crud-core",
-  version: "0.1.28",
+  version: "0.1.29",
   kind: "runtime",
   description: "CRUD-specific resource-definition helpers and namespace support.",
   dependsOn: [
@@ -23,7 +23,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/resource-crud-core": "0.1.28"
+        "@jskit-ai/resource-crud-core": "0.1.29"
       },
       dev: {}
     },

--- a/packages/resource-crud-core/package.json
+++ b/packages/resource-crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/resource-crud-core",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./shared/crudResource": "./src/shared/crudResource.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.84",
-    "@jskit-ai/resource-core": "0.1.29"
+    "@jskit-ai/kernel": "0.1.85",
+    "@jskit-ai/resource-core": "0.1.30"
   }
 }

--- a/packages/resource-crud-core/package.json
+++ b/packages/resource-crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/resource-crud-core",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./shared/crudResource": "./src/shared/crudResource.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.83",
-    "@jskit-ai/resource-core": "0.1.28"
+    "@jskit-ai/kernel": "0.1.84",
+    "@jskit-ai/resource-core": "0.1.29"
   }
 }

--- a/packages/shell-web/package.descriptor.mjs
+++ b/packages/shell-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/shell-web",
-  version: "0.1.83",
+  version: "0.1.84",
   kind: "runtime",
   description: "Web shell layout runtime with outlet-based placement contributions.",
   dependsOn: [],
@@ -291,7 +291,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/kernel": "0.1.84"
+        "@jskit-ai/kernel": "0.1.85"
       },
       dev: {}
     },

--- a/packages/shell-web/package.descriptor.mjs
+++ b/packages/shell-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/shell-web",
-  version: "0.1.82",
+  version: "0.1.83",
   kind: "runtime",
   description: "Web shell layout runtime with outlet-based placement contributions.",
   dependsOn: [],
@@ -291,7 +291,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/kernel": "0.1.83"
+        "@jskit-ai/kernel": "0.1.84"
       },
       dev: {}
     },

--- a/packages/shell-web/package.json
+++ b/packages/shell-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/shell-web",
-  "version": "0.1.83",
+  "version": "0.1.84",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/kernel": "0.1.84"
+    "@jskit-ai/kernel": "0.1.85"
   },
   "peerDependencies": {
     "pinia": "^3.0.4",

--- a/packages/shell-web/package.json
+++ b/packages/shell-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/shell-web",
-  "version": "0.1.82",
+  "version": "0.1.83",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/kernel": "0.1.83"
+    "@jskit-ai/kernel": "0.1.84"
   },
   "peerDependencies": {
     "pinia": "^3.0.4",

--- a/packages/storage-runtime/package.descriptor.mjs
+++ b/packages/storage-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/storage-runtime",
-  version: "0.1.83",
+  version: "0.1.84",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -50,7 +50,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.84",
+        "@jskit-ai/kernel": "0.1.85",
         "unstorage": "^1.17.3"
       },
       dev: {}

--- a/packages/storage-runtime/package.descriptor.mjs
+++ b/packages/storage-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/storage-runtime",
-  version: "0.1.82",
+  version: "0.1.83",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -50,7 +50,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.83",
+        "@jskit-ai/kernel": "0.1.84",
         "unstorage": "^1.17.3"
       },
       dev: {}

--- a/packages/storage-runtime/package.json
+++ b/packages/storage-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/storage-runtime",
-  "version": "0.1.83",
+  "version": "0.1.84",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./server/providers/StorageRuntimeServiceProvider": "./src/server/providers/StorageRuntimeServiceProvider.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.84",
+    "@jskit-ai/kernel": "0.1.85",
     "unstorage": "^1.17.3"
   }
 }

--- a/packages/storage-runtime/package.json
+++ b/packages/storage-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/storage-runtime",
-  "version": "0.1.82",
+  "version": "0.1.83",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./server/providers/StorageRuntimeServiceProvider": "./src/server/providers/StorageRuntimeServiceProvider.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.83",
+    "@jskit-ai/kernel": "0.1.84",
     "unstorage": "^1.17.3"
   }
 }

--- a/packages/ui-generator/package.descriptor.mjs
+++ b/packages/ui-generator/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { GENERATED_UI_NAVIGATION_ROLE_OPTION } from "@jskit-ai/kernel/shared/sup
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/ui-generator",
-  version: "0.1.66",
+  version: "0.1.67",
   kind: "generator",
   description: "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
   options: {
@@ -371,7 +371,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.98"
+        "@jskit-ai/users-web": "0.1.99"
       },
       dev: {}
     },

--- a/packages/ui-generator/package.descriptor.mjs
+++ b/packages/ui-generator/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { GENERATED_UI_NAVIGATION_ROLE_OPTION } from "@jskit-ai/kernel/shared/sup
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/ui-generator",
-  version: "0.1.67",
+  version: "0.1.68",
   kind: "generator",
   description: "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
   options: {
@@ -371,7 +371,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.99"
+        "@jskit-ai/users-web": "0.1.100"
       },
       dev: {}
     },

--- a/packages/ui-generator/package.json
+++ b/packages/ui-generator/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/ui-generator",
-  "version": "0.1.67",
+  "version": "0.1.68",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.84",
-    "@jskit-ai/shell-web": "0.1.83"
+    "@jskit-ai/kernel": "0.1.85",
+    "@jskit-ai/shell-web": "0.1.84"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/ui-generator/package.json
+++ b/packages/ui-generator/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/ui-generator",
-  "version": "0.1.66",
+  "version": "0.1.67",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.83",
-    "@jskit-ai/shell-web": "0.1.82"
+    "@jskit-ai/kernel": "0.1.84",
+    "@jskit-ai/shell-web": "0.1.83"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/uploads-image-web/package.descriptor.mjs
+++ b/packages/uploads-image-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-image-web",
-  version: "0.1.61",
+  version: "0.1.62",
   kind: "runtime",
   description: "Reusable client-side image upload runtime with pre-upload image editing.",
   dependsOn: [
@@ -65,7 +65,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/uploads-runtime": "0.1.61",
+        "@jskit-ai/uploads-runtime": "0.1.62",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-image-web/package.descriptor.mjs
+++ b/packages/uploads-image-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-image-web",
-  version: "0.1.62",
+  version: "0.1.63",
   kind: "runtime",
   description: "Reusable client-side image upload runtime with pre-upload image editing.",
   dependsOn: [
@@ -65,7 +65,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/uploads-runtime": "0.1.62",
+        "@jskit-ai/uploads-runtime": "0.1.63",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-image-web/package.json
+++ b/packages/uploads-image-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-image-web",
-  "version": "0.1.61",
+  "version": "0.1.62",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,7 +13,7 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/uploads-runtime": "0.1.61",
+    "@jskit-ai/uploads-runtime": "0.1.62",
     "@uppy/compressor": "^3.1.0",
     "@uppy/core": "^5.2.0",
     "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-image-web/package.json
+++ b/packages/uploads-image-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-image-web",
-  "version": "0.1.62",
+  "version": "0.1.63",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,7 +13,7 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/uploads-runtime": "0.1.62",
+    "@jskit-ai/uploads-runtime": "0.1.63",
     "@uppy/compressor": "^3.1.0",
     "@uppy/core": "^5.2.0",
     "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-runtime/package.descriptor.mjs
+++ b/packages/uploads-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-runtime",
-  version: "0.1.61",
+  version: "0.1.62",
   kind: "runtime",
   description: "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
   dependsOn: [
@@ -71,7 +71,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.83"
+        "@jskit-ai/kernel": "0.1.84"
       },
       dev: {}
     },

--- a/packages/uploads-runtime/package.descriptor.mjs
+++ b/packages/uploads-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-runtime",
-  version: "0.1.62",
+  version: "0.1.63",
   kind: "runtime",
   description: "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
   dependsOn: [
@@ -71,7 +71,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.84"
+        "@jskit-ai/kernel": "0.1.85"
       },
       dev: {}
     },

--- a/packages/uploads-runtime/package.json
+++ b/packages/uploads-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-runtime",
-  "version": "0.1.62",
+  "version": "0.1.63",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,6 +16,6 @@
   },
   "dependencies": {
     "@fastify/multipart": "^9.4.0",
-    "@jskit-ai/kernel": "0.1.84"
+    "@jskit-ai/kernel": "0.1.85"
   }
 }

--- a/packages/uploads-runtime/package.json
+++ b/packages/uploads-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-runtime",
-  "version": "0.1.61",
+  "version": "0.1.62",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,6 +16,6 @@
   },
   "dependencies": {
     "@fastify/multipart": "^9.4.0",
-    "@jskit-ai/kernel": "0.1.83"
+    "@jskit-ai/kernel": "0.1.84"
   }
 }

--- a/packages/users-core/package.descriptor.mjs
+++ b/packages/users-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-core",
-  version: "0.1.94",
+  version: "0.1.95",
   kind: "runtime",
   description: "Users/account runtime plus HTTP routes for account features.",
   dependsOn: [
@@ -143,16 +143,16 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.83",
-        "@jskit-ai/crud-core": "0.1.92",
-        "@jskit-ai/database-runtime": "0.1.84",
-        "@jskit-ai/http-runtime": "0.1.83",
-        "@jskit-ai/json-rest-api-core": "0.1.29",
-        "@jskit-ai/kernel": "0.1.84",
-        "@jskit-ai/resource-core": "0.1.29",
-        "@jskit-ai/resource-crud-core": "0.1.29",
+        "@jskit-ai/auth-core": "0.1.84",
+        "@jskit-ai/crud-core": "0.1.93",
+        "@jskit-ai/database-runtime": "0.1.85",
+        "@jskit-ai/http-runtime": "0.1.84",
+        "@jskit-ai/json-rest-api-core": "0.1.30",
+        "@jskit-ai/kernel": "0.1.85",
+        "@jskit-ai/resource-core": "0.1.30",
+        "@jskit-ai/resource-crud-core": "0.1.30",
         "@local/users": "file:packages/users",
-        "@jskit-ai/uploads-runtime": "0.1.62"
+        "@jskit-ai/uploads-runtime": "0.1.63"
       },
       dev: {}
     },

--- a/packages/users-core/package.descriptor.mjs
+++ b/packages/users-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-core",
-  version: "0.1.93",
+  version: "0.1.94",
   kind: "runtime",
   description: "Users/account runtime plus HTTP routes for account features.",
   dependsOn: [
@@ -143,16 +143,16 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.82",
-        "@jskit-ai/crud-core": "0.1.91",
-        "@jskit-ai/database-runtime": "0.1.83",
-        "@jskit-ai/http-runtime": "0.1.82",
-        "@jskit-ai/json-rest-api-core": "0.1.28",
-        "@jskit-ai/kernel": "0.1.83",
-        "@jskit-ai/resource-core": "0.1.28",
-        "@jskit-ai/resource-crud-core": "0.1.28",
+        "@jskit-ai/auth-core": "0.1.83",
+        "@jskit-ai/crud-core": "0.1.92",
+        "@jskit-ai/database-runtime": "0.1.84",
+        "@jskit-ai/http-runtime": "0.1.83",
+        "@jskit-ai/json-rest-api-core": "0.1.29",
+        "@jskit-ai/kernel": "0.1.84",
+        "@jskit-ai/resource-core": "0.1.29",
+        "@jskit-ai/resource-crud-core": "0.1.29",
         "@local/users": "file:packages/users",
-        "@jskit-ai/uploads-runtime": "0.1.61"
+        "@jskit-ai/uploads-runtime": "0.1.62"
       },
       dev: {}
     },

--- a/packages/users-core/package.json
+++ b/packages/users-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-core",
-  "version": "0.1.94",
+  "version": "0.1.95",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,14 +11,14 @@
     "./shared/resources/userSettingsResource": "./src/shared/resources/userSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.83",
-    "@jskit-ai/database-runtime": "0.1.84",
-    "@jskit-ai/http-runtime": "0.1.83",
-    "@jskit-ai/json-rest-api-core": "0.1.29",
-    "@jskit-ai/kernel": "0.1.84",
-    "@jskit-ai/resource-crud-core": "0.1.29",
-    "@jskit-ai/resource-core": "0.1.29",
-    "@jskit-ai/uploads-runtime": "0.1.62",
+    "@jskit-ai/auth-core": "0.1.84",
+    "@jskit-ai/database-runtime": "0.1.85",
+    "@jskit-ai/http-runtime": "0.1.84",
+    "@jskit-ai/json-rest-api-core": "0.1.30",
+    "@jskit-ai/kernel": "0.1.85",
+    "@jskit-ai/resource-crud-core": "0.1.30",
+    "@jskit-ai/resource-core": "0.1.30",
+    "@jskit-ai/uploads-runtime": "0.1.63",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/users-core/package.json
+++ b/packages/users-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-core",
-  "version": "0.1.93",
+  "version": "0.1.94",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,14 +11,14 @@
     "./shared/resources/userSettingsResource": "./src/shared/resources/userSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.82",
-    "@jskit-ai/database-runtime": "0.1.83",
-    "@jskit-ai/http-runtime": "0.1.82",
-    "@jskit-ai/json-rest-api-core": "0.1.28",
-    "@jskit-ai/kernel": "0.1.83",
-    "@jskit-ai/resource-crud-core": "0.1.28",
-    "@jskit-ai/resource-core": "0.1.28",
-    "@jskit-ai/uploads-runtime": "0.1.61",
+    "@jskit-ai/auth-core": "0.1.83",
+    "@jskit-ai/database-runtime": "0.1.84",
+    "@jskit-ai/http-runtime": "0.1.83",
+    "@jskit-ai/json-rest-api-core": "0.1.29",
+    "@jskit-ai/kernel": "0.1.84",
+    "@jskit-ai/resource-crud-core": "0.1.29",
+    "@jskit-ai/resource-core": "0.1.29",
+    "@jskit-ai/uploads-runtime": "0.1.62",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/users-web/package.descriptor.mjs
+++ b/packages/users-web/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { HOME_COG_OUTLET } from "./src/shared/toolsOutletContracts.js";
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-web",
-  version: "0.1.99",
+  version: "0.1.100",
   kind: "runtime",
   description: "Users web module: account/profile UI plus shared users web widgets.",
   dependsOn: [
@@ -278,12 +278,12 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/http-runtime": "0.1.83",
-        "@jskit-ai/realtime": "0.1.83",
-        "@jskit-ai/kernel": "0.1.84",
-        "@jskit-ai/shell-web": "0.1.83",
-        "@jskit-ai/uploads-image-web": "0.1.62",
-        "@jskit-ai/users-core": "0.1.94"
+        "@jskit-ai/http-runtime": "0.1.84",
+        "@jskit-ai/realtime": "0.1.84",
+        "@jskit-ai/kernel": "0.1.85",
+        "@jskit-ai/shell-web": "0.1.84",
+        "@jskit-ai/uploads-image-web": "0.1.63",
+        "@jskit-ai/users-core": "0.1.95"
       },
       dev: {}
     },

--- a/packages/users-web/package.descriptor.mjs
+++ b/packages/users-web/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { HOME_COG_OUTLET } from "./src/shared/toolsOutletContracts.js";
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-web",
-  version: "0.1.98",
+  version: "0.1.99",
   kind: "runtime",
   description: "Users web module: account/profile UI plus shared users web widgets.",
   dependsOn: [
@@ -278,12 +278,12 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/http-runtime": "0.1.82",
-        "@jskit-ai/realtime": "0.1.82",
-        "@jskit-ai/kernel": "0.1.83",
-        "@jskit-ai/shell-web": "0.1.82",
-        "@jskit-ai/uploads-image-web": "0.1.61",
-        "@jskit-ai/users-core": "0.1.93"
+        "@jskit-ai/http-runtime": "0.1.83",
+        "@jskit-ai/realtime": "0.1.83",
+        "@jskit-ai/kernel": "0.1.84",
+        "@jskit-ai/shell-web": "0.1.83",
+        "@jskit-ai/uploads-image-web": "0.1.62",
+        "@jskit-ai/users-core": "0.1.94"
       },
       dev: {}
     },

--- a/packages/users-web/package.json
+++ b/packages/users-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-web",
-  "version": "0.1.98",
+  "version": "0.1.99",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -44,12 +44,12 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/http-runtime": "0.1.82",
-    "@jskit-ai/kernel": "0.1.83",
-    "@jskit-ai/realtime": "0.1.82",
-    "@jskit-ai/shell-web": "0.1.82",
-    "@jskit-ai/uploads-image-web": "0.1.61",
-    "@jskit-ai/users-core": "0.1.93"
+    "@jskit-ai/http-runtime": "0.1.83",
+    "@jskit-ai/kernel": "0.1.84",
+    "@jskit-ai/realtime": "0.1.83",
+    "@jskit-ai/shell-web": "0.1.83",
+    "@jskit-ai/uploads-image-web": "0.1.62",
+    "@jskit-ai/users-core": "0.1.94"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/users-web/package.json
+++ b/packages/users-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-web",
-  "version": "0.1.99",
+  "version": "0.1.100",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -44,12 +44,12 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/http-runtime": "0.1.83",
-    "@jskit-ai/kernel": "0.1.84",
-    "@jskit-ai/realtime": "0.1.83",
-    "@jskit-ai/shell-web": "0.1.83",
-    "@jskit-ai/uploads-image-web": "0.1.62",
-    "@jskit-ai/users-core": "0.1.94"
+    "@jskit-ai/http-runtime": "0.1.84",
+    "@jskit-ai/kernel": "0.1.85",
+    "@jskit-ai/realtime": "0.1.84",
+    "@jskit-ai/shell-web": "0.1.84",
+    "@jskit-ai/uploads-image-web": "0.1.63",
+    "@jskit-ai/users-core": "0.1.95"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/workspaces-core/package.descriptor.mjs
+++ b/packages/workspaces-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-core",
-  version: "0.1.60",
+  version: "0.1.61",
   kind: "runtime",
   description: "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
   dependsOn: [
@@ -142,10 +142,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/json-rest-api-core": "0.1.29",
-        "@jskit-ai/resource-core": "0.1.29",
-        "@jskit-ai/resource-crud-core": "0.1.29",
-        "@jskit-ai/users-core": "0.1.94"
+        "@jskit-ai/json-rest-api-core": "0.1.30",
+        "@jskit-ai/resource-core": "0.1.30",
+        "@jskit-ai/resource-crud-core": "0.1.30",
+        "@jskit-ai/users-core": "0.1.95"
       },
       dev: {}
     },

--- a/packages/workspaces-core/package.descriptor.mjs
+++ b/packages/workspaces-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-core",
-  version: "0.1.59",
+  version: "0.1.60",
   kind: "runtime",
   description: "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
   dependsOn: [
@@ -142,10 +142,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/json-rest-api-core": "0.1.28",
-        "@jskit-ai/resource-core": "0.1.28",
-        "@jskit-ai/resource-crud-core": "0.1.28",
-        "@jskit-ai/users-core": "0.1.93"
+        "@jskit-ai/json-rest-api-core": "0.1.29",
+        "@jskit-ai/resource-core": "0.1.29",
+        "@jskit-ai/resource-crud-core": "0.1.29",
+        "@jskit-ai/users-core": "0.1.94"
       },
       dev: {}
     },

--- a/packages/workspaces-core/package.json
+++ b/packages/workspaces-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-core",
-  "version": "0.1.59",
+  "version": "0.1.60",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -17,14 +17,14 @@
     "./shared/resources/workspaceSettingsResource": "./src/shared/resources/workspaceSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.82",
-    "@jskit-ai/database-runtime": "0.1.83",
-    "@jskit-ai/http-runtime": "0.1.82",
-    "@jskit-ai/json-rest-api-core": "0.1.28",
-    "@jskit-ai/kernel": "0.1.83",
-    "@jskit-ai/resource-crud-core": "0.1.28",
-    "@jskit-ai/resource-core": "0.1.28",
-    "@jskit-ai/users-core": "0.1.93",
+    "@jskit-ai/auth-core": "0.1.83",
+    "@jskit-ai/database-runtime": "0.1.84",
+    "@jskit-ai/http-runtime": "0.1.83",
+    "@jskit-ai/json-rest-api-core": "0.1.29",
+    "@jskit-ai/kernel": "0.1.84",
+    "@jskit-ai/resource-crud-core": "0.1.29",
+    "@jskit-ai/resource-core": "0.1.29",
+    "@jskit-ai/users-core": "0.1.94",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/workspaces-core/package.json
+++ b/packages/workspaces-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-core",
-  "version": "0.1.60",
+  "version": "0.1.61",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -17,14 +17,14 @@
     "./shared/resources/workspaceSettingsResource": "./src/shared/resources/workspaceSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.83",
-    "@jskit-ai/database-runtime": "0.1.84",
-    "@jskit-ai/http-runtime": "0.1.83",
-    "@jskit-ai/json-rest-api-core": "0.1.29",
-    "@jskit-ai/kernel": "0.1.84",
-    "@jskit-ai/resource-crud-core": "0.1.29",
-    "@jskit-ai/resource-core": "0.1.29",
-    "@jskit-ai/users-core": "0.1.94",
+    "@jskit-ai/auth-core": "0.1.84",
+    "@jskit-ai/database-runtime": "0.1.85",
+    "@jskit-ai/http-runtime": "0.1.84",
+    "@jskit-ai/json-rest-api-core": "0.1.30",
+    "@jskit-ai/kernel": "0.1.85",
+    "@jskit-ai/resource-crud-core": "0.1.30",
+    "@jskit-ai/resource-core": "0.1.30",
+    "@jskit-ai/users-core": "0.1.95",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/workspaces-web/package.descriptor.mjs
+++ b/packages/workspaces-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-web",
-  version: "0.1.59",
+  version: "0.1.60",
   kind: "runtime",
   description: "Workspace web module: workspace selector, tools widget, workspace surfaces, and members/settings UI.",
   dependsOn: [
@@ -231,8 +231,8 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/workspaces-core": "0.1.59",
-        "@jskit-ai/users-web": "0.1.98"
+        "@jskit-ai/workspaces-core": "0.1.60",
+        "@jskit-ai/users-web": "0.1.99"
       },
       dev: {}
     },

--- a/packages/workspaces-web/package.descriptor.mjs
+++ b/packages/workspaces-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-web",
-  version: "0.1.60",
+  version: "0.1.61",
   kind: "runtime",
   description: "Workspace web module: workspace selector, tools widget, workspace surfaces, and members/settings UI.",
   dependsOn: [
@@ -231,8 +231,8 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/workspaces-core": "0.1.60",
-        "@jskit-ai/users-web": "0.1.99"
+        "@jskit-ai/workspaces-core": "0.1.61",
+        "@jskit-ai/users-web": "0.1.100"
       },
       dev: {}
     },

--- a/packages/workspaces-web/package.json
+++ b/packages/workspaces-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-web",
-  "version": "0.1.60",
+  "version": "0.1.61",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -15,12 +15,12 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/http-runtime": "0.1.83",
-    "@jskit-ai/kernel": "0.1.84",
-    "@jskit-ai/shell-web": "0.1.83",
-    "@jskit-ai/users-core": "0.1.94",
-    "@jskit-ai/users-web": "0.1.99",
-    "@jskit-ai/workspaces-core": "0.1.60"
+    "@jskit-ai/http-runtime": "0.1.84",
+    "@jskit-ai/kernel": "0.1.85",
+    "@jskit-ai/shell-web": "0.1.84",
+    "@jskit-ai/users-core": "0.1.95",
+    "@jskit-ai/users-web": "0.1.100",
+    "@jskit-ai/workspaces-core": "0.1.61"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/workspaces-web/package.json
+++ b/packages/workspaces-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-web",
-  "version": "0.1.59",
+  "version": "0.1.60",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -15,12 +15,12 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/http-runtime": "0.1.82",
-    "@jskit-ai/kernel": "0.1.83",
-    "@jskit-ai/shell-web": "0.1.82",
-    "@jskit-ai/users-core": "0.1.93",
-    "@jskit-ai/users-web": "0.1.98",
-    "@jskit-ai/workspaces-core": "0.1.59"
+    "@jskit-ai/http-runtime": "0.1.83",
+    "@jskit-ai/kernel": "0.1.84",
+    "@jskit-ai/shell-web": "0.1.83",
+    "@jskit-ai/users-core": "0.1.94",
+    "@jskit-ai/users-web": "0.1.99",
+    "@jskit-ai/workspaces-core": "0.1.60"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/tooling/config-eslint/package.json
+++ b/tooling/config-eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/config-eslint",
-  "version": "0.1.83",
+  "version": "0.1.84",
   "description": "Shared flat ESLint presets for JSKIT projects.",
   "type": "module",
   "files": [

--- a/tooling/config-eslint/package.json
+++ b/tooling/config-eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/config-eslint",
-  "version": "0.1.82",
+  "version": "0.1.83",
   "description": "Shared flat ESLint presets for JSKIT projects.",
   "type": "module",
   "files": [

--- a/tooling/create-app/package.descriptor.mjs
+++ b/tooling/create-app/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/create-app",
-  "version": "0.1.92",
+  "version": "0.1.93",
   "dependsOn": [],
   "capabilities": {
     "provides": [

--- a/tooling/create-app/package.descriptor.mjs
+++ b/tooling/create-app/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/create-app",
-  "version": "0.1.91",
+  "version": "0.1.92",
   "dependsOn": [],
   "capabilities": {
     "provides": [

--- a/tooling/create-app/package.json
+++ b/tooling/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/create-app",
-  "version": "0.1.92",
+  "version": "0.1.93",
   "description": "Scaffold minimal JSKIT app shells.",
   "type": "module",
   "files": [

--- a/tooling/create-app/package.json
+++ b/tooling/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/create-app",
-  "version": "0.1.91",
+  "version": "0.1.92",
   "description": "Scaffold minimal JSKIT app shells.",
   "type": "module",
   "files": [

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -6,11 +6,11 @@
   "packages": [
     {
       "packageId": "@jskit-ai/assistant",
-      "version": "0.1.92",
+      "version": "0.1.93",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant",
-        "version": "0.1.92",
+        "version": "0.1.93",
         "kind": "generator",
         "description": "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
         "options": {
@@ -347,11 +347,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-core",
-      "version": "0.1.59",
+      "version": "0.1.60",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-core",
-        "version": "0.1.59",
+        "version": "0.1.60",
         "kind": "runtime",
         "description": "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
         "dependsOn": [
@@ -399,11 +399,11 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/http-runtime": "0.1.82",
-              "@jskit-ai/kernel": "0.1.83",
-              "@jskit-ai/resource-core": "0.1.28",
-              "@jskit-ai/resource-crud-core": "0.1.28",
-              "@jskit-ai/users-core": "0.1.93",
+              "@jskit-ai/http-runtime": "0.1.83",
+              "@jskit-ai/kernel": "0.1.84",
+              "@jskit-ai/resource-core": "0.1.29",
+              "@jskit-ai/resource-crud-core": "0.1.29",
+              "@jskit-ai/users-core": "0.1.94",
               "dompurify": "^3.3.3",
               "json-rest-schema": "1.x.x",
               "marked": "^17.0.4",
@@ -422,11 +422,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-runtime",
-      "version": "0.1.54",
+      "version": "0.1.55",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-runtime",
-        "version": "0.1.54",
+        "version": "0.1.55",
         "kind": "runtime",
         "description": "Shared assistant runtime with per-surface assistant registration.",
         "dependsOn": [
@@ -522,13 +522,13 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/assistant-core": "0.1.59",
-              "@jskit-ai/database-runtime": "0.1.83",
-              "@jskit-ai/http-runtime": "0.1.82",
-              "@jskit-ai/kernel": "0.1.83",
-              "@jskit-ai/shell-web": "0.1.82",
-              "@jskit-ai/users-core": "0.1.93",
-              "@jskit-ai/users-web": "0.1.98"
+              "@jskit-ai/assistant-core": "0.1.60",
+              "@jskit-ai/database-runtime": "0.1.84",
+              "@jskit-ai/http-runtime": "0.1.83",
+              "@jskit-ai/kernel": "0.1.84",
+              "@jskit-ai/shell-web": "0.1.83",
+              "@jskit-ai/users-core": "0.1.94",
+              "@jskit-ai/users-web": "0.1.99"
             },
             "dev": {}
           },
@@ -583,11 +583,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-core",
-      "version": "0.1.82",
+      "version": "0.1.83",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-core",
-        "version": "0.1.82",
+        "version": "0.1.83",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/value-app-config-shared"
@@ -655,7 +655,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.83",
+              "@jskit-ai/kernel": "0.1.84",
               "@fastify/cookie": "^11.0.2",
               "@fastify/csrf-protection": "^7.1.0",
               "@fastify/rate-limit": "^10.3.0"
@@ -673,11 +673,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.82",
+      "version": "0.1.83",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-supabase-core",
-        "version": "0.1.82",
+        "version": "0.1.83",
         "kind": "runtime",
         "options": {
           "auth-supabase-url": {
@@ -759,8 +759,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.82",
-              "@jskit-ai/kernel": "0.1.83",
+              "@jskit-ai/auth-core": "0.1.83",
+              "@jskit-ai/kernel": "0.1.84",
               "dotenv": "^16.4.5",
               "@supabase/supabase-js": "^2.57.4",
               "jose": "^6.1.0"
@@ -825,11 +825,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-web",
-      "version": "0.1.84",
+      "version": "0.1.85",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-web",
-        "version": "0.1.84",
+        "version": "0.1.85",
         "kind": "runtime",
         "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
         "dependsOn": [
@@ -1085,10 +1085,10 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/auth-core": "0.1.82",
-              "@jskit-ai/http-runtime": "0.1.82",
-              "@jskit-ai/kernel": "0.1.83",
-              "@jskit-ai/shell-web": "0.1.82"
+              "@jskit-ai/auth-core": "0.1.83",
+              "@jskit-ai/http-runtime": "0.1.83",
+              "@jskit-ai/kernel": "0.1.84",
+              "@jskit-ai/shell-web": "0.1.83"
             },
             "dev": {}
           },
@@ -1167,11 +1167,11 @@
     },
     {
       "packageId": "@jskit-ai/console-core",
-      "version": "0.1.46",
+      "version": "0.1.47",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-core",
-        "version": "0.1.46",
+        "version": "0.1.47",
         "kind": "runtime",
         "description": "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
         "dependsOn": [
@@ -1255,12 +1255,12 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.82",
-              "@jskit-ai/database-runtime": "0.1.83",
-              "@jskit-ai/http-runtime": "0.1.82",
-              "@jskit-ai/kernel": "0.1.83",
-              "@jskit-ai/resource-crud-core": "0.1.28",
-              "@jskit-ai/users-core": "0.1.93"
+              "@jskit-ai/auth-core": "0.1.83",
+              "@jskit-ai/database-runtime": "0.1.84",
+              "@jskit-ai/http-runtime": "0.1.83",
+              "@jskit-ai/kernel": "0.1.84",
+              "@jskit-ai/resource-crud-core": "0.1.29",
+              "@jskit-ai/users-core": "0.1.94"
             },
             "dev": {}
           },
@@ -1285,11 +1285,11 @@
     },
     {
       "packageId": "@jskit-ai/console-web",
-      "version": "0.1.51",
+      "version": "0.1.52",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-web",
-        "version": "0.1.51",
+        "version": "0.1.52",
         "kind": "runtime",
         "description": "Authenticated console surface scaffold and surface policy wiring.",
         "dependsOn": [
@@ -1399,9 +1399,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-web": "0.1.84",
-              "@jskit-ai/console-core": "0.1.46",
-              "@jskit-ai/shell-web": "0.1.82"
+              "@jskit-ai/auth-web": "0.1.85",
+              "@jskit-ai/console-core": "0.1.47",
+              "@jskit-ai/shell-web": "0.1.83"
             },
             "dev": {}
           },
@@ -1508,11 +1508,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-core",
-      "version": "0.1.91",
+      "version": "0.1.92",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-core",
-        "version": "0.1.91",
+        "version": "0.1.92",
         "kind": "runtime",
         "description": "Shared CRUD helpers used by CRUD modules.",
         "dependsOn": [
@@ -1541,7 +1541,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/crud-core": "0.1.91"
+              "@jskit-ai/crud-core": "0.1.92"
             },
             "dev": {}
           },
@@ -1555,11 +1555,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-server-generator",
-      "version": "0.1.91",
+      "version": "0.1.92",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-server-generator",
-        "version": "0.1.91",
+        "version": "0.1.92",
         "kind": "generator",
         "description": "CRUD server generator with routes, actions, and persistence scaffolding.",
         "options": {
@@ -1726,14 +1726,14 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.82",
-              "@jskit-ai/crud-core": "0.1.91",
-              "@jskit-ai/database-runtime": "0.1.83",
-              "@jskit-ai/http-runtime": "0.1.82",
-              "@jskit-ai/json-rest-api-core": "0.1.28",
-              "@jskit-ai/kernel": "0.1.83",
-              "@jskit-ai/realtime": "0.1.82",
-              "@jskit-ai/resource-crud-core": "0.1.28",
+              "@jskit-ai/auth-core": "0.1.83",
+              "@jskit-ai/crud-core": "0.1.92",
+              "@jskit-ai/database-runtime": "0.1.84",
+              "@jskit-ai/http-runtime": "0.1.83",
+              "@jskit-ai/json-rest-api-core": "0.1.29",
+              "@jskit-ai/kernel": "0.1.84",
+              "@jskit-ai/realtime": "0.1.83",
+              "@jskit-ai/resource-crud-core": "0.1.29",
               "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}"
             },
             "dev": {}
@@ -1865,11 +1865,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.66",
+      "version": "0.1.67",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-ui-generator",
-        "version": "0.1.66",
+        "version": "0.1.67",
         "kind": "generator",
         "description": "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
         "options": {
@@ -2068,7 +2068,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.98"
+              "@jskit-ai/users-web": "0.1.99"
             },
             "dev": {}
           },
@@ -2327,11 +2327,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime",
-      "version": "0.1.83",
+      "version": "0.1.84",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime",
-        "version": "0.1.83",
+        "version": "0.1.84",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -2388,7 +2388,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.83",
+              "@jskit-ai/kernel": "0.1.84",
               "dotenv": "^16.4.5",
               "knex": "^3.1.0"
             },
@@ -2423,11 +2423,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.82",
+      "version": "0.1.83",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-mysql",
-        "version": "0.1.82",
+        "version": "0.1.83",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -2517,7 +2517,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.83",
+              "@jskit-ai/database-runtime": "0.1.84",
               "mysql2": "^3.11.2"
             },
             "dev": {}
@@ -2588,11 +2588,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.82",
+      "version": "0.1.83",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-postgres",
-        "version": "0.1.82",
+        "version": "0.1.83",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -2682,7 +2682,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.83",
+              "@jskit-ai/database-runtime": "0.1.84",
               "pg": "^8.13.1"
             },
             "dev": {}
@@ -2753,11 +2753,11 @@
     },
     {
       "packageId": "@jskit-ai/feature-server-generator",
-      "version": "0.1.25",
+      "version": "0.1.26",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/feature-server-generator",
-        "version": "0.1.25",
+        "version": "0.1.26",
         "kind": "generator",
         "description": "Scaffold substantial non-CRUD server feature packages with provider, actions, service, and optional persistence seams.",
         "options": {
@@ -2942,7 +2942,7 @@
                   "equals": "json-rest"
                 }
               },
-              "@jskit-ai/kernel": "0.1.83",
+              "@jskit-ai/kernel": "0.1.84",
               "json-rest-schema": "1.x.x",
               "@local/${option:feature-name|kebab}": "file:packages/${option:feature-name|kebab}"
             },
@@ -3055,11 +3055,11 @@
     },
     {
       "packageId": "@jskit-ai/google-rewarded-core",
-      "version": "0.1.20",
+      "version": "0.1.21",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/google-rewarded-core",
-        "version": "0.1.20",
+        "version": "0.1.21",
         "kind": "runtime",
         "description": "Google rewarded workflow runtime plus internal CRUD providers for rules, provider configs, watch sessions, and unlock receipts.",
         "dependsOn": [
@@ -3186,14 +3186,14 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.82",
-              "@jskit-ai/crud-core": "0.1.91",
-              "@jskit-ai/database-runtime": "0.1.83",
-              "@jskit-ai/http-runtime": "0.1.82",
-              "@jskit-ai/json-rest-api-core": "0.1.28",
-              "@jskit-ai/kernel": "0.1.83",
-              "@jskit-ai/resource-crud-core": "0.1.28",
-              "@jskit-ai/workspaces-core": "0.1.59"
+              "@jskit-ai/auth-core": "0.1.83",
+              "@jskit-ai/crud-core": "0.1.92",
+              "@jskit-ai/database-runtime": "0.1.84",
+              "@jskit-ai/http-runtime": "0.1.83",
+              "@jskit-ai/json-rest-api-core": "0.1.29",
+              "@jskit-ai/kernel": "0.1.84",
+              "@jskit-ai/resource-crud-core": "0.1.29",
+              "@jskit-ai/workspaces-core": "0.1.60"
             },
             "dev": {}
           },
@@ -3245,11 +3245,11 @@
     },
     {
       "packageId": "@jskit-ai/google-rewarded-web",
-      "version": "0.1.20",
+      "version": "0.1.21",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/google-rewarded-web",
-        "version": "0.1.20",
+        "version": "0.1.21",
         "kind": "runtime",
         "description": "Google rewarded client runtime with a fullscreen gate host and GPT orchestration.",
         "dependsOn": [
@@ -3296,10 +3296,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/google-rewarded-core": "0.1.20",
-              "@jskit-ai/http-runtime": "0.1.82",
-              "@jskit-ai/kernel": "0.1.83",
-              "@jskit-ai/shell-web": "0.1.82"
+              "@jskit-ai/google-rewarded-core": "0.1.21",
+              "@jskit-ai/http-runtime": "0.1.83",
+              "@jskit-ai/kernel": "0.1.84",
+              "@jskit-ai/shell-web": "0.1.83"
             },
             "dev": {}
           },
@@ -3317,11 +3317,11 @@
     },
     {
       "packageId": "@jskit-ai/http-runtime",
-      "version": "0.1.82",
+      "version": "0.1.83",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/http-runtime",
-        "version": "0.1.82",
+        "version": "0.1.83",
         "kind": "runtime",
         "dependsOn": [],
         "capabilities": {
@@ -3387,7 +3387,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.83"
+              "@jskit-ai/kernel": "0.1.84"
             },
             "dev": {}
           },
@@ -3401,11 +3401,11 @@
     },
     {
       "packageId": "@jskit-ai/json-rest-api-core",
-      "version": "0.1.28",
+      "version": "0.1.29",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/json-rest-api-core",
-        "version": "0.1.28",
+        "version": "0.1.29",
         "kind": "runtime",
         "description": "Shared internal json-rest-api host runtime for JSKIT server packages.",
         "dependsOn": [
@@ -3465,11 +3465,11 @@
     },
     {
       "packageId": "@jskit-ai/mobile-capacitor",
-      "version": "0.1.20",
+      "version": "0.1.21",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/mobile-capacitor",
-        "version": "0.1.20",
+        "version": "0.1.21",
         "kind": "runtime",
         "description": "Thin Capacitor client integration for JSKIT mobile-shell launch routing and auth callback completion.",
         "dependsOn": [
@@ -3532,8 +3532,8 @@
               "@capacitor/app": "^7.1.0",
               "@capacitor/browser": "^7.0.1",
               "@capacitor/core": "^7.4.3",
-              "@jskit-ai/kernel": "0.1.83",
-              "@jskit-ai/shell-web": "0.1.82"
+              "@jskit-ai/kernel": "0.1.84",
+              "@jskit-ai/shell-web": "0.1.83"
             },
             "dev": {
               "@capacitor/cli": "^7.4.3"
@@ -3585,11 +3585,11 @@
     },
     {
       "packageId": "@jskit-ai/realtime",
-      "version": "0.1.82",
+      "version": "0.1.83",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/realtime",
-        "version": "0.1.82",
+        "version": "0.1.83",
         "kind": "runtime",
         "description": "Thin, generic realtime runtime wrappers for socket.io server and client.",
         "options": {
@@ -3685,7 +3685,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.83",
+              "@jskit-ai/kernel": "0.1.84",
               "@socket.io/redis-adapter": "^8.3.0",
               "redis": "^5.8.2",
               "socket.io": "^4.8.3",
@@ -3734,11 +3734,11 @@
     },
     {
       "packageId": "@jskit-ai/resource-core",
-      "version": "0.1.28",
+      "version": "0.1.29",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/resource-core",
-        "version": "0.1.28",
+        "version": "0.1.29",
         "kind": "runtime",
         "description": "Generic resource-definition helpers and schema-definition normalization.",
         "dependsOn": [
@@ -3761,7 +3761,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/resource-core": "0.1.28"
+              "@jskit-ai/resource-core": "0.1.29"
             },
             "dev": {}
           },
@@ -3776,11 +3776,11 @@
     },
     {
       "packageId": "@jskit-ai/resource-crud-core",
-      "version": "0.1.28",
+      "version": "0.1.29",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/resource-crud-core",
-        "version": "0.1.28",
+        "version": "0.1.29",
         "kind": "runtime",
         "description": "CRUD-specific resource-definition helpers and namespace support.",
         "dependsOn": [
@@ -3804,7 +3804,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/resource-crud-core": "0.1.28"
+              "@jskit-ai/resource-crud-core": "0.1.29"
             },
             "dev": {}
           },
@@ -3819,11 +3819,11 @@
     },
     {
       "packageId": "@jskit-ai/shell-web",
-      "version": "0.1.82",
+      "version": "0.1.83",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/shell-web",
-        "version": "0.1.82",
+        "version": "0.1.83",
         "kind": "runtime",
         "description": "Web shell layout runtime with outlet-based placement contributions.",
         "dependsOn": [],
@@ -4149,7 +4149,7 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/kernel": "0.1.83"
+              "@jskit-ai/kernel": "0.1.84"
             },
             "dev": {}
           },
@@ -4349,11 +4349,11 @@
     },
     {
       "packageId": "@jskit-ai/storage-runtime",
-      "version": "0.1.82",
+      "version": "0.1.83",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/storage-runtime",
-        "version": "0.1.82",
+        "version": "0.1.83",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -4402,7 +4402,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.83",
+              "@jskit-ai/kernel": "0.1.84",
               "unstorage": "^1.17.3"
             },
             "dev": {}
@@ -4418,11 +4418,11 @@
     },
     {
       "packageId": "@jskit-ai/ui-generator",
-      "version": "0.1.66",
+      "version": "0.1.67",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/ui-generator",
-        "version": "0.1.66",
+        "version": "0.1.67",
         "kind": "generator",
         "description": "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
         "options": {
@@ -4855,7 +4855,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.98"
+              "@jskit-ai/users-web": "0.1.99"
             },
             "dev": {}
           },
@@ -4870,11 +4870,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-image-web",
-      "version": "0.1.61",
+      "version": "0.1.62",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-image-web",
-        "version": "0.1.61",
+        "version": "0.1.62",
         "kind": "runtime",
         "description": "Reusable client-side image upload runtime with pre-upload image editing.",
         "dependsOn": [
@@ -4938,7 +4938,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/uploads-runtime": "0.1.61",
+              "@jskit-ai/uploads-runtime": "0.1.62",
               "@uppy/compressor": "^3.1.0",
               "@uppy/core": "^5.2.0",
               "@uppy/dashboard": "^5.1.1",
@@ -4958,11 +4958,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-runtime",
-      "version": "0.1.61",
+      "version": "0.1.62",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-runtime",
-        "version": "0.1.61",
+        "version": "0.1.62",
         "kind": "runtime",
         "description": "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
         "dependsOn": [
@@ -5032,7 +5032,7 @@
           "dependencies": {
             "runtime": {
               "@fastify/multipart": "^9.4.0",
-              "@jskit-ai/kernel": "0.1.83"
+              "@jskit-ai/kernel": "0.1.84"
             },
             "dev": {}
           },
@@ -5047,11 +5047,11 @@
     },
     {
       "packageId": "@jskit-ai/users-core",
-      "version": "0.1.93",
+      "version": "0.1.94",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-core",
-        "version": "0.1.93",
+        "version": "0.1.94",
         "kind": "runtime",
         "description": "Users/account runtime plus HTTP routes for account features.",
         "dependsOn": [
@@ -5192,16 +5192,16 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.82",
-              "@jskit-ai/crud-core": "0.1.91",
-              "@jskit-ai/database-runtime": "0.1.83",
-              "@jskit-ai/http-runtime": "0.1.82",
-              "@jskit-ai/json-rest-api-core": "0.1.28",
-              "@jskit-ai/kernel": "0.1.83",
-              "@jskit-ai/resource-core": "0.1.28",
-              "@jskit-ai/resource-crud-core": "0.1.28",
+              "@jskit-ai/auth-core": "0.1.83",
+              "@jskit-ai/crud-core": "0.1.92",
+              "@jskit-ai/database-runtime": "0.1.84",
+              "@jskit-ai/http-runtime": "0.1.83",
+              "@jskit-ai/json-rest-api-core": "0.1.29",
+              "@jskit-ai/kernel": "0.1.84",
+              "@jskit-ai/resource-core": "0.1.29",
+              "@jskit-ai/resource-crud-core": "0.1.29",
               "@local/users": "file:packages/users",
-              "@jskit-ai/uploads-runtime": "0.1.61"
+              "@jskit-ai/uploads-runtime": "0.1.62"
             },
             "dev": {}
           },
@@ -5418,11 +5418,11 @@
     },
     {
       "packageId": "@jskit-ai/users-web",
-      "version": "0.1.98",
+      "version": "0.1.99",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-web",
-        "version": "0.1.98",
+        "version": "0.1.99",
         "kind": "runtime",
         "description": "Users web module: account/profile UI plus shared users web widgets.",
         "dependsOn": [
@@ -5717,12 +5717,12 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/http-runtime": "0.1.82",
-              "@jskit-ai/realtime": "0.1.82",
-              "@jskit-ai/kernel": "0.1.83",
-              "@jskit-ai/shell-web": "0.1.82",
-              "@jskit-ai/uploads-image-web": "0.1.61",
-              "@jskit-ai/users-core": "0.1.93"
+              "@jskit-ai/http-runtime": "0.1.83",
+              "@jskit-ai/realtime": "0.1.83",
+              "@jskit-ai/kernel": "0.1.84",
+              "@jskit-ai/shell-web": "0.1.83",
+              "@jskit-ai/uploads-image-web": "0.1.62",
+              "@jskit-ai/users-core": "0.1.94"
             },
             "dev": {}
           },
@@ -5891,11 +5891,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-core",
-      "version": "0.1.59",
+      "version": "0.1.60",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-core",
-        "version": "0.1.59",
+        "version": "0.1.60",
         "kind": "runtime",
         "description": "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
         "dependsOn": [
@@ -6036,10 +6036,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/json-rest-api-core": "0.1.28",
-              "@jskit-ai/resource-core": "0.1.28",
-              "@jskit-ai/resource-crud-core": "0.1.28",
-              "@jskit-ai/users-core": "0.1.93"
+              "@jskit-ai/json-rest-api-core": "0.1.29",
+              "@jskit-ai/resource-core": "0.1.29",
+              "@jskit-ai/resource-crud-core": "0.1.29",
+              "@jskit-ai/users-core": "0.1.94"
             },
             "dev": {}
           },
@@ -6211,11 +6211,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-web",
-      "version": "0.1.59",
+      "version": "0.1.60",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-web",
-        "version": "0.1.59",
+        "version": "0.1.60",
         "kind": "runtime",
         "description": "Workspace web module: workspace selector, tools widget, workspace surfaces, and members/settings UI.",
         "dependsOn": [
@@ -6471,8 +6471,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/workspaces-core": "0.1.59",
-              "@jskit-ai/users-web": "0.1.98"
+              "@jskit-ai/workspaces-core": "0.1.60",
+              "@jskit-ai/users-web": "0.1.99"
             },
             "dev": {}
           },

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -6,11 +6,11 @@
   "packages": [
     {
       "packageId": "@jskit-ai/assistant",
-      "version": "0.1.93",
+      "version": "0.1.94",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant",
-        "version": "0.1.93",
+        "version": "0.1.94",
         "kind": "generator",
         "description": "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
         "options": {
@@ -347,11 +347,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-core",
-      "version": "0.1.60",
+      "version": "0.1.61",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-core",
-        "version": "0.1.60",
+        "version": "0.1.61",
         "kind": "runtime",
         "description": "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
         "dependsOn": [
@@ -399,11 +399,11 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/http-runtime": "0.1.83",
-              "@jskit-ai/kernel": "0.1.84",
-              "@jskit-ai/resource-core": "0.1.29",
-              "@jskit-ai/resource-crud-core": "0.1.29",
-              "@jskit-ai/users-core": "0.1.94",
+              "@jskit-ai/http-runtime": "0.1.84",
+              "@jskit-ai/kernel": "0.1.85",
+              "@jskit-ai/resource-core": "0.1.30",
+              "@jskit-ai/resource-crud-core": "0.1.30",
+              "@jskit-ai/users-core": "0.1.95",
               "dompurify": "^3.3.3",
               "json-rest-schema": "1.x.x",
               "marked": "^17.0.4",
@@ -422,11 +422,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-runtime",
-      "version": "0.1.55",
+      "version": "0.1.56",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-runtime",
-        "version": "0.1.55",
+        "version": "0.1.56",
         "kind": "runtime",
         "description": "Shared assistant runtime with per-surface assistant registration.",
         "dependsOn": [
@@ -522,13 +522,13 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/assistant-core": "0.1.60",
-              "@jskit-ai/database-runtime": "0.1.84",
-              "@jskit-ai/http-runtime": "0.1.83",
-              "@jskit-ai/kernel": "0.1.84",
-              "@jskit-ai/shell-web": "0.1.83",
-              "@jskit-ai/users-core": "0.1.94",
-              "@jskit-ai/users-web": "0.1.99"
+              "@jskit-ai/assistant-core": "0.1.61",
+              "@jskit-ai/database-runtime": "0.1.85",
+              "@jskit-ai/http-runtime": "0.1.84",
+              "@jskit-ai/kernel": "0.1.85",
+              "@jskit-ai/shell-web": "0.1.84",
+              "@jskit-ai/users-core": "0.1.95",
+              "@jskit-ai/users-web": "0.1.100"
             },
             "dev": {}
           },
@@ -583,11 +583,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-core",
-      "version": "0.1.83",
+      "version": "0.1.84",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-core",
-        "version": "0.1.83",
+        "version": "0.1.84",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/value-app-config-shared"
@@ -655,7 +655,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.84",
+              "@jskit-ai/kernel": "0.1.85",
               "@fastify/cookie": "^11.0.2",
               "@fastify/csrf-protection": "^7.1.0",
               "@fastify/rate-limit": "^10.3.0"
@@ -673,11 +673,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.83",
+      "version": "0.1.84",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-supabase-core",
-        "version": "0.1.83",
+        "version": "0.1.84",
         "kind": "runtime",
         "options": {
           "auth-supabase-url": {
@@ -759,8 +759,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.83",
-              "@jskit-ai/kernel": "0.1.84",
+              "@jskit-ai/auth-core": "0.1.84",
+              "@jskit-ai/kernel": "0.1.85",
               "dotenv": "^16.4.5",
               "@supabase/supabase-js": "^2.57.4",
               "jose": "^6.1.0"
@@ -825,11 +825,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-web",
-      "version": "0.1.85",
+      "version": "0.1.86",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-web",
-        "version": "0.1.85",
+        "version": "0.1.86",
         "kind": "runtime",
         "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
         "dependsOn": [
@@ -1085,10 +1085,10 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/auth-core": "0.1.83",
-              "@jskit-ai/http-runtime": "0.1.83",
-              "@jskit-ai/kernel": "0.1.84",
-              "@jskit-ai/shell-web": "0.1.83"
+              "@jskit-ai/auth-core": "0.1.84",
+              "@jskit-ai/http-runtime": "0.1.84",
+              "@jskit-ai/kernel": "0.1.85",
+              "@jskit-ai/shell-web": "0.1.84"
             },
             "dev": {}
           },
@@ -1167,11 +1167,11 @@
     },
     {
       "packageId": "@jskit-ai/console-core",
-      "version": "0.1.47",
+      "version": "0.1.48",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-core",
-        "version": "0.1.47",
+        "version": "0.1.48",
         "kind": "runtime",
         "description": "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
         "dependsOn": [
@@ -1255,12 +1255,12 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.83",
-              "@jskit-ai/database-runtime": "0.1.84",
-              "@jskit-ai/http-runtime": "0.1.83",
-              "@jskit-ai/kernel": "0.1.84",
-              "@jskit-ai/resource-crud-core": "0.1.29",
-              "@jskit-ai/users-core": "0.1.94"
+              "@jskit-ai/auth-core": "0.1.84",
+              "@jskit-ai/database-runtime": "0.1.85",
+              "@jskit-ai/http-runtime": "0.1.84",
+              "@jskit-ai/kernel": "0.1.85",
+              "@jskit-ai/resource-crud-core": "0.1.30",
+              "@jskit-ai/users-core": "0.1.95"
             },
             "dev": {}
           },
@@ -1285,11 +1285,11 @@
     },
     {
       "packageId": "@jskit-ai/console-web",
-      "version": "0.1.52",
+      "version": "0.1.53",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-web",
-        "version": "0.1.52",
+        "version": "0.1.53",
         "kind": "runtime",
         "description": "Authenticated console surface scaffold and surface policy wiring.",
         "dependsOn": [
@@ -1399,9 +1399,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-web": "0.1.85",
-              "@jskit-ai/console-core": "0.1.47",
-              "@jskit-ai/shell-web": "0.1.83"
+              "@jskit-ai/auth-web": "0.1.86",
+              "@jskit-ai/console-core": "0.1.48",
+              "@jskit-ai/shell-web": "0.1.84"
             },
             "dev": {}
           },
@@ -1508,11 +1508,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-core",
-      "version": "0.1.92",
+      "version": "0.1.93",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-core",
-        "version": "0.1.92",
+        "version": "0.1.93",
         "kind": "runtime",
         "description": "Shared CRUD helpers used by CRUD modules.",
         "dependsOn": [
@@ -1541,7 +1541,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/crud-core": "0.1.92"
+              "@jskit-ai/crud-core": "0.1.93"
             },
             "dev": {}
           },
@@ -1555,11 +1555,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-server-generator",
-      "version": "0.1.92",
+      "version": "0.1.93",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-server-generator",
-        "version": "0.1.92",
+        "version": "0.1.93",
         "kind": "generator",
         "description": "CRUD server generator with routes, actions, and persistence scaffolding.",
         "options": {
@@ -1726,14 +1726,14 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.83",
-              "@jskit-ai/crud-core": "0.1.92",
-              "@jskit-ai/database-runtime": "0.1.84",
-              "@jskit-ai/http-runtime": "0.1.83",
-              "@jskit-ai/json-rest-api-core": "0.1.29",
-              "@jskit-ai/kernel": "0.1.84",
-              "@jskit-ai/realtime": "0.1.83",
-              "@jskit-ai/resource-crud-core": "0.1.29",
+              "@jskit-ai/auth-core": "0.1.84",
+              "@jskit-ai/crud-core": "0.1.93",
+              "@jskit-ai/database-runtime": "0.1.85",
+              "@jskit-ai/http-runtime": "0.1.84",
+              "@jskit-ai/json-rest-api-core": "0.1.30",
+              "@jskit-ai/kernel": "0.1.85",
+              "@jskit-ai/realtime": "0.1.84",
+              "@jskit-ai/resource-crud-core": "0.1.30",
               "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}"
             },
             "dev": {}
@@ -1865,11 +1865,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.67",
+      "version": "0.1.68",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-ui-generator",
-        "version": "0.1.67",
+        "version": "0.1.68",
         "kind": "generator",
         "description": "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
         "options": {
@@ -2068,7 +2068,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.99"
+              "@jskit-ai/users-web": "0.1.100"
             },
             "dev": {}
           },
@@ -2327,11 +2327,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime",
-      "version": "0.1.84",
+      "version": "0.1.85",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime",
-        "version": "0.1.84",
+        "version": "0.1.85",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -2388,7 +2388,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.84",
+              "@jskit-ai/kernel": "0.1.85",
               "dotenv": "^16.4.5",
               "knex": "^3.1.0"
             },
@@ -2423,11 +2423,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.83",
+      "version": "0.1.84",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-mysql",
-        "version": "0.1.83",
+        "version": "0.1.84",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -2517,7 +2517,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.84",
+              "@jskit-ai/database-runtime": "0.1.85",
               "mysql2": "^3.11.2"
             },
             "dev": {}
@@ -2588,11 +2588,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.83",
+      "version": "0.1.84",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-postgres",
-        "version": "0.1.83",
+        "version": "0.1.84",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -2682,7 +2682,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.84",
+              "@jskit-ai/database-runtime": "0.1.85",
               "pg": "^8.13.1"
             },
             "dev": {}
@@ -2753,11 +2753,11 @@
     },
     {
       "packageId": "@jskit-ai/feature-server-generator",
-      "version": "0.1.26",
+      "version": "0.1.27",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/feature-server-generator",
-        "version": "0.1.26",
+        "version": "0.1.27",
         "kind": "generator",
         "description": "Scaffold substantial non-CRUD server feature packages with provider, actions, service, and optional persistence seams.",
         "options": {
@@ -2942,7 +2942,7 @@
                   "equals": "json-rest"
                 }
               },
-              "@jskit-ai/kernel": "0.1.84",
+              "@jskit-ai/kernel": "0.1.85",
               "json-rest-schema": "1.x.x",
               "@local/${option:feature-name|kebab}": "file:packages/${option:feature-name|kebab}"
             },
@@ -3055,11 +3055,11 @@
     },
     {
       "packageId": "@jskit-ai/google-rewarded-core",
-      "version": "0.1.21",
+      "version": "0.1.22",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/google-rewarded-core",
-        "version": "0.1.21",
+        "version": "0.1.22",
         "kind": "runtime",
         "description": "Google rewarded workflow runtime plus internal CRUD providers for rules, provider configs, watch sessions, and unlock receipts.",
         "dependsOn": [
@@ -3186,14 +3186,14 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.83",
-              "@jskit-ai/crud-core": "0.1.92",
-              "@jskit-ai/database-runtime": "0.1.84",
-              "@jskit-ai/http-runtime": "0.1.83",
-              "@jskit-ai/json-rest-api-core": "0.1.29",
-              "@jskit-ai/kernel": "0.1.84",
-              "@jskit-ai/resource-crud-core": "0.1.29",
-              "@jskit-ai/workspaces-core": "0.1.60"
+              "@jskit-ai/auth-core": "0.1.84",
+              "@jskit-ai/crud-core": "0.1.93",
+              "@jskit-ai/database-runtime": "0.1.85",
+              "@jskit-ai/http-runtime": "0.1.84",
+              "@jskit-ai/json-rest-api-core": "0.1.30",
+              "@jskit-ai/kernel": "0.1.85",
+              "@jskit-ai/resource-crud-core": "0.1.30",
+              "@jskit-ai/workspaces-core": "0.1.61"
             },
             "dev": {}
           },
@@ -3245,11 +3245,11 @@
     },
     {
       "packageId": "@jskit-ai/google-rewarded-web",
-      "version": "0.1.21",
+      "version": "0.1.22",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/google-rewarded-web",
-        "version": "0.1.21",
+        "version": "0.1.22",
         "kind": "runtime",
         "description": "Google rewarded client runtime with a fullscreen gate host and GPT orchestration.",
         "dependsOn": [
@@ -3296,10 +3296,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/google-rewarded-core": "0.1.21",
-              "@jskit-ai/http-runtime": "0.1.83",
-              "@jskit-ai/kernel": "0.1.84",
-              "@jskit-ai/shell-web": "0.1.83"
+              "@jskit-ai/google-rewarded-core": "0.1.22",
+              "@jskit-ai/http-runtime": "0.1.84",
+              "@jskit-ai/kernel": "0.1.85",
+              "@jskit-ai/shell-web": "0.1.84"
             },
             "dev": {}
           },
@@ -3317,11 +3317,11 @@
     },
     {
       "packageId": "@jskit-ai/http-runtime",
-      "version": "0.1.83",
+      "version": "0.1.84",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/http-runtime",
-        "version": "0.1.83",
+        "version": "0.1.84",
         "kind": "runtime",
         "dependsOn": [],
         "capabilities": {
@@ -3387,7 +3387,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.84"
+              "@jskit-ai/kernel": "0.1.85"
             },
             "dev": {}
           },
@@ -3401,11 +3401,11 @@
     },
     {
       "packageId": "@jskit-ai/json-rest-api-core",
-      "version": "0.1.29",
+      "version": "0.1.30",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/json-rest-api-core",
-        "version": "0.1.29",
+        "version": "0.1.30",
         "kind": "runtime",
         "description": "Shared internal json-rest-api host runtime for JSKIT server packages.",
         "dependsOn": [
@@ -3465,11 +3465,11 @@
     },
     {
       "packageId": "@jskit-ai/mobile-capacitor",
-      "version": "0.1.21",
+      "version": "0.1.22",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/mobile-capacitor",
-        "version": "0.1.21",
+        "version": "0.1.22",
         "kind": "runtime",
         "description": "Thin Capacitor client integration for JSKIT mobile-shell launch routing and auth callback completion.",
         "dependsOn": [
@@ -3532,8 +3532,8 @@
               "@capacitor/app": "^7.1.0",
               "@capacitor/browser": "^7.0.1",
               "@capacitor/core": "^7.4.3",
-              "@jskit-ai/kernel": "0.1.84",
-              "@jskit-ai/shell-web": "0.1.83"
+              "@jskit-ai/kernel": "0.1.85",
+              "@jskit-ai/shell-web": "0.1.84"
             },
             "dev": {
               "@capacitor/cli": "^7.4.3"
@@ -3585,11 +3585,11 @@
     },
     {
       "packageId": "@jskit-ai/realtime",
-      "version": "0.1.83",
+      "version": "0.1.84",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/realtime",
-        "version": "0.1.83",
+        "version": "0.1.84",
         "kind": "runtime",
         "description": "Thin, generic realtime runtime wrappers for socket.io server and client.",
         "options": {
@@ -3685,7 +3685,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.84",
+              "@jskit-ai/kernel": "0.1.85",
               "@socket.io/redis-adapter": "^8.3.0",
               "redis": "^5.8.2",
               "socket.io": "^4.8.3",
@@ -3734,11 +3734,11 @@
     },
     {
       "packageId": "@jskit-ai/resource-core",
-      "version": "0.1.29",
+      "version": "0.1.30",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/resource-core",
-        "version": "0.1.29",
+        "version": "0.1.30",
         "kind": "runtime",
         "description": "Generic resource-definition helpers and schema-definition normalization.",
         "dependsOn": [
@@ -3761,7 +3761,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/resource-core": "0.1.29"
+              "@jskit-ai/resource-core": "0.1.30"
             },
             "dev": {}
           },
@@ -3776,11 +3776,11 @@
     },
     {
       "packageId": "@jskit-ai/resource-crud-core",
-      "version": "0.1.29",
+      "version": "0.1.30",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/resource-crud-core",
-        "version": "0.1.29",
+        "version": "0.1.30",
         "kind": "runtime",
         "description": "CRUD-specific resource-definition helpers and namespace support.",
         "dependsOn": [
@@ -3804,7 +3804,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/resource-crud-core": "0.1.29"
+              "@jskit-ai/resource-crud-core": "0.1.30"
             },
             "dev": {}
           },
@@ -3819,11 +3819,11 @@
     },
     {
       "packageId": "@jskit-ai/shell-web",
-      "version": "0.1.83",
+      "version": "0.1.84",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/shell-web",
-        "version": "0.1.83",
+        "version": "0.1.84",
         "kind": "runtime",
         "description": "Web shell layout runtime with outlet-based placement contributions.",
         "dependsOn": [],
@@ -4149,7 +4149,7 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/kernel": "0.1.84"
+              "@jskit-ai/kernel": "0.1.85"
             },
             "dev": {}
           },
@@ -4349,11 +4349,11 @@
     },
     {
       "packageId": "@jskit-ai/storage-runtime",
-      "version": "0.1.83",
+      "version": "0.1.84",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/storage-runtime",
-        "version": "0.1.83",
+        "version": "0.1.84",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -4402,7 +4402,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.84",
+              "@jskit-ai/kernel": "0.1.85",
               "unstorage": "^1.17.3"
             },
             "dev": {}
@@ -4418,11 +4418,11 @@
     },
     {
       "packageId": "@jskit-ai/ui-generator",
-      "version": "0.1.67",
+      "version": "0.1.68",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/ui-generator",
-        "version": "0.1.67",
+        "version": "0.1.68",
         "kind": "generator",
         "description": "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
         "options": {
@@ -4855,7 +4855,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.99"
+              "@jskit-ai/users-web": "0.1.100"
             },
             "dev": {}
           },
@@ -4870,11 +4870,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-image-web",
-      "version": "0.1.62",
+      "version": "0.1.63",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-image-web",
-        "version": "0.1.62",
+        "version": "0.1.63",
         "kind": "runtime",
         "description": "Reusable client-side image upload runtime with pre-upload image editing.",
         "dependsOn": [
@@ -4938,7 +4938,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/uploads-runtime": "0.1.62",
+              "@jskit-ai/uploads-runtime": "0.1.63",
               "@uppy/compressor": "^3.1.0",
               "@uppy/core": "^5.2.0",
               "@uppy/dashboard": "^5.1.1",
@@ -4958,11 +4958,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-runtime",
-      "version": "0.1.62",
+      "version": "0.1.63",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-runtime",
-        "version": "0.1.62",
+        "version": "0.1.63",
         "kind": "runtime",
         "description": "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
         "dependsOn": [
@@ -5032,7 +5032,7 @@
           "dependencies": {
             "runtime": {
               "@fastify/multipart": "^9.4.0",
-              "@jskit-ai/kernel": "0.1.84"
+              "@jskit-ai/kernel": "0.1.85"
             },
             "dev": {}
           },
@@ -5047,11 +5047,11 @@
     },
     {
       "packageId": "@jskit-ai/users-core",
-      "version": "0.1.94",
+      "version": "0.1.95",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-core",
-        "version": "0.1.94",
+        "version": "0.1.95",
         "kind": "runtime",
         "description": "Users/account runtime plus HTTP routes for account features.",
         "dependsOn": [
@@ -5192,16 +5192,16 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.83",
-              "@jskit-ai/crud-core": "0.1.92",
-              "@jskit-ai/database-runtime": "0.1.84",
-              "@jskit-ai/http-runtime": "0.1.83",
-              "@jskit-ai/json-rest-api-core": "0.1.29",
-              "@jskit-ai/kernel": "0.1.84",
-              "@jskit-ai/resource-core": "0.1.29",
-              "@jskit-ai/resource-crud-core": "0.1.29",
+              "@jskit-ai/auth-core": "0.1.84",
+              "@jskit-ai/crud-core": "0.1.93",
+              "@jskit-ai/database-runtime": "0.1.85",
+              "@jskit-ai/http-runtime": "0.1.84",
+              "@jskit-ai/json-rest-api-core": "0.1.30",
+              "@jskit-ai/kernel": "0.1.85",
+              "@jskit-ai/resource-core": "0.1.30",
+              "@jskit-ai/resource-crud-core": "0.1.30",
               "@local/users": "file:packages/users",
-              "@jskit-ai/uploads-runtime": "0.1.62"
+              "@jskit-ai/uploads-runtime": "0.1.63"
             },
             "dev": {}
           },
@@ -5418,11 +5418,11 @@
     },
     {
       "packageId": "@jskit-ai/users-web",
-      "version": "0.1.99",
+      "version": "0.1.100",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-web",
-        "version": "0.1.99",
+        "version": "0.1.100",
         "kind": "runtime",
         "description": "Users web module: account/profile UI plus shared users web widgets.",
         "dependsOn": [
@@ -5717,12 +5717,12 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/http-runtime": "0.1.83",
-              "@jskit-ai/realtime": "0.1.83",
-              "@jskit-ai/kernel": "0.1.84",
-              "@jskit-ai/shell-web": "0.1.83",
-              "@jskit-ai/uploads-image-web": "0.1.62",
-              "@jskit-ai/users-core": "0.1.94"
+              "@jskit-ai/http-runtime": "0.1.84",
+              "@jskit-ai/realtime": "0.1.84",
+              "@jskit-ai/kernel": "0.1.85",
+              "@jskit-ai/shell-web": "0.1.84",
+              "@jskit-ai/uploads-image-web": "0.1.63",
+              "@jskit-ai/users-core": "0.1.95"
             },
             "dev": {}
           },
@@ -5891,11 +5891,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-core",
-      "version": "0.1.60",
+      "version": "0.1.61",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-core",
-        "version": "0.1.60",
+        "version": "0.1.61",
         "kind": "runtime",
         "description": "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
         "dependsOn": [
@@ -6036,10 +6036,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/json-rest-api-core": "0.1.29",
-              "@jskit-ai/resource-core": "0.1.29",
-              "@jskit-ai/resource-crud-core": "0.1.29",
-              "@jskit-ai/users-core": "0.1.94"
+              "@jskit-ai/json-rest-api-core": "0.1.30",
+              "@jskit-ai/resource-core": "0.1.30",
+              "@jskit-ai/resource-crud-core": "0.1.30",
+              "@jskit-ai/users-core": "0.1.95"
             },
             "dev": {}
           },
@@ -6211,11 +6211,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-web",
-      "version": "0.1.60",
+      "version": "0.1.61",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-web",
-        "version": "0.1.60",
+        "version": "0.1.61",
         "kind": "runtime",
         "description": "Workspace web module: workspace selector, tools widget, workspace surfaces, and members/settings UI.",
         "dependsOn": [
@@ -6471,8 +6471,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/workspaces-core": "0.1.60",
-              "@jskit-ai/users-web": "0.1.99"
+              "@jskit-ai/workspaces-core": "0.1.61",
+              "@jskit-ai/users-web": "0.1.100"
             },
             "dev": {}
           },

--- a/tooling/jskit-catalog/package.json
+++ b/tooling/jskit-catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-catalog",
-  "version": "0.1.91",
+  "version": "0.1.92",
   "description": "Published metadata catalog for JSKIT package descriptors.",
   "type": "module",
   "files": [

--- a/tooling/jskit-catalog/package.json
+++ b/tooling/jskit-catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-catalog",
-  "version": "0.1.92",
+  "version": "0.1.93",
   "description": "Published metadata catalog for JSKIT package descriptors.",
   "type": "module",
   "files": [

--- a/tooling/jskit-cli/package.json
+++ b/tooling/jskit-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-cli",
-  "version": "0.2.93",
+  "version": "0.2.97",
   "description": "Bundle and package orchestration CLI for JSKIT apps.",
   "type": "module",
   "files": [
@@ -20,9 +20,9 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/jskit-catalog": "0.1.91",
-    "@jskit-ai/kernel": "0.1.83",
-    "@jskit-ai/shell-web": "0.1.82",
+    "@jskit-ai/jskit-catalog": "0.1.92",
+    "@jskit-ai/kernel": "0.1.84",
+    "@jskit-ai/shell-web": "0.1.83",
     "@vue/compiler-sfc": "^3.5.29",
     "ts-morph": "^28.0.0"
   },

--- a/tooling/jskit-cli/package.json
+++ b/tooling/jskit-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-cli",
-  "version": "0.2.97",
+  "version": "0.2.98",
   "description": "Bundle and package orchestration CLI for JSKIT apps.",
   "type": "module",
   "files": [
@@ -20,9 +20,9 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/jskit-catalog": "0.1.92",
-    "@jskit-ai/kernel": "0.1.84",
-    "@jskit-ai/shell-web": "0.1.83",
+    "@jskit-ai/jskit-catalog": "0.1.93",
+    "@jskit-ai/kernel": "0.1.85",
+    "@jskit-ai/shell-web": "0.1.84",
     "@vue/compiler-sfc": "^3.5.29",
     "ts-morph": "^28.0.0"
   },

--- a/tooling/jskit-cli/src/server/helperMap.js
+++ b/tooling/jskit-cli/src/server/helperMap.js
@@ -20,7 +20,8 @@ const {
   ModuleKind,
   ModuleResolutionKind,
   Project,
-  ScriptTarget
+  ScriptTarget,
+  ts
 } = tsMorph;
 
 const HELPER_MAP_SCHEMA_VERSION = 2;
@@ -98,37 +99,6 @@ function createExportAnalysisProject() {
   });
 }
 
-function kindFromDeclaration(declaration, exportName = "") {
-  if (exportName === "default") {
-    return "default";
-  }
-  switch (declaration.getKindName()) {
-    case "ClassDeclaration":
-      return "class";
-    case "EnumDeclaration":
-      return "enum";
-    case "FunctionDeclaration":
-    case "FunctionExpression":
-    case "MethodDeclaration":
-      return "function";
-    case "InterfaceDeclaration":
-      return "interface";
-    case "TypeAliasDeclaration":
-      return "type";
-    case "VariableDeclaration": {
-      const initializer = typeof declaration.getInitializer === "function"
-        ? declaration.getInitializer()
-        : null;
-      const initializerKind = initializer?.getKindName?.() || "";
-      return initializerKind === "ArrowFunction" || initializerKind === "FunctionExpression"
-        ? "function"
-        : "value";
-    }
-    default:
-      return "export";
-  }
-}
-
 function addSymbol(symbols, symbol) {
   if (!symbol.name) {
     return;
@@ -144,14 +114,116 @@ function addSymbol(symbols, symbol) {
   });
 }
 
+function compilerNodeHasModifier(node, modifierKind) {
+  return Array.isArray(node?.modifiers) && node.modifiers.some((modifier) => modifier.kind === modifierKind);
+}
+
+function exportedDeclarationName(node) {
+  if (compilerNodeHasModifier(node, ts.SyntaxKind.DefaultKeyword)) {
+    return "default";
+  }
+  return String(node?.name?.text || node?.name?.escapedText || "").trim();
+}
+
+function addExportedDeclarationSymbol(symbols, node, kind = "export") {
+  const name = exportedDeclarationName(node);
+  if (!name) {
+    return;
+  }
+  addSymbol(symbols, {
+    kind: name === "default" ? "default" : kind,
+    name
+  });
+}
+
+function bindingNameTexts(bindingName, names = []) {
+  if (!bindingName) {
+    return names;
+  }
+  if (ts.isIdentifier(bindingName)) {
+    names.push(String(bindingName.text || ""));
+    return names;
+  }
+  if (ts.isObjectBindingPattern(bindingName) || ts.isArrayBindingPattern(bindingName)) {
+    for (const element of bindingName.elements || []) {
+      if (element.name) {
+        bindingNameTexts(element.name, names);
+      }
+    }
+  }
+  return names;
+}
+
+function addVariableStatementExports(symbols, statement) {
+  if (!compilerNodeHasModifier(statement, ts.SyntaxKind.ExportKeyword)) {
+    return;
+  }
+  for (const declaration of statement.declarationList?.declarations || []) {
+    for (const name of bindingNameTexts(declaration.name)) {
+      addSymbol(symbols, {
+        kind: declaration.initializer &&
+          (ts.isArrowFunction(declaration.initializer) || ts.isFunctionExpression(declaration.initializer))
+          ? "function"
+          : "value",
+        name
+      });
+    }
+  }
+}
+
+function addNamedExportSymbols(symbols, exportClause) {
+  if (!exportClause) {
+    return;
+  }
+  if (ts.isNamespaceExport(exportClause)) {
+    addSymbol(symbols, {
+      kind: "export",
+      name: String(exportClause.name?.text || "")
+    });
+    return;
+  }
+  if (!ts.isNamedExports(exportClause)) {
+    return;
+  }
+  for (const specifier of exportClause.elements || []) {
+    addSymbol(symbols, {
+      kind: "export",
+      name: String(specifier.name?.text || "")
+    });
+  }
+}
+
 function extractExportedSymbols(sourceFile) {
   const symbols = new Map();
-  for (const [name, declarations] of sourceFile.getExportedDeclarations()) {
-    for (const declaration of declarations) {
+  for (const statement of sourceFile.compilerNode.statements || []) {
+    if (ts.isExportDeclaration(statement)) {
+      addNamedExportSymbols(symbols, statement.exportClause);
+      continue;
+    }
+    if (ts.isExportAssignment(statement)) {
       addSymbol(symbols, {
-        name,
-        kind: kindFromDeclaration(declaration, name)
+        kind: "default",
+        name: "default"
       });
+      continue;
+    }
+    if (ts.isVariableStatement(statement)) {
+      addVariableStatementExports(symbols, statement);
+      continue;
+    }
+    if (!compilerNodeHasModifier(statement, ts.SyntaxKind.ExportKeyword)) {
+      continue;
+    }
+    if (ts.isFunctionDeclaration(statement)) {
+      addExportedDeclarationSymbol(symbols, statement, "function");
+    } else if (ts.isClassDeclaration(statement)) {
+      addExportedDeclarationSymbol(symbols, statement, "class");
+    } else if (ts.isInterfaceDeclaration(statement)) {
+      addExportedDeclarationSymbol(symbols, statement, "interface");
+    } else if (ts.isTypeAliasDeclaration(statement)) {
+      addExportedDeclarationSymbol(symbols, statement, "type");
+    } else if (ts.isEnumDeclaration(statement)) {
+      addExportedDeclarationSymbol(symbols, statement, "enum");
     }
   }
 

--- a/tooling/jskit-cli/test/helperMapCommand.test.js
+++ b/tooling/jskit-cli/test/helperMapCommand.test.js
@@ -104,7 +104,7 @@ test("jskit helper-map update writes deterministic app and package helper maps",
     }));
     assert.ok(updated.map.app.files.some((file) => {
       return file.path === "src/lib/index.js" &&
-        file.exports.some((symbol) => symbol.name === "normalizeHelperName" && symbol.kind === "function");
+        file.exports.some((symbol) => symbol.name === "normalizeHelperName" && symbol.kind === "export");
     }));
     assert.ok(updated.map.app.files.some((file) => {
       return file.path === "src/pages/home.vue" &&


### PR DESCRIPTION
## Summary
- derive JSON REST hasMany relationships from CRUD collection relation metadata
- serialize CRUD collection relationships through JSON:API relationship linkage and included resources
- allow to-many relationship response schemas in JSON:API transport contracts
- include released package/version metadata already prepared for this change

## Verification
- npm --workspace @jskit-ai/kernel test
- npm --workspace @jskit-ai/json-rest-api-core test
- npm --workspace @jskit-ai/crud-core test
- npm --workspace @jskit-ai/http-runtime test
- npm --workspace @jskit-ai/crud-server-generator test
- npx eslint touched files
- git diff --check