### PR TITLE
Fix preview auth provisioning and logout state

### DIFF
--- a/packages/agent-docs/reference/autogen/packages/auth-provider-supabase-core.md
+++ b/packages/agent-docs/reference/autogen/packages/auth-provider-supabase-core.md
@@ -36,6 +36,7 @@ Local functions
 Exports
 - `safeRequestCookies(request)`
 - `cookieOptions(isProduction, maxAge)`
+- `cookieClearOptions(isProduction)`
 
 ### `src/server/lib/authenticatedProfile.js`
 Exports

--- a/packages/agent-docs/reference/autogen/packages/kernel.md
+++ b/packages/agent-docs/reference/autogen/packages/kernel.md
@@ -678,7 +678,7 @@ Exports
 Exports
 - `normalizeDescriptorUiRoutes(value)`
 - `normalizeDescriptorClientProviders(value)`
-- `normalizeDescriptorClientOptimizeIncludeSpecifiers(value)`
+- `normalizeDescriptorClientOptimizeSpecifiers(value)`
 - `normalizeClientDescriptorSections(descriptorValue)`
 
 ### `client/index.js`
@@ -782,7 +782,7 @@ Exports
 - `CLIENT_BOOTSTRAP_VIRTUAL_ID`
 - `CLIENT_BOOTSTRAP_RESOLVED_ID`
 - `createVirtualModuleSource(clientModules = [])`
-- `resolveClientOptimizeIncludeSpecifiers(clientModules = [])`
+- `resolveClientOptimizeIncludeSpecifiers(clientModules = [], excludeSpecifiers = [])`
 - `resolveClientOptimizeExcludeSpecifiers(clientModules = [])`
 - `resolveLocalScopeOptimizeExcludeSpecifiers(localScopePackageIds = [])`
 - `resolveInstalledClientPackageIds(options)`

--- a/packages/agent-docs/reference/autogen/packages/users-core.md
+++ b/packages/agent-docs/reference/autogen/packages/users-core.md
@@ -198,6 +198,26 @@ Local functions
 Exports
 - `resolveActionUser(context, input)`
 
+### `src/server/previewUserProvisioning.js`
+Exports
+- `DEFAULT_AUTH_PROVIDER`
+- `DEFAULT_DISPLAY_NAME`
+- `DEFAULT_EMAIL`
+- `ensurePreviewUser(db, profileInput = {})`
+- `normalizePreviewUserProfile(profile = {})`
+- `profileFromUserRow(user = {}, fallback = {})`
+Local functions
+- `normalizeText(value = "")`
+- `normalizeLowerText(value = "")`
+- `normalizeUsername(value = "")`
+- `usernameBaseFromEmail(email = "")`
+- `buildUsernameCandidate(baseUsername = "", suffix = 0)`
+- `isDuplicateError(error)`
+- `resolveUniqueUsername(db, baseUsername = "", { excludeUserId = "" } = {})`
+- `findPreviewUser(db, profile = {})`
+- `ensurePreviewUserRow(db, profile = {})`
+- `ensureUserSettings(db, user = {})`
+
 ### `src/server/profileSyncLifecycleContributorRegistry.js`
 Exports
 - `PROFILE_SYNC_LIFECYCLE_CONTRIBUTOR_TAG`

--- a/packages/agent-docs/reference/autogen/packages/workspaces-core.md
+++ b/packages/agent-docs/reference/autogen/packages/workspaces-core.md
@@ -114,6 +114,25 @@ Exports
 - `routeParamsValidator`
 - `workspaceSlugParamsValidator`
 
+### `src/server/previewWorkspaceProvisioning.js`
+Exports
+- `buildWorkspaceBaseSlug(profile = {})`
+- `buildWorkspaceName(profile = {})`
+- `ensurePreviewWorkspace(db, user = {}, profile = {}, { appConfig = {}, tenancyMode = "" } = {})`
+- `normalizeWorkspaceResult(workspace = null)`
+Local functions
+- `normalizeText(value = "")`
+- `normalizeLowerText(value = "")`
+- `workspaceSlugPart(value = "")`
+- `usernameBaseFromEmail(email = "")`
+- `buildWorkspaceSlugCandidate(baseSlug = "", suffix = 0)`
+- `isDuplicateError(error)`
+- `resolveUniqueWorkspaceSlug(db, baseSlug = "", { excludeWorkspaceId = "" } = {})`
+- `hasWorkspaceTables(db)`
+- `findPreviewWorkspace(db, user = {}, { isPersonal = true } = {})`
+- `ensureWorkspaceSettings(db, workspace = {})`
+- `ensureOwnerMembership(db, workspace = {}, user = {})`
+
 ### `src/server/registerWorkspaceBootstrap.js`
 Exports
 - `registerWorkspaceBootstrap(app)`

--- a/packages/agent-docs/reference/autogen/tooling/jskit-cli.md
+++ b/packages/agent-docs/reference/autogen/tooling/jskit-cli.md
@@ -400,6 +400,23 @@ Local functions
 - `replaceWithSymlink(targetPath = "", sourceDir = "", { packageName = "" } = {})`
 - `maybeLinkCompanionPackages({ appRoot = "", repoRoot = "", stdout, createCliError })`
 
+### `src/server/commandHandlers/appCommands/preparePreviewUser.js`
+Exports
+- `runAppPreparePreviewUserCommand(_ctx = {}, { appRoot = "", options = {}, stdout = process.stdout })`
+Local functions
+- `normalizeText(value = "")`
+- `normalizeLowerText(value = "")`
+- `profileFromOptions(options = {})`
+- `fileExists(filePath = "")`
+- `createAppRequire(appRoot = "")`
+- `importFreshModule(filePath = "")`
+- `loadKnexConfig(appRoot = "")`
+- `importAppPackageExport(appRoot = "", specifier = "", { required = true } = {})`
+- `writeProfile(profileFile = "", authProfile = {})`
+- `isTrueOption(value)`
+- `normalizeTenancyMode(value = "")`
+- `hasWorkspaceTables(db)`
+
 ### `src/server/commandHandlers/appCommands/release.js`
 Exports
 - `runAppReleaseCommand(ctx = {}, { appRoot = "", options = {}, stdout, stderr })`

--- a/packages/auth-provider-supabase-core/src/server/lib/actions/auth.contributor.js
+++ b/packages/auth-provider-supabase-core/src/server/lib/actions/auth.contributor.js
@@ -240,14 +240,22 @@ const authActionsAfterDevLogin = Object.freeze([
     },
     observability: {},
     async execute(_input, context, deps) {
+      let logoutResult = {
+        ok: true,
+        clearSession: true
+      };
+      if (deps.authService && typeof deps.authService.logout === "function") {
+        logoutResult = await deps.authService.logout(requireRequestContext(context, "auth.logout"));
+      }
+
       if (deps.authSessionEventsService && typeof deps.authSessionEventsService.notifySessionChanged === "function") {
         await deps.authSessionEventsService.notifySessionChanged({
           context
         });
       }
       return {
-        ok: true,
-        clearSession: true
+        ok: logoutResult?.ok !== false,
+        clearSession: logoutResult?.clearSession !== false
       };
     }
   },

--- a/packages/auth-provider-supabase-core/src/server/lib/authCookies.js
+++ b/packages/auth-provider-supabase-core/src/server/lib/authCookies.js
@@ -21,4 +21,14 @@ function cookieOptions(isProduction, maxAge) {
   return options;
 }
 
-export { safeRequestCookies, cookieOptions };
+function cookieClearOptions(isProduction) {
+  return [
+    cookieOptions(isProduction, 0),
+    {
+      ...cookieOptions(isProduction, 0),
+      path: "/api"
+    }
+  ];
+}
+
+export { safeRequestCookies, cookieOptions, cookieClearOptions };

--- a/packages/auth-provider-supabase-core/src/server/lib/service.js
+++ b/packages/auth-provider-supabase-core/src/server/lib/service.js
@@ -42,7 +42,7 @@ import {
   findAuthMethodById,
   findLinkedIdentityByProvider
 } from "./authMethodStatus.js";
-import { safeRequestCookies, cookieOptions } from "./authCookies.js";
+import { safeRequestCookies, cookieOptions, cookieClearOptions } from "./authCookies.js";
 import { loadJose, isExpiredJwtError, classifyJwtVerifyError } from "./authJwt.js";
 import { buildDisabledPasswordSecret } from "./authSecrets.js";
 import { createAccountFlows } from "./accountFlows.js";
@@ -55,6 +55,7 @@ import {
   authenticateDevAuthRequest,
   createDevAuthSession,
   ensureDevAuthBootstrapAvailable,
+  isDevAuthToken,
   resolveDevAuthConfig,
   resolveDevAuthProfile
 } from "./devAuthBootstrap.js";
