### PR TITLE
Fix shell route transitions and scaffold polish

### DIFF
--- a/packages/agent-docs/guide/agent/app-setup/a-more-interesting-shell.md
+++ b/packages/agent-docs/guide/agent/app-setup/a-more-interesting-shell.md
@@ -211,9 +211,11 @@ There are two different paths to keep straight:
 1. placement and menu metadata such as `src/placement.js`
 2. direct Vuetify icon props inside normal `.vue` components
 
-In placement metadata, raw `mdi-*` strings are acceptable because the shell menu runtime normalizes them before Vuetify renders the icon. A menu entry like this is fine:
+For placement metadata, prefer importing app-specific icons from `@mdi/js` in the placement file itself. The shell menu runtime accepts the resolved SVG path value and passes it through to Vuetify:
 
 ```js
+import { mdiAccountCircleOutline } from "@mdi/js";
+
 addPlacement({
   id: "home.settings.profile.link",
   target: "page.section-nav",
@@ -223,18 +225,18 @@ addPlacement({
   props: {
     label: "Profile",
     to: "./profile",
-    icon: "mdi-account-circle-outline"
+    icon: mdiAccountCircleOutline
   }
 });
 ```
 
-But do not copy that same string into a normal Vue component:
+Do not copy raw `mdi-*` strings into a normal Vue component:
 
 ```vue
 <v-list-item prepend-icon="mdi-account-circle-outline" />
 ```
 
-JSKIT apps use Vuetify's SVG MDI renderer, so direct Vue icon props should use an `@mdi/js` path or a Vuetify alias instead:
+JSKIT apps use Vuetify's SVG MDI renderer, so direct Vue icon props should use the same `@mdi/js` path or a Vuetify alias instead:
 
 ```vue
 <script setup>
@@ -246,7 +248,8 @@ import { mdiAccountCircleOutline } from "@mdi/js";
 
 So the practical rule is:
 
-- editing `src/placement.js` or other shell menu metadata: `mdi-*` strings are fine
+- editing `src/placement.js` or other shell menu metadata: import app-specific icons from `@mdi/js` and pass the constant
+- raw `mdi-*` metadata strings are only safe for shell-web's small core normalized icon map
 - editing a normal `.vue` file: use `@mdi/js` or a Vuetify alias such as `$close`
 
 Later in the guide, `jskit doctor` will help catch the second mistake automatically.

--- a/packages/agent-docs/guide/agent/app-setup/working-with-the-jskit-cli.md
+++ b/packages/agent-docs/guide/agent/app-setup/working-with-the-jskit-cli.md
@@ -686,13 +686,15 @@ That last check is narrower than it sounds. `doctor` is looking for the broken c
 <v-icon icon="mdi-paw" />
 ```
 
-It does not flag the normal menu-metadata case in `src/placement.js`, where a shell menu link may still use:
+It does not flag `src/placement.js` menu metadata because shell menu links normalize a small core icon map and also accept imported `@mdi/js` path constants. For app-specific icons, prefer a local import:
 
 ```js
-icon: "mdi-cog-outline"
+import { mdiPaw } from "@mdi/js";
+
+icon: mdiPaw
 ```
 
-because the shell runtime normalizes that metadata before Vuetify renders it. So if you see a `doctor` icon warning, the fix is usually "switch this Vue component to `@mdi/js`", not "remove every `mdi-*` string from the app."
+So if you see a `doctor` icon warning, the fix is usually "switch this Vue component to `@mdi/js`", not "centralize every icon in the app."
 
 In other words, `doctor` helps catch drift between:
 

--- a/packages/agent-docs/guide/agent/generators/ui-generators.md
+++ b/packages/agent-docs/guide/agent/generators/ui-generators.md
@@ -100,20 +100,23 @@ normally get adjusted.
 
 The important icon rule is this:
 
-- inside `src/placement.js` menu metadata, raw `mdi-*` strings are fine
-- inside normal Vue component props, they are not
+- inside `src/placement.js` menu metadata, import app-specific icons from `@mdi/js` and pass the path constant
+- only use raw `mdi-*` strings for the small set of shell-web core icons that JSKIT normalizes
+- inside normal Vue component props, use the same `@mdi/js` path constants or a Vuetify alias
 
 So this is a valid menu-placement customization:
 
 ```js
+import { mdiChartBoxOutline } from "@mdi/js";
+
 props: {
   label: "Reports",
   to: "/reports",
-  icon: "mdi-chart-box-outline"
+  icon: mdiChartBoxOutline
 }
 ```
 
