### PR TITLE
Fix shell-web Vite optimizer handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6669,7 +6669,7 @@
     },
     "packages/agent-docs": {
       "name": "@jskit-ai/agent-docs",
-      "version": "0.1.57",
+      "version": "0.1.58",
       "engines": {
         "node": ">=20 <23"
       }
@@ -7062,7 +7062,7 @@
     },
     "tooling/create-app": {
       "name": "@jskit-ai/create-app",
-      "version": "0.1.104",
+      "version": "0.1.105",
       "bin": {
         "jskit-create-app": "bin/jskit-create-app.js"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -6701,6 +6701,14 @@
         "vuetify": "^4.0.0"
       }
     },
+    "packages/assistant-core/node_modules/@jskit-ai/kernel": {
+      "version": "0.1.96",
+      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.96.tgz",
+      "integrity": "sha512-aBBsAkoaOyWYxmbyQqnaoXrVRKvofBeTlfrYXOTcYkaAU+YDxHIO11SlUBeVicVBFve7zX405zXD/z14F7BRXw==",
+      "dependencies": {
+        "json-rest-schema": "1.x.x"
+      }
+    },
     "packages/assistant-runtime": {
       "name": "@jskit-ai/assistant-runtime",
       "version": "0.1.67",
@@ -6720,6 +6728,37 @@
         "vuetify": "^4.0.0"
       }
     },
+    "packages/assistant-runtime/node_modules/@jskit-ai/kernel": {
+      "version": "0.1.96",
+      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.96.tgz",
+      "integrity": "sha512-aBBsAkoaOyWYxmbyQqnaoXrVRKvofBeTlfrYXOTcYkaAU+YDxHIO11SlUBeVicVBFve7zX405zXD/z14F7BRXw==",
+      "dependencies": {
+        "json-rest-schema": "1.x.x"
+      }
+    },
+    "packages/assistant-runtime/node_modules/@jskit-ai/shell-web": {
+      "version": "0.1.95",
+      "resolved": "https://registry.npmjs.org/@jskit-ai/shell-web/-/shell-web-0.1.95.tgz",
+      "integrity": "sha512-QqStS3A0J8jU8f5iOZ7At7wLB+O0jcfvOH2ekxrxkt3yJN58MMz1ry+cw9Dkl1/D0J6ldbONzRKAfAVMTAc0mQ==",
+      "dependencies": {
+        "@jskit-ai/kernel": "0.1.96",
+        "@mdi/js": "^7.4.47"
+      },
+      "peerDependencies": {
+        "pinia": "^3.0.4",
+        "vue": "^3.5.13",
+        "vue-router": "^5.0.4",
+        "vuetify": "^4.0.0"
+      }
+    },
+    "packages/assistant/node_modules/@jskit-ai/kernel": {
+      "version": "0.1.96",
+      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.96.tgz",
+      "integrity": "sha512-aBBsAkoaOyWYxmbyQqnaoXrVRKvofBeTlfrYXOTcYkaAU+YDxHIO11SlUBeVicVBFve7zX405zXD/z14F7BRXw==",
+      "dependencies": {
+        "json-rest-schema": "1.x.x"
+      }
+    },
     "packages/auth-core": {
       "name": "@jskit-ai/auth-core",
       "version": "0.1.95",
@@ -6728,6 +6767,14 @@
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0",
         "@jskit-ai/kernel": "0.1.96",
+        "json-rest-schema": "1.x.x"
+      }
+    },
+    "packages/auth-core/node_modules/@jskit-ai/kernel": {
+      "version": "0.1.96",
+      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.96.tgz",
+      "integrity": "sha512-aBBsAkoaOyWYxmbyQqnaoXrVRKvofBeTlfrYXOTcYkaAU+YDxHIO11SlUBeVicVBFve7zX405zXD/z14F7BRXw==",
+      "dependencies": {
         "json-rest-schema": "1.x.x"
       }
     },
@@ -6741,6 +6788,14 @@
         "jose": "^6.1.0",
         "json-rest-schema": "1.x.x",
         "ws": "^8.18.3"
+      }
+    },
+    "packages/auth-provider-supabase-core/node_modules/@jskit-ai/kernel": {
+      "version": "0.1.96",
+      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.96.tgz",
+      "integrity": "sha512-aBBsAkoaOyWYxmbyQqnaoXrVRKvofBeTlfrYXOTcYkaAU+YDxHIO11SlUBeVicVBFve7zX405zXD/z14F7BRXw==",
+      "dependencies": {
+        "json-rest-schema": "1.x.x"
       }
     },
     "packages/auth-web": {
@@ -6761,6 +6816,29 @@
         "vuetify": "^4.0.0"
       }
     },
+    "packages/auth-web/node_modules/@jskit-ai/kernel": {
+      "version": "0.1.96",
+      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.96.tgz",
+      "integrity": "sha512-aBBsAkoaOyWYxmbyQqnaoXrVRKvofBeTlfrYXOTcYkaAU+YDxHIO11SlUBeVicVBFve7zX405zXD/z14F7BRXw==",
+      "dependencies": {
+        "json-rest-schema": "1.x.x"
+      }
+    },
+    "packages/auth-web/node_modules/@jskit-ai/shell-web": {
+      "version": "0.1.95",
+      "resolved": "https://registry.npmjs.org/@jskit-ai/shell-web/-/shell-web-0.1.95.tgz",
+      "integrity": "sha512-QqStS3A0J8jU8f5iOZ7At7wLB+O0jcfvOH2ekxrxkt3yJN58MMz1ry+cw9Dkl1/D0J6ldbONzRKAfAVMTAc0mQ==",
+      "dependencies": {
+        "@jskit-ai/kernel": "0.1.96",
+        "@mdi/js": "^7.4.47"
+      },
+      "peerDependencies": {
+        "pinia": "^3.0.4",
+        "vue": "^3.5.13",
+        "vue-router": "^5.0.4",
+        "vuetify": "^4.0.0"
+      }
+    },
     "packages/console-core": {
       "name": "@jskit-ai/console-core",
       "version": "0.1.59",
@@ -6774,6 +6852,14 @@
         "json-rest-schema": "1.x.x"
       }
     },
