### PR TITLE
Add realtime entity change publisher

### DIFF
--- a/packages/agent-docs/guide/agent/app-extras/realtime.md
+++ b/packages/agent-docs/guide/agent/app-extras/realtime.md
@@ -124,6 +124,79 @@ So the mental model is:
 - `realtime` gives the app a live transport
 - your own app code, or later packages, decide which events should travel across it
 
+## Publishing server events
+
+Server code should publish realtime lifecycle events through JSKIT's entity-change helpers instead of hand-rolling `domainEvents.publish()` payloads.
+
+Keep `operation` limited to resource invalidation semantics:
+
+- `created`
+- `updated`
+- `deleted`
+
+Use `action` for the domain lifecycle transition, and `reason` only when you need to explain why that transition happened.
+
+For direct publishers, use `createRealtimeEntityChangePublisher()` from `@jskit-ai/kernel/server/runtime/entityChangeEvents`:
+
+```js
+import { createRealtimeEntityChangePublisher } from "@jskit-ai/kernel/server/runtime/entityChangeEvents";
+
+const publishProjectRuntimeChanged = createRealtimeEntityChangePublisher({
+  domainEvents,
+  source: "vibe64",
+  entity: "project",
+  event: "vibe64.project.changed",
+  serviceToken: "vibe64.terminals.service",
+  methodName: "projectRuntime"
+});
+
+await publishProjectRuntimeChanged("updated", projectSlug, {
+  action: "runtime-closed",
+  payload: {
+    message: "Project is closed.",
+    runtime: {
+      open: false
+    }
+  }
+});
+```
+
+The helper emits a normal `entity.changed` domain event with service metadata and `meta.realtime.event`. The realtime bridge uses that service metadata to find the registered socket dispatcher, then emits the socket event with canonical fields such as `source`, `entity`, `operation`, `entityId`, `scope`, and the lifecycle `action`.
+
+For services registered through `app.service()`, declare the same semantics in service metadata:
+
+```js
+app.service(
+  "vibe64.terminals.service",
+  (scope) => createTerminalsService({
+    repository: scope.make("vibe64.repository.terminals")
+  }),
+  {
+    events: {
+      projectRuntime: [
+        {
+          type: "entity.changed",
+          source: "vibe64",
+          entity: "project",
+          operation: "updated",
+          entityId: ({ args }) => args?.[0]?.projectSlug,
+          action: "runtime-closed",
+          realtime: {
+            event: "vibe64.project.changed",
+            payload: ({ result }) => ({
+              message: result?.message || "",
+              runtime: result?.runtime || null
+            })
+          }
+        }
+      ]
+    }
+  }
+);
+```
+
+`action`, `reason`, and `realtime.payload` may be functions when the value depends on the service result or arguments. Do not encode lifecycle names by widening `operation`; keep `operation` truthful for CRUD/resource contracts and put domain-specific lifecycle meaning in metadata.
+
 ## What `realtime` adds to the app
 
 This chapter is small enough that it is worth looking directly at the app-owned files it changes.

--- a/packages/agent-docs/reference/autogen/packages/kernel.md
+++ b/packages/agent-docs/reference/autogen/packages/kernel.md
@@ -1163,6 +1163,7 @@ Local functions
 - `normalizeServiceEventType(value, { context = "service event" } = {})`
 - `normalizeServiceEventOperation(value, { context = "service event" } = {})`
 - `normalizeServiceEventEntityId(value)`
+- `normalizeServiceEventMetaField(value, { context = "service event meta field" } = {})`
 - `normalizeRealtimeDispatch(value, { context = "service event.realtime" } = {})`
 - `normalizeRealtimeAudience(value, { context = "service event.realtime.audience" } = {})`
 - `normalizeServiceEventSpec(entry, { context = "service event" } = {})`
@@ -1171,6 +1172,7 @@ Local functions
 - `resolveMethodOptions(args = [])`
 - `resolveEventOperation(spec, state)`
 - `resolveEventEntityId(spec, state)`
+- `resolveEventMetaField(value, state)`
 - `resolveEventMeta(spec, state)`
 - `createServiceMethodEventPublisher(scope, serviceToken, methodName, specs = [])`
 
