### PR TITLE
Fix dev-auth account security status

### DIFF
--- a/packages/auth-provider-supabase-core/src/server/lib/passwordSecurityFlows.js
+++ b/packages/auth-provider-supabase-core/src/server/lib/passwordSecurityFlows.js
@@ -32,7 +32,8 @@ function createPasswordSecurityFlows(deps) {
     buildAuthMethodsStatusFromSupabaseUser,
     buildSecurityStatusFromAuthMethodsStatus,
     authMethodPasswordProvider,
-    buildAuthMethodsStatusFromProviderIds
+    buildAuthMethodsStatusFromProviderIds,
+    resolveDevAuthSecurityStatus
   } = deps;
 
   async function requestPasswordReset(payload) {
@@ -314,6 +315,13 @@ function createPasswordSecurityFlows(deps) {
         passwordSetupRequired: false
       });
       return buildSecurityStatusFromAuthMethodsStatus(authMethodsStatus);
+    }
+
+    if (typeof resolveDevAuthSecurityStatus === "function") {
+      const devAuthSecurityStatus = await resolveDevAuthSecurityStatus(request);
+      if (devAuthSecurityStatus) {
+        return devAuthSecurityStatus;
+      }
     }
 
     const current = await resolveCurrentAuthContext(request);

--- a/packages/auth-provider-supabase-core/src/server/lib/service.js
+++ b/packages/auth-provider-supabase-core/src/server/lib/service.js
@@ -373,6 +373,39 @@ function createService(options) {
     };
   }
 
+  function resolveRequestSessionTokens(request) {
+    const cookies = safeRequestCookies(request);
+    return {
+      accessToken: String(cookies[ACCESS_TOKEN_COOKIE] || ""),
+      refreshToken: String(cookies[REFRESH_TOKEN_COOKIE] || "")
+    };
+  }
+
+  async function authenticateDevAuthRequestFromCookies(request, tokens = resolveRequestSessionTokens(request)) {
+    const devAuthResult = await authenticateDevAuthRequest(
+      {
+        request,
+        accessToken: tokens.accessToken,
+        refreshToken: tokens.refreshToken
+      },
+      {
+        config: devAuthConfig,
+        userProfilesRepository
+      }
+    );
+
+    if (!devAuthResult || devAuthResult.authenticated !== true) {
+      return devAuthResult;
+    }
+
+    return {
+      ...devAuthResult,
+      profile: requireAuthenticatedProfile(devAuthResult.profile, {
+        context: "dev auth profile"
+      })
+    };
+  }
+
   function writeSessionCookies(reply, session) {
     const accessToken = String(session?.access_token || "");
     const refreshToken = String(session?.refresh_token || "");
@@ -612,6 +645,25 @@ function createService(options) {
     };
   }
 
+  async function resolveDevAuthSecurityStatus(request) {
+    const devAuthResult = await authenticateDevAuthRequestFromCookies(request);
+    if (!devAuthResult) {
+      return null;
+    }
+
+    if (devAuthResult.authenticated !== true) {
+      throw new AppError(401, "Authentication required.");
+    }
+
+    const passwordSignInPolicy = await resolvePasswordSignInPolicyForUserId(devAuthResult.profile.id);
+    const authMethodsStatus = buildAuthMethodsStatusFromProviderIds([AUTH_METHOD_PASSWORD_PROVIDER], {
+      ...passwordSignInPolicy,
+      oauthProviders: authOAuthProviders
+    });
+
+    return buildSecurityStatusFromAuthMethodsStatus(authMethodsStatus);
+  }
+
   const { register, resendRegisterConfirmation, login, requestOtpLogin, verifyOtpLogin, updateDisplayName } = createAccountFlows({
     ensureConfigured,
     validationError,
@@ -693,34 +745,15 @@ function createService(options) {
       buildAuthMethodsStatusFromProviderIds(providerIds, {
         ...statusOptions,
         oauthProviders: authOAuthProviders
-      })
+      }),
+    resolveDevAuthSecurityStatus
   });
 
   async function authenticateRequest(request) {
-    const cookies = safeRequestCookies(request);
-    const accessToken = String(cookies[ACCESS_TOKEN_COOKIE] || "");
-    const refreshToken = String(cookies[REFRESH_TOKEN_COOKIE] || "");
+    const { accessToken, refreshToken } = resolveRequestSessionTokens(request);
 
-    const devAuthResult = await authenticateDevAuthRequest(
-      {
-        request,
-        accessToken,
-        refreshToken
-      },
-      {
-        config: devAuthConfig,
-        userProfilesRepository
-      }
-    );
+    const devAuthResult = await authenticateDevAuthRequestFromCookies(request, { accessToken, refreshToken });
     if (devAuthResult) {
-      if (devAuthResult.authenticated === true) {
-        return {
-          ...devAuthResult,
-          profile: requireAuthenticatedProfile(devAuthResult.profile, {
-            context: "dev auth profile"
-          })
-        };
-      }
       return devAuthResult;
     }
 

--- a/packages/auth-provider-supabase-core/test/devAuthBootstrap.test.js
+++ b/packages/auth-provider-supabase-core/test/devAuthBootstrap.test.js
@@ -109,6 +109,47 @@ test("dev auth bootstrap can issue and authenticate a local session without Supa
   assert.equal(authResult.session, null);
 });
 
+test("dev auth bootstrap resolves security status without Supabase", async () => {
+  const authService = createServiceFixture();
+  const loginResult = await authService.devLoginAs(createLocalRequest(), {
+    userId: "7"
+  });
+
+  const securityStatus = await authService.getSecurityStatus(
+    createLocalRequest({
+      cookies: {
+        sb_access_token: loginResult.session.access_token,
+        sb_refresh_token: loginResult.session.refresh_token
+      }
+    })
+  );
+
+  const passwordMethod = securityStatus.authMethods.find((method) => method.id === "password");
+  assert.equal(securityStatus.authPolicy.minimumEnabledMethods, 1);
+  assert.equal(passwordMethod?.configured, true);
+  assert.equal(passwordMethod?.enabled, true);
+});
+
+test("dev auth security status rejects invalid dev sessions without recovery-link errors", async () => {
+  const authService = createServiceFixture();
+
+  await assert.rejects(
+    () =>
+      authService.getSecurityStatus(
+        createLocalRequest({
+          cookies: {
+            sb_access_token: "jskit-dev.invalid"
+          }
+        })
+      ),
+    (error) => {
+      assert.equal(error.statusCode || error.status, 401);
+      assert.equal(error.message, "Authentication required.");
+      return true;
+    }
+  );
+});
+
 test("dev auth bootstrap supports email lookup", async () => {
   const authService = createServiceFixture();
 


### PR DESCRIPTION
## Summary
- resolve account security status from JSKIT dev-auth cookies before attempting Supabase session restoration
- reuse the dev-auth cookie authentication path used by authenticateRequest
- add regression coverage for valid and invalid dev-auth security-status requests

## Verification
- npm --workspace @jskit-ai/auth-provider-supabase-core test
- npm run verify