+    "packages/console-core/node_modules/@jskit-ai/kernel": {
+      "version": "0.1.96",
+      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.96.tgz",
+      "integrity": "sha512-aBBsAkoaOyWYxmbyQqnaoXrVRKvofBeTlfrYXOTcYkaAU+YDxHIO11SlUBeVicVBFve7zX405zXD/z14F7BRXw==",
+      "dependencies": {
+        "json-rest-schema": "1.x.x"
+      }
+    },
     "packages/console-web": {
       "name": "@jskit-ai/console-web",
       "version": "0.1.64",
@@ -6781,6 +6867,29 @@
         "@jskit-ai/auth-web": "0.1.97",
         "@jskit-ai/console-core": "0.1.59",
         "@jskit-ai/shell-web": "0.1.95"
+      }
+    },
+    "packages/console-web/node_modules/@jskit-ai/kernel": {
+      "version": "0.1.96",
+      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.96.tgz",
+      "integrity": "sha512-aBBsAkoaOyWYxmbyQqnaoXrVRKvofBeTlfrYXOTcYkaAU+YDxHIO11SlUBeVicVBFve7zX405zXD/z14F7BRXw==",
+      "dependencies": {
+        "json-rest-schema": "1.x.x"
+      }
+    },
+    "packages/console-web/node_modules/@jskit-ai/shell-web": {
+      "version": "0.1.95",
+      "resolved": "https://registry.npmjs.org/@jskit-ai/shell-web/-/shell-web-0.1.95.tgz",
+      "integrity": "sha512-QqStS3A0J8jU8f5iOZ7At7wLB+O0jcfvOH2ekxrxkt3yJN58MMz1ry+cw9Dkl1/D0J6ldbONzRKAfAVMTAc0mQ==",
+      "dependencies": {
+        "@jskit-ai/kernel": "0.1.96",
+        "@mdi/js": "^7.4.47"
+      },
+      "peerDependencies": {
+        "pinia": "^3.0.4",
+        "vue": "^3.5.13",
+        "vue-router": "^5.0.4",
+        "vuetify": "^4.0.0"
       }
     },
     "packages/crud-core": {
@@ -6803,6 +6912,29 @@
         "vue-router": "^5.0.4"
       }
     },
+    "packages/crud-core/node_modules/@jskit-ai/kernel": {
+      "version": "0.1.96",
+      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.96.tgz",
+      "integrity": "sha512-aBBsAkoaOyWYxmbyQqnaoXrVRKvofBeTlfrYXOTcYkaAU+YDxHIO11SlUBeVicVBFve7zX405zXD/z14F7BRXw==",
+      "dependencies": {
+        "json-rest-schema": "1.x.x"
+      }
+    },
+    "packages/crud-core/node_modules/@jskit-ai/shell-web": {
+      "version": "0.1.95",
+      "resolved": "https://registry.npmjs.org/@jskit-ai/shell-web/-/shell-web-0.1.95.tgz",
+      "integrity": "sha512-QqStS3A0J8jU8f5iOZ7At7wLB+O0jcfvOH2ekxrxkt3yJN58MMz1ry+cw9Dkl1/D0J6ldbONzRKAfAVMTAc0mQ==",
+      "dependencies": {
+        "@jskit-ai/kernel": "0.1.96",
+        "@mdi/js": "^7.4.47"
+      },
+      "peerDependencies": {
+        "pinia": "^3.0.4",
+        "vue": "^3.5.13",
+        "vue-router": "^5.0.4",
+        "vuetify": "^4.0.0"
+      }
+    },
     "packages/crud-server-generator": {
       "name": "@jskit-ai/crud-server-generator",
       "version": "0.1.104",
@@ -6817,6 +6949,14 @@
         "recast": "^0.23.11"
       }
     },
+    "packages/crud-server-generator/node_modules/@jskit-ai/kernel": {
+      "version": "0.1.96",
+      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.96.tgz",
+      "integrity": "sha512-aBBsAkoaOyWYxmbyQqnaoXrVRKvofBeTlfrYXOTcYkaAU+YDxHIO11SlUBeVicVBFve7zX405zXD/z14F7BRXw==",
+      "dependencies": {
+        "json-rest-schema": "1.x.x"
+      }
+    },
     "packages/crud-ui-generator": {
       "name": "@jskit-ai/crud-ui-generator",
       "version": "0.1.79",
@@ -6824,6 +6964,14 @@
         "@jskit-ai/crud-core": "0.1.104",
         "@jskit-ai/kernel": "0.1.96",
         "@jskit-ai/resource-crud-core": "0.1.41"
+      }
+    },
+    "packages/crud-ui-generator/node_modules/@jskit-ai/kernel": {
+      "version": "0.1.96",
+      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.96.tgz",
+      "integrity": "sha512-aBBsAkoaOyWYxmbyQqnaoXrVRKvofBeTlfrYXOTcYkaAU+YDxHIO11SlUBeVicVBFve7zX405zXD/z14F7BRXw==",
+      "dependencies": {
+        "json-rest-schema": "1.x.x"
       }
     },
     "packages/database-runtime": {
@@ -6841,11 +6989,27 @@
         "@jskit-ai/kernel": "0.1.96"
       }
     },
+    "packages/database-runtime-mysql/node_modules/@jskit-ai/kernel": {
+      "version": "0.1.96",
+      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.96.tgz",
+      "integrity": "sha512-aBBsAkoaOyWYxmbyQqnaoXrVRKvofBeTlfrYXOTcYkaAU+YDxHIO11SlUBeVicVBFve7zX405zXD/z14F7BRXw==",
+      "dependencies": {
+        "json-rest-schema": "1.x.x"
+      }
+    },
     "packages/database-runtime-postgres": {
       "name": "@jskit-ai/database-runtime-postgres",
       "version": "0.1.95",
       "dependencies": {
         "@jskit-ai/database-runtime": "0.1.96"
+      }
+    },
+    "packages/database-runtime/node_modules/@jskit-ai/kernel": {
+      "version": "0.1.96",
+      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.96.tgz",
+      "integrity": "sha512-aBBsAkoaOyWYxmbyQqnaoXrVRKvofBeTlfrYXOTcYkaAU+YDxHIO11SlUBeVicVBFve7zX405zXD/z14F7BRXw==",
+      "dependencies": {
+        "json-rest-schema": "1.x.x"
       }
     },
     "packages/feature-server-generator": {
@@ -6868,6 +7032,14 @@
         "json-rest-schema": "1.x.x"
       }
     },
+    "packages/http-runtime/node_modules/@jskit-ai/kernel": {
+      "version": "0.1.96",
+      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.96.tgz",
+      "integrity": "sha512-aBBsAkoaOyWYxmbyQqnaoXrVRKvofBeTlfrYXOTcYkaAU+YDxHIO11SlUBeVicVBFve7zX405zXD/z14F7BRXw==",
+      "dependencies": {
+        "json-rest-schema": "1.x.x"
+      }
+    },
     "packages/json-rest-api-core": {
       "name": "@jskit-ai/json-rest-api-core",
       "version": "0.1.41",
@@ -6877,9 +7049,17 @@
         "json-rest-api": "1.x.x"
       }
     },