@@ -1217,12 +1219,17 @@ Exports
 Exports
 - `resolveDefaultScope(visibilityContext = {}, runtime = {})`
 - `createEntityChangePublisher({ domainEvents, source, entity, scopeResolver = resolveDefaultScope } = {})`
+- `createRealtimeEntityChangePublisher({ domainEvents, source, entity, event, serviceToken, methodName, scopeResolver = resolveDefaultScope } = {})`
 - `createNoopEntityChangePublisher()`
 Local functions
 - `resolveContextScope(context = {})`
 - `resolveVisibilityScope(visibilityContext = {}, runtimeContext = {})`
 - `resolveCommandId(requestMeta = {})`
 - `resolveSourceClientId(requestMeta = {})`
+- `normalizeMetaTextField(source = {}, fieldName = "", { context = "realtime entity change" } = {})`
+- `normalizeRealtimePayload(value, { context = "realtime entity change.payload" } = {})`
+- `createRealtimeEntityChangeMeta({ serviceToken, methodName, event, change = {} } = {})`
+- `resolveRealtimeEntityChangeOptions(change = {}, options = {})`
 
 ### `server/runtime/errors.js`
 Exports

--- a/packages/agent-docs/site/guide/app-extras/realtime.md
+++ b/packages/agent-docs/site/guide/app-extras/realtime.md
@@ -168,6 +168,79 @@ So the mental model is:
 - `realtime` gives the app a live transport
 - your own app code, or later packages, decide which events should travel across it
 
+## Publishing server events
+
+Server code should publish realtime lifecycle events through JSKIT's entity-change helpers instead of hand-rolling `domainEvents.publish()` payloads.
+
+Keep `operation` limited to resource invalidation semantics:
+
+- `created`
+- `updated`
+- `deleted`
+
+Use `action` for the domain lifecycle transition, and `reason` only when you need to explain why that transition happened.
+
+For direct publishers, use `createRealtimeEntityChangePublisher()` from `@jskit-ai/kernel/server/runtime/entityChangeEvents`:
+
+```js
+import { createRealtimeEntityChangePublisher } from "@jskit-ai/kernel/server/runtime/entityChangeEvents";
+
+const publishProjectRuntimeChanged = createRealtimeEntityChangePublisher({
+  domainEvents,
+  source: "vibe64",
+  entity: "project",
+  event: "vibe64.project.changed",
+  serviceToken: "vibe64.terminals.service",
+  methodName: "projectRuntime"
+});
+
+await publishProjectRuntimeChanged("updated", projectSlug, {
+  action: "runtime-closed",
+  payload: {
+    message: "Project is closed.",
+    runtime: {
+      open: false
+    }
+  }
+});
+```
+
+The helper emits a normal `entity.changed` domain event with service metadata and `meta.realtime.event`. The realtime bridge uses that service metadata to find the registered socket dispatcher, then emits the socket event with canonical fields such as `source`, `entity`, `operation`, `entityId`, `scope`, and the lifecycle `action`.
+
+For services registered through `app.service()`, declare the same semantics in service metadata:
+
+```js
+app.service(
+  "vibe64.terminals.service",
+  (scope) => createTerminalsService({
+    repository: scope.make("vibe64.repository.terminals")
+  }),
+  {
+    events: {
+      projectRuntime: [
+        {
+          type: "entity.changed",
+          source: "vibe64",
+          entity: "project",
+          operation: "updated",
+          entityId: ({ args }) => args?.[0]?.projectSlug,
+          action: "runtime-closed",
+          realtime: {
+            event: "vibe64.project.changed",
+            payload: ({ result }) => ({
+              message: result?.message || "",
+              runtime: result?.runtime || null
+            })
+          }
+        }
+      ]
+    }
+  }
+);
+```
+
+`action`, `reason`, and `realtime.payload` may be functions when the value depends on the service result or arguments. Do not encode lifecycle names by widening `operation`; keep `operation` truthful for CRUD/resource contracts and put domain-specific lifecycle meaning in metadata.
+
 ## What `realtime` adds to the app
 
 This chapter is small enough that it is worth looking directly at the app-owned files it changes.

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -29,6 +29,7 @@
     "./server/platform": "./server/platform/index.js",
     "./server/registries": "./server/registries/index.js",
     "./server/runtime": "./server/runtime/index.js",