@@ -387,9 +388,49 @@ function createService(options) {
   }
 
   function clearSessionCookies(reply) {
-    const clearOptions = cookieOptions(isProduction, 0);
-    reply.clearCookie(ACCESS_TOKEN_COOKIE, clearOptions);
-    reply.clearCookie(REFRESH_TOKEN_COOKIE, clearOptions);
+    for (const clearOptions of cookieClearOptions(isProduction)) {
+      reply.clearCookie(ACCESS_TOKEN_COOKIE, clearOptions);
+      reply.clearCookie(REFRESH_TOKEN_COOKIE, clearOptions);
+    }
+  }
+
+  async function logout(request) {
+    const cookies = safeRequestCookies(request);
+    const accessToken = String(cookies[ACCESS_TOKEN_COOKIE] || "").trim();
+    const refreshToken = String(cookies[REFRESH_TOKEN_COOKIE] || "").trim();
+
+    if (!accessToken && !refreshToken) {
+      return {
+        ok: true,
+        clearSession: true
+      };
+    }
+
+    if (isDevAuthToken(accessToken) || isDevAuthToken(refreshToken)) {
+      return {
+        ok: true,
+        clearSession: true
+      };
+    }
+
+    ensureConfigured();
+    const supabase = getSupabaseClient();
+    await setSessionFromRequestCookies(request, {
+      supabaseClient: supabase
+    });
+
+    const response = await supabase.auth.signOut({
+      scope: "local"
+    });
+
+    if (response.error) {
+      throw mapAuthError(response.error, Number(response.error?.status || 400));
+    }
+
+    return {
+      ok: true,
+      clearSession: true
+    };
   }
 
   function requireSynchronizedProfile(profile) {
@@ -860,6 +901,7 @@ function createService(options) {
     setPasswordSignInEnabled,
     unlinkProvider,
     signOutOtherSessions,
+    logout,
     getSecurityStatus,
     getSettingsProfileAuthInfo,
     getOAuthProviderCatalog,
@@ -909,6 +951,7 @@ const __testables = {
   findLinkedIdentityByProvider,
   safeRequestCookies,
   cookieOptions,
+  cookieClearOptions,
   isExpiredJwtError,
   classifyJwtVerifyError
 };

--- a/packages/auth-provider-supabase-core/test/auth.provider.supabase.test.js
+++ b/packages/auth-provider-supabase-core/test/auth.provider.supabase.test.js
@@ -5,3 +5,163 @@ import * as authProviderSupabase from "../src/server/lib/index.js";
 test("auth.provider.supabase exports required symbols", () => {
   assert.equal(typeof authProviderSupabase.createService, "function");
 });
+
+function createServiceFixture(overrides = {}) {
+  return authProviderSupabase.createService({
+    authProvider: {
+      id: "supabase",
+      supabaseUrl: "",
+      supabasePublishableKey: ""
+    },
+    appPublicUrl: "http://localhost:5173",
+    nodeEnv: "development",
+    userProfileSyncService: {
+      async findByIdentity() {
+        return null;
+      },
+      async syncIdentityProfile(profile) {
+        return {
+          id: "1",
+          email: String(profile?.email || "ada@example.com"),
+          displayName: String(profile?.displayName || "Ada Example"),
+          authProvider: String(profile?.authProvider || "supabase"),
+          authProviderUserSid: String(profile?.authProviderUserSid || "supabase-user-1")
+        };
+      }
+    },
+    ...overrides
+  });
+}
+
+test("clearSessionCookies clears root and API path session cookie variants", () => {
+  const authService = createServiceFixture();
+  const clearCalls = [];
+  const reply = {
+    clearCookie(name, options) {
+      clearCalls.push({
+        name,
+        options
+      });
+    }
+  };
+
+  authService.clearSessionCookies(reply);
+
+  assert.deepEqual(
+    clearCalls.map((call) => ({ name: call.name, path: call.options.path, maxAge: call.options.maxAge })),
+    [
+      { name: "sb_access_token", path: "/", maxAge: 0 },
+      { name: "sb_refresh_token", path: "/", maxAge: 0 },
+      { name: "sb_access_token", path: "/api", maxAge: 0 },
+      { name: "sb_refresh_token", path: "/api", maxAge: 0 }
+    ]
+  );
+});
+
+test("clearSessionCookies preserves secure cookie clearing in production", () => {
+  const authService = createServiceFixture({
+    nodeEnv: "production"
+  });
+  const clearCalls = [];
+  const reply = {
+    clearCookie(name, options) {
+      clearCalls.push({
+        name,
+        options
+      });
+    }
+  };
+
+  authService.clearSessionCookies(reply);
+
+  assert.equal(clearCalls.length, 4);
+  assert.equal(clearCalls.every((call) => call.options.secure === true), true);
+});
+
+test("logout is local-only when no session cookies are present", async () => {
+  const authService = createServiceFixture();
+
+  const result = await authService.logout({
+    cookies: {}
+  });
+
+  assert.deepEqual(result, {
+    ok: true,
+    clearSession: true
+  });
+});
+
+test("logout is local-only for dev auth cookies", async () => {
+  const authService = createServiceFixture();
+
+  const result = await authService.logout({
+    cookies: {
+      sb_access_token: "jskit-dev.invalid"
+    }
+  });
+
+  assert.deepEqual(result, {
+    ok: true,
+    clearSession: true
+  });
+});
+
+test("auth logout action delegates to provider logout and notifies session changes", async () => {
+  const action = authProviderSupabase
+    .buildAuthActions()
+    .find((definition) => definition.id === "auth.logout");
+  const request = {
+    id: "request-1"
+  };
+  const calls = [];
+
+  const result = await action.execute(
+    {},
+    {
+      requestMeta: {
+        request
+      }
+    },
+    {
+      authService: {
+        async logout(receivedRequest) {
+          calls.push({
+            type: "logout",
+            request: receivedRequest
+          });
+          return {
+            ok: true,
+            clearSession: true
+          };
+        }
+      },
+      authSessionEventsService: {
+        async notifySessionChanged(payload) {
+          calls.push({
+            type: "notify",
+            context: payload.context
+          });
+        }
+      }
+    }
+  );
+
+  assert.deepEqual(result, {
+    ok: true,
+    clearSession: true
+  });
+  assert.deepEqual(calls, [
+    {
+      type: "logout",
+      request
+    },
+    {
+      type: "notify",
+      context: {
+        requestMeta: {
+          request
+        }
+      }
+    }
+  ]);
+});

--- a/packages/crud-server-generator/test/routeInputContracts.test.js
+++ b/packages/crud-server-generator/test/routeInputContracts.test.js
@@ -41,6 +41,26 @@ function findRoute(routes, method, path) {
   return routes.find((route) => route.method === method && route.path === path) || null;
 }
 
+function assertRecordIdOnlyParamsValidator(actual) {
+  assert.equal(actual?.mode, recordIdParamsValidator.mode);
+  assert.deepEqual(actual?.schema?.structure, recordIdParamsValidator.schema.structure);
+  assert.deepEqual(actual.schema.patch({ recordId: "42" }), {
+    validatedObject: {
+      recordId: "42"
+    },
+    errors: {}
+  });
+
+  const withWorkspaceSlug = actual.schema.patch({
+    recordId: "42",
+    workspaceSlug: "acme"
+  });
+  assert.deepEqual(withWorkspaceSlug.validatedObject, {
+    recordId: "42"
+  });
+  assert.equal(withWorkspaceSlug.errors.workspaceSlug?.code, "FIELD_NOT_ALLOWED");
+}
+
 test("crud routes build flattened create/update action input", async () => {
   const registeredRoutes = [];
   const router = {
@@ -204,9 +224,9 @@ test("crud non-workspace record routes validate only recordId params", () => {
   assert.ok(viewRoute);
   assert.ok(updateRoute);
   assert.ok(deleteRoute);
-  assert.equal(viewRoute.route.params, recordIdParamsValidator);
-  assert.equal(updateRoute.route.params, recordIdParamsValidator);
-  assert.equal(deleteRoute.route.params, recordIdParamsValidator);
+  assertRecordIdOnlyParamsValidator(viewRoute.route.params);
+  assertRecordIdOnlyParamsValidator(updateRoute.route.params);
+  assertRecordIdOnlyParamsValidator(deleteRoute.route.params);
 });
 
 test("crud routes register JSON:API transport contracts and delete replies with 204", async () => {

--- a/packages/feature-server-generator/package.descriptor.mjs
+++ b/packages/feature-server-generator/package.descriptor.mjs
@@ -174,7 +174,7 @@ export default Object.freeze({
             equals: "json-rest"
           }
         },
-        "@jskit-ai/kernel": "0.1.96",
+        "@jskit-ai/kernel": "0.1.97",
         "json-rest-schema": "1.x.x",
         "@local/${option:feature-name|kebab}": "file:packages/${option:feature-name|kebab}"
       },

--- a/packages/users-core/package.json
+++ b/packages/users-core/package.json
@@ -6,6 +6,7 @@
     "test": "node --test"
   },
   "exports": {
+    "./server/previewUserProvisioning": "./src/server/previewUserProvisioning.js",
     "./server/profileSyncLifecycleContributorRegistry": "./src/server/profileSyncLifecycleContributorRegistry.js",
     "./shared/resources/userProfileResource": "./src/shared/resources/userProfileResource.js",
     "./shared/resources/userSettingsResource": "./src/shared/resources/userSettingsResource.js"

--- a/packages/users-core/src/server/previewUserProvisioning.js
+++ b/packages/users-core/src/server/previewUserProvisioning.js
@@ -1,0 +1,207 @@
+import { DEFAULT_USER_SETTINGS } from "../shared/settings.js";
+
+const DEFAULT_AUTH_PROVIDER = "jskit-preview";
+const DEFAULT_EMAIL = "preview@jskit.local";
+const DEFAULT_DISPLAY_NAME = "JSKIT Preview";
+const USERNAME_MAX_LENGTH = 120;
+
+function normalizeText(value = "") {
+  return String(value || "").trim();
+}
+
+function normalizeLowerText(value = "") {
+  return normalizeText(value).toLowerCase();
+}
+
+function normalizeUsername(value = "") {
+  const normalized = normalizeLowerText(value)
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, USERNAME_MAX_LENGTH);
+  return normalized || "";
+}
+
+function usernameBaseFromEmail(email = "") {
+  const normalizedEmail = normalizeLowerText(email);
+  const localPart = normalizedEmail.includes("@") ? normalizedEmail.split("@")[0] : normalizedEmail;
+  return normalizeUsername(localPart) || "user";
+}
+
+function buildUsernameCandidate(baseUsername = "", suffix = 0) {
+  const base = normalizeUsername(baseUsername) || "user";
+  if (suffix < 1) {
+    return base;
+  }
+  const suffixText = `-${suffix + 1}`;
+  return `${base.slice(0, USERNAME_MAX_LENGTH - suffixText.length)}${suffixText}`;
+}
+
+function isDuplicateError(error) {
+  return (
+    ["23505", "ER_DUP_ENTRY", "SQLITE_CONSTRAINT", "SQLITE_CONSTRAINT_UNIQUE"].includes(String(error?.code || "")) ||
+    Number(error?.errno) === 1062
+  );
+}
+
+function normalizePreviewUserProfile(profile = {}) {
+  const email = normalizeLowerText(profile.email || DEFAULT_EMAIL);
+  const authProvider = normalizeLowerText(profile.authProvider || DEFAULT_AUTH_PROVIDER);
+  const username = normalizeUsername(profile.username || usernameBaseFromEmail(email));
+
+  return {
+    authProvider,
+    authProviderUserSid: normalizeText(profile.authProviderUserSid || `${authProvider}:${email}`),
+    displayName: normalizeText(profile.displayName || username || email || DEFAULT_DISPLAY_NAME),
+    email,
+    username: username || usernameBaseFromEmail(email)
+  };
+}
+
+function profileFromUserRow(user = {}, fallback = {}) {
+  return {
+    id: normalizeText(user.id),
+    authProvider: normalizeLowerText(user.auth_provider || fallback.authProvider || DEFAULT_AUTH_PROVIDER),
+    authProviderUserSid: normalizeText(user.auth_provider_user_sid || fallback.authProviderUserSid || user.id || ""),
+    displayName: normalizeText(user.display_name || fallback.displayName || fallback.email || DEFAULT_DISPLAY_NAME),
+    email: normalizeLowerText(user.email || fallback.email || DEFAULT_EMAIL),
+    username: normalizeUsername(user.username || fallback.username || usernameBaseFromEmail(fallback.email))
+  };
+}
+
+async function resolveUniqueUsername(db, baseUsername = "", { excludeUserId = "" } = {}) {
+  const normalizedExcludeUserId = normalizeText(excludeUserId);
+  for (let suffix = 0; suffix < 1000; suffix += 1) {
+    const candidate = buildUsernameCandidate(baseUsername, suffix);
+    const existing = await db("users")
+      .where({ username: candidate })
+      .first();
+    if (!existing || normalizeText(existing.id) === normalizedExcludeUserId) {
+      return candidate;
+    }
+  }
+  throw new Error("Unable to generate unique preview username.");
+}
+
+async function findPreviewUser(db, profile = {}) {
+  if (profile.email) {
+    const byEmail = await db("users")
+      .where({ email: profile.email })
+      .first();
+    if (byEmail) {
+      return byEmail;
+    }
+  }
+  return db("users")
+    .where({
+      auth_provider: profile.authProvider,
+      auth_provider_user_sid: profile.authProviderUserSid
+    })
+    .first();
+}
+
+async function ensurePreviewUserRow(db, profile = {}) {
+  const existing = await findPreviewUser(db, profile);
+  const username = await resolveUniqueUsername(db, profile.username, {
+    excludeUserId: existing?.id
+  });
+  const record = {
+    auth_provider: profile.authProvider,
+    auth_provider_user_sid: profile.authProviderUserSid,
+    display_name: profile.displayName,
+    email: profile.email,
+    username
+  };
+
+  if (existing) {
+    await db("users")
+      .where({ id: existing.id })
+      .update(record);
+    return db("users")
+      .where({ id: existing.id })
+      .first();
+  }
+
+  try {
+    await db("users").insert(record);
+  } catch (error) {
+    if (!isDuplicateError(error)) {
+      throw error;
+    }
+  }
+
+  const inserted = await findPreviewUser(db, {
+    ...profile,
+    username
+  });
+  if (!inserted) {
+    throw new Error("Preview auth profile could not be inserted or found.");
+  }
+  return inserted;
+}
+
+async function ensureUserSettings(db, user = {}) {
+  if (!(await db.schema.hasTable("user_settings"))) {
+    return false;
+  }
+  const userId = user?.id;
+  const existing = await db("user_settings")
+    .where({ user_id: userId })
+    .first();
+  if (existing) {
+    return false;
+  }
+  try {
+    await db("user_settings").insert({
+      user_id: userId,
+      theme: DEFAULT_USER_SETTINGS.theme,
+      locale: DEFAULT_USER_SETTINGS.locale,
+      time_zone: DEFAULT_USER_SETTINGS.timeZone,
+      date_format: DEFAULT_USER_SETTINGS.dateFormat,
+      number_format: DEFAULT_USER_SETTINGS.numberFormat,
+      currency_code: DEFAULT_USER_SETTINGS.currencyCode,
+      avatar_size: DEFAULT_USER_SETTINGS.avatarSize,
+      password_sign_in_enabled: DEFAULT_USER_SETTINGS.passwordSignInEnabled,
+      password_setup_required: DEFAULT_USER_SETTINGS.passwordSetupRequired,
+      notify_product_updates: DEFAULT_USER_SETTINGS.productUpdates,
+      notify_account_activity: DEFAULT_USER_SETTINGS.accountActivity,
+      notify_security_alerts: DEFAULT_USER_SETTINGS.securityAlerts
+    });
+  } catch (error) {
+    if (!isDuplicateError(error)) {
+      throw error;
+    }
+  }
+  return true;
+}
+
+async function ensurePreviewUser(db, profileInput = {}) {
+  if (!db || typeof db !== "function" || !db.schema || typeof db.schema.hasTable !== "function") {
+    throw new TypeError("ensurePreviewUser requires a Knex database instance.");
+  }
+  if (!(await db.schema.hasTable("users"))) {
+    return {
+      user: null,
+      profile: null,
+      skipped: "users table was not found"
+    };
+  }
+
+  const profile = normalizePreviewUserProfile(profileInput);
+  const user = await ensurePreviewUserRow(db, profile);
+  await ensureUserSettings(db, user);
+
+  return {
+    user,
+    profile: profileFromUserRow(user, profile),
+    skipped: ""
+  };
+}
+
+export {
+  DEFAULT_AUTH_PROVIDER,
+  DEFAULT_DISPLAY_NAME,
+  DEFAULT_EMAIL,
+  ensurePreviewUser,
+  normalizePreviewUserProfile,
+  profileFromUserRow
+};

--- a/packages/users-core/test/exportsContract.test.js
+++ b/packages/users-core/test/exportsContract.test.js
@@ -12,7 +12,10 @@ test("users-core exports are explicit and aligned with production/template usage
   const result = evaluatePackageExportsContract({
     repoRoot: REPO_ROOT,
     packageDir: PACKAGE_DIR,
-    packageId: "@jskit-ai/users-core"
+    packageId: "@jskit-ai/users-core",
+    requiredExports: [
+      "./server/previewUserProvisioning"
+    ]
   });
 
   assert.deepEqual(

--- a/packages/users-core/test/previewUserProvisioning.test.js
+++ b/packages/users-core/test/previewUserProvisioning.test.js
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { ensurePreviewUser } from "../src/server/previewUserProvisioning.js";
+
+function matches(row = {}, criteria = {}) {
+  return Object.entries(criteria).every(([key, value]) => row[key] === value);
+}
+
+function createMemoryDb(initialTables = {}) {
+  const tables = {};
+  for (const [tableName, rows] of Object.entries(initialTables)) {
+    tables[tableName] = rows.map((row) => ({ ...row }));
+  }
+
+  function db(tableName) {
+    const rows = tables[tableName];
+    if (!rows) {
+      throw new Error(`Unknown table: ${tableName}`);
+    }
+    let criteria = {};
+
+    return {
+      where(nextCriteria = {}) {
+        criteria = { ...criteria, ...nextCriteria };
+        return this;
+      },
+      async first() {
+        return rows.find((row) => matches(row, criteria)) || null;
+      },
+      async insert(record = {}) {
+        rows.push({
+          id: record.id || String(rows.length + 1),
+          ...record
+        });
+      },
+      async update(patch = {}) {
+        for (const row of rows.filter((entry) => matches(entry, criteria))) {
+          Object.assign(row, patch);
+        }
+      }
+    };
+  }
+
+  db.schema = {
+    async hasTable(tableName) {
+      return Object.hasOwn(tables, tableName);
+    }
+  };
+  db.tables = tables;
+  return db;
+}
+
+test("ensurePreviewUser creates preview user and settings with package defaults", async () => {
+  const db = createMemoryDb({
+    users: [],
+    user_settings: []
+  });
+
+  const result = await ensurePreviewUser(db, {
+    email: " Preview@Example.TEST ",
+    displayName: "Preview User"
+  });
+
+  assert.equal(result.skipped, "");
+  assert.equal(result.profile.email, "preview@example.test");
+  assert.equal(result.profile.username, "preview");
+  assert.equal(result.profile.authProvider, "jskit-preview");
+  assert.equal(db.tables.users.length, 1);
+  assert.equal(db.tables.user_settings.length, 1);
+  assert.equal(db.tables.user_settings[0].theme, "system");
+  assert.equal(db.tables.user_settings[0].password_sign_in_enabled, true);
+});
+
+test("ensurePreviewUser updates the existing preview row without stealing another username", async () => {
+  const db = createMemoryDb({
+    users: [
+      {
+        id: "1",
+        auth_provider: "supabase",
+        auth_provider_user_sid: "other",
+        email: "taken@example.test",
+        username: "preview",
+        display_name: "Other"
+      },
+      {
+        id: "2",
+        auth_provider: "jskit-preview",
+        auth_provider_user_sid: "jskit-preview:preview@example.test",
+        email: "preview@example.test",
+        username: "old-preview",
+        display_name: "Old"
+      }
+    ],
+    user_settings: [
+      {
+        user_id: "2"
+      }
+    ]
+  });
+
+  const result = await ensurePreviewUser(db, {
+    email: "preview@example.test",
+    username: "preview",
+    displayName: "New Preview"
+  });
+
+  assert.equal(result.profile.id, "2");
+  assert.equal(result.profile.username, "preview-2");
+  assert.equal(db.tables.users.find((row) => row.id === "2").display_name, "New Preview");
+  assert.equal(db.tables.user_settings.length, 1);
+});
+
+test("ensurePreviewUser skips when the users table is absent", async () => {
+  const db = createMemoryDb({});
+
+  const result = await ensurePreviewUser(db, {
+    email: "preview@example.test"
+  });
+
+  assert.deepEqual(result, {
+    user: null,
+    profile: null,
+    skipped: "users table was not found"
+  });
+});

--- a/packages/workspaces-core/package.json
+++ b/packages/workspaces-core/package.json
@@ -7,6 +7,7 @@
   },
   "exports": {
     "./server/WorkspacesCoreServiceProvider": "./src/server/WorkspacesCoreServiceProvider.js",
+    "./server/previewWorkspaceProvisioning": "./src/server/previewWorkspaceProvisioning.js",
     "./server/validators/routeParamsValidator": "./src/server/common/validators/routeParamsValidator.js",
     "./server/support/workspaceRouteInput": "./src/server/support/workspaceRouteInput.js",
     "./shared/jsonApiTransports": "./src/shared/jsonApiTransports.js",

--- a/packages/workspaces-core/src/server/previewWorkspaceProvisioning.js
+++ b/packages/workspaces-core/src/server/previewWorkspaceProvisioning.js
@@ -1,0 +1,227 @@
+import { normalizeTenancyMode, TENANCY_MODE_NONE, TENANCY_MODE_PERSONAL } from "../shared/tenancyMode.js";
+import { resolveTenancyProfile } from "../shared/tenancyProfile.js";
+import { OWNER_ROLE_ID } from "../shared/roles.js";
+import { resolveWorkspaceThemePalettes } from "../shared/settings.js";
+
+const WORKSPACE_SLUG_MAX_LENGTH = 48;
+
+function normalizeText(value = "") {
+  return String(value || "").trim();
+}
+
+function normalizeLowerText(value = "") {
+  return normalizeText(value).toLowerCase();
+}
+
+function workspaceSlugPart(value = "") {
+  const normalized = normalizeLowerText(value)
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, WORKSPACE_SLUG_MAX_LENGTH);
+  return normalized || "workspace";
+}
+
+function usernameBaseFromEmail(email = "") {
+  const normalizedEmail = normalizeLowerText(email);
+  const localPart = normalizedEmail.includes("@") ? normalizedEmail.split("@")[0] : normalizedEmail;
+  return workspaceSlugPart(localPart) || "user";
+}
+
+function buildWorkspaceBaseSlug(profile = {}) {
+  return workspaceSlugPart(profile.username || profile.displayName || usernameBaseFromEmail(profile.email));
+}
+
+function buildWorkspaceName(profile = {}) {
+  const displayName = normalizeText(profile.displayName);
+  if (displayName) {
+    return `${displayName}'s Workspace`;
+  }
+  const email = normalizeLowerText(profile.email);
+  return email ? `${email}'s Workspace` : "Workspace";
+}
+
+function buildWorkspaceSlugCandidate(baseSlug = "", suffix = 0) {
+  const base = workspaceSlugPart(baseSlug);
+  if (suffix < 1) {
+    return base;
+  }
+  const suffixText = `-${suffix + 1}`;
+  return `${base.slice(0, WORKSPACE_SLUG_MAX_LENGTH - suffixText.length)}${suffixText}`;
+}
+
+function isDuplicateError(error) {
+  return (
+    ["23505", "ER_DUP_ENTRY", "SQLITE_CONSTRAINT", "SQLITE_CONSTRAINT_UNIQUE"].includes(String(error?.code || "")) ||
+    Number(error?.errno) === 1062
+  );
+}
+
+function normalizeWorkspaceResult(workspace = null) {
+  if (!workspace) {
+    return null;
+  }
+  return {
+    id: normalizeText(workspace.id),
+    slug: normalizeLowerText(workspace.slug)
+  };
+}
+
+async function resolveUniqueWorkspaceSlug(db, baseSlug = "", { excludeWorkspaceId = "" } = {}) {
+  const normalizedExcludeWorkspaceId = normalizeText(excludeWorkspaceId);
+  for (let suffix = 0; suffix < 1000; suffix += 1) {
+    const candidate = buildWorkspaceSlugCandidate(baseSlug, suffix);
+    const existing = await db("workspaces")
+      .where({ slug: candidate })
+      .first();
+    if (!existing || normalizeText(existing.id) === normalizedExcludeWorkspaceId) {
+      return candidate;
+    }
+  }
+  throw new Error("Unable to generate unique preview workspace slug.");
+}
+
+async function hasWorkspaceTables(db) {
+  return (
+    (await db.schema.hasTable("workspaces")) &&
+    (await db.schema.hasTable("workspace_memberships")) &&
+    (await db.schema.hasTable("workspace_settings"))
+  );
+}
+
+async function findPreviewWorkspace(db, user = {}, { isPersonal = true } = {}) {
+  return db("workspaces")
+    .where({
+      owner_user_id: user.id,
+      is_personal: isPersonal
+    })
+    .orderBy("id", "asc")
+    .first();
+}
+
+async function ensureWorkspaceSettings(db, workspace = {}) {
+  const existing = await db("workspace_settings")
+    .where({ workspace_id: workspace.id })
+    .first();
+  if (existing) {
+    return false;
+  }
+
+  const palettes = resolveWorkspaceThemePalettes({});
+  try {
+    await db("workspace_settings").insert({
+      workspace_id: workspace.id,
+      light_primary_color: palettes.light.color,
+      light_secondary_color: palettes.light.secondaryColor,
+      light_surface_color: palettes.light.surfaceColor,
+      light_surface_variant_color: palettes.light.surfaceVariantColor,
+      dark_primary_color: palettes.dark.color,
+      dark_secondary_color: palettes.dark.secondaryColor,
+      dark_surface_color: palettes.dark.surfaceColor,
+      dark_surface_variant_color: palettes.dark.surfaceVariantColor,
+      invites_enabled: true
+    });
+  } catch (error) {
+    if (!isDuplicateError(error)) {
+      throw error;
+    }
+  }
+  return true;
+}
+
+async function ensureOwnerMembership(db, workspace = {}, user = {}) {
+  const existing = await db("workspace_memberships")
+    .where({
+      workspace_id: workspace.id,
+      user_id: user.id
+    })
+    .first();
+  if (existing) {
+    if (existing.role_sid !== OWNER_ROLE_ID || existing.status !== "active") {
+      await db("workspace_memberships")
+        .where({ id: existing.id })
+        .update({
+          role_sid: OWNER_ROLE_ID,
+          status: "active",
+          updated_at: new Date()
+        });
+      return true;
+    }
+    return false;
+  }
+
+  try {
+    await db("workspace_memberships").insert({
+      workspace_id: workspace.id,
+      user_id: user.id,
+      role_sid: OWNER_ROLE_ID,
+      status: "active"
+    });
+  } catch (error) {
+    if (!isDuplicateError(error)) {
+      throw error;
+    }
+  }
+  return true;
+}
+
+async function ensurePreviewWorkspace(db, user = {}, profile = {}, { appConfig = {}, tenancyMode = "" } = {}) {
+  if (!db || typeof db !== "function" || !db.schema || typeof db.schema.hasTable !== "function") {
+    throw new TypeError("ensurePreviewWorkspace requires a Knex database instance.");
+  }
+
+  const resolvedTenancyMode = normalizeTenancyMode(tenancyMode || resolveTenancyProfile(appConfig).mode);
+  if (resolvedTenancyMode === TENANCY_MODE_NONE) {
+    return {
+      workspace: null,
+      skipped: "workspace tenancy is disabled"
+    };
+  }
+
+  if (!(await hasWorkspaceTables(db))) {
+    return {
+      workspace: null,
+      skipped: "workspace tables were not found"
+    };
+  }
+
+  const isPersonal = resolvedTenancyMode === TENANCY_MODE_PERSONAL;
+  let workspace = await findPreviewWorkspace(db, user, { isPersonal });
+  if (!workspace) {
+    const slug = await resolveUniqueWorkspaceSlug(db, buildWorkspaceBaseSlug(profile));
+    try {
+      await db("workspaces").insert({
+        avatar_url: "",
+        is_personal: isPersonal,
+        name: buildWorkspaceName(profile),
+        owner_user_id: user.id,
+        slug
+      });
+    } catch (error) {
+      if (!isDuplicateError(error)) {
+        throw error;
+      }
+    }
+    workspace = await db("workspaces")
+      .where({ slug })
+      .first();
+  }
+
+  if (!workspace) {
+    throw new Error("Preview workspace could not be inserted or found.");
+  }
+
+  await ensureOwnerMembership(db, workspace, user);
+  await ensureWorkspaceSettings(db, workspace);
+
+  return {
+    workspace: normalizeWorkspaceResult(workspace),
+    skipped: ""
+  };
+}
+
+export {
+  buildWorkspaceBaseSlug,
+  buildWorkspaceName,
+  ensurePreviewWorkspace,
+  normalizeWorkspaceResult
+};

--- a/packages/workspaces-core/test/exportsContract.test.js
+++ b/packages/workspaces-core/test/exportsContract.test.js
@@ -15,6 +15,7 @@ test("workspaces-core exports are explicit and aligned with production usage", (
     packageId: "@jskit-ai/workspaces-core",
     requiredExports: [
       "./server/WorkspacesCoreServiceProvider",
+      "./server/previewWorkspaceProvisioning",
       "./server/validators/routeParamsValidator",
       "./server/support/workspaceRouteInput",
       "./shared/resources/workspaceResource",

--- a/packages/workspaces-core/test/previewWorkspaceProvisioning.test.js
+++ b/packages/workspaces-core/test/previewWorkspaceProvisioning.test.js
@@ -1,0 +1,149 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { ensurePreviewWorkspace } from "../src/server/previewWorkspaceProvisioning.js";
+
+function matches(row = {}, criteria = {}) {
+  return Object.entries(criteria).every(([key, value]) => row[key] === value);
+}
+
+function createMemoryDb(initialTables = {}) {
+  const tables = {};
+  for (const [tableName, rows] of Object.entries(initialTables)) {
+    tables[tableName] = rows.map((row) => ({ ...row }));
+  }
+
+  function db(tableName) {
+    const rows = tables[tableName];
+    if (!rows) {
+      throw new Error(`Unknown table: ${tableName}`);
+    }
+    let criteria = {};
+    let order = null;
+
+    return {
+      where(nextCriteria = {}) {
+        criteria = { ...criteria, ...nextCriteria };
+        return this;
+      },
+      orderBy(column, direction = "asc") {
+        order = { column, direction };
+        return this;
+      },
+      async first() {
+        const found = rows.filter((row) => matches(row, criteria));
+        if (order) {
+          found.sort((left, right) => {
+            const leftValue = Number(left[order.column]);
+            const rightValue = Number(right[order.column]);
+            const delta = Number.isFinite(leftValue) && Number.isFinite(rightValue)
+              ? leftValue - rightValue
+              : String(left[order.column] || "").localeCompare(String(right[order.column] || ""));
+            return order.direction === "desc" ? delta * -1 : delta;
+          });
+        }
+        return found[0] || null;
+      },
+      async insert(record = {}) {
+        rows.push({
+          id: record.id || String(rows.length + 1),
+          ...record
+        });
+      },
+      async update(patch = {}) {
+        for (const row of rows.filter((entry) => matches(entry, criteria))) {
+          Object.assign(row, patch);
+        }
+      }
+    };
+  }
+
+  db.schema = {
+    async hasTable(tableName) {
+      return Object.hasOwn(tables, tableName);
+    }
+  };
+  db.tables = tables;
+  return db;
+}
+
+test("ensurePreviewWorkspace creates a personal workspace, owner membership, and settings", async () => {
+  const db = createMemoryDb({
+    workspaces: [],
+    workspace_memberships: [],
+    workspace_settings: []
+  });
+
+  const result = await ensurePreviewWorkspace(
+    db,
+    { id: "7" },
+    { email: "preview@example.test", username: "preview", displayName: "Preview User" },
+    { appConfig: { tenancyMode: "personal" } }
+  );
+
+  assert.equal(result.skipped, "");
+  assert.deepEqual(result.workspace, {
+    id: "1",
+    slug: "preview"
+  });
+  assert.equal(db.tables.workspaces[0].is_personal, true);
+  assert.equal(db.tables.workspace_memberships[0].role_sid, "owner");
+  assert.equal(db.tables.workspace_memberships[0].status, "active");
+  assert.equal(db.tables.workspace_settings[0].light_primary_color, "#1867C0");
+});
+
+test("ensurePreviewWorkspace repairs an existing owner membership", async () => {
+  const db = createMemoryDb({
+    workspaces: [
+      {
+        id: "3",
+        slug: "preview",
+        owner_user_id: "7",
+        is_personal: true,
+        name: "Preview",
+        avatar_url: ""
+      }
+    ],
+    workspace_memberships: [
+      {
+        id: "9",
+        workspace_id: "3",
+        user_id: "7",
+        role_sid: "member",
+        status: "inactive"
+      }
+    ],
+    workspace_settings: []
+  });
+
+  const result = await ensurePreviewWorkspace(
+    db,
+    { id: "7" },
+    { email: "preview@example.test", username: "preview" },
+    { appConfig: { tenancyMode: "personal" } }
+  );
+
+  assert.equal(result.workspace.id, "3");
+  assert.equal(db.tables.workspace_memberships[0].role_sid, "owner");
+  assert.equal(db.tables.workspace_memberships[0].status, "active");
+  assert.equal(db.tables.workspace_settings.length, 1);
+});
+
+test("ensurePreviewWorkspace skips when workspace tenancy is disabled", async () => {
+  const db = createMemoryDb({
+    workspaces: [],
+    workspace_memberships: [],
+    workspace_settings: []
+  });
+
+  const result = await ensurePreviewWorkspace(
+    db,
+    { id: "7" },
+    { email: "preview@example.test" },
+    { appConfig: { tenancyMode: "none" } }
+  );
+
+  assert.deepEqual(result, {
+    workspace: null,
+    skipped: "workspace tenancy is disabled"
+  });
+});

--- a/packages/workspaces-web/src/client/account-settings/useAccountSettingsInvitesSectionRuntime.js
+++ b/packages/workspaces-web/src/client/account-settings/useAccountSettingsInvitesSectionRuntime.js
@@ -132,7 +132,7 @@ function useAccountSettingsInvitesSectionRuntime() {
   const pendingInvites = computed(() =>
     Array.isArray(pendingInvitesModel.pendingInvites) ? pendingInvitesModel.pendingInvites : []
   );
-  const isResolvingInvite = computed(() => Boolean(redeemInviteCommand.isRunning.value));
+  const isResolvingInvite = computed(() => Boolean(redeemInviteCommand.isRunning));
 
   const { workspaceSurfaceId } = useWorkspaceSurfaceId({
     route,

--- a/packages/workspaces-web/src/client/components/WorkspaceMembersClientElement.vue
+++ b/packages/workspaces-web/src/client/components/WorkspaceMembersClientElement.vue
@@ -413,9 +413,9 @@ const memberRemoveCommand = useCommand({
 
 const status = computed(() => {
   return {
-    isCreatingInvite: Boolean(inviteCreateCommand.isRunning.value),
-    isRevokingInvite: Boolean(revokeInviteCommand.isRunning.value),
-    isRemovingMember: Boolean(memberRemoveCommand.isRunning.value),
+    isCreatingInvite: Boolean(inviteCreateCommand.isRunning),
+    isRevokingInvite: Boolean(revokeInviteCommand.isRunning),
+    isRemovingMember: Boolean(memberRemoveCommand.isRunning),
     hasLoadedWorkspaceSettings: !canInviteMembers.value || !workspaceSettingsView.isLoading,
     hasLoadedMembersList: !canViewMembers.value || !workspaceMembersList.isInitialLoading,
     hasLoadedInviteList: !canViewMembers.value || !workspaceInvitesList.isInitialLoading,
@@ -574,7 +574,7 @@ watch(
 );
 
 async function submitInvite() {
-  if (inviteCreateCommand.isRunning.value || !canInviteMembers.value) {
+  if (inviteCreateCommand.isRunning || !canInviteMembers.value) {
     return;
   }
 
@@ -594,7 +594,7 @@ async function submitInvite() {
 }
 
 async function submitRevokeInvite(inviteId) {
-  if (revokeInviteCommand.isRunning.value || !canRevokeInvites.value) {
+  if (revokeInviteCommand.isRunning || !canRevokeInvites.value) {
     return;
   }
 
@@ -645,7 +645,7 @@ async function submitMemberRoleUpdate(member, roleSid) {
 }
 
 async function submitRemoveMember(member) {
-  if (memberRemoveCommand.isRunning.value || !canManageMembers.value) {
+  if (memberRemoveCommand.isRunning || !canManageMembers.value) {
     return;
   }
 

--- a/packages/workspaces-web/src/client/components/WorkspacesClientElement.vue
+++ b/packages/workspaces-web/src/client/components/WorkspacesClientElement.vue
@@ -165,7 +165,7 @@ const isBootstrapping = computed(() => Boolean(bootstrapView.isLoading));
 const isRefreshingBootstrap = computed(() => Boolean(bootstrapView.isRefetching));
 const bootstrapLoadError = computed(() => String(bootstrapView.loadError || "").trim());
 const canCreateWorkspace = computed(() => bootstrapModel.workspaceAllowSelfCreate === true);
-const isCreatingWorkspace = computed(() => Boolean(createWorkspaceCommand.isRunning.value));
+const isCreatingWorkspace = computed(() => Boolean(createWorkspaceCommand.isRunning));
 
 function reportFeedback({
   message,

--- a/packages/workspaces-web/test/settingsPlacementContract.test.js
+++ b/packages/workspaces-web/test/settingsPlacementContract.test.js
@@ -126,6 +126,42 @@ test("workspaces-web resource load states expose local retry actions", async () 
   }
 });
 
+test("workspaces-web command loading state uses users-web proxyRefs contract", async () => {
+  const expectations = new Map([
+    [
+      "src/client/components/WorkspaceMembersClientElement.vue",
+      [
+        /isCreatingInvite: Boolean\(inviteCreateCommand\.isRunning\)/,
+        /if \(inviteCreateCommand\.isRunning \|\| !canInviteMembers\.value\)/
+      ]
+    ],
+    [
+      "src/client/components/WorkspacesClientElement.vue",
+      [
+        /const isCreatingWorkspace = computed\(\(\) => Boolean\(createWorkspaceCommand\.isRunning\)\)/
+      ]
+    ],
+    [
+      "src/client/account-settings/useAccountSettingsInvitesSectionRuntime.js",
+      [
+        /const isResolvingInvite = computed\(\(\) => Boolean\(redeemInviteCommand\.isRunning\)\)/
+      ]
+    ]
+  ]);
+
+  for (const [relativePath, patterns] of expectations) {
+    const source = await readFile(path.join(PACKAGE_DIR, relativePath), "utf8");
+    assert.doesNotMatch(
+      source,
+      /\.isRunning\.value/,
+      `${relativePath} must not read useCommand().isRunning.value; useCommand returns proxyRefs.`
+    );
+    for (const pattern of patterns) {
+      assert.match(source, pattern, `${relativePath} must expose command loading state to the UI.`);
+    }
+  }
+});
+
 test("workspaces-web installs an account invites cue scaffold that reads placement runtime state", async () => {
   const source = await readFile(
     path.join(PACKAGE_DIR, "templates", "packages", "main", "src", "client", "components", "AccountPendingInvitesCue.vue"),

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -2942,7 +2942,7 @@
                   "equals": "json-rest"
                 }
               },
-              "@jskit-ai/kernel": "0.1.96",
+              "@jskit-ai/kernel": "0.1.97",
               "json-rest-schema": "1.x.x",
               "@local/${option:feature-name|kebab}": "file:packages/${option:feature-name|kebab}"
             },
@@ -3819,11 +3819,11 @@
     },
     {
       "packageId": "@jskit-ai/shell-web",
-      "version": "0.1.95",
+      "version": "0.1.96",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/shell-web",
-        "version": "0.1.95",
+        "version": "0.1.96",
         "kind": "runtime",
         "description": "Web shell layout runtime with outlet-based placement contributions.",
         "dependsOn": [],
@@ -3850,6 +3850,13 @@
           }
         },
         "metadata": {
+          "client": {
+            "optimizeDeps": {
+              "exclude": [
+                "@jskit-ai/shell-web/client"
+              ]
+            }
+          },
           "apiSummary": {
             "surfaces": [
               {
@@ -4158,7 +4165,7 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/kernel": "0.1.96"
+              "@jskit-ai/kernel": "0.1.97"
             },
             "dev": {}
           },

--- a/tooling/jskit-cli/src/server/commandHandlers/app.js
+++ b/tooling/jskit-cli/src/server/commandHandlers/app.js
@@ -10,6 +10,7 @@ import {
 } from "./appCommandCatalog.js";
 import { runAppAdoptManagedScriptsCommand } from "./appCommands/adoptManagedScripts.js";
 import { runAppLinkLocalPackagesCommand } from "./appCommands/linkLocalPackages.js";
+import { runAppPreparePreviewUserCommand } from "./appCommands/preparePreviewUser.js";
 import { runAppReleaseCommand } from "./appCommands/release.js";
 import { runAppUpdatePackagesCommand } from "./appCommands/updatePackages.js";
 import { runAppVerifyCommand } from "./appCommands/verify.js";
@@ -150,6 +151,9 @@ function createAppCommands(ctx = {}) {
     }
     if (definition.name === "adopt-managed-scripts") {
       return runAppAdoptManagedScriptsCommand(ctx, { appRoot, options, stdout, stderr });
+    }
+    if (definition.name === "prepare-preview-user") {
+      return runAppPreparePreviewUserCommand(ctx, { appRoot, options, stdout, stderr });
     }
 
     throw createCliError(`Unhandled app subcommand: ${definition.name}.`, {

--- a/tooling/jskit-cli/src/server/commandHandlers/appCommandCatalog.js
+++ b/tooling/jskit-cli/src/server/commandHandlers/appCommandCatalog.js
@@ -109,6 +109,46 @@ const APP_COMMAND_DEFINITIONS = Object.freeze({
       "Clears node_modules/.vite so Vite does not keep stale prebundled paths."
     ])
   }),
+  "prepare-preview-user": Object.freeze({
+    name: "prepare-preview-user",
+    summary: "Prepare the JSKIT preview auth user and optional first workspace.",
+    usage: "jskit app prepare-preview-user [--profile-file <path>] [--email <email>] [--username <username>] [--display-name <name>] [--auth-provider <provider>] [--auth-provider-user-sid <sid>] [--ensure-workspace]",
+    options: Object.freeze([
+      Object.freeze({
+        label: "--profile-file <path>",
+        description: "JSON profile path to write for the preview auth bridge. Defaults to VIBE64_PREVIEW_AUTH_PROFILE_FILE."
+      }),
+      Object.freeze({
+        label: "--email <email>",
+        description: "Email address for the preview user."
+      }),
+      Object.freeze({
+        label: "--username <username>",
+        description: "Preferred username for the preview user."
+      }),
+      Object.freeze({
+        label: "--display-name <name>",
+        description: "Display name for the preview user."
+      }),
+      Object.freeze({
+        label: "--auth-provider <provider>",
+        description: "Auth provider id stored on the preview user."
+      }),
+      Object.freeze({
+        label: "--auth-provider-user-sid <sid>",
+        description: "Provider user id stored on the preview user."
+      }),
+      Object.freeze({
+        label: "--ensure-workspace",
+        description: "When workspace tables and tenancy config exist, ensure the preview user owns a first workspace."
+      })
+    ]),
+    defaults: Object.freeze([
+      "Runs after migrations and before the app server starts.",
+      "Exits successfully without changes when the app has no knexfile.js or users table.",
+      "Uses the app knexfile and app-local JSKIT package provisioning contracts instead of booting the HTTP server."
+    ])
+  }),
   release: Object.freeze({
     name: "release",
     summary: "Run the JSKIT release helper for an app repository.",
@@ -197,6 +237,15 @@ function buildAppCommandOptionMeta(subcommandName = "") {
   }
   if (definition.name === "link-local-packages") {
     optionMeta["repo-root"] = { inputType: "text" };
+  }
+  if (definition.name === "prepare-preview-user") {
+    optionMeta["profile-file"] = { inputType: "text" };
+    optionMeta.email = { inputType: "text" };
+    optionMeta.username = { inputType: "text" };
+    optionMeta["display-name"] = { inputType: "text" };
+    optionMeta["auth-provider"] = { inputType: "text" };
+    optionMeta["auth-provider-user-sid"] = { inputType: "text" };
+    optionMeta["ensure-workspace"] = { inputType: "flag" };
   }
 
   return optionMeta;

--- a/tooling/jskit-cli/src/server/commandHandlers/appCommands/preparePreviewUser.js
+++ b/tooling/jskit-cli/src/server/commandHandlers/appCommands/preparePreviewUser.js
@@ -1,0 +1,215 @@
+import { access, mkdir, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { loadAppConfigFromAppRoot } from "@jskit-ai/kernel/server/support";
+
+const TENANCY_MODE_NONE = "none";
+
+function normalizeText(value = "") {
+  return String(value || "").trim();
+}
+
+function normalizeLowerText(value = "") {
+  return normalizeText(value).toLowerCase();
+}
+
+function profileFromOptions(options = {}) {
+  const inlineOptions = options?.inlineOptions && typeof options.inlineOptions === "object" ? options.inlineOptions : {};
+  const profile = {};
+
+  const email = normalizeLowerText(inlineOptions.email || process.env.JSKIT_PREVIEW_USER_EMAIL);
+  const authProvider = normalizeLowerText(inlineOptions["auth-provider"] || process.env.JSKIT_PREVIEW_AUTH_PROVIDER);
+  const username = normalizeLowerText(inlineOptions.username || process.env.JSKIT_PREVIEW_USER_USERNAME);
+  const displayName = normalizeText(inlineOptions["display-name"] || process.env.JSKIT_PREVIEW_USER_DISPLAY_NAME);
+  const authProviderUserSid = normalizeText(
+    inlineOptions["auth-provider-user-sid"] || process.env.JSKIT_PREVIEW_AUTH_PROVIDER_USER_SID
+  );
+
+  if (authProvider) {
+    profile.authProvider = authProvider;
+  }
+  if (authProviderUserSid) {
+    profile.authProviderUserSid = authProviderUserSid;
+  }
+  if (displayName) {
+    profile.displayName = displayName;
+  }
+  if (email) {
+    profile.email = email;
+  }
+  if (username) {
+    profile.username = username;
+  }
+
+  return profile;
+}
+
+async function fileExists(filePath = "") {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function createAppRequire(appRoot = "") {
+  return createRequire(path.join(appRoot, "package.json"));
+}
+
+async function importFreshModule(filePath = "") {
+  return import(`${pathToFileURL(filePath).href}?mtime=${Date.now()}`);
+}
+
+async function loadKnexConfig(appRoot = "") {
+  const knexfilePath = path.join(appRoot, "knexfile.js");
+  if (!(await fileExists(knexfilePath))) {
+    return null;
+  }
+
+  const requireFromApp = createAppRequire(appRoot);
+  const moduleValue = requireFromApp("knex");
+  const createKnex =
+    typeof moduleValue === "function"
+      ? moduleValue
+      : typeof moduleValue?.default === "function"
+        ? moduleValue.default
+        : null;
+  if (!createKnex) {
+    throw new Error("App-local knex package resolved but did not expose a callable factory.");
+  }
+
+  const knexfileModule = await importFreshModule(knexfilePath);
+  const exported = knexfileModule.default || knexfileModule.config || knexfileModule;
+  const knexfile = typeof exported === "function" ? await exported() : exported;
+  const environment = normalizeText(process.env.NODE_ENV) || "development";
+
+  return {
+    createKnex,
+    knexConfig: knexfile?.[environment] || knexfile
+  };
+}
+
+async function importAppPackageExport(appRoot = "", specifier = "", { required = true } = {}) {
+  const requireFromApp = createAppRequire(appRoot);
+  let resolvedPath = "";
+  try {
+    resolvedPath = requireFromApp.resolve(specifier);
+  } catch {
+    if (!required) {
+      return null;
+    }
+    throw new Error(
+      `Unable to load app-local ${specifier}. Upgrade the installed JSKIT package that owns this preview provisioning contract.`
+    );
+  }
+  return importFreshModule(resolvedPath);
+}
+
+async function writeProfile(profileFile = "", authProfile = {}) {
+  if (!profileFile) {
+    return false;
+  }
+  await mkdir(path.dirname(profileFile), { recursive: true });
+  await writeFile(profileFile, `${JSON.stringify(authProfile, null, 2)}\n`, "utf8");
+  return true;
+}
+
+function isTrueOption(value) {
+  const normalized = normalizeLowerText(value);
+  return value === true || normalized === "true" || normalized === "1" || normalized === "yes";
+}
+
+function normalizeTenancyMode(value = "") {
+  const normalized = normalizeLowerText(value);
+  return normalized === "personal" || normalized === "workspaces" ? normalized : TENANCY_MODE_NONE;
+}
+
+async function hasWorkspaceTables(db) {
+  return (
+    (await db.schema.hasTable("workspaces")) &&
+    (await db.schema.hasTable("workspace_memberships")) &&
+    (await db.schema.hasTable("workspace_settings"))
+  );
+}
+
+async function runAppPreparePreviewUserCommand(_ctx = {}, { appRoot = "", options = {}, stdout = process.stdout }) {
+  const inlineOptions = options?.inlineOptions && typeof options.inlineOptions === "object" ? options.inlineOptions : {};
+  const profileFile = normalizeText(inlineOptions["profile-file"] || process.env.VIBE64_PREVIEW_AUTH_PROFILE_FILE);
+  const ensureWorkspace = isTrueOption(inlineOptions["ensure-workspace"]);
+  const loadedKnex = await loadKnexConfig(appRoot);
+  if (!loadedKnex) {
+    stdout.write("[jskit:preview] skipped: knexfile.js was not found.\n");
+    return 0;
+  }
+
+  const db = loadedKnex.createKnex(loadedKnex.knexConfig);
+  try {
+    if (!(await db.schema.hasTable("users"))) {
+      stdout.write("[jskit:preview] skipped: users table was not found.\n");
+      return 0;
+    }
+
+    const usersPreviewModule = await importAppPackageExport(
+      appRoot,
+      "@jskit-ai/users-core/server/previewUserProvisioning"
+    );
+    if (typeof usersPreviewModule?.ensurePreviewUser !== "function") {
+      throw new Error("@jskit-ai/users-core preview provisioning export is missing ensurePreviewUser().");
+    }
+
+    const userResult = await usersPreviewModule.ensurePreviewUser(db, profileFromOptions(options));
+    if (userResult?.skipped) {
+      stdout.write(`[jskit:preview] skipped: ${userResult.skipped}.\n`);
+      return 0;
+    }
+
+    const authProfile = userResult.profile;
+    let workspace = null;
+
+    if (ensureWorkspace) {
+      const appConfig = await loadAppConfigFromAppRoot({ appRoot });
+      const tenancyMode = normalizeTenancyMode(appConfig?.tenancyMode);
+      if (tenancyMode === TENANCY_MODE_NONE) {
+        stdout.write("[jskit:preview] skipped workspace: workspace tenancy is disabled.\n");
+      } else if (!(await hasWorkspaceTables(db))) {
+        throw new Error(
+          `Workspace tenancy is "${tenancyMode}", but workspace tables were not found. Run migrations before prepare-preview-user.`
+        );
+      } else {
+        const workspacesPreviewModule = await importAppPackageExport(
+          appRoot,
+          "@jskit-ai/workspaces-core/server/previewWorkspaceProvisioning"
+        );
+        if (typeof workspacesPreviewModule?.ensurePreviewWorkspace !== "function") {
+          throw new Error("@jskit-ai/workspaces-core preview provisioning export is missing ensurePreviewWorkspace().");
+        }
+
+        const workspaceResult = await workspacesPreviewModule.ensurePreviewWorkspace(db, userResult.user, authProfile, {
+          appConfig,
+          tenancyMode
+        });
+        workspace = workspaceResult?.workspace || null;
+        if (workspaceResult?.skipped) {
+          stdout.write(`[jskit:preview] skipped workspace: ${workspaceResult.skipped}.\n`);
+        }
+      }
+    }
+
+    const outputProfile = {
+      ...authProfile,
+      ...(workspace ? { workspace } : {})
+    };
+    await writeProfile(profileFile, outputProfile);
+    stdout.write(`[jskit:preview] user is ready: ${outputProfile.email} (${outputProfile.id}).\n`);
+    if (workspace) {
+      stdout.write(`[jskit:preview] workspace is ready: ${workspace.slug} (${workspace.id}).\n`);
+    }
+    return 0;
+  } finally {
+    await db.destroy();
+  }
+}
+
+export { runAppPreparePreviewUserCommand };

--- a/tooling/jskit-cli/src/server/core/argParser.js
+++ b/tooling/jskit-cli/src/server/core/argParser.js
@@ -137,6 +137,10 @@ function parseArgs(argv, { createCliError } = {}) {
       options.inlineOptions["skip-main-sync"] = "true";
       continue;
     }
+    if (token === "--ensure-workspace") {
+      options.inlineOptions["ensure-workspace"] = "true";
+      continue;
+    }
 
     if (token.startsWith("--")) {
       const withoutPrefix = token.slice(2);

--- a/tooling/jskit-cli/test/appCommand.test.js
+++ b/tooling/jskit-cli/test/appCommand.test.js
@@ -89,6 +89,100 @@ async function readLogLines(logPath) {
   return content.split(/\r?\n/u).filter(Boolean);
 }
 
+async function installFakePreviewKnex(appRoot, { tableNames = [] } = {}) {
+  await mkdir(path.join(appRoot, "node_modules", "knex"), { recursive: true });
+  await writeFile(
+    path.join(appRoot, "node_modules", "knex", "package.json"),
+    `${JSON.stringify({ name: "knex", version: "0.0.0", main: "index.cjs" }, null, 2)}\n`,
+    "utf8"
+  );
+  await writeFile(
+    path.join(appRoot, "node_modules", "knex", "index.cjs"),
+    `const tableNames = new Set(${JSON.stringify(tableNames)});
+module.exports = function createKnex() {
+  return {
+    schema: {
+      async hasTable(name) {
+        return tableNames.has(name);
+      }
+    },
+    async destroy() {}
+  };
+};
+`,
+    "utf8"
+  );
+}
+
+async function installFakePreviewUsersCore(appRoot, logPath) {
+  await mkdir(path.join(appRoot, "node_modules", "@jskit-ai", "users-core", "server"), { recursive: true });
+  await writeFile(
+    path.join(appRoot, "node_modules", "@jskit-ai", "users-core", "package.json"),
+    `${JSON.stringify({
+      name: "@jskit-ai/users-core",
+      version: "0.0.0",
+      type: "module",
+      exports: {
+        "./server/previewUserProvisioning": "./server/previewUserProvisioning.js"
+      }
+    }, null, 2)}\n`,
+    "utf8"
+  );
+  await writeFile(
+    path.join(appRoot, "node_modules", "@jskit-ai", "users-core", "server", "previewUserProvisioning.js"),
+    `import { appendFile } from "node:fs/promises";
+export async function ensurePreviewUser(_db, profile) {
+  await appendFile(${JSON.stringify(logPath)}, "users:" + profile.email + "\\n");
+  return {
+    user: { id: "7" },
+    profile: {
+      id: "7",
+      email: profile.email,
+      username: profile.username,
+      displayName: profile.displayName,
+      authProvider: profile.authProvider,
+      authProviderUserSid: profile.authProviderUserSid
+    },
+    skipped: ""
+  };
+}
+`,
+    "utf8"
+  );
+}
+
+async function installFakePreviewWorkspacesCore(appRoot, logPath) {
+  await mkdir(path.join(appRoot, "node_modules", "@jskit-ai", "workspaces-core", "server"), { recursive: true });
+  await writeFile(
+    path.join(appRoot, "node_modules", "@jskit-ai", "workspaces-core", "package.json"),
+    `${JSON.stringify({
+      name: "@jskit-ai/workspaces-core",
+      version: "0.0.0",
+      type: "module",
+      exports: {
+        "./server/previewWorkspaceProvisioning": "./server/previewWorkspaceProvisioning.js"
+      }
+    }, null, 2)}\n`,
+    "utf8"
+  );
+  await writeFile(
+    path.join(appRoot, "node_modules", "@jskit-ai", "workspaces-core", "server", "previewWorkspaceProvisioning.js"),
+    `import { appendFile } from "node:fs/promises";
+export async function ensurePreviewWorkspace(_db, user, profile, options) {
+  await appendFile(
+    ${JSON.stringify(logPath)},
+    "workspace:" + user.id + ":" + profile.email + ":" + options.tenancyMode + "\\n"
+  );
+  return {
+    workspace: { id: "11", slug: "preview" },
+    skipped: ""
+  };
+}
+`,
+    "utf8"
+  );
+}
+
 function runGit(appRoot, args = []) {
   const result = spawnSync("git", Array.isArray(args) ? args : [], {
     cwd: appRoot,
@@ -170,6 +264,160 @@ fs.appendFileSync(process.env.TEST_LOG_PATH, ["npm", ...process.argv.slice(2)].j
       "npm run --if-present build",
       "local-jskit doctor --against origin/main"
     ]);
+  });
+});
+
+test("jskit app prepare-preview-user skips apps without a knexfile", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "app");
+    const profilePath = path.join(cwd, "preview-profile.json");
+
+    await createMinimalApp(appRoot);
+
+    const result = runCli({
+      cwd: appRoot,
+      args: [
+        "app",
+        "prepare-preview-user",
+        "--email",
+        "preview@example.test",
+        "--profile-file",
+        profilePath,
+        "--ensure-workspace"
+      ]
+    });
+
+    assert.equal(result.status, 0, String(result.stderr || ""));
+    assert.match(String(result.stdout || ""), /skipped: knexfile\.js was not found/);
+  });
+});
+
+test("jskit app prepare-preview-user delegates to app-local preview provisioning helpers", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "app");
+    const profilePath = path.join(cwd, "preview-profile.json");
+    const logPath = path.join(cwd, "preview.log");
+
+    await createMinimalApp(appRoot);
+    await mkdir(path.join(appRoot, "config"), { recursive: true });
+    await writeFile(
+      path.join(appRoot, "config", "public.js"),
+      "export const config = { tenancyMode: \"personal\" };\n",
+      "utf8"
+    );
+    await writeFile(path.join(appRoot, "knexfile.js"), "export default { client: \"fake\" };\n", "utf8");
+
+    await installFakePreviewKnex(appRoot, {
+      tableNames: ["users", "workspaces", "workspace_memberships", "workspace_settings"]
+    });
+    await installFakePreviewUsersCore(appRoot, logPath);
+    await installFakePreviewWorkspacesCore(appRoot, logPath);
+
+    const result = runCli({
+      cwd: appRoot,
+      args: [
+        "app",
+        "prepare-preview-user",
+        "--email",
+        "preview@example.test",
+        "--username",
+        "preview",
+        "--display-name",
+        "Preview User",
+        "--profile-file",
+        profilePath,
+        "--ensure-workspace"
+      ]
+    });
+
+    assert.equal(result.status, 0, String(result.stderr || ""));
+    assert.match(String(result.stdout || ""), /user is ready: preview@example\.test \(7\)/);
+    assert.match(String(result.stdout || ""), /workspace is ready: preview \(11\)/);
+    assert.deepEqual(await readLogLines(logPath), [
+      "users:preview@example.test",
+      "workspace:7:preview@example.test:personal"
+    ]);
+
+    const profile = JSON.parse(await readFile(profilePath, "utf8"));
+    assert.deepEqual(profile.workspace, {
+      id: "11",
+      slug: "preview"
+    });
+  });
+});
+
+test("jskit app prepare-preview-user reports skipped workspace when tenancy is disabled", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "app");
+    const profilePath = path.join(cwd, "preview-profile.json");
+    const logPath = path.join(cwd, "preview.log");
+
+    await createMinimalApp(appRoot);
+    await mkdir(path.join(appRoot, "config"), { recursive: true });
+    await writeFile(path.join(appRoot, "config", "public.js"), "export const config = {};\n", "utf8");
+    await writeFile(path.join(appRoot, "knexfile.js"), "export default { client: \"fake\" };\n", "utf8");
+    await installFakePreviewKnex(appRoot, {
+      tableNames: ["users"]
+    });
+    await installFakePreviewUsersCore(appRoot, logPath);
+
+    const result = runCli({
+      cwd: appRoot,
+      args: [
+        "app",
+        "prepare-preview-user",
+        "--email",
+        "preview@example.test",
+        "--profile-file",
+        profilePath,
+        "--ensure-workspace"
+      ]
+    });
+
+    assert.equal(result.status, 0, String(result.stderr || ""));
+    assert.match(String(result.stdout || ""), /skipped workspace: workspace tenancy is disabled/);
+    assert.deepEqual(await readLogLines(logPath), ["users:preview@example.test"]);
+
+    const profile = JSON.parse(await readFile(profilePath, "utf8"));
+    assert.equal(Object.hasOwn(profile, "workspace"), false);
+  });
+});
+
+test("jskit app prepare-preview-user fails when workspace tenancy lacks workspace tables", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "app");
+    const logPath = path.join(cwd, "preview.log");
+
+    await createMinimalApp(appRoot);
+    await mkdir(path.join(appRoot, "config"), { recursive: true });
+    await writeFile(
+      path.join(appRoot, "config", "public.js"),
+      "export const config = { tenancyMode: \"personal\" };\n",
+      "utf8"
+    );
+    await writeFile(path.join(appRoot, "knexfile.js"), "export default { client: \"fake\" };\n", "utf8");
+    await installFakePreviewKnex(appRoot, {
+      tableNames: ["users"]
+    });
+    await installFakePreviewUsersCore(appRoot, logPath);
+
+    const result = runCli({
+      cwd: appRoot,
+      args: [
+        "app",
+        "prepare-preview-user",
+        "--email",
+        "preview@example.test",
+        "--ensure-workspace"
+      ]
+    });
+
+    assert.notEqual(result.status, 0);
+    assert.match(
+      String(result.stderr || ""),
+      /Workspace tenancy is "personal", but workspace tables were not found/
+    );
+    assert.deepEqual(await readLogLines(logPath), ["users:preview@example.test"]);
   });
 });
 

--- a/tooling/jskit-cli/test/completionCommand.test.js
+++ b/tooling/jskit-cli/test/completionCommand.test.js
@@ -88,7 +88,15 @@ test("completion bash __complete__ lists app subcommands and app-specific option
   assert.equal(subcommandResult.status, 0, String(subcommandResult.stderr || ""));
   assert.deepEqual(
     String(subcommandResult.stdout || "").trim().split(/\r?\n/u).filter(Boolean),
-    ["adopt-managed-scripts", "link-local-packages", "release", "update-packages", "verify", "verify-ui"]
+    [
+      "adopt-managed-scripts",
+      "link-local-packages",
+      "prepare-preview-user",
+      "release",
+      "update-packages",
+      "verify",
+      "verify-ui"
+    ]
   );
 
   const optionResult = runCli({
@@ -119,6 +127,25 @@ test("completion bash __complete__ lists app subcommands and app-specific option
   assert.deepEqual(
     String(verifyUiOptionResult.stdout || "").trim().split(/\r?\n/u).filter(Boolean),
     ["--against", "--auth-mode", "--command", "--feature", "--help"]
+  );
+
+  const previewUserOptionResult = runCli({
+    args: ["completion", "bash", "__complete__", "4", "--", "npx", "jskit", "app", "prepare-preview-user", "--"]
+  });
+
+  assert.equal(previewUserOptionResult.status, 0, String(previewUserOptionResult.stderr || ""));
+  assert.deepEqual(
+    String(previewUserOptionResult.stdout || "").trim().split(/\r?\n/u).filter(Boolean),
+    [
+      "--auth-provider",
+      "--auth-provider-user-sid",
+      "--display-name",
+      "--email",
+      "--ensure-workspace",
+      "--help",
+      "--profile-file",
+      "--username"
+    ]
   );
 
   const verifyOptionResult = runCli({


### PR DESCRIPTION
## Summary
- fix workspace invite command loading state by using the users-web proxyRefs contract
- add JSKIT-owned `jskit app prepare-preview-user` orchestration with users-core/workspaces-core provisioning helpers
- harden auth logout by delegating provider logout and clearing root plus `/api` session cookie variants
- refresh generated catalog and agent docs

## Verification
- `npm run verify`