### PR TITLE
Release packages after auth fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6669,28 +6669,28 @@
     },
     "packages/agent-docs": {
       "name": "@jskit-ai/agent-docs",
-      "version": "0.1.58",
+      "version": "0.1.59",
       "engines": {
         "node": ">=20 <23"
       }
     },
     "packages/assistant": {
       "name": "@jskit-ai/assistant",
-      "version": "0.1.105",
+      "version": "0.1.106",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.96"
+        "@jskit-ai/kernel": "0.1.98"
       }
     },
     "packages/assistant-core": {
       "name": "@jskit-ai/assistant-core",
-      "version": "0.1.72",
+      "version": "0.1.73",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.96",
-        "@jskit-ai/http-runtime": "0.1.95",
-        "@jskit-ai/kernel": "0.1.96",
-        "@jskit-ai/resource-core": "0.1.41",
-        "@jskit-ai/resource-crud-core": "0.1.41",
-        "@jskit-ai/users-core": "0.1.106",
+        "@jskit-ai/database-runtime": "0.1.97",
+        "@jskit-ai/http-runtime": "0.1.96",
+        "@jskit-ai/kernel": "0.1.98",
+        "@jskit-ai/resource-core": "0.1.42",
+        "@jskit-ai/resource-crud-core": "0.1.42",
+        "@jskit-ai/users-core": "0.1.107",
         "dompurify": "^3.3.3",
         "json-rest-schema": "1.x.x",
         "marked": "^17.0.4",
@@ -6701,25 +6701,17 @@
         "vuetify": "^4.0.0"
       }
     },
-    "packages/assistant-core/node_modules/@jskit-ai/kernel": {
-      "version": "0.1.96",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.96.tgz",
-      "integrity": "sha512-aBBsAkoaOyWYxmbyQqnaoXrVRKvofBeTlfrYXOTcYkaAU+YDxHIO11SlUBeVicVBFve7zX405zXD/z14F7BRXw==",
-      "dependencies": {
-        "json-rest-schema": "1.x.x"
-      }
-    },
     "packages/assistant-runtime": {
       "name": "@jskit-ai/assistant-runtime",
-      "version": "0.1.67",
+      "version": "0.1.68",
       "dependencies": {
-        "@jskit-ai/assistant-core": "0.1.72",
-        "@jskit-ai/database-runtime": "0.1.96",
-        "@jskit-ai/http-runtime": "0.1.95",
-        "@jskit-ai/kernel": "0.1.96",
-        "@jskit-ai/shell-web": "0.1.95",
-        "@jskit-ai/users-core": "0.1.106",
-        "@jskit-ai/users-web": "0.1.111",
+        "@jskit-ai/assistant-core": "0.1.73",
+        "@jskit-ai/database-runtime": "0.1.97",
+        "@jskit-ai/http-runtime": "0.1.96",
+        "@jskit-ai/kernel": "0.1.98",
+        "@jskit-ai/shell-web": "0.1.97",
+        "@jskit-ai/users-core": "0.1.107",
+        "@jskit-ai/users-web": "0.1.112",
         "json-rest-schema": "1.x.x"
       },
       "peerDependencies": {
@@ -6728,111 +6720,41 @@
         "vuetify": "^4.0.0"
       }
     },
-    "packages/assistant-runtime/node_modules/@jskit-ai/kernel": {
-      "version": "0.1.96",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.96.tgz",
-      "integrity": "sha512-aBBsAkoaOyWYxmbyQqnaoXrVRKvofBeTlfrYXOTcYkaAU+YDxHIO11SlUBeVicVBFve7zX405zXD/z14F7BRXw==",
-      "dependencies": {
-        "json-rest-schema": "1.x.x"
-      }
-    },
-    "packages/assistant-runtime/node_modules/@jskit-ai/shell-web": {
-      "version": "0.1.95",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/shell-web/-/shell-web-0.1.95.tgz",
-      "integrity": "sha512-QqStS3A0J8jU8f5iOZ7At7wLB+O0jcfvOH2ekxrxkt3yJN58MMz1ry+cw9Dkl1/D0J6ldbONzRKAfAVMTAc0mQ==",
-      "dependencies": {
-        "@jskit-ai/kernel": "0.1.96",
-        "@mdi/js": "^7.4.47"
-      },
-      "peerDependencies": {
-        "pinia": "^3.0.4",
-        "vue": "^3.5.13",
-        "vue-router": "^5.0.4",
-        "vuetify": "^4.0.0"
-      }
-    },
-    "packages/assistant/node_modules/@jskit-ai/kernel": {
-      "version": "0.1.96",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.96.tgz",
-      "integrity": "sha512-aBBsAkoaOyWYxmbyQqnaoXrVRKvofBeTlfrYXOTcYkaAU+YDxHIO11SlUBeVicVBFve7zX405zXD/z14F7BRXw==",
-      "dependencies": {
-        "json-rest-schema": "1.x.x"
-      }
-    },
     "packages/auth-core": {
       "name": "@jskit-ai/auth-core",
-      "version": "0.1.95",
+      "version": "0.1.96",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0",
-        "@jskit-ai/kernel": "0.1.96",
-        "json-rest-schema": "1.x.x"
-      }
-    },
-    "packages/auth-core/node_modules/@jskit-ai/kernel": {
-      "version": "0.1.96",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.96.tgz",
-      "integrity": "sha512-aBBsAkoaOyWYxmbyQqnaoXrVRKvofBeTlfrYXOTcYkaAU+YDxHIO11SlUBeVicVBFve7zX405zXD/z14F7BRXw==",
-      "dependencies": {
+        "@jskit-ai/kernel": "0.1.98",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/auth-provider-supabase-core": {
       "name": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.95",
+      "version": "0.1.96",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.95",
-        "@jskit-ai/kernel": "0.1.96",
+        "@jskit-ai/auth-core": "0.1.96",
+        "@jskit-ai/kernel": "0.1.98",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0",
         "json-rest-schema": "1.x.x",
         "ws": "^8.18.3"
       }
     },
-    "packages/auth-provider-supabase-core/node_modules/@jskit-ai/kernel": {
-      "version": "0.1.96",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.96.tgz",
-      "integrity": "sha512-aBBsAkoaOyWYxmbyQqnaoXrVRKvofBeTlfrYXOTcYkaAU+YDxHIO11SlUBeVicVBFve7zX405zXD/z14F7BRXw==",
-      "dependencies": {
-        "json-rest-schema": "1.x.x"
-      }
-    },
     "packages/auth-web": {
       "name": "@jskit-ai/auth-web",
-      "version": "0.1.97",
+      "version": "0.1.98",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.95",
-        "@jskit-ai/http-runtime": "0.1.95",
-        "@jskit-ai/kernel": "0.1.96",
-        "@jskit-ai/shell-web": "0.1.95",
+        "@jskit-ai/auth-core": "0.1.96",
+        "@jskit-ai/http-runtime": "0.1.96",
+        "@jskit-ai/kernel": "0.1.98",
+        "@jskit-ai/shell-web": "0.1.97",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
         "@tanstack/vue-query": "^5.90.5",
-        "pinia": "^3.0.4",
-        "vue": "^3.5.13",
-        "vue-router": "^5.0.4",
-        "vuetify": "^4.0.0"
-      }
-    },
-    "packages/auth-web/node_modules/@jskit-ai/kernel": {
-      "version": "0.1.96",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.96.tgz",
-      "integrity": "sha512-aBBsAkoaOyWYxmbyQqnaoXrVRKvofBeTlfrYXOTcYkaAU+YDxHIO11SlUBeVicVBFve7zX405zXD/z14F7BRXw==",
-      "dependencies": {
-        "json-rest-schema": "1.x.x"
-      }
-    },
-    "packages/auth-web/node_modules/@jskit-ai/shell-web": {
-      "version": "0.1.95",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/shell-web/-/shell-web-0.1.95.tgz",
-      "integrity": "sha512-QqStS3A0J8jU8f5iOZ7At7wLB+O0jcfvOH2ekxrxkt3yJN58MMz1ry+cw9Dkl1/D0J6ldbONzRKAfAVMTAc0mQ==",
-      "dependencies": {
-        "@jskit-ai/kernel": "0.1.96",
-        "@mdi/js": "^7.4.47"
-      },
-      "peerDependencies": {
         "pinia": "^3.0.4",
         "vue": "^3.5.13",
         "vue-router": "^5.0.4",
@@ -6841,69 +6763,38 @@
     },
     "packages/console-core": {
       "name": "@jskit-ai/console-core",
-      "version": "0.1.59",
+      "version": "0.1.60",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.95",
-        "@jskit-ai/database-runtime": "0.1.96",
-        "@jskit-ai/http-runtime": "0.1.95",
-        "@jskit-ai/kernel": "0.1.96",
-        "@jskit-ai/resource-crud-core": "0.1.41",
-        "@jskit-ai/users-core": "0.1.106",
-        "json-rest-schema": "1.x.x"
-      }
-    },
-    "packages/console-core/node_modules/@jskit-ai/kernel": {
-      "version": "0.1.96",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.96.tgz",
-      "integrity": "sha512-aBBsAkoaOyWYxmbyQqnaoXrVRKvofBeTlfrYXOTcYkaAU+YDxHIO11SlUBeVicVBFve7zX405zXD/z14F7BRXw==",
-      "dependencies": {
+        "@jskit-ai/auth-core": "0.1.96",
+        "@jskit-ai/database-runtime": "0.1.97",
+        "@jskit-ai/http-runtime": "0.1.96",
+        "@jskit-ai/kernel": "0.1.98",
+        "@jskit-ai/resource-crud-core": "0.1.42",
+        "@jskit-ai/users-core": "0.1.107",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/console-web": {
       "name": "@jskit-ai/console-web",
-      "version": "0.1.64",
+      "version": "0.1.65",
       "dependencies": {
-        "@jskit-ai/auth-web": "0.1.97",
-        "@jskit-ai/console-core": "0.1.59",
-        "@jskit-ai/shell-web": "0.1.95"
-      }
-    },
-    "packages/console-web/node_modules/@jskit-ai/kernel": {
-      "version": "0.1.96",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.96.tgz",
-      "integrity": "sha512-aBBsAkoaOyWYxmbyQqnaoXrVRKvofBeTlfrYXOTcYkaAU+YDxHIO11SlUBeVicVBFve7zX405zXD/z14F7BRXw==",
-      "dependencies": {
-        "json-rest-schema": "1.x.x"
-      }
-    },
-    "packages/console-web/node_modules/@jskit-ai/shell-web": {
-      "version": "0.1.95",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/shell-web/-/shell-web-0.1.95.tgz",
-      "integrity": "sha512-QqStS3A0J8jU8f5iOZ7At7wLB+O0jcfvOH2ekxrxkt3yJN58MMz1ry+cw9Dkl1/D0J6ldbONzRKAfAVMTAc0mQ==",
-      "dependencies": {
-        "@jskit-ai/kernel": "0.1.96",
-        "@mdi/js": "^7.4.47"
-      },
-      "peerDependencies": {
-        "pinia": "^3.0.4",
-        "vue": "^3.5.13",
-        "vue-router": "^5.0.4",
-        "vuetify": "^4.0.0"
+        "@jskit-ai/auth-web": "0.1.98",
+        "@jskit-ai/console-core": "0.1.60",
+        "@jskit-ai/shell-web": "0.1.97"
       }
     },
     "packages/crud-core": {
       "name": "@jskit-ai/crud-core",
-      "version": "0.1.104",
+      "version": "0.1.105",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.96",
-        "@jskit-ai/http-runtime": "0.1.95",
-        "@jskit-ai/kernel": "0.1.96",
-        "@jskit-ai/realtime": "0.1.95",
-        "@jskit-ai/resource-crud-core": "0.1.41",
-        "@jskit-ai/shell-web": "0.1.95",
-        "@jskit-ai/users-core": "0.1.106",
-        "@jskit-ai/users-web": "0.1.111",
+        "@jskit-ai/database-runtime": "0.1.97",
+        "@jskit-ai/http-runtime": "0.1.96",
+        "@jskit-ai/kernel": "0.1.98",
+        "@jskit-ai/realtime": "0.1.96",
+        "@jskit-ai/resource-crud-core": "0.1.42",
+        "@jskit-ai/shell-web": "0.1.97",
+        "@jskit-ai/users-core": "0.1.107",
+        "@jskit-ai/users-web": "0.1.112",
         "json-rest-schema": "1.x.x"
       },
       "peerDependencies": {
@@ -6912,179 +6803,100 @@
         "vue-router": "^5.0.4"
       }
     },
