### PR TITLE
Document package-first auth install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6682,28 +6682,28 @@
     },
     "packages/agent-docs": {
       "name": "@jskit-ai/agent-docs",
-      "version": "0.1.63",
+      "version": "0.1.64",
       "engines": {
         "node": ">=20 <23"
       }
     },
     "packages/assistant": {
       "name": "@jskit-ai/assistant",
-      "version": "0.1.110",
+      "version": "0.1.111",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.102"
+        "@jskit-ai/kernel": "0.1.103"
       }
     },
     "packages/assistant-core": {
       "name": "@jskit-ai/assistant-core",
-      "version": "0.1.77",
+      "version": "0.1.78",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.101",
-        "@jskit-ai/http-runtime": "0.1.100",
-        "@jskit-ai/kernel": "0.1.102",
-        "@jskit-ai/resource-core": "0.1.46",
-        "@jskit-ai/resource-crud-core": "0.1.46",
-        "@jskit-ai/users-core": "0.1.111",
+        "@jskit-ai/database-runtime": "0.1.102",
+        "@jskit-ai/http-runtime": "0.1.101",
+        "@jskit-ai/kernel": "0.1.103",
+        "@jskit-ai/resource-core": "0.1.47",
+        "@jskit-ai/resource-crud-core": "0.1.47",
+        "@jskit-ai/users-core": "0.1.112",
         "dompurify": "^3.3.3",
         "json-rest-schema": "1.x.x",
         "marked": "^17.0.4",
@@ -6716,15 +6716,15 @@
     },
     "packages/assistant-runtime": {
       "name": "@jskit-ai/assistant-runtime",
-      "version": "0.1.72",
+      "version": "0.1.73",
       "dependencies": {
-        "@jskit-ai/assistant-core": "0.1.77",
-        "@jskit-ai/database-runtime": "0.1.101",
-        "@jskit-ai/http-runtime": "0.1.100",
-        "@jskit-ai/kernel": "0.1.102",
-        "@jskit-ai/shell-web": "0.1.101",
-        "@jskit-ai/users-core": "0.1.111",
-        "@jskit-ai/users-web": "0.1.116",
+        "@jskit-ai/assistant-core": "0.1.78",
+        "@jskit-ai/database-runtime": "0.1.102",
+        "@jskit-ai/http-runtime": "0.1.101",
+        "@jskit-ai/kernel": "0.1.103",
+        "@jskit-ai/shell-web": "0.1.102",
+        "@jskit-ai/users-core": "0.1.112",
+        "@jskit-ai/users-web": "0.1.117",
         "json-rest-schema": "1.x.x"
       },
       "peerDependencies": {
@@ -6735,30 +6735,30 @@
     },
     "packages/auth-core": {
       "name": "@jskit-ai/auth-core",
-      "version": "0.1.100",
+      "version": "0.1.101",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0",
-        "@jskit-ai/kernel": "0.1.102",
+        "@jskit-ai/kernel": "0.1.103",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/auth-provider-local-core": {
       "name": "@jskit-ai/auth-provider-local-core",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.100",
-        "@jskit-ai/kernel": "0.1.102",
+        "@jskit-ai/auth-core": "0.1.101",
+        "@jskit-ai/kernel": "0.1.103",
         "nodemailer": "^7.0.10"
       }
     },
     "packages/auth-provider-supabase-core": {
       "name": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.100",
+      "version": "0.1.101",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.100",
-        "@jskit-ai/kernel": "0.1.102",
+        "@jskit-ai/auth-core": "0.1.101",
+        "@jskit-ai/kernel": "0.1.103",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0",
         "json-rest-schema": "1.x.x",
@@ -6767,12 +6767,12 @@
     },
     "packages/auth-web": {
       "name": "@jskit-ai/auth-web",
-      "version": "0.1.102",
+      "version": "0.1.103",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.100",
-        "@jskit-ai/http-runtime": "0.1.100",
-        "@jskit-ai/kernel": "0.1.102",
-        "@jskit-ai/shell-web": "0.1.101",
+        "@jskit-ai/auth-core": "0.1.101",
+        "@jskit-ai/http-runtime": "0.1.101",
+        "@jskit-ai/kernel": "0.1.103",
+        "@jskit-ai/shell-web": "0.1.102",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -6785,38 +6785,38 @@
     },
     "packages/console-core": {
       "name": "@jskit-ai/console-core",
-      "version": "0.1.64",
+      "version": "0.1.65",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.100",
-        "@jskit-ai/database-runtime": "0.1.101",
-        "@jskit-ai/http-runtime": "0.1.100",
-        "@jskit-ai/kernel": "0.1.102",
-        "@jskit-ai/resource-crud-core": "0.1.46",
-        "@jskit-ai/users-core": "0.1.111",
+        "@jskit-ai/auth-core": "0.1.101",
+        "@jskit-ai/database-runtime": "0.1.102",
+        "@jskit-ai/http-runtime": "0.1.101",
+        "@jskit-ai/kernel": "0.1.103",
+        "@jskit-ai/resource-crud-core": "0.1.47",
+        "@jskit-ai/users-core": "0.1.112",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/console-web": {
       "name": "@jskit-ai/console-web",
-      "version": "0.1.69",
+      "version": "0.1.70",
       "dependencies": {
-        "@jskit-ai/auth-web": "0.1.102",
-        "@jskit-ai/console-core": "0.1.64",
-        "@jskit-ai/shell-web": "0.1.101"
+        "@jskit-ai/auth-web": "0.1.103",
+        "@jskit-ai/console-core": "0.1.65",
+        "@jskit-ai/shell-web": "0.1.102"
       }
     },
     "packages/crud-core": {
       "name": "@jskit-ai/crud-core",
-      "version": "0.1.109",
+      "version": "0.1.110",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.101",
-        "@jskit-ai/http-runtime": "0.1.100",
-        "@jskit-ai/kernel": "0.1.102",
-        "@jskit-ai/realtime": "0.1.100",
-        "@jskit-ai/resource-crud-core": "0.1.46",
-        "@jskit-ai/shell-web": "0.1.101",
-        "@jskit-ai/users-core": "0.1.111",
-        "@jskit-ai/users-web": "0.1.116",
+        "@jskit-ai/database-runtime": "0.1.102",
+        "@jskit-ai/http-runtime": "0.1.101",
+        "@jskit-ai/kernel": "0.1.103",
+        "@jskit-ai/realtime": "0.1.101",
+        "@jskit-ai/resource-crud-core": "0.1.47",
+        "@jskit-ai/shell-web": "0.1.102",
+        "@jskit-ai/users-core": "0.1.112",
+        "@jskit-ai/users-web": "0.1.117",
         "json-rest-schema": "1.x.x"
       },
       "peerDependencies": {
@@ -6827,98 +6827,98 @@
     },
     "packages/crud-server-generator": {
       "name": "@jskit-ai/crud-server-generator",
-      "version": "0.1.109",
+      "version": "0.1.110",
       "dependencies": {
         "@babel/parser": "^7.29.2",
-        "@jskit-ai/crud-core": "0.1.109",
-        "@jskit-ai/database-runtime": "0.1.101",
-        "@jskit-ai/http-runtime": "0.1.100",
-        "@jskit-ai/json-rest-api-core": "0.1.46",
-        "@jskit-ai/kernel": "0.1.102",
-        "@jskit-ai/resource-crud-core": "0.1.46",
+        "@jskit-ai/crud-core": "0.1.110",
+        "@jskit-ai/database-runtime": "0.1.102",
+        "@jskit-ai/http-runtime": "0.1.101",
+        "@jskit-ai/json-rest-api-core": "0.1.47",
+        "@jskit-ai/kernel": "0.1.103",
+        "@jskit-ai/resource-crud-core": "0.1.47",
         "recast": "^0.23.11"
       }
     },
     "packages/crud-ui-generator": {
       "name": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.84",
+      "version": "0.1.85",
       "dependencies": {
-        "@jskit-ai/crud-core": "0.1.109",
-        "@jskit-ai/kernel": "0.1.102",
-        "@jskit-ai/resource-crud-core": "0.1.46"
+        "@jskit-ai/crud-core": "0.1.110",
+        "@jskit-ai/kernel": "0.1.103",
+        "@jskit-ai/resource-crud-core": "0.1.47"
       }
     },
     "packages/database-runtime": {
       "name": "@jskit-ai/database-runtime",
-      "version": "0.1.101",
+      "version": "0.1.102",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.102"
+        "@jskit-ai/kernel": "0.1.103"
       }
     },
     "packages/database-runtime-mysql": {
       "name": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.100",
+      "version": "0.1.101",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.101",
-        "@jskit-ai/kernel": "0.1.102"
+        "@jskit-ai/database-runtime": "0.1.102",
+        "@jskit-ai/kernel": "0.1.103"
       }
     },
     "packages/database-runtime-postgres": {
       "name": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.100",
+      "version": "0.1.101",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.101"
+        "@jskit-ai/database-runtime": "0.1.102"
       }
     },
     "packages/feature-server-generator": {
       "name": "@jskit-ai/feature-server-generator",
-      "version": "0.1.43"
+      "version": "0.1.44"
     },
     "packages/google-rewarded-core": {
       "name": "@jskit-ai/google-rewarded-core",
-      "version": "0.1.38"
+      "version": "0.1.39"
     },
     "packages/google-rewarded-web": {
       "name": "@jskit-ai/google-rewarded-web",
-      "version": "0.1.38"
+      "version": "0.1.39"
     },
     "packages/http-runtime": {
       "name": "@jskit-ai/http-runtime",
-      "version": "0.1.100",
+      "version": "0.1.101",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.102",
+        "@jskit-ai/kernel": "0.1.103",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/json-rest-api-core": {
       "name": "@jskit-ai/json-rest-api-core",
-      "version": "0.1.46",
+      "version": "0.1.47",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.102",
+        "@jskit-ai/kernel": "0.1.103",
         "hooked-api": "1.x.x",
         "json-rest-api": "1.x.x"
       }
     },
     "packages/kernel": {
       "name": "@jskit-ai/kernel",
-      "version": "0.1.102",
+      "version": "0.1.103",
       "dependencies": {
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/mobile-capacitor": {
       "name": "@jskit-ai/mobile-capacitor",
-      "version": "0.1.38",
+      "version": "0.1.39",
       "dependencies": {
         "@capacitor/browser": "^7.0.1",
-        "@jskit-ai/kernel": "0.1.102"
+        "@jskit-ai/kernel": "0.1.103"
       }
     },
     "packages/realtime": {
       "name": "@jskit-ai/realtime",
-      "version": "0.1.100",
+      "version": "0.1.101",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.102",
+        "@jskit-ai/kernel": "0.1.103",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",
@@ -6930,24 +6930,24 @@
     },
     "packages/resource-core": {
       "name": "@jskit-ai/resource-core",
-      "version": "0.1.46",
+      "version": "0.1.47",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.102"
+        "@jskit-ai/kernel": "0.1.103"
       }
     },
     "packages/resource-crud-core": {
       "name": "@jskit-ai/resource-crud-core",
-      "version": "0.1.46",
+      "version": "0.1.47",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.102",
-        "@jskit-ai/resource-core": "0.1.46"
+        "@jskit-ai/kernel": "0.1.103",
+        "@jskit-ai/resource-core": "0.1.47"
       }
     },
     "packages/shell-web": {
       "name": "@jskit-ai/shell-web",
-      "version": "0.1.101",
+      "version": "0.1.102",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.102",
+        "@jskit-ai/kernel": "0.1.103",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -6959,25 +6959,25 @@
     },
     "packages/storage-runtime": {
       "name": "@jskit-ai/storage-runtime",
-      "version": "0.1.100",
+      "version": "0.1.101",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.102",
+        "@jskit-ai/kernel": "0.1.103",
         "unstorage": "^1.17.3"
       }
     },
     "packages/ui-generator": {
       "name": "@jskit-ai/ui-generator",
-      "version": "0.1.84",
+      "version": "0.1.85",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.102",
-        "@jskit-ai/shell-web": "0.1.101"
+        "@jskit-ai/kernel": "0.1.103",
+        "@jskit-ai/shell-web": "0.1.102"
       }
     },
     "packages/uploads-image-web": {
       "name": "@jskit-ai/uploads-image-web",
-      "version": "0.1.79",
+      "version": "0.1.80",
       "dependencies": {
-        "@jskit-ai/uploads-runtime": "0.1.79",
+        "@jskit-ai/uploads-runtime": "0.1.80",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",
@@ -6990,37 +6990,37 @@
     },
     "packages/uploads-runtime": {
       "name": "@jskit-ai/uploads-runtime",
-      "version": "0.1.79",
+      "version": "0.1.80",
       "dependencies": {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.102"
+        "@jskit-ai/kernel": "0.1.103"
       }
     },
     "packages/users-core": {
       "name": "@jskit-ai/users-core",
-      "version": "0.1.111",
+      "version": "0.1.112",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.100",
-        "@jskit-ai/database-runtime": "0.1.101",
-        "@jskit-ai/http-runtime": "0.1.100",
-        "@jskit-ai/json-rest-api-core": "0.1.46",
-        "@jskit-ai/kernel": "0.1.102",
-        "@jskit-ai/resource-core": "0.1.46",
-        "@jskit-ai/resource-crud-core": "0.1.46",
-        "@jskit-ai/uploads-runtime": "0.1.79",
+        "@jskit-ai/auth-core": "0.1.101",
+        "@jskit-ai/database-runtime": "0.1.102",
+        "@jskit-ai/http-runtime": "0.1.101",
+        "@jskit-ai/json-rest-api-core": "0.1.47",
+        "@jskit-ai/kernel": "0.1.103",
+        "@jskit-ai/resource-core": "0.1.47",
+        "@jskit-ai/resource-crud-core": "0.1.47",
+        "@jskit-ai/uploads-runtime": "0.1.80",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/users-web": {
       "name": "@jskit-ai/users-web",
-      "version": "0.1.116",
+      "version": "0.1.117",
       "dependencies": {
-        "@jskit-ai/http-runtime": "0.1.100",
-        "@jskit-ai/kernel": "0.1.102",
-        "@jskit-ai/realtime": "0.1.100",
-        "@jskit-ai/shell-web": "0.1.101",
-        "@jskit-ai/uploads-image-web": "0.1.79",
-        "@jskit-ai/users-core": "0.1.111",
+        "@jskit-ai/http-runtime": "0.1.101",
+        "@jskit-ai/kernel": "0.1.103",
+        "@jskit-ai/realtime": "0.1.101",
+        "@jskit-ai/shell-web": "0.1.102",
+        "@jskit-ai/uploads-image-web": "0.1.80",
+        "@jskit-ai/users-core": "0.1.112",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -7032,29 +7032,29 @@
     },
     "packages/workspaces-core": {
       "name": "@jskit-ai/workspaces-core",
-      "version": "0.1.77",
+      "version": "0.1.78",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.100",
-        "@jskit-ai/database-runtime": "0.1.101",
-        "@jskit-ai/http-runtime": "0.1.100",
-        "@jskit-ai/json-rest-api-core": "0.1.46",
-        "@jskit-ai/kernel": "0.1.102",
-        "@jskit-ai/resource-core": "0.1.46",
-        "@jskit-ai/resource-crud-core": "0.1.46",
-        "@jskit-ai/users-core": "0.1.111",
+        "@jskit-ai/auth-core": "0.1.101",
+        "@jskit-ai/database-runtime": "0.1.102",
+        "@jskit-ai/http-runtime": "0.1.101",
+        "@jskit-ai/json-rest-api-core": "0.1.47",
+        "@jskit-ai/kernel": "0.1.103",
+        "@jskit-ai/resource-core": "0.1.47",
+        "@jskit-ai/resource-crud-core": "0.1.47",
+        "@jskit-ai/users-core": "0.1.112",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/workspaces-web": {
       "name": "@jskit-ai/workspaces-web",
-      "version": "0.1.78",
+      "version": "0.1.79",
       "dependencies": {
-        "@jskit-ai/http-runtime": "0.1.100",
-        "@jskit-ai/kernel": "0.1.102",
-        "@jskit-ai/shell-web": "0.1.101",
-        "@jskit-ai/users-core": "0.1.111",
-        "@jskit-ai/users-web": "0.1.116",
-        "@jskit-ai/workspaces-core": "0.1.77",
+        "@jskit-ai/http-runtime": "0.1.101",
+        "@jskit-ai/kernel": "0.1.103",
+        "@jskit-ai/shell-web": "0.1.102",
+        "@jskit-ai/users-core": "0.1.112",
+        "@jskit-ai/users-web": "0.1.117",
+        "@jskit-ai/workspaces-core": "0.1.78",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -7066,7 +7066,7 @@
     },
     "tooling/config-eslint": {
       "name": "@jskit-ai/config-eslint",
-      "version": "0.1.100",
+      "version": "0.1.101",
       "dependencies": {
         "@eslint/js": "^9.39.1",
         "eslint-plugin-vue": "^10.5.1",
@@ -7084,7 +7084,7 @@
     },
     "tooling/create-app": {
       "name": "@jskit-ai/create-app",
-      "version": "0.1.110",
+      "version": "0.1.111",
       "bin": {
         "jskit-create-app": "bin/jskit-create-app.js"
       },
@@ -7094,18 +7094,18 @@
     },
     "tooling/jskit-catalog": {
       "name": "@jskit-ai/jskit-catalog",
-      "version": "0.1.109",
+      "version": "0.1.110",
       "engines": {
         "node": ">=20 <23"
       }
     },
     "tooling/jskit-cli": {
       "name": "@jskit-ai/jskit-cli",
-      "version": "0.2.114",
+      "version": "0.2.115",
       "dependencies": {
-        "@jskit-ai/jskit-catalog": "0.1.109",
-        "@jskit-ai/kernel": "0.1.102",
-        "@jskit-ai/shell-web": "0.1.101",
+        "@jskit-ai/jskit-catalog": "0.1.110",
+        "@jskit-ai/kernel": "0.1.103",
+        "@jskit-ai/shell-web": "0.1.102",
         "@vue/compiler-sfc": "^3.5.29",
         "ts-morph": "^28.0.0"
       },

--- a/packages/agent-docs/guide/agent/app-setup/authentication.md
+++ b/packages/agent-docs/guide/agent/app-setup/authentication.md
@@ -18,7 +18,7 @@ If you are already continuing from the previous chapter, you are already in the 
 
 **Default: Start With Local Auth**
 
-The default auth path does not require a Supabase project or a database. It uses `auth-local`, which stores local credentials and sessions in `.jskit/auth/` by default.
+The default auth path does not require a Supabase project or a database. It uses the local provider package, `auth-provider-local-core`, together with `auth-web`. The local provider stores credentials and sessions in `.jskit/auth/` by default.
 
 That is the recommended first step for most apps. After the app's core flow is working, switch to Supabase or add richer auth methods only if the product needs them.
 
@@ -27,11 +27,12 @@ That is the recommended first step for most apps. After the app's core flow is w
 From inside `exampleapp`, run:
 
 ```bash
-npx jskit add bundle auth-local
+npx jskit add package auth-provider-local-core
+npx jskit add package auth-web
 npm install
 ```
 
-`auth-local` installs the provider-neutral auth core, the auth web layer, and the local provider. It gives the app working register, login, logout, session, and password recovery flows without requiring an external auth service.
+These package installs add the provider-neutral auth core, the auth web layer, and the local provider. They give the app working register, login, logout, session, and password recovery flows without requiring an external auth service.
 
 The final `npm install` matters for the same reason it did in the shell chapter: `jskit add` rewrites the scaffold and updates `package.json`, but `npm install` is what actually downloads the newly referenced runtime packages.
 
@@ -468,7 +469,7 @@ At this point the guide has shown three distinct layers of client state:
 
 That progression is intentional. Packages keep their operational runtimes internally, but the app-facing shared state they surface to Vue code is store-based.
 
-## What `auth-local` adds to the app
+## What the local auth install adds to the app
 
 The interesting part of this chapter is that authentication appears in several different layers at once: environment config, public routing config, shell placements, and app-owned view wrappers.
 
@@ -527,7 +528,7 @@ config.surfaceDefinitions.auth = {
 
 That `requiresAuth: false` line is important. The auth surface must stay public, otherwise users would need to be logged in before they could reach the login page.
 
-The local provider does not need an app database profile mode or OAuth config. The stock login UI asks `/api/session` for the active provider capabilities and renders only what the selected provider actually supports. With `auth-local`, that means email/password login, registration, sign-out, session refresh, and password recovery when recovery is configured.
+The local provider does not need an app database profile mode or OAuth config. The stock login UI asks `/api/session` for the active provider capabilities and renders only what the selected provider actually supports. With the local provider, that means email/password login, registration, sign-out, session refresh, and password recovery when recovery is configured.
 
 Later, if you switch to Supabase, the Supabase provider can append the app-owned OAuth visibility config and profile mode settings it needs.
 

--- a/packages/agent-docs/guide/agent/app-setup/initial-scaffolding.md
+++ b/packages/agent-docs/guide/agent/app-setup/initial-scaffolding.md
@@ -53,7 +53,8 @@ npx @jskit-ai/create-app exampleapp --tenancy-mode none
 cd exampleapp
 npm install
 
-npx jskit add bundle auth-local
+npx jskit add package auth-provider-local-core
+npx jskit add package auth-web
 
 npx jskit add package database-runtime-mysql \
   --db-host "$DB_HOST" \

--- a/packages/agent-docs/guide/agent/app-setup/quickstart.md
+++ b/packages/agent-docs/guide/agent/app-setup/quickstart.md
@@ -48,7 +48,8 @@ npx @jskit-ai/create-app testapp --tenancy-mode personal
 cd testapp
 npm install
 
-npx jskit add bundle auth-local
+npx jskit add package auth-provider-local-core
+npx jskit add package auth-web
 
 npx jskit add package database-runtime-mysql \
   --db-host "$DB_HOST" \
@@ -82,7 +83,7 @@ npm install
 npm run db:migrate
 ```
 
-Keep authentication deliberately basic while the product is still taking shape. Start with `auth-local`, build the app's core workflows, then add Supabase, OAuth, OTP, provider linking, app-user projection, or workspace/account complexity when the product actually needs those features.
+Keep authentication deliberately basic while the product is still taking shape. Start with the local provider and `auth-web`, build the app's core workflows, then add Supabase, OAuth, OTP, provider linking, app-user projection, or workspace/account complexity when the product actually needs those features.
 
 At this point you have:
 

--- a/packages/agent-docs/guide/agent/app-setup/working-with-the-jskit-cli.md
+++ b/packages/agent-docs/guide/agent/app-setup/working-with-the-jskit-cli.md
@@ -9,7 +9,7 @@ This chapter steps back and treats the CLI as a subject in its own right.
 That matters because `jskit` is not just "the thing that installs packages". It is the tool that helps you:
 
 - discover what JSKIT can do
-- inspect bundles, packages, and generators before using them
+- inspect packages, generators, and any catalog shortcuts before using them
 - apply and re-apply JSKIT-managed mutations to your app
 - keep managed files and lock state healthy
 - create your own app-local runtime packages
@@ -28,7 +28,7 @@ The easiest way to understand `jskit` is to separate it from the other tools in 
 
 That separation is crucial.
 
-When you run a command such as `npx jskit add bundle auth-local`, JSKIT updates app-owned files and records what it changed. It does **not** replace npm, Vite, or Knex.
+When you run a command such as `npx jskit add package auth-provider-local-core`, JSKIT updates app-owned files and records what it changed. It does **not** replace npm, Vite, or Knex.
 
 The most important record of that managed state lives here:
 
@@ -151,9 +151,7 @@ That distinction matters.
 
 #### Bundles
 
-A bundle is a curated install shortcut for several runtime packages that are meant to go together.
-
-In the current catalog, `auth-local` is the obvious example. It is a single bundle id, but it expands to several real runtime packages.
+A bundle is a curated install shortcut for several runtime packages that are meant to go together. Bundles can still appear in the catalog for compatibility and quick inspection, but the guide uses explicit package installs so the real runtime packages stay visible.
 
 #### Runtime packages
 
@@ -188,7 +186,7 @@ npx jskit list generators
 
 Those two commands are especially useful later in the guide, once you already know roughly what kind of thing you are looking for.
 
-If you want bundle members printed inline too, `npx jskit list --full` expands the bundle view. That is useful when you want a quick catalog scan without dropping straight into `show`.
+If you want bundle members printed inline too, `npx jskit list --full` expands the bundle view. That is useful when you are auditing a shortcut, but package ids are still the normal install vocabulary in this guide.
 
 One more detail is worth noticing. In repos that contain local package descriptors, `list packages` can also show app-local or repo-local packages in addition to the published catalog. So `list` is not only a remote catalog browser. It is also a view of what this app can currently see.
 
@@ -208,7 +206,7 @@ And the more useful inspection form is:
 npx jskit show <id> --details
 ```
 
-This command is unusually valuable in JSKIT because packages and bundles do more than "add a dependency". They can:
+This command is unusually valuable in JSKIT because packages and catalog shortcuts do more than "add a dependency". They can:
 
 - provide or require capabilities
 - register runtime providers
@@ -230,39 +228,42 @@ The plain form is useful when you only want to identify something quickly. `--de
 
 There are two especially common cases:
 
-- you found a bundle or package in `jskit list` and want to know what it really does before you install it
+- you found a package or shortcut in `jskit list` and want to know what it really does before you install it
 - you already know a package changed the shell, the runtime graph, or the app tree, and you want to see *how*
 
 That second case matters just as much as the first one. Later in the guide, chapters explain package behavior one feature at a time. `show --details` is the generic command that lets you inspect those same package contracts directly.
 
-### A first example: what does `auth-local` actually install?
+### A first example: inspect the local auth provider
 
 Run:
 
 ```bash
-npx jskit show auth-local --details
+npx jskit show auth-provider-local-core --details
 ```
 
 This output is short, but it already teaches something important:
 
-- `auth-local` is a **bundle**
-- it is not a runtime package by itself
+- `auth-provider-local-core` is a **runtime package**
+- it selects the local auth provider
+- it depends on the provider-neutral `auth-core`
 
-It expands to three real runtime packages:
+The default local auth install uses two direct package commands:
 
-- `@jskit-ai/auth-core`
-- `@jskit-ai/auth-web`
-- `@jskit-ai/auth-provider-local-core`
+```bash
+npx jskit add package auth-provider-local-core
+npx jskit add package auth-web
+```
 
-That is exactly the kind of thing you want to know before you mutate the app. For a bundle, this is often the main question:
+That is exactly the kind of thing you want to know before you mutate the app:
 
-- *what real packages am I about to get?*
+- which package selects the active provider?
+- which package adds the web auth routes and login UI?
 
-`auth-local` is a good example because the bundle name is short and convenient, but the detailed view makes the underlying install explicit. It also helps you keep the mental model straight:
+It also helps you keep the mental model straight:
 
-- bundles are install shortcuts
 - runtime packages are the things that actually provide capabilities
-- provider bundles also select one concrete `auth.provider`
+- `auth-provider-local-core` provides the selected `auth.provider`
+- `auth-web` consumes the selected provider and adds the web surface
 
 ### A richer example: what does `workspaces-web` contribute?
 
@@ -475,14 +476,13 @@ This is not required, but it is genuinely useful once you start using commands s
 
 ## Installing runtime capability: `add`
 
-The install command comes in two main forms:
+The install command you will use most often is:
 
 ```bash
 npx jskit add package users-web
-npx jskit add bundle auth-local
 ```
 
-Those two examples look similar, but they do different things.
+That command installs one runtime package and its dependency chain.
 
 ### `add package`
 
@@ -518,15 +518,9 @@ npm run devlinks
 
 ### `add bundle`
 
-Use this when the catalog already offers a sensible grouped install:
+Bundles are a convenience layer for catalog shortcuts. Prefer package commands in setup docs and normal app work, especially for auth, because provider ownership is clearer when the selected provider package is installed explicitly.
 
-```bash
-npx jskit add bundle auth-local
-```
-
-Bundles are a convenience layer. They save you from having to remember and install several related runtime packages one by one.
-
-This is why `show auth-local --details` is useful first: it lets you see what the bundle will actually install. Lower-level bundles such as `auth-base` can still be useful when you are composing your own provider stack, but they require an installed selected provider such as `auth-provider-local-core` or `auth-provider-supabase-core`.
+If you do use a bundle shortcut, inspect it first with `npx jskit show <bundle-id> --details` so you can see the real packages and capabilities it will install.
 
 ### Generator packages are different
 

--- a/packages/agent-docs/package.json
+++ b/packages/agent-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/agent-docs",
-  "version": "0.1.63",
+  "version": "0.1.64",
   "description": "Distributed JSKIT agent references, prompts, guides, and generated reference maps.",
   "type": "module",
   "files": [

--- a/packages/agent-docs/site/guide/app-extras/assistant.md
+++ b/packages/agent-docs/site/guide/app-extras/assistant.md
@@ -34,7 +34,8 @@ npx @jskit-ai/create-app exampleapp --tenancy-mode personal
 cd exampleapp
 npm install
 
-npx jskit add bundle auth-local
+npx jskit add package auth-provider-local-core
+npx jskit add package auth-web
 npx jskit add package database-runtime-mysql \
   --db-host "$DB_HOST" \
   --db-port "$DB_PORT" \

--- a/packages/agent-docs/site/guide/app-extras/realtime.md
+++ b/packages/agent-docs/site/guide/app-extras/realtime.md
@@ -21,7 +21,8 @@ npx @jskit-ai/create-app exampleapp --tenancy-mode personal
 cd exampleapp
 npm install
 
-npx jskit add bundle auth-local
+npx jskit add package auth-provider-local-core
+npx jskit add package auth-web
 npx jskit add package database-runtime-mysql \
   --db-host "$DB_HOST" \
   --db-port "$DB_PORT" \

--- a/packages/agent-docs/site/guide/app-setup/authentication.md
+++ b/packages/agent-docs/site/guide/app-setup/authentication.md
@@ -15,7 +15,7 @@ npm install
 If you are already continuing from the previous chapter, you are already in the right place and can skip that setup.
 
 <DocsTerminalTip label="Default" title="Start With Local Auth">
-The default auth path does not require a Supabase project or a database. It uses `auth-local`, which stores local credentials and sessions in `.jskit/auth/` by default.
+The default auth path does not require a Supabase project or a database. It uses the local provider package, `auth-provider-local-core`, together with `auth-web`. The local provider stores credentials and sessions in `.jskit/auth/` by default.
 
 That is the recommended first step for most apps. After the app's core flow is working, switch to Supabase or add richer auth methods only if the product needs them.
 </DocsTerminalTip>
@@ -25,11 +25,12 @@ That is the recommended first step for most apps. After the app's core flow is w
 From inside `exampleapp`, run:
 
 ```bash
-npx jskit add bundle auth-local
+npx jskit add package auth-provider-local-core
+npx jskit add package auth-web
 npm install
 ```
 
-`auth-local` installs the provider-neutral auth core, the auth web layer, and the local provider. It gives the app working register, login, logout, session, and password recovery flows without requiring an external auth service.
+These package installs add the provider-neutral auth core, the auth web layer, and the local provider. They give the app working register, login, logout, session, and password recovery flows without requiring an external auth service.
 
 The final `npm install` matters for the same reason it did in the shell chapter: `jskit add` rewrites the scaffold and updates `package.json`, but `npm install` is what actually downloads the newly referenced runtime packages.
 
@@ -481,7 +482,7 @@ At this point the guide has shown three distinct layers of client state:
 
 That progression is intentional. Packages keep their operational runtimes internally, but the app-facing shared state they surface to Vue code is store-based.
 
-## What `auth-local` adds to the app
+## What the local auth install adds to the app
 
 The interesting part of this chapter is that authentication appears in several different layers at once: environment config, public routing config, shell placements, and app-owned view wrappers.
 
@@ -540,7 +541,7 @@ config.surfaceDefinitions.auth = {
 
 That `requiresAuth: false` line is important. The auth surface must stay public, otherwise users would need to be logged in before they could reach the login page.
 
-The local provider does not need an app database profile mode or OAuth config. The stock login UI asks `/api/session` for the active provider capabilities and renders only what the selected provider actually supports. With `auth-local`, that means email/password login, registration, sign-out, session refresh, and password recovery when recovery is configured.
+The local provider does not need an app database profile mode or OAuth config. The stock login UI asks `/api/session` for the active provider capabilities and renders only what the selected provider actually supports. With the local provider, that means email/password login, registration, sign-out, session refresh, and password recovery when recovery is configured.
 
 Later, if you switch to Supabase, the Supabase provider can append the app-owned OAuth visibility config and profile mode settings it needs.
 

--- a/packages/agent-docs/site/guide/app-setup/console.md
+++ b/packages/agent-docs/site/guide/app-setup/console.md
@@ -23,7 +23,8 @@ npx @jskit-ai/create-app exampleapp --tenancy-mode none
 cd exampleapp
 npm install
 
-npx jskit add bundle auth-local
+npx jskit add package auth-provider-local-core
+npx jskit add package auth-web
 npx jskit add package database-runtime-mysql \
   --db-host "$DB_HOST" \
   --db-port "$DB_PORT" \

--- a/packages/agent-docs/site/guide/app-setup/database-layer.md
+++ b/packages/agent-docs/site/guide/app-setup/database-layer.md
@@ -13,7 +13,8 @@ npx @jskit-ai/create-app exampleapp --tenancy-mode none
 cd exampleapp
 npm install
 
-npx jskit add bundle auth-local
+npx jskit add package auth-provider-local-core
+npx jskit add package auth-web
 npm install
 ```
 

--- a/packages/agent-docs/site/guide/app-setup/initial-scaffolding.md
+++ b/packages/agent-docs/site/guide/app-setup/initial-scaffolding.md
@@ -51,7 +51,8 @@ npx @jskit-ai/create-app exampleapp --tenancy-mode none
 cd exampleapp
 npm install
 
-npx jskit add bundle auth-local
+npx jskit add package auth-provider-local-core
+npx jskit add package auth-web
 
 npx jskit add package database-runtime-mysql \
   --db-host "$DB_HOST" \

--- a/packages/agent-docs/site/guide/app-setup/multi-homing.md
+++ b/packages/agent-docs/site/guide/app-setup/multi-homing.md
@@ -48,7 +48,8 @@ npx @jskit-ai/create-app exampleapp --tenancy-mode personal
 cd exampleapp
 npm install
 
-npx jskit add bundle auth-local
+npx jskit add package auth-provider-local-core
+npx jskit add package auth-web
 npx jskit add package database-runtime-mysql \
   --db-host "$DB_HOST" \
   --db-port "$DB_PORT" \

--- a/packages/agent-docs/site/guide/app-setup/quickstart.md
+++ b/packages/agent-docs/site/guide/app-setup/quickstart.md
@@ -46,7 +46,8 @@ npx @jskit-ai/create-app testapp --tenancy-mode personal
 cd testapp
 npm install
 
-npx jskit add bundle auth-local
+npx jskit add package auth-provider-local-core
+npx jskit add package auth-web
 
 npx jskit add package database-runtime-mysql \
   --db-host "$DB_HOST" \
@@ -80,7 +81,7 @@ npm install
 npm run db:migrate
 ```
 
-Keep authentication deliberately basic while the product is still taking shape. Start with `auth-local`, build the app's core workflows, then add Supabase, OAuth, OTP, provider linking, app-user projection, or workspace/account complexity when the product actually needs those features.
+Keep authentication deliberately basic while the product is still taking shape. Start with the local provider and `auth-web`, build the app's core workflows, then add Supabase, OAuth, OTP, provider linking, app-user projection, or workspace/account complexity when the product actually needs those features.
 
 At this point you have:
 

--- a/packages/agent-docs/site/guide/app-setup/users.md
+++ b/packages/agent-docs/site/guide/app-setup/users.md
@@ -27,7 +27,8 @@ npx @jskit-ai/create-app exampleapp --tenancy-mode none
 cd exampleapp
 npm install
 
-npx jskit add bundle auth-local
+npx jskit add package auth-provider-local-core
+npx jskit add package auth-web
 npx jskit add package database-runtime-mysql \
   --db-host "$DB_HOST" \
   --db-port "$DB_PORT" \

--- a/packages/agent-docs/site/guide/app-setup/working-with-the-jskit-cli.md
+++ b/packages/agent-docs/site/guide/app-setup/working-with-the-jskit-cli.md
@@ -7,7 +7,7 @@ This chapter steps back and treats the CLI as a subject in its own right.
 That matters because `jskit` is not just "the thing that installs packages". It is the tool that helps you:
 
 - discover what JSKIT can do
-- inspect bundles, packages, and generators before using them
+- inspect packages, generators, and any catalog shortcuts before using them
 - apply and re-apply JSKIT-managed mutations to your app
 - keep managed files and lock state healthy
 - create your own app-local runtime packages
@@ -40,7 +40,7 @@ The easiest way to understand `jskit` is to separate it from the other tools in 
 
 That separation is crucial.
 
-When you run a command such as `npx jskit add bundle auth-local`, JSKIT updates app-owned files and records what it changed. It does **not** replace npm, Vite, or Knex.
+When you run a command such as `npx jskit add package auth-provider-local-core`, JSKIT updates app-owned files and records what it changed. It does **not** replace npm, Vite, or Knex.
 
 The most important record of that managed state lives here:
 
@@ -163,9 +163,7 @@ That distinction matters.
 
 #### Bundles
 
-A bundle is a curated install shortcut for several runtime packages that are meant to go together.
-
-In the current catalog, `auth-local` is the obvious example. It is a single bundle id, but it expands to several real runtime packages.
+A bundle is a curated install shortcut for several runtime packages that are meant to go together. Bundles can still appear in the catalog for compatibility and quick inspection, but the guide uses explicit package installs so the real runtime packages stay visible.
 
 #### Runtime packages
 
@@ -200,7 +198,7 @@ npx jskit list generators
 
 Those two commands are especially useful later in the guide, once you already know roughly what kind of thing you are looking for.
 
-If you want bundle members printed inline too, `npx jskit list --full` expands the bundle view. That is useful when you want a quick catalog scan without dropping straight into `show`.
+If you want bundle members printed inline too, `npx jskit list --full` expands the bundle view. That is useful when you are auditing a shortcut, but package ids are still the normal install vocabulary in this guide.
 
 One more detail is worth noticing. In repos that contain local package descriptors, `list packages` can also show app-local or repo-local packages in addition to the published catalog. So `list` is not only a remote catalog browser. It is also a view of what this app can currently see.
 
@@ -220,7 +218,7 @@ And the more useful inspection form is:
 npx jskit show <id> --details
 ```
 
-This command is unusually valuable in JSKIT because packages and bundles do more than "add a dependency". They can:
+This command is unusually valuable in JSKIT because packages and catalog shortcuts do more than "add a dependency". They can:
 
 - provide or require capabilities
 - register runtime providers
@@ -242,39 +240,42 @@ The plain form is useful when you only want to identify something quickly. `--de
 
 There are two especially common cases:
 
-- you found a bundle or package in `jskit list` and want to know what it really does before you install it
+- you found a package or shortcut in `jskit list` and want to know what it really does before you install it
 - you already know a package changed the shell, the runtime graph, or the app tree, and you want to see *how*
 
 That second case matters just as much as the first one. Later in the guide, chapters explain package behavior one feature at a time. `show --details` is the generic command that lets you inspect those same package contracts directly.
 
-### A first example: what does `auth-local` actually install?
+### A first example: inspect the local auth provider
 
 Run:
 
 ```bash
-npx jskit show auth-local --details
+npx jskit show auth-provider-local-core --details
 ```
 
 This output is short, but it already teaches something important:
 
-- `auth-local` is a **bundle**
-- it is not a runtime package by itself
+- `auth-provider-local-core` is a **runtime package**
+- it selects the local auth provider
+- it depends on the provider-neutral `auth-core`
 
-It expands to three real runtime packages:
+The default local auth install uses two direct package commands:
 
-- `@jskit-ai/auth-core`
-- `@jskit-ai/auth-web`
-- `@jskit-ai/auth-provider-local-core`
+```bash
+npx jskit add package auth-provider-local-core
+npx jskit add package auth-web
+```
 
-That is exactly the kind of thing you want to know before you mutate the app. For a bundle, this is often the main question:
+That is exactly the kind of thing you want to know before you mutate the app:
 
-- *what real packages am I about to get?*
+- which package selects the active provider?
+- which package adds the web auth routes and login UI?
 
-`auth-local` is a good example because the bundle name is short and convenient, but the detailed view makes the underlying install explicit. It also helps you keep the mental model straight:
+It also helps you keep the mental model straight:
 
-- bundles are install shortcuts
 - runtime packages are the things that actually provide capabilities
-- provider bundles also select one concrete `auth.provider`
+- `auth-provider-local-core` provides the selected `auth.provider`
+- `auth-web` consumes the selected provider and adds the web surface
 
 ### A richer example: what does `workspaces-web` contribute?
 
@@ -487,14 +488,13 @@ This is not required, but it is genuinely useful once you start using commands s
 
 ## Installing runtime capability: `add`
 
-The install command comes in two main forms:
+The install command you will use most often is:
 
 ```bash
 npx jskit add package users-web
-npx jskit add bundle auth-local
 ```
 
-Those two examples look similar, but they do different things.
+That command installs one runtime package and its dependency chain.
 
 ### `add package`
 
@@ -530,15 +530,9 @@ npm run devlinks
 
 ### `add bundle`
 
-Use this when the catalog already offers a sensible grouped install:
+Bundles are a convenience layer for catalog shortcuts. Prefer package commands in setup docs and normal app work, especially for auth, because provider ownership is clearer when the selected provider package is installed explicitly.
 
-```bash
-npx jskit add bundle auth-local
-```
-
-Bundles are a convenience layer. They save you from having to remember and install several related runtime packages one by one.
-
-This is why `show auth-local --details` is useful first: it lets you see what the bundle will actually install. Lower-level bundles such as `auth-base` can still be useful when you are composing your own provider stack, but they require an installed selected provider such as `auth-provider-local-core` or `auth-provider-supabase-core`.
+If you do use a bundle shortcut, inspect it first with `npx jskit show <bundle-id> --details` so you can see the real packages and capabilities it will install.
 
 ### Generator packages are different
 

--- a/packages/agent-docs/site/guide/generators/intro.md
+++ b/packages/agent-docs/site/guide/generators/intro.md
@@ -43,7 +43,8 @@ npx @jskit-ai/create-app exampleapp --tenancy-mode personal
 cd exampleapp
 npm install
 
-npx jskit add bundle auth-local
+npx jskit add package auth-provider-local-core
+npx jskit add package auth-web
 npx jskit add package database-runtime-mysql \
   --db-host "$DB_HOST" \
   --db-port "$DB_PORT" \

--- a/packages/assistant-core/package.descriptor.mjs
+++ b/packages/assistant-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-core",
-  version: "0.1.77",
+  version: "0.1.78",
   kind: "runtime",
   description: "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
   dependsOn: [
@@ -47,11 +47,11 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/http-runtime": "0.1.100",
-        "@jskit-ai/kernel": "0.1.102",
-        "@jskit-ai/resource-core": "0.1.46",
-        "@jskit-ai/resource-crud-core": "0.1.46",
-        "@jskit-ai/users-core": "0.1.111",
+        "@jskit-ai/http-runtime": "0.1.101",
+        "@jskit-ai/kernel": "0.1.103",
+        "@jskit-ai/resource-core": "0.1.47",
+        "@jskit-ai/resource-crud-core": "0.1.47",
+        "@jskit-ai/users-core": "0.1.112",
         "dompurify": "^3.3.3",
         "json-rest-schema": "1.x.x",
         "marked": "^17.0.4",

--- a/packages/assistant-core/package.json
+++ b/packages/assistant-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-core",
-  "version": "0.1.77",
+  "version": "0.1.78",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,12 +11,12 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.101",
-    "@jskit-ai/http-runtime": "0.1.100",
-    "@jskit-ai/kernel": "0.1.102",
-    "@jskit-ai/resource-crud-core": "0.1.46",
-    "@jskit-ai/resource-core": "0.1.46",
-    "@jskit-ai/users-core": "0.1.111",
+    "@jskit-ai/database-runtime": "0.1.102",
+    "@jskit-ai/http-runtime": "0.1.101",
+    "@jskit-ai/kernel": "0.1.103",
+    "@jskit-ai/resource-crud-core": "0.1.47",
+    "@jskit-ai/resource-core": "0.1.47",
+    "@jskit-ai/users-core": "0.1.112",
     "dompurify": "^3.3.3",
     "json-rest-schema": "1.x.x",
     "marked": "^17.0.4",

--- a/packages/assistant-runtime/package.descriptor.mjs
+++ b/packages/assistant-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-runtime",
-  version: "0.1.72",
+  version: "0.1.73",
   kind: "runtime",
   description: "Shared assistant runtime with per-surface assistant registration.",
   dependsOn: [
@@ -95,13 +95,13 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/assistant-core": "0.1.77",
-        "@jskit-ai/database-runtime": "0.1.101",
-        "@jskit-ai/http-runtime": "0.1.100",
-        "@jskit-ai/kernel": "0.1.102",
-        "@jskit-ai/shell-web": "0.1.101",
-        "@jskit-ai/users-core": "0.1.111",
-        "@jskit-ai/users-web": "0.1.116"
+        "@jskit-ai/assistant-core": "0.1.78",
+        "@jskit-ai/database-runtime": "0.1.102",
+        "@jskit-ai/http-runtime": "0.1.101",
+        "@jskit-ai/kernel": "0.1.103",
+        "@jskit-ai/shell-web": "0.1.102",
+        "@jskit-ai/users-core": "0.1.112",
+        "@jskit-ai/users-web": "0.1.117"
       },
       dev: {}
     },

--- a/packages/assistant-runtime/package.json
+++ b/packages/assistant-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-runtime",
-  "version": "0.1.72",
+  "version": "0.1.73",
   "type": "module",
   "exports": {
     "./client": "./src/client/index.js",
@@ -8,13 +8,13 @@
     "./server/actionIds": "./src/server/actionIds.js"
   },
   "dependencies": {
-    "@jskit-ai/assistant-core": "0.1.77",
-    "@jskit-ai/database-runtime": "0.1.101",
-    "@jskit-ai/http-runtime": "0.1.100",
-    "@jskit-ai/kernel": "0.1.102",
-    "@jskit-ai/shell-web": "0.1.101",
-    "@jskit-ai/users-core": "0.1.111",
-    "@jskit-ai/users-web": "0.1.116",
+    "@jskit-ai/assistant-core": "0.1.78",
+    "@jskit-ai/database-runtime": "0.1.102",
+    "@jskit-ai/http-runtime": "0.1.101",
+    "@jskit-ai/kernel": "0.1.103",
+    "@jskit-ai/shell-web": "0.1.102",
+    "@jskit-ai/users-core": "0.1.112",
+    "@jskit-ai/users-web": "0.1.117",
     "json-rest-schema": "1.x.x"
   },
   "peerDependencies": {

--- a/packages/assistant/package.descriptor.mjs
+++ b/packages/assistant/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant",
-  version: "0.1.110",
+  version: "0.1.111",
   kind: "generator",
   description: "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
   options: {

--- a/packages/assistant/package.json
+++ b/packages/assistant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant",
-  "version": "0.1.110",
+  "version": "0.1.111",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.102"
+    "@jskit-ai/kernel": "0.1.103"
   }
 }

--- a/packages/auth-core/package.descriptor.mjs
+++ b/packages/auth-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-core",
-  "version": "0.1.100",
+  "version": "0.1.101",
   "kind": "runtime",
   "dependsOn": [
     "@jskit-ai/value-app-config-shared"
@@ -74,7 +74,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.102",
+        "@jskit-ai/kernel": "0.1.103",
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0"

--- a/packages/auth-core/package.json
+++ b/packages/auth-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-core",
-  "version": "0.1.100",
+  "version": "0.1.101",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -54,7 +54,7 @@
     "./shared/commands/authSessionReadCommand": "./src/shared/commands/authSessionReadCommand.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.102",
+    "@jskit-ai/kernel": "0.1.103",
     "@fastify/cookie": "^11.0.2",
     "@fastify/csrf-protection": "^7.1.0",
     "@fastify/rate-limit": "^10.3.0",

--- a/packages/auth-provider-local-core/package.descriptor.mjs
+++ b/packages/auth-provider-local-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-provider-local-core",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "kind": "runtime",
   "description": "Local auth provider with a file backend default and no database requirement.",
   "dependsOn": [
@@ -56,8 +56,8 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/auth-core": "0.1.100",
-        "@jskit-ai/kernel": "0.1.102",
+        "@jskit-ai/auth-core": "0.1.101",
+        "@jskit-ai/kernel": "0.1.103",
         "nodemailer": "^7.0.10",
         "dotenv": "^16.4.5"
       },

--- a/packages/auth-provider-local-core/package.json
+++ b/packages/auth-provider-local-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-local-core",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,8 +11,8 @@
     "./server/lib/index": "./src/server/lib/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.100",
-    "@jskit-ai/kernel": "0.1.102",
+    "@jskit-ai/auth-core": "0.1.101",
+    "@jskit-ai/kernel": "0.1.103",
     "nodemailer": "^7.0.10"
   }
 }

--- a/packages/auth-provider-supabase-core/package.descriptor.mjs
+++ b/packages/auth-provider-supabase-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.100",
+  "version": "0.1.101",
   "kind": "runtime",
   "options": {
     "auth-supabase-url": {
@@ -83,8 +83,8 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/auth-core": "0.1.100",
-        "@jskit-ai/kernel": "0.1.102",
+        "@jskit-ai/auth-core": "0.1.101",
+        "@jskit-ai/kernel": "0.1.103",
         "dotenv": "^16.4.5",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0"

--- a/packages/auth-provider-supabase-core/package.json
+++ b/packages/auth-provider-supabase-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.100",
+  "version": "0.1.101",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,8 +12,8 @@
     "./client": "./src/client/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.100",
-    "@jskit-ai/kernel": "0.1.102",
+    "@jskit-ai/auth-core": "0.1.101",
+    "@jskit-ai/kernel": "0.1.103",
     "json-rest-schema": "1.x.x",
     "jose": "^6.1.0",
     "@supabase/supabase-js": "^2.57.4",

--- a/packages/auth-web/package.descriptor.mjs
+++ b/packages/auth-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-web",
-  "version": "0.1.102",
+  "version": "0.1.103",
   "kind": "runtime",
   "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
   "dependsOn": [
@@ -260,10 +260,10 @@ export default Object.freeze({
     "dependencies": {
       "runtime": {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/auth-core": "0.1.100",
-        "@jskit-ai/http-runtime": "0.1.100",
-        "@jskit-ai/kernel": "0.1.102",
-        "@jskit-ai/shell-web": "0.1.101"
+        "@jskit-ai/auth-core": "0.1.101",
+        "@jskit-ai/http-runtime": "0.1.101",
+        "@jskit-ai/kernel": "0.1.103",
+        "@jskit-ai/shell-web": "0.1.102"
       },
       "dev": {}
     },

--- a/packages/auth-web/package.json
+++ b/packages/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-web",
-  "version": "0.1.102",
+  "version": "0.1.103",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -19,11 +19,11 @@
     "./client/runtime/useSignOut": "./src/client/runtime/useSignOut.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.100",
+    "@jskit-ai/auth-core": "0.1.101",
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/kernel": "0.1.102",
-    "@jskit-ai/shell-web": "0.1.101",
-    "@jskit-ai/http-runtime": "0.1.100"
+    "@jskit-ai/kernel": "0.1.103",
+    "@jskit-ai/shell-web": "0.1.102",
+    "@jskit-ai/http-runtime": "0.1.101"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/console-core/package.descriptor.mjs
+++ b/packages/console-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-core",
-  version: "0.1.64",
+  version: "0.1.65",
   kind: "runtime",
   description: "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
   dependsOn: [
@@ -85,12 +85,12 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.100",
-        "@jskit-ai/database-runtime": "0.1.101",
-        "@jskit-ai/http-runtime": "0.1.100",
-        "@jskit-ai/kernel": "0.1.102",
-        "@jskit-ai/resource-crud-core": "0.1.46",
-        "@jskit-ai/users-core": "0.1.111"
+        "@jskit-ai/auth-core": "0.1.101",
+        "@jskit-ai/database-runtime": "0.1.102",
+        "@jskit-ai/http-runtime": "0.1.101",
+        "@jskit-ai/kernel": "0.1.103",
+        "@jskit-ai/resource-crud-core": "0.1.47",
+        "@jskit-ai/users-core": "0.1.112"
       },
       dev: {}
     },

--- a/packages/console-core/package.json
+++ b/packages/console-core/package.json
@@ -1,17 +1,17 @@
 {
   "name": "@jskit-ai/console-core",
-  "version": "0.1.64",
+  "version": "0.1.65",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.100",
-    "@jskit-ai/database-runtime": "0.1.101",
-    "@jskit-ai/http-runtime": "0.1.100",
-    "@jskit-ai/kernel": "0.1.102",
-    "@jskit-ai/resource-crud-core": "0.1.46",
-    "@jskit-ai/users-core": "0.1.111",
+    "@jskit-ai/auth-core": "0.1.101",
+    "@jskit-ai/database-runtime": "0.1.102",
+    "@jskit-ai/http-runtime": "0.1.101",
+    "@jskit-ai/kernel": "0.1.103",
+    "@jskit-ai/resource-crud-core": "0.1.47",
+    "@jskit-ai/users-core": "0.1.112",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/console-web/package.descriptor.mjs
+++ b/packages/console-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-web",
-  version: "0.1.69",
+  version: "0.1.70",
   kind: "runtime",
   description: "Authenticated console surface scaffold and surface policy wiring.",
   dependsOn: [
@@ -103,9 +103,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-web": "0.1.102",
-        "@jskit-ai/console-core": "0.1.64",
-        "@jskit-ai/shell-web": "0.1.101",
+        "@jskit-ai/auth-web": "0.1.103",
+        "@jskit-ai/console-core": "0.1.65",
+        "@jskit-ai/shell-web": "0.1.102",
       },
       dev: {}
     },

--- a/packages/console-web/package.json
+++ b/packages/console-web/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/console-web",
-  "version": "0.1.69",
+  "version": "0.1.70",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-web": "0.1.102",
-    "@jskit-ai/console-core": "0.1.64",
-    "@jskit-ai/shell-web": "0.1.101"
+    "@jskit-ai/auth-web": "0.1.103",
+    "@jskit-ai/console-core": "0.1.65",
+    "@jskit-ai/shell-web": "0.1.102"
   }
 }

--- a/packages/crud-core/package.descriptor.mjs
+++ b/packages/crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-core",
-  version: "0.1.109",
+  version: "0.1.110",
   kind: "runtime",
   description: "Shared CRUD helpers used by CRUD modules.",
   dependsOn: [
@@ -28,7 +28,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/crud-core": "0.1.109"
+        "@jskit-ai/crud-core": "0.1.110"
       },
       dev: {}
     },

--- a/packages/crud-core/package.json
+++ b/packages/crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-core",
-  "version": "0.1.109",
+  "version": "0.1.110",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -27,15 +27,15 @@
     "./server/routeContracts": "./src/server/routeContracts.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.101",
-    "@jskit-ai/http-runtime": "0.1.100",
-    "@jskit-ai/kernel": "0.1.102",
+    "@jskit-ai/database-runtime": "0.1.102",
+    "@jskit-ai/http-runtime": "0.1.101",
+    "@jskit-ai/kernel": "0.1.103",
     "json-rest-schema": "1.x.x",
-    "@jskit-ai/realtime": "0.1.100",
-    "@jskit-ai/resource-crud-core": "0.1.46",
-    "@jskit-ai/shell-web": "0.1.101",
-    "@jskit-ai/users-core": "0.1.111",
-    "@jskit-ai/users-web": "0.1.116"
+    "@jskit-ai/realtime": "0.1.101",
+    "@jskit-ai/resource-crud-core": "0.1.47",
+    "@jskit-ai/shell-web": "0.1.102",
+    "@jskit-ai/users-core": "0.1.112",
+    "@jskit-ai/users-web": "0.1.117"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/crud-server-generator/package.descriptor.mjs
+++ b/packages/crud-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-server-generator",
-  version: "0.1.109",
+  version: "0.1.110",
   kind: "generator",
   description: "CRUD server generator with routes, actions, and persistence scaffolding.",
   options: {
@@ -160,14 +160,14 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.100",
-        "@jskit-ai/crud-core": "0.1.109",
-        "@jskit-ai/database-runtime": "0.1.101",
-        "@jskit-ai/http-runtime": "0.1.100",
-        "@jskit-ai/json-rest-api-core": "0.1.46",
-        "@jskit-ai/kernel": "0.1.102",
-        "@jskit-ai/realtime": "0.1.100",
-        "@jskit-ai/resource-crud-core": "0.1.46",
+        "@jskit-ai/auth-core": "0.1.101",
+        "@jskit-ai/crud-core": "0.1.110",
+        "@jskit-ai/database-runtime": "0.1.102",
+        "@jskit-ai/http-runtime": "0.1.101",
+        "@jskit-ai/json-rest-api-core": "0.1.47",
+        "@jskit-ai/kernel": "0.1.103",
+        "@jskit-ai/realtime": "0.1.101",
+        "@jskit-ai/resource-crud-core": "0.1.47",
         "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}"
       },
       dev: {}

--- a/packages/crud-server-generator/package.json
+++ b/packages/crud-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-server-generator",
-  "version": "0.1.109",
+  "version": "0.1.110",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,12 +13,12 @@
   },
   "dependencies": {
     "@babel/parser": "^7.29.2",
-    "@jskit-ai/crud-core": "0.1.109",
-    "@jskit-ai/database-runtime": "0.1.101",
-    "@jskit-ai/http-runtime": "0.1.100",
-    "@jskit-ai/json-rest-api-core": "0.1.46",
-    "@jskit-ai/kernel": "0.1.102",
-    "@jskit-ai/resource-crud-core": "0.1.46",
+    "@jskit-ai/crud-core": "0.1.110",
+    "@jskit-ai/database-runtime": "0.1.102",
+    "@jskit-ai/http-runtime": "0.1.101",
+    "@jskit-ai/json-rest-api-core": "0.1.47",
+    "@jskit-ai/kernel": "0.1.103",
+    "@jskit-ai/resource-crud-core": "0.1.47",
     "recast": "^0.23.11"
   }
 }

--- a/packages/crud-ui-generator/package.descriptor.mjs
+++ b/packages/crud-ui-generator/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { GENERATED_UI_NAVIGATION_ROLE_OPTION } from "@jskit-ai/kernel/shared/sup
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-ui-generator",
-  version: "0.1.84",
+  version: "0.1.85",
   kind: "generator",
   description: "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
   options: {
@@ -175,7 +175,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.116"
+        "@jskit-ai/users-web": "0.1.117"
       },
       dev: {}
     },

--- a/packages/crud-ui-generator/package.json
+++ b/packages/crud-ui-generator/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@jskit-ai/crud-ui-generator",
-  "version": "0.1.84",
+  "version": "0.1.85",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/crud-core": "0.1.109",
-    "@jskit-ai/kernel": "0.1.102",
-    "@jskit-ai/resource-crud-core": "0.1.46"
+    "@jskit-ai/crud-core": "0.1.110",
+    "@jskit-ai/kernel": "0.1.103",
+    "@jskit-ai/resource-crud-core": "0.1.47"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/database-runtime-mysql/package.descriptor.mjs
+++ b/packages/database-runtime-mysql/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-mysql",
-  version: "0.1.100",
+  version: "0.1.101",
   kind: "runtime",
   options: {
     "db-host": {
@@ -91,7 +91,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.101",
+        "@jskit-ai/database-runtime": "0.1.102",
         "mysql2": "^3.11.2"
       },
       dev: {}

--- a/packages/database-runtime-mysql/package.json
+++ b/packages/database-runtime-mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-mysql",
-  "version": "0.1.100",
+  "version": "0.1.101",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,7 +12,7 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.101",
-    "@jskit-ai/kernel": "0.1.102"
+    "@jskit-ai/database-runtime": "0.1.102",
+    "@jskit-ai/kernel": "0.1.103"
   }
 }

--- a/packages/database-runtime-postgres/package.descriptor.mjs
+++ b/packages/database-runtime-postgres/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-postgres",
-  version: "0.1.100",
+  version: "0.1.101",
   kind: "runtime",
   options: {
     "db-host": {
@@ -91,7 +91,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.101",
+        "@jskit-ai/database-runtime": "0.1.102",
         "pg": "^8.13.1"
       },
       dev: {}

--- a/packages/database-runtime-postgres/package.json
+++ b/packages/database-runtime-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-postgres",
-  "version": "0.1.100",
+  "version": "0.1.101",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,6 +12,6 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.101"
+    "@jskit-ai/database-runtime": "0.1.102"
   }
 }

--- a/packages/database-runtime/package.descriptor.mjs
+++ b/packages/database-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime",
-  version: "0.1.101",
+  version: "0.1.102",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -58,7 +58,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.102",
+        "@jskit-ai/kernel": "0.1.103",
         "dotenv": "^16.4.5",
         "knex": "^3.1.0"
       },

--- a/packages/database-runtime/package.json
+++ b/packages/database-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime",
-  "version": "0.1.101",
+  "version": "0.1.102",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -25,6 +25,6 @@
     "./shared/transactions": "./src/shared/transactions.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.102"
+    "@jskit-ai/kernel": "0.1.103"
   }
 }

--- a/packages/feature-server-generator/package.descriptor.mjs
+++ b/packages/feature-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/feature-server-generator",
-  version: "0.1.43",
+  version: "0.1.44",
   kind: "generator",
   description: "Scaffold substantial non-CRUD server feature packages with provider, actions, service, and optional persistence seams.",
   options: {
@@ -174,7 +174,7 @@ export default Object.freeze({
             equals: "json-rest"
           }
         },
-        "@jskit-ai/kernel": "0.1.102",
+        "@jskit-ai/kernel": "0.1.103",
         "json-rest-schema": "1.x.x",
         "@local/${option:feature-name|kebab}": "file:packages/${option:feature-name|kebab}"
       },

--- a/packages/feature-server-generator/package.json
+++ b/packages/feature-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/feature-server-generator",
-  "version": "0.1.43",
+  "version": "0.1.44",
   "type": "module",
   "scripts": {
     "test": "node --test"

--- a/packages/google-rewarded-core/package.descriptor.mjs
+++ b/packages/google-rewarded-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/google-rewarded-core",
-  version: "0.1.38",
+  version: "0.1.39",
   kind: "runtime",
   description: "Google rewarded workflow runtime plus internal CRUD providers for rules, provider configs, watch sessions, and unlock receipts.",
   dependsOn: [
@@ -128,14 +128,14 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.100",
-        "@jskit-ai/crud-core": "0.1.109",
-        "@jskit-ai/database-runtime": "0.1.101",
-        "@jskit-ai/http-runtime": "0.1.100",
-        "@jskit-ai/json-rest-api-core": "0.1.46",
-        "@jskit-ai/kernel": "0.1.102",
-        "@jskit-ai/resource-crud-core": "0.1.46",
-        "@jskit-ai/workspaces-core": "0.1.77"
+        "@jskit-ai/auth-core": "0.1.101",
+        "@jskit-ai/crud-core": "0.1.110",
+        "@jskit-ai/database-runtime": "0.1.102",
+        "@jskit-ai/http-runtime": "0.1.101",
+        "@jskit-ai/json-rest-api-core": "0.1.47",
+        "@jskit-ai/kernel": "0.1.103",
+        "@jskit-ai/resource-crud-core": "0.1.47",
+        "@jskit-ai/workspaces-core": "0.1.78"
       },
       dev: {}
     },

--- a/packages/google-rewarded-core/package.json
+++ b/packages/google-rewarded-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/google-rewarded-core",
-  "version": "0.1.38",
+  "version": "0.1.39",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/google-rewarded-web/package.descriptor.mjs
+++ b/packages/google-rewarded-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/google-rewarded-web",
-  version: "0.1.38",
+  version: "0.1.39",
   kind: "runtime",
   description: "Google rewarded client runtime with a fullscreen gate host and GPT orchestration.",
   dependsOn: [
@@ -46,10 +46,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/google-rewarded-core": "0.1.38",
-        "@jskit-ai/http-runtime": "0.1.100",
-        "@jskit-ai/kernel": "0.1.102",
-        "@jskit-ai/shell-web": "0.1.101"
+        "@jskit-ai/google-rewarded-core": "0.1.39",
+        "@jskit-ai/http-runtime": "0.1.101",
+        "@jskit-ai/kernel": "0.1.103",
+        "@jskit-ai/shell-web": "0.1.102"
       },
       dev: {}
     },

--- a/packages/google-rewarded-web/package.json
+++ b/packages/google-rewarded-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/google-rewarded-web",
-  "version": "0.1.38",
+  "version": "0.1.39",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/http-runtime/package.descriptor.mjs
+++ b/packages/http-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/http-runtime",
-  "version": "0.1.100",
+  "version": "0.1.101",
   "kind": "runtime",
   "dependsOn": [],
   "capabilities": {
@@ -67,7 +67,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.102"
+        "@jskit-ai/kernel": "0.1.103"
       },
       "dev": {}
     },

--- a/packages/http-runtime/package.json
+++ b/packages/http-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/http-runtime",
-  "version": "0.1.100",
+  "version": "0.1.101",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -18,7 +18,7 @@
     "./shared/validators/operationValidation": "./src/shared/validators/operationValidation.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.102",
+    "@jskit-ai/kernel": "0.1.103",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/json-rest-api-core/package.descriptor.mjs
+++ b/packages/json-rest-api-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/json-rest-api-core",
-  version: "0.1.46",
+  version: "0.1.47",
   kind: "runtime",
   description: "Shared internal json-rest-api host runtime for JSKIT server packages.",
   dependsOn: [

--- a/packages/json-rest-api-core/package.json
+++ b/packages/json-rest-api-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/json-rest-api-core",
-  "version": "0.1.46",
+  "version": "0.1.47",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,6 +11,6 @@
   "dependencies": {
     "hooked-api": "1.x.x",
     "json-rest-api": "1.x.x",
-    "@jskit-ai/kernel": "0.1.102"
+    "@jskit-ai/kernel": "0.1.103"
   }
 }

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/kernel",
-  "version": "0.1.102",
+  "version": "0.1.103",
   "type": "module",
   "dependencies": {
     "json-rest-schema": "1.x.x"

--- a/packages/mobile-capacitor/package.descriptor.mjs
+++ b/packages/mobile-capacitor/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/mobile-capacitor",
-  version: "0.1.38",
+  version: "0.1.39",
   kind: "runtime",
   description: "Thin Capacitor client integration for JSKIT mobile-shell launch routing and auth callback completion.",
   dependsOn: [
@@ -62,8 +62,8 @@ export default Object.freeze({
         "@capacitor/app": "^7.1.0",
         "@capacitor/browser": "^7.0.1",
         "@capacitor/core": "^7.4.3",
-        "@jskit-ai/kernel": "0.1.102",
-        "@jskit-ai/shell-web": "0.1.101"
+        "@jskit-ai/kernel": "0.1.103",
+        "@jskit-ai/shell-web": "0.1.102"
       },
       dev: {
         "@capacitor/cli": "^7.4.3"

--- a/packages/mobile-capacitor/package.json
+++ b/packages/mobile-capacitor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/mobile-capacitor",
-  "version": "0.1.38",
+  "version": "0.1.39",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,6 +12,6 @@
   },
   "dependencies": {
     "@capacitor/browser": "^7.0.1",
-    "@jskit-ai/kernel": "0.1.102"
+    "@jskit-ai/kernel": "0.1.103"
   }
 }

--- a/packages/realtime/package.descriptor.mjs
+++ b/packages/realtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/realtime",
-  version: "0.1.100",
+  version: "0.1.101",
   kind: "runtime",
   description: "Thin, generic realtime runtime wrappers for socket.io server and client.",
   options: {
@@ -95,7 +95,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.102",
+        "@jskit-ai/kernel": "0.1.103",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/realtime",
-  "version": "0.1.100",
+  "version": "0.1.101",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@socket.io/redis-adapter": "^8.3.0",
-    "@jskit-ai/kernel": "0.1.102",
+    "@jskit-ai/kernel": "0.1.103",
     "redis": "^5.8.2",
     "socket.io": "^4.8.3",
     "socket.io-client": "^4.8.3"

--- a/packages/resource-core/package.descriptor.mjs
+++ b/packages/resource-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/resource-core",
-  version: "0.1.46",
+  version: "0.1.47",
   kind: "runtime",
   description: "Generic resource-definition helpers and schema-definition normalization.",
   dependsOn: [
@@ -22,7 +22,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/resource-core": "0.1.46"
+        "@jskit-ai/resource-core": "0.1.47"
       },
       dev: {}
     },

--- a/packages/resource-core/package.json
+++ b/packages/resource-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/resource-core",
-  "version": "0.1.46",
+  "version": "0.1.47",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./shared/resource": "./src/shared/resource.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.102"
+    "@jskit-ai/kernel": "0.1.103"
   }
 }

--- a/packages/resource-crud-core/package.descriptor.mjs
+++ b/packages/resource-crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/resource-crud-core",
-  version: "0.1.46",
+  version: "0.1.47",
   kind: "runtime",
   description: "CRUD-specific resource-definition helpers and namespace support.",
   dependsOn: [
@@ -23,7 +23,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/resource-crud-core": "0.1.46"
+        "@jskit-ai/resource-crud-core": "0.1.47"
       },
       dev: {}
     },

--- a/packages/resource-crud-core/package.json
+++ b/packages/resource-crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/resource-crud-core",
-  "version": "0.1.46",
+  "version": "0.1.47",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./shared/crudResource": "./src/shared/crudResource.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.102",
-    "@jskit-ai/resource-core": "0.1.46"
+    "@jskit-ai/kernel": "0.1.103",
+    "@jskit-ai/resource-core": "0.1.47"
   }
 }

--- a/packages/shell-web/package.descriptor.mjs
+++ b/packages/shell-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/shell-web",
-  version: "0.1.101",
+  version: "0.1.102",
   kind: "runtime",
   description: "Web shell layout runtime with outlet-based placement contributions.",
   dependsOn: [],
@@ -307,7 +307,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/kernel": "0.1.102"
+        "@jskit-ai/kernel": "0.1.103"
       },
       dev: {}
     },

--- a/packages/shell-web/package.json
+++ b/packages/shell-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/shell-web",
-  "version": "0.1.101",
+  "version": "0.1.102",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/kernel": "0.1.102"
+    "@jskit-ai/kernel": "0.1.103"
   },
   "peerDependencies": {
     "pinia": "^3.0.4",

--- a/packages/storage-runtime/package.descriptor.mjs
+++ b/packages/storage-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/storage-runtime",
-  version: "0.1.100",
+  version: "0.1.101",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -50,7 +50,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.102",
+        "@jskit-ai/kernel": "0.1.103",
         "unstorage": "^1.17.3"
       },
       dev: {}

--- a/packages/storage-runtime/package.json
+++ b/packages/storage-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/storage-runtime",
-  "version": "0.1.100",
+  "version": "0.1.101",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./server/providers/StorageRuntimeServiceProvider": "./src/server/providers/StorageRuntimeServiceProvider.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.102",
+    "@jskit-ai/kernel": "0.1.103",
     "unstorage": "^1.17.3"
   }
 }

--- a/packages/ui-generator/package.descriptor.mjs
+++ b/packages/ui-generator/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { GENERATED_UI_NAVIGATION_ROLE_OPTION } from "@jskit-ai/kernel/shared/sup
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/ui-generator",
-  version: "0.1.84",
+  version: "0.1.85",
   kind: "generator",
   description: "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
   options: {
@@ -371,7 +371,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.116"
+        "@jskit-ai/users-web": "0.1.117"
       },
       dev: {}
     },

--- a/packages/ui-generator/package.json
+++ b/packages/ui-generator/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/ui-generator",
-  "version": "0.1.84",
+  "version": "0.1.85",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.102",
-    "@jskit-ai/shell-web": "0.1.101"
+    "@jskit-ai/kernel": "0.1.103",
+    "@jskit-ai/shell-web": "0.1.102"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/uploads-image-web/package.descriptor.mjs
+++ b/packages/uploads-image-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-image-web",
-  version: "0.1.79",
+  version: "0.1.80",
   kind: "runtime",
   description: "Reusable client-side image upload runtime with pre-upload image editing.",
   dependsOn: [
@@ -65,7 +65,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/uploads-runtime": "0.1.79",
+        "@jskit-ai/uploads-runtime": "0.1.80",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-image-web/package.json
+++ b/packages/uploads-image-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-image-web",
-  "version": "0.1.79",
+  "version": "0.1.80",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,7 +13,7 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/uploads-runtime": "0.1.79",
+    "@jskit-ai/uploads-runtime": "0.1.80",
     "@uppy/compressor": "^3.1.0",
     "@uppy/core": "^5.2.0",
     "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-runtime/package.descriptor.mjs
+++ b/packages/uploads-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-runtime",
-  version: "0.1.79",
+  version: "0.1.80",
   kind: "runtime",
   description: "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
   dependsOn: [
@@ -71,7 +71,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.102"
+        "@jskit-ai/kernel": "0.1.103"
       },
       dev: {}
     },

--- a/packages/uploads-runtime/package.json
+++ b/packages/uploads-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-runtime",
-  "version": "0.1.79",
+  "version": "0.1.80",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,6 +16,6 @@
   },
   "dependencies": {
     "@fastify/multipart": "^9.4.0",
-    "@jskit-ai/kernel": "0.1.102"
+    "@jskit-ai/kernel": "0.1.103"
   }
 }

--- a/packages/users-core/package.descriptor.mjs
+++ b/packages/users-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-core",
-  version: "0.1.111",
+  version: "0.1.112",
   kind: "runtime",
   description: "Users/account runtime plus HTTP routes for account features.",
   dependsOn: [
@@ -146,16 +146,16 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.100",
-        "@jskit-ai/crud-core": "0.1.109",
-        "@jskit-ai/database-runtime": "0.1.101",
-        "@jskit-ai/http-runtime": "0.1.100",
-        "@jskit-ai/json-rest-api-core": "0.1.46",
-        "@jskit-ai/kernel": "0.1.102",
-        "@jskit-ai/resource-core": "0.1.46",
-        "@jskit-ai/resource-crud-core": "0.1.46",
+        "@jskit-ai/auth-core": "0.1.101",
+        "@jskit-ai/crud-core": "0.1.110",
+        "@jskit-ai/database-runtime": "0.1.102",
+        "@jskit-ai/http-runtime": "0.1.101",
+        "@jskit-ai/json-rest-api-core": "0.1.47",
+        "@jskit-ai/kernel": "0.1.103",
+        "@jskit-ai/resource-core": "0.1.47",
+        "@jskit-ai/resource-crud-core": "0.1.47",
         "@local/users": "file:packages/users",
-        "@jskit-ai/uploads-runtime": "0.1.79"
+        "@jskit-ai/uploads-runtime": "0.1.80"
       },
       dev: {}
     },

--- a/packages/users-core/package.json
+++ b/packages/users-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-core",
-  "version": "0.1.111",
+  "version": "0.1.112",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,14 +12,14 @@
     "./shared/resources/userSettingsResource": "./src/shared/resources/userSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.100",
-    "@jskit-ai/database-runtime": "0.1.101",
-    "@jskit-ai/http-runtime": "0.1.100",
-    "@jskit-ai/json-rest-api-core": "0.1.46",
-    "@jskit-ai/kernel": "0.1.102",
-    "@jskit-ai/resource-crud-core": "0.1.46",
-    "@jskit-ai/resource-core": "0.1.46",
-    "@jskit-ai/uploads-runtime": "0.1.79",
+    "@jskit-ai/auth-core": "0.1.101",
+    "@jskit-ai/database-runtime": "0.1.102",
+    "@jskit-ai/http-runtime": "0.1.101",
+    "@jskit-ai/json-rest-api-core": "0.1.47",
+    "@jskit-ai/kernel": "0.1.103",
+    "@jskit-ai/resource-crud-core": "0.1.47",
+    "@jskit-ai/resource-core": "0.1.47",
+    "@jskit-ai/uploads-runtime": "0.1.80",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/users-web/package.descriptor.mjs
+++ b/packages/users-web/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { HOME_COG_OUTLET } from "./src/shared/toolsOutletContracts.js";
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-web",
-  version: "0.1.116",
+  version: "0.1.117",
   kind: "runtime",
   description: "Users web module: account/profile UI plus shared users web widgets.",
   dependsOn: [
@@ -286,12 +286,12 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/http-runtime": "0.1.100",
-        "@jskit-ai/realtime": "0.1.100",
-        "@jskit-ai/kernel": "0.1.102",
-        "@jskit-ai/shell-web": "0.1.101",
-        "@jskit-ai/uploads-image-web": "0.1.79",
-        "@jskit-ai/users-core": "0.1.111"
+        "@jskit-ai/http-runtime": "0.1.101",
+        "@jskit-ai/realtime": "0.1.101",
+        "@jskit-ai/kernel": "0.1.103",
+        "@jskit-ai/shell-web": "0.1.102",
+        "@jskit-ai/uploads-image-web": "0.1.80",
+        "@jskit-ai/users-core": "0.1.112"
       },
       dev: {}
     },

--- a/packages/users-web/package.json
+++ b/packages/users-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-web",
-  "version": "0.1.116",
+  "version": "0.1.117",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -46,12 +46,12 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/http-runtime": "0.1.100",
-    "@jskit-ai/kernel": "0.1.102",
-    "@jskit-ai/realtime": "0.1.100",
-    "@jskit-ai/shell-web": "0.1.101",
-    "@jskit-ai/uploads-image-web": "0.1.79",
-    "@jskit-ai/users-core": "0.1.111"
+    "@jskit-ai/http-runtime": "0.1.101",
+    "@jskit-ai/kernel": "0.1.103",
+    "@jskit-ai/realtime": "0.1.101",
+    "@jskit-ai/shell-web": "0.1.102",
+    "@jskit-ai/uploads-image-web": "0.1.80",
+    "@jskit-ai/users-core": "0.1.112"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/workspaces-core/package.descriptor.mjs
+++ b/packages/workspaces-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-core",
-  version: "0.1.77",
+  version: "0.1.78",
   kind: "runtime",
   description: "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
   dependsOn: [
@@ -142,10 +142,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/json-rest-api-core": "0.1.46",
-        "@jskit-ai/resource-core": "0.1.46",
-        "@jskit-ai/resource-crud-core": "0.1.46",
-        "@jskit-ai/users-core": "0.1.111"
+        "@jskit-ai/json-rest-api-core": "0.1.47",
+        "@jskit-ai/resource-core": "0.1.47",
+        "@jskit-ai/resource-crud-core": "0.1.47",
+        "@jskit-ai/users-core": "0.1.112"
       },
       dev: {}
     },

--- a/packages/workspaces-core/package.json
+++ b/packages/workspaces-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-core",
-  "version": "0.1.77",
+  "version": "0.1.78",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -18,14 +18,14 @@
     "./shared/resources/workspaceSettingsResource": "./src/shared/resources/workspaceSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.100",
-    "@jskit-ai/database-runtime": "0.1.101",
-    "@jskit-ai/http-runtime": "0.1.100",
-    "@jskit-ai/json-rest-api-core": "0.1.46",
-    "@jskit-ai/kernel": "0.1.102",
-    "@jskit-ai/resource-crud-core": "0.1.46",
-    "@jskit-ai/resource-core": "0.1.46",
-    "@jskit-ai/users-core": "0.1.111",
+    "@jskit-ai/auth-core": "0.1.101",
+    "@jskit-ai/database-runtime": "0.1.102",
+    "@jskit-ai/http-runtime": "0.1.101",
+    "@jskit-ai/json-rest-api-core": "0.1.47",
+    "@jskit-ai/kernel": "0.1.103",
+    "@jskit-ai/resource-crud-core": "0.1.47",
+    "@jskit-ai/resource-core": "0.1.47",
+    "@jskit-ai/users-core": "0.1.112",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/workspaces-web/package.descriptor.mjs
+++ b/packages/workspaces-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-web",
-  version: "0.1.78",
+  version: "0.1.79",
   kind: "runtime",
   description: "Workspace web module: workspace selector, tools widget, workspace surfaces, members UI, and settings hosts.",
   dependsOn: [
@@ -227,8 +227,8 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/workspaces-core": "0.1.77",
-        "@jskit-ai/users-web": "0.1.116"
+        "@jskit-ai/workspaces-core": "0.1.78",
+        "@jskit-ai/users-web": "0.1.117"
       },
       dev: {}
     },

--- a/packages/workspaces-web/package.json
+++ b/packages/workspaces-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-web",
-  "version": "0.1.78",
+  "version": "0.1.79",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -14,12 +14,12 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/http-runtime": "0.1.100",
-    "@jskit-ai/kernel": "0.1.102",
-    "@jskit-ai/shell-web": "0.1.101",
-    "@jskit-ai/users-core": "0.1.111",
-    "@jskit-ai/users-web": "0.1.116",
-    "@jskit-ai/workspaces-core": "0.1.77"
+    "@jskit-ai/http-runtime": "0.1.101",
+    "@jskit-ai/kernel": "0.1.103",
+    "@jskit-ai/shell-web": "0.1.102",
+    "@jskit-ai/users-core": "0.1.112",
+    "@jskit-ai/users-web": "0.1.117",
+    "@jskit-ai/workspaces-core": "0.1.78"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/plan.md
+++ b/plan.md
@@ -649,7 +649,7 @@ Add `/auth/reset-password` as a provider-neutral route. It should exchange recov
 
 Add package descriptor for `@jskit-ai/auth-provider-local-core`.
 
-Add a convenience bundle:
+Keep any auth convenience bundle as an optional compatibility shortcut, not the recommended install surface:
 
 ```text
 auth-local
@@ -665,8 +665,9 @@ Bundle contents:
 
 Change first-app auth guidance:
 
-- `create-app --initial-bundles auth` installs or prints `npx jskit add bundle auth-local`
+- `create-app --initial-bundles auth` installs or prints package commands for `auth-provider-local-core` and `auth-web`
 - docs should start with local auth
+- docs should show package installs rather than recommending auth bundles
 - Supabase docs become an upgrade/provider swap chapter
 
 The first auth install should be possible without collecting provider keys.
@@ -713,8 +714,8 @@ Rules:
 
 - Supabase package keeps its current public package id.
 - Existing Supabase env vars continue to work.
-- Existing `auth-base` bundle can remain provider-neutral.
-- New `auth-local` bundle is the low-friction first-app path.
+- Existing `auth-base` bundle can remain provider-neutral as a compatibility shortcut.
+- Existing `auth-local` bundle can remain as a shortcut, but package-first install guidance is the low-friction first-app path.
 - provider conflict checks prevent accidentally selecting local and Supabase providers together.
 - explicit provider-switch or migration mode may install multiple concrete provider packages temporarily, but must still expose one selected `auth.provider`.
 - provider-switch documentation must tell users how to remove or migrate the previous provider.
@@ -813,8 +814,8 @@ npm run verify
 18. Add SMTP/dev recovery delivery.
 19. Add `/auth/reset-password` UI in `auth-web`.
 20. Make `auth-web` capability-driven across password, OTP, OAuth, linking, recovery, and security status.
-21. Add `auth-local` bundle and catalog entries.
-22. Update `create-app --initial-bundles auth`.
+21. Keep or add auth bundle catalog entries only as optional shortcuts, not as documented first-app recommendations.
+22. Update `create-app --initial-bundles auth` to print package-first local auth commands.
 23. Update human guide and generated agent docs.
 24. Run focused tests, then full verification.
 

--- a/tooling/config-eslint/package.json
+++ b/tooling/config-eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/config-eslint",
-  "version": "0.1.100",
+  "version": "0.1.101",
   "description": "Shared flat ESLint presets for JSKIT projects.",
   "type": "module",
   "files": [

--- a/tooling/create-app/package.descriptor.mjs
+++ b/tooling/create-app/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/create-app",
-  "version": "0.1.110",
+  "version": "0.1.111",
   "dependsOn": [],
   "capabilities": {
     "provides": [

--- a/tooling/create-app/package.json
+++ b/tooling/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/create-app",
-  "version": "0.1.110",
+  "version": "0.1.111",
   "description": "Scaffold JSKIT app shells.",
   "type": "module",
   "files": [

--- a/tooling/create-app/src/server/index.js
+++ b/tooling/create-app/src/server/index.js
@@ -54,7 +54,8 @@ function buildInitialSetupCommands(initialBundles) {
 
   const commands = [];
   if (normalizedPreset === "auth") {
-    commands.push("npx jskit add bundle auth-local");
+    commands.push("npx jskit add package auth-provider-local-core");
+    commands.push("npx jskit add package auth-web");
   }
 
   return commands;
@@ -229,7 +230,7 @@ function printUsage(stream = process.stderr) {
   stream.write("  --minimal          Use the bare minimal-shell template instead of the default shell-web app scaffold\n");
   stream.write("  --title <text>     App title used for template replacements\n");
   stream.write("  --target <path>    Target directory (default: ./<app-name>)\n");
-  stream.write("  --initial-bundles <preset>  Optional bundle preset: none | auth (default: none)\n");
+  stream.write("  --initial-bundles <preset>  Optional initial setup preset: none | auth (default: none)\n");
   stream.write("  --tenancy-mode <mode>  Optional config seed: none | personal | workspaces\n");
   stream.write("  --force            Allow writing into a non-empty target directory\n");
   stream.write("  --dry-run          Print planned writes without changing the filesystem\n");
@@ -466,7 +467,7 @@ async function collectInteractiveOptions({
     while (true) {
       const candidate = await askQuestion(
         readline,
-        "Initial bundle preset (none|auth)",
+        "Initial setup preset (none|auth)",
         initialBundles
       );
       try {

--- a/tooling/create-app/test/createApp.test.js
+++ b/tooling/create-app/test/createApp.test.js
@@ -402,6 +402,7 @@ test("create-app scaffolds the base shell with placeholder replacements", async 
     assert.doesNotMatch(result.stdout, /Then add framework capabilities:/);
     assert.doesNotMatch(result.stdout, /npx jskit add package auth-provider-supabase-core/);
     assert.doesNotMatch(result.stdout, /npx jskit add bundle auth-base/);
+    assert.doesNotMatch(result.stdout, /npx jskit add bundle auth-local/);
   });
 });
 
@@ -461,7 +462,7 @@ test("ai-seed agent instructions do not hardcode machine-specific paths and poin
   assert.doesNotMatch(body, /AUTH_SUPABASE_PUBLISHABLE_KEY/);
 });
 
-test("create-app interactive flow captures initial bundle selection in guidance", async () => {
+test("create-app interactive flow captures initial auth setup preset in guidance", async () => {
   await withCreateAppTempDir(async (cwd) => {
     const stdoutCapture = createCaptureWritable();
     const stderrCapture = createCaptureWritable();
@@ -500,7 +501,9 @@ test("create-app interactive flow captures initial bundle selection in guidance"
     assert.deepEqual(answers, []);
     assert.ok(askedPrompts.length >= 7);
     assert.match(stdout, /Initial framework setup commands \(auth\):/);
-    assert.match(stdout, /npx jskit add bundle auth-local/);
+    assert.match(stdout, /npx jskit add package auth-provider-local-core/);
+    assert.match(stdout, /npx jskit add package auth-web/);
+    assert.doesNotMatch(stdout, /npx jskit add bundle auth-local/);
     assert.doesNotMatch(stdout, /auth-provider-supabase-core/);
 
     const publicConfig = await readFile(path.join(cwd, "interactive-app/config/public.js"), "utf8");
@@ -914,11 +917,17 @@ test("generated default shell app supports auth progressive installation", async
     const publicConfig = await readFile(publicConfigPath, "utf8");
     await writeFile(publicConfigPath, `${publicConfig}\nconfig.tenancyMode = "workspaces";\n`, "utf8");
 
-    const addAuthResult = runJskit({
+    const addLocalProviderResult = runJskit({
       cwd: appRoot,
-      args: ["add", "bundle", "auth-local"]
+      args: ["add", "package", "auth-provider-local-core"]
     });
-    assert.equal(addAuthResult.status, 0, addAuthResult.stderr);
+    assert.equal(addLocalProviderResult.status, 0, addLocalProviderResult.stderr);
+
+    const addAuthWebResult = runJskit({
+      cwd: appRoot,
+      args: ["add", "package", "auth-web"]
+    });
+    assert.equal(addAuthWebResult.status, 0, addAuthWebResult.stderr);
 
     const doctorResult = runJskit({ cwd: appRoot, args: ["doctor"] });
     assert.equal(doctorResult.status, 0, doctorResult.stderr);

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -6,11 +6,11 @@
   "packages": [
     {
       "packageId": "@jskit-ai/assistant",
-      "version": "0.1.110",
+      "version": "0.1.111",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant",
-        "version": "0.1.110",
+        "version": "0.1.111",
         "kind": "generator",
         "description": "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
         "options": {
@@ -347,11 +347,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-core",
-      "version": "0.1.77",
+      "version": "0.1.78",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-core",
-        "version": "0.1.77",
+        "version": "0.1.78",
         "kind": "runtime",
         "description": "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
         "dependsOn": [
@@ -399,11 +399,11 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/http-runtime": "0.1.100",
-              "@jskit-ai/kernel": "0.1.102",
-              "@jskit-ai/resource-core": "0.1.46",
-              "@jskit-ai/resource-crud-core": "0.1.46",
-              "@jskit-ai/users-core": "0.1.111",
+              "@jskit-ai/http-runtime": "0.1.101",
+              "@jskit-ai/kernel": "0.1.103",
+              "@jskit-ai/resource-core": "0.1.47",
+              "@jskit-ai/resource-crud-core": "0.1.47",
+              "@jskit-ai/users-core": "0.1.112",
               "dompurify": "^3.3.3",
               "json-rest-schema": "1.x.x",
               "marked": "^17.0.4",
@@ -422,11 +422,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-runtime",
-      "version": "0.1.72",
+      "version": "0.1.73",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-runtime",
-        "version": "0.1.72",
+        "version": "0.1.73",
         "kind": "runtime",
         "description": "Shared assistant runtime with per-surface assistant registration.",
         "dependsOn": [
@@ -522,13 +522,13 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/assistant-core": "0.1.77",
-              "@jskit-ai/database-runtime": "0.1.101",
-              "@jskit-ai/http-runtime": "0.1.100",
-              "@jskit-ai/kernel": "0.1.102",
-              "@jskit-ai/shell-web": "0.1.101",
-              "@jskit-ai/users-core": "0.1.111",
-              "@jskit-ai/users-web": "0.1.116"
+              "@jskit-ai/assistant-core": "0.1.78",
+              "@jskit-ai/database-runtime": "0.1.102",
+              "@jskit-ai/http-runtime": "0.1.101",
+              "@jskit-ai/kernel": "0.1.103",
+              "@jskit-ai/shell-web": "0.1.102",
+              "@jskit-ai/users-core": "0.1.112",
+              "@jskit-ai/users-web": "0.1.117"
             },
             "dev": {}
           },
@@ -583,11 +583,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-core",
-      "version": "0.1.100",
+      "version": "0.1.101",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-core",
-        "version": "0.1.100",
+        "version": "0.1.101",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/value-app-config-shared"
@@ -660,7 +660,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.102",
+              "@jskit-ai/kernel": "0.1.103",
               "@fastify/cookie": "^11.0.2",
               "@fastify/csrf-protection": "^7.1.0",
               "@fastify/rate-limit": "^10.3.0"
@@ -678,11 +678,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-local-core",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-local-core",
-        "version": "0.1.1",
+        "version": "0.1.2",
         "kind": "runtime",
         "description": "Local auth provider with a file backend default and no database requirement.",
         "dependsOn": [
@@ -737,8 +737,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.100",
-              "@jskit-ai/kernel": "0.1.102",
+              "@jskit-ai/auth-core": "0.1.101",
+              "@jskit-ai/kernel": "0.1.103",
               "nodemailer": "^7.0.10",
               "dotenv": "^16.4.5"
             },
@@ -784,11 +784,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.100",
+      "version": "0.1.101",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-supabase-core",
-        "version": "0.1.100",
+        "version": "0.1.101",
         "kind": "runtime",
         "options": {
           "auth-supabase-url": {
@@ -870,8 +870,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.100",
-              "@jskit-ai/kernel": "0.1.102",
+              "@jskit-ai/auth-core": "0.1.101",
+              "@jskit-ai/kernel": "0.1.103",
               "dotenv": "^16.4.5",
               "@supabase/supabase-js": "^2.57.4",
               "jose": "^6.1.0"
@@ -949,11 +949,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-web",
-      "version": "0.1.102",
+      "version": "0.1.103",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-web",
-        "version": "0.1.102",
+        "version": "0.1.103",
         "kind": "runtime",
         "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
         "dependsOn": [
@@ -1222,10 +1222,10 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/auth-core": "0.1.100",
-              "@jskit-ai/http-runtime": "0.1.100",
-              "@jskit-ai/kernel": "0.1.102",
-              "@jskit-ai/shell-web": "0.1.101"
+              "@jskit-ai/auth-core": "0.1.101",
+              "@jskit-ai/http-runtime": "0.1.101",
+              "@jskit-ai/kernel": "0.1.103",
+              "@jskit-ai/shell-web": "0.1.102"
             },
             "dev": {}
           },
@@ -1318,11 +1318,11 @@
     },
     {
       "packageId": "@jskit-ai/console-core",
-      "version": "0.1.64",
+      "version": "0.1.65",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-core",
-        "version": "0.1.64",
+        "version": "0.1.65",
         "kind": "runtime",
         "description": "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
         "dependsOn": [
@@ -1406,12 +1406,12 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.100",
-              "@jskit-ai/database-runtime": "0.1.101",
-              "@jskit-ai/http-runtime": "0.1.100",
-              "@jskit-ai/kernel": "0.1.102",
-              "@jskit-ai/resource-crud-core": "0.1.46",
-              "@jskit-ai/users-core": "0.1.111"
+              "@jskit-ai/auth-core": "0.1.101",
+              "@jskit-ai/database-runtime": "0.1.102",
+              "@jskit-ai/http-runtime": "0.1.101",
+              "@jskit-ai/kernel": "0.1.103",
+              "@jskit-ai/resource-crud-core": "0.1.47",
+              "@jskit-ai/users-core": "0.1.112"
             },
             "dev": {}
           },
@@ -1436,11 +1436,11 @@
     },
     {
       "packageId": "@jskit-ai/console-web",
-      "version": "0.1.69",
+      "version": "0.1.70",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-web",
-        "version": "0.1.69",
+        "version": "0.1.70",
         "kind": "runtime",
         "description": "Authenticated console surface scaffold and surface policy wiring.",
         "dependsOn": [
@@ -1550,9 +1550,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-web": "0.1.102",
-              "@jskit-ai/console-core": "0.1.64",
-              "@jskit-ai/shell-web": "0.1.101"
+              "@jskit-ai/auth-web": "0.1.103",
+              "@jskit-ai/console-core": "0.1.65",
+              "@jskit-ai/shell-web": "0.1.102"
             },
             "dev": {}
           },
@@ -1659,11 +1659,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-core",
-      "version": "0.1.109",
+      "version": "0.1.110",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-core",
-        "version": "0.1.109",
+        "version": "0.1.110",
         "kind": "runtime",
         "description": "Shared CRUD helpers used by CRUD modules.",
         "dependsOn": [
@@ -1692,7 +1692,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/crud-core": "0.1.109"
+              "@jskit-ai/crud-core": "0.1.110"
             },
             "dev": {}
           },
@@ -1706,11 +1706,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-server-generator",
-      "version": "0.1.109",
+      "version": "0.1.110",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-server-generator",
-        "version": "0.1.109",
+        "version": "0.1.110",
         "kind": "generator",
         "description": "CRUD server generator with routes, actions, and persistence scaffolding.",
         "options": {
@@ -1877,14 +1877,14 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.100",
-              "@jskit-ai/crud-core": "0.1.109",
-              "@jskit-ai/database-runtime": "0.1.101",
-              "@jskit-ai/http-runtime": "0.1.100",
-              "@jskit-ai/json-rest-api-core": "0.1.46",
-              "@jskit-ai/kernel": "0.1.102",
-              "@jskit-ai/realtime": "0.1.100",
-              "@jskit-ai/resource-crud-core": "0.1.46",
+              "@jskit-ai/auth-core": "0.1.101",
+              "@jskit-ai/crud-core": "0.1.110",
+              "@jskit-ai/database-runtime": "0.1.102",
+              "@jskit-ai/http-runtime": "0.1.101",
+              "@jskit-ai/json-rest-api-core": "0.1.47",
+              "@jskit-ai/kernel": "0.1.103",
+              "@jskit-ai/realtime": "0.1.101",
+              "@jskit-ai/resource-crud-core": "0.1.47",
               "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}"
             },
             "dev": {}
@@ -2016,11 +2016,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.84",
+      "version": "0.1.85",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-ui-generator",
-        "version": "0.1.84",
+        "version": "0.1.85",
         "kind": "generator",
         "description": "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
         "options": {
@@ -2219,7 +2219,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.116"
+              "@jskit-ai/users-web": "0.1.117"
             },
             "dev": {}
           },
@@ -2478,11 +2478,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime",
-      "version": "0.1.101",
+      "version": "0.1.102",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime",
-        "version": "0.1.101",
+        "version": "0.1.102",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -2539,7 +2539,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.102",
+              "@jskit-ai/kernel": "0.1.103",
               "dotenv": "^16.4.5",
               "knex": "^3.1.0"
             },
@@ -2574,11 +2574,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.100",
+      "version": "0.1.101",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-mysql",
-        "version": "0.1.100",
+        "version": "0.1.101",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -2668,7 +2668,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.101",
+              "@jskit-ai/database-runtime": "0.1.102",
               "mysql2": "^3.11.2"
             },
             "dev": {}
@@ -2739,11 +2739,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.100",
+      "version": "0.1.101",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-postgres",
-        "version": "0.1.100",
+        "version": "0.1.101",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -2833,7 +2833,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.101",
+              "@jskit-ai/database-runtime": "0.1.102",
               "pg": "^8.13.1"
             },
             "dev": {}
@@ -2904,11 +2904,11 @@
     },
     {
       "packageId": "@jskit-ai/feature-server-generator",
-      "version": "0.1.43",
+      "version": "0.1.44",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/feature-server-generator",
-        "version": "0.1.43",
+        "version": "0.1.44",
         "kind": "generator",
         "description": "Scaffold substantial non-CRUD server feature packages with provider, actions, service, and optional persistence seams.",
         "options": {
@@ -3093,7 +3093,7 @@
                   "equals": "json-rest"
                 }
               },
-              "@jskit-ai/kernel": "0.1.102",
+              "@jskit-ai/kernel": "0.1.103",
               "json-rest-schema": "1.x.x",
               "@local/${option:feature-name|kebab}": "file:packages/${option:feature-name|kebab}"
             },
@@ -3206,11 +3206,11 @@
     },
     {
       "packageId": "@jskit-ai/google-rewarded-core",
-      "version": "0.1.38",
+      "version": "0.1.39",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/google-rewarded-core",
-        "version": "0.1.38",
+        "version": "0.1.39",
         "kind": "runtime",
         "description": "Google rewarded workflow runtime plus internal CRUD providers for rules, provider configs, watch sessions, and unlock receipts.",
         "dependsOn": [
@@ -3337,14 +3337,14 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.100",
-              "@jskit-ai/crud-core": "0.1.109",
-              "@jskit-ai/database-runtime": "0.1.101",
-              "@jskit-ai/http-runtime": "0.1.100",
-              "@jskit-ai/json-rest-api-core": "0.1.46",
-              "@jskit-ai/kernel": "0.1.102",
-              "@jskit-ai/resource-crud-core": "0.1.46",
-              "@jskit-ai/workspaces-core": "0.1.77"
+              "@jskit-ai/auth-core": "0.1.101",
+              "@jskit-ai/crud-core": "0.1.110",
+              "@jskit-ai/database-runtime": "0.1.102",
+              "@jskit-ai/http-runtime": "0.1.101",
+              "@jskit-ai/json-rest-api-core": "0.1.47",
+              "@jskit-ai/kernel": "0.1.103",
+              "@jskit-ai/resource-crud-core": "0.1.47",
+              "@jskit-ai/workspaces-core": "0.1.78"
             },
             "dev": {}
           },
@@ -3396,11 +3396,11 @@
     },
     {
       "packageId": "@jskit-ai/google-rewarded-web",
-      "version": "0.1.38",
+      "version": "0.1.39",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/google-rewarded-web",
-        "version": "0.1.38",
+        "version": "0.1.39",
         "kind": "runtime",
         "description": "Google rewarded client runtime with a fullscreen gate host and GPT orchestration.",
         "dependsOn": [
@@ -3447,10 +3447,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/google-rewarded-core": "0.1.38",
-              "@jskit-ai/http-runtime": "0.1.100",
-              "@jskit-ai/kernel": "0.1.102",
-              "@jskit-ai/shell-web": "0.1.101"
+              "@jskit-ai/google-rewarded-core": "0.1.39",
+              "@jskit-ai/http-runtime": "0.1.101",
+              "@jskit-ai/kernel": "0.1.103",
+              "@jskit-ai/shell-web": "0.1.102"
             },
             "dev": {}
           },
@@ -3468,11 +3468,11 @@
     },
     {
       "packageId": "@jskit-ai/http-runtime",
-      "version": "0.1.100",
+      "version": "0.1.101",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/http-runtime",
-        "version": "0.1.100",
+        "version": "0.1.101",
         "kind": "runtime",
         "dependsOn": [],
         "capabilities": {
@@ -3538,7 +3538,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.102"
+              "@jskit-ai/kernel": "0.1.103"
             },
             "dev": {}
           },
@@ -3552,11 +3552,11 @@
     },
     {
       "packageId": "@jskit-ai/json-rest-api-core",
-      "version": "0.1.46",
+      "version": "0.1.47",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/json-rest-api-core",
-        "version": "0.1.46",
+        "version": "0.1.47",
         "kind": "runtime",
         "description": "Shared internal json-rest-api host runtime for JSKIT server packages.",
         "dependsOn": [
@@ -3616,11 +3616,11 @@
     },
     {
       "packageId": "@jskit-ai/mobile-capacitor",
-      "version": "0.1.38",
+      "version": "0.1.39",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/mobile-capacitor",
-        "version": "0.1.38",
+        "version": "0.1.39",
         "kind": "runtime",
         "description": "Thin Capacitor client integration for JSKIT mobile-shell launch routing and auth callback completion.",
         "dependsOn": [
@@ -3683,8 +3683,8 @@
               "@capacitor/app": "^7.1.0",
               "@capacitor/browser": "^7.0.1",
               "@capacitor/core": "^7.4.3",
-              "@jskit-ai/kernel": "0.1.102",
-              "@jskit-ai/shell-web": "0.1.101"
+              "@jskit-ai/kernel": "0.1.103",
+              "@jskit-ai/shell-web": "0.1.102"
             },
             "dev": {
               "@capacitor/cli": "^7.4.3"
@@ -3736,11 +3736,11 @@
     },
     {
       "packageId": "@jskit-ai/realtime",
-      "version": "0.1.100",
+      "version": "0.1.101",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/realtime",
-        "version": "0.1.100",
+        "version": "0.1.101",
         "kind": "runtime",
         "description": "Thin, generic realtime runtime wrappers for socket.io server and client.",
         "options": {
@@ -3836,7 +3836,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.102",
+              "@jskit-ai/kernel": "0.1.103",
               "@socket.io/redis-adapter": "^8.3.0",
               "redis": "^5.8.2",
               "socket.io": "^4.8.3",
@@ -3885,11 +3885,11 @@
     },
     {
       "packageId": "@jskit-ai/resource-core",
-      "version": "0.1.46",
+      "version": "0.1.47",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/resource-core",
-        "version": "0.1.46",
+        "version": "0.1.47",
         "kind": "runtime",
         "description": "Generic resource-definition helpers and schema-definition normalization.",
         "dependsOn": [
@@ -3912,7 +3912,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/resource-core": "0.1.46"
+              "@jskit-ai/resource-core": "0.1.47"
             },
             "dev": {}
           },
@@ -3927,11 +3927,11 @@
     },
     {
       "packageId": "@jskit-ai/resource-crud-core",
-      "version": "0.1.46",
+      "version": "0.1.47",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/resource-crud-core",
-        "version": "0.1.46",
+        "version": "0.1.47",
         "kind": "runtime",
         "description": "CRUD-specific resource-definition helpers and namespace support.",
         "dependsOn": [
@@ -3955,7 +3955,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/resource-crud-core": "0.1.46"
+              "@jskit-ai/resource-crud-core": "0.1.47"
             },
             "dev": {}
           },
@@ -3970,11 +3970,11 @@
     },
     {
       "packageId": "@jskit-ai/shell-web",
-      "version": "0.1.101",
+      "version": "0.1.102",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/shell-web",
-        "version": "0.1.101",
+        "version": "0.1.102",
         "kind": "runtime",
         "description": "Web shell layout runtime with outlet-based placement contributions.",
         "dependsOn": [],
@@ -4316,7 +4316,7 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/kernel": "0.1.102"
+              "@jskit-ai/kernel": "0.1.103"
             },
             "dev": {}
           },
@@ -4516,11 +4516,11 @@
     },
     {
       "packageId": "@jskit-ai/storage-runtime",
-      "version": "0.1.100",
+      "version": "0.1.101",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/storage-runtime",
-        "version": "0.1.100",
+        "version": "0.1.101",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -4569,7 +4569,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.102",
+              "@jskit-ai/kernel": "0.1.103",
               "unstorage": "^1.17.3"
             },
             "dev": {}
@@ -4585,11 +4585,11 @@
     },
     {
       "packageId": "@jskit-ai/ui-generator",
-      "version": "0.1.84",
+      "version": "0.1.85",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/ui-generator",
-        "version": "0.1.84",
+        "version": "0.1.85",
         "kind": "generator",
         "description": "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
         "options": {
@@ -5022,7 +5022,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.116"
+              "@jskit-ai/users-web": "0.1.117"
             },
             "dev": {}
           },
@@ -5037,11 +5037,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-image-web",
-      "version": "0.1.79",
+      "version": "0.1.80",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-image-web",
-        "version": "0.1.79",
+        "version": "0.1.80",
         "kind": "runtime",
         "description": "Reusable client-side image upload runtime with pre-upload image editing.",
         "dependsOn": [
@@ -5105,7 +5105,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/uploads-runtime": "0.1.79",
+              "@jskit-ai/uploads-runtime": "0.1.80",
               "@uppy/compressor": "^3.1.0",
               "@uppy/core": "^5.2.0",
               "@uppy/dashboard": "^5.1.1",
@@ -5125,11 +5125,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-runtime",
-      "version": "0.1.79",
+      "version": "0.1.80",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-runtime",
-        "version": "0.1.79",
+        "version": "0.1.80",
         "kind": "runtime",
         "description": "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
         "dependsOn": [
@@ -5199,7 +5199,7 @@
           "dependencies": {
             "runtime": {
               "@fastify/multipart": "^9.4.0",
-              "@jskit-ai/kernel": "0.1.102"
+              "@jskit-ai/kernel": "0.1.103"
             },
             "dev": {}
           },
@@ -5214,11 +5214,11 @@
     },
     {
       "packageId": "@jskit-ai/users-core",
-      "version": "0.1.111",
+      "version": "0.1.112",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-core",
-        "version": "0.1.111",
+        "version": "0.1.112",
         "kind": "runtime",
         "description": "Users/account runtime plus HTTP routes for account features.",
         "dependsOn": [
@@ -5362,16 +5362,16 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.100",
-              "@jskit-ai/crud-core": "0.1.109",
-              "@jskit-ai/database-runtime": "0.1.101",
-              "@jskit-ai/http-runtime": "0.1.100",
-              "@jskit-ai/json-rest-api-core": "0.1.46",
-              "@jskit-ai/kernel": "0.1.102",
-              "@jskit-ai/resource-core": "0.1.46",
-              "@jskit-ai/resource-crud-core": "0.1.46",
+              "@jskit-ai/auth-core": "0.1.101",
+              "@jskit-ai/crud-core": "0.1.110",
+              "@jskit-ai/database-runtime": "0.1.102",
+              "@jskit-ai/http-runtime": "0.1.101",
+              "@jskit-ai/json-rest-api-core": "0.1.47",
+              "@jskit-ai/kernel": "0.1.103",
+              "@jskit-ai/resource-core": "0.1.47",
+              "@jskit-ai/resource-crud-core": "0.1.47",
               "@local/users": "file:packages/users",
-              "@jskit-ai/uploads-runtime": "0.1.79"
+              "@jskit-ai/uploads-runtime": "0.1.80"
             },
             "dev": {}
           },
@@ -5589,11 +5589,11 @@
     },
     {
       "packageId": "@jskit-ai/users-web",
-      "version": "0.1.116",
+      "version": "0.1.117",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-web",
-        "version": "0.1.116",
+        "version": "0.1.117",
         "kind": "runtime",
         "description": "Users web module: account/profile UI plus shared users web widgets.",
         "dependsOn": [
@@ -5896,12 +5896,12 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/http-runtime": "0.1.100",
-              "@jskit-ai/realtime": "0.1.100",
-              "@jskit-ai/kernel": "0.1.102",
-              "@jskit-ai/shell-web": "0.1.101",
-              "@jskit-ai/uploads-image-web": "0.1.79",
-              "@jskit-ai/users-core": "0.1.111"
+              "@jskit-ai/http-runtime": "0.1.101",
+              "@jskit-ai/realtime": "0.1.101",
+              "@jskit-ai/kernel": "0.1.103",
+              "@jskit-ai/shell-web": "0.1.102",
+              "@jskit-ai/uploads-image-web": "0.1.80",
+              "@jskit-ai/users-core": "0.1.112"
             },
             "dev": {}
           },
@@ -6070,11 +6070,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-core",
-      "version": "0.1.77",
+      "version": "0.1.78",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-core",
-        "version": "0.1.77",
+        "version": "0.1.78",
         "kind": "runtime",
         "description": "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
         "dependsOn": [
@@ -6215,10 +6215,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/json-rest-api-core": "0.1.46",
-              "@jskit-ai/resource-core": "0.1.46",
-              "@jskit-ai/resource-crud-core": "0.1.46",
-              "@jskit-ai/users-core": "0.1.111"
+              "@jskit-ai/json-rest-api-core": "0.1.47",
+              "@jskit-ai/resource-core": "0.1.47",
+              "@jskit-ai/resource-crud-core": "0.1.47",
+              "@jskit-ai/users-core": "0.1.112"
             },
             "dev": {}
           },
@@ -6390,11 +6390,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-web",
-      "version": "0.1.78",
+      "version": "0.1.79",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-web",
-        "version": "0.1.78",
+        "version": "0.1.79",
         "kind": "runtime",
         "description": "Workspace web module: workspace selector, tools widget, workspace surfaces, members UI, and settings hosts.",
         "dependsOn": [
@@ -6646,8 +6646,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/workspaces-core": "0.1.77",
-              "@jskit-ai/users-web": "0.1.116"
+              "@jskit-ai/workspaces-core": "0.1.78",
+              "@jskit-ai/users-web": "0.1.117"
             },
             "dev": {}
           },

--- a/tooling/jskit-catalog/package.json
+++ b/tooling/jskit-catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-catalog",
-  "version": "0.1.109",
+  "version": "0.1.110",
   "description": "Published metadata catalog for JSKIT package descriptors.",
   "type": "module",
   "files": [

--- a/tooling/jskit-cli/package.json
+++ b/tooling/jskit-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-cli",
-  "version": "0.2.114",
+  "version": "0.2.115",
   "description": "Bundle and package orchestration CLI for JSKIT apps.",
   "type": "module",
   "files": [
@@ -20,9 +20,9 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/jskit-catalog": "0.1.109",
-    "@jskit-ai/kernel": "0.1.102",
-    "@jskit-ai/shell-web": "0.1.101",
+    "@jskit-ai/jskit-catalog": "0.1.110",
+    "@jskit-ai/kernel": "0.1.103",
+    "@jskit-ai/shell-web": "0.1.102",
     "@vue/compiler-sfc": "^3.5.29",
     "ts-morph": "^28.0.0"
   },


### PR DESCRIPTION
## Summary
- document local auth setup with explicit provider and auth-web package installs instead of auth bundles
- update create-app auth preset guidance to print package commands
- keep auth bundles described only as optional catalog shortcuts and include release/catalog version bumps

## Checks
- npm run agent-docs:build
- npm test --workspace @jskit-ai/create-app
- git diff --check