-But if you later open the generated page file itself and add a Vuetify icon to the template, switch back to `@mdi/js`:
+If you later open the generated page file itself and add a Vuetify icon to the template, use the same `@mdi/js` pattern:
 
 ```vue
 <script setup>
@@ -123,7 +126,7 @@ import { mdiChartBoxOutline } from "@mdi/js";
 <v-icon :icon="mdiChartBoxOutline" />
 ```
 
-This split matters because JSKIT's shell menu components normalize menu metadata icons for you, while direct Vue icon props go straight to Vuetify.
+This keeps icon imports local and tree-shakeable. Do not import the whole `@mdi/js` namespace just to look up icon names dynamically.
 
 ## What `page` is really good at
 

--- a/packages/agent-docs/reference/autogen/packages/auth-provider-supabase-core.md
+++ b/packages/agent-docs/reference/autogen/packages/auth-provider-supabase-core.md
@@ -194,7 +194,7 @@ Local functions
 Exports
 - `buildSupabaseServerClientOptions(options = {})`
 Local functions
-- `resolveRealtimeTransport({ nativeWebSocket = globalThis.WebSocket, fallbackTransport = WebSocket } = {})`
+- `resolveRealtimeTransport(options = {})`
 
 ### `src/server/lib/test-utils.js`
 Exports

--- a/packages/agent-docs/reference/autogen/packages/shell-web.md
+++ b/packages/agent-docs/reference/autogen/packages/shell-web.md
@@ -353,6 +353,12 @@ Local functions
 - `isRelativeMenuLinkTarget(target = "")`
 - `surfaceRequiresWorkspaceFromPlacementContext(contextValue = null, surfaceId = "")`
 
+### `src/client/support/routeTransitionKey.js`
+Exports
+- `resolveShellRouteTransitionKey({ routePathKey = "", routeTransitionName = "", surfaceId = "" } = {})`
+Local functions
+- `normalizeText(value = "")`
+
 ### `src/server/support/localLinkItemScaffolds.js`
 Exports
 - `LOCAL_LINK_ITEM_COMPONENT_DEFINITIONS`

--- a/packages/agent-docs/site/guide/app-setup/a-more-interesting-shell.md
+++ b/packages/agent-docs/site/guide/app-setup/a-more-interesting-shell.md
@@ -298,9 +298,11 @@ There are two different paths to keep straight:
 1. placement and menu metadata such as `src/placement.js`
 2. direct Vuetify icon props inside normal `.vue` components
 
-In placement metadata, raw `mdi-*` strings are acceptable because the shell menu runtime normalizes them before Vuetify renders the icon. A menu entry like this is fine:
+For placement metadata, prefer importing app-specific icons from `@mdi/js` in the placement file itself. The shell menu runtime accepts the resolved SVG path value and passes it through to Vuetify:
 
 ```js
+import { mdiAccountCircleOutline } from "@mdi/js";
+
 addPlacement({
   id: "home.settings.profile.link",
   target: "page.section-nav",
@@ -310,18 +312,18 @@ addPlacement({
   props: {
     label: "Profile",
     to: "./profile",
-    icon: "mdi-account-circle-outline"
+    icon: mdiAccountCircleOutline
   }
 });
 ```
 
-But do not copy that same string into a normal Vue component:
+Do not copy raw `mdi-*` strings into a normal Vue component:
 
 ```vue
 <v-list-item prepend-icon="mdi-account-circle-outline" />
 ```
 