-    "packages/crud-core/node_modules/@jskit-ai/kernel": {
-      "version": "0.1.96",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.96.tgz",
-      "integrity": "sha512-aBBsAkoaOyWYxmbyQqnaoXrVRKvofBeTlfrYXOTcYkaAU+YDxHIO11SlUBeVicVBFve7zX405zXD/z14F7BRXw==",
-      "dependencies": {
-        "json-rest-schema": "1.x.x"
-      }
-    },
-    "packages/crud-core/node_modules/@jskit-ai/shell-web": {
-      "version": "0.1.95",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/shell-web/-/shell-web-0.1.95.tgz",
-      "integrity": "sha512-QqStS3A0J8jU8f5iOZ7At7wLB+O0jcfvOH2ekxrxkt3yJN58MMz1ry+cw9Dkl1/D0J6ldbONzRKAfAVMTAc0mQ==",
-      "dependencies": {
-        "@jskit-ai/kernel": "0.1.96",
-        "@mdi/js": "^7.4.47"
-      },
-      "peerDependencies": {
-        "pinia": "^3.0.4",
-        "vue": "^3.5.13",
-        "vue-router": "^5.0.4",
-        "vuetify": "^4.0.0"
-      }
-    },
     "packages/crud-server-generator": {
       "name": "@jskit-ai/crud-server-generator",
-      "version": "0.1.104",
+      "version": "0.1.105",
       "dependencies": {
         "@babel/parser": "^7.29.2",
-        "@jskit-ai/crud-core": "0.1.104",
-        "@jskit-ai/database-runtime": "0.1.96",
-        "@jskit-ai/http-runtime": "0.1.95",
-        "@jskit-ai/json-rest-api-core": "0.1.41",
-        "@jskit-ai/kernel": "0.1.96",
-        "@jskit-ai/resource-crud-core": "0.1.41",
+        "@jskit-ai/crud-core": "0.1.105",
+        "@jskit-ai/database-runtime": "0.1.97",
+        "@jskit-ai/http-runtime": "0.1.96",
+        "@jskit-ai/json-rest-api-core": "0.1.42",
+        "@jskit-ai/kernel": "0.1.98",
+        "@jskit-ai/resource-crud-core": "0.1.42",
         "recast": "^0.23.11"
-      }
-    },
-    "packages/crud-server-generator/node_modules/@jskit-ai/kernel": {
-      "version": "0.1.96",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.96.tgz",
-      "integrity": "sha512-aBBsAkoaOyWYxmbyQqnaoXrVRKvofBeTlfrYXOTcYkaAU+YDxHIO11SlUBeVicVBFve7zX405zXD/z14F7BRXw==",
-      "dependencies": {
-        "json-rest-schema": "1.x.x"
       }
     },
     "packages/crud-ui-generator": {
       "name": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.79",
+      "version": "0.1.80",
       "dependencies": {
-        "@jskit-ai/crud-core": "0.1.104",
-        "@jskit-ai/kernel": "0.1.96",
-        "@jskit-ai/resource-crud-core": "0.1.41"
-      }
-    },
-    "packages/crud-ui-generator/node_modules/@jskit-ai/kernel": {
-      "version": "0.1.96",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.96.tgz",
-      "integrity": "sha512-aBBsAkoaOyWYxmbyQqnaoXrVRKvofBeTlfrYXOTcYkaAU+YDxHIO11SlUBeVicVBFve7zX405zXD/z14F7BRXw==",
-      "dependencies": {
-        "json-rest-schema": "1.x.x"
+        "@jskit-ai/crud-core": "0.1.105",
+        "@jskit-ai/kernel": "0.1.98",
+        "@jskit-ai/resource-crud-core": "0.1.42"
       }
     },
     "packages/database-runtime": {
       "name": "@jskit-ai/database-runtime",
-      "version": "0.1.96",
+      "version": "0.1.97",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.96"
+        "@jskit-ai/kernel": "0.1.98"
       }
     },
     "packages/database-runtime-mysql": {
       "name": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.95",
-      "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.96",
-        "@jskit-ai/kernel": "0.1.96"
-      }
-    },
-    "packages/database-runtime-mysql/node_modules/@jskit-ai/kernel": {
       "version": "0.1.96",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.96.tgz",
-      "integrity": "sha512-aBBsAkoaOyWYxmbyQqnaoXrVRKvofBeTlfrYXOTcYkaAU+YDxHIO11SlUBeVicVBFve7zX405zXD/z14F7BRXw==",
       "dependencies": {
-        "json-rest-schema": "1.x.x"
+        "@jskit-ai/database-runtime": "0.1.97",
+        "@jskit-ai/kernel": "0.1.98"
       }
     },
     "packages/database-runtime-postgres": {
       "name": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.95",
-      "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.96"
-      }
-    },
-    "packages/database-runtime/node_modules/@jskit-ai/kernel": {
       "version": "0.1.96",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.96.tgz",
-      "integrity": "sha512-aBBsAkoaOyWYxmbyQqnaoXrVRKvofBeTlfrYXOTcYkaAU+YDxHIO11SlUBeVicVBFve7zX405zXD/z14F7BRXw==",
       "dependencies": {
-        "json-rest-schema": "1.x.x"
+        "@jskit-ai/database-runtime": "0.1.97"
       }
     },
     "packages/feature-server-generator": {
       "name": "@jskit-ai/feature-server-generator",
-      "version": "0.1.38"
+      "version": "0.1.39"
     },
     "packages/google-rewarded-core": {
       "name": "@jskit-ai/google-rewarded-core",
-      "version": "0.1.33"
+      "version": "0.1.34"
     },
     "packages/google-rewarded-web": {
       "name": "@jskit-ai/google-rewarded-web",
-      "version": "0.1.33"
+      "version": "0.1.34"
     },
     "packages/http-runtime": {
       "name": "@jskit-ai/http-runtime",
-      "version": "0.1.95",
-      "dependencies": {
-        "@jskit-ai/kernel": "0.1.96",
-        "json-rest-schema": "1.x.x"
-      }
-    },
-    "packages/http-runtime/node_modules/@jskit-ai/kernel": {
       "version": "0.1.96",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.96.tgz",
-      "integrity": "sha512-aBBsAkoaOyWYxmbyQqnaoXrVRKvofBeTlfrYXOTcYkaAU+YDxHIO11SlUBeVicVBFve7zX405zXD/z14F7BRXw==",
       "dependencies": {
+        "@jskit-ai/kernel": "0.1.98",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/json-rest-api-core": {
       "name": "@jskit-ai/json-rest-api-core",
-      "version": "0.1.41",
+      "version": "0.1.42",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.96",
+        "@jskit-ai/kernel": "0.1.98",
         "hooked-api": "1.x.x",
         "json-rest-api": "1.x.x"
       }
     },
-    "packages/json-rest-api-core/node_modules/@jskit-ai/kernel": {
-      "version": "0.1.96",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.96.tgz",
-      "integrity": "sha512-aBBsAkoaOyWYxmbyQqnaoXrVRKvofBeTlfrYXOTcYkaAU+YDxHIO11SlUBeVicVBFve7zX405zXD/z14F7BRXw==",
-      "dependencies": {
-        "json-rest-schema": "1.x.x"
-      }
-    },
     "packages/kernel": {
       "name": "@jskit-ai/kernel",
-      "version": "0.1.97",
+      "version": "0.1.98",
       "dependencies": {
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/mobile-capacitor": {
       "name": "@jskit-ai/mobile-capacitor",
-      "version": "0.1.33",
+      "version": "0.1.34",
       "dependencies": {
         "@capacitor/browser": "^7.0.1",
-        "@jskit-ai/kernel": "0.1.96"
-      }
-    },
-    "packages/mobile-capacitor/node_modules/@jskit-ai/kernel": {
-      "version": "0.1.96",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.96.tgz",
-      "integrity": "sha512-aBBsAkoaOyWYxmbyQqnaoXrVRKvofBeTlfrYXOTcYkaAU+YDxHIO11SlUBeVicVBFve7zX405zXD/z14F7BRXw==",
-      "dependencies": {
-        "json-rest-schema": "1.x.x"
+        "@jskit-ai/kernel": "0.1.98"
       }
     },
     "packages/realtime": {
       "name": "@jskit-ai/realtime",
-      "version": "0.1.95",
+      "version": "0.1.96",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.96",
+        "@jskit-ai/kernel": "0.1.98",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",
@@ -7094,50 +6906,26 @@
         "vue": "^3.5.13"
       }
     },