+    "packages/json-rest-api-core/node_modules/@jskit-ai/kernel": {
+      "version": "0.1.96",
+      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.96.tgz",
+      "integrity": "sha512-aBBsAkoaOyWYxmbyQqnaoXrVRKvofBeTlfrYXOTcYkaAU+YDxHIO11SlUBeVicVBFve7zX405zXD/z14F7BRXw==",
+      "dependencies": {
+        "json-rest-schema": "1.x.x"
+      }
+    },
     "packages/kernel": {
       "name": "@jskit-ai/kernel",
-      "version": "0.1.96",
+      "version": "0.1.97",
       "dependencies": {
         "json-rest-schema": "1.x.x"
       }
@@ -6890,6 +7070,14 @@
       "dependencies": {
         "@capacitor/browser": "^7.0.1",
         "@jskit-ai/kernel": "0.1.96"
+      }
+    },
+    "packages/mobile-capacitor/node_modules/@jskit-ai/kernel": {
+      "version": "0.1.96",
+      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.96.tgz",
+      "integrity": "sha512-aBBsAkoaOyWYxmbyQqnaoXrVRKvofBeTlfrYXOTcYkaAU+YDxHIO11SlUBeVicVBFve7zX405zXD/z14F7BRXw==",
+      "dependencies": {
+        "json-rest-schema": "1.x.x"
       }
     },
     "packages/realtime": {
@@ -6906,11 +7094,27 @@
         "vue": "^3.5.13"
       }
     },
+    "packages/realtime/node_modules/@jskit-ai/kernel": {
+      "version": "0.1.96",
+      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.96.tgz",
+      "integrity": "sha512-aBBsAkoaOyWYxmbyQqnaoXrVRKvofBeTlfrYXOTcYkaAU+YDxHIO11SlUBeVicVBFve7zX405zXD/z14F7BRXw==",
+      "dependencies": {
+        "json-rest-schema": "1.x.x"
+      }
+    },
     "packages/resource-core": {
       "name": "@jskit-ai/resource-core",
       "version": "0.1.41",
       "dependencies": {
         "@jskit-ai/kernel": "0.1.96"
+      }
+    },
+    "packages/resource-core/node_modules/@jskit-ai/kernel": {
+      "version": "0.1.96",
+      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.96.tgz",
+      "integrity": "sha512-aBBsAkoaOyWYxmbyQqnaoXrVRKvofBeTlfrYXOTcYkaAU+YDxHIO11SlUBeVicVBFve7zX405zXD/z14F7BRXw==",
+      "dependencies": {
+        "json-rest-schema": "1.x.x"
       }
     },
     "packages/resource-crud-core": {
@@ -6921,11 +7125,19 @@
         "@jskit-ai/resource-core": "0.1.41"
       }
     },
+    "packages/resource-crud-core/node_modules/@jskit-ai/kernel": {
+      "version": "0.1.96",
+      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.96.tgz",
+      "integrity": "sha512-aBBsAkoaOyWYxmbyQqnaoXrVRKvofBeTlfrYXOTcYkaAU+YDxHIO11SlUBeVicVBFve7zX405zXD/z14F7BRXw==",
+      "dependencies": {
+        "json-rest-schema": "1.x.x"
+      }
+    },
     "packages/shell-web": {
       "name": "@jskit-ai/shell-web",
-      "version": "0.1.95",
+      "version": "0.1.96",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.96",
+        "@jskit-ai/kernel": "0.1.97",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -6943,12 +7155,43 @@
         "unstorage": "^1.17.3"
       }
     },
+    "packages/storage-runtime/node_modules/@jskit-ai/kernel": {
+      "version": "0.1.96",
+      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.96.tgz",
+      "integrity": "sha512-aBBsAkoaOyWYxmbyQqnaoXrVRKvofBeTlfrYXOTcYkaAU+YDxHIO11SlUBeVicVBFve7zX405zXD/z14F7BRXw==",
+      "dependencies": {
+        "json-rest-schema": "1.x.x"
+      }
+    },
     "packages/ui-generator": {
       "name": "@jskit-ai/ui-generator",
       "version": "0.1.79",
       "dependencies": {
         "@jskit-ai/kernel": "0.1.96",
         "@jskit-ai/shell-web": "0.1.95"
+      }
+    },
+    "packages/ui-generator/node_modules/@jskit-ai/kernel": {
+      "version": "0.1.96",
+      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.96.tgz",
+      "integrity": "sha512-aBBsAkoaOyWYxmbyQqnaoXrVRKvofBeTlfrYXOTcYkaAU+YDxHIO11SlUBeVicVBFve7zX405zXD/z14F7BRXw==",
+      "dependencies": {
+        "json-rest-schema": "1.x.x"
+      }
+    },
+    "packages/ui-generator/node_modules/@jskit-ai/shell-web": {
+      "version": "0.1.95",
+      "resolved": "https://registry.npmjs.org/@jskit-ai/shell-web/-/shell-web-0.1.95.tgz",
+      "integrity": "sha512-QqStS3A0J8jU8f5iOZ7At7wLB+O0jcfvOH2ekxrxkt3yJN58MMz1ry+cw9Dkl1/D0J6ldbONzRKAfAVMTAc0mQ==",
+      "dependencies": {
+        "@jskit-ai/kernel": "0.1.96",
+        "@mdi/js": "^7.4.47"
+      },
+      "peerDependencies": {
+        "pinia": "^3.0.4",
+        "vue": "^3.5.13",
+        "vue-router": "^5.0.4",
+        "vuetify": "^4.0.0"
       }
     },
     "packages/uploads-image-web": {
@@ -6974,6 +7217,14 @@
         "@jskit-ai/kernel": "0.1.96"
       }
     },
+    "packages/uploads-runtime/node_modules/@jskit-ai/kernel": {
+      "version": "0.1.96",
+      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.96.tgz",
+      "integrity": "sha512-aBBsAkoaOyWYxmbyQqnaoXrVRKvofBeTlfrYXOTcYkaAU+YDxHIO11SlUBeVicVBFve7zX405zXD/z14F7BRXw==",
+      "dependencies": {
+        "json-rest-schema": "1.x.x"
+      }
+    },
     "packages/users-core": {
       "name": "@jskit-ai/users-core",
       "version": "0.1.106",
@@ -6986,6 +7237,14 @@
         "@jskit-ai/resource-core": "0.1.41",
         "@jskit-ai/resource-crud-core": "0.1.41",
         "@jskit-ai/uploads-runtime": "0.1.74",
+        "json-rest-schema": "1.x.x"
+      }
+    },
+    "packages/users-core/node_modules/@jskit-ai/kernel": {
+      "version": "0.1.96",
+      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.96.tgz",
+      "integrity": "sha512-aBBsAkoaOyWYxmbyQqnaoXrVRKvofBeTlfrYXOTcYkaAU+YDxHIO11SlUBeVicVBFve7zX405zXD/z14F7BRXw==",
+      "dependencies": {
         "json-rest-schema": "1.x.x"
       }
     },
@@ -7008,6 +7267,29 @@
         "vuetify": "^4.0.0"
       }
     },
