### PR TITLE
Fix generated path check for source imports

### DIFF
--- a/packages/agent-docs/reference/autogen/packages/crud-ui-generator.md
+++ b/packages/agent-docs/reference/autogen/packages/crud-ui-generator.md
@@ -83,7 +83,7 @@ Exports
 - `buildViewColumns(fields = [])`
 - `buildFormColumns(fields = [])`
 - `resolveRecordIdFieldKey(fields = [])`
-- `renderObjectPushLines(arrayName, entries = [])`
+- `renderObjectArrayEntryLines(entries = [], { indent = " " } = {})`
 - `resolveRecordChangedEventName`
 - `resolveRecordIdExpression(fields = [])`
 Local functions
@@ -131,6 +131,10 @@ Local functions
 - `resolveOperationFields(resource, operationName)`
 - `resolveFieldDefinition(fields = [], fieldKey = "")`
 - `insertBeforeAnchor(source, { anchor = "", snippet = "" } = {})`
+- `findMatchingDelimiter(sourceText = "", openIndex = -1, openChar = "[", closeChar = "]")`
+- `resolveAnchorLineIndex(sourceText = "", anchor = "")`
+- `findArrayDeclarationBeforeIndex(sourceText = "", arrayName = "", index = -1)`
+- `insertFormFieldDefinition(source, insertion = {})`
 - `resolveAnchorScopeStart(source = "", { anchorIndex = -1, anchor = "" } = {})`
 - `buildAnchorInsertions(operationName, field)`
 - `resolveGeneratedTargetComment(source = "", commentName = "")`

--- a/packages/agent-docs/reference/autogen/tooling/jskit-cli.md
+++ b/packages/agent-docs/reference/autogen/tooling/jskit-cli.md
@@ -447,8 +447,9 @@ Local functions
 - `readFormFieldKeys(sourceText = "")`
 - `formatArrayEntry(entrySource = "", indent = " ")`
 - `findFormFieldArrayDeclaration(sourceText = "", arrayName = "")`
+- `findLineRangeContaining(sourceText = "", searchText = "", { afterIndex = -1 } = {})`
 - `findFormFieldPushCalls(sourceText = "", arrayName = "")`
-- `buildArrayContentWithAddedEntries(existingContent = "", entries = [], indent = "")`
+- `buildArrayContentWithAddedEntries(existingContent = "", entries = [], indent = "", { marker = "" } = {})`
 - `applyTextReplacements(sourceText = "", replacements = [])`
 - `collectCrudFormFieldCandidateFiles(appRoot = "")`
 

--- a/scripts/check-generated-reference-paths.mjs
+++ b/scripts/check-generated-reference-paths.mjs
@@ -44,9 +44,18 @@ function collectRelativePathReferences(node, location = "descriptor", references
     return references;
   }
 
+  const isSourceImportMutation =
+    location.includes(".mutations.source[") &&
+    String(node.op || "").trim() === "ensure-import";
+
   for (const [key, value] of Object.entries(node)) {
     const nextLocation = `${location}.${key}`;
-    if ((key === "from" || key === "expectedExistingFrom") && typeof value === "string" && String(value).trim()) {
+    if (
+      (key === "from" || key === "expectedExistingFrom") &&
+      !isSourceImportMutation &&
+      typeof value === "string" &&
+      String(value).trim()
+    ) {
       references.push({
         location: nextLocation,
         relativePath: String(value).trim()

--- a/tooling/jskit-cli/test/capabilityClosure.test.js
+++ b/tooling/jskit-cli/test/capabilityClosure.test.js
@@ -12,6 +12,7 @@ const runCli = createCliRunner(CLI_PATH);
 async function createMinimalApp(appRoot) {
   await mkdir(appRoot, { recursive: true });
   await mkdir(path.join(appRoot, "config"), { recursive: true });
+  await mkdir(path.join(appRoot, "packages", "main", "src", "client", "providers"), { recursive: true });
   await writeFile(
     path.join(appRoot, "package.json"),
     `${JSON.stringify(
@@ -40,6 +41,25 @@ async function createMinimalApp(appRoot) {
     "utf8"
   );
   await writeFile(path.join(appRoot, "config/server.js"), "export const config = {};\n", "utf8");
+  await writeFile(
+    path.join(appRoot, "packages", "main", "src", "client", "providers", "MainClientProvider.js"),
+    `const mainClientComponents = [];
+
+function registerMainClientComponent(token, resolveComponent) {
+  mainClientComponents.push({ token, resolveComponent });
+}
+
+class MainClientProvider {
+  static id = "local.main.client";
+}
+
+export {
+  MainClientProvider,
+  registerMainClientComponent
+};
+`,
+    "utf8"
+  );
 }
 
 test("add bundle auth-base fails when required capabilities have no provider", async () => {

--- a/tooling/jskit-cli/test/completionCommand.test.js
+++ b/tooling/jskit-cli/test/completionCommand.test.js
@@ -91,6 +91,7 @@ test("completion bash __complete__ lists app subcommands and app-specific option
     [
       "adopt-managed-scripts",
       "link-local-packages",
+      "migrate-source-mutations",
       "prepare-preview-user",
       "release",
       "update-packages",

--- a/tooling/jskit-cli/test/mobileCommand.test.js
+++ b/tooling/jskit-cli/test/mobileCommand.test.js
@@ -154,6 +154,7 @@ async function createMobileReadyApp(appRoot, {
   await mkdir(path.join(appRoot, "config"), { recursive: true });
   await mkdir(path.join(appRoot, ".jskit"), { recursive: true });
   await mkdir(path.join(appRoot, "node_modules", ".bin"), { recursive: true });
+  await mkdir(path.join(appRoot, "packages", "main", "src", "client", "providers"), { recursive: true });
 
   await writeFile(
     path.join(appRoot, "package.json"),
@@ -216,6 +217,25 @@ ${includeMobileConfig ? `,
       versionName: "1.0.0"
     }
   }` : ""}
+};
+`,
+    "utf8"
+  );
+  await writeFile(
+    path.join(appRoot, "packages", "main", "src", "client", "providers", "MainClientProvider.js"),
+    `const mainClientComponents = [];
+
+function registerMainClientComponent(token, resolveComponent) {
+  mainClientComponents.push({ token, resolveComponent });
+}
+
+class MainClientProvider {
+  static id = "local.main.client";
+}
+
+export {
+  MainClientProvider,
+  registerMainClientComponent
 };
 `,
     "utf8"


### PR DESCRIPTION
## Summary
- stop generated path validation from treating source mutation `ensure-import.from` values as package file paths
- rebuild generated agent docs after source-mutation generator changes
- update CLI test fixtures and completion expectations for source-mutation installs

## Checks
- `TMPDIR=/dev/shm npm run verify`
- `TMPDIR=/dev/shm node --test tooling/jskit-cli/test/capabilityClosure.test.js tooling/jskit-cli/test/completionCommand.test.js`
- `TMPDIR=/dev/shm node --test tooling/jskit-cli/test/mobileCommand.test.js --test-name-pattern 'mobile-capacitor installs|reprovisions|reapplies lifecycle'`
- `TMPDIR=/dev/shm npm run lint`
- `TMPDIR=/dev/shm npm run generated:check`