+    "./server/runtime/entityChangeEvents": "./server/runtime/entityChangeEvents.js",
     "./server/runtime/errors": "./server/runtime/errors.js",
     "./server/runtime/requestUrl": "./server/runtime/requestUrl.js",
     "./server/support": "./server/support/index.js",

--- a/packages/kernel/server/registries/serviceRegistrationRegistry.js
+++ b/packages/kernel/server/registries/serviceRegistrationRegistry.js
@@ -60,6 +60,25 @@ function normalizeServiceEventEntityId(value) {
   return null;
 }
 
+function normalizeServiceEventMetaField(value, { context = "service event meta field" } = {}) {
+  if (value == null) {
+    return null;
+  }
+
+  if (typeof value === "function") {
+    return value;
+  }
+  if (typeof value !== "string") {
+    throw new TypeError(`${context} must be a non-empty string or function.`);
+  }
+
+  const normalized = normalizeText(value);
+  if (!normalized) {
+    throw new TypeError(`${context} must be a non-empty string or function.`);
+  }
+  return normalized;
+}
+
 function normalizeRealtimeDispatch(value, { context = "service event.realtime" } = {}) {
   const source = normalizeObject(value);
   if (Object.keys(source).length < 1) {
@@ -118,6 +137,8 @@ function normalizeServiceEventSpec(entry, { context = "service event" } = {}) {
     entity: normalizeText(source.entity),
     operation: normalizeServiceEventOperation(source.operation, { context }),
     entityId: normalizeServiceEventEntityId(source.entityId),
+    action: normalizeServiceEventMetaField(source.action, { context: `${context}.action` }),
+    reason: normalizeServiceEventMetaField(source.reason, { context: `${context}.reason` }),
     realtime: normalizeRealtimeDispatch(source.realtime, { context: `${context}.realtime` })
   });
 }
@@ -230,6 +251,28 @@ function resolveEventEntityId(spec, state) {
   return state?.result?.id;
 }
 
