### PR TITLE
Expose auth denial reasons in login flow

### DIFF
--- a/packages/agent-docs/reference/autogen/packages/auth-core.md
+++ b/packages/agent-docs/reference/autogen/packages/auth-core.md
@@ -176,6 +176,18 @@ Exports
 - `AUTH_ACCESS_TOKEN_MAX_LENGTH`
 - `AUTH_REFRESH_TOKEN_MAX_LENGTH`
 
+### `src/shared/authDenied.js`
+Exports
+- `AUTH_DENIED_CODE_MAX_LENGTH`
+- `AUTH_DENIED_CODE_PATTERN`
+- `AUTH_DENIED_CODES`
+- `AUTH_DENIED_DEFAULT_MESSAGES`
+- `AUTH_DENIED_LOGIN_MESSAGES`
+- `AUTH_DENIED_MESSAGE_MAX_LENGTH`
+- `normalizeAuthDenied(input = null)`
+- `normalizeAuthDeniedCode(value = "")`
+- `resolveAuthDeniedLoginMessage(input = null)`
+
 ### `src/shared/authMethods.js`
 Exports
 - `AUTH_METHOD_PASSWORD_ID`
@@ -234,6 +246,7 @@ Exports
 - `devLoginAsOutputValidator`
 - `logoutOutputValidator`
 - `oauthProviderCatalogEntryOutputValidator`
+- `authDeniedOutputSchema`
 - `sessionOutputValidator`
 - `sessionUnavailableOutputValidator`
 - `createCommandMessages({ fields = {}, defaultMessage = "Invalid value." } = {})`
@@ -347,6 +360,11 @@ Exports
 Exports
 - `createApi`
 - `runAuthSignOutFlow`
+- `AUTH_DENIED_CODES`
+- `AUTH_DENIED_DEFAULT_MESSAGES`
+- `AUTH_DENIED_LOGIN_MESSAGES`
+- `normalizeAuthDenied`
+- `resolveAuthDeniedLoginMessage`
 - `AUTH_PATHS`
 - `buildAuthOauthStartPath`
 

--- a/packages/auth-core/package.json
+++ b/packages/auth-core/package.json
@@ -23,6 +23,7 @@
     "./shared": "./src/shared/index.js",
     "./shared/authApi": "./src/shared/authApi.js",
     "./shared/signOutFlow": "./src/shared/signOutFlow.js",
+    "./shared/authDenied": "./src/shared/authDenied.js",
     "./shared/authPaths": "./src/shared/authPaths.js",
     "./shared/authConstraints": "./src/shared/authConstraints.js",
     "./shared/authMethods": "./src/shared/authMethods.js",

--- a/packages/auth-core/src/shared/authDenied.js
+++ b/packages/auth-core/src/shared/authDenied.js
@@ -1,0 +1,70 @@
+const AUTH_DENIED_CODE_MAX_LENGTH = 80;
+const AUTH_DENIED_MESSAGE_MAX_LENGTH = 240;
+const AUTH_DENIED_CODE_PATTERN = "^[a-z][a-z0-9_.:-]{1,79}$";
+
+const AUTH_DENIED_CODES = Object.freeze({
+  NOT_ALLOWLISTED: "not_allowlisted",
+  BLOCKED: "blocked"
+});
+
+const AUTH_DENIED_DEFAULT_MESSAGES = Object.freeze({
+  [AUTH_DENIED_CODES.NOT_ALLOWLISTED]: "This account is not allowed to access this application.",
+  [AUTH_DENIED_CODES.BLOCKED]: "This account has been blocked from accessing this application."
+});
+
+const AUTH_DENIED_LOGIN_MESSAGES = Object.freeze({
+  [AUTH_DENIED_CODES.NOT_ALLOWLISTED]:
+    "Sign-in succeeded, but this account is not allowed to access this application.",
+  [AUTH_DENIED_CODES.BLOCKED]:
+    "Sign-in succeeded, but this account has been blocked from accessing this application."
+});
+
+function normalizeAuthDeniedCode(value = "") {
+  const code = String(value || "")
+    .trim()
+    .toLowerCase();
+  if (!code || code.length > AUTH_DENIED_CODE_MAX_LENGTH) {
+    return "";
+  }
+  return new RegExp(AUTH_DENIED_CODE_PATTERN).test(code) ? code : "";
+}
+
+function normalizeAuthDenied(input = null) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    return null;
+  }
+
+  const code = normalizeAuthDeniedCode(input.code);
+  if (!code) {
+    return null;
+  }
+
+  const explicitMessage = String(input.message || "").trim();
+  const message = explicitMessage || AUTH_DENIED_DEFAULT_MESSAGES[code] || "This account cannot access this application.";
+
+  return Object.freeze({
+    code,
+    message: message.slice(0, AUTH_DENIED_MESSAGE_MAX_LENGTH)
+  });
+}
+
+function resolveAuthDeniedLoginMessage(input = null) {
+  const authDenied = normalizeAuthDenied(input);
+  if (!authDenied) {
+    return "";
+  }
+
+  return AUTH_DENIED_LOGIN_MESSAGES[authDenied.code] || authDenied.message;
+}
+
+export {
+  AUTH_DENIED_CODE_MAX_LENGTH,
+  AUTH_DENIED_CODE_PATTERN,
+  AUTH_DENIED_CODES,
+  AUTH_DENIED_DEFAULT_MESSAGES,
+  AUTH_DENIED_LOGIN_MESSAGES,
+  AUTH_DENIED_MESSAGE_MAX_LENGTH,
+  normalizeAuthDenied,
+  normalizeAuthDeniedCode,
+  resolveAuthDeniedLoginMessage
+};