+    "packages/users-web/node_modules/@jskit-ai/kernel": {
+      "version": "0.1.96",
+      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.96.tgz",
+      "integrity": "sha512-aBBsAkoaOyWYxmbyQqnaoXrVRKvofBeTlfrYXOTcYkaAU+YDxHIO11SlUBeVicVBFve7zX405zXD/z14F7BRXw==",
+      "dependencies": {
+        "json-rest-schema": "1.x.x"
+      }
+    },
+    "packages/users-web/node_modules/@jskit-ai/shell-web": {
+      "version": "0.1.95",
+      "resolved": "https://registry.npmjs.org/@jskit-ai/shell-web/-/shell-web-0.1.95.tgz",
+      "integrity": "sha512-QqStS3A0J8jU8f5iOZ7At7wLB+O0jcfvOH2ekxrxkt3yJN58MMz1ry+cw9Dkl1/D0J6ldbONzRKAfAVMTAc0mQ==",
+      "dependencies": {
+        "@jskit-ai/kernel": "0.1.96",
+        "@mdi/js": "^7.4.47"
+      },
+      "peerDependencies": {
+        "pinia": "^3.0.4",
+        "vue": "^3.5.13",
+        "vue-router": "^5.0.4",
+        "vuetify": "^4.0.0"
+      }
+    },
     "packages/workspaces-core": {
       "name": "@jskit-ai/workspaces-core",
       "version": "0.1.72",
@@ -7020,6 +7302,14 @@
         "@jskit-ai/resource-core": "0.1.41",
         "@jskit-ai/resource-crud-core": "0.1.41",
         "@jskit-ai/users-core": "0.1.106",
+        "json-rest-schema": "1.x.x"
+      }
+    },
+    "packages/workspaces-core/node_modules/@jskit-ai/kernel": {
+      "version": "0.1.96",
+      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.96.tgz",
+      "integrity": "sha512-aBBsAkoaOyWYxmbyQqnaoXrVRKvofBeTlfrYXOTcYkaAU+YDxHIO11SlUBeVicVBFve7zX405zXD/z14F7BRXw==",
+      "dependencies": {
         "json-rest-schema": "1.x.x"
       }
     },
@@ -7037,6 +7327,29 @@
       },
       "peerDependencies": {
         "@tanstack/vue-query": "^5.90.5",
+        "vue": "^3.5.13",
+        "vue-router": "^5.0.4",
+        "vuetify": "^4.0.0"
+      }
+    },
+    "packages/workspaces-web/node_modules/@jskit-ai/kernel": {
+      "version": "0.1.96",
+      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.96.tgz",
+      "integrity": "sha512-aBBsAkoaOyWYxmbyQqnaoXrVRKvofBeTlfrYXOTcYkaAU+YDxHIO11SlUBeVicVBFve7zX405zXD/z14F7BRXw==",
+      "dependencies": {
+        "json-rest-schema": "1.x.x"
+      }
+    },
+    "packages/workspaces-web/node_modules/@jskit-ai/shell-web": {
+      "version": "0.1.95",
+      "resolved": "https://registry.npmjs.org/@jskit-ai/shell-web/-/shell-web-0.1.95.tgz",
+      "integrity": "sha512-QqStS3A0J8jU8f5iOZ7At7wLB+O0jcfvOH2ekxrxkt3yJN58MMz1ry+cw9Dkl1/D0J6ldbONzRKAfAVMTAc0mQ==",
+      "dependencies": {
+        "@jskit-ai/kernel": "0.1.96",
+        "@mdi/js": "^7.4.47"
+      },
+      "peerDependencies": {
+        "pinia": "^3.0.4",
         "vue": "^3.5.13",
         "vue-router": "^5.0.4",
         "vuetify": "^4.0.0"
@@ -7092,6 +7405,29 @@
       },
       "engines": {
         "node": ">=20 <23"
+      }
+    },
+    "tooling/jskit-cli/node_modules/@jskit-ai/kernel": {
+      "version": "0.1.96",
+      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.96.tgz",
+      "integrity": "sha512-aBBsAkoaOyWYxmbyQqnaoXrVRKvofBeTlfrYXOTcYkaAU+YDxHIO11SlUBeVicVBFve7zX405zXD/z14F7BRXw==",
+      "dependencies": {
+        "json-rest-schema": "1.x.x"
+      }
+    },
+    "tooling/jskit-cli/node_modules/@jskit-ai/shell-web": {
+      "version": "0.1.95",
+      "resolved": "https://registry.npmjs.org/@jskit-ai/shell-web/-/shell-web-0.1.95.tgz",
+      "integrity": "sha512-QqStS3A0J8jU8f5iOZ7At7wLB+O0jcfvOH2ekxrxkt3yJN58MMz1ry+cw9Dkl1/D0J6ldbONzRKAfAVMTAc0mQ==",
+      "dependencies": {
+        "@jskit-ai/kernel": "0.1.96",
+        "@mdi/js": "^7.4.47"
+      },
+      "peerDependencies": {
+        "pinia": "^3.0.4",
+        "vue": "^3.5.13",
+        "vue-router": "^5.0.4",
+        "vuetify": "^4.0.0"
       }
     },
     "tooling/testUtils": {}

--- a/packages/agent-docs/guide/agent/app-setup/initial-scaffolding.md
+++ b/packages/agent-docs/guide/agent/app-setup/initial-scaffolding.md
@@ -159,6 +159,9 @@ The most important parts look like this:
 
 ```json
 {
+  "engines": {
+    "node": "^20.19.0 || ^22.12.0"
+  },
   "scripts": {
     "server": "node ./bin/server.js",
     "server:all": "node ./bin/server.js",
@@ -181,26 +184,26 @@ The most important parts look like this:
   },
   "dependencies": {
     "@local/main": "file:packages/main",
-    "@fastify/static": "^9.1.1",
+    "@fastify/static": "^9.1.3",
     "@jskit-ai/kernel": "0.x",
-    "@tanstack/vue-query": "^5.90.5",
+    "@tanstack/vue-query": "^5.101.0",
     "@jskit-ai/http-runtime": "0.x",
-    "fastify": "^5.7.4",
-    "json-rest-schema": "^1.0.13",
+    "fastify": "^5.8.5",
+    "json-rest-schema": "^1.0.16",
     "pinia": "^3.0.4",
-    "vue": "^3.5.13",
-    "vue-router": "^5.0.4",
-    "vuetify": "^4.0.0"
+    "vue": "^3.5.38",
+    "vue-router": "^5.1.0",
+    "vuetify": "^4.1.2"
   },
   "devDependencies": {
     "@jskit-ai/agent-docs": "0.x",
     "@jskit-ai/config-eslint": "0.x",
     "@jskit-ai/jskit-cli": "0.x",
-    "@playwright/test": "^1.57.0",
-    "@vitejs/plugin-vue": "^5.2.1",
-    "eslint": "^9.39.1",
-    "vite": "^6.1.0",
-    "vitest": "^4.0.18"
+    "@playwright/test": "^1.61.0",
+    "@vitejs/plugin-vue": "^6.0.7",
+    "eslint": "^9.39.4",
+    "vite": "^8.0.16",
+    "vitest": "^4.1.9"
   }
 }
 ```