-JSKIT apps use Vuetify's SVG MDI renderer, so direct Vue icon props should use an `@mdi/js` path or a Vuetify alias instead:
+JSKIT apps use Vuetify's SVG MDI renderer, so direct Vue icon props should use the same `@mdi/js` path or a Vuetify alias instead:
 
 ```vue
 <script setup>
@@ -333,7 +335,8 @@ import { mdiAccountCircleOutline } from "@mdi/js";
 
 So the practical rule is:
 
-- editing `src/placement.js` or other shell menu metadata: `mdi-*` strings are fine
+- editing `src/placement.js` or other shell menu metadata: import app-specific icons from `@mdi/js` and pass the constant
+- raw `mdi-*` metadata strings are only safe for shell-web's small core normalized icon map
 - editing a normal `.vue` file: use `@mdi/js` or a Vuetify alias such as `$close`
 
 Later in the guide, `jskit doctor` will help catch the second mistake automatically.

--- a/packages/agent-docs/site/guide/app-setup/working-with-the-jskit-cli.md
+++ b/packages/agent-docs/site/guide/app-setup/working-with-the-jskit-cli.md
@@ -698,13 +698,15 @@ That last check is narrower than it sounds. `doctor` is looking for the broken c
 <v-icon icon="mdi-paw" />
 ```
 
-It does not flag the normal menu-metadata case in `src/placement.js`, where a shell menu link may still use:
+It does not flag `src/placement.js` menu metadata because shell menu links normalize a small core icon map and also accept imported `@mdi/js` path constants. For app-specific icons, prefer a local import:
 
 ```js
-icon: "mdi-cog-outline"
+import { mdiPaw } from "@mdi/js";
+
+icon: mdiPaw
 ```
 
-because the shell runtime normalizes that metadata before Vuetify renders it. So if you see a `doctor` icon warning, the fix is usually "switch this Vue component to `@mdi/js`", not "remove every `mdi-*` string from the app."
+So if you see a `doctor` icon warning, the fix is usually "switch this Vue component to `@mdi/js`", not "centralize every icon in the app."
 
 In other words, `doctor` helps catch drift between:
 

--- a/packages/agent-docs/site/guide/generators/ui-generators.md
+++ b/packages/agent-docs/site/guide/generators/ui-generators.md
@@ -115,20 +115,23 @@ normally get adjusted.
 
 The important icon rule is this:
 
-- inside `src/placement.js` menu metadata, raw `mdi-*` strings are fine
-- inside normal Vue component props, they are not
+- inside `src/placement.js` menu metadata, import app-specific icons from `@mdi/js` and pass the path constant
+- only use raw `mdi-*` strings for the small set of shell-web core icons that JSKIT normalizes
+- inside normal Vue component props, use the same `@mdi/js` path constants or a Vuetify alias
 
 So this is a valid menu-placement customization:
 
 ```js
+import { mdiChartBoxOutline } from "@mdi/js";
+
 props: {
   label: "Reports",
   to: "/reports",
-  icon: "mdi-chart-box-outline"
+  icon: mdiChartBoxOutline
 }
 ```
 
-But if you later open the generated page file itself and add a Vuetify icon to the template, switch back to `@mdi/js`:
+If you later open the generated page file itself and add a Vuetify icon to the template, use the same `@mdi/js` pattern:
 
 ```vue
 <script setup>
@@ -138,7 +141,7 @@ import { mdiChartBoxOutline } from "@mdi/js";
 <v-icon :icon="mdiChartBoxOutline" />
 ```
 
-This split matters because JSKIT's shell menu components normalize menu metadata icons for you, while direct Vue icon props go straight to Vuetify.
+This keeps icon imports local and tree-shakeable. Do not import the whole `@mdi/js` namespace just to look up icon names dynamically.
 
 ## What `page` is really good at
 

--- a/packages/auth-provider-supabase-core/src/server/lib/supabaseClientOptions.js
+++ b/packages/auth-provider-supabase-core/src/server/lib/supabaseClientOptions.js
@@ -1,9 +1,11 @@
 import WebSocket from "ws";
 