--- a/packages/auth-core/src/shared/commands/authCommandValidators.js
+++ b/packages/auth-core/src/shared/commands/authCommandValidators.js
@@ -1,6 +1,11 @@
 import { createSchema } from "json-rest-schema";
 import { deepFreeze } from "@jskit-ai/kernel/shared/support/deepFreeze";
 import {
+  AUTH_DENIED_CODE_MAX_LENGTH,
+  AUTH_DENIED_CODE_PATTERN,
+  AUTH_DENIED_MESSAGE_MAX_LENGTH
+} from "../authDenied.js";
+import {
   AUTH_ACCESS_TOKEN_MAX_LENGTH,
   AUTH_EMAIL_MAX_LENGTH,
   AUTH_EMAIL_MIN_LENGTH,
@@ -209,6 +214,22 @@ const oauthProviderCatalogEntryOutputValidator = deepFreeze({
   mode: "replace"
 });
 
+const authDeniedOutputSchema = createSchema({
+  code: {
+    type: "string",
+    required: true,
+    minLength: 2,
+    maxLength: AUTH_DENIED_CODE_MAX_LENGTH,
+    pattern: AUTH_DENIED_CODE_PATTERN
+  },
+  message: {
+    type: "string",
+    required: true,
+    minLength: 1,
+    maxLength: AUTH_DENIED_MESSAGE_MAX_LENGTH
+  }
+});
+
 const sessionOutputSchema = createSchema({
   authenticated: { type: "boolean", required: true },
   username: { type: "string", required: false, minLength: 1, maxLength: 120 },
@@ -221,6 +242,11 @@ const sessionOutputSchema = createSchema({
       minLength: 1,
       maxLength: 200
     }
+  },
+  authDenied: {
+    type: "object",
+    required: false,
+    schema: authDeniedOutputSchema
   },
   csrfToken: { type: "string", required: true, minLength: 1 },
   oauthProviders: {
@@ -306,6 +332,7 @@ export {
   devLoginAsOutputValidator,
   logoutOutputValidator,
   oauthProviderCatalogEntryOutputValidator,
+  authDeniedOutputSchema,
   sessionOutputValidator,
   sessionUnavailableOutputValidator,
   createCommandMessages

--- a/packages/auth-core/src/shared/index.js
+++ b/packages/auth-core/src/shared/index.js
@@ -1,3 +1,10 @@
 export { createApi } from "./authApi.js";
 export { runAuthSignOutFlow } from "./signOutFlow.js";
+export {
+  AUTH_DENIED_CODES,
+  AUTH_DENIED_DEFAULT_MESSAGES,
+  AUTH_DENIED_LOGIN_MESSAGES,
+  normalizeAuthDenied,
+  resolveAuthDeniedLoginMessage
+} from "./authDenied.js";
 export { AUTH_PATHS, buildAuthOauthStartPath } from "./authPaths.js";

--- a/packages/auth-core/test/authDenied.test.js
+++ b/packages/auth-core/test/authDenied.test.js
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  AUTH_DENIED_CODES,
+  normalizeAuthDenied,
+  resolveAuthDeniedLoginMessage
+} from "../src/shared/authDenied.js";
+
+test("normalizeAuthDenied preserves stable denial codes and messages", () => {
+  assert.deepEqual(
+    normalizeAuthDenied({
+      code: "NOT_ALLOWLISTED",
+      message: "  Custom denial.  "
+    }),
+    {
+      code: AUTH_DENIED_CODES.NOT_ALLOWLISTED,
+      message: "Custom denial."
+    }
+  );
+
+  assert.deepEqual(
+    normalizeAuthDenied({
+      code: AUTH_DENIED_CODES.BLOCKED
+    }),
+    {
+      code: AUTH_DENIED_CODES.BLOCKED,
+      message: "This account has been blocked from accessing this application."
+    }
+  );
+
+  assert.equal(normalizeAuthDenied({ message: "Missing code" }), null);
+  assert.equal(normalizeAuthDenied({ code: "../bad" }), null);
+});
+
+test("resolveAuthDeniedLoginMessage maps default denial reasons to post-login messages", () => {
+  assert.equal(
+    resolveAuthDeniedLoginMessage({ code: AUTH_DENIED_CODES.NOT_ALLOWLISTED }),
+    "Sign-in succeeded, but this account is not allowed to access this application."
+  );
+  assert.equal(
+    resolveAuthDeniedLoginMessage({ code: AUTH_DENIED_CODES.BLOCKED }),
+    "Sign-in succeeded, but this account has been blocked from accessing this application."
+  );
+  assert.equal(resolveAuthDeniedLoginMessage(null), "");
+});

--- a/packages/auth-core/test/commandValidators.test.js
+++ b/packages/auth-core/test/commandValidators.test.js
@@ -104,6 +104,9 @@ test("auth session and oauth start commands expose explicit nested response sche
   assert.equal(sessionResponseSchema.properties.oauthProviders.items["x-json-rest-schema"]?.castType, "object");
   assert.equal(Array.isArray(sessionResponseSchema.properties.oauthProviders.items.allOf), true);
   assert.match(sessionResponseSchema.properties.oauthProviders.items.allOf[0]?.$ref || "", /^#\/definitions\//);
+  assert.equal(sessionResponseSchema.properties.authDenied["x-json-rest-schema"]?.castType, "object");
+  assert.equal(Array.isArray(sessionResponseSchema.properties.authDenied.allOf), true);
+  assert.match(sessionResponseSchema.properties.authDenied.allOf[0]?.$ref || "", /^#\/definitions\//);
   assert.equal(Array.isArray(sessionUnavailableSchema.properties.oauthDefaultProvider.anyOf), true);
   assert.equal(oauthStartResponseSchema.properties.provider.type, "string");
   assert.equal(oauthStartResponseSchema.properties.returnTo.type, "string");

--- a/packages/auth-web/src/client/composables/loginView/useLoginViewActions.js
+++ b/packages/auth-web/src/client/composables/loginView/useLoginViewActions.js
@@ -7,6 +7,7 @@ import { authLoginOtpVerifyCommand } from "@jskit-ai/auth-core/shared/commands/a
 import { authLoginOAuthStartCommand } from "@jskit-ai/auth-core/shared/commands/authLoginOAuthStartCommand";
 import { authPasswordResetRequestCommand } from "@jskit-ai/auth-core/shared/commands/authPasswordResetRequestCommand";
 import { AUTH_PATHS, buildAuthOauthStartPath } from "@jskit-ai/auth-core/shared/authPaths";
+import { resolveAuthDeniedLoginMessage } from "@jskit-ai/auth-core/shared/authDenied";
 import { authHttpRequest } from "../../runtime/authHttpClient.js";
 import { completeOAuthCallbackFromCurrentLocation } from "../../runtime/oauthCallbackRuntime.js";
 import { normalizeAuthReturnToPath } from "../../lib/returnToPath.js";
@@ -136,6 +137,10 @@ export function useLoginViewActions({
   async function completeLogin() {
     const session = await refreshSession();
     if (!session?.authenticated) {
+      const authDeniedMessage = resolveAuthDeniedLoginMessage(session?.authDenied);
+      if (authDeniedMessage) {
+        throw new Error(authDeniedMessage);
+      }
       throw new Error("Login succeeded but the session is not active yet. Please retry.");
     }
     if (typeof window === "object" && window.location) {

--- a/packages/auth-web/src/client/runtime/oauthCallbackRuntime.js
+++ b/packages/auth-web/src/client/runtime/oauthCallbackRuntime.js
@@ -1,4 +1,5 @@
 import { authLoginOAuthCompleteCommand } from "@jskit-ai/auth-core/shared/commands/authLoginOAuthCompleteCommand";
+import { resolveAuthDeniedLoginMessage } from "@jskit-ai/auth-core/shared/authDenied";
 import {
   OAUTH_QUERY_PARAM_PROVIDER,
   OAUTH_QUERY_PARAM_RETURN_TO
@@ -148,6 +149,10 @@ async function completeOAuthCallbackFromUrl({
     });
     const session = await refreshSession();
     if (!session?.authenticated) {
+      const authDeniedMessage = resolveAuthDeniedLoginMessage(session?.authDenied);
+      if (authDeniedMessage) {
+        throw new Error(authDeniedMessage);
+      }
       throw new Error("Login succeeded but the session is not active yet. Please retry.");
     }
 

--- a/packages/auth-web/src/server/controllers/AuthController.js
+++ b/packages/auth-web/src/server/controllers/AuthController.js
@@ -1,3 +1,4 @@
+import { normalizeAuthDenied } from "@jskit-ai/auth-core/shared/authDenied";
 import { AUTH_ACTION_IDS } from "../constants/authActionIds.js";
 import { AuthWebService } from "../services/AuthWebService.js";
 
@@ -146,9 +147,11 @@ class AuthController {
     }
 
     if (!authResult.authenticated) {
+      const authDenied = normalizeAuthDenied(authResult.authDenied);
       reply.code(200).send({
         authenticated: false,
         csrfToken,
+        ...(authDenied ? { authDenied } : {}),
         ...oauthCatalogPayload
       });
       return;

--- a/packages/auth-web/test/loginViewActions.test.js
+++ b/packages/auth-web/test/loginViewActions.test.js
@@ -2,6 +2,25 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { buildAuthOauthStartPath } from "@jskit-ai/auth-core/shared/authPaths";
 import { useLoginViewActions } from "../src/client/composables/loginView/useLoginViewActions.js";
+import { clearAuthCsrfTokenCache } from "../src/client/runtime/authHttpClient.js";
+
+function createJsonResponse(payload = {}, { status = 200 } = {}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: {
+      get(name) {
+        return String(name || "").toLowerCase() === "content-type" ? "application/json" : null;
+      }
+    },
+    async json() {
+      return payload;
+    },
+    async text() {
+      return JSON.stringify(payload);
+    }
+  };
+}
 
 function createMinimalLoginViewState(requestedReturnTo = "/") {
   return {
@@ -10,15 +29,18 @@ function createMinimalLoginViewState(requestedReturnTo = "/") {
     errorMessage: { value: "" },
     infoMessage: { value: "" },
     loading: { value: false },
+    submitAttempted: { value: false },
     email: { value: "" },
-    password: { value: "" },
+    password: { value: "password-123" },
     otpCode: { value: "" },
     otpRequestPending: { value: false },
     registerConfirmationResendPending: { value: false },
     pendingEmailConfirmationAddress: { value: "" },
+    rememberAccountOnDevice: { value: true },
     oauthProviders: { value: [] },
     oauthDefaultProvider: { value: "google" },
     isRegister: { value: false },
+    isForgot: { value: false },
     isOtp: { value: false },
     showRememberedAccount: { value: false },
     rememberedAccountDisplayName: { value: "" },
@@ -56,4 +78,103 @@ test("useLoginViewActions preserves the intended destination when starting OAuth
     ]);
     assert.equal(state.errorMessage.value, "");
   });
+});
+
+async function runPasswordLoginWithPostLoginSession(sessionPayload) {
+  clearAuthCsrfTokenCache();
+  const state = createMinimalLoginViewState("/");
+  const fetchCalls = [];
+  const reports = [];
+  const originalFetch = globalThis.fetch;
+  let sessionReads = 0;
+
+  globalThis.fetch = async (url, options = {}) => {
+    const normalizedUrl = String(url || "");
+    const method = String(options.method || "GET").toUpperCase();
+    fetchCalls.push({ url: normalizedUrl, method });
+
+    if (normalizedUrl === "/api/session" && method === "GET") {
+      sessionReads += 1;
+      return createJsonResponse(
+        sessionReads === 1
+          ? { authenticated: false, csrfToken: "csrf-a" }
+          : { csrfToken: "csrf-b", ...sessionPayload }
+      );
+    }
+
+    if (normalizedUrl === "/api/login" && method === "POST") {
+      return createJsonResponse({ ok: true, username: "Ada" });
+    }
+
+    throw new Error(`Unexpected fetch call: ${method} ${normalizedUrl}`);
+  };
+
+  try {
+    const actions = useLoginViewActions({
+      state,
+      validation: {
+        canSubmit: { value: true }
+      },
+      queryClient: {
+        async fetchQuery({ queryFn }) {
+          return queryFn();
+        }
+      },
+      errorRuntime: {
+        report(entry) {
+          reports.push(entry);
+        }
+      }
+    });
+
+    await actions.submitAuth();
+    return { state, fetchCalls, reports };
+  } finally {
+    globalThis.fetch = originalFetch;
+    clearAuthCsrfTokenCache();
+  }
+}
+
+test("useLoginViewActions shows allowlist denial after successful password login", async () => {
+  const { state, fetchCalls, reports } = await runPasswordLoginWithPostLoginSession({
+    authenticated: false,
+    authDenied: {
+      code: "not_allowlisted",
+      message: "This account is not allowed to access this application."
+    }
+  });
+
+  assert.equal(
+    state.errorMessage.value,
+    "Sign-in succeeded, but this account is not allowed to access this application."
+  );
+  assert.deepEqual(fetchCalls.map((entry) => `${entry.method} ${entry.url}`), [
+    "GET /api/session",
+    "POST /api/login",
+    "GET /api/session"
+  ]);
+  assert.equal(reports[0]?.message, state.errorMessage.value);
+});
+
+test("useLoginViewActions shows blocked denial after successful password login", async () => {
+  const { state } = await runPasswordLoginWithPostLoginSession({
+    authenticated: false,
+    authDenied: {
+      code: "blocked",
+      message: "This account has been blocked from accessing this application."
+    }
+  });
+
+  assert.equal(
+    state.errorMessage.value,
+    "Sign-in succeeded, but this account has been blocked from accessing this application."
+  );
+});
+
+test("useLoginViewActions keeps retry message for generic post-login unauthenticated sessions", async () => {
+  const { state } = await runPasswordLoginWithPostLoginSession({
+    authenticated: false
+  });
+
+  assert.equal(state.errorMessage.value, "Login succeeded but the session is not active yet. Please retry.");
 });

--- a/packages/auth-web/test/oauthCallbackRuntime.test.js
+++ b/packages/auth-web/test/oauthCallbackRuntime.test.js
@@ -138,6 +138,52 @@ test("completeOAuthCallbackFromUrl fails when the refreshed session is still una
   assert.equal(result.errorMessage, "Login succeeded but the session is not active yet. Please retry.");
 });
 
+test("completeOAuthCallbackFromUrl maps allowlist auth denial to a clear message", async () => {
+  const result = await completeOAuthCallbackFromUrl({
+    url: "/auth/login?oauthProvider=google&code=abc",
+    request: async () => ({
+      username: "Ada"
+    }),
+    refreshSession: async () => ({
+      authenticated: false,
+      authDenied: {
+        code: "not_allowlisted",
+        message: "This account is not allowed to access this application."
+      }
+    })
+  });
+
+  assert.equal(result.handled, true);
+  assert.equal(result.completed, false);
+  assert.equal(
+    result.errorMessage,
+    "Sign-in succeeded, but this account is not allowed to access this application."
+  );
+});
+
+test("completeOAuthCallbackFromUrl maps blocked auth denial to a clear message", async () => {
+  const result = await completeOAuthCallbackFromUrl({
+    url: "/auth/login?oauthProvider=google&code=abc",
+    request: async () => ({
+      username: "Ada"
+    }),
+    refreshSession: async () => ({
+      authenticated: false,
+      authDenied: {
+        code: "blocked",
+        message: "This account has been blocked from accessing this application."
+      }
+    })
+  });
+
+  assert.equal(result.handled, true);
+  assert.equal(result.completed, false);
+  assert.equal(
+    result.errorMessage,
+    "Sign-in succeeded, but this account has been blocked from accessing this application."
+  );
+});
+
 test("completeOAuthCallbackFromCurrentLocation reads from window.location.href", async () => {
   const originalWindow = globalThis.window;
   globalThis.window = {

--- a/packages/auth-web/test/providerRuntime.test.js
+++ b/packages/auth-web/test/providerRuntime.test.js
@@ -28,6 +28,9 @@ function createReplyStub() {
     sent: false,
     statusCode: null,
     payload: null,
+    async generateCsrf() {
+      return "csrf-test";
+    },
     code(value) {
       this.statusCode = value;
       return this;
@@ -222,4 +225,63 @@ test("auth route provider does not resolve authService during boot", async () =>
   await loginRoute.handler({ body: { email: "ada@example.com", password: "pass" } }, loginReply);
   assert.equal(loginReply.statusCode, 200);
   assert.equal(authServiceResolutions, 1);
+});
+
+test("auth session route exposes denial reason when policy clears a rejected authenticated session", async () => {
+  const events = [];
+  const fastify = createFastifyStub();
+  const app = createApplication();
+  const httpRuntime = createHttpRuntime({ app, fastify });
+
+  const authService = {
+    writeSessionCookies() {
+      events.push({ type: "writeSession" });
+    },
+    clearSessionCookies() {
+      events.push({ type: "clearSession" });
+    },
+    getOAuthProviderCatalog() {
+      return { providers: [], defaultProvider: "" };
+    }
+  };
+
+  app.instance("authService", authService);
+  app.instance("actionExecutor", {
+    async execute({ actionId }) {
+      if (actionId === "auth.session.read") {
+        return {
+          authenticated: false,
+          clearSession: true,
+          transientFailure: false,
+          authDenied: {
+            code: "not_allowlisted",
+            message: "This account is not allowed to access this application."
+          }
+        };
+      }
+      return {};
+    }
+  });
+
+  class MockAuthProvider {
+    static id = "auth.provider";
+  }
+
+  await app.start({ providers: [MockAuthProvider, AuthWebServiceProvider, AuthRouteServiceProvider] });
+
+  const registration = httpRuntime.registerRoutes();
+  assert.equal(registration.routeCount > 0, true);
+
+  const sessionRoute = fastify.routes.find((route) => route.method === "GET" && route.url === "/api/session");
+  assert.ok(sessionRoute);
+  const sessionReply = createReplyStub();
+  await sessionRoute.handler({}, sessionReply);
+
+  assert.equal(sessionReply.statusCode, 200);
+  assert.equal(sessionReply.payload.authenticated, false);
+  assert.deepEqual(sessionReply.payload.authDenied, {
+    code: "not_allowlisted",
+    message: "This account is not allowed to access this application."
+  });
+  assert.deepEqual(events, [{ type: "clearSession" }]);
 });


### PR DESCRIPTION
## Summary
- add shared auth-denial normalization and session response schema support
- return normalized auth denial details from the auth session route
- show clear login/OAuth messages when sign-in succeeds but policy denies the resulting session
- update generated auth-core reference docs

## Verification
- npm ci
- npm --workspace @jskit-ai/auth-core test
- npm --workspace @jskit-ai/auth-web test
- npm run agent-docs:build
- npm run generated:refs:check
- npm run lint
- npm run generated:check

Release/version/catalog/lockfile changes are intentionally excluded.