-    "packages/realtime/node_modules/@jskit-ai/kernel": {
-      "version": "0.1.96",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.96.tgz",
-      "integrity": "sha512-aBBsAkoaOyWYxmbyQqnaoXrVRKvofBeTlfrYXOTcYkaAU+YDxHIO11SlUBeVicVBFve7zX405zXD/z14F7BRXw==",
-      "dependencies": {
-        "json-rest-schema": "1.x.x"
-      }
-    },
     "packages/resource-core": {
       "name": "@jskit-ai/resource-core",
-      "version": "0.1.41",
+      "version": "0.1.42",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.96"
-      }
-    },
-    "packages/resource-core/node_modules/@jskit-ai/kernel": {
-      "version": "0.1.96",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.96.tgz",
-      "integrity": "sha512-aBBsAkoaOyWYxmbyQqnaoXrVRKvofBeTlfrYXOTcYkaAU+YDxHIO11SlUBeVicVBFve7zX405zXD/z14F7BRXw==",
-      "dependencies": {
-        "json-rest-schema": "1.x.x"
+        "@jskit-ai/kernel": "0.1.98"
       }
     },
     "packages/resource-crud-core": {
       "name": "@jskit-ai/resource-crud-core",
-      "version": "0.1.41",
+      "version": "0.1.42",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.96",
-        "@jskit-ai/resource-core": "0.1.41"
-      }
-    },
-    "packages/resource-crud-core/node_modules/@jskit-ai/kernel": {
-      "version": "0.1.96",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.96.tgz",
-      "integrity": "sha512-aBBsAkoaOyWYxmbyQqnaoXrVRKvofBeTlfrYXOTcYkaAU+YDxHIO11SlUBeVicVBFve7zX405zXD/z14F7BRXw==",
-      "dependencies": {
-        "json-rest-schema": "1.x.x"
+        "@jskit-ai/kernel": "0.1.98",
+        "@jskit-ai/resource-core": "0.1.42"
       }
     },
     "packages/shell-web": {
       "name": "@jskit-ai/shell-web",
-      "version": "0.1.96",
+      "version": "0.1.97",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.97",
+        "@jskit-ai/kernel": "0.1.98",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -7149,56 +6937,25 @@
     },
     "packages/storage-runtime": {
       "name": "@jskit-ai/storage-runtime",
-      "version": "0.1.95",
-      "dependencies": {
-        "@jskit-ai/kernel": "0.1.96",
-        "unstorage": "^1.17.3"
-      }
-    },
-    "packages/storage-runtime/node_modules/@jskit-ai/kernel": {
       "version": "0.1.96",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.96.tgz",
-      "integrity": "sha512-aBBsAkoaOyWYxmbyQqnaoXrVRKvofBeTlfrYXOTcYkaAU+YDxHIO11SlUBeVicVBFve7zX405zXD/z14F7BRXw==",
       "dependencies": {
-        "json-rest-schema": "1.x.x"
+        "@jskit-ai/kernel": "0.1.98",
+        "unstorage": "^1.17.3"
       }
     },
     "packages/ui-generator": {
       "name": "@jskit-ai/ui-generator",
-      "version": "0.1.79",
+      "version": "0.1.80",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.96",
-        "@jskit-ai/shell-web": "0.1.95"
-      }
-    },
-    "packages/ui-generator/node_modules/@jskit-ai/kernel": {
-      "version": "0.1.96",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.96.tgz",
-      "integrity": "sha512-aBBsAkoaOyWYxmbyQqnaoXrVRKvofBeTlfrYXOTcYkaAU+YDxHIO11SlUBeVicVBFve7zX405zXD/z14F7BRXw==",
-      "dependencies": {
-        "json-rest-schema": "1.x.x"
-      }
-    },
-    "packages/ui-generator/node_modules/@jskit-ai/shell-web": {
-      "version": "0.1.95",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/shell-web/-/shell-web-0.1.95.tgz",
-      "integrity": "sha512-QqStS3A0J8jU8f5iOZ7At7wLB+O0jcfvOH2ekxrxkt3yJN58MMz1ry+cw9Dkl1/D0J6ldbONzRKAfAVMTAc0mQ==",
-      "dependencies": {
-        "@jskit-ai/kernel": "0.1.96",
-        "@mdi/js": "^7.4.47"
-      },
-      "peerDependencies": {
-        "pinia": "^3.0.4",
-        "vue": "^3.5.13",
-        "vue-router": "^5.0.4",
-        "vuetify": "^4.0.0"
+        "@jskit-ai/kernel": "0.1.98",
+        "@jskit-ai/shell-web": "0.1.97"
       }
     },
     "packages/uploads-image-web": {
       "name": "@jskit-ai/uploads-image-web",
-      "version": "0.1.74",
+      "version": "0.1.75",
       "dependencies": {
-        "@jskit-ai/uploads-runtime": "0.1.74",
+        "@jskit-ai/uploads-runtime": "0.1.75",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",
@@ -7211,80 +6968,41 @@
     },
     "packages/uploads-runtime": {
       "name": "@jskit-ai/uploads-runtime",
-      "version": "0.1.74",
+      "version": "0.1.75",
       "dependencies": {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.96"
-      }
-    },
-    "packages/uploads-runtime/node_modules/@jskit-ai/kernel": {
-      "version": "0.1.96",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.96.tgz",
-      "integrity": "sha512-aBBsAkoaOyWYxmbyQqnaoXrVRKvofBeTlfrYXOTcYkaAU+YDxHIO11SlUBeVicVBFve7zX405zXD/z14F7BRXw==",
-      "dependencies": {
-        "json-rest-schema": "1.x.x"
+        "@jskit-ai/kernel": "0.1.98"
       }
     },
     "packages/users-core": {
       "name": "@jskit-ai/users-core",
-      "version": "0.1.106",
+      "version": "0.1.107",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.95",
-        "@jskit-ai/database-runtime": "0.1.96",
-        "@jskit-ai/http-runtime": "0.1.95",
-        "@jskit-ai/json-rest-api-core": "0.1.41",
-        "@jskit-ai/kernel": "0.1.96",
-        "@jskit-ai/resource-core": "0.1.41",
-        "@jskit-ai/resource-crud-core": "0.1.41",
-        "@jskit-ai/uploads-runtime": "0.1.74",
-        "json-rest-schema": "1.x.x"
-      }
-    },
-    "packages/users-core/node_modules/@jskit-ai/kernel": {
-      "version": "0.1.96",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.96.tgz",
-      "integrity": "sha512-aBBsAkoaOyWYxmbyQqnaoXrVRKvofBeTlfrYXOTcYkaAU+YDxHIO11SlUBeVicVBFve7zX405zXD/z14F7BRXw==",
-      "dependencies": {
+        "@jskit-ai/auth-core": "0.1.96",
+        "@jskit-ai/database-runtime": "0.1.97",
+        "@jskit-ai/http-runtime": "0.1.96",
+        "@jskit-ai/json-rest-api-core": "0.1.42",
+        "@jskit-ai/kernel": "0.1.98",
+        "@jskit-ai/resource-core": "0.1.42",
+        "@jskit-ai/resource-crud-core": "0.1.42",
+        "@jskit-ai/uploads-runtime": "0.1.75",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/users-web": {
       "name": "@jskit-ai/users-web",
-      "version": "0.1.111",
+      "version": "0.1.112",
       "dependencies": {
-        "@jskit-ai/http-runtime": "0.1.95",
-        "@jskit-ai/kernel": "0.1.96",
-        "@jskit-ai/realtime": "0.1.95",
-        "@jskit-ai/shell-web": "0.1.95",
-        "@jskit-ai/uploads-image-web": "0.1.74",
-        "@jskit-ai/users-core": "0.1.106",
+        "@jskit-ai/http-runtime": "0.1.96",
+        "@jskit-ai/kernel": "0.1.98",
+        "@jskit-ai/realtime": "0.1.96",
+        "@jskit-ai/shell-web": "0.1.97",
+        "@jskit-ai/uploads-image-web": "0.1.75",
+        "@jskit-ai/users-core": "0.1.107",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
         "@tanstack/vue-query": "^5.90.5",
-        "vue": "^3.5.13",
-        "vue-router": "^5.0.4",
-        "vuetify": "^4.0.0"
-      }
-    },
-    "packages/users-web/node_modules/@jskit-ai/kernel": {
-      "version": "0.1.96",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.96.tgz",
-      "integrity": "sha512-aBBsAkoaOyWYxmbyQqnaoXrVRKvofBeTlfrYXOTcYkaAU+YDxHIO11SlUBeVicVBFve7zX405zXD/z14F7BRXw==",
-      "dependencies": {
-        "json-rest-schema": "1.x.x"
-      }
-    },
-    "packages/users-web/node_modules/@jskit-ai/shell-web": {
-      "version": "0.1.95",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/shell-web/-/shell-web-0.1.95.tgz",
-      "integrity": "sha512-QqStS3A0J8jU8f5iOZ7At7wLB+O0jcfvOH2ekxrxkt3yJN58MMz1ry+cw9Dkl1/D0J6ldbONzRKAfAVMTAc0mQ==",
-      "dependencies": {
-        "@jskit-ai/kernel": "0.1.96",
-        "@mdi/js": "^7.4.47"
-      },
-      "peerDependencies": {
-        "pinia": "^3.0.4",
         "vue": "^3.5.13",
         "vue-router": "^5.0.4",
         "vuetify": "^4.0.0"
@@ -7292,37 +7010,29 @@
     },
     "packages/workspaces-core": {
       "name": "@jskit-ai/workspaces-core",
-      "version": "0.1.72",
+      "version": "0.1.73",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.95",
-        "@jskit-ai/database-runtime": "0.1.96",
-        "@jskit-ai/http-runtime": "0.1.95",
-        "@jskit-ai/json-rest-api-core": "0.1.41",
-        "@jskit-ai/kernel": "0.1.96",
-        "@jskit-ai/resource-core": "0.1.41",
-        "@jskit-ai/resource-crud-core": "0.1.41",
-        "@jskit-ai/users-core": "0.1.106",
-        "json-rest-schema": "1.x.x"
-      }
-    },
-    "packages/workspaces-core/node_modules/@jskit-ai/kernel": {
-      "version": "0.1.96",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.96.tgz",
-      "integrity": "sha512-aBBsAkoaOyWYxmbyQqnaoXrVRKvofBeTlfrYXOTcYkaAU+YDxHIO11SlUBeVicVBFve7zX405zXD/z14F7BRXw==",
-      "dependencies": {
+        "@jskit-ai/auth-core": "0.1.96",
+        "@jskit-ai/database-runtime": "0.1.97",
+        "@jskit-ai/http-runtime": "0.1.96",
+        "@jskit-ai/json-rest-api-core": "0.1.42",
+        "@jskit-ai/kernel": "0.1.98",
+        "@jskit-ai/resource-core": "0.1.42",
+        "@jskit-ai/resource-crud-core": "0.1.42",
+        "@jskit-ai/users-core": "0.1.107",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/workspaces-web": {
       "name": "@jskit-ai/workspaces-web",
-      "version": "0.1.73",
+      "version": "0.1.74",
       "dependencies": {
-        "@jskit-ai/http-runtime": "0.1.95",
-        "@jskit-ai/kernel": "0.1.96",
-        "@jskit-ai/shell-web": "0.1.95",
-        "@jskit-ai/users-core": "0.1.106",
-        "@jskit-ai/users-web": "0.1.111",
-        "@jskit-ai/workspaces-core": "0.1.72",
+        "@jskit-ai/http-runtime": "0.1.96",
+        "@jskit-ai/kernel": "0.1.98",
+        "@jskit-ai/shell-web": "0.1.97",
+        "@jskit-ai/users-core": "0.1.107",
+        "@jskit-ai/users-web": "0.1.112",
+        "@jskit-ai/workspaces-core": "0.1.73",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -7332,32 +7042,9 @@
         "vuetify": "^4.0.0"
       }
     },
-    "packages/workspaces-web/node_modules/@jskit-ai/kernel": {
-      "version": "0.1.96",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.96.tgz",
-      "integrity": "sha512-aBBsAkoaOyWYxmbyQqnaoXrVRKvofBeTlfrYXOTcYkaAU+YDxHIO11SlUBeVicVBFve7zX405zXD/z14F7BRXw==",
-      "dependencies": {
-        "json-rest-schema": "1.x.x"
-      }
-    },
-    "packages/workspaces-web/node_modules/@jskit-ai/shell-web": {
-      "version": "0.1.95",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/shell-web/-/shell-web-0.1.95.tgz",
-      "integrity": "sha512-QqStS3A0J8jU8f5iOZ7At7wLB+O0jcfvOH2ekxrxkt3yJN58MMz1ry+cw9Dkl1/D0J6ldbONzRKAfAVMTAc0mQ==",
-      "dependencies": {
-        "@jskit-ai/kernel": "0.1.96",
-        "@mdi/js": "^7.4.47"
-      },
-      "peerDependencies": {
-        "pinia": "^3.0.4",
-        "vue": "^3.5.13",
-        "vue-router": "^5.0.4",
-        "vuetify": "^4.0.0"
-      }
-    },
     "tooling/config-eslint": {
       "name": "@jskit-ai/config-eslint",
-      "version": "0.1.95",
+      "version": "0.1.96",
       "dependencies": {
         "@eslint/js": "^9.39.1",
         "eslint-plugin-vue": "^10.5.1",
@@ -7375,7 +7062,7 @@
     },
     "tooling/create-app": {
       "name": "@jskit-ai/create-app",
-      "version": "0.1.105",
+      "version": "0.1.106",
       "bin": {
         "jskit-create-app": "bin/jskit-create-app.js"
       },
@@ -7385,18 +7072,18 @@
     },
     "tooling/jskit-catalog": {
       "name": "@jskit-ai/jskit-catalog",
-      "version": "0.1.104",
+      "version": "0.1.105",
       "engines": {
         "node": ">=20 <23"
       }
     },
     "tooling/jskit-cli": {
       "name": "@jskit-ai/jskit-cli",
-      "version": "0.2.109",
+      "version": "0.2.110",
       "dependencies": {
-        "@jskit-ai/jskit-catalog": "0.1.104",
-        "@jskit-ai/kernel": "0.1.96",
-        "@jskit-ai/shell-web": "0.1.95",
+        "@jskit-ai/jskit-catalog": "0.1.105",
+        "@jskit-ai/kernel": "0.1.98",
+        "@jskit-ai/shell-web": "0.1.97",
         "@vue/compiler-sfc": "^3.5.29",
         "ts-morph": "^28.0.0"
       },
@@ -7405,29 +7092,6 @@
       },
       "engines": {
         "node": ">=20 <23"
-      }
-    },
-    "tooling/jskit-cli/node_modules/@jskit-ai/kernel": {
-      "version": "0.1.96",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.96.tgz",
-      "integrity": "sha512-aBBsAkoaOyWYxmbyQqnaoXrVRKvofBeTlfrYXOTcYkaAU+YDxHIO11SlUBeVicVBFve7zX405zXD/z14F7BRXw==",
-      "dependencies": {
-        "json-rest-schema": "1.x.x"
-      }
-    },
-    "tooling/jskit-cli/node_modules/@jskit-ai/shell-web": {
-      "version": "0.1.95",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/shell-web/-/shell-web-0.1.95.tgz",
-      "integrity": "sha512-QqStS3A0J8jU8f5iOZ7At7wLB+O0jcfvOH2ekxrxkt3yJN58MMz1ry+cw9Dkl1/D0J6ldbONzRKAfAVMTAc0mQ==",
-      "dependencies": {
-        "@jskit-ai/kernel": "0.1.96",
-        "@mdi/js": "^7.4.47"
-      },
-      "peerDependencies": {
-        "pinia": "^3.0.4",
-        "vue": "^3.5.13",
-        "vue-router": "^5.0.4",
-        "vuetify": "^4.0.0"
       }
     },
     "tooling/testUtils": {}

--- a/packages/agent-docs/package.json
+++ b/packages/agent-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/agent-docs",
-  "version": "0.1.58",
+  "version": "0.1.59",
   "description": "Distributed JSKIT agent references, prompts, guides, and generated reference maps.",
   "type": "module",
   "files": [

--- a/packages/assistant-core/package.descriptor.mjs
+++ b/packages/assistant-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-core",
-  version: "0.1.72",
+  version: "0.1.73",
   kind: "runtime",
   description: "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
   dependsOn: [
@@ -47,11 +47,11 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/http-runtime": "0.1.95",
-        "@jskit-ai/kernel": "0.1.96",
-        "@jskit-ai/resource-core": "0.1.41",
-        "@jskit-ai/resource-crud-core": "0.1.41",
-        "@jskit-ai/users-core": "0.1.106",
+        "@jskit-ai/http-runtime": "0.1.96",
+        "@jskit-ai/kernel": "0.1.98",
+        "@jskit-ai/resource-core": "0.1.42",
+        "@jskit-ai/resource-crud-core": "0.1.42",
+        "@jskit-ai/users-core": "0.1.107",
         "dompurify": "^3.3.3",
         "json-rest-schema": "1.x.x",
         "marked": "^17.0.4",

--- a/packages/assistant-core/package.json
+++ b/packages/assistant-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-core",
-  "version": "0.1.72",
+  "version": "0.1.73",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,12 +11,12 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.96",
-    "@jskit-ai/http-runtime": "0.1.95",
-    "@jskit-ai/kernel": "0.1.96",
-    "@jskit-ai/resource-crud-core": "0.1.41",
-    "@jskit-ai/resource-core": "0.1.41",
-    "@jskit-ai/users-core": "0.1.106",
+    "@jskit-ai/database-runtime": "0.1.97",
+    "@jskit-ai/http-runtime": "0.1.96",
+    "@jskit-ai/kernel": "0.1.98",
+    "@jskit-ai/resource-crud-core": "0.1.42",
+    "@jskit-ai/resource-core": "0.1.42",
+    "@jskit-ai/users-core": "0.1.107",
     "dompurify": "^3.3.3",
     "json-rest-schema": "1.x.x",
     "marked": "^17.0.4",

--- a/packages/assistant-runtime/package.descriptor.mjs
+++ b/packages/assistant-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-runtime",
-  version: "0.1.67",
+  version: "0.1.68",
   kind: "runtime",
   description: "Shared assistant runtime with per-surface assistant registration.",
   dependsOn: [
@@ -95,13 +95,13 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/assistant-core": "0.1.72",
-        "@jskit-ai/database-runtime": "0.1.96",
-        "@jskit-ai/http-runtime": "0.1.95",
-        "@jskit-ai/kernel": "0.1.96",
-        "@jskit-ai/shell-web": "0.1.95",
-        "@jskit-ai/users-core": "0.1.106",
-        "@jskit-ai/users-web": "0.1.111"
+        "@jskit-ai/assistant-core": "0.1.73",
+        "@jskit-ai/database-runtime": "0.1.97",
+        "@jskit-ai/http-runtime": "0.1.96",
+        "@jskit-ai/kernel": "0.1.98",
+        "@jskit-ai/shell-web": "0.1.97",
+        "@jskit-ai/users-core": "0.1.107",
+        "@jskit-ai/users-web": "0.1.112"
       },
       dev: {}
     },

--- a/packages/assistant-runtime/package.json
+++ b/packages/assistant-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-runtime",
-  "version": "0.1.67",
+  "version": "0.1.68",
   "type": "module",
   "exports": {
     "./client": "./src/client/index.js",
@@ -8,13 +8,13 @@
     "./server/actionIds": "./src/server/actionIds.js"
   },
   "dependencies": {
-    "@jskit-ai/assistant-core": "0.1.72",
-    "@jskit-ai/database-runtime": "0.1.96",
-    "@jskit-ai/http-runtime": "0.1.95",
-    "@jskit-ai/kernel": "0.1.96",
-    "@jskit-ai/shell-web": "0.1.95",
-    "@jskit-ai/users-core": "0.1.106",
-    "@jskit-ai/users-web": "0.1.111",
+    "@jskit-ai/assistant-core": "0.1.73",
+    "@jskit-ai/database-runtime": "0.1.97",
+    "@jskit-ai/http-runtime": "0.1.96",
+    "@jskit-ai/kernel": "0.1.98",
+    "@jskit-ai/shell-web": "0.1.97",
+    "@jskit-ai/users-core": "0.1.107",
+    "@jskit-ai/users-web": "0.1.112",
     "json-rest-schema": "1.x.x"
   },
   "peerDependencies": {

--- a/packages/assistant/package.descriptor.mjs
+++ b/packages/assistant/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant",
-  version: "0.1.105",
+  version: "0.1.106",
   kind: "generator",
   description: "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
   options: {

--- a/packages/assistant/package.json
+++ b/packages/assistant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant",
-  "version": "0.1.105",
+  "version": "0.1.106",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.96"
+    "@jskit-ai/kernel": "0.1.98"
   }
 }

--- a/packages/auth-core/package.descriptor.mjs
+++ b/packages/auth-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-core",
-  "version": "0.1.95",
+  "version": "0.1.96",
   "kind": "runtime",
   "dependsOn": [
     "@jskit-ai/value-app-config-shared"
@@ -69,7 +69,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.96",
+        "@jskit-ai/kernel": "0.1.98",
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0"

--- a/packages/auth-core/package.json
+++ b/packages/auth-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-core",
-  "version": "0.1.95",
+  "version": "0.1.96",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -47,7 +47,7 @@
     "./shared/commands/authSessionReadCommand": "./src/shared/commands/authSessionReadCommand.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.96",
+    "@jskit-ai/kernel": "0.1.98",
     "@fastify/cookie": "^11.0.2",
     "@fastify/csrf-protection": "^7.1.0",
     "@fastify/rate-limit": "^10.3.0",

--- a/packages/auth-provider-supabase-core/package.descriptor.mjs
+++ b/packages/auth-provider-supabase-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.95",
+  "version": "0.1.96",
   "kind": "runtime",
   "options": {
     "auth-supabase-url": {
@@ -83,8 +83,8 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/auth-core": "0.1.95",
-        "@jskit-ai/kernel": "0.1.96",
+        "@jskit-ai/auth-core": "0.1.96",
+        "@jskit-ai/kernel": "0.1.98",
         "dotenv": "^16.4.5",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0"

--- a/packages/auth-provider-supabase-core/package.json
+++ b/packages/auth-provider-supabase-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.95",
+  "version": "0.1.96",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,8 +12,8 @@
     "./client": "./src/client/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.95",
-    "@jskit-ai/kernel": "0.1.96",
+    "@jskit-ai/auth-core": "0.1.96",
+    "@jskit-ai/kernel": "0.1.98",
     "json-rest-schema": "1.x.x",
     "jose": "^6.1.0",
     "@supabase/supabase-js": "^2.57.4",

--- a/packages/auth-web/package.descriptor.mjs
+++ b/packages/auth-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-web",
-  "version": "0.1.97",
+  "version": "0.1.98",
   "kind": "runtime",
   "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
   "dependsOn": [
@@ -247,10 +247,10 @@ export default Object.freeze({
     "dependencies": {
       "runtime": {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/auth-core": "0.1.95",
-        "@jskit-ai/http-runtime": "0.1.95",
-        "@jskit-ai/kernel": "0.1.96",
-        "@jskit-ai/shell-web": "0.1.95"
+        "@jskit-ai/auth-core": "0.1.96",
+        "@jskit-ai/http-runtime": "0.1.96",
+        "@jskit-ai/kernel": "0.1.98",
+        "@jskit-ai/shell-web": "0.1.97"
       },
       "dev": {}
     },

--- a/packages/auth-web/package.json
+++ b/packages/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-web",
-  "version": "0.1.97",
+  "version": "0.1.98",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -18,11 +18,11 @@
     "./client/runtime/useSignOut": "./src/client/runtime/useSignOut.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.95",
+    "@jskit-ai/auth-core": "0.1.96",
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/kernel": "0.1.96",
-    "@jskit-ai/shell-web": "0.1.95",
-    "@jskit-ai/http-runtime": "0.1.95"
+    "@jskit-ai/kernel": "0.1.98",
+    "@jskit-ai/shell-web": "0.1.97",
+    "@jskit-ai/http-runtime": "0.1.96"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/console-core/package.descriptor.mjs
+++ b/packages/console-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-core",
-  version: "0.1.59",
+  version: "0.1.60",
   kind: "runtime",
   description: "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
   dependsOn: [
@@ -85,12 +85,12 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.95",
-        "@jskit-ai/database-runtime": "0.1.96",
-        "@jskit-ai/http-runtime": "0.1.95",
-        "@jskit-ai/kernel": "0.1.96",
-        "@jskit-ai/resource-crud-core": "0.1.41",
-        "@jskit-ai/users-core": "0.1.106"
+        "@jskit-ai/auth-core": "0.1.96",
+        "@jskit-ai/database-runtime": "0.1.97",
+        "@jskit-ai/http-runtime": "0.1.96",
+        "@jskit-ai/kernel": "0.1.98",
+        "@jskit-ai/resource-crud-core": "0.1.42",
+        "@jskit-ai/users-core": "0.1.107"
       },
       dev: {}
     },

--- a/packages/console-core/package.json
+++ b/packages/console-core/package.json
@@ -1,17 +1,17 @@
 {
   "name": "@jskit-ai/console-core",
-  "version": "0.1.59",
+  "version": "0.1.60",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.95",
-    "@jskit-ai/database-runtime": "0.1.96",
-    "@jskit-ai/http-runtime": "0.1.95",
-    "@jskit-ai/kernel": "0.1.96",
-    "@jskit-ai/resource-crud-core": "0.1.41",
-    "@jskit-ai/users-core": "0.1.106",
+    "@jskit-ai/auth-core": "0.1.96",
+    "@jskit-ai/database-runtime": "0.1.97",
+    "@jskit-ai/http-runtime": "0.1.96",
+    "@jskit-ai/kernel": "0.1.98",
+    "@jskit-ai/resource-crud-core": "0.1.42",
+    "@jskit-ai/users-core": "0.1.107",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/console-web/package.descriptor.mjs
+++ b/packages/console-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-web",
-  version: "0.1.64",
+  version: "0.1.65",
   kind: "runtime",
   description: "Authenticated console surface scaffold and surface policy wiring.",
   dependsOn: [
@@ -103,9 +103,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-web": "0.1.97",
-        "@jskit-ai/console-core": "0.1.59",
-        "@jskit-ai/shell-web": "0.1.95",
+        "@jskit-ai/auth-web": "0.1.98",
+        "@jskit-ai/console-core": "0.1.60",
+        "@jskit-ai/shell-web": "0.1.97",
       },
       dev: {}
     },

--- a/packages/console-web/package.json
+++ b/packages/console-web/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/console-web",
-  "version": "0.1.64",
+  "version": "0.1.65",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-web": "0.1.97",
-    "@jskit-ai/console-core": "0.1.59",
-    "@jskit-ai/shell-web": "0.1.95"
+    "@jskit-ai/auth-web": "0.1.98",
+    "@jskit-ai/console-core": "0.1.60",
+    "@jskit-ai/shell-web": "0.1.97"
   }
 }

--- a/packages/crud-core/package.descriptor.mjs
+++ b/packages/crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-core",
-  version: "0.1.104",
+  version: "0.1.105",
   kind: "runtime",
   description: "Shared CRUD helpers used by CRUD modules.",
   dependsOn: [
@@ -28,7 +28,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/crud-core": "0.1.104"
+        "@jskit-ai/crud-core": "0.1.105"
       },
       dev: {}
     },

--- a/packages/crud-core/package.json
+++ b/packages/crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-core",
-  "version": "0.1.104",
+  "version": "0.1.105",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -27,15 +27,15 @@
     "./server/routeContracts": "./src/server/routeContracts.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.96",
-    "@jskit-ai/http-runtime": "0.1.95",
-    "@jskit-ai/kernel": "0.1.96",
+    "@jskit-ai/database-runtime": "0.1.97",
+    "@jskit-ai/http-runtime": "0.1.96",
+    "@jskit-ai/kernel": "0.1.98",
     "json-rest-schema": "1.x.x",
-    "@jskit-ai/realtime": "0.1.95",
-    "@jskit-ai/resource-crud-core": "0.1.41",
-    "@jskit-ai/shell-web": "0.1.95",
-    "@jskit-ai/users-core": "0.1.106",
-    "@jskit-ai/users-web": "0.1.111"
+    "@jskit-ai/realtime": "0.1.96",
+    "@jskit-ai/resource-crud-core": "0.1.42",
+    "@jskit-ai/shell-web": "0.1.97",
+    "@jskit-ai/users-core": "0.1.107",
+    "@jskit-ai/users-web": "0.1.112"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/crud-server-generator/package.descriptor.mjs
+++ b/packages/crud-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-server-generator",
-  version: "0.1.104",
+  version: "0.1.105",
   kind: "generator",
   description: "CRUD server generator with routes, actions, and persistence scaffolding.",
   options: {
@@ -160,14 +160,14 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.95",
-        "@jskit-ai/crud-core": "0.1.104",
-        "@jskit-ai/database-runtime": "0.1.96",
-        "@jskit-ai/http-runtime": "0.1.95",
-        "@jskit-ai/json-rest-api-core": "0.1.41",
-        "@jskit-ai/kernel": "0.1.96",
-        "@jskit-ai/realtime": "0.1.95",
-        "@jskit-ai/resource-crud-core": "0.1.41",
+        "@jskit-ai/auth-core": "0.1.96",
+        "@jskit-ai/crud-core": "0.1.105",
+        "@jskit-ai/database-runtime": "0.1.97",
+        "@jskit-ai/http-runtime": "0.1.96",
+        "@jskit-ai/json-rest-api-core": "0.1.42",
+        "@jskit-ai/kernel": "0.1.98",
+        "@jskit-ai/realtime": "0.1.96",
+        "@jskit-ai/resource-crud-core": "0.1.42",
         "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}"
       },
       dev: {}

--- a/packages/crud-server-generator/package.json
+++ b/packages/crud-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-server-generator",
-  "version": "0.1.104",
+  "version": "0.1.105",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,12 +13,12 @@
   },
   "dependencies": {
     "@babel/parser": "^7.29.2",
-    "@jskit-ai/crud-core": "0.1.104",
-    "@jskit-ai/database-runtime": "0.1.96",
-    "@jskit-ai/http-runtime": "0.1.95",
-    "@jskit-ai/json-rest-api-core": "0.1.41",
-    "@jskit-ai/kernel": "0.1.96",
-    "@jskit-ai/resource-crud-core": "0.1.41",
+    "@jskit-ai/crud-core": "0.1.105",
+    "@jskit-ai/database-runtime": "0.1.97",
+    "@jskit-ai/http-runtime": "0.1.96",
+    "@jskit-ai/json-rest-api-core": "0.1.42",
+    "@jskit-ai/kernel": "0.1.98",
+    "@jskit-ai/resource-crud-core": "0.1.42",
     "recast": "^0.23.11"
   }
 }

--- a/packages/crud-ui-generator/package.descriptor.mjs
+++ b/packages/crud-ui-generator/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { GENERATED_UI_NAVIGATION_ROLE_OPTION } from "@jskit-ai/kernel/shared/sup
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-ui-generator",
-  version: "0.1.79",
+  version: "0.1.80",
   kind: "generator",
   description: "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
   options: {
@@ -175,7 +175,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.111"
+        "@jskit-ai/users-web": "0.1.112"
       },
       dev: {}
     },

--- a/packages/crud-ui-generator/package.json
+++ b/packages/crud-ui-generator/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@jskit-ai/crud-ui-generator",
-  "version": "0.1.79",
+  "version": "0.1.80",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/crud-core": "0.1.104",
-    "@jskit-ai/kernel": "0.1.96",
-    "@jskit-ai/resource-crud-core": "0.1.41"
+    "@jskit-ai/crud-core": "0.1.105",
+    "@jskit-ai/kernel": "0.1.98",
+    "@jskit-ai/resource-crud-core": "0.1.42"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/database-runtime-mysql/package.descriptor.mjs
+++ b/packages/database-runtime-mysql/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-mysql",
-  version: "0.1.95",
+  version: "0.1.96",
   kind: "runtime",
   options: {
     "db-host": {
@@ -91,7 +91,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.96",
+        "@jskit-ai/database-runtime": "0.1.97",
         "mysql2": "^3.11.2"
       },
       dev: {}

--- a/packages/database-runtime-mysql/package.json
+++ b/packages/database-runtime-mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-mysql",
-  "version": "0.1.95",
+  "version": "0.1.96",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,7 +12,7 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.96",
-    "@jskit-ai/kernel": "0.1.96"
+    "@jskit-ai/database-runtime": "0.1.97",
+    "@jskit-ai/kernel": "0.1.98"
   }
 }

--- a/packages/database-runtime-postgres/package.descriptor.mjs
+++ b/packages/database-runtime-postgres/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-postgres",
-  version: "0.1.95",
+  version: "0.1.96",
   kind: "runtime",
   options: {
     "db-host": {
@@ -91,7 +91,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.96",
+        "@jskit-ai/database-runtime": "0.1.97",
         "pg": "^8.13.1"
       },
       dev: {}

--- a/packages/database-runtime-postgres/package.json
+++ b/packages/database-runtime-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-postgres",
-  "version": "0.1.95",
+  "version": "0.1.96",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,6 +12,6 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.96"
+    "@jskit-ai/database-runtime": "0.1.97"
   }
 }

