### PR TITLE
Add safe-read request recovery metadata

### DIFF
--- a/packages/agent-docs/guide/agent/app-setup/a-more-interesting-shell.md
+++ b/packages/agent-docs/guide/agent/app-setup/a-more-interesting-shell.md
@@ -574,31 +574,40 @@ try {
 
 Use the narrow `@jskit-ai/shell-web/client/asyncModuleRecovery` subpath for this runtime, especially from modules that are imported by Node-mode Vitest suites. The aggregate `@jskit-ai/shell-web/client` barrel also exports the composable for normal Vite app code, but that barrel includes `.vue` component exports and can require Vue SFC handling in tests.
 
-Request connectivity failures use a separate shell recovery path. Generated apps already configure TanStack Query to retry transient failures with capped backoff. `shell-web` then observes the app's `jskit.client.query-client` and, when an active query finishes in a transport failure such as `Network request failed.` or `Failed to fetch`, reports an `app-recoverable` banner with a `Retry` action that refetches that exact query. Normal HTTP validation and application errors stay local to the screen.
+Request connectivity failures use a separate shell recovery path. Generated apps already configure TanStack Query to retry transient failures with capped backoff. `shell-web` then observes the app's `jskit.client.query-client` and, when an active safe-read query finishes in a transport failure such as `Network request failed.` or `Failed to fetch`, reports an `app-recoverable` banner with a `Retry` action that refetches that exact query. Normal HTTP validation and application errors stay local to the screen.
 
-Imperative app code only needs the public runtime when it catches a request failure outside the standard query/resource composables:
+That recovery path is intentionally a safe `GET`/`HEAD` read refetch system, not a general HTTP replay system. User-visible reads should go through Query-backed JSKIT primitives such as `useEndpointResource()`, `useList()`, `useView()`, `useAddEdit()`, or generated CRUD screen composables. Those primitives mark Query entries with `jskit.requestRecoveryMethod`, so the shell only offers Retry for safe reads. Do not catch raw `fetch(...)` failures in each panel just to call the shell recovery runtime manually.
+
+For a custom endpoint read, attach the recovery label to the Query-backed resource:
 
 ```js
-import { useShellRequestRecoveryRuntime } from "@jskit-ai/shell-web/client/requestRecovery";
-
-const requestRecovery = useShellRequestRecoveryRuntime();
-
-async function loadProjectAccess() {
-  try {
-    return await fetch("/api/project-access");
-  } catch (error) {
-    requestRecovery?.report(error, {
-      label: "Project access",
-      retry: loadProjectAccess
-    });
-    throw error;
-  }
-}
+const projectAccess = useEndpointResource({
+  queryKey: ["project-access", projectId],
+  path: `/api/projects/${projectId}/access`,
+  requestRecoveryLabel: "Project access"
+});
 ```
 
-`useShellRequestRecoveryRuntime()` returns `null` when the shell runtime is not available in the current Vue context. Use the narrow `@jskit-ai/shell-web/client/requestRecovery` subpath for the same reason as async module recovery: it avoids pulling `.vue` component exports into Node-mode test suites.
+If you need lower-level Query options, the same metadata can live on query meta:
 
-For query-backed screens, the default is automatic. Set `meta: { jskit: { requestRecovery: false } }` only when a query deliberately owns its entire connectivity recovery UI. Set `meta: { jskit: { requestRecoveryLabel: "Project access" } }` when the default `Request` label is too generic.
+```js
+const projectAccess = useEndpointResource({
+  queryKey: ["project-access", projectId],
+  path: `/api/projects/${projectId}/access`,
+  queryOptions: {
+    meta: {
+      jskit: {
+        requestRecoveryLabel: "Project access",
+        requestRecoveryMethod: "GET"
+      }
+    }
+  }
+});
+```
+
+For JSKIT read-composable screens, the default is automatic. Hand-written TanStack Query reads outside those composables must set `meta.jskit.requestRecoveryMethod` to `GET` or `HEAD`; unmarked queries are ignored by the shell recovery observer. Set `meta: { jskit: { requestRecovery: false } }` only when a query deliberately owns its entire connectivity recovery UI.
+
+Writes are different. JSKIT does not automatically replay `POST`, `PATCH`, `PUT`, or `DELETE` after a network failure because the server may already have received the request. Save and command screens keep ownership of mutation state, field errors, conflict handling, and user feedback.
 
 ### The home page talks to the backend
 

--- a/packages/agent-docs/guide/agent/generators/advanced-cruds.md
+++ b/packages/agent-docs/guide/agent/generators/advanced-cruds.md
@@ -682,6 +682,18 @@ Why this is the standard JSKIT shape:
 - The higher-level list, view, add/edit, and command runtimes send requests through the standard HTTP runtime instead of ad hoc request code.
 - The default client runtime uses `usersWebHttpClient`, which already handles credentials and CSRF token behavior.
 - `useEndpointResource()` gives the shared endpoint primitive for loading, saving, and standard load/save error handling. Higher-level runtimes like `useCommand()` and `useAddEdit()` layer UI feedback and field-error behavior on top of that primitive.
+- `shell-web` observes the shared TanStack Query client for recoverable transport failures. Generated CRUD reads and custom reads built with `useEndpointResource()`, `useList()`, `useView()`, or `useAddEdit()` get the shell recovery banner with a Retry action that refetches the failed query.
+- Automatic shell request recovery is only for safe `GET`/`HEAD` read refetches. JSKIT read composables mark Query entries with `jskit.requestRecoveryMethod`, and the shell ignores unmarked or unsafe methods. Do not rely on it to replay `POST`, `PATCH`, `PUT`, or `DELETE`; mutation screens own save state, field errors, and user feedback.
+
+When a custom read needs a better recovery banner label, pass it through the read primitive rather than reporting the failure manually:
+
+```js
+const resource = useEndpointResource({
+  queryKey: ["project-access", projectId],
+  path: `/api/projects/${projectId}/access`,
+  requestRecoveryLabel: "Project access"
+});
+```
 
 If you need a custom scoped endpoint path outside the higher-level runtimes, prefer `usePaths().api(...)` rather than hand-building scoped URLs:
 

--- a/packages/agent-docs/patterns/client-requests.md
+++ b/packages/agent-docs/patterns/client-requests.md
@@ -68,9 +68,11 @@ Error presentation rules:
 
 - Resource load failures should stay local to the screen with the runtime's `loadError` state and a retry action.
 - Do not force global banners for ordinary list/view/add-edit load failures; the shell error policy treats `resource-load` as `silent` by default.
-- Transport/connectivity failures are different from ordinary resource-load errors. `shell-web` observes the app QueryClient and reports active query failures such as `Network request failed.` or `Failed to fetch` through request recovery with a `Retry` action.
-- For imperative app-caught request failures outside the standard query/resource composables, use `useShellRequestRecoveryRuntime()` from `@jskit-ai/shell-web/client/requestRecovery` and pass a retry callback.
-- Use query meta `jskit.requestRecovery = false` only when a query owns its full connectivity recovery UI, and `jskit.requestRecoveryLabel` when the recovery banner needs a better label.
+- Transport/connectivity failures are different from ordinary resource-load errors. `shell-web` observes the app QueryClient and reports active safe-read query failures such as `Network request failed.` or `Failed to fetch` through request recovery with a `Retry` action that calls `query.refetch()`.
+- User-visible reads should be TanStack Query-backed through `useEndpointResource()`, `useList()`, `useView()`, `useAddEdit()`, or CRUD screen composables. Do not load panel data with raw `fetch(...)` plus manual request recovery reporting.
+- Automatic shell request recovery is for `GET` and `HEAD` read refetches. Do not use it to replay `POST`, `PATCH`, `PUT`, or `DELETE`; saving and command screens own their mutation state and feedback.
+- JSKIT read composables mark their Query entries with `jskit.requestRecoveryMethod`. For hand-written TanStack Query reads outside those composables, set `meta.jskit.requestRecoveryMethod` to `GET` or `HEAD`.
+- Use `requestRecoveryLabel` on JSKIT read composables, or query meta `jskit.requestRecoveryLabel`, when the recovery banner needs a better label. Use `jskit.requestRecovery = false` only when a query owns its full connectivity recovery UI.
 - Use `useUiFeedback()` or `useCommand()` for user-triggered action feedback. Those flows report `action-feedback`, and the app-owned shell error policy decides the channel.
 - Use explicit shell error intents only for exceptional app-level cases: `app-recoverable` for recoverable shell/runtime failures and `blocking` for failures that require user attention.
 
@@ -82,3 +84,4 @@ Avoid:
 - using a lower-level seam when a higher-level routed CRUD or command runtime already fits
 - smuggling query params into `apiUrlTemplate`
 - reporting routine resource load errors through hand-written global snackbar/banner calls
+- calling `useShellRequestRecoveryRuntime().report(...)` from normal panels just to recover an HTTP read

--- a/packages/agent-docs/reference/autogen/packages/shell-web.md
+++ b/packages/agent-docs/reference/autogen/packages/shell-web.md
@@ -374,6 +374,11 @@ Local functions
 - `resolveQueryMeta(query = null)`
 - `isRequestRecoveryDisabled(query = null)`
 - `resolveQueryRecoveryLabel(query = null)`
+- `resolveQueryRecoverySource(query = null)`
+- `resolveQueryRecoveryDedupeKey(query = null, fallback = "")`
+- `resolveQueryRecoveryDedupeWindowMs(query = null)`
+- `resolveQueryRecoveryMethod(query = null)`
+- `isSafeQueryRecoveryMethod(query = null)`
 - `isActiveQuery(query = null)`
 - `recoverableQueryError(query = null)`
 - `createQueryRetry(queryClient, query = null)`

--- a/packages/agent-docs/reference/autogen/packages/users-web.md
+++ b/packages/agent-docs/reference/autogen/packages/users-web.md
@@ -212,7 +212,7 @@ Local functions
 
 ### `src/client/composables/records/useAddEdit.js`
 Exports
-- `useAddEdit({ ownershipFilter = ROUTE_VISIBILITY_WORKSPACE, surfaceId = "", access = "auto", resource = null, apiSuffix = "", queryKeyFactory = null, viewPermissions = [], savePermissions = [], readMethod = "GET", readEnabled = true, writeMethod = "PATCH", transport = null, placementSource = "users-web.add-edit", fallbackLoadError = "Unable to load resource.", fallbackSaveError = "Unable to save resource.", fieldErrorKeys = [], clearOnRouteChange = true, model, input, mapLoadedToModel, buildRawPayload, buildSavePayload, onSaveSuccess, requestQueryParams = null, recordIdParam = "recordId", routeParams = null, routeRecordId = null, apiUrlTemplate = "", viewUrlTemplate = "", listUrlTemplate = "", saveRecordIdSelector = null, messages = {}, realtime = null, adapter = null } = {})`
+- `useAddEdit({ ownershipFilter = ROUTE_VISIBILITY_WORKSPACE, surfaceId = "", access = "auto", resource = null, apiSuffix = "", queryKeyFactory = null, viewPermissions = [], savePermissions = [], readMethod = "GET", readEnabled = true, writeMethod = "PATCH", transport = null, requestRecovery = null, requestRecoveryLabel = "Resource", placementSource = "users-web.add-edit", fallbackLoadError = "Unable to load resource.", fallbackSaveError = "Unable to save resource.", fieldErrorKeys = [], clearOnRouteChange = true, model, input, mapLoadedToModel, buildRawPayload, buildSavePayload, onSaveSuccess, requestQueryParams = null, recordIdParam = "recordId", routeParams = null, routeRecordId = null, apiUrlTemplate = "", viewUrlTemplate = "", listUrlTemplate = "", saveRecordIdSelector = null, messages = {}, realtime = null, adapter = null } = {})`
 
 ### `src/client/composables/records/useCrudAddEdit.js`
 Exports
@@ -234,11 +234,11 @@ Exports
 
 ### `src/client/composables/records/useList.js`
 Exports
-- `useList({ ownershipFilter = ROUTE_VISIBILITY_WORKSPACE, surfaceId = "", access = "auto", apiSuffix = "", queryKeyFactory = null, viewPermissions = [], readEnabled = true, placementSource = "users-web.list", fallbackLoadError = "Unable to load list.", initialPageParam = null, getNextPageParam, selectItems, transport = null, requestOptions, queryOptions, realtime = null, adapter = null, recordIdParam = "recordId", recordIdSelector = null, viewUrlTemplate = "", editUrlTemplate = "", search = null, queryParams = null, requestQueryParams = null, syncToRoute = false } = {})`
+- `useList({ ownershipFilter = ROUTE_VISIBILITY_WORKSPACE, surfaceId = "", access = "auto", apiSuffix = "", queryKeyFactory = null, viewPermissions = [], readEnabled = true, placementSource = "users-web.list", fallbackLoadError = "Unable to load list.", initialPageParam = null, getNextPageParam, selectItems, transport = null, requestOptions, queryOptions, requestRecovery, requestRecoveryLabel = "List", realtime = null, adapter = null, recordIdParam = "recordId", recordIdSelector = null, viewUrlTemplate = "", editUrlTemplate = "", search = null, queryParams = null, requestQueryParams = null, syncToRoute = false } = {})`
 
 ### `src/client/composables/records/useView.js`
 Exports
-- `useView({ resource = null, ownershipFilter = ROUTE_VISIBILITY_WORKSPACE, surfaceId = "", access = "auto", apiSuffix = "", queryKeyFactory = null, viewPermissions = [], readMethod = "GET", readEnabled = true, transport = null, placementSource = "users-web.view", fallbackLoadError = "Unable to load resource.", notFoundStatuses = [404], notFoundMessage = "Record not found.", model, mapLoadedToModel, requestQueryParams = null, recordIdParam = "recordId", routeParams = null, routeRecordId = null, apiUrlTemplate = "", listUrlTemplate = "", editUrlTemplate = "", includeRecordIdInQueryKey = false, realtime = undefined, adapter = null } = {})`
+- `useView({ resource = null, ownershipFilter = ROUTE_VISIBILITY_WORKSPACE, surfaceId = "", access = "auto", apiSuffix = "", queryKeyFactory = null, viewPermissions = [], readMethod = "GET", readEnabled = true, transport = null, requestRecovery = null, requestRecoveryLabel = "Resource", placementSource = "users-web.view", fallbackLoadError = "Unable to load resource.", notFoundStatuses = [404], notFoundMessage = "Record not found.", model, mapLoadedToModel, requestQueryParams = null, recordIdParam = "recordId", routeParams = null, routeRecordId = null, apiUrlTemplate = "", listUrlTemplate = "", editUrlTemplate = "", includeRecordIdInQueryKey = false, realtime = undefined, adapter = null } = {})`
 
 ### `src/client/composables/runtime/addEditUiRuntime.js`
 Exports
@@ -290,7 +290,7 @@ Exports
 Exports
 - `buildEndpointReadRequestOptions({ method = "GET", query = null, transport = null } = {})`
 - `buildEndpointWriteRequestOptions({ method = "PATCH", body = undefined, options = null, transport = null } = {})`
-- `useEndpointResource({ queryKey, path = "", enabled = true, client = usersWebHttpClient, readMethod = "GET", writeMethod = "PATCH", readQuery = null, transport = null, refreshOnPull = false, realtime = null, queryOptions = null, mutationOptions = null, fallbackLoadError = "Unable to load resource.", fallbackSaveError = "Unable to save resource." } = {})`
+- `useEndpointResource({ queryKey, path = "", enabled = true, client = usersWebHttpClient, readMethod = "GET", writeMethod = "PATCH", readQuery = null, transport = null, refreshOnPull = false, realtime = null, queryOptions = null, mutationOptions = null, requestRecovery = null, requestRecoveryLabel = "Request", fallbackLoadError = "Unable to load resource.", fallbackSaveError = "Unable to save resource." } = {})`
 Local functions
 - `resolveRequestQuery(value = null)`
 
@@ -303,9 +303,10 @@ Local functions
 ### `src/client/composables/runtime/useListCore.js`
 Exports
 - `buildListRequestOptions({ requestOptions = null, transport = null, pageParam = null } = {})`
-- `useListCore({ queryKey, path = "", enabled = true, client = usersWebHttpClient, transport = null, initialPageParam = null, getNextPageParam, selectItems, requestOptions = null, queryOptions = null, fallbackLoadError = "Unable to load list." } = {})`
+- `useListCore({ queryKey, path = "", enabled = true, client = usersWebHttpClient, transport = null, initialPageParam = null, getNextPageParam, selectItems, requestOptions = null, queryOptions = null, requestRecovery = null, requestRecoveryLabel = "List", fallbackLoadError = "Unable to load list." } = {})`
 Local functions
 - `resolveRequestOptionsObject(value = null)`
+- `resolveListRequestMethod(requestOptions = null)`
 
 ### `src/client/composables/runtime/useUiFeedback.js`
 Exports
@@ -380,8 +381,21 @@ Exports
 
 ### `src/client/composables/support/resourceLoadStateHelpers.js`
 Exports
+- `buildRequestRecoveryMeta(requestRecovery = null, defaults = {})`
 - `hasResolvedQueryData({ query = null, data = null } = {})`
 - `mergeQueryMeta(queryOptions = null, meta = {})`
+- `mergeRequestRecoveryQueryMeta(queryOptions = null, requestRecovery = null, defaults = {})`
+Local functions
+- `normalizeText(value = "")`
+- `firstNormalizedText(...values)`
+- `firstNonNegativeFiniteNumber(...values)`
+- `normalizePlainObject(value = null)`
+- `normalizeRequestRecoveryInput(requestRecovery = null)`
+- `normalizeRequestRecoveryMethod(value = "")`
+- `isRequestRecoveryMetaDisabled(sourceJskitMeta = {}, sourceMeta = {})`
+- `hasUsableMetaValue(source = {}, key = "")`
+- `hasRequestRecoveryMetaValue(sourceJskitMeta = {}, sourceMeta = {}, key = "")`
+- `resolveRequestRecoveryDefaults(queryOptions = null, defaults = {})`
 
 ### `src/client/composables/support/routeTemplateHelpers.js`
 Exports
@@ -472,13 +486,13 @@ Local functions
 
 ### `src/client/composables/useCrudListScreen.js`
 Exports
-- `useCrudListScreen({ adapter = null, resource = null, resourceNamespace = "resource", apiSuffix = "", recordIdParam = "recordId", recordIdSelector = null, titleFallbackFieldKey = "", viewUrlTemplate = "", editUrlTemplate = "", newUrlTemplate = "", recordChangedEvents = [], listFilters = {}, listBulkActions = [], routeQueryBlacklist = Object.freeze(["include", "cursor", "limit"]), fallbackLoadError = "Unable to load records." } = {})`
+- `useCrudListScreen({ adapter = null, resource = null, resourceNamespace = "resource", apiSuffix = "", recordIdParam = "recordId", recordIdSelector = null, titleFallbackFieldKey = "", viewUrlTemplate = "", editUrlTemplate = "", newUrlTemplate = "", recordChangedEvents = [], listFilters = {}, listBulkActions = [], routeQueryBlacklist = Object.freeze(["include", "cursor", "limit"]), requestRecoveryLabel = "Records", fallbackLoadError = "Unable to load records." } = {})`
 Local functions
 - `formatCrudListCardValue(value)`
 
 ### `src/client/composables/useCrudViewScreen.js`
 Exports
-- `useCrudViewScreen({ adapter = null, resource = null, resourceNamespace = "resource", apiUrlTemplate = "", recordIdParam = "recordId", titleFallbackFieldKey = "", listUrlTemplate = "", editUrlTemplate = "", recordChangedEvent = "", fallbackLoadError = "Unable to load record.", notFoundMessage = "Record not found." } = {})`
+- `useCrudViewScreen({ adapter = null, resource = null, resourceNamespace = "resource", apiUrlTemplate = "", recordIdParam = "recordId", titleFallbackFieldKey = "", listUrlTemplate = "", editUrlTemplate = "", recordChangedEvent = "", requestRecoveryLabel = "Record", fallbackLoadError = "Unable to load record.", notFoundMessage = "Record not found." } = {})`
 
 ### `src/client/composables/usePagedCollection.js`
 Exports

--- a/packages/agent-docs/site/guide/app-setup/a-more-interesting-shell.md
+++ b/packages/agent-docs/site/guide/app-setup/a-more-interesting-shell.md
@@ -662,31 +662,40 @@ try {
 
 Use the narrow `@jskit-ai/shell-web/client/asyncModuleRecovery` subpath for this runtime, especially from modules that are imported by Node-mode Vitest suites. The aggregate `@jskit-ai/shell-web/client` barrel also exports the composable for normal Vite app code, but that barrel includes `.vue` component exports and can require Vue SFC handling in tests.
 
-Request connectivity failures use a separate shell recovery path. Generated apps already configure TanStack Query to retry transient failures with capped backoff. `shell-web` then observes the app's `jskit.client.query-client` and, when an active query finishes in a transport failure such as `Network request failed.` or `Failed to fetch`, reports an `app-recoverable` banner with a `Retry` action that refetches that exact query. Normal HTTP validation and application errors stay local to the screen.
+Request connectivity failures use a separate shell recovery path. Generated apps already configure TanStack Query to retry transient failures with capped backoff. `shell-web` then observes the app's `jskit.client.query-client` and, when an active safe-read query finishes in a transport failure such as `Network request failed.` or `Failed to fetch`, reports an `app-recoverable` banner with a `Retry` action that refetches that exact query. Normal HTTP validation and application errors stay local to the screen.
 
-Imperative app code only needs the public runtime when it catches a request failure outside the standard query/resource composables:
+That recovery path is intentionally a safe `GET`/`HEAD` read refetch system, not a general HTTP replay system. User-visible reads should go through Query-backed JSKIT primitives such as `useEndpointResource()`, `useList()`, `useView()`, `useAddEdit()`, or generated CRUD screen composables. Those primitives mark Query entries with `jskit.requestRecoveryMethod`, so the shell only offers Retry for safe reads. Do not catch raw `fetch(...)` failures in each panel just to call the shell recovery runtime manually.
+
+For a custom endpoint read, attach the recovery label to the Query-backed resource:
 
 ```js
-import { useShellRequestRecoveryRuntime } from "@jskit-ai/shell-web/client/requestRecovery";
-
-const requestRecovery = useShellRequestRecoveryRuntime();
-
-async function loadProjectAccess() {
-  try {
-    return await fetch("/api/project-access");
-  } catch (error) {
-    requestRecovery?.report(error, {
-      label: "Project access",
-      retry: loadProjectAccess
-    });
-    throw error;
-  }
-}
+const projectAccess = useEndpointResource({
+  queryKey: ["project-access", projectId],
+  path: `/api/projects/${projectId}/access`,
+  requestRecoveryLabel: "Project access"
+});
 ```
 
-`useShellRequestRecoveryRuntime()` returns `null` when the shell runtime is not available in the current Vue context. Use the narrow `@jskit-ai/shell-web/client/requestRecovery` subpath for the same reason as async module recovery: it avoids pulling `.vue` component exports into Node-mode test suites.
+If you need lower-level Query options, the same metadata can live on query meta:
 
-For query-backed screens, the default is automatic. Set `meta: { jskit: { requestRecovery: false } }` only when a query deliberately owns its entire connectivity recovery UI. Set `meta: { jskit: { requestRecoveryLabel: "Project access" } }` when the default `Request` label is too generic.
+```js
+const projectAccess = useEndpointResource({
+  queryKey: ["project-access", projectId],
+  path: `/api/projects/${projectId}/access`,
+  queryOptions: {
+    meta: {
+      jskit: {
+        requestRecoveryLabel: "Project access",
+        requestRecoveryMethod: "GET"
+      }
+    }
+  }
+});
+```
+
+For JSKIT read-composable screens, the default is automatic. Hand-written TanStack Query reads outside those composables must set `meta.jskit.requestRecoveryMethod` to `GET` or `HEAD`; unmarked queries are ignored by the shell recovery observer. Set `meta: { jskit: { requestRecovery: false } }` only when a query deliberately owns its entire connectivity recovery UI.
+
+Writes are different. JSKIT does not automatically replay `POST`, `PATCH`, `PUT`, or `DELETE` after a network failure because the server may already have received the request. Save and command screens keep ownership of mutation state, field errors, conflict handling, and user feedback.
 
 ### The home page talks to the backend
 

--- a/packages/agent-docs/site/guide/generators/advanced-cruds.md
+++ b/packages/agent-docs/site/guide/generators/advanced-cruds.md
@@ -680,6 +680,18 @@ Why this is the standard JSKIT shape:
 - The higher-level list, view, add/edit, and command runtimes send requests through the standard HTTP runtime instead of ad hoc request code.
 - The default client runtime uses `usersWebHttpClient`, which already handles credentials and CSRF token behavior.
 - `useEndpointResource()` gives the shared endpoint primitive for loading, saving, and standard load/save error handling. Higher-level runtimes like `useCommand()` and `useAddEdit()` layer UI feedback and field-error behavior on top of that primitive.
+- `shell-web` observes the shared TanStack Query client for recoverable transport failures. Generated CRUD reads and custom reads built with `useEndpointResource()`, `useList()`, `useView()`, or `useAddEdit()` get the shell recovery banner with a Retry action that refetches the failed query.
+- Automatic shell request recovery is only for safe `GET`/`HEAD` read refetches. JSKIT read composables mark Query entries with `jskit.requestRecoveryMethod`, and the shell ignores unmarked or unsafe methods. Do not rely on it to replay `POST`, `PATCH`, `PUT`, or `DELETE`; mutation screens own save state, field errors, and user feedback.
+
+When a custom read needs a better recovery banner label, pass it through the read primitive rather than reporting the failure manually:
+
+```js
+const resource = useEndpointResource({
+  queryKey: ["project-access", projectId],
+  path: `/api/projects/${projectId}/access`,
+  requestRecoveryLabel: "Project access"
+});
+```
 
 If you need a custom scoped endpoint path outside the higher-level runtimes, prefer `usePaths().api(...)` rather than hand-building scoped URLs:
 

--- a/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/EditElement.vue
+++ b/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/EditElement.vue
@@ -71,6 +71,7 @@ const screen = useCrudAddEditScreen({
     ],
     placementSource: "ui-generator.__JSKIT_UI_RESOURCE_NAMESPACE__.edit",
     writeMethod: "PATCH",
+    requestRecoveryLabel: "__JSKIT_UI_RESOURCE_SINGULAR_TITLE__",
     fallbackLoadError: "Unable to load record.",
     fallbackSaveError: "Unable to save record.",
     recordIdParam: UI_RECORD_ID_PARAM,

--- a/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/EditWrapperElement.vue
+++ b/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/EditWrapperElement.vue
@@ -60,6 +60,7 @@ const screen = useCrudAddEditScreen({
     ],
     placementSource: "ui-generator.__JSKIT_UI_RESOURCE_NAMESPACE__.edit",
     writeMethod: "PATCH",
+    requestRecoveryLabel: "__JSKIT_UI_RESOURCE_SINGULAR_TITLE__",
     fallbackLoadError: "Unable to load record.",
     fallbackSaveError: "Unable to save record.",
     recordIdParam: UI_RECORD_ID_PARAM,

--- a/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/ListElement.vue
+++ b/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/ListElement.vue
@@ -61,6 +61,7 @@ const screen = useCrudListScreen({
   listFilters,
   listBulkActions,
   routeQueryBlacklist: UI_ROUTE_QUERY_BLACKLIST,
+  requestRecoveryLabel: "__JSKIT_UI_RESOURCE_PLURAL_TITLE__",
   fallbackLoadError: "Unable to load records."
 });
 const listRuntime = screen.records;

--- a/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/ViewElement.vue
+++ b/packages/crud-ui-generator/templates/src/pages/admin/ui-generator/ViewElement.vue
@@ -36,6 +36,7 @@ const screen = useCrudViewScreen({
   listUrlTemplate: UI_LIST_URL,
   editUrlTemplate: UI_EDIT_URL,
   recordChangedEvent: UI_RECORD_CHANGED_EVENT,
+  requestRecoveryLabel: "__JSKIT_UI_RESOURCE_SINGULAR_TITLE__",
   fallbackLoadError: "Unable to load record.",
   notFoundMessage: "Record not found."
 });

--- a/packages/crud-ui-generator/test/buildTemplateContext.test.js
+++ b/packages/crud-ui-generator/test/buildTemplateContext.test.js
@@ -969,6 +969,7 @@ test("crud ui templates derive JSON:API transport from the shared CRUD resource"
   assert.match(listTemplateSource, /const screen = useCrudListScreen\(\{/);
   assert.match(listTemplateSource, /listFilters,/);
   assert.match(listTemplateSource, /listBulkActions,/);
+  assert.match(listTemplateSource, /requestRecoveryLabel: "__JSKIT_UI_RESOURCE_PLURAL_TITLE__"/);
   assert.match(listTemplateSource, /#card-fields="__JSKIT_UI_LIST_CARD_SLOT_PROPS__"/);
   assert.match(listTemplateSource, /#table-header/);
   assert.match(listTemplateSource, /#table-row="__JSKIT_UI_LIST_ROW_SLOT_PROPS__"/);
@@ -992,6 +993,7 @@ test("crud ui templates derive JSON:API transport from the shared CRUD resource"
   assert.match(viewTemplateSource, /import CrudViewScreen from "@jskit-ai\/users-web\/client\/components\/CrudViewScreen"/);
   assert.match(viewTemplateSource, /import \{ useCrudViewScreen \} from "@jskit-ai\/users-web\/client\/composables\/useCrudViewScreen"/);
   assert.match(viewTemplateSource, /const screen = useCrudViewScreen\(\{/);
+  assert.match(viewTemplateSource, /requestRecoveryLabel: "__JSKIT_UI_RESOURCE_SINGULAR_TITLE__"/);
   assert.match(viewTemplateSource, /#fields="\{ view \}"/);
   assert.doesNotMatch(viewTemplateSource, /<v-card\b|View and manage this/);
   assert.doesNotMatch(viewTemplateSource, /const UI_VIEW_TRANSPORT = Object\.freeze\(\{/);
@@ -1011,6 +1013,7 @@ test("crud ui templates derive JSON:API transport from the shared CRUD resource"
   assert.match(editTemplateSource, /import \{ useCrudAddEditScreen \} from "@jskit-ai\/users-web\/client\/composables\/useCrudAddEditScreen"/);
   assert.match(editTemplateSource, /const screen = useCrudAddEditScreen\(\{/);
   assert.match(editTemplateSource, /preserveCancelQuery: true/);
+  assert.match(editTemplateSource, /requestRecoveryLabel: "__JSKIT_UI_RESOURCE_SINGULAR_TITLE__"/);
   assert.match(editTemplateSource, /#fields=/);
   assert.doesNotMatch(editTemplateSource, /<v-card\b|<v-card-title/);
   assert.doesNotMatch(editTemplateSource, /const UI_EDIT_TRANSPORT = Object\.freeze\(\{/);
@@ -1032,6 +1035,7 @@ test("crud ui templates derive JSON:API transport from the shared CRUD resource"
   assert.match(editWrapperTemplateSource, /import \{ useCrudAddEditScreen \} from "@jskit-ai\/users-web\/client\/composables\/useCrudAddEditScreen"/);
   assert.match(editWrapperTemplateSource, /:screen="screen"/);
   assert.match(editWrapperTemplateSource, /preserveCancelQuery: true/);
+  assert.match(editWrapperTemplateSource, /requestRecoveryLabel: "__JSKIT_UI_RESOURCE_SINGULAR_TITLE__"/);
   assert.doesNotMatch(editWrapperTemplateSource, /<v-card\b/);
   assert.doesNotMatch(editWrapperTemplateSource, /const UI_EDIT_TRANSPORT = Object\.freeze\(\{/);
   assert.doesNotMatch(editWrapperTemplateSource, /transport:\s*UI_EDIT_TRANSPORT,/);

--- a/packages/shell-web/src/client/requestRecovery/runtime.js
+++ b/packages/shell-web/src/client/requestRecovery/runtime.js
@@ -31,6 +31,11 @@ const CANCELED_REQUEST_ERROR_CODES = Object.freeze(new Set([
   "ERR_CANCELED"
 ]));
 
+const SAFE_REQUEST_RECOVERY_METHODS = Object.freeze(new Set([
+  "GET",
+  "HEAD"
+]));
+
 function normalizeText(value, fallback = "") {
   const normalized = String(value || "").trim();
   return normalized || String(fallback || "").trim();
@@ -142,6 +147,56 @@ function resolveQueryRecoveryLabel(query = null) {
   );
 }
 
+function resolveQueryRecoverySource(query = null) {
+  const meta = resolveQueryMeta(query);
+  const jskitMeta = isRecord(meta.jskit) ? meta.jskit : {};
+
+  return normalizeText(
+    jskitMeta.requestRecoverySource ||
+      meta.jskitRequestRecoverySource ||
+      meta.requestRecoverySource,
+    "shell-web.request-recovery.query"
+  );
+}
+
+function resolveQueryRecoveryDedupeKey(query = null, fallback = "") {
+  const meta = resolveQueryMeta(query);
+  const jskitMeta = isRecord(meta.jskit) ? meta.jskit : {};
+
+  return normalizeText(
+    jskitMeta.requestRecoveryDedupeKey ||
+      meta.jskitRequestRecoveryDedupeKey ||
+      meta.requestRecoveryDedupeKey,
+    fallback
+  );
+}
+
+function resolveQueryRecoveryDedupeWindowMs(query = null) {
+  const meta = resolveQueryMeta(query);
+  const jskitMeta = isRecord(meta.jskit) ? meta.jskit : {};
+  const value =
+    jskitMeta.requestRecoveryDedupeWindowMs ??
+      meta.jskitRequestRecoveryDedupeWindowMs ??
+      meta.requestRecoveryDedupeWindowMs;
+
+  return Number.isFinite(Number(value)) ? Math.max(0, Number(value)) : null;
+}
+
+function resolveQueryRecoveryMethod(query = null) {
+  const meta = resolveQueryMeta(query);
+  const jskitMeta = isRecord(meta.jskit) ? meta.jskit : {};
+
+  return normalizeText(
+    jskitMeta.requestRecoveryMethod ||
+      meta.jskitRequestRecoveryMethod ||
+      meta.requestRecoveryMethod
+  ).toUpperCase();
+}
+
+function isSafeQueryRecoveryMethod(query = null) {
+  return SAFE_REQUEST_RECOVERY_METHODS.has(resolveQueryRecoveryMethod(query));
+}
+
 function isActiveQuery(query = null) {
   if (typeof query?.isActive === "function") {
     return Boolean(query.isActive());
@@ -223,7 +278,12 @@ function installRecoverableQueryObserver({
   const reportedErrorUpdateByQueryHash = new Map();
 
   function inspectQuery(query = null) {
-    if (!query || isRequestRecoveryDisabled(query) || !isActiveQuery(query)) {
+    if (
+      !query ||
+      isRequestRecoveryDisabled(query) ||
+      !isSafeQueryRecoveryMethod(query) ||
+      !isActiveQuery(query)
+    ) {
       return;
     }
 
@@ -241,12 +301,19 @@ function installRecoverableQueryObserver({
     }
     reportedErrorUpdateByQueryHash.set(queryHash, reportKey);
 
+    const source = resolveQueryRecoverySource(query);
+    const dedupeKey = resolveQueryRecoveryDedupeKey(
+      query,
+      `shell-web.request-recovery.query.${queryHash}.${errorUpdateCount}`
+    );
+    const dedupeWindowMs = resolveQueryRecoveryDedupeWindowMs(query);
     runtime.report(error, {
       label: resolveQueryRecoveryLabel(query),
       retry: createQueryRetry(queryClient, query),
-      source: "shell-web.request-recovery.query",
+      source,
       stale: query?.state?.data !== undefined,
-      dedupeKey: `shell-web.request-recovery.query.${queryHash}.${errorUpdateCount}`
+      dedupeKey,
+      ...(dedupeWindowMs !== null ? { dedupeWindowMs } : {})
     });
   }
 

--- a/packages/shell-web/test/provider.test.js
+++ b/packages/shell-web/test/provider.test.js
@@ -371,13 +371,21 @@ test("shell request recovery reports active query transport failures with retry 
     const provider = new ShellWebClientProvider();
     provider.register(app);
     await provider.boot(app);
+    const reportEvents = [];
+    app.make("runtime.web-error.client").subscribe((event = {}) => {
+      reportEvents.push(event);
+    });
 
     const failedQuery = {
       queryHash: "[\"project-access\"]",
       queryKey: ["project-access"],
       meta: {
         jskit: {
-          requestRecoveryLabel: "Project access"
+          requestRecoveryLabel: "Project access",
+          requestRecoverySource: "project-access.panel",
+          requestRecoveryDedupeKey: "project-access",
+          requestRecoveryMethod: "GET",
+          requestRecoveryDedupeWindowMs: 100
         }
       },
       state: {
@@ -403,6 +411,9 @@ test("shell request recovery reports active query transport failures with retry 
       "Project access could not reach the server or network. Check the connection and try again."
     );
     assert.equal(state.channels.banner[0].action.label, "Retry");
+    assert.equal(state.channels.banner[0].dedupeKey, "project-access");
+    assert.equal(reportEvents[0]?.result?.event?.source, "project-access.panel");
+    assert.equal(reportEvents[0]?.result?.decision?.dedupeWindowMs, 100);
 
     await state.channels.banner[0].action.handler();
     assert.equal(refetchCalls.length, 1);
@@ -414,6 +425,55 @@ test("shell request recovery reports active query transport failures with retry 
     assert.deepEqual(refetchCalls[0].options, {
       throwOnError: false
     });
+  });
+});
+
+test("shell request recovery ignores query transport failures without a safe read method", async () => {
+  await withFetchStub({ surfaceAccess: {} }, async () => {
+    const queryCache = createQueryCacheDouble();
+    const queryClient = {
+      getQueryCache() {
+        return queryCache;
+      },
+      async refetchQueries() {}
+    };
+    const app = createAppDouble({ queryClient });
+    const provider = new ShellWebClientProvider();
+    provider.register(app);
+    await provider.boot(app);
+
+    for (const [queryKey, meta] of [
+      [["unmarked"], {}],
+      [["unsafe"], {
+        jskit: {
+          requestRecoveryMethod: "POST"
+        }
+      }]
+    ]) {
+      queryCache.emit({
+        type: "updated",
+        query: {
+          queryHash: JSON.stringify(queryKey),
+          queryKey,
+          meta,
+          state: {
+            status: "error",
+            fetchStatus: "idle",
+            error: {
+              status: 0,
+              message: "Network request failed."
+            },
+            errorUpdateCount: 1
+          },
+          isActive() {
+            return true;
+          }
+        }
+      });
+    }
+
+    const errorStore = app.make("runtime.web-error.presentation-store.client");
+    assert.equal(errorStore.getState().channels.banner.length, 0);
   });
 });
 
@@ -433,10 +493,15 @@ test("shell request recovery ignores ordinary active query validation failures",
 
     queryCache.emit({
       type: "updated",
-      query: {
-        queryHash: "[\"project-access\"]",
-        queryKey: ["project-access"],
-        state: {
+        query: {
+          queryHash: "[\"project-access\"]",
+          queryKey: ["project-access"],
+          meta: {
+            jskit: {
+              requestRecoveryMethod: "GET"
+            }
+          },
+          state: {
           status: "error",
           fetchStatus: "idle",
           error: {

--- a/packages/users-web/src/client/composables/records/useAddEdit.js
+++ b/packages/users-web/src/client/composables/records/useAddEdit.js
@@ -30,6 +30,8 @@ function useAddEdit({
   readEnabled = true,
   writeMethod = "PATCH",
   transport = null,
+  requestRecovery = null,
+  requestRecoveryLabel = "Resource",
   placementSource = "users-web.add-edit",
   fallbackLoadError = "Unable to load resource.",
   fallbackSaveError = "Unable to save resource.",
@@ -121,6 +123,8 @@ function useAddEdit({
     writeMethod,
     readQuery: requestQueryRuntime.requestQuery,
     transport,
+    requestRecovery,
+    requestRecoveryLabel,
     fallbackLoadError,
     fallbackSaveError: String(fallbackSaveError || effectiveMessages.saveError || "Unable to save resource.")
   });

--- a/packages/users-web/src/client/composables/records/useList.js
+++ b/packages/users-web/src/client/composables/records/useList.js
@@ -46,6 +46,8 @@ function useList({
   transport = null,
   requestOptions,
   queryOptions,
+  requestRecovery,
+  requestRecoveryLabel = "List",
   realtime = null,
   adapter = null,
   recordIdParam = "recordId",
@@ -228,6 +230,8 @@ function useList({
     selectItems,
     requestOptions: listRequestOptions,
     queryOptions,
+    requestRecovery,
+    requestRecoveryLabel,
     fallbackLoadError
   });
   const routeSyncHydrated = ref(routeSyncConfig.enabled !== true);

--- a/packages/users-web/src/client/composables/records/useView.js
+++ b/packages/users-web/src/client/composables/records/useView.js
@@ -21,6 +21,8 @@ function useView({
   readMethod = "GET",
   readEnabled = true,
   transport = null,
+  requestRecovery = null,
+  requestRecoveryLabel = "Resource",
   placementSource = "users-web.view",
   fallbackLoadError = "Unable to load resource.",
   notFoundStatuses = [404],
@@ -104,6 +106,8 @@ function useView({
     readMethod,
     readQuery: requestQueryRuntime.requestQuery,
     transport,
+    requestRecovery,
+    requestRecoveryLabel,
     refreshOnPull: true,
     fallbackLoadError
   });

--- a/packages/users-web/src/client/composables/runtime/useEndpointResource.js
+++ b/packages/users-web/src/client/composables/runtime/useEndpointResource.js
@@ -7,7 +7,8 @@ import { toQueryErrorMessage } from "../support/errorMessageHelpers.js";
 import { useOperationRealtime } from "../useRealtimeQueryInvalidation.js";
 import {
   hasResolvedQueryData,
-  mergeQueryMeta
+  mergeQueryMeta,
+  mergeRequestRecoveryQueryMeta
 } from "../support/resourceLoadStateHelpers.js";
 
 function buildEndpointReadRequestOptions({
@@ -75,6 +76,8 @@ function useEndpointResource({
   realtime = null,
   queryOptions = null,
   mutationOptions = null,
+  requestRecovery = null,
+  requestRecoveryLabel = "Request",
   fallbackLoadError = "Unable to load resource.",
   fallbackSaveError = "Unable to save resource."
 } = {}) {
@@ -102,13 +105,20 @@ function useEndpointResource({
       });
     },
     enabled: queryEnabled,
-    ...(refreshOnPull
-      ? mergeQueryMeta(asPlainObject(queryOptions), {
-        jskit: {
-          refreshOnPull: true
-        }
-      })
-      : asPlainObject(queryOptions))
+    ...mergeRequestRecoveryQueryMeta(
+      refreshOnPull
+        ? mergeQueryMeta(asPlainObject(queryOptions), {
+          jskit: {
+            refreshOnPull: true
+          }
+        })
+        : asPlainObject(queryOptions),
+      requestRecovery,
+      {
+        label: requestRecoveryLabel,
+        method: readMethod
+      }
+    )
   });
   const realtimeBinding = useOperationRealtime({
     realtime,

--- a/packages/users-web/src/client/composables/runtime/useListCore.js
+++ b/packages/users-web/src/client/composables/runtime/useListCore.js
@@ -3,6 +3,7 @@ import { usersWebHttpClient } from "../../lib/httpClient.js";
 import { asPlainObject } from "../support/scopeHelpers.js";
 import { resolveEnabledRef, resolveTextRef } from "../support/refValueHelpers.js";
 import { usePagedCollection } from "../usePagedCollection.js";
+import { mergeRequestRecoveryQueryMeta } from "../support/resourceLoadStateHelpers.js";
 
 const DEFAULT_LIST_LIMIT = 20;
 
@@ -47,6 +48,10 @@ function resolveRequestOptionsObject(value = null) {
   return asPlainObject(source);
 }
 
+function resolveListRequestMethod(requestOptions = null) {
+  return String(resolveRequestOptionsObject(requestOptions).method || "GET").toUpperCase();
+}
+
 function useListCore({
   queryKey,
   path = "",
@@ -58,6 +63,8 @@ function useListCore({
   selectItems,
   requestOptions = null,
   queryOptions = null,
+  requestRecovery = null,
+  requestRecoveryLabel = "List",
   fallbackLoadError = "Unable to load list."
 } = {}) {
   if (!client || typeof client.request !== "function") {
@@ -88,7 +95,10 @@ function useListCore({
     },
     getNextPageParam,
     selectItems,
-    queryOptions,
+    queryOptions: mergeRequestRecoveryQueryMeta(queryOptions, requestRecovery, {
+      label: requestRecoveryLabel,
+      method: resolveListRequestMethod(requestOptions)
+    }),
     fallbackLoadError
   });
 

--- a/packages/users-web/src/client/composables/support/resourceLoadStateHelpers.js
+++ b/packages/users-web/src/client/composables/support/resourceLoadStateHelpers.js
@@ -36,7 +36,194 @@ function mergeQueryMeta(queryOptions = null, meta = {}) {
   };
 }
 
+function normalizeText(value = "") {
+  return String(value || "").trim();
+}
+
+function firstNormalizedText(...values) {
+  for (const value of values) {
+    const normalized = normalizeText(value);
+    if (normalized) {
+      return normalized;
+    }
+  }
+  return "";
+}
+
+function firstNonNegativeFiniteNumber(...values) {
+  for (const value of values) {
+    const numberValue = Number(value);
+    if (Number.isFinite(numberValue)) {
+      return Math.max(0, numberValue);
+    }
+  }
+  return null;
+}
+
+function normalizePlainObject(value = null) {
+  return value && typeof value === "object" && !Array.isArray(value) ? value : {};
+}
+
+function normalizeRequestRecoveryInput(requestRecovery = null) {
+  if (typeof requestRecovery === "string") {
+    return {
+      label: requestRecovery
+    };
+  }
+  return normalizePlainObject(requestRecovery);
+}
+
+function normalizeRequestRecoveryMethod(value = "") {
+  return normalizeText(value).toUpperCase();
+}
+
+function isRequestRecoveryMetaDisabled(sourceJskitMeta = {}, sourceMeta = {}) {
+  return Boolean(
+    sourceJskitMeta.requestRecovery === false ||
+      sourceMeta.jskitRequestRecovery === false ||
+      sourceMeta.requestRecovery === false
+  );
+}
+
+function hasUsableMetaValue(source = {}, key = "") {
+  return Object.hasOwn(source, key) && source[key] !== undefined && source[key] !== null && source[key] !== "";
+}
+
+function buildRequestRecoveryMeta(requestRecovery = null, defaults = {}) {
+  if (requestRecovery === false) {
+    return {
+      jskit: {
+        requestRecovery: false
+      }
+    };
+  }
+
+  const fallback = normalizePlainObject(defaults);
+  const source = normalizeRequestRecoveryInput(requestRecovery);
+  if (source.requestRecovery === false || source.enabled === false) {
+    return {
+      jskit: {
+        requestRecovery: false
+      }
+    };
+  }
+
+  const label = firstNormalizedText(
+    source.requestRecoveryLabel,
+    source.label,
+    fallback.requestRecoveryLabel,
+    fallback.label
+  );
+  const recoverySource = firstNormalizedText(
+    source.requestRecoverySource,
+    source.source,
+    fallback.requestRecoverySource,
+    fallback.source
+  );
+  const dedupeKey = firstNormalizedText(
+    source.requestRecoveryDedupeKey,
+    source.dedupeKey,
+    fallback.requestRecoveryDedupeKey,
+    fallback.dedupeKey
+  );
+  const method = normalizeRequestRecoveryMethod(
+    firstNormalizedText(
+      source.requestRecoveryMethod,
+      source.method,
+      fallback.requestRecoveryMethod,
+      fallback.method
+    )
+  );
+  const dedupeWindowMs = firstNonNegativeFiniteNumber(
+    source.requestRecoveryDedupeWindowMs,
+    source.dedupeWindowMs,
+    fallback.requestRecoveryDedupeWindowMs,
+    fallback.dedupeWindowMs
+  );
+
+  const jskit = {};
+  if (label) {
+    jskit.requestRecoveryLabel = label;
+  }
+  if (recoverySource) {
+    jskit.requestRecoverySource = recoverySource;
+  }
+  if (dedupeKey) {
+    jskit.requestRecoveryDedupeKey = dedupeKey;
+  }
+  if (method) {
+    jskit.requestRecoveryMethod = method;
+  }
+  if (dedupeWindowMs !== null) {
+    jskit.requestRecoveryDedupeWindowMs = dedupeWindowMs;
+  }
+
+  return Object.keys(jskit).length > 0 ? { jskit } : {};
+}
+
+function hasRequestRecoveryMetaValue(sourceJskitMeta = {}, sourceMeta = {}, key = "") {
+  const suffix = String(key || "").trim();
+  if (!suffix) {
+    return false;
+  }
+
+  const jskitKey = `requestRecovery${suffix}`;
+  const legacyJskitKey = `jskitRequestRecovery${suffix}`;
+  const legacyKey = `requestRecovery${suffix}`;
+
+  return Boolean(
+    hasUsableMetaValue(sourceJskitMeta, jskitKey) ||
+      hasUsableMetaValue(sourceMeta, legacyJskitKey) ||
+      hasUsableMetaValue(sourceMeta, legacyKey)
+  );
+}
+
+function resolveRequestRecoveryDefaults(queryOptions = null, defaults = {}) {
+  const sourceOptions = normalizePlainObject(queryOptions);
+  const sourceMeta = normalizePlainObject(sourceOptions.meta);
+  const sourceJskitMeta = normalizePlainObject(sourceMeta.jskit);
+  const fallback = normalizePlainObject(defaults);
+  if (isRequestRecoveryMetaDisabled(sourceJskitMeta, sourceMeta)) {
+    return {};
+  }
+
+  const hasExplicitLabel = hasRequestRecoveryMetaValue(sourceJskitMeta, sourceMeta, "Label");
+  const hasExplicitSource = hasRequestRecoveryMetaValue(sourceJskitMeta, sourceMeta, "Source");
+  const hasExplicitDedupeKey = hasRequestRecoveryMetaValue(sourceJskitMeta, sourceMeta, "DedupeKey");
+  const hasExplicitDedupeWindowMs = hasRequestRecoveryMetaValue(sourceJskitMeta, sourceMeta, "DedupeWindowMs");
+  const hasExplicitMethod = hasRequestRecoveryMetaValue(sourceJskitMeta, sourceMeta, "Method");
+
+  return {
+    ...fallback,
+    requestRecoveryLabel: hasExplicitLabel ? "" : fallback.requestRecoveryLabel,
+    label: hasExplicitLabel ? "" : fallback.label,
+    requestRecoverySource: hasExplicitSource ? "" : fallback.requestRecoverySource,
+    source: hasExplicitSource ? "" : fallback.source,
+    requestRecoveryDedupeKey: hasExplicitDedupeKey ? "" : fallback.requestRecoveryDedupeKey,
+    dedupeKey: hasExplicitDedupeKey ? "" : fallback.dedupeKey,
+    requestRecoveryDedupeWindowMs: hasExplicitDedupeWindowMs ? "" : fallback.requestRecoveryDedupeWindowMs,
+    dedupeWindowMs: hasExplicitDedupeWindowMs ? "" : fallback.dedupeWindowMs,
+    requestRecoveryMethod: hasExplicitMethod ? "" : fallback.requestRecoveryMethod,
+    method: hasExplicitMethod ? "" : fallback.method
+  };
+}
+
+function mergeRequestRecoveryQueryMeta(queryOptions = null, requestRecovery = null, defaults = {}) {
+  const sourceOptions = normalizePlainObject(queryOptions);
+  const effectiveDefaults =
+    requestRecovery == null
+      ? resolveRequestRecoveryDefaults(sourceOptions, defaults)
+      : normalizePlainObject(defaults);
+  const meta = buildRequestRecoveryMeta(requestRecovery, effectiveDefaults);
+  if (Object.keys(meta).length < 1) {
+    return sourceOptions;
+  }
+  return mergeQueryMeta(sourceOptions, meta);
+}
+
 export {
+  buildRequestRecoveryMeta,
   hasResolvedQueryData,
-  mergeQueryMeta
+  mergeQueryMeta,
+  mergeRequestRecoveryQueryMeta
 };

--- a/packages/users-web/src/client/composables/useCrudListScreen.js
+++ b/packages/users-web/src/client/composables/useCrudListScreen.js
@@ -31,6 +31,7 @@ function useCrudListScreen({
   listFilters = {},
   listBulkActions = [],
   routeQueryBlacklist = Object.freeze(["include", "cursor", "limit"]),
+  requestRecoveryLabel = "Records",
   fallbackLoadError = "Unable to load records."
 } = {}) {
   const filterRuntime = useCrudListFilters(listFilters);
@@ -62,6 +63,7 @@ function useCrudListScreen({
       queryParamBlacklist: routeQueryBlacklist
     },
     placementSource: `ui-generator.${normalizedResourceNamespace}.list`,
+    requestRecoveryLabel,
     fallbackLoadError,
     recordIdParam,
     recordIdSelector,

--- a/packages/users-web/src/client/composables/useCrudViewScreen.js
+++ b/packages/users-web/src/client/composables/useCrudViewScreen.js
@@ -12,6 +12,7 @@ function useCrudViewScreen({
   listUrlTemplate = "",
   editUrlTemplate = "",
   recordChangedEvent = "",
+  requestRecoveryLabel = "Record",
   fallbackLoadError = "Unable to load record.",
   notFoundMessage = "Record not found."
 } = {}) {
@@ -31,6 +32,7 @@ function useCrudViewScreen({
       String(workspaceSlug || "")
     ],
     placementSource: `ui-generator.${normalizedResourceNamespace}.view`,
+    requestRecoveryLabel,
     fallbackLoadError,
     notFoundMessage,
     listUrlTemplate,

--- a/packages/users-web/test/requestTransportOptions.test.js
+++ b/packages/users-web/test/requestTransportOptions.test.js
@@ -249,3 +249,41 @@ test("endpoint resources invalidate their query key from configured realtime eve
     }
   ]);
 });
+
+test("endpoint resource reads attach request recovery metadata to query options", async () => {
+  const queryClient = new QueryClient();
+  const queryKey = ["project-access", "beepollen"];
+  const app = createSSRApp({
+    setup() {
+      useEndpointResource({
+        queryKey,
+        path: "/api/project-access",
+        client: {
+          async request() {
+            return {};
+          }
+        },
+        requestRecovery: {
+          label: "Project access",
+          source: "project-access.panel",
+          dedupeKey: "project-access"
+        }
+      });
+      return () => h("div");
+    }
+  });
+  app.use(VueQueryPlugin, {
+    queryClient
+  });
+  await renderToString(app);
+
+  const query = queryClient.getQueryCache().find({
+    queryKey
+  });
+  assert.deepEqual(query?.meta?.jskit, {
+    requestRecoveryLabel: "Project access",
+    requestRecoverySource: "project-access.panel",
+    requestRecoveryDedupeKey: "project-access",
+    requestRecoveryMethod: "GET"
+  });
+});

--- a/packages/users-web/test/resourceLoadStateHelpers.test.js
+++ b/packages/users-web/test/resourceLoadStateHelpers.test.js
@@ -2,8 +2,10 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { ref } from "vue";
 import {
+  buildRequestRecoveryMeta,
   hasResolvedQueryData,
-  mergeQueryMeta
+  mergeQueryMeta,
+  mergeRequestRecoveryQueryMeta
 } from "../src/client/composables/support/resourceLoadStateHelpers.js";
 
 test("hasResolvedQueryData returns true when the query succeeded", () => {
@@ -66,6 +68,120 @@ test("mergeQueryMeta preserves caller metadata while adding JSKIT refresh policy
         jskit: {
           feature: "list",
           refreshOnPull: true
+        }
+      }
+    }
+  );
+});
+
+test("request recovery query metadata supports labels and disabling recovery", () => {
+  assert.deepEqual(
+    buildRequestRecoveryMeta("Project access"),
+    {
+      jskit: {
+        requestRecoveryLabel: "Project access"
+      }
+    }
+  );
+
+  assert.deepEqual(
+    buildRequestRecoveryMeta(false),
+    {
+      jskit: {
+        requestRecovery: false
+      }
+    }
+  );
+});
+
+test("mergeRequestRecoveryQueryMeta preserves caller metadata while adding recovery hints", () => {
+  assert.deepEqual(
+    mergeRequestRecoveryQueryMeta(
+      {
+        staleTime: 5000,
+        meta: {
+          owner: "project-access",
+          jskit: {
+            refreshOnPull: true
+          }
+        }
+      },
+      {
+        label: "Project access",
+        source: "app.project-access",
+        dedupeKey: "project-access",
+        method: "get",
+        dedupeWindowMs: 100
+      }
+    ),
+    {
+      staleTime: 5000,
+      meta: {
+        owner: "project-access",
+        jskit: {
+          refreshOnPull: true,
+          requestRecoveryLabel: "Project access",
+          requestRecoverySource: "app.project-access",
+          requestRecoveryDedupeKey: "project-access",
+          requestRecoveryMethod: "GET",
+          requestRecoveryDedupeWindowMs: 100
+        }
+      }
+    }
+  );
+});
+
+test("mergeRequestRecoveryQueryMeta does not overwrite explicit query recovery labels with defaults", () => {
+  assert.deepEqual(
+    mergeRequestRecoveryQueryMeta(
+      {
+        meta: {
+          jskit: {
+            requestRecoveryLabel: "Explicit label",
+            requestRecoveryMethod: "HEAD",
+            requestRecoveryDedupeWindowMs: 0
+          }
+        }
+      },
+      null,
+      {
+        label: "Default label",
+        method: "GET",
+        dedupeWindowMs: 5000
+      }
+    ),
+    {
+      meta: {
+        jskit: {
+          requestRecoveryLabel: "Explicit label",
+          requestRecoveryMethod: "HEAD",
+          requestRecoveryDedupeWindowMs: 0
+        }
+      }
+    }
+  );
+});
+
+test("mergeRequestRecoveryQueryMeta preserves disabled recovery metadata", () => {
+  assert.deepEqual(
+    mergeRequestRecoveryQueryMeta(
+      {
+        meta: {
+          jskit: {
+            requestRecovery: false
+          }
+        }
+      },
+      null,
+      {
+        label: "Default label",
+        method: "GET"
+      }
+    ),
+    {
+      meta: {
+        jskit: {
+          requestRecovery: false
         }
       }
     }


### PR DESCRIPTION
## Summary
- mark JSKIT users-web read composables and generated CRUD screens with request recovery labels plus safe request methods
- require shell-web Query recovery to be explicitly marked as GET or HEAD before showing Retry/refetch UI
- document the generated-app recovery contract and refresh distributed agent docs

## Verification
- npm --workspace @jskit-ai/users-web test
- npm --workspace @jskit-ai/shell-web test
- npm --workspace @jskit-ai/crud-ui-generator test
- npm --workspace @jskit-ai/agent-docs test
- npm run agent-docs:build
- npm run catalog:build
- npm run lint
- npm run check:runtime-deps
- npm run jskit -- lint-descriptors
- npm run generated:check
- git diff --check