-function resolveRealtimeTransport({
-  nativeWebSocket = globalThis.WebSocket,
-  fallbackTransport = WebSocket
-} = {}) {
+function resolveRealtimeTransport(options = {}) {
+  const nativeWebSocket = Object.hasOwn(options, "nativeWebSocket")
+    ? options.nativeWebSocket
+    : globalThis.WebSocket;
+  const { fallbackTransport = WebSocket } = options;
+
   if (typeof nativeWebSocket === "function") {
     return null;
   }

--- a/packages/console-web/templates/src/pages/console/settings.vue
+++ b/packages/console-web/templates/src/pages/console/settings.vue
@@ -13,7 +13,7 @@ import { RouterView } from "vue-router";
 
     <v-sheet rounded="lg" border class="settings-shell__panel">
       <nav class="settings-shell__nav" aria-label="Console settings sections">
-        <v-list nav density="comfortable" class="settings-shell__nav-list">
+        <v-list nav density="compact" class="settings-shell__nav-list">
           <ShellOutlet target="console-settings:primary-menu" />
         </v-list>
       </nav>
@@ -41,11 +41,31 @@ import { RouterView } from "vue-router";
 }
 
 .settings-shell__nav-list {
-  padding: 0;
+  padding: 0.35rem;
+}
+
+.settings-shell__nav-list :deep(.v-list-item) {
+  min-height: 48px;
+  padding-inline: 0.6rem 0.7rem;
+}
+
+.settings-shell__nav-list :deep(.v-list-item__prepend) {
+  margin-inline-end: 0;
+}
+
+.settings-shell__nav-list :deep(.v-list-item__spacer) {
+  min-width: 0.5rem;
+  width: 0.5rem;
+}
+
+.settings-shell__nav-list :deep(.v-list-item-title) {
+  line-height: 1.2;
 }
 
 .settings-shell__content {
+  border-left: 1px solid rgba(var(--v-theme-on-surface), 0.18);
   min-width: 0;
+  padding-left: 1rem;
 }
 
 @media (max-width: 960px) {
@@ -59,12 +79,17 @@ import { RouterView } from "vue-router";
 
   .settings-shell__nav-list {
     display: flex;
-    gap: 0.5rem;
+    gap: 0.25rem;
     min-width: max-content;
   }
 
   .settings-shell__nav-list :deep(.v-list-item) {
     min-height: 48px;
+  }
+
+  .settings-shell__content {
+    border-left: 0;
+    padding-left: 0;
   }
 }
 </style>

--- a/packages/shell-web/src/client/components/ShellRouteTransition.vue
+++ b/packages/shell-web/src/client/components/ShellRouteTransition.vue
@@ -24,6 +24,7 @@ import {
   normalizeMenuLinkPathname,
   resolveMenuLinkTarget
 } from "../support/menuLinkTarget.js";
+import { resolveShellRouteTransitionKey } from "../support/routeTransitionKey.js";
 
 const props = defineProps({
   enabled: {
@@ -232,7 +233,16 @@ const routeTransitionName = computed(() => {
   return "";
 });
 
-const routeTransitionKey = computed(() => normalizeComparablePathname(route?.path || route?.fullPath || "/") || "/");
+const routeTransitionKey = computed(() => {
+  const routePathKey = routeTransitionName.value
+    ? normalizeComparablePathname(route?.path || route?.fullPath || "/")
+    : "";
+  return resolveShellRouteTransitionKey({
+    routePathKey,
+    routeTransitionName: routeTransitionName.value,
+    surfaceId: currentSurfaceId.value
+  });
+});
 
 const swipeNavigationEnabled = computed(() =>
   Boolean(
@@ -409,7 +419,12 @@ function isSwipeIgnoredTarget(target) {
 <style scoped>
 .shell-route-transition {
   --shell-route-transition-distance: 100%;
+  align-items: stretch;
   --shell-route-transition-opacity: 1;
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  min-height: 0;
   overflow-x: clip;
   position: relative;
 }
@@ -420,6 +435,10 @@ function isSwipeIgnoredTarget(target) {
 
 .shell-route-transition__pane {
   background: rgb(var(--v-theme-background));
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  min-height: 0;
   width: 100%;
 }
 

--- a/packages/shell-web/src/client/support/routeTransitionKey.js
+++ b/packages/shell-web/src/client/support/routeTransitionKey.js
@@ -1,0 +1,22 @@
+function normalizeText(value = "") {
+  return String(value || "").trim();
+}
+
+function resolveShellRouteTransitionKey({
+  routePathKey = "",
+  routeTransitionName = "",
+  surfaceId = ""
+} = {}) {
+  if (normalizeText(routeTransitionName)) {
+    return normalizeText(routePathKey) || "/";
+  }
+
+  const surfaceKey = normalizeText(surfaceId);
+  if (surfaceKey && surfaceKey !== "*") {
+    return `surface:${surfaceKey}`;
+  }
+
+  return "stable";
+}
+
+export { resolveShellRouteTransitionKey };

--- a/packages/shell-web/templates/src/pages/home/settings.vue
+++ b/packages/shell-web/templates/src/pages/home/settings.vue
@@ -14,7 +14,7 @@ import { RouterView } from "vue-router";
     <v-sheet rounded="lg" border class="settings-shell__panel">
       <div class="settings-shell__body">
         <nav class="settings-shell__nav" aria-label="Home settings sections">
-          <v-list nav density="comfortable" rounded="lg" border>
+          <v-list nav density="compact" rounded="lg">
             <ShellOutlet target="home-settings:primary-menu" />
           </v-list>
         </nav>
@@ -53,7 +53,31 @@ import { RouterView } from "vue-router";
 }
 
 .settings-shell__content {
+  border-left: 1px solid rgba(var(--v-theme-on-surface), 0.18);
   min-width: 0;
+  padding-left: 1rem;
+}
+
+.settings-shell__nav :deep(.v-list) {
+  padding: 0.35rem;
+}
+
+.settings-shell__nav :deep(.v-list-item) {
+  min-height: 48px;
+  padding-inline: 0.6rem 0.7rem;
+}
+
+.settings-shell__nav :deep(.v-list-item__prepend) {
+  margin-inline-end: 0;
+}
+
+.settings-shell__nav :deep(.v-list-item__spacer) {
+  min-width: 0.5rem;
+  width: 0.5rem;
+}
+
+.settings-shell__nav :deep(.v-list-item-title) {
+  line-height: 1.2;
 }
 
 @media (max-width: 960px) {
@@ -71,6 +95,11 @@ import { RouterView } from "vue-router";
   .settings-shell__nav :deep(.v-list-item) {
     flex: 0 0 auto;
     min-height: 48px;
+  }
+
+  .settings-shell__content {
+    border-left: 0;
+    padding-left: 0;
   }
 }
 </style>

--- a/packages/shell-web/test/menuIcons.test.js
+++ b/packages/shell-web/test/menuIcons.test.js
@@ -4,6 +4,7 @@ import test from "node:test";
 import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import {
+  mdiAccountKeyOutline,
   mdiCogOutline,
   mdiConsoleNetworkOutline,
   mdiViewListOutline
@@ -27,6 +28,10 @@ test("shell-web resolves supported explicit mdi metadata icons from a finite map
 
 test("shell-web leaves unknown explicit mdi metadata icons unchanged", () => {
   assert.equal(resolveMenuLinkIcon({ icon: "mdi-not-a-real-supported-icon" }), "mdi-not-a-real-supported-icon");
+});
+
+test("shell-web accepts imported @mdi/js path constants as explicit menu icons", () => {
+  assert.equal(resolveMenuLinkIcon({ icon: mdiAccountKeyOutline }), mdiAccountKeyOutline);
 });
 
 test("shell-web menu icon resolution does not import the full mdi namespace", async () => {

--- a/packages/shell-web/test/settingsPlacementContract.test.js
+++ b/packages/shell-web/test/settingsPlacementContract.test.js
@@ -5,6 +5,7 @@ import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { assertGeneratedUiSourceContract } from "@jskit-ai/kernel/shared/support/generatedUiContract";
 import descriptor from "../package.descriptor.mjs";
+import { resolveShellRouteTransitionKey } from "../src/client/support/routeTransitionKey.js";
 
 const TEST_DIRECTORY = path.dirname(fileURLToPath(import.meta.url));
 const PACKAGE_DIR = path.resolve(TEST_DIRECTORY, "..");
@@ -159,8 +160,52 @@ test("shell-web route transition keeps mobile route motion placement-driven", as
   assert.match(source, /router\.push\(nextEntry\.href\)/);
   assert.match(source, /isSwipeIgnoredTarget/);
   assert.match(source, /touch-action:\s*pan-y/);
+  assert.match(source, /\.shell-route-transition\s*\{[\s\S]*display:\s*flex/);
+  assert.match(source, /\.shell-route-transition\s*\{[\s\S]*min-height:\s*0/);
+  assert.match(source, /\.shell-route-transition__pane\s*\{[\s\S]*flex:\s*1 1 auto/);
+  assert.match(source, /\.shell-route-transition__pane\s*\{[\s\S]*min-height:\s*0/);
   assert.match(source, /transitionDirection\.value = nextIndex > previousIndex \? "forward" : "reverse"/);
+  assert.match(
+    source,
+    /const routeTransitionKey = computed\(\(\) => \{[\s\S]*const routePathKey = routeTransitionName\.value[\s\S]*normalizeComparablePathname\(route\?\.path \|\| route\?\.fullPath \|\| "\/"\)[\s\S]*resolveShellRouteTransitionKey\(\{[\s\S]*routeTransitionName: routeTransitionName\.value,[\s\S]*surfaceId: currentSurfaceId\.value[\s\S]*\}\);[\s\S]*\}\);/
+  );
   assert.match(source, /prefers-reduced-motion:\s*reduce/);
+});
+
+test("shell-web route transition key preserves no-motion surfaces and animated path transitions", () => {
+  const previewSurfaceKey = "surface:vibe64-preview";
+  assert.equal(
+    resolveShellRouteTransitionKey({
+      routeTransitionName: "",
+      routePathKey: "/preview",
+      surfaceId: "vibe64-preview"
+    }),
+    previewSurfaceKey
+  );
+  assert.equal(
+    resolveShellRouteTransitionKey({
+      routeTransitionName: "",
+      routePathKey: "/preview/dashboard",
+      surfaceId: "vibe64-preview"
+    }),
+    previewSurfaceKey
+  );
+  assert.equal(
+    resolveShellRouteTransitionKey({
+      routeTransitionName: "shell-route-slide-forward",
+      routePathKey: "/dashboard",
+      surfaceId: "home"
+    }),
+    "/dashboard"
+  );
+  assert.equal(
+    resolveShellRouteTransitionKey({
+      routeTransitionName: "",
+      routePathKey: "/dashboard",
+      surfaceId: "*"
+    }),
+    "stable"
+  );
 });
 
 test("shell-web settings landing page redirects to the starter child page", async () => {

--- a/packages/ui-generator/src/server/subcommands/pageSupport.js
+++ b/packages/ui-generator/src/server/subcommands/pageSupport.js
@@ -164,7 +164,7 @@ const hasTabs = computed(() => Boolean(slots.tabs));
       <p v-if="resolvedSubtitle" class="text-body-2 text-medium-emphasis mb-0">{{ resolvedSubtitle }}</p>
     </header>
 
-    <v-sheet v-if="hasTabs" rounded="lg" border class="section-container-shell__nav">
+    <v-sheet v-if="hasTabs" rounded="lg" class="section-container-shell__nav">
       <slot name="tabs" />
     </v-sheet>
 
@@ -188,9 +188,9 @@ const hasTabs = computed(() => Boolean(slots.tabs));
 .section-container-shell__nav {
   align-items: center;
   display: flex;
-  gap: 0.5rem;
+  gap: 0.375rem;
   overflow-x: auto;
-  padding: 0.5rem;
+  padding: 0.375rem;
   scrollbar-width: thin;
 }
 

--- a/packages/workspaces-web/templates/src/pages/admin/workspace/settings.vue
+++ b/packages/workspaces-web/templates/src/pages/admin/workspace/settings.vue
@@ -13,7 +13,7 @@ import { RouterView } from "vue-router";
 
     <v-sheet rounded="lg" border class="settings-shell__panel">
       <nav class="settings-shell__nav" aria-label="Workspace settings sections">
-        <v-list nav density="comfortable" class="settings-shell__nav-list">
+        <v-list nav density="compact" class="settings-shell__nav-list">
           <ShellOutlet target="admin-settings:primary-menu" />
         </v-list>
       </nav>
@@ -41,11 +41,31 @@ import { RouterView } from "vue-router";
 }
 
 .settings-shell__nav-list {
-  padding: 0;
+  padding: 0.35rem;
+}
+
+.settings-shell__nav-list :deep(.v-list-item) {
+  min-height: 48px;
+  padding-inline: 0.6rem 0.7rem;
+}
+
+.settings-shell__nav-list :deep(.v-list-item__prepend) {
+  margin-inline-end: 0;
+}
+
+.settings-shell__nav-list :deep(.v-list-item__spacer) {
+  min-width: 0.5rem;
+  width: 0.5rem;
+}
+
+.settings-shell__nav-list :deep(.v-list-item-title) {
+  line-height: 1.2;
 }
 
 .settings-shell__content {
+  border-left: 1px solid rgba(var(--v-theme-on-surface), 0.18);
   min-width: 0;
+  padding-left: 1rem;
 }
 
 @media (max-width: 960px) {
@@ -59,12 +79,17 @@ import { RouterView } from "vue-router";
 
   .settings-shell__nav-list {
     display: flex;
-    gap: 0.5rem;
+    gap: 0.25rem;
     min-width: max-content;
   }
 
   .settings-shell__nav-list :deep(.v-list-item) {
     min-height: 48px;
+  }
+
+  .settings-shell__content {
+    border-left: 0;
+    padding-left: 0;
   }
 }
 </style>

--- a/tooling/create-app/templates/base-shell/vite.config.mjs
+++ b/tooling/create-app/templates/base-shell/vite.config.mjs
@@ -57,8 +57,22 @@ export default defineConfig({
   test: {
     include: ["tests/client/**/*.vitest.js"]
   },
+  optimizeDeps: {
+    entries: [
+      "index.html",
+      "src/**/*.{js,ts,vue}"
+    ]
+  },
   server: {
     port: devPort,
+    warmup: {
+      clientFiles: [
+        "src/main.{js,ts}",
+        "src/router/**/*.{js,ts}",
+        "src/pages/**/*.{js,ts,vue}",
+        "src/components/**/*.{js,ts,vue}"
+      ]
+    },
     proxy: {
       "/api": {
         target: apiProxyTarget,

--- a/tooling/create-app/test/createApp.test.js
+++ b/tooling/create-app/test/createApp.test.js
@@ -359,6 +359,12 @@ test("create-app scaffolds the base shell with placeholder replacements", async 
     assert.doesNotMatch(viteConfig, /^\s*beforeWriteFiles:\s*reparentNestedChildrenToIndexOwners/m);
     assert.match(viteConfig, /nestedChildren deprecated/);
     assert.doesNotMatch(viteConfig, /dedupe:\s*\[/);
+    assert.match(viteConfig, /optimizeDeps:\s*\{/);
+    assert.match(viteConfig, /entries:\s*\[/);
+    assert.match(viteConfig, /"src\/\*\*\/\*\.\{js,ts,vue\}"/);
+    assert.match(viteConfig, /warmup:\s*\{/);
+    assert.match(viteConfig, /clientFiles:\s*\[/);
+    assert.match(viteConfig, /"src\/pages\/\*\*\/\*\.\{js,ts,vue\}"/);
 
     assert.doesNotMatch(result.stdout, /Then add framework capabilities:/);
     assert.doesNotMatch(result.stdout, /npx jskit add package auth-provider-supabase-core/);


### PR DESCRIPTION
## Summary

- Fix shell route transition pane sizing and keep route content persistent for no-motion same-surface route changes while preserving path keys for active compact route transitions.
- Refine settings/subpage navigation layout across shell, console, workspace, and ui-generator templates while preserving 48px targets.
- Clarify menu icon metadata guidance and lock in imported @mdi/js path constants for shell menu icons.
- Add Vite optimizeDeps entries and server warmup to create-app base-shell scaffolds.

## Commits

- 5ac688b5 Fix shell route transition remounts
- 97972203 Refine settings navigation layout
- a83fdcf3 Clarify menu icon metadata guidance
- 0de80224 Warm scaffolded Vite dev entries

## Verification

- npm --workspace @jskit-ai/shell-web test
- npm --workspace @jskit-ai/ui-generator test
- npm --workspace @jskit-ai/create-app test
- npm --workspace @jskit-ai/console-web test
- npm --workspace @jskit-ai/workspaces-web test
- npm run agent-docs:build
- npm --workspace @jskit-ai/agent-docs test
- git diff --check origin/main..HEAD

Note: the first agent-docs test run raced with agent-docs:build because I ran them in parallel; rerunning after the build passed and left the worktree clean.