+function resolveEventMetaField(value, state) {
+  const context = `service metadata.events.${state.methodName}.meta`;
+  if (typeof value === "function") {
+    const resolved = value({
+      result: state.result,
+      args: state.args,
+      options: state.options,
+      methodName: state.methodName,
+      serviceToken: state.serviceToken,
+      event: state.event
+    });
+    if (resolved == null) {
+      return "";
+    }
+    if (typeof resolved !== "string") {
+      throw new TypeError(`${context} field resolver must return a string.`);
+    }
+    return normalizeText(resolved);
+  }
+  return normalizeText(value);
+}
+
 function resolveEventMeta(spec, state) {
   const meta = {
     service: Object.freeze({
@@ -237,6 +280,22 @@ function resolveEventMeta(spec, state) {
       method: state.methodName
     })
   };
+
+  const action = resolveEventMetaField(spec.action, {
+    ...state,
+    event: spec
+  });
+  if (action) {
+    meta.action = action;
+  }
+
+  const reason = resolveEventMetaField(spec.reason, {
+    ...state,
+    event: spec
+  });
+  if (reason) {
+    meta.reason = reason;
+  }
 
   if (spec.realtime) {
     meta.realtime = spec.realtime.payload

--- a/packages/kernel/server/runtime/entityChangeEvents.js
+++ b/packages/kernel/server/runtime/entityChangeEvents.js
@@ -1,3 +1,4 @@
+import { isContainerToken } from "../../shared/support/containerToken.js";
 import { normalizeObject, normalizeOpaqueId, normalizeText } from "../../shared/support/normalize.js";
 import { resolveServiceContext } from "./serviceAuthorization.js";
 
@@ -169,6 +170,129 @@ function createEntityChangePublisher({
   };
 }
 
+function normalizeMetaTextField(source = {}, fieldName = "", { context = "realtime entity change" } = {}) {
+  if (!Object.hasOwn(source, fieldName)) {
+    return "";
+  }
+
+  const value = source[fieldName];
+  if (value == null) {
+    return "";
+  }
+  if (typeof value !== "string") {
+    throw new TypeError(`${context}.${fieldName} must be a non-empty string.`);
+  }
+
+  const normalized = normalizeText(value);
+  if (!normalized) {
+    throw new TypeError(`${context}.${fieldName} must be a non-empty string.`);
+  }
+  return normalized;
+}
+
+function normalizeRealtimePayload(value, { context = "realtime entity change.payload" } = {}) {
+  if (value == null) {
+    return null;
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError(`${context} must be an object.`);
+  }
+  return Object.freeze({
+    ...value
+  });
+}
+
+function createRealtimeEntityChangeMeta({
+  serviceToken,
+  methodName,
+  event,
+  change = {}
+} = {}) {
+  const source = normalizeObject(change);
+  const baseMeta = normalizeObject(source.meta);
+  const meta = {
+    ...baseMeta,
+    service: Object.freeze({
+      token: serviceToken,
+      method: methodName
+    })
+  };
+
+  const action = normalizeMetaTextField(source, "action");
+  if (action) {
+    meta.action = action;
+  }
+
+  const reason = normalizeMetaTextField(source, "reason");
+  if (reason) {
+    meta.reason = reason;
+  }
+
+  const realtimeSource = normalizeObject(source.realtime);
+  const payloadSource = Object.hasOwn(source, "payload") ? source.payload : realtimeSource.payload;
+  const payload = normalizeRealtimePayload(payloadSource);
+  meta.realtime = payload
+    ? Object.freeze({
+        event,
+        payload
+      })
+    : Object.freeze({
+        event
+      });
+
+  return Object.freeze(meta);
+}
+
+function resolveRealtimeEntityChangeOptions(change = {}, options = {}) {
+  const source = normalizeObject(change);
+  if (Object.hasOwn(source, "options")) {
+    return normalizeObject(source.options);
+  }
+  return normalizeObject(options);
+}
+
+function createRealtimeEntityChangePublisher({
+  domainEvents,
+  source,
+  entity,
+  event,
+  serviceToken,
+  methodName,
+  scopeResolver = resolveDefaultScope
+} = {}) {
+  const normalizedEvent = normalizeText(event);
+  if (!normalizedEvent) {
+    throw new TypeError("createRealtimeEntityChangePublisher requires event.");
+  }
+
+  if (!isContainerToken(serviceToken)) {
+    throw new TypeError("createRealtimeEntityChangePublisher requires a valid serviceToken.");
+  }
+
+  const normalizedMethodName = normalizeText(methodName);
+  if (!normalizedMethodName) {
+    throw new TypeError("createRealtimeEntityChangePublisher requires methodName.");
+  }
+
+  const publishEntityChange = createEntityChangePublisher({
+    domainEvents,
+    source,
+    entity,
+    scopeResolver
+  });
+
+  return async function publishRealtimeEntityChange(operation, entityId, change = {}, options = {}) {
+    const runtimeOptions = resolveRealtimeEntityChangeOptions(change, options);
+    const meta = createRealtimeEntityChangeMeta({
+      serviceToken,
+      methodName: normalizedMethodName,
+      event: normalizedEvent,
+      change
+    });
+    return publishEntityChange(operation, entityId, runtimeOptions, meta);
+  };
+}
+
 function createNoopEntityChangePublisher() {
   return async function publishEntityChange() {
     return null;
@@ -178,5 +302,6 @@ function createNoopEntityChangePublisher() {
 export {
   resolveDefaultScope,
   createEntityChangePublisher,
+  createRealtimeEntityChangePublisher,
   createNoopEntityChangePublisher
 };

--- a/packages/kernel/server/runtime/entityChangeEvents.test.js
+++ b/packages/kernel/server/runtime/entityChangeEvents.test.js
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { createEntityChangePublisher } from "./entityChangeEvents.js";
+import {
+  createEntityChangePublisher,
+  createRealtimeEntityChangePublisher
+} from "./entityChangeEvents.js";
 
 test("entity change publisher emits normalized event payload", async () => {
   const published = [];
@@ -207,5 +210,65 @@ test("entity change publisher does not infer actor scope from scope kind suffix"
     id: "workspace_23"
   });
   assert.equal(payload?.actorId, null);
+  assert.equal(published.length, 1);
+});
+
+test("realtime entity change publisher adds service, semantic, and realtime metadata", async () => {
+  const published = [];
+  const publishProjectChange = createRealtimeEntityChangePublisher({
+    domainEvents: {
+      async publish(payload) {
+        published.push(payload);
+      }
+    },
+    source: "vibe64",
+    entity: "project",
+    event: "vibe64.project.changed",
+    serviceToken: "vibe64.terminals.service",
+    methodName: "projectRuntime"
+  });
+
+  const payload = await publishProjectChange("updated", "project_acme", {
+    action: "runtime-closed",
+    reason: "user-request",
+    payload: {
+      message: "Project is closed.",
+      runtime: {
+        open: false
+      }
+    },
+    options: {
+      context: {
+        actor: {
+          id: "user_17"
+        },
+        visibilityContext: {
+          scopeKind: "workspace",
+          scopeOwnerId: "workspace_23"
+        }
+      }
+    }
+  });
+
+  assert.equal(payload?.source, "vibe64");
+  assert.equal(payload?.entity, "project");
+  assert.equal(payload?.operation, "updated");
+  assert.equal(payload?.entityId, "project_acme");
+  assert.deepEqual(payload?.scope, {
+    kind: "workspace",
+    id: "workspace_23"
+  });
+  assert.equal(payload?.actorId, "user_17");
+  assert.equal(payload?.meta?.service?.token, "vibe64.terminals.service");
+  assert.equal(payload?.meta?.service?.method, "projectRuntime");
+  assert.equal(payload?.meta?.action, "runtime-closed");
+  assert.equal(payload?.meta?.reason, "user-request");
+  assert.equal(payload?.meta?.realtime?.event, "vibe64.project.changed");
+  assert.deepEqual(payload?.meta?.realtime?.payload, {
+    message: "Project is closed.",
+    runtime: {
+      open: false
+    }
+  });
   assert.equal(published.length, 1);
 });

--- a/packages/kernel/server/runtime/serviceRegistration.test.js
+++ b/packages/kernel/server/runtime/serviceRegistration.test.js
@@ -93,6 +93,64 @@ test("app.service rejects deprecated permissions metadata", () => {
   );
 });
 
+test("app.service publishes lifecycle action, reason, and realtime payload metadata", async () => {
+  const app = createContainer();
+  const published = [];
+  app.singleton("domainEvents", () => ({
+    async publish(payload) {
+      published.push(payload);
+      return null;
+    }
+  }));
+  installServiceRegistrationApi(app);
+
+  app.service(
+    "test.projects.service",
+    () => ({
+      async closeRuntime() {
+        return {
+          id: "project_acme",
+          action: "runtime-closed",
+          message: "Project is closed."
+        };
+      }
+    }),
+    {
+      events: {
+        closeRuntime: [
+          {
+            type: "entity.changed",
+            source: "vibe64",
+            entity: "project",
+            operation: "updated",
+            action: ({ result }) => result?.action,
+            reason: "user-request",
+            realtime: {
+              event: "vibe64.project.changed",
+              payload: ({ result }) => ({
+                message: result?.message || ""
+              })
+            }
+          }
+        ]
+      }
+    }
+  );
+
+  const service = app.make("test.projects.service");
+  await service.closeRuntime();
+
+  assert.equal(service.serviceEvents.closeRuntime[0].reason, "user-request");
+  assert.equal(typeof service.serviceEvents.closeRuntime[0].action, "function");
+  assert.equal(published.length, 1);
+  assert.equal(published[0].meta?.action, "runtime-closed");
+  assert.equal(published[0].meta?.reason, "user-request");
+  assert.equal(published[0].meta?.realtime?.event, "vibe64.project.changed");
+  assert.deepEqual(published[0].meta?.realtime?.payload, {
+    message: "Project is closed."
+  });
+});
+
 test("resolveServiceRegistrations returns declared service metadata", () => {
   const app = createContainer();
   app.singleton("domainEvents", () => ({

--- a/packages/kernel/test/exportsContract.test.js
+++ b/packages/kernel/test/exportsContract.test.js
@@ -25,7 +25,9 @@ const EXPORTED_UNUSED_ALLOWLIST = new Set([
   // Used by generated app bootstrap code emitted from kernel client vite plugin.
   "./client/moduleBootstrap",
   // Intentionally retained as an explicit low-level kernel API subpath.
-  "./shared/support/tokens"
+  "./shared/support/tokens",
+  // Public helper API for packages that publish entity-change realtime events.
+  "./server/runtime/entityChangeEvents"
 ]);
 
 function normalizeSlash(value) {

--- a/packages/realtime/src/server/RealtimeServiceProvider.js
+++ b/packages/realtime/src/server/RealtimeServiceProvider.js
@@ -169,16 +169,32 @@ function buildRealtimeDispatchIndex(registrations = []) {
 
 function mergeRealtimePayload(event, payloadPatch) {
   const basePayload = event && typeof event === "object" && !Array.isArray(event) ? event : {};
+  const action = normalizeText(basePayload?.meta?.action);
+  const reason = normalizeText(basePayload?.meta?.reason);
+  const semanticPatch = {};
+  if (action) {
+    semanticPatch.action = action;
+  }
+  if (reason) {
+    semanticPatch.reason = reason;
+  }
+
   if (payloadPatch == null) {
-    return basePayload;
+    return Object.keys(semanticPatch).length > 0
+      ? {
+          ...semanticPatch,
+          ...basePayload
+        }
+      : basePayload;
   }
   if (!payloadPatch || typeof payloadPatch !== "object" || Array.isArray(payloadPatch)) {
     throw new TypeError("Realtime payload callback must return an object.");
   }
 
-  // Keep canonical domain-event fields authoritative while allowing additive metadata.
+  // Keep canonical domain-event fields and standard lifecycle metadata authoritative.
   return {
     ...payloadPatch,
+    ...semanticPatch,
     ...basePayload
   };
 }

--- a/packages/realtime/test/providerRuntime.test.js
+++ b/packages/realtime/test/providerRuntime.test.js
@@ -615,6 +615,8 @@ test("RealtimeServiceProvider merges custom realtime payload with canonical doma
             source: "workspace",
             entity: "settings",
             operation: "updated",
+            action: "settings-saved",
+            reason: "profile-update",
             realtime: {
               event: "workspace.settings.changed",
               payload: ({ result }) => ({
@@ -670,10 +672,14 @@ test("RealtimeServiceProvider merges custom realtime payload with canonical doma
   assert.equal(emitted.length, 1);
   assert.equal(emitted[0].room, "workspace:11");
   assert.equal(emitted[0].eventName, "workspace.settings.changed");
+  assert.equal(emitted[0].payload?.action, "settings-saved");
+  assert.equal(emitted[0].payload?.reason, "profile-update");
   assert.equal(emitted[0].payload?.workspaceSlug, "acme");
   assert.equal(emitted[0].payload?.source, "workspace");
   assert.equal(emitted[0].payload?.entity, "settings");
   assert.equal(emitted[0].payload?.operation, "updated");
+  assert.equal(emitted[0].payload?.meta?.action, "settings-saved");
+  assert.equal(emitted[0].payload?.meta?.reason, "profile-update");
   assert.equal(emitted[0].payload?.scope?.kind, "workspace");
   assert.equal(emitted[0].payload?.scope?.id, "11");
 });


### PR DESCRIPTION
## Summary
- add createRealtimeEntityChangePublisher() on a dedicated kernel entity-change subpath
- preserve CRUD operation semantics while carrying lifecycle action/reason metadata
- project action/reason into realtime socket payloads and document the server publishing pattern

## Verification
- node --test packages/kernel/server/runtime/entityChangeEvents.test.js packages/kernel/server/runtime/serviceRegistration.test.js packages/realtime/test/providerRuntime.test.js
- npm --workspace @jskit-ai/kernel test
- npm --workspace @jskit-ai/realtime test
- npm run agent-docs:build
- npm run generated:refs:check
- npm run check:runtime-deps
- npm run lint
- git diff --check

Note: npm run generated:check was not useful before commit because generated docs were intentionally modified and therefore reported as uncommitted.