--- a/packages/database-runtime/package.descriptor.mjs
+++ b/packages/database-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime",
-  version: "0.1.96",
+  version: "0.1.97",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -58,7 +58,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.96",
+        "@jskit-ai/kernel": "0.1.98",
         "dotenv": "^16.4.5",
         "knex": "^3.1.0"
       },

--- a/packages/database-runtime/package.json
+++ b/packages/database-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime",
-  "version": "0.1.96",
+  "version": "0.1.97",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -25,6 +25,6 @@
     "./shared/transactions": "./src/shared/transactions.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.96"
+    "@jskit-ai/kernel": "0.1.98"
   }
 }

--- a/packages/feature-server-generator/package.descriptor.mjs
+++ b/packages/feature-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/feature-server-generator",
-  version: "0.1.38",
+  version: "0.1.39",
   kind: "generator",
   description: "Scaffold substantial non-CRUD server feature packages with provider, actions, service, and optional persistence seams.",
   options: {
@@ -174,7 +174,7 @@ export default Object.freeze({
             equals: "json-rest"
           }
         },
-        "@jskit-ai/kernel": "0.1.97",
+        "@jskit-ai/kernel": "0.1.98",
         "json-rest-schema": "1.x.x",
         "@local/${option:feature-name|kebab}": "file:packages/${option:feature-name|kebab}"
       },