--- a/packages/agent-docs/package.json
+++ b/packages/agent-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/agent-docs",
-  "version": "0.1.57",
+  "version": "0.1.58",
   "description": "Distributed JSKIT agent references, prompts, guides, and generated reference maps.",
   "type": "module",
   "files": [

--- a/packages/agent-docs/site/guide/app-setup/initial-scaffolding.md
+++ b/packages/agent-docs/site/guide/app-setup/initial-scaffolding.md
@@ -174,6 +174,9 @@ The most important parts look like this:
 
 ```json
 {
+  "engines": {
+    "node": "^20.19.0 || ^22.12.0"
+  },
   "scripts": {
     "server": "node ./bin/server.js",
     "server:all": "node ./bin/server.js",
@@ -196,26 +199,26 @@ The most important parts look like this:
   },
   "dependencies": {
     "@local/main": "file:packages/main",
-    "@fastify/static": "^9.1.1",
+    "@fastify/static": "^9.1.3",
     "@jskit-ai/kernel": "0.x",
-    "@tanstack/vue-query": "^5.90.5",
+    "@tanstack/vue-query": "^5.101.0",
     "@jskit-ai/http-runtime": "0.x",
-    "fastify": "^5.7.4",
-    "json-rest-schema": "^1.0.13",
+    "fastify": "^5.8.5",
+    "json-rest-schema": "^1.0.16",
     "pinia": "^3.0.4",
-    "vue": "^3.5.13",
-    "vue-router": "^5.0.4",
-    "vuetify": "^4.0.0"
+    "vue": "^3.5.38",
+    "vue-router": "^5.1.0",
+    "vuetify": "^4.1.2"
   },
   "devDependencies": {
     "@jskit-ai/agent-docs": "0.x",
     "@jskit-ai/config-eslint": "0.x",
     "@jskit-ai/jskit-cli": "0.x",
-    "@playwright/test": "^1.57.0",
-    "@vitejs/plugin-vue": "^5.2.1",
-    "eslint": "^9.39.1",
-    "vite": "^6.1.0",
-    "vitest": "^4.0.18"
+    "@playwright/test": "^1.61.0",
+    "@vitejs/plugin-vue": "^6.0.7",
+    "eslint": "^9.39.4",
+    "vite": "^8.0.16",
+    "vitest": "^4.1.9"
   }
 }
 ```

--- a/packages/kernel/client/descriptorSections.js
+++ b/packages/kernel/client/descriptorSections.js
@@ -45,7 +45,7 @@ function normalizeDescriptorClientProviders(value) {
   return Object.freeze(providers);
 }
 
-function normalizeDescriptorClientOptimizeIncludeSpecifiers(value) {
+function normalizeDescriptorClientOptimizeSpecifiers(value) {
   return Object.freeze(sortStrings(value));
 }
 
@@ -61,15 +61,14 @@ function normalizeClientDescriptorSections(descriptorValue) {
   return Object.freeze({
     descriptorUiRoutes: normalizeDescriptorUiRoutes(ui.routes),
     descriptorClientProviders: normalizeDescriptorClientProviders(runtimeClient.providers),
-    descriptorClientOptimizeIncludeSpecifiers: normalizeDescriptorClientOptimizeIncludeSpecifiers(
-      optimizeDeps.include
-    )
+    descriptorClientOptimizeIncludeSpecifiers: normalizeDescriptorClientOptimizeSpecifiers(optimizeDeps.include),
+    descriptorClientOptimizeExcludeSpecifiers: normalizeDescriptorClientOptimizeSpecifiers(optimizeDeps.exclude)
   });
 }
 
 export {
   normalizeDescriptorUiRoutes,
   normalizeDescriptorClientProviders,
-  normalizeDescriptorClientOptimizeIncludeSpecifiers,
+  normalizeDescriptorClientOptimizeSpecifiers,
   normalizeClientDescriptorSections
 };

--- a/packages/kernel/client/vite/clientBootstrapPlugin.js
+++ b/packages/kernel/client/vite/clientBootstrapPlugin.js
@@ -5,7 +5,7 @@ import { normalizeObject } from "../../shared/support/normalize.js";
 import { sortStrings } from "../../shared/support/sorting.js";
 import {
   normalizeDescriptorClientProviders,
-  normalizeDescriptorClientOptimizeIncludeSpecifiers,
+  normalizeDescriptorClientOptimizeSpecifiers,
   normalizeDescriptorUiRoutes,
   normalizeClientDescriptorSections
 } from "../descriptorSections.js";
@@ -67,7 +67,8 @@ async function resolveInstalledClientModules({ appRoot, lockPath }) {
         sourceType: String(installedPackageState?.source?.type || "").trim().toLowerCase(),
         descriptorUiRoutes: descriptorSections.descriptorUiRoutes,
         descriptorClientProviders: descriptorSections.descriptorClientProviders,
-        descriptorClientOptimizeIncludeSpecifiers: descriptorSections.descriptorClientOptimizeIncludeSpecifiers
+        descriptorClientOptimizeIncludeSpecifiers: descriptorSections.descriptorClientOptimizeIncludeSpecifiers,
+        descriptorClientOptimizeExcludeSpecifiers: descriptorSections.descriptorClientOptimizeExcludeSpecifiers
       })
     );
   }
@@ -113,8 +114,11 @@ function normalizeClientModuleDescriptors(value) {
       sourceType,
       descriptorUiRoutes: normalizeDescriptorUiRoutes(record.descriptorUiRoutes),
       descriptorClientProviders: normalizeDescriptorClientProviders(record.descriptorClientProviders),
-      descriptorClientOptimizeIncludeSpecifiers: normalizeDescriptorClientOptimizeIncludeSpecifiers(
+      descriptorClientOptimizeIncludeSpecifiers: normalizeDescriptorClientOptimizeSpecifiers(
         record.descriptorClientOptimizeIncludeSpecifiers
+      ),
+      descriptorClientOptimizeExcludeSpecifiers: normalizeDescriptorClientOptimizeSpecifiers(
+        record.descriptorClientOptimizeExcludeSpecifiers
       )
     });
   }
@@ -158,22 +162,26 @@ function resolveClientOptimizeExcludeSpecifiers(clientModules = []) {
   const moduleDescriptors = normalizeClientModuleDescriptors(clientModules);
   const localSourceTypes = new Set(["local-package", "app-local-package"]);
   return sortStrings(
-    moduleDescriptors
-      .filter((entry) => localSourceTypes.has(entry.sourceType))
-      .flatMap((entry) => [entry.packageId, `${entry.packageId}/shared`, `${entry.packageId}/client`])
+    [
+      ...moduleDescriptors
+        .filter((entry) => localSourceTypes.has(entry.sourceType))
+        .flatMap((entry) => [entry.packageId, `${entry.packageId}/shared`, `${entry.packageId}/client`]),
+      ...moduleDescriptors.flatMap((entry) => entry.descriptorClientOptimizeExcludeSpecifiers || [])
+    ]
   );
 }
 
