### PR TITLE
Expose shell async recovery runtime

### DIFF
--- a/packages/agent-docs/guide/agent/app-setup/a-more-interesting-shell.md
+++ b/packages/agent-docs/guide/agent/app-setup/a-more-interesting-shell.md
@@ -554,6 +554,24 @@ The default error policy is intent-based. Runtime code reports what kind of erro
 - `app-recoverable` uses `banner`; shell refresh and recoverable navigation failures stay visible without blocking the app.
 - `blocking` uses `dialog`; unexpected UI failures and other blocking errors require explicit attention.
 
+When app code catches a dynamic import failure itself, report it through the shell async module recovery runtime so it uses the same reload banner as router chunk failures:
+
+```js
+import { useShellAsyncModuleRecoveryRuntime } from "@jskit-ai/shell-web/client";
+
+const asyncModuleRecovery = useShellAsyncModuleRecoveryRuntime();
+
+try {
+  await import("@xterm/xterm");
+} catch (error) {
+  asyncModuleRecovery?.notify(error, {
+    label: "Terminal"
+  });
+}
+```
+
+`useShellAsyncModuleRecoveryRuntime()` returns `null` when the shell runtime is not available in the current Vue context. That lets app-owned components use optional chaining instead of duplicating shell-web's internal injection token.
+
 ### The home page talks to the backend
 
 `src/pages/home/index.vue` uses Vue Query to fetch `/api/health` and display the result in the UI.

--- a/packages/agent-docs/reference/autogen/packages/shell-web.md
+++ b/packages/agent-docs/reference/autogen/packages/shell-web.md
@@ -14,6 +14,17 @@ Use this on demand; do not load the full index at startup.
 
 ### src
 
+### `src/client/asyncModuleRecovery/index.js`
+Exports
+- `SHELL_ASYNC_MODULE_RECOVERY_RUNTIME_KEY`
+- `useShellAsyncModuleRecoveryRuntime`
+
+### `src/client/asyncModuleRecovery/inject.js`
+Exports
+- `SHELL_ASYNC_MODULE_RECOVERY_RUNTIME_KEY`
+- `isShellAsyncModuleRecoveryRuntime(value)`
+- `useShellAsyncModuleRecoveryRuntime()`
+
 ### `src/client/bootstrap/bootstrapErrorStatus.js`
 Exports
 - `resolveBootstrapErrorStatusCode(error)`
@@ -194,6 +205,8 @@ Exports
 - `useShellLayoutState`
 - `useShellLayoutStore`
 - `useShellErrorPresentationStore`
+- `SHELL_ASYNC_MODULE_RECOVERY_RUNTIME_KEY`
+- `useShellAsyncModuleRecoveryRuntime`
 - `BOOTSTRAP_PAYLOAD_HANDLER_TAG`
 - `registerBootstrapPayloadHandler`
 - `resolveBootstrapPayloadHandlers`

--- a/packages/agent-docs/site/guide/app-setup/a-more-interesting-shell.md
+++ b/packages/agent-docs/site/guide/app-setup/a-more-interesting-shell.md
@@ -642,6 +642,24 @@ The default error policy is intent-based. Runtime code reports what kind of erro
 - `app-recoverable` uses `banner`; shell refresh and recoverable navigation failures stay visible without blocking the app.
 - `blocking` uses `dialog`; unexpected UI failures and other blocking errors require explicit attention.
 
+When app code catches a dynamic import failure itself, report it through the shell async module recovery runtime so it uses the same reload banner as router chunk failures:
+
+```js
+import { useShellAsyncModuleRecoveryRuntime } from "@jskit-ai/shell-web/client";
+
+const asyncModuleRecovery = useShellAsyncModuleRecoveryRuntime();
+
+try {
+  await import("@xterm/xterm");
+} catch (error) {
+  asyncModuleRecovery?.notify(error, {
+    label: "Terminal"
+  });
+}
+```
+
+`useShellAsyncModuleRecoveryRuntime()` returns `null` when the shell runtime is not available in the current Vue context. That lets app-owned components use optional chaining instead of duplicating shell-web's internal injection token.
+
 ### The home page talks to the backend
 
 `src/pages/home/index.vue` uses Vue Query to fetch `/api/health` and display the result in the UI.

--- a/packages/shell-web/package.json
+++ b/packages/shell-web/package.json
@@ -9,6 +9,7 @@
     "./client": "./src/client/index.js",
     "./client/error": "./src/client/error/index.js",
     "./client/placement": "./src/client/placement/index.js",
+    "./client/asyncModuleRecovery": "./src/client/asyncModuleRecovery/index.js",
     "./client/bootstrap": "./src/client/bootstrap/index.js",
     "./server/support/localLinkItemScaffolds": "./src/server/support/localLinkItemScaffolds.js",
     "./client/navigation/linkResolver": "./src/client/navigation/linkResolver.js",

--- a/packages/shell-web/src/client/asyncModuleRecovery/index.js
+++ b/packages/shell-web/src/client/asyncModuleRecovery/index.js
@@ -1,0 +1,4 @@
+export {
+  SHELL_ASYNC_MODULE_RECOVERY_RUNTIME_KEY,
+  useShellAsyncModuleRecoveryRuntime
+} from "./inject.js";

--- a/packages/shell-web/src/client/asyncModuleRecovery/inject.js
+++ b/packages/shell-web/src/client/asyncModuleRecovery/inject.js
@@ -1,0 +1,30 @@
+import {
+  hasInjectionContext,
+  inject
+} from "vue";
+
+const SHELL_ASYNC_MODULE_RECOVERY_RUNTIME_KEY =
+  "jskit.shell-web.runtime.web-async-module-recovery.client";
+
+function isShellAsyncModuleRecoveryRuntime(value) {
+  return Boolean(
+    value &&
+      typeof value.notify === "function" &&
+      typeof value.reload === "function"
+  );
+}
+
+function useShellAsyncModuleRecoveryRuntime() {
+  if (!hasInjectionContext()) {
+    return null;
+  }
+
+  const runtime = inject(SHELL_ASYNC_MODULE_RECOVERY_RUNTIME_KEY, null);
+  return isShellAsyncModuleRecoveryRuntime(runtime) ? runtime : null;
+}
+
+export {
+  SHELL_ASYNC_MODULE_RECOVERY_RUNTIME_KEY,
+  isShellAsyncModuleRecoveryRuntime,
+  useShellAsyncModuleRecoveryRuntime
+};

--- a/packages/shell-web/src/client/index.js
+++ b/packages/shell-web/src/client/index.js
@@ -18,6 +18,10 @@ export { useShellLayoutState } from "./composables/useShellLayoutState.js";
 export { useShellLayoutStore } from "./stores/useShellLayoutStore.js";
 export { useShellErrorPresentationStore } from "./stores/useShellErrorPresentationStore.js";
 export {
+  SHELL_ASYNC_MODULE_RECOVERY_RUNTIME_KEY,
+  useShellAsyncModuleRecoveryRuntime
+} from "./asyncModuleRecovery/index.js";
+export {
   BOOTSTRAP_PAYLOAD_HANDLER_TAG,
   registerBootstrapPayloadHandler,
   resolveBootstrapPayloadHandlers

--- a/packages/shell-web/src/client/providers/ShellWebClientProvider.js
+++ b/packages/shell-web/src/client/providers/ShellWebClientProvider.js
@@ -11,6 +11,9 @@ import {
   notifyDynamicImportFailure
 } from "./appModuleLoadFailure.js";
 import {
+  SHELL_ASYNC_MODULE_RECOVERY_RUNTIME_KEY
+} from "../asyncModuleRecovery/inject.js";
+import {
   isRecord
 } from "@jskit-ai/kernel/shared/support";
 import { createProviderLogger as createSharedProviderLogger } from "@jskit-ai/kernel/shared/support/providerLogger";
@@ -654,7 +657,7 @@ class ShellWebClientProvider {
     vueApp.provide("jskit.shell-web.runtime.web-placement.client", placementRuntime);
     vueApp.provide("jskit.shell-web.runtime.web-refresh.client", refreshRuntime);
     vueApp.provide("jskit.shell-web.runtime.web-error.client", errorRuntime);
-    vueApp.provide("jskit.shell-web.runtime.web-async-module-recovery.client", asyncModuleRecoveryRuntime);
+    vueApp.provide(SHELL_ASYNC_MODULE_RECOVERY_RUNTIME_KEY, asyncModuleRecoveryRuntime);
     vueApp.provide(
       "jskit.shell-web.runtime.web-error.presentation-store.client",
       errorPresentationStore

--- a/packages/shell-web/test/asyncModuleRecoveryInject.test.js
+++ b/packages/shell-web/test/asyncModuleRecoveryInject.test.js
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createApp } from "vue";
+import {
+  SHELL_ASYNC_MODULE_RECOVERY_RUNTIME_KEY,
+  useShellAsyncModuleRecoveryRuntime
+} from "../src/client/asyncModuleRecovery/index.js";
+
+test("shell async module recovery runtime composable returns null outside Vue injection context", () => {
+  assert.equal(useShellAsyncModuleRecoveryRuntime(), null);
+});
+
+test("shell async module recovery runtime composable resolves the provided public runtime", async () => {
+  const runtime = {
+    notify(error, options) {
+      return { error, options };
+    },
+    async reload() {
+      return true;
+    }
+  };
+  const app = createApp({
+    render() {
+      return null;
+    }
+  });
+  app.provide(SHELL_ASYNC_MODULE_RECOVERY_RUNTIME_KEY, runtime);
+
+  assert.equal(
+    app.runWithContext(() => useShellAsyncModuleRecoveryRuntime()),
+    runtime
+  );
+});
+
+test("shell async module recovery runtime composable rejects incomplete runtimes", () => {
+  const app = createApp({
+    render() {
+      return null;
+    }
+  });
+  app.provide(SHELL_ASYNC_MODULE_RECOVERY_RUNTIME_KEY, {
+    notify() {}
+  });
+
+  assert.equal(
+    app.runWithContext(() => useShellAsyncModuleRecoveryRuntime()),
+    null
+  );
+});

--- a/packages/shell-web/test/provider.test.js
+++ b/packages/shell-web/test/provider.test.js
@@ -8,6 +8,9 @@ import {
 import {
   isMissingDynamicModule
 } from "../src/client/providers/appModuleLoadFailure.js";
+import {
+  SHELL_ASYNC_MODULE_RECOVERY_RUNTIME_KEY
+} from "../src/client/asyncModuleRecovery/index.js";
 import { useShellErrorPresentationStore } from "../src/client/stores/useShellErrorPresentationStore.js";
 const CLIENT_APP_CONFIG_GLOBAL_KEY = "__JSKIT_CLIENT_APP_CONFIG__";
 
@@ -229,7 +232,7 @@ test("shell web client provider binds runtime and injects it into Vue app", asyn
     assert.equal(providedByKey.has("jskit.shell-web.runtime.web-placement.client"), true);
     assert.equal(providedByKey.has("jskit.shell-web.runtime.web-refresh.client"), true);
     assert.equal(providedByKey.has("jskit.shell-web.runtime.web-error.client"), true);
-    assert.equal(providedByKey.has("jskit.shell-web.runtime.web-async-module-recovery.client"), true);
+    assert.equal(providedByKey.has(SHELL_ASYNC_MODULE_RECOVERY_RUNTIME_KEY), true);
     assert.equal(providedByKey.has("jskit.shell-web.runtime.web-error.presentation-store.client"), true);
 
     const placementRuntime = providedByKey.get("jskit.shell-web.runtime.web-placement.client");
@@ -245,7 +248,7 @@ test("shell web client provider binds runtime and injects it into Vue app", asyn
     const refreshRuntime = providedByKey.get("jskit.shell-web.runtime.web-refresh.client");
     assert.equal(typeof refreshRuntime.refresh, "function");
 
-    const asyncModuleRecoveryRuntime = providedByKey.get("jskit.shell-web.runtime.web-async-module-recovery.client");
+    const asyncModuleRecoveryRuntime = providedByKey.get(SHELL_ASYNC_MODULE_RECOVERY_RUNTIME_KEY);
     assert.equal(typeof asyncModuleRecoveryRuntime.install, "function");
     assert.equal(typeof asyncModuleRecoveryRuntime.notify, "function");
     assert.equal(typeof asyncModuleRecoveryRuntime.reload, "function");

--- a/packages/shell-web/test/settingsPlacementContract.test.js
+++ b/packages/shell-web/test/settingsPlacementContract.test.js
@@ -148,6 +148,29 @@ test("shell-web installs generated adaptive shell Playwright smoke coverage", as
   assert.equal(packageJson?.exports?.["./test/adaptiveShellSmoke"], "./src/test/adaptiveShellSmoke.js");
 });
 
+test("shell-web exports async module recovery runtime access as a public client API", async () => {
+  const packageJson = JSON.parse(await readFile(path.join(PACKAGE_DIR, "package.json"), "utf8"));
+  const clientIndex = await readFile(path.join(PACKAGE_DIR, "src", "client", "index.js"), "utf8");
+  const recoveryIndex = await readFile(
+    path.join(PACKAGE_DIR, "src", "client", "asyncModuleRecovery", "index.js"),
+    "utf8"
+  );
+  const providerSource = await readFile(
+    path.join(PACKAGE_DIR, "src", "client", "providers", "ShellWebClientProvider.js"),
+    "utf8"
+  );
+
+  assert.equal(
+    packageJson?.exports?.["./client/asyncModuleRecovery"],
+    "./src/client/asyncModuleRecovery/index.js"
+  );
+  assert.match(clientIndex, /useShellAsyncModuleRecoveryRuntime/);
+  assert.match(clientIndex, /SHELL_ASYNC_MODULE_RECOVERY_RUNTIME_KEY/);
+  assert.match(recoveryIndex, /useShellAsyncModuleRecoveryRuntime/);
+  assert.match(recoveryIndex, /SHELL_ASYNC_MODULE_RECOVERY_RUNTIME_KEY/);
+  assert.match(providerSource, /SHELL_ASYNC_MODULE_RECOVERY_RUNTIME_KEY/);
+});
+
 test("shell-web route transition keeps mobile route motion placement-driven", async () => {
   const source = await readFile(
     path.join(PACKAGE_DIR, "src", "client", "components", "ShellRouteTransition.vue"),


### PR DESCRIPTION
## Summary
- expose `useShellAsyncModuleRecoveryRuntime()` from `@jskit-ai/shell-web/client`
- export `SHELL_ASYNC_MODULE_RECOVERY_RUNTIME_KEY` and a `./client/asyncModuleRecovery` subpath
- wire `ShellWebClientProvider` to use the public key instead of a private literal
- document app-caught dynamic import failure reporting

## Verification
- `npm --workspace @jskit-ai/shell-web test`
- `npm run catalog:build`
- `npm run agent-docs:build`
- `npm run jskit -- lint-descriptors`
- `npm run check:runtime-deps`
- `git diff --check`
- `npm run generated:check`