--- a/packages/feature-server-generator/package.json
+++ b/packages/feature-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/feature-server-generator",
-  "version": "0.1.38",
+  "version": "0.1.39",
   "type": "module",
   "scripts": {
     "test": "node --test"

--- a/packages/google-rewarded-core/package.descriptor.mjs
+++ b/packages/google-rewarded-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/google-rewarded-core",
-  version: "0.1.33",
+  version: "0.1.34",
   kind: "runtime",
   description: "Google rewarded workflow runtime plus internal CRUD providers for rules, provider configs, watch sessions, and unlock receipts.",
   dependsOn: [
@@ -128,14 +128,14 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.95",
-        "@jskit-ai/crud-core": "0.1.104",
-        "@jskit-ai/database-runtime": "0.1.96",
-        "@jskit-ai/http-runtime": "0.1.95",
-        "@jskit-ai/json-rest-api-core": "0.1.41",
-        "@jskit-ai/kernel": "0.1.96",
-        "@jskit-ai/resource-crud-core": "0.1.41",
-        "@jskit-ai/workspaces-core": "0.1.72"
+        "@jskit-ai/auth-core": "0.1.96",
+        "@jskit-ai/crud-core": "0.1.105",
+        "@jskit-ai/database-runtime": "0.1.97",
+        "@jskit-ai/http-runtime": "0.1.96",
+        "@jskit-ai/json-rest-api-core": "0.1.42",
+        "@jskit-ai/kernel": "0.1.98",
+        "@jskit-ai/resource-crud-core": "0.1.42",
+        "@jskit-ai/workspaces-core": "0.1.73"
       },
       dev: {}
     },

--- a/packages/google-rewarded-core/package.json
+++ b/packages/google-rewarded-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/google-rewarded-core",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/google-rewarded-web/package.descriptor.mjs
+++ b/packages/google-rewarded-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/google-rewarded-web",
-  version: "0.1.33",
+  version: "0.1.34",
   kind: "runtime",
   description: "Google rewarded client runtime with a fullscreen gate host and GPT orchestration.",
   dependsOn: [
@@ -46,10 +46,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/google-rewarded-core": "0.1.33",
-        "@jskit-ai/http-runtime": "0.1.95",
-        "@jskit-ai/kernel": "0.1.96",
-        "@jskit-ai/shell-web": "0.1.95"
+        "@jskit-ai/google-rewarded-core": "0.1.34",
+        "@jskit-ai/http-runtime": "0.1.96",
+        "@jskit-ai/kernel": "0.1.98",
+        "@jskit-ai/shell-web": "0.1.97"
       },
       dev: {}
     },

--- a/packages/google-rewarded-web/package.json
+++ b/packages/google-rewarded-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/google-rewarded-web",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/http-runtime/package.descriptor.mjs
+++ b/packages/http-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/http-runtime",
-  "version": "0.1.95",
+  "version": "0.1.96",
   "kind": "runtime",
   "dependsOn": [],
   "capabilities": {
@@ -67,7 +67,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.96"
+        "@jskit-ai/kernel": "0.1.98"
       },
       "dev": {}
     },

--- a/packages/http-runtime/package.json
+++ b/packages/http-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/http-runtime",
-  "version": "0.1.95",
+  "version": "0.1.96",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -18,7 +18,7 @@
     "./shared/validators/operationValidation": "./src/shared/validators/operationValidation.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.96",
+    "@jskit-ai/kernel": "0.1.98",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/json-rest-api-core/package.descriptor.mjs
+++ b/packages/json-rest-api-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/json-rest-api-core",
-  version: "0.1.41",
+  version: "0.1.42",
   kind: "runtime",
   description: "Shared internal json-rest-api host runtime for JSKIT server packages.",
   dependsOn: [

--- a/packages/json-rest-api-core/package.json
+++ b/packages/json-rest-api-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/json-rest-api-core",
-  "version": "0.1.41",
+  "version": "0.1.42",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,6 +11,6 @@
   "dependencies": {
     "hooked-api": "1.x.x",
     "json-rest-api": "1.x.x",
-    "@jskit-ai/kernel": "0.1.96"
+    "@jskit-ai/kernel": "0.1.98"
   }
 }

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/kernel",
-  "version": "0.1.97",
+  "version": "0.1.98",
   "type": "module",
   "dependencies": {
     "json-rest-schema": "1.x.x"

--- a/packages/mobile-capacitor/package.descriptor.mjs
+++ b/packages/mobile-capacitor/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/mobile-capacitor",
-  version: "0.1.33",
+  version: "0.1.34",
   kind: "runtime",
   description: "Thin Capacitor client integration for JSKIT mobile-shell launch routing and auth callback completion.",
   dependsOn: [
@@ -62,8 +62,8 @@ export default Object.freeze({
         "@capacitor/app": "^7.1.0",
         "@capacitor/browser": "^7.0.1",
         "@capacitor/core": "^7.4.3",
-        "@jskit-ai/kernel": "0.1.96",
-        "@jskit-ai/shell-web": "0.1.95"
+        "@jskit-ai/kernel": "0.1.98",
+        "@jskit-ai/shell-web": "0.1.97"
       },
       dev: {
         "@capacitor/cli": "^7.4.3"

--- a/packages/mobile-capacitor/package.json
+++ b/packages/mobile-capacitor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/mobile-capacitor",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,6 +12,6 @@
   },
   "dependencies": {
     "@capacitor/browser": "^7.0.1",
-    "@jskit-ai/kernel": "0.1.96"
+    "@jskit-ai/kernel": "0.1.98"
   }
 }

--- a/packages/realtime/package.descriptor.mjs
+++ b/packages/realtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/realtime",
-  version: "0.1.95",
+  version: "0.1.96",
   kind: "runtime",
   description: "Thin, generic realtime runtime wrappers for socket.io server and client.",
   options: {
@@ -95,7 +95,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.96",
+        "@jskit-ai/kernel": "0.1.98",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/realtime",
-  "version": "0.1.95",
+  "version": "0.1.96",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@socket.io/redis-adapter": "^8.3.0",
-    "@jskit-ai/kernel": "0.1.96",
+    "@jskit-ai/kernel": "0.1.98",
     "redis": "^5.8.2",
     "socket.io": "^4.8.3",
     "socket.io-client": "^4.8.3"

--- a/packages/resource-core/package.descriptor.mjs
+++ b/packages/resource-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/resource-core",
-  version: "0.1.41",
+  version: "0.1.42",
   kind: "runtime",
   description: "Generic resource-definition helpers and schema-definition normalization.",
   dependsOn: [
@@ -22,7 +22,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/resource-core": "0.1.41"
+        "@jskit-ai/resource-core": "0.1.42"
       },
       dev: {}
     },

--- a/packages/resource-core/package.json
+++ b/packages/resource-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/resource-core",
-  "version": "0.1.41",
+  "version": "0.1.42",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./shared/resource": "./src/shared/resource.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.96"
+    "@jskit-ai/kernel": "0.1.98"
   }
 }

--- a/packages/resource-crud-core/package.descriptor.mjs
+++ b/packages/resource-crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/resource-crud-core",
-  version: "0.1.41",
+  version: "0.1.42",
   kind: "runtime",
   description: "CRUD-specific resource-definition helpers and namespace support.",
   dependsOn: [
@@ -23,7 +23,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/resource-crud-core": "0.1.41"
+        "@jskit-ai/resource-crud-core": "0.1.42"
       },
       dev: {}
     },

--- a/packages/resource-crud-core/package.json
+++ b/packages/resource-crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/resource-crud-core",
-  "version": "0.1.41",
+  "version": "0.1.42",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./shared/crudResource": "./src/shared/crudResource.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.96",
-    "@jskit-ai/resource-core": "0.1.41"
+    "@jskit-ai/kernel": "0.1.98",
+    "@jskit-ai/resource-core": "0.1.42"
   }
 }

--- a/packages/shell-web/package.descriptor.mjs
+++ b/packages/shell-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/shell-web",
-  version: "0.1.96",
+  version: "0.1.97",
   kind: "runtime",
   description: "Web shell layout runtime with outlet-based placement contributions.",
   dependsOn: [],
@@ -307,7 +307,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/kernel": "0.1.97"
+        "@jskit-ai/kernel": "0.1.98"
       },
       dev: {}
     },

--- a/packages/shell-web/package.json
+++ b/packages/shell-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/shell-web",
-  "version": "0.1.96",
+  "version": "0.1.97",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/kernel": "0.1.97"
+    "@jskit-ai/kernel": "0.1.98"
   },
   "peerDependencies": {
     "pinia": "^3.0.4",

--- a/packages/storage-runtime/package.descriptor.mjs
+++ b/packages/storage-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/storage-runtime",
-  version: "0.1.95",
+  version: "0.1.96",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -50,7 +50,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.96",
+        "@jskit-ai/kernel": "0.1.98",
         "unstorage": "^1.17.3"
       },
       dev: {}

--- a/packages/storage-runtime/package.json
+++ b/packages/storage-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/storage-runtime",
-  "version": "0.1.95",
+  "version": "0.1.96",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./server/providers/StorageRuntimeServiceProvider": "./src/server/providers/StorageRuntimeServiceProvider.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.96",
+    "@jskit-ai/kernel": "0.1.98",
     "unstorage": "^1.17.3"
   }
 }

--- a/packages/ui-generator/package.descriptor.mjs
+++ b/packages/ui-generator/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { GENERATED_UI_NAVIGATION_ROLE_OPTION } from "@jskit-ai/kernel/shared/sup
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/ui-generator",
-  version: "0.1.79",
+  version: "0.1.80",
   kind: "generator",
   description: "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
   options: {
@@ -371,7 +371,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.111"
+        "@jskit-ai/users-web": "0.1.112"
       },
       dev: {}
     },

--- a/packages/ui-generator/package.json
+++ b/packages/ui-generator/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/ui-generator",
-  "version": "0.1.79",
+  "version": "0.1.80",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.96",
-    "@jskit-ai/shell-web": "0.1.95"
+    "@jskit-ai/kernel": "0.1.98",
+    "@jskit-ai/shell-web": "0.1.97"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/uploads-image-web/package.descriptor.mjs
+++ b/packages/uploads-image-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-image-web",
-  version: "0.1.74",
+  version: "0.1.75",
   kind: "runtime",
   description: "Reusable client-side image upload runtime with pre-upload image editing.",
   dependsOn: [
@@ -65,7 +65,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/uploads-runtime": "0.1.74",
+        "@jskit-ai/uploads-runtime": "0.1.75",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-image-web/package.json
+++ b/packages/uploads-image-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-image-web",
-  "version": "0.1.74",
+  "version": "0.1.75",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,7 +13,7 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/uploads-runtime": "0.1.74",
+    "@jskit-ai/uploads-runtime": "0.1.75",
     "@uppy/compressor": "^3.1.0",
     "@uppy/core": "^5.2.0",
     "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-runtime/package.descriptor.mjs
+++ b/packages/uploads-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-runtime",
-  version: "0.1.74",
+  version: "0.1.75",
   kind: "runtime",
   description: "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
   dependsOn: [
@@ -71,7 +71,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.96"
+        "@jskit-ai/kernel": "0.1.98"
       },
       dev: {}
     },

--- a/packages/uploads-runtime/package.json
+++ b/packages/uploads-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-runtime",
-  "version": "0.1.74",
+  "version": "0.1.75",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,6 +16,6 @@
   },
   "dependencies": {
     "@fastify/multipart": "^9.4.0",
-    "@jskit-ai/kernel": "0.1.96"
+    "@jskit-ai/kernel": "0.1.98"
   }
 }

--- a/packages/users-core/package.descriptor.mjs
+++ b/packages/users-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-core",
-  version: "0.1.106",
+  version: "0.1.107",
   kind: "runtime",
   description: "Users/account runtime plus HTTP routes for account features.",
   dependsOn: [
@@ -143,16 +143,16 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.95",
-        "@jskit-ai/crud-core": "0.1.104",
-        "@jskit-ai/database-runtime": "0.1.96",
-        "@jskit-ai/http-runtime": "0.1.95",
-        "@jskit-ai/json-rest-api-core": "0.1.41",
-        "@jskit-ai/kernel": "0.1.96",
-        "@jskit-ai/resource-core": "0.1.41",
-        "@jskit-ai/resource-crud-core": "0.1.41",
+        "@jskit-ai/auth-core": "0.1.96",
+        "@jskit-ai/crud-core": "0.1.105",
+        "@jskit-ai/database-runtime": "0.1.97",
+        "@jskit-ai/http-runtime": "0.1.96",
+        "@jskit-ai/json-rest-api-core": "0.1.42",
+        "@jskit-ai/kernel": "0.1.98",
+        "@jskit-ai/resource-core": "0.1.42",
+        "@jskit-ai/resource-crud-core": "0.1.42",
         "@local/users": "file:packages/users",
-        "@jskit-ai/uploads-runtime": "0.1.74"
+        "@jskit-ai/uploads-runtime": "0.1.75"
       },
       dev: {}
     },

--- a/packages/users-core/package.json
+++ b/packages/users-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-core",
-  "version": "0.1.106",
+  "version": "0.1.107",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,14 +12,14 @@
     "./shared/resources/userSettingsResource": "./src/shared/resources/userSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.95",
-    "@jskit-ai/database-runtime": "0.1.96",
-    "@jskit-ai/http-runtime": "0.1.95",
-    "@jskit-ai/json-rest-api-core": "0.1.41",
-    "@jskit-ai/kernel": "0.1.96",
-    "@jskit-ai/resource-crud-core": "0.1.41",
-    "@jskit-ai/resource-core": "0.1.41",
-    "@jskit-ai/uploads-runtime": "0.1.74",
+    "@jskit-ai/auth-core": "0.1.96",
+    "@jskit-ai/database-runtime": "0.1.97",
+    "@jskit-ai/http-runtime": "0.1.96",
+    "@jskit-ai/json-rest-api-core": "0.1.42",
+    "@jskit-ai/kernel": "0.1.98",
+    "@jskit-ai/resource-crud-core": "0.1.42",
+    "@jskit-ai/resource-core": "0.1.42",
+    "@jskit-ai/uploads-runtime": "0.1.75",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/users-web/package.descriptor.mjs
+++ b/packages/users-web/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { HOME_COG_OUTLET } from "./src/shared/toolsOutletContracts.js";
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-web",
-  version: "0.1.111",
+  version: "0.1.112",
   kind: "runtime",
   description: "Users web module: account/profile UI plus shared users web widgets.",
   dependsOn: [
@@ -286,12 +286,12 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/http-runtime": "0.1.95",
-        "@jskit-ai/realtime": "0.1.95",
-        "@jskit-ai/kernel": "0.1.96",
-        "@jskit-ai/shell-web": "0.1.95",
-        "@jskit-ai/uploads-image-web": "0.1.74",
-        "@jskit-ai/users-core": "0.1.106"
+        "@jskit-ai/http-runtime": "0.1.96",
+        "@jskit-ai/realtime": "0.1.96",
+        "@jskit-ai/kernel": "0.1.98",
+        "@jskit-ai/shell-web": "0.1.97",
+        "@jskit-ai/uploads-image-web": "0.1.75",
+        "@jskit-ai/users-core": "0.1.107"
       },
       dev: {}
     },

--- a/packages/users-web/package.json
+++ b/packages/users-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-web",
-  "version": "0.1.111",
+  "version": "0.1.112",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -46,12 +46,12 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/http-runtime": "0.1.95",
-    "@jskit-ai/kernel": "0.1.96",
-    "@jskit-ai/realtime": "0.1.95",
-    "@jskit-ai/shell-web": "0.1.95",
-    "@jskit-ai/uploads-image-web": "0.1.74",
-    "@jskit-ai/users-core": "0.1.106"
+    "@jskit-ai/http-runtime": "0.1.96",
+    "@jskit-ai/kernel": "0.1.98",
+    "@jskit-ai/realtime": "0.1.96",
+    "@jskit-ai/shell-web": "0.1.97",
+    "@jskit-ai/uploads-image-web": "0.1.75",
+    "@jskit-ai/users-core": "0.1.107"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/workspaces-core/package.descriptor.mjs
+++ b/packages/workspaces-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-core",
-  version: "0.1.72",
+  version: "0.1.73",
   kind: "runtime",
   description: "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
   dependsOn: [
@@ -142,10 +142,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/json-rest-api-core": "0.1.41",
-        "@jskit-ai/resource-core": "0.1.41",
-        "@jskit-ai/resource-crud-core": "0.1.41",
-        "@jskit-ai/users-core": "0.1.106"
+        "@jskit-ai/json-rest-api-core": "0.1.42",
+        "@jskit-ai/resource-core": "0.1.42",
+        "@jskit-ai/resource-crud-core": "0.1.42",
+        "@jskit-ai/users-core": "0.1.107"
       },
       dev: {}
     },

--- a/packages/workspaces-core/package.json
+++ b/packages/workspaces-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-core",
-  "version": "0.1.72",
+  "version": "0.1.73",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -18,14 +18,14 @@
     "./shared/resources/workspaceSettingsResource": "./src/shared/resources/workspaceSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.95",
-    "@jskit-ai/database-runtime": "0.1.96",
-    "@jskit-ai/http-runtime": "0.1.95",
-    "@jskit-ai/json-rest-api-core": "0.1.41",
-    "@jskit-ai/kernel": "0.1.96",
-    "@jskit-ai/resource-crud-core": "0.1.41",
-    "@jskit-ai/resource-core": "0.1.41",
-    "@jskit-ai/users-core": "0.1.106",
+    "@jskit-ai/auth-core": "0.1.96",
+    "@jskit-ai/database-runtime": "0.1.97",
+    "@jskit-ai/http-runtime": "0.1.96",
+    "@jskit-ai/json-rest-api-core": "0.1.42",
+    "@jskit-ai/kernel": "0.1.98",
+    "@jskit-ai/resource-crud-core": "0.1.42",
+    "@jskit-ai/resource-core": "0.1.42",
+    "@jskit-ai/users-core": "0.1.107",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/workspaces-web/package.descriptor.mjs
+++ b/packages/workspaces-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-web",
-  version: "0.1.73",
+  version: "0.1.74",
   kind: "runtime",
   description: "Workspace web module: workspace selector, tools widget, workspace surfaces, members UI, and settings hosts.",
   dependsOn: [
@@ -227,8 +227,8 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/workspaces-core": "0.1.72",
-        "@jskit-ai/users-web": "0.1.111"
+        "@jskit-ai/workspaces-core": "0.1.73",
+        "@jskit-ai/users-web": "0.1.112"
       },
       dev: {}
     },