-function resolveClientOptimizeIncludeSpecifiers(clientModules = []) {
+function resolveClientOptimizeIncludeSpecifiers(clientModules = [], excludeSpecifiers = []) {
   const moduleDescriptors = normalizeClientModuleDescriptors(clientModules);
   const localSourceTypes = new Set(["local-package", "app-local-package"]);
+  const excluded = new Set(sortStrings(excludeSpecifiers));
   return sortStrings(
     [
       ...moduleDescriptors
       .filter((entry) => !localSourceTypes.has(entry.sourceType))
       .map((entry) => `${entry.packageId}/client`),
       ...moduleDescriptors.flatMap((entry) => entry.descriptorClientOptimizeIncludeSpecifiers || [])
-    ]
+    ].filter((specifier) => !excluded.has(specifier))
   );
 }
 
@@ -204,12 +212,12 @@ function createJskitClientBootstrapPlugin({ lockPath = ".jskit/lock.json" } = {}
       });
       const clientExcludeSpecifiers = resolveClientOptimizeExcludeSpecifiers(clientModules);
       const localScopeExcludeSpecifiers = resolveLocalScopeOptimizeExcludeSpecifiers(localScopePackageIds);
-      const clientIncludeSpecifiers = resolveClientOptimizeIncludeSpecifiers(clientModules);
       const userOptimizeDeps = normalizeObject(userConfig.optimizeDeps);
       const userExclude = sortStrings(userOptimizeDeps.exclude);
       const userInclude = sortStrings(userOptimizeDeps.include);
       const exclude = sortStrings([...userExclude, ...clientExcludeSpecifiers, ...localScopeExcludeSpecifiers]);
-      const include = sortStrings([...userInclude, ...clientIncludeSpecifiers]);
+      const clientIncludeSpecifiers = resolveClientOptimizeIncludeSpecifiers(clientModules, exclude);
+      const include = sortStrings([...userInclude, ...clientIncludeSpecifiers].filter((specifier) => !exclude.includes(specifier)));
       const userResolve = normalizeObject(userConfig.resolve);
       const dedupe = resolveClientRuntimeDedupeSpecifiers(userResolve);
 

--- a/packages/kernel/client/vite/clientBootstrapPlugin.test.js
+++ b/packages/kernel/client/vite/clientBootstrapPlugin.test.js
@@ -82,6 +82,31 @@ test("resolveClientOptimizeExcludeSpecifiers excludes local/app-local package ro
   ]);
 });
 