--- a/packages/workspaces-web/package.json
+++ b/packages/workspaces-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-web",
-  "version": "0.1.73",
+  "version": "0.1.74",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -14,12 +14,12 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/http-runtime": "0.1.95",
-    "@jskit-ai/kernel": "0.1.96",
-    "@jskit-ai/shell-web": "0.1.95",
-    "@jskit-ai/users-core": "0.1.106",
-    "@jskit-ai/users-web": "0.1.111",
-    "@jskit-ai/workspaces-core": "0.1.72"
+    "@jskit-ai/http-runtime": "0.1.96",
+    "@jskit-ai/kernel": "0.1.98",
+    "@jskit-ai/shell-web": "0.1.97",
+    "@jskit-ai/users-core": "0.1.107",
+    "@jskit-ai/users-web": "0.1.112",
+    "@jskit-ai/workspaces-core": "0.1.73"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/tooling/config-eslint/package.json
+++ b/tooling/config-eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/config-eslint",
-  "version": "0.1.95",
+  "version": "0.1.96",
   "description": "Shared flat ESLint presets for JSKIT projects.",
   "type": "module",
   "files": [

--- a/tooling/create-app/package.descriptor.mjs
+++ b/tooling/create-app/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/create-app",
-  "version": "0.1.105",
+  "version": "0.1.106",
   "dependsOn": [],
   "capabilities": {
     "provides": [

--- a/tooling/create-app/package.json
+++ b/tooling/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/create-app",
-  "version": "0.1.105",
+  "version": "0.1.106",
   "description": "Scaffold JSKIT app shells.",
   "type": "module",
   "files": [

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -6,11 +6,11 @@
   "packages": [
     {
       "packageId": "@jskit-ai/assistant",
-      "version": "0.1.105",
+      "version": "0.1.106",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant",
-        "version": "0.1.105",
+        "version": "0.1.106",
         "kind": "generator",
         "description": "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
         "options": {
@@ -347,11 +347,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-core",
-      "version": "0.1.72",
+      "version": "0.1.73",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-core",
-        "version": "0.1.72",
+        "version": "0.1.73",
         "kind": "runtime",
         "description": "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
         "dependsOn": [
@@ -399,11 +399,11 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/http-runtime": "0.1.95",
-              "@jskit-ai/kernel": "0.1.96",
-              "@jskit-ai/resource-core": "0.1.41",
-              "@jskit-ai/resource-crud-core": "0.1.41",
-              "@jskit-ai/users-core": "0.1.106",
+              "@jskit-ai/http-runtime": "0.1.96",
+              "@jskit-ai/kernel": "0.1.98",
+              "@jskit-ai/resource-core": "0.1.42",
+              "@jskit-ai/resource-crud-core": "0.1.42",
+              "@jskit-ai/users-core": "0.1.107",
               "dompurify": "^3.3.3",
               "json-rest-schema": "1.x.x",
               "marked": "^17.0.4",
@@ -422,11 +422,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-runtime",
-      "version": "0.1.67",
+      "version": "0.1.68",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-runtime",
-        "version": "0.1.67",
+        "version": "0.1.68",
         "kind": "runtime",
         "description": "Shared assistant runtime with per-surface assistant registration.",
         "dependsOn": [
@@ -522,13 +522,13 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/assistant-core": "0.1.72",
-              "@jskit-ai/database-runtime": "0.1.96",
-              "@jskit-ai/http-runtime": "0.1.95",
-              "@jskit-ai/kernel": "0.1.96",
-              "@jskit-ai/shell-web": "0.1.95",
-              "@jskit-ai/users-core": "0.1.106",
-              "@jskit-ai/users-web": "0.1.111"
+              "@jskit-ai/assistant-core": "0.1.73",
+              "@jskit-ai/database-runtime": "0.1.97",
+              "@jskit-ai/http-runtime": "0.1.96",
+              "@jskit-ai/kernel": "0.1.98",
+              "@jskit-ai/shell-web": "0.1.97",
+              "@jskit-ai/users-core": "0.1.107",
+              "@jskit-ai/users-web": "0.1.112"
             },
             "dev": {}
           },
@@ -583,11 +583,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-core",
-      "version": "0.1.95",
+      "version": "0.1.96",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-core",
-        "version": "0.1.95",
+        "version": "0.1.96",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/value-app-config-shared"
@@ -655,7 +655,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.96",
+              "@jskit-ai/kernel": "0.1.98",
               "@fastify/cookie": "^11.0.2",
               "@fastify/csrf-protection": "^7.1.0",
               "@fastify/rate-limit": "^10.3.0"
@@ -673,11 +673,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.95",
+      "version": "0.1.96",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-supabase-core",
-        "version": "0.1.95",
+        "version": "0.1.96",
         "kind": "runtime",
         "options": {
           "auth-supabase-url": {
@@ -759,8 +759,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.95",
-              "@jskit-ai/kernel": "0.1.96",
+              "@jskit-ai/auth-core": "0.1.96",
+              "@jskit-ai/kernel": "0.1.98",
               "dotenv": "^16.4.5",
               "@supabase/supabase-js": "^2.57.4",
               "jose": "^6.1.0"
@@ -825,11 +825,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-web",
-      "version": "0.1.97",
+      "version": "0.1.98",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-web",
-        "version": "0.1.97",
+        "version": "0.1.98",
         "kind": "runtime",
         "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
         "dependsOn": [
@@ -1085,10 +1085,10 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/auth-core": "0.1.95",
-              "@jskit-ai/http-runtime": "0.1.95",
-              "@jskit-ai/kernel": "0.1.96",
-              "@jskit-ai/shell-web": "0.1.95"
+              "@jskit-ai/auth-core": "0.1.96",
+              "@jskit-ai/http-runtime": "0.1.96",
+              "@jskit-ai/kernel": "0.1.98",
+              "@jskit-ai/shell-web": "0.1.97"
             },
             "dev": {}
           },
@@ -1167,11 +1167,11 @@
     },
     {
       "packageId": "@jskit-ai/console-core",
-      "version": "0.1.59",
+      "version": "0.1.60",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-core",
-        "version": "0.1.59",
+        "version": "0.1.60",
         "kind": "runtime",
         "description": "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
         "dependsOn": [
@@ -1255,12 +1255,12 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.95",
-              "@jskit-ai/database-runtime": "0.1.96",
-              "@jskit-ai/http-runtime": "0.1.95",
-              "@jskit-ai/kernel": "0.1.96",
-              "@jskit-ai/resource-crud-core": "0.1.41",
-              "@jskit-ai/users-core": "0.1.106"
+              "@jskit-ai/auth-core": "0.1.96",
+              "@jskit-ai/database-runtime": "0.1.97",
+              "@jskit-ai/http-runtime": "0.1.96",
+              "@jskit-ai/kernel": "0.1.98",
+              "@jskit-ai/resource-crud-core": "0.1.42",
+              "@jskit-ai/users-core": "0.1.107"
             },
             "dev": {}
           },
@@ -1285,11 +1285,11 @@
     },
     {
       "packageId": "@jskit-ai/console-web",
-      "version": "0.1.64",
+      "version": "0.1.65",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-web",
-        "version": "0.1.64",
+        "version": "0.1.65",
         "kind": "runtime",
         "description": "Authenticated console surface scaffold and surface policy wiring.",
         "dependsOn": [
@@ -1399,9 +1399,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-web": "0.1.97",
-              "@jskit-ai/console-core": "0.1.59",
-              "@jskit-ai/shell-web": "0.1.95"
+              "@jskit-ai/auth-web": "0.1.98",
+              "@jskit-ai/console-core": "0.1.60",
+              "@jskit-ai/shell-web": "0.1.97"
             },
             "dev": {}
           },
@@ -1508,11 +1508,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-core",
-      "version": "0.1.104",
+      "version": "0.1.105",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-core",
-        "version": "0.1.104",
+        "version": "0.1.105",
         "kind": "runtime",
         "description": "Shared CRUD helpers used by CRUD modules.",
         "dependsOn": [
@@ -1541,7 +1541,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/crud-core": "0.1.104"
+              "@jskit-ai/crud-core": "0.1.105"
             },
             "dev": {}
           },
@@ -1555,11 +1555,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-server-generator",
-      "version": "0.1.104",
+      "version": "0.1.105",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-server-generator",
-        "version": "0.1.104",
+        "version": "0.1.105",
         "kind": "generator",
         "description": "CRUD server generator with routes, actions, and persistence scaffolding.",
         "options": {
@@ -1726,14 +1726,14 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.95",
-              "@jskit-ai/crud-core": "0.1.104",
-              "@jskit-ai/database-runtime": "0.1.96",
-              "@jskit-ai/http-runtime": "0.1.95",
-              "@jskit-ai/json-rest-api-core": "0.1.41",
-              "@jskit-ai/kernel": "0.1.96",
-              "@jskit-ai/realtime": "0.1.95",
-              "@jskit-ai/resource-crud-core": "0.1.41",
+              "@jskit-ai/auth-core": "0.1.96",
+              "@jskit-ai/crud-core": "0.1.105",
+              "@jskit-ai/database-runtime": "0.1.97",
+              "@jskit-ai/http-runtime": "0.1.96",
+              "@jskit-ai/json-rest-api-core": "0.1.42",
+              "@jskit-ai/kernel": "0.1.98",
+              "@jskit-ai/realtime": "0.1.96",
+              "@jskit-ai/resource-crud-core": "0.1.42",
               "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}"
             },
             "dev": {}
@@ -1865,11 +1865,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.79",
+      "version": "0.1.80",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-ui-generator",
-        "version": "0.1.79",
+        "version": "0.1.80",
         "kind": "generator",
         "description": "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
         "options": {
@@ -2068,7 +2068,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.111"
+              "@jskit-ai/users-web": "0.1.112"
             },
             "dev": {}
           },
@@ -2327,11 +2327,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime",
-      "version": "0.1.96",
+      "version": "0.1.97",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime",
-        "version": "0.1.96",
+        "version": "0.1.97",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -2388,7 +2388,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.96",
+              "@jskit-ai/kernel": "0.1.98",
               "dotenv": "^16.4.5",
               "knex": "^3.1.0"
             },
@@ -2423,11 +2423,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.95",
+      "version": "0.1.96",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-mysql",
-        "version": "0.1.95",
+        "version": "0.1.96",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -2517,7 +2517,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.96",
+              "@jskit-ai/database-runtime": "0.1.97",
               "mysql2": "^3.11.2"
             },
             "dev": {}
@@ -2588,11 +2588,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.95",
+      "version": "0.1.96",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-postgres",
-        "version": "0.1.95",
+        "version": "0.1.96",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -2682,7 +2682,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.96",
+              "@jskit-ai/database-runtime": "0.1.97",
               "pg": "^8.13.1"
             },
             "dev": {}
@@ -2753,11 +2753,11 @@
     },
     {
       "packageId": "@jskit-ai/feature-server-generator",
-      "version": "0.1.38",
+      "version": "0.1.39",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/feature-server-generator",
-        "version": "0.1.38",
+        "version": "0.1.39",
         "kind": "generator",
         "description": "Scaffold substantial non-CRUD server feature packages with provider, actions, service, and optional persistence seams.",
         "options": {
@@ -2942,7 +2942,7 @@
                   "equals": "json-rest"
                 }
               },
-              "@jskit-ai/kernel": "0.1.97",
+              "@jskit-ai/kernel": "0.1.98",
               "json-rest-schema": "1.x.x",
               "@local/${option:feature-name|kebab}": "file:packages/${option:feature-name|kebab}"
             },
@@ -3055,11 +3055,11 @@
     },
     {
       "packageId": "@jskit-ai/google-rewarded-core",
-      "version": "0.1.33",
+      "version": "0.1.34",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/google-rewarded-core",
-        "version": "0.1.33",
+        "version": "0.1.34",
         "kind": "runtime",
         "description": "Google rewarded workflow runtime plus internal CRUD providers for rules, provider configs, watch sessions, and unlock receipts.",
         "dependsOn": [
@@ -3186,14 +3186,14 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.95",
-              "@jskit-ai/crud-core": "0.1.104",
-              "@jskit-ai/database-runtime": "0.1.96",
-              "@jskit-ai/http-runtime": "0.1.95",
-              "@jskit-ai/json-rest-api-core": "0.1.41",
-              "@jskit-ai/kernel": "0.1.96",
-              "@jskit-ai/resource-crud-core": "0.1.41",
-              "@jskit-ai/workspaces-core": "0.1.72"
+              "@jskit-ai/auth-core": "0.1.96",
+              "@jskit-ai/crud-core": "0.1.105",
+              "@jskit-ai/database-runtime": "0.1.97",
+              "@jskit-ai/http-runtime": "0.1.96",
+              "@jskit-ai/json-rest-api-core": "0.1.42",
+              "@jskit-ai/kernel": "0.1.98",
+              "@jskit-ai/resource-crud-core": "0.1.42",
+              "@jskit-ai/workspaces-core": "0.1.73"
             },
             "dev": {}
           },
@@ -3245,11 +3245,11 @@
     },
     {
       "packageId": "@jskit-ai/google-rewarded-web",
-      "version": "0.1.33",
+      "version": "0.1.34",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/google-rewarded-web",
-        "version": "0.1.33",
+        "version": "0.1.34",
         "kind": "runtime",
         "description": "Google rewarded client runtime with a fullscreen gate host and GPT orchestration.",
         "dependsOn": [
@@ -3296,10 +3296,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/google-rewarded-core": "0.1.33",
-              "@jskit-ai/http-runtime": "0.1.95",
-              "@jskit-ai/kernel": "0.1.96",
-              "@jskit-ai/shell-web": "0.1.95"
+              "@jskit-ai/google-rewarded-core": "0.1.34",
+              "@jskit-ai/http-runtime": "0.1.96",
+              "@jskit-ai/kernel": "0.1.98",
+              "@jskit-ai/shell-web": "0.1.97"
             },
             "dev": {}
           },
@@ -3317,11 +3317,11 @@
     },
     {
       "packageId": "@jskit-ai/http-runtime",
-      "version": "0.1.95",
+      "version": "0.1.96",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/http-runtime",
-        "version": "0.1.95",
+        "version": "0.1.96",
         "kind": "runtime",
         "dependsOn": [],
         "capabilities": {
@@ -3387,7 +3387,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.96"
+              "@jskit-ai/kernel": "0.1.98"
             },
             "dev": {}
           },
@@ -3401,11 +3401,11 @@
     },
     {
       "packageId": "@jskit-ai/json-rest-api-core",
-      "version": "0.1.41",
+      "version": "0.1.42",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/json-rest-api-core",
-        "version": "0.1.41",
+        "version": "0.1.42",
         "kind": "runtime",
         "description": "Shared internal json-rest-api host runtime for JSKIT server packages.",
         "dependsOn": [
@@ -3465,11 +3465,11 @@
     },
     {
       "packageId": "@jskit-ai/mobile-capacitor",
-      "version": "0.1.33",
+      "version": "0.1.34",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/mobile-capacitor",
-        "version": "0.1.33",
+        "version": "0.1.34",
         "kind": "runtime",
         "description": "Thin Capacitor client integration for JSKIT mobile-shell launch routing and auth callback completion.",
         "dependsOn": [
@@ -3532,8 +3532,8 @@
               "@capacitor/app": "^7.1.0",
               "@capacitor/browser": "^7.0.1",
               "@capacitor/core": "^7.4.3",
-              "@jskit-ai/kernel": "0.1.96",
-              "@jskit-ai/shell-web": "0.1.95"
+              "@jskit-ai/kernel": "0.1.98",
+              "@jskit-ai/shell-web": "0.1.97"
             },
             "dev": {
               "@capacitor/cli": "^7.4.3"
@@ -3585,11 +3585,11 @@
     },
     {
       "packageId": "@jskit-ai/realtime",
-      "version": "0.1.95",
+      "version": "0.1.96",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/realtime",
-        "version": "0.1.95",
+        "version": "0.1.96",
         "kind": "runtime",
         "description": "Thin, generic realtime runtime wrappers for socket.io server and client.",
         "options": {
@@ -3685,7 +3685,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.96",
+              "@jskit-ai/kernel": "0.1.98",
               "@socket.io/redis-adapter": "^8.3.0",
               "redis": "^5.8.2",
               "socket.io": "^4.8.3",
@@ -3734,11 +3734,11 @@
     },
     {
       "packageId": "@jskit-ai/resource-core",
-      "version": "0.1.41",
+      "version": "0.1.42",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/resource-core",
-        "version": "0.1.41",
+        "version": "0.1.42",
         "kind": "runtime",
         "description": "Generic resource-definition helpers and schema-definition normalization.",
         "dependsOn": [
@@ -3761,7 +3761,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/resource-core": "0.1.41"
+              "@jskit-ai/resource-core": "0.1.42"
             },
             "dev": {}
           },
@@ -3776,11 +3776,11 @@
     },
     {
       "packageId": "@jskit-ai/resource-crud-core",
-      "version": "0.1.41",
+      "version": "0.1.42",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/resource-crud-core",
-        "version": "0.1.41",
+        "version": "0.1.42",
         "kind": "runtime",
         "description": "CRUD-specific resource-definition helpers and namespace support.",
         "dependsOn": [
@@ -3804,7 +3804,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/resource-crud-core": "0.1.41"
+              "@jskit-ai/resource-crud-core": "0.1.42"
             },
             "dev": {}
           },
@@ -3819,11 +3819,11 @@
     },
     {
       "packageId": "@jskit-ai/shell-web",
-      "version": "0.1.96",
+      "version": "0.1.97",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/shell-web",
-        "version": "0.1.96",
+        "version": "0.1.97",
         "kind": "runtime",
         "description": "Web shell layout runtime with outlet-based placement contributions.",
         "dependsOn": [],
@@ -4165,7 +4165,7 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/kernel": "0.1.97"
+              "@jskit-ai/kernel": "0.1.98"
             },
             "dev": {}
           },
@@ -4365,11 +4365,11 @@
     },
     {
       "packageId": "@jskit-ai/storage-runtime",
-      "version": "0.1.95",
+      "version": "0.1.96",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/storage-runtime",
-        "version": "0.1.95",
+        "version": "0.1.96",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -4418,7 +4418,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.96",
+              "@jskit-ai/kernel": "0.1.98",
               "unstorage": "^1.17.3"
             },
             "dev": {}
@@ -4434,11 +4434,11 @@
     },
     {
       "packageId": "@jskit-ai/ui-generator",
-      "version": "0.1.79",
+      "version": "0.1.80",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/ui-generator",
-        "version": "0.1.79",
+        "version": "0.1.80",
         "kind": "generator",
         "description": "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
         "options": {
@@ -4871,7 +4871,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.111"
+              "@jskit-ai/users-web": "0.1.112"
             },
             "dev": {}
           },
@@ -4886,11 +4886,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-image-web",
-      "version": "0.1.74",
+      "version": "0.1.75",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-image-web",
-        "version": "0.1.74",
+        "version": "0.1.75",
         "kind": "runtime",
         "description": "Reusable client-side image upload runtime with pre-upload image editing.",
         "dependsOn": [
@@ -4954,7 +4954,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/uploads-runtime": "0.1.74",
+              "@jskit-ai/uploads-runtime": "0.1.75",
               "@uppy/compressor": "^3.1.0",
               "@uppy/core": "^5.2.0",
               "@uppy/dashboard": "^5.1.1",
@@ -4974,11 +4974,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-runtime",
-      "version": "0.1.74",
+      "version": "0.1.75",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-runtime",
-        "version": "0.1.74",
+        "version": "0.1.75",
         "kind": "runtime",
         "description": "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
         "dependsOn": [
@@ -5048,7 +5048,7 @@
           "dependencies": {
             "runtime": {
               "@fastify/multipart": "^9.4.0",
-              "@jskit-ai/kernel": "0.1.96"
+              "@jskit-ai/kernel": "0.1.98"
             },
             "dev": {}
           },
@@ -5063,11 +5063,11 @@
     },
     {
       "packageId": "@jskit-ai/users-core",
-      "version": "0.1.106",
+      "version": "0.1.107",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-core",
-        "version": "0.1.106",
+        "version": "0.1.107",
         "kind": "runtime",
         "description": "Users/account runtime plus HTTP routes for account features.",
         "dependsOn": [
@@ -5208,16 +5208,16 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.95",
-              "@jskit-ai/crud-core": "0.1.104",
-              "@jskit-ai/database-runtime": "0.1.96",
-              "@jskit-ai/http-runtime": "0.1.95",
-              "@jskit-ai/json-rest-api-core": "0.1.41",
-              "@jskit-ai/kernel": "0.1.96",
-              "@jskit-ai/resource-core": "0.1.41",
-              "@jskit-ai/resource-crud-core": "0.1.41",
+              "@jskit-ai/auth-core": "0.1.96",
+              "@jskit-ai/crud-core": "0.1.105",
+              "@jskit-ai/database-runtime": "0.1.97",
+              "@jskit-ai/http-runtime": "0.1.96",
+              "@jskit-ai/json-rest-api-core": "0.1.42",
+              "@jskit-ai/kernel": "0.1.98",
+              "@jskit-ai/resource-core": "0.1.42",
+              "@jskit-ai/resource-crud-core": "0.1.42",
               "@local/users": "file:packages/users",
-              "@jskit-ai/uploads-runtime": "0.1.74"
+              "@jskit-ai/uploads-runtime": "0.1.75"
             },
             "dev": {}
           },
@@ -5434,11 +5434,11 @@
     },
     {
       "packageId": "@jskit-ai/users-web",
-      "version": "0.1.111",
+      "version": "0.1.112",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-web",
-        "version": "0.1.111",
+        "version": "0.1.112",
         "kind": "runtime",
         "description": "Users web module: account/profile UI plus shared users web widgets.",
         "dependsOn": [
@@ -5741,12 +5741,12 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/http-runtime": "0.1.95",
-              "@jskit-ai/realtime": "0.1.95",
-              "@jskit-ai/kernel": "0.1.96",
-              "@jskit-ai/shell-web": "0.1.95",
-              "@jskit-ai/uploads-image-web": "0.1.74",
-              "@jskit-ai/users-core": "0.1.106"
+              "@jskit-ai/http-runtime": "0.1.96",
+              "@jskit-ai/realtime": "0.1.96",
+              "@jskit-ai/kernel": "0.1.98",
+              "@jskit-ai/shell-web": "0.1.97",
+              "@jskit-ai/uploads-image-web": "0.1.75",
+              "@jskit-ai/users-core": "0.1.107"
             },
             "dev": {}
           },
@@ -5915,11 +5915,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-core",
-      "version": "0.1.72",
+      "version": "0.1.73",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-core",
-        "version": "0.1.72",
+        "version": "0.1.73",
         "kind": "runtime",
         "description": "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
         "dependsOn": [
@@ -6060,10 +6060,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/json-rest-api-core": "0.1.41",
-              "@jskit-ai/resource-core": "0.1.41",
-              "@jskit-ai/resource-crud-core": "0.1.41",
-              "@jskit-ai/users-core": "0.1.106"
+              "@jskit-ai/json-rest-api-core": "0.1.42",
+              "@jskit-ai/resource-core": "0.1.42",
+              "@jskit-ai/resource-crud-core": "0.1.42",
+              "@jskit-ai/users-core": "0.1.107"
             },
             "dev": {}
           },
@@ -6235,11 +6235,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-web",
-      "version": "0.1.73",
+      "version": "0.1.74",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-web",
-        "version": "0.1.73",
+        "version": "0.1.74",
         "kind": "runtime",
         "description": "Workspace web module: workspace selector, tools widget, workspace surfaces, members UI, and settings hosts.",
         "dependsOn": [
@@ -6491,8 +6491,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/workspaces-core": "0.1.72",
-              "@jskit-ai/users-web": "0.1.111"
+              "@jskit-ai/workspaces-core": "0.1.73",
+              "@jskit-ai/users-web": "0.1.112"
             },
             "dev": {}
           },

--- a/tooling/jskit-catalog/package.json
+++ b/tooling/jskit-catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-catalog",
-  "version": "0.1.104",
+  "version": "0.1.105",
   "description": "Published metadata catalog for JSKIT package descriptors.",
   "type": "module",
   "files": [

--- a/tooling/jskit-cli/package.json
+++ b/tooling/jskit-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-cli",
-  "version": "0.2.109",
+  "version": "0.2.110",
   "description": "Bundle and package orchestration CLI for JSKIT apps.",
   "type": "module",
   "files": [
@@ -20,9 +20,9 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/jskit-catalog": "0.1.104",
-    "@jskit-ai/kernel": "0.1.96",
-    "@jskit-ai/shell-web": "0.1.95",
+    "@jskit-ai/jskit-catalog": "0.1.105",
+    "@jskit-ai/kernel": "0.1.98",
+    "@jskit-ai/shell-web": "0.1.97",
     "@vue/compiler-sfc": "^3.5.29",
     "ts-morph": "^28.0.0"
   },


### PR DESCRIPTION
## Summary
- bump JSKIT package and descriptor versions after the auth/workspace fixes
- refresh the package lockfile and published catalog metadata
- include generated catalog output from the release build

## Verification
- npm run verify