+test("resolveClientOptimizeExcludeSpecifiers includes descriptor-declared excludes", () => {
+  const exclude = resolveClientOptimizeExcludeSpecifiers([
+    {
+      packageId: "@z/pkg",
+      sourceType: "packages-directory",
+      descriptorUiRoutes: [],
+      descriptorClientOptimizeExcludeSpecifiers: ["@z/pkg/client"]
+    },
+    {
+      packageId: "@a/pkg",
+      sourceType: "local-package",
+      descriptorUiRoutes: [],
+      descriptorClientOptimizeExcludeSpecifiers: ["external-problem-dep"]
+    }
+  ]);
+
+  assert.deepEqual(exclude, [
+    "@a/pkg",
+    "@a/pkg/client",
+    "@a/pkg/shared",
+    "@z/pkg/client",
+    "external-problem-dep"
+  ]);
+});
+
 test("resolveClientOptimizeIncludeSpecifiers includes only non-local package clients", () => {
   const include = resolveClientOptimizeIncludeSpecifiers([
     {
@@ -107,6 +132,27 @@ test("resolveClientOptimizeIncludeSpecifiers includes only non-local package cli
   ]);
 
   assert.deepEqual(include, ["@c/pkg/client", "@z/pkg/client"]);
+});
+
+test("resolveClientOptimizeIncludeSpecifiers omits excluded package clients", () => {
+  const include = resolveClientOptimizeIncludeSpecifiers(
+    [
+      {
+        packageId: "@z/pkg",
+        sourceType: "packages-directory",
+        descriptorUiRoutes: []
+      },
+      {
+        packageId: "@c/pkg",
+        sourceType: "npm",
+        descriptorUiRoutes: [],
+        descriptorClientOptimizeIncludeSpecifiers: ["extra-dep"]
+      }
+    ],
+    ["@z/pkg/client", "extra-dep"]
+  );
+
+  assert.deepEqual(include, ["@c/pkg/client"]);
 });
 
 test("resolveLocalScopeOptimizeExcludeSpecifiers expands @local package ids to root/client/shared", () => {
@@ -405,6 +451,58 @@ test("createJskitClientBootstrapPlugin config excludes installed client package 
     assert.deepEqual(result.optimizeDeps.exclude, ["already/excluded"]);
     assert.deepEqual(result.optimizeDeps.include, ["@example/has-client/client", "a"]);
     assert.deepEqual(result.resolve.dedupe, ["@tanstack/vue-query", "pinia", "vue", "vue-router", "vuetify"]);
+  } finally {
+    process.chdir(previousCwd);
+  }
+});
+
+test("createJskitClientBootstrapPlugin config lets descriptor excludes override automatic client includes", async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "jskit-client-bootstrap-config-descriptor-exclude-"));
+  const previousCwd = process.cwd();
+
+  try {
+    await mkdir(path.join(tempRoot, ".jskit"), { recursive: true });
+    await writeJson(path.join(tempRoot, ".jskit", "lock.json"), {
+      lockVersion: 1,
+      installedPackages: {
+        "@example/app-bound-client": {
+          source: {
+            type: "npm"
+          }
+        }
+      }
+    });
+
+    const packageRoot = path.join(tempRoot, "node_modules", "@example", "app-bound-client");
+    await mkdir(packageRoot, { recursive: true });
+    await writeJson(path.join(packageRoot, "package.json"), {
+      name: "@example/app-bound-client",
+      exports: {
+        "./client": "./src/client/index.js"
+      }
+    });
+    await writeDescriptor(path.join(packageRoot, "package.descriptor.mjs"), {
+      metadata: {
+        client: {
+          optimizeDeps: {
+            include: ["safe-helper"],
+            exclude: ["@example/app-bound-client/client"]
+          }
+        }
+      }
+    });
+
+    process.chdir(tempRoot);
+    const plugin = createJskitClientBootstrapPlugin();
+    const result = await plugin.config({
+      optimizeDeps: {
+        include: ["@example/app-bound-client/client", "user-helper"],
+        exclude: ["user-excluded"]
+      }
+    });
+
+    assert.deepEqual(result.optimizeDeps.exclude, ["@example/app-bound-client/client", "user-excluded"]);
+    assert.deepEqual(result.optimizeDeps.include, ["safe-helper", "user-helper"]);
   } finally {
     process.chdir(previousCwd);
   }

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/kernel",
-  "version": "0.1.96",
+  "version": "0.1.97",
   "type": "module",
   "dependencies": {
     "json-rest-schema": "1.x.x"

--- a/packages/shell-web/package.descriptor.mjs
+++ b/packages/shell-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/shell-web",
-  version: "0.1.95",
+  version: "0.1.96",
   kind: "runtime",
   description: "Web shell layout runtime with outlet-based placement contributions.",
   dependsOn: [],
@@ -28,6 +28,13 @@ export default Object.freeze({
     }
   },
   metadata: {
+    client: {
+      optimizeDeps: {
+        exclude: [
+          "@jskit-ai/shell-web/client"
+        ]
+      }
+    },
     apiSummary: {
       surfaces: [
         {
@@ -300,7 +307,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/kernel": "0.1.96"
+        "@jskit-ai/kernel": "0.1.97"
       },
       dev: {}
     },

--- a/packages/shell-web/package.json
+++ b/packages/shell-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/shell-web",
-  "version": "0.1.95",
+  "version": "0.1.96",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/kernel": "0.1.96"
+    "@jskit-ai/kernel": "0.1.97"
   },
   "peerDependencies": {
     "pinia": "^3.0.4",

--- a/packages/shell-web/src/client/components/ShellMenuLinkItem.vue
+++ b/packages/shell-web/src/client/components/ShellMenuLinkItem.vue
@@ -61,6 +61,7 @@ const resolvedIcon = computed(() =>
 <template>
   <v-list-item
     v-if="resolvedTarget.href"
+    class="shell-menu-link-item"
     :title="props.label"
     :to="resolvedTarget.sameOrigin ? resolvedTarget.href : undefined"
     :href="resolvedTarget.sameOrigin ? undefined : resolvedTarget.href"
@@ -69,3 +70,9 @@ const resolvedIcon = computed(() =>
     :exact="props.exact"
   />
 </template>
+
+<style scoped>
+.shell-menu-link-item {
+  min-height: 48px;
+}
+</style>

--- a/packages/shell-web/src/client/components/ShellSurfaceAwareMenuLinkItem.vue
+++ b/packages/shell-web/src/client/components/ShellSurfaceAwareMenuLinkItem.vue
@@ -106,6 +106,7 @@ const resolvedIcon = computed(() =>
 <template>
   <v-list-item
     v-if="resolvedTarget.href"
+    class="shell-menu-link-item"
     :title="props.label"
     :to="resolvedTarget.sameOrigin ? resolvedTarget.href : undefined"
     :href="resolvedTarget.sameOrigin ? undefined : resolvedTarget.href"
@@ -114,3 +115,9 @@ const resolvedIcon = computed(() =>
     :exact="props.exact"
   />
 </template>
+
+<style scoped>
+.shell-menu-link-item {
+  min-height: 48px;
+}
+</style>

--- a/packages/shell-web/test/linkItemScaffoldContract.test.js
+++ b/packages/shell-web/test/linkItemScaffoldContract.test.js
@@ -151,8 +151,12 @@ test("shell-web generic link items support the expected shared route and icon be
 
   assert.match(shellMenuSource, /exact:\s*\{/);
   assert.match(shellMenuSource, /:exact="props\.exact"/);
+  assert.match(shellMenuSource, /class="shell-menu-link-item"/);
+  assert.match(shellMenuSource, /min-height:\s*48px/);
   assert.match(shellSurfaceAwareSource, /exact:\s*\{/);
   assert.match(shellSurfaceAwareSource, /:exact="props\.exact"/);
+  assert.match(shellSurfaceAwareSource, /class="shell-menu-link-item"/);
+  assert.match(shellSurfaceAwareSource, /min-height:\s*48px/);
   assert.match(shellTabSource, /icon:\s*\{/);
   assert.match(shellTabSource, /resolveMenuLinkIcon/);
   assert.match(shellTabSource, /<v-btn/);

--- a/packages/shell-web/test/settingsPlacementContract.test.js
+++ b/packages/shell-web/test/settingsPlacementContract.test.js
@@ -316,6 +316,10 @@ test("shell-web placement topology seeds global actions as a semantic shell plac
 });
 
 test("shell-web descriptor metadata advertises adaptive shell outlets, default links, and installs the scaffold page", () => {
+  assert.deepEqual(descriptor?.metadata?.client?.optimizeDeps?.exclude, [
+    "@jskit-ai/shell-web/client"
+  ]);
+
   assert.deepEqual(readClientContainerTokens(), [
     "runtime.web-placement.client",
     "runtime.web-bootstrap.client",

--- a/tooling/create-app/package.descriptor.mjs
+++ b/tooling/create-app/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/create-app",
-  "version": "0.1.104",
+  "version": "0.1.105",
   "dependsOn": [],
   "capabilities": {
     "provides": [

--- a/tooling/create-app/package.json
+++ b/tooling/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/create-app",
-  "version": "0.1.104",
+  "version": "0.1.105",
   "description": "Scaffold JSKIT app shells.",
   "type": "module",
   "files": [

--- a/tooling/create-app/templates/base-shell/package.json
+++ b/tooling/create-app/templates/base-shell/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "description": "JSKIT shell-web app (Fastify + Vue)",
   "engines": {
-    "node": ">=20 <23"
+    "node": "^20.19.0 || ^22.12.0"
   },
   "scripts": {
     "server": "node ./bin/server.js",
@@ -30,15 +30,15 @@
   },
   "dependencies": {
     "@local/main": "file:packages/main",
-    "@fastify/static": "^9.1.1",
+    "@fastify/static": "^9.1.3",
     "@jskit-ai/kernel": "0.x",
-    "@tanstack/vue-query": "^5.90.5",
-    "fastify": "^5.7.4",
-    "json-rest-schema": "^1.0.13",
+    "@tanstack/vue-query": "^5.101.0",
+    "fastify": "^5.8.5",
+    "json-rest-schema": "^1.0.16",
     "pinia": "^3.0.4",
-    "vue": "^3.5.13",
-    "vue-router": "^5.0.4",
-    "vuetify": "^4.0.0",
+    "vue": "^3.5.38",
+    "vue-router": "^5.1.0",
+    "vuetify": "^4.1.2",
     "@jskit-ai/http-runtime": "0.x",
     "@mdi/js": "^7.4.47",
     "@jskit-ai/shell-web": "0.x"
@@ -47,11 +47,11 @@
     "@jskit-ai/agent-docs": "0.x",
     "@jskit-ai/config-eslint": "0.x",
     "@jskit-ai/jskit-cli": "0.x",
-    "@playwright/test": "^1.57.0",
-    "@vitejs/plugin-vue": "^5.2.1",
-    "eslint": "^9.39.1",
-    "vite": "^6.1.0",
+    "@playwright/test": "^1.61.0",
+    "@vitejs/plugin-vue": "^6.0.7",
+    "eslint": "^9.39.4",
+    "vite": "^8.0.16",
     "vite-plugin-vuetify": "^2.1.3",
-    "vitest": "^4.0.18"
+    "vitest": "^4.1.9"
   }
 }

--- a/tooling/create-app/templates/minimal-shell/package.json
+++ b/tooling/create-app/templates/minimal-shell/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "description": "Minimal JSKIT base app (Fastify + Vue)",
   "engines": {
-    "node": ">=20 <23"
+    "node": "^20.19.0 || ^22.12.0"
   },
   "scripts": {
     "server": "node ./bin/server.js",
@@ -30,26 +30,26 @@
   },
   "dependencies": {
     "@local/main": "file:packages/main",
-    "@fastify/static": "^9.1.1",
+    "@fastify/static": "^9.1.3",
     "@jskit-ai/kernel": "0.x",
-    "@tanstack/vue-query": "^5.90.5",
-    "fastify": "^5.7.4",
-    "json-rest-schema": "^1.0.13",
+    "@tanstack/vue-query": "^5.101.0",
+    "fastify": "^5.8.5",
+    "json-rest-schema": "^1.0.16",
     "pinia": "^3.0.4",
-    "vue": "^3.5.13",
-    "vue-router": "^5.0.4",
-    "vuetify": "^4.0.0",
+    "vue": "^3.5.38",
+    "vue-router": "^5.1.0",
+    "vuetify": "^4.1.2",
     "@jskit-ai/http-runtime": "0.x"
   },
   "devDependencies": {
     "@jskit-ai/agent-docs": "0.x",
     "@jskit-ai/config-eslint": "0.x",
     "@jskit-ai/jskit-cli": "0.x",
-    "@playwright/test": "^1.57.0",
-    "@vitejs/plugin-vue": "^5.2.1",
-    "eslint": "^9.39.1",
-    "vite": "^6.1.0",
+    "@playwright/test": "^1.61.0",
+    "@vitejs/plugin-vue": "^6.0.7",
+    "eslint": "^9.39.4",
+    "vite": "^8.0.16",
     "vite-plugin-vuetify": "^2.1.3",
-    "vitest": "^4.0.18"
+    "vitest": "^4.1.9"
   }
 }

--- a/tooling/create-app/test/createApp.test.js
+++ b/tooling/create-app/test/createApp.test.js
@@ -118,6 +118,7 @@ test("create-app scaffolds the base shell with placeholder replacements", async 
     const appRoot = path.join(cwd, "sample-app");
     const packageJson = JSON.parse(await readFile(path.join(appRoot, "package.json"), "utf8"));
     assert.equal(packageJson.name, "sample-app");
+    assert.equal(packageJson.engines.node, "^20.19.0 || ^22.12.0");
     assert.equal(packageJson.scripts.preinstall, undefined);
     assert.equal(packageJson.scripts["verdaccio:reset:publish"], undefined);
     assert.equal(packageJson.scripts.postinstall, undefined);
@@ -149,7 +150,7 @@ test("create-app scaffolds the base shell with placeholder replacements", async 
     assert.equal(packageJson.scripts.release, "jskit app release");
     assert.equal(packageJson.scripts["jskit:update"], "jskit app update-packages");
     assert.equal(packageJson.dependencies["@local/main"], "file:packages/main");
-    assert.equal(packageJson.dependencies["@fastify/static"], "^9.1.1");
+    assert.equal(packageJson.dependencies["@fastify/static"], "^9.1.3");
     assert.match(packageJson.dependencies["@jskit-ai/http-runtime"], /^\d+\.x$/);
     assert.equal(packageJson.dependencies["@mdi/js"], "^7.4.47");
     assert.match(packageJson.dependencies["@jskit-ai/shell-web"], /^\d+\.x$/);
@@ -158,8 +159,15 @@ test("create-app scaffolds the base shell with placeholder replacements", async 
       false
     );
     assert.equal(packageJson.dependencies.pinia, "^3.0.4");
-    assert.equal(packageJson.dependencies["@tanstack/vue-query"], "^5.90.5");
-    assert.equal(packageJson.devDependencies["@playwright/test"], "^1.57.0");
+    assert.equal(packageJson.dependencies.vue, "^3.5.38");
+    assert.equal(packageJson.dependencies["vue-router"], "^5.1.0");
+    assert.equal(packageJson.dependencies.vuetify, "^4.1.2");
+    assert.equal(packageJson.dependencies["@tanstack/vue-query"], "^5.101.0");
+    assert.equal(packageJson.devDependencies["@playwright/test"], "^1.61.0");
+    assert.equal(packageJson.devDependencies["@vitejs/plugin-vue"], "^6.0.7");
+    assert.equal(packageJson.devDependencies.eslint, "^9.39.4");
+    assert.equal(packageJson.devDependencies.vite, "^8.0.16");
+    assert.equal(packageJson.devDependencies.vitest, "^4.1.9");
     await assert.rejects(access(path.join(appRoot, "scripts/devel-link-local-packages-postinstall.sh")), /ENOENT/);
     await assert.rejects(access(path.join(appRoot, "scripts/copy-local-packages.sh")), /ENOENT/);
     await assert.rejects(access(path.join(appRoot, "scripts/link-local-jskit-packages.sh")), /ENOENT/);
@@ -672,7 +680,10 @@ test("create-app minimal mode keeps the bare scaffold and can still install shel
 
     const appRoot = path.join(cwd, "minimal-app");
     const packageJsonBefore = JSON.parse(await readFile(path.join(appRoot, "package.json"), "utf8"));
+    assert.equal(packageJsonBefore.engines.node, "^20.19.0 || ^22.12.0");
     assert.equal(packageJsonBefore.dependencies["@jskit-ai/shell-web"], undefined);
+    assert.equal(packageJsonBefore.dependencies["vue-router"], "^5.1.0");
+    assert.equal(packageJsonBefore.devDependencies.vite, "^8.0.16");
     const homeViewBefore = await readFile(path.join(appRoot, "src/pages/home/index.vue"), "utf8");
     assert.match(homeViewBefore, /home-start-screen/);
     assert.match(homeViewBefore, /Home base/);


### PR DESCRIPTION
## Summary
- add descriptor-level client optimizeDeps excludes and make excludes win over auto includes
- mark @jskit-ai/shell-web/client as excluded from Vite dep optimization
- enforce 48px shell menu link targets in shell-web
- include published release bumps for @jskit-ai/kernel@0.1.97 and @jskit-ai/shell-web@0.1.96

## Checks
- npm run lint
- npm run jskit -- lint-descriptors
- npm run check:runtime-deps
- node --test packages/kernel/client/descriptorSections.test.js packages/kernel/client/vite/clientBootstrapPlugin.test.js packages/shell-web/test/linkItemScaffoldContract.test.js packages/shell-web/test/settingsPlacementContract.test.js