### PR TITLE
Commit republished package metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6682,28 +6682,28 @@
     },
     "packages/agent-docs": {
       "name": "@jskit-ai/agent-docs",
-      "version": "0.1.66",
+      "version": "0.1.67",
       "engines": {
         "node": ">=20 <23"
       }
     },
     "packages/assistant": {
       "name": "@jskit-ai/assistant",
-      "version": "0.1.113",
+      "version": "0.1.114",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.105"
+        "@jskit-ai/kernel": "0.1.106"
       }
     },
     "packages/assistant-core": {
       "name": "@jskit-ai/assistant-core",
-      "version": "0.1.80",
+      "version": "0.1.81",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.104",
-        "@jskit-ai/http-runtime": "0.1.103",
-        "@jskit-ai/kernel": "0.1.105",
-        "@jskit-ai/resource-core": "0.1.49",
-        "@jskit-ai/resource-crud-core": "0.1.49",
-        "@jskit-ai/users-core": "0.1.114",
+        "@jskit-ai/database-runtime": "0.1.105",
+        "@jskit-ai/http-runtime": "0.1.104",
+        "@jskit-ai/kernel": "0.1.106",
+        "@jskit-ai/resource-core": "0.1.50",
+        "@jskit-ai/resource-crud-core": "0.1.50",
+        "@jskit-ai/users-core": "0.1.115",
         "dompurify": "^3.3.3",
         "json-rest-schema": "1.x.x",
         "marked": "^17.0.4",
@@ -6716,15 +6716,15 @@
     },
     "packages/assistant-runtime": {
       "name": "@jskit-ai/assistant-runtime",
-      "version": "0.1.75",
+      "version": "0.1.76",
       "dependencies": {
-        "@jskit-ai/assistant-core": "0.1.80",
-        "@jskit-ai/database-runtime": "0.1.104",
-        "@jskit-ai/http-runtime": "0.1.103",
-        "@jskit-ai/kernel": "0.1.105",
-        "@jskit-ai/shell-web": "0.1.104",
-        "@jskit-ai/users-core": "0.1.114",
-        "@jskit-ai/users-web": "0.1.119",
+        "@jskit-ai/assistant-core": "0.1.81",
+        "@jskit-ai/database-runtime": "0.1.105",
+        "@jskit-ai/http-runtime": "0.1.104",
+        "@jskit-ai/kernel": "0.1.106",
+        "@jskit-ai/shell-web": "0.1.105",
+        "@jskit-ai/users-core": "0.1.115",
+        "@jskit-ai/users-web": "0.1.120",
         "json-rest-schema": "1.x.x"
       },
       "peerDependencies": {
@@ -6735,30 +6735,30 @@
     },
     "packages/auth-core": {
       "name": "@jskit-ai/auth-core",
-      "version": "0.1.103",
+      "version": "0.1.104",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0",
-        "@jskit-ai/kernel": "0.1.105",
+        "@jskit-ai/kernel": "0.1.106",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/auth-provider-local-core": {
       "name": "@jskit-ai/auth-provider-local-core",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.103",
-        "@jskit-ai/kernel": "0.1.105",
+        "@jskit-ai/auth-core": "0.1.104",
+        "@jskit-ai/kernel": "0.1.106",
         "nodemailer": "^7.0.10"
       }
     },
     "packages/auth-provider-supabase-core": {
       "name": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.103",
+      "version": "0.1.104",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.103",
-        "@jskit-ai/kernel": "0.1.105",
+        "@jskit-ai/auth-core": "0.1.104",
+        "@jskit-ai/kernel": "0.1.106",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0",
         "json-rest-schema": "1.x.x",
@@ -6767,12 +6767,12 @@
     },
     "packages/auth-web": {
       "name": "@jskit-ai/auth-web",
-      "version": "0.1.105",
+      "version": "0.1.106",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.103",
-        "@jskit-ai/http-runtime": "0.1.103",
-        "@jskit-ai/kernel": "0.1.105",
-        "@jskit-ai/shell-web": "0.1.104",
+        "@jskit-ai/auth-core": "0.1.104",
+        "@jskit-ai/http-runtime": "0.1.104",
+        "@jskit-ai/kernel": "0.1.106",
+        "@jskit-ai/shell-web": "0.1.105",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -6785,38 +6785,38 @@
     },
     "packages/console-core": {
       "name": "@jskit-ai/console-core",
-      "version": "0.1.67",
+      "version": "0.1.68",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.103",
-        "@jskit-ai/database-runtime": "0.1.104",
-        "@jskit-ai/http-runtime": "0.1.103",
-        "@jskit-ai/kernel": "0.1.105",
-        "@jskit-ai/resource-crud-core": "0.1.49",
-        "@jskit-ai/users-core": "0.1.114",
+        "@jskit-ai/auth-core": "0.1.104",
+        "@jskit-ai/database-runtime": "0.1.105",
+        "@jskit-ai/http-runtime": "0.1.104",
+        "@jskit-ai/kernel": "0.1.106",
+        "@jskit-ai/resource-crud-core": "0.1.50",
+        "@jskit-ai/users-core": "0.1.115",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/console-web": {
       "name": "@jskit-ai/console-web",
-      "version": "0.1.72",
+      "version": "0.1.73",
       "dependencies": {
-        "@jskit-ai/auth-web": "0.1.105",
-        "@jskit-ai/console-core": "0.1.67",
-        "@jskit-ai/shell-web": "0.1.104"
+        "@jskit-ai/auth-web": "0.1.106",
+        "@jskit-ai/console-core": "0.1.68",
+        "@jskit-ai/shell-web": "0.1.105"
       }
     },
     "packages/crud-core": {
       "name": "@jskit-ai/crud-core",
-      "version": "0.1.112",
+      "version": "0.1.113",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.104",
-        "@jskit-ai/http-runtime": "0.1.103",
-        "@jskit-ai/kernel": "0.1.105",
-        "@jskit-ai/realtime": "0.1.103",
-        "@jskit-ai/resource-crud-core": "0.1.49",
-        "@jskit-ai/shell-web": "0.1.104",
-        "@jskit-ai/users-core": "0.1.114",
-        "@jskit-ai/users-web": "0.1.119",
+        "@jskit-ai/database-runtime": "0.1.105",
+        "@jskit-ai/http-runtime": "0.1.104",
+        "@jskit-ai/kernel": "0.1.106",
+        "@jskit-ai/realtime": "0.1.104",
+        "@jskit-ai/resource-crud-core": "0.1.50",
+        "@jskit-ai/shell-web": "0.1.105",
+        "@jskit-ai/users-core": "0.1.115",
+        "@jskit-ai/users-web": "0.1.120",
         "json-rest-schema": "1.x.x"
       },
       "peerDependencies": {
@@ -6827,98 +6827,98 @@
     },
     "packages/crud-server-generator": {
       "name": "@jskit-ai/crud-server-generator",
-      "version": "0.1.112",
+      "version": "0.1.113",
       "dependencies": {
         "@babel/parser": "^7.29.2",
-        "@jskit-ai/crud-core": "0.1.112",
-        "@jskit-ai/database-runtime": "0.1.104",
-        "@jskit-ai/http-runtime": "0.1.103",
-        "@jskit-ai/json-rest-api-core": "0.1.49",
-        "@jskit-ai/kernel": "0.1.105",
-        "@jskit-ai/resource-crud-core": "0.1.49",
+        "@jskit-ai/crud-core": "0.1.113",
+        "@jskit-ai/database-runtime": "0.1.105",
+        "@jskit-ai/http-runtime": "0.1.104",
+        "@jskit-ai/json-rest-api-core": "0.1.50",
+        "@jskit-ai/kernel": "0.1.106",
+        "@jskit-ai/resource-crud-core": "0.1.50",
         "recast": "^0.23.11"
       }
     },
     "packages/crud-ui-generator": {
       "name": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.87",
+      "version": "0.1.88",
       "dependencies": {
-        "@jskit-ai/crud-core": "0.1.112",
-        "@jskit-ai/kernel": "0.1.105",
-        "@jskit-ai/resource-crud-core": "0.1.49"
+        "@jskit-ai/crud-core": "0.1.113",
+        "@jskit-ai/kernel": "0.1.106",
+        "@jskit-ai/resource-crud-core": "0.1.50"
       }
     },
     "packages/database-runtime": {
       "name": "@jskit-ai/database-runtime",
-      "version": "0.1.104",
+      "version": "0.1.105",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.105"
+        "@jskit-ai/kernel": "0.1.106"
       }
     },
     "packages/database-runtime-mysql": {
       "name": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.103",
+      "version": "0.1.104",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.104",
-        "@jskit-ai/kernel": "0.1.105"
+        "@jskit-ai/database-runtime": "0.1.105",
+        "@jskit-ai/kernel": "0.1.106"
       }
     },
     "packages/database-runtime-postgres": {
       "name": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.103",
+      "version": "0.1.104",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.104"
+        "@jskit-ai/database-runtime": "0.1.105"
       }
     },
     "packages/feature-server-generator": {
       "name": "@jskit-ai/feature-server-generator",
-      "version": "0.1.46"
+      "version": "0.1.47"
     },
     "packages/google-rewarded-core": {
       "name": "@jskit-ai/google-rewarded-core",
-      "version": "0.1.41"
+      "version": "0.1.42"
     },
     "packages/google-rewarded-web": {
       "name": "@jskit-ai/google-rewarded-web",
-      "version": "0.1.41"
+      "version": "0.1.42"
     },
     "packages/http-runtime": {
       "name": "@jskit-ai/http-runtime",
-      "version": "0.1.103",
+      "version": "0.1.104",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.105",
+        "@jskit-ai/kernel": "0.1.106",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/json-rest-api-core": {
       "name": "@jskit-ai/json-rest-api-core",
-      "version": "0.1.49",
+      "version": "0.1.50",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.105",
+        "@jskit-ai/kernel": "0.1.106",
         "hooked-api": "1.x.x",
         "json-rest-api": "1.x.x"
       }
     },
     "packages/kernel": {
       "name": "@jskit-ai/kernel",
-      "version": "0.1.105",
+      "version": "0.1.106",
       "dependencies": {
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/mobile-capacitor": {
       "name": "@jskit-ai/mobile-capacitor",
-      "version": "0.1.41",
+      "version": "0.1.42",
       "dependencies": {
         "@capacitor/browser": "^7.0.1",
-        "@jskit-ai/kernel": "0.1.105"
+        "@jskit-ai/kernel": "0.1.106"
       }
     },
     "packages/realtime": {
       "name": "@jskit-ai/realtime",
-      "version": "0.1.103",
+      "version": "0.1.104",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.105",
+        "@jskit-ai/kernel": "0.1.106",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",
@@ -6930,24 +6930,24 @@
     },
     "packages/resource-core": {
       "name": "@jskit-ai/resource-core",
-      "version": "0.1.49",
+      "version": "0.1.50",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.105"
+        "@jskit-ai/kernel": "0.1.106"
       }
     },
     "packages/resource-crud-core": {
       "name": "@jskit-ai/resource-crud-core",
-      "version": "0.1.49",
+      "version": "0.1.50",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.105",
-        "@jskit-ai/resource-core": "0.1.49"
+        "@jskit-ai/kernel": "0.1.106",
+        "@jskit-ai/resource-core": "0.1.50"
       }
     },
     "packages/shell-web": {
       "name": "@jskit-ai/shell-web",
-      "version": "0.1.104",
+      "version": "0.1.105",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.105",
+        "@jskit-ai/kernel": "0.1.106",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -6959,25 +6959,25 @@
     },
     "packages/storage-runtime": {
       "name": "@jskit-ai/storage-runtime",
-      "version": "0.1.103",
+      "version": "0.1.104",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.105",
+        "@jskit-ai/kernel": "0.1.106",
         "unstorage": "^1.17.3"
       }
     },
     "packages/ui-generator": {
       "name": "@jskit-ai/ui-generator",
-      "version": "0.1.87",
+      "version": "0.1.88",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.105",
-        "@jskit-ai/shell-web": "0.1.104"
+        "@jskit-ai/kernel": "0.1.106",
+        "@jskit-ai/shell-web": "0.1.105"
       }
     },
     "packages/uploads-image-web": {
       "name": "@jskit-ai/uploads-image-web",
-      "version": "0.1.82",
+      "version": "0.1.83",
       "dependencies": {
-        "@jskit-ai/uploads-runtime": "0.1.82",
+        "@jskit-ai/uploads-runtime": "0.1.83",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",
@@ -6990,37 +6990,37 @@
     },
     "packages/uploads-runtime": {
       "name": "@jskit-ai/uploads-runtime",
-      "version": "0.1.82",
+      "version": "0.1.83",
       "dependencies": {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.105"
+        "@jskit-ai/kernel": "0.1.106"
       }
     },
     "packages/users-core": {
       "name": "@jskit-ai/users-core",
-      "version": "0.1.114",
+      "version": "0.1.115",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.103",
-        "@jskit-ai/database-runtime": "0.1.104",
-        "@jskit-ai/http-runtime": "0.1.103",
-        "@jskit-ai/json-rest-api-core": "0.1.49",
-        "@jskit-ai/kernel": "0.1.105",
-        "@jskit-ai/resource-core": "0.1.49",
-        "@jskit-ai/resource-crud-core": "0.1.49",
-        "@jskit-ai/uploads-runtime": "0.1.82",
+        "@jskit-ai/auth-core": "0.1.104",
+        "@jskit-ai/database-runtime": "0.1.105",
+        "@jskit-ai/http-runtime": "0.1.104",
+        "@jskit-ai/json-rest-api-core": "0.1.50",
+        "@jskit-ai/kernel": "0.1.106",
+        "@jskit-ai/resource-core": "0.1.50",
+        "@jskit-ai/resource-crud-core": "0.1.50",
+        "@jskit-ai/uploads-runtime": "0.1.83",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/users-web": {
       "name": "@jskit-ai/users-web",
-      "version": "0.1.119",
+      "version": "0.1.120",
       "dependencies": {
-        "@jskit-ai/http-runtime": "0.1.103",
-        "@jskit-ai/kernel": "0.1.105",
-        "@jskit-ai/realtime": "0.1.103",
-        "@jskit-ai/shell-web": "0.1.104",
-        "@jskit-ai/uploads-image-web": "0.1.82",
-        "@jskit-ai/users-core": "0.1.114",
+        "@jskit-ai/http-runtime": "0.1.104",
+        "@jskit-ai/kernel": "0.1.106",
+        "@jskit-ai/realtime": "0.1.104",
+        "@jskit-ai/shell-web": "0.1.105",
+        "@jskit-ai/uploads-image-web": "0.1.83",
+        "@jskit-ai/users-core": "0.1.115",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -7032,29 +7032,29 @@
     },
     "packages/workspaces-core": {
       "name": "@jskit-ai/workspaces-core",
-      "version": "0.1.80",
+      "version": "0.1.81",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.103",
-        "@jskit-ai/database-runtime": "0.1.104",
-        "@jskit-ai/http-runtime": "0.1.103",
-        "@jskit-ai/json-rest-api-core": "0.1.49",
-        "@jskit-ai/kernel": "0.1.105",
-        "@jskit-ai/resource-core": "0.1.49",
-        "@jskit-ai/resource-crud-core": "0.1.49",
-        "@jskit-ai/users-core": "0.1.114",
+        "@jskit-ai/auth-core": "0.1.104",
+        "@jskit-ai/database-runtime": "0.1.105",
+        "@jskit-ai/http-runtime": "0.1.104",
+        "@jskit-ai/json-rest-api-core": "0.1.50",
+        "@jskit-ai/kernel": "0.1.106",
+        "@jskit-ai/resource-core": "0.1.50",
+        "@jskit-ai/resource-crud-core": "0.1.50",
+        "@jskit-ai/users-core": "0.1.115",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/workspaces-web": {
       "name": "@jskit-ai/workspaces-web",
-      "version": "0.1.81",
+      "version": "0.1.82",
       "dependencies": {
-        "@jskit-ai/http-runtime": "0.1.103",
-        "@jskit-ai/kernel": "0.1.105",
-        "@jskit-ai/shell-web": "0.1.104",
-        "@jskit-ai/users-core": "0.1.114",
-        "@jskit-ai/users-web": "0.1.119",
-        "@jskit-ai/workspaces-core": "0.1.80",
+        "@jskit-ai/http-runtime": "0.1.104",
+        "@jskit-ai/kernel": "0.1.106",
+        "@jskit-ai/shell-web": "0.1.105",
+        "@jskit-ai/users-core": "0.1.115",
+        "@jskit-ai/users-web": "0.1.120",
+        "@jskit-ai/workspaces-core": "0.1.81",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -7066,7 +7066,7 @@
     },
     "tooling/config-eslint": {
       "name": "@jskit-ai/config-eslint",
-      "version": "0.1.103",
+      "version": "0.1.104",
       "dependencies": {
         "@eslint/js": "^9.39.1",
         "eslint-plugin-vue": "^10.5.1",
@@ -7084,7 +7084,7 @@
     },
     "tooling/create-app": {
       "name": "@jskit-ai/create-app",
-      "version": "0.1.113",
+      "version": "0.1.114",
       "bin": {
         "jskit-create-app": "bin/jskit-create-app.js"
       },
@@ -7094,18 +7094,18 @@
     },
     "tooling/jskit-catalog": {
       "name": "@jskit-ai/jskit-catalog",
-      "version": "0.1.112",
+      "version": "0.1.113",
       "engines": {
         "node": ">=20 <23"
       }
     },
     "tooling/jskit-cli": {
       "name": "@jskit-ai/jskit-cli",
-      "version": "0.2.117",
+      "version": "0.2.118",
       "dependencies": {
-        "@jskit-ai/jskit-catalog": "0.1.112",
-        "@jskit-ai/kernel": "0.1.105",
-        "@jskit-ai/shell-web": "0.1.104",
+        "@jskit-ai/jskit-catalog": "0.1.113",
+        "@jskit-ai/kernel": "0.1.106",
+        "@jskit-ai/shell-web": "0.1.105",
         "@vue/compiler-sfc": "^3.5.29",
         "ts-morph": "^28.0.0"
       },

--- a/packages/agent-docs/package.json
+++ b/packages/agent-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/agent-docs",
-  "version": "0.1.66",
+  "version": "0.1.67",
   "description": "Distributed JSKIT agent references, prompts, guides, and generated reference maps.",
   "type": "module",
   "files": [

--- a/packages/assistant-core/package.descriptor.mjs
+++ b/packages/assistant-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-core",
-  version: "0.1.80",
+  version: "0.1.81",
   kind: "runtime",
   description: "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
   dependsOn: [
@@ -47,11 +47,11 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/http-runtime": "0.1.103",
-        "@jskit-ai/kernel": "0.1.105",
-        "@jskit-ai/resource-core": "0.1.49",
-        "@jskit-ai/resource-crud-core": "0.1.49",
-        "@jskit-ai/users-core": "0.1.114",
+        "@jskit-ai/http-runtime": "0.1.104",
+        "@jskit-ai/kernel": "0.1.106",
+        "@jskit-ai/resource-core": "0.1.50",
+        "@jskit-ai/resource-crud-core": "0.1.50",
+        "@jskit-ai/users-core": "0.1.115",
         "dompurify": "^3.3.3",
         "json-rest-schema": "1.x.x",
         "marked": "^17.0.4",

--- a/packages/assistant-core/package.json
+++ b/packages/assistant-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-core",
-  "version": "0.1.80",
+  "version": "0.1.81",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,12 +11,12 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.104",
-    "@jskit-ai/http-runtime": "0.1.103",
-    "@jskit-ai/kernel": "0.1.105",
-    "@jskit-ai/resource-crud-core": "0.1.49",
-    "@jskit-ai/resource-core": "0.1.49",
-    "@jskit-ai/users-core": "0.1.114",
+    "@jskit-ai/database-runtime": "0.1.105",
+    "@jskit-ai/http-runtime": "0.1.104",
+    "@jskit-ai/kernel": "0.1.106",
+    "@jskit-ai/resource-crud-core": "0.1.50",
+    "@jskit-ai/resource-core": "0.1.50",
+    "@jskit-ai/users-core": "0.1.115",
     "dompurify": "^3.3.3",
     "json-rest-schema": "1.x.x",
     "marked": "^17.0.4",

--- a/packages/assistant-runtime/package.descriptor.mjs
+++ b/packages/assistant-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-runtime",
-  version: "0.1.75",
+  version: "0.1.76",
   kind: "runtime",
   description: "Shared assistant runtime with per-surface assistant registration.",
   dependsOn: [
@@ -95,13 +95,13 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/assistant-core": "0.1.80",
-        "@jskit-ai/database-runtime": "0.1.104",
-        "@jskit-ai/http-runtime": "0.1.103",
-        "@jskit-ai/kernel": "0.1.105",
-        "@jskit-ai/shell-web": "0.1.104",
-        "@jskit-ai/users-core": "0.1.114",
-        "@jskit-ai/users-web": "0.1.119"
+        "@jskit-ai/assistant-core": "0.1.81",
+        "@jskit-ai/database-runtime": "0.1.105",
+        "@jskit-ai/http-runtime": "0.1.104",
+        "@jskit-ai/kernel": "0.1.106",
+        "@jskit-ai/shell-web": "0.1.105",
+        "@jskit-ai/users-core": "0.1.115",
+        "@jskit-ai/users-web": "0.1.120"
       },
       dev: {}
     },

--- a/packages/assistant-runtime/package.json
+++ b/packages/assistant-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-runtime",
-  "version": "0.1.75",
+  "version": "0.1.76",
   "type": "module",
   "exports": {
     "./client": "./src/client/index.js",
@@ -8,13 +8,13 @@
     "./server/actionIds": "./src/server/actionIds.js"
   },
   "dependencies": {
-    "@jskit-ai/assistant-core": "0.1.80",
-    "@jskit-ai/database-runtime": "0.1.104",
-    "@jskit-ai/http-runtime": "0.1.103",
-    "@jskit-ai/kernel": "0.1.105",
-    "@jskit-ai/shell-web": "0.1.104",
-    "@jskit-ai/users-core": "0.1.114",
-    "@jskit-ai/users-web": "0.1.119",
+    "@jskit-ai/assistant-core": "0.1.81",
+    "@jskit-ai/database-runtime": "0.1.105",
+    "@jskit-ai/http-runtime": "0.1.104",
+    "@jskit-ai/kernel": "0.1.106",
+    "@jskit-ai/shell-web": "0.1.105",
+    "@jskit-ai/users-core": "0.1.115",
+    "@jskit-ai/users-web": "0.1.120",
     "json-rest-schema": "1.x.x"
   },
   "peerDependencies": {

--- a/packages/assistant/package.descriptor.mjs
+++ b/packages/assistant/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant",
-  version: "0.1.113",
+  version: "0.1.114",
   kind: "generator",
   description: "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
   options: {

--- a/packages/assistant/package.json
+++ b/packages/assistant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant",
-  "version": "0.1.113",
+  "version": "0.1.114",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.105"
+    "@jskit-ai/kernel": "0.1.106"
   }
 }

--- a/packages/auth-core/package.descriptor.mjs
+++ b/packages/auth-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-core",
-  "version": "0.1.103",
+  "version": "0.1.104",
   "kind": "runtime",
   "dependsOn": [
     "@jskit-ai/value-app-config-shared"
@@ -74,7 +74,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.105",
+        "@jskit-ai/kernel": "0.1.106",
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0"

--- a/packages/auth-core/package.json
+++ b/packages/auth-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-core",
-  "version": "0.1.103",
+  "version": "0.1.104",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -54,7 +54,7 @@
     "./shared/commands/authSessionReadCommand": "./src/shared/commands/authSessionReadCommand.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.105",
+    "@jskit-ai/kernel": "0.1.106",
     "@fastify/cookie": "^11.0.2",
     "@fastify/csrf-protection": "^7.1.0",
     "@fastify/rate-limit": "^10.3.0",

--- a/packages/auth-provider-local-core/package.descriptor.mjs
+++ b/packages/auth-provider-local-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-provider-local-core",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "kind": "runtime",
   "description": "Local auth provider with a file backend default and no database requirement.",
   "dependsOn": [
@@ -57,8 +57,8 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/auth-core": "0.1.103",
-        "@jskit-ai/kernel": "0.1.105",
+        "@jskit-ai/auth-core": "0.1.104",
+        "@jskit-ai/kernel": "0.1.106",
         "nodemailer": "^7.0.10",
         "dotenv": "^16.4.5"
       },

--- a/packages/auth-provider-local-core/package.json
+++ b/packages/auth-provider-local-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-local-core",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,8 +11,8 @@
     "./server/lib/index": "./src/server/lib/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.103",
-    "@jskit-ai/kernel": "0.1.105",
+    "@jskit-ai/auth-core": "0.1.104",
+    "@jskit-ai/kernel": "0.1.106",
     "nodemailer": "^7.0.10"
   }
 }

--- a/packages/auth-provider-supabase-core/package.descriptor.mjs
+++ b/packages/auth-provider-supabase-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.103",
+  "version": "0.1.104",
   "kind": "runtime",
   "options": {
     "auth-supabase-url": {
@@ -83,8 +83,8 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/auth-core": "0.1.103",
-        "@jskit-ai/kernel": "0.1.105",
+        "@jskit-ai/auth-core": "0.1.104",
+        "@jskit-ai/kernel": "0.1.106",
         "dotenv": "^16.4.5",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0"

--- a/packages/auth-provider-supabase-core/package.json
+++ b/packages/auth-provider-supabase-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.103",
+  "version": "0.1.104",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,8 +12,8 @@
     "./client": "./src/client/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.103",
-    "@jskit-ai/kernel": "0.1.105",
+    "@jskit-ai/auth-core": "0.1.104",
+    "@jskit-ai/kernel": "0.1.106",
     "json-rest-schema": "1.x.x",
     "jose": "^6.1.0",
     "@supabase/supabase-js": "^2.57.4",

--- a/packages/auth-web/package.descriptor.mjs
+++ b/packages/auth-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-web",
-  "version": "0.1.105",
+  "version": "0.1.106",
   "kind": "runtime",
   "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
   "dependsOn": [
@@ -260,10 +260,10 @@ export default Object.freeze({
     "dependencies": {
       "runtime": {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/auth-core": "0.1.103",
-        "@jskit-ai/http-runtime": "0.1.103",
-        "@jskit-ai/kernel": "0.1.105",
-        "@jskit-ai/shell-web": "0.1.104"
+        "@jskit-ai/auth-core": "0.1.104",
+        "@jskit-ai/http-runtime": "0.1.104",
+        "@jskit-ai/kernel": "0.1.106",
+        "@jskit-ai/shell-web": "0.1.105"
       },
       "dev": {}
     },

--- a/packages/auth-web/package.json
+++ b/packages/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-web",
-  "version": "0.1.105",
+  "version": "0.1.106",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -19,11 +19,11 @@
     "./client/runtime/useSignOut": "./src/client/runtime/useSignOut.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.103",
+    "@jskit-ai/auth-core": "0.1.104",
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/kernel": "0.1.105",
-    "@jskit-ai/shell-web": "0.1.104",
-    "@jskit-ai/http-runtime": "0.1.103"
+    "@jskit-ai/kernel": "0.1.106",
+    "@jskit-ai/shell-web": "0.1.105",
+    "@jskit-ai/http-runtime": "0.1.104"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/console-core/package.descriptor.mjs
+++ b/packages/console-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-core",
-  version: "0.1.67",
+  version: "0.1.68",
   kind: "runtime",
   description: "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
   dependsOn: [
@@ -85,12 +85,12 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.103",
-        "@jskit-ai/database-runtime": "0.1.104",
-        "@jskit-ai/http-runtime": "0.1.103",
-        "@jskit-ai/kernel": "0.1.105",
-        "@jskit-ai/resource-crud-core": "0.1.49",
-        "@jskit-ai/users-core": "0.1.114"
+        "@jskit-ai/auth-core": "0.1.104",
+        "@jskit-ai/database-runtime": "0.1.105",
+        "@jskit-ai/http-runtime": "0.1.104",
+        "@jskit-ai/kernel": "0.1.106",
+        "@jskit-ai/resource-crud-core": "0.1.50",
+        "@jskit-ai/users-core": "0.1.115"
       },
       dev: {}
     },

--- a/packages/console-core/package.json
+++ b/packages/console-core/package.json
@@ -1,17 +1,17 @@
 {
   "name": "@jskit-ai/console-core",
-  "version": "0.1.67",
+  "version": "0.1.68",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.103",
-    "@jskit-ai/database-runtime": "0.1.104",
-    "@jskit-ai/http-runtime": "0.1.103",
-    "@jskit-ai/kernel": "0.1.105",
-    "@jskit-ai/resource-crud-core": "0.1.49",
-    "@jskit-ai/users-core": "0.1.114",
+    "@jskit-ai/auth-core": "0.1.104",
+    "@jskit-ai/database-runtime": "0.1.105",
+    "@jskit-ai/http-runtime": "0.1.104",
+    "@jskit-ai/kernel": "0.1.106",
+    "@jskit-ai/resource-crud-core": "0.1.50",
+    "@jskit-ai/users-core": "0.1.115",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/console-web/package.descriptor.mjs
+++ b/packages/console-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-web",
-  version: "0.1.72",
+  version: "0.1.73",
   kind: "runtime",
   description: "Authenticated console surface scaffold and surface policy wiring.",
   dependsOn: [
@@ -103,9 +103,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-web": "0.1.105",
-        "@jskit-ai/console-core": "0.1.67",
-        "@jskit-ai/shell-web": "0.1.104",
+        "@jskit-ai/auth-web": "0.1.106",
+        "@jskit-ai/console-core": "0.1.68",
+        "@jskit-ai/shell-web": "0.1.105",
       },
       dev: {}
     },

--- a/packages/console-web/package.json
+++ b/packages/console-web/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/console-web",
-  "version": "0.1.72",
+  "version": "0.1.73",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-web": "0.1.105",
-    "@jskit-ai/console-core": "0.1.67",
-    "@jskit-ai/shell-web": "0.1.104"
+    "@jskit-ai/auth-web": "0.1.106",
+    "@jskit-ai/console-core": "0.1.68",
+    "@jskit-ai/shell-web": "0.1.105"
   }
 }

--- a/packages/crud-core/package.descriptor.mjs
+++ b/packages/crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-core",
-  version: "0.1.112",
+  version: "0.1.113",
   kind: "runtime",
   description: "Shared CRUD helpers used by CRUD modules.",
   dependsOn: [
@@ -28,7 +28,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/crud-core": "0.1.112"
+        "@jskit-ai/crud-core": "0.1.113"
       },
       dev: {}
     },

--- a/packages/crud-core/package.json
+++ b/packages/crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-core",
-  "version": "0.1.112",
+  "version": "0.1.113",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -27,15 +27,15 @@
     "./server/routeContracts": "./src/server/routeContracts.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.104",
-    "@jskit-ai/http-runtime": "0.1.103",
-    "@jskit-ai/kernel": "0.1.105",
+    "@jskit-ai/database-runtime": "0.1.105",
+    "@jskit-ai/http-runtime": "0.1.104",
+    "@jskit-ai/kernel": "0.1.106",
     "json-rest-schema": "1.x.x",
-    "@jskit-ai/realtime": "0.1.103",
-    "@jskit-ai/resource-crud-core": "0.1.49",
-    "@jskit-ai/shell-web": "0.1.104",
-    "@jskit-ai/users-core": "0.1.114",
-    "@jskit-ai/users-web": "0.1.119"
+    "@jskit-ai/realtime": "0.1.104",
+    "@jskit-ai/resource-crud-core": "0.1.50",
+    "@jskit-ai/shell-web": "0.1.105",
+    "@jskit-ai/users-core": "0.1.115",
+    "@jskit-ai/users-web": "0.1.120"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/crud-server-generator/package.descriptor.mjs
+++ b/packages/crud-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-server-generator",
-  version: "0.1.112",
+  version: "0.1.113",
   kind: "generator",
   description: "CRUD server generator with routes, actions, and persistence scaffolding.",
   options: {
@@ -160,14 +160,14 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.103",
-        "@jskit-ai/crud-core": "0.1.112",
-        "@jskit-ai/database-runtime": "0.1.104",
-        "@jskit-ai/http-runtime": "0.1.103",
-        "@jskit-ai/json-rest-api-core": "0.1.49",
-        "@jskit-ai/kernel": "0.1.105",
-        "@jskit-ai/realtime": "0.1.103",
-        "@jskit-ai/resource-crud-core": "0.1.49",
+        "@jskit-ai/auth-core": "0.1.104",
+        "@jskit-ai/crud-core": "0.1.113",
+        "@jskit-ai/database-runtime": "0.1.105",
+        "@jskit-ai/http-runtime": "0.1.104",
+        "@jskit-ai/json-rest-api-core": "0.1.50",
+        "@jskit-ai/kernel": "0.1.106",
+        "@jskit-ai/realtime": "0.1.104",
+        "@jskit-ai/resource-crud-core": "0.1.50",
         "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}"
       },
       dev: {}

--- a/packages/crud-server-generator/package.json
+++ b/packages/crud-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-server-generator",
-  "version": "0.1.112",
+  "version": "0.1.113",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,12 +13,12 @@
   },
   "dependencies": {
     "@babel/parser": "^7.29.2",
-    "@jskit-ai/crud-core": "0.1.112",
-    "@jskit-ai/database-runtime": "0.1.104",
-    "@jskit-ai/http-runtime": "0.1.103",
-    "@jskit-ai/json-rest-api-core": "0.1.49",
-    "@jskit-ai/kernel": "0.1.105",
-    "@jskit-ai/resource-crud-core": "0.1.49",
+    "@jskit-ai/crud-core": "0.1.113",
+    "@jskit-ai/database-runtime": "0.1.105",
+    "@jskit-ai/http-runtime": "0.1.104",
+    "@jskit-ai/json-rest-api-core": "0.1.50",
+    "@jskit-ai/kernel": "0.1.106",
+    "@jskit-ai/resource-crud-core": "0.1.50",
     "recast": "^0.23.11"
   }
 }

--- a/packages/crud-ui-generator/package.descriptor.mjs
+++ b/packages/crud-ui-generator/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { GENERATED_UI_NAVIGATION_ROLE_OPTION } from "@jskit-ai/kernel/shared/sup
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-ui-generator",
-  version: "0.1.87",
+  version: "0.1.88",
   kind: "generator",
   description: "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
   options: {
@@ -175,7 +175,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.119"
+        "@jskit-ai/users-web": "0.1.120"
       },
       dev: {}
     },

--- a/packages/crud-ui-generator/package.json
+++ b/packages/crud-ui-generator/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@jskit-ai/crud-ui-generator",
-  "version": "0.1.87",
+  "version": "0.1.88",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/crud-core": "0.1.112",
-    "@jskit-ai/kernel": "0.1.105",
-    "@jskit-ai/resource-crud-core": "0.1.49"
+    "@jskit-ai/crud-core": "0.1.113",
+    "@jskit-ai/kernel": "0.1.106",
+    "@jskit-ai/resource-crud-core": "0.1.50"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/database-runtime-mysql/package.descriptor.mjs
+++ b/packages/database-runtime-mysql/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-mysql",
-  version: "0.1.103",
+  version: "0.1.104",
   kind: "runtime",
   options: {
     "db-host": {
@@ -91,7 +91,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.104",
+        "@jskit-ai/database-runtime": "0.1.105",
         "mysql2": "^3.11.2"
       },
       dev: {}

--- a/packages/database-runtime-mysql/package.json
+++ b/packages/database-runtime-mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-mysql",
-  "version": "0.1.103",
+  "version": "0.1.104",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,7 +12,7 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.104",
-    "@jskit-ai/kernel": "0.1.105"
+    "@jskit-ai/database-runtime": "0.1.105",
+    "@jskit-ai/kernel": "0.1.106"
   }
 }

--- a/packages/database-runtime-postgres/package.descriptor.mjs
+++ b/packages/database-runtime-postgres/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-postgres",
-  version: "0.1.103",
+  version: "0.1.104",
   kind: "runtime",
   options: {
     "db-host": {
@@ -91,7 +91,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.104",
+        "@jskit-ai/database-runtime": "0.1.105",
         "pg": "^8.13.1"
       },
       dev: {}

--- a/packages/database-runtime-postgres/package.json
+++ b/packages/database-runtime-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-postgres",
-  "version": "0.1.103",
+  "version": "0.1.104",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,6 +12,6 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.104"
+    "@jskit-ai/database-runtime": "0.1.105"
   }
 }

--- a/packages/database-runtime/package.descriptor.mjs
+++ b/packages/database-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime",
-  version: "0.1.104",
+  version: "0.1.105",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -58,7 +58,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.105",
+        "@jskit-ai/kernel": "0.1.106",
         "dotenv": "^16.4.5",
         "knex": "^3.1.0"
       },

--- a/packages/database-runtime/package.json
+++ b/packages/database-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime",
-  "version": "0.1.104",
+  "version": "0.1.105",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -25,6 +25,6 @@
     "./shared/transactions": "./src/shared/transactions.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.105"
+    "@jskit-ai/kernel": "0.1.106"
   }
 }

--- a/packages/feature-server-generator/package.descriptor.mjs
+++ b/packages/feature-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/feature-server-generator",
-  version: "0.1.46",
+  version: "0.1.47",
   kind: "generator",
   description: "Scaffold substantial non-CRUD server feature packages with provider, actions, service, and optional persistence seams.",
   options: {
@@ -174,7 +174,7 @@ export default Object.freeze({
             equals: "json-rest"
           }
         },
-        "@jskit-ai/kernel": "0.1.105",
+        "@jskit-ai/kernel": "0.1.106",
         "json-rest-schema": "1.x.x",
         "@local/${option:feature-name|kebab}": "file:packages/${option:feature-name|kebab}"
       },

--- a/packages/feature-server-generator/package.json
+++ b/packages/feature-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/feature-server-generator",
-  "version": "0.1.46",
+  "version": "0.1.47",
   "type": "module",
   "scripts": {
     "test": "node --test"

--- a/packages/google-rewarded-core/package.descriptor.mjs
+++ b/packages/google-rewarded-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/google-rewarded-core",
-  version: "0.1.41",
+  version: "0.1.42",
   kind: "runtime",
   description: "Google rewarded workflow runtime plus internal CRUD providers for rules, provider configs, watch sessions, and unlock receipts.",
   dependsOn: [
@@ -128,14 +128,14 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.103",
-        "@jskit-ai/crud-core": "0.1.112",
-        "@jskit-ai/database-runtime": "0.1.104",
-        "@jskit-ai/http-runtime": "0.1.103",
-        "@jskit-ai/json-rest-api-core": "0.1.49",
-        "@jskit-ai/kernel": "0.1.105",
-        "@jskit-ai/resource-crud-core": "0.1.49",
-        "@jskit-ai/workspaces-core": "0.1.80"
+        "@jskit-ai/auth-core": "0.1.104",
+        "@jskit-ai/crud-core": "0.1.113",
+        "@jskit-ai/database-runtime": "0.1.105",
+        "@jskit-ai/http-runtime": "0.1.104",
+        "@jskit-ai/json-rest-api-core": "0.1.50",
+        "@jskit-ai/kernel": "0.1.106",
+        "@jskit-ai/resource-crud-core": "0.1.50",
+        "@jskit-ai/workspaces-core": "0.1.81"
       },
       dev: {}
     },

--- a/packages/google-rewarded-core/package.json
+++ b/packages/google-rewarded-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/google-rewarded-core",
-  "version": "0.1.41",
+  "version": "0.1.42",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/google-rewarded-web/package.descriptor.mjs
+++ b/packages/google-rewarded-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/google-rewarded-web",
-  version: "0.1.41",
+  version: "0.1.42",
   kind: "runtime",
   description: "Google rewarded client runtime with a fullscreen gate host and GPT orchestration.",
   dependsOn: [
@@ -46,10 +46,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/google-rewarded-core": "0.1.41",
-        "@jskit-ai/http-runtime": "0.1.103",
-        "@jskit-ai/kernel": "0.1.105",
-        "@jskit-ai/shell-web": "0.1.104"
+        "@jskit-ai/google-rewarded-core": "0.1.42",
+        "@jskit-ai/http-runtime": "0.1.104",
+        "@jskit-ai/kernel": "0.1.106",
+        "@jskit-ai/shell-web": "0.1.105"
       },
       dev: {}
     },

--- a/packages/google-rewarded-web/package.json
+++ b/packages/google-rewarded-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/google-rewarded-web",
-  "version": "0.1.41",
+  "version": "0.1.42",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/http-runtime/package.descriptor.mjs
+++ b/packages/http-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/http-runtime",
-  "version": "0.1.103",
+  "version": "0.1.104",
   "kind": "runtime",
   "dependsOn": [],
   "capabilities": {
@@ -67,7 +67,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.105"
+        "@jskit-ai/kernel": "0.1.106"
       },
       "dev": {}
     },

--- a/packages/http-runtime/package.json
+++ b/packages/http-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/http-runtime",
-  "version": "0.1.103",
+  "version": "0.1.104",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -18,7 +18,7 @@
     "./shared/validators/operationValidation": "./src/shared/validators/operationValidation.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.105",
+    "@jskit-ai/kernel": "0.1.106",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/json-rest-api-core/package.descriptor.mjs
+++ b/packages/json-rest-api-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/json-rest-api-core",
-  version: "0.1.49",
+  version: "0.1.50",
   kind: "runtime",
   description: "Shared internal json-rest-api host runtime for JSKIT server packages.",
   dependsOn: [

--- a/packages/json-rest-api-core/package.json
+++ b/packages/json-rest-api-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/json-rest-api-core",
-  "version": "0.1.49",
+  "version": "0.1.50",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,6 +11,6 @@
   "dependencies": {
     "hooked-api": "1.x.x",
     "json-rest-api": "1.x.x",
-    "@jskit-ai/kernel": "0.1.105"
+    "@jskit-ai/kernel": "0.1.106"
   }
 }

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/kernel",
-  "version": "0.1.105",
+  "version": "0.1.106",
   "type": "module",
   "dependencies": {
     "json-rest-schema": "1.x.x"

--- a/packages/mobile-capacitor/package.descriptor.mjs
+++ b/packages/mobile-capacitor/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/mobile-capacitor",
-  version: "0.1.41",
+  version: "0.1.42",
   kind: "runtime",
   description: "Thin Capacitor client integration for JSKIT mobile-shell launch routing and auth callback completion.",
   dependsOn: [
@@ -62,8 +62,8 @@ export default Object.freeze({
         "@capacitor/app": "^7.1.0",
         "@capacitor/browser": "^7.0.1",
         "@capacitor/core": "^7.4.3",
-        "@jskit-ai/kernel": "0.1.105",
-        "@jskit-ai/shell-web": "0.1.104"
+        "@jskit-ai/kernel": "0.1.106",
+        "@jskit-ai/shell-web": "0.1.105"
       },
       dev: {
         "@capacitor/cli": "^7.4.3"

--- a/packages/mobile-capacitor/package.json
+++ b/packages/mobile-capacitor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/mobile-capacitor",
-  "version": "0.1.41",
+  "version": "0.1.42",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,6 +12,6 @@
   },
   "dependencies": {
     "@capacitor/browser": "^7.0.1",
-    "@jskit-ai/kernel": "0.1.105"
+    "@jskit-ai/kernel": "0.1.106"
   }
 }

--- a/packages/realtime/package.descriptor.mjs
+++ b/packages/realtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/realtime",
-  version: "0.1.103",
+  version: "0.1.104",
   kind: "runtime",
   description: "Thin, generic realtime runtime wrappers for socket.io server and client.",
   options: {
@@ -95,7 +95,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.105",
+        "@jskit-ai/kernel": "0.1.106",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/realtime",
-  "version": "0.1.103",
+  "version": "0.1.104",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@socket.io/redis-adapter": "^8.3.0",
-    "@jskit-ai/kernel": "0.1.105",
+    "@jskit-ai/kernel": "0.1.106",
     "redis": "^5.8.2",
     "socket.io": "^4.8.3",
     "socket.io-client": "^4.8.3"

--- a/packages/resource-core/package.descriptor.mjs
+++ b/packages/resource-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/resource-core",
-  version: "0.1.49",
+  version: "0.1.50",
   kind: "runtime",
   description: "Generic resource-definition helpers and schema-definition normalization.",
   dependsOn: [
@@ -22,7 +22,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/resource-core": "0.1.49"
+        "@jskit-ai/resource-core": "0.1.50"
       },
       dev: {}
     },

--- a/packages/resource-core/package.json
+++ b/packages/resource-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/resource-core",
-  "version": "0.1.49",
+  "version": "0.1.50",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./shared/resource": "./src/shared/resource.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.105"
+    "@jskit-ai/kernel": "0.1.106"
   }
 }

--- a/packages/resource-crud-core/package.descriptor.mjs
+++ b/packages/resource-crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/resource-crud-core",
-  version: "0.1.49",
+  version: "0.1.50",
   kind: "runtime",
   description: "CRUD-specific resource-definition helpers and namespace support.",
   dependsOn: [
@@ -23,7 +23,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/resource-crud-core": "0.1.49"
+        "@jskit-ai/resource-crud-core": "0.1.50"
       },
       dev: {}
     },

--- a/packages/resource-crud-core/package.json
+++ b/packages/resource-crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/resource-crud-core",
-  "version": "0.1.49",
+  "version": "0.1.50",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./shared/crudResource": "./src/shared/crudResource.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.105",
-    "@jskit-ai/resource-core": "0.1.49"
+    "@jskit-ai/kernel": "0.1.106",
+    "@jskit-ai/resource-core": "0.1.50"
   }
 }

--- a/packages/shell-web/package.descriptor.mjs
+++ b/packages/shell-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/shell-web",
-  version: "0.1.104",
+  version: "0.1.105",
   kind: "runtime",
   description: "Web shell layout runtime with outlet-based placement contributions.",
   dependsOn: [],
@@ -307,7 +307,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/kernel": "0.1.105"
+        "@jskit-ai/kernel": "0.1.106"
       },
       dev: {}
     },

--- a/packages/shell-web/package.json
+++ b/packages/shell-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/shell-web",
-  "version": "0.1.104",
+  "version": "0.1.105",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/kernel": "0.1.105"
+    "@jskit-ai/kernel": "0.1.106"
   },
   "peerDependencies": {
     "pinia": "^3.0.4",

--- a/packages/storage-runtime/package.descriptor.mjs
+++ b/packages/storage-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/storage-runtime",
-  version: "0.1.103",
+  version: "0.1.104",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -50,7 +50,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.105",
+        "@jskit-ai/kernel": "0.1.106",
         "unstorage": "^1.17.3"
       },
       dev: {}

--- a/packages/storage-runtime/package.json
+++ b/packages/storage-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/storage-runtime",
-  "version": "0.1.103",
+  "version": "0.1.104",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./server/providers/StorageRuntimeServiceProvider": "./src/server/providers/StorageRuntimeServiceProvider.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.105",
+    "@jskit-ai/kernel": "0.1.106",
     "unstorage": "^1.17.3"
   }
 }

--- a/packages/ui-generator/package.descriptor.mjs
+++ b/packages/ui-generator/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { GENERATED_UI_NAVIGATION_ROLE_OPTION } from "@jskit-ai/kernel/shared/sup
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/ui-generator",
-  version: "0.1.87",
+  version: "0.1.88",
   kind: "generator",
   description: "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
   options: {
@@ -371,7 +371,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.119"
+        "@jskit-ai/users-web": "0.1.120"
       },
       dev: {}
     },

--- a/packages/ui-generator/package.json
+++ b/packages/ui-generator/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/ui-generator",
-  "version": "0.1.87",
+  "version": "0.1.88",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.105",
-    "@jskit-ai/shell-web": "0.1.104"
+    "@jskit-ai/kernel": "0.1.106",
+    "@jskit-ai/shell-web": "0.1.105"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/uploads-image-web/package.descriptor.mjs
+++ b/packages/uploads-image-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-image-web",
-  version: "0.1.82",
+  version: "0.1.83",
   kind: "runtime",
   description: "Reusable client-side image upload runtime with pre-upload image editing.",
   dependsOn: [
@@ -65,7 +65,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/uploads-runtime": "0.1.82",
+        "@jskit-ai/uploads-runtime": "0.1.83",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-image-web/package.json
+++ b/packages/uploads-image-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-image-web",
-  "version": "0.1.82",
+  "version": "0.1.83",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,7 +13,7 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/uploads-runtime": "0.1.82",
+    "@jskit-ai/uploads-runtime": "0.1.83",
     "@uppy/compressor": "^3.1.0",
     "@uppy/core": "^5.2.0",
     "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-runtime/package.descriptor.mjs
+++ b/packages/uploads-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-runtime",
-  version: "0.1.82",
+  version: "0.1.83",
   kind: "runtime",
   description: "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
   dependsOn: [
@@ -71,7 +71,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.105"
+        "@jskit-ai/kernel": "0.1.106"
       },
       dev: {}
     },

--- a/packages/uploads-runtime/package.json
+++ b/packages/uploads-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-runtime",
-  "version": "0.1.82",
+  "version": "0.1.83",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,6 +16,6 @@
   },
   "dependencies": {
     "@fastify/multipart": "^9.4.0",
-    "@jskit-ai/kernel": "0.1.105"
+    "@jskit-ai/kernel": "0.1.106"
   }
 }

--- a/packages/users-core/package.descriptor.mjs
+++ b/packages/users-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-core",
-  version: "0.1.114",
+  version: "0.1.115",
   kind: "runtime",
   description: "Users/account runtime plus HTTP routes for account features.",
   dependsOn: [
@@ -146,16 +146,16 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.103",
-        "@jskit-ai/crud-core": "0.1.112",
-        "@jskit-ai/database-runtime": "0.1.104",
-        "@jskit-ai/http-runtime": "0.1.103",
-        "@jskit-ai/json-rest-api-core": "0.1.49",
-        "@jskit-ai/kernel": "0.1.105",
-        "@jskit-ai/resource-core": "0.1.49",
-        "@jskit-ai/resource-crud-core": "0.1.49",
+        "@jskit-ai/auth-core": "0.1.104",
+        "@jskit-ai/crud-core": "0.1.113",
+        "@jskit-ai/database-runtime": "0.1.105",
+        "@jskit-ai/http-runtime": "0.1.104",
+        "@jskit-ai/json-rest-api-core": "0.1.50",
+        "@jskit-ai/kernel": "0.1.106",
+        "@jskit-ai/resource-core": "0.1.50",
+        "@jskit-ai/resource-crud-core": "0.1.50",
         "@local/users": "file:packages/users",
-        "@jskit-ai/uploads-runtime": "0.1.82"
+        "@jskit-ai/uploads-runtime": "0.1.83"
       },
       dev: {}
     },

--- a/packages/users-core/package.json
+++ b/packages/users-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-core",
-  "version": "0.1.114",
+  "version": "0.1.115",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,14 +12,14 @@
     "./shared/resources/userSettingsResource": "./src/shared/resources/userSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.103",
-    "@jskit-ai/database-runtime": "0.1.104",
-    "@jskit-ai/http-runtime": "0.1.103",
-    "@jskit-ai/json-rest-api-core": "0.1.49",
-    "@jskit-ai/kernel": "0.1.105",
-    "@jskit-ai/resource-crud-core": "0.1.49",
-    "@jskit-ai/resource-core": "0.1.49",
-    "@jskit-ai/uploads-runtime": "0.1.82",
+    "@jskit-ai/auth-core": "0.1.104",
+    "@jskit-ai/database-runtime": "0.1.105",
+    "@jskit-ai/http-runtime": "0.1.104",
+    "@jskit-ai/json-rest-api-core": "0.1.50",
+    "@jskit-ai/kernel": "0.1.106",
+    "@jskit-ai/resource-crud-core": "0.1.50",
+    "@jskit-ai/resource-core": "0.1.50",
+    "@jskit-ai/uploads-runtime": "0.1.83",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/users-web/package.descriptor.mjs
+++ b/packages/users-web/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { HOME_COG_OUTLET } from "./src/shared/toolsOutletContracts.js";
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-web",
-  version: "0.1.119",
+  version: "0.1.120",
   kind: "runtime",
   description: "Users web module: account/profile UI plus shared users web widgets.",
   dependsOn: [
@@ -286,12 +286,12 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/http-runtime": "0.1.103",
-        "@jskit-ai/realtime": "0.1.103",
-        "@jskit-ai/kernel": "0.1.105",
-        "@jskit-ai/shell-web": "0.1.104",
-        "@jskit-ai/uploads-image-web": "0.1.82",
-        "@jskit-ai/users-core": "0.1.114"
+        "@jskit-ai/http-runtime": "0.1.104",
+        "@jskit-ai/realtime": "0.1.104",
+        "@jskit-ai/kernel": "0.1.106",
+        "@jskit-ai/shell-web": "0.1.105",
+        "@jskit-ai/uploads-image-web": "0.1.83",
+        "@jskit-ai/users-core": "0.1.115"
       },
       dev: {}
     },

--- a/packages/users-web/package.json
+++ b/packages/users-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-web",
-  "version": "0.1.119",
+  "version": "0.1.120",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -46,12 +46,12 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/http-runtime": "0.1.103",
-    "@jskit-ai/kernel": "0.1.105",
-    "@jskit-ai/realtime": "0.1.103",
-    "@jskit-ai/shell-web": "0.1.104",
-    "@jskit-ai/uploads-image-web": "0.1.82",
-    "@jskit-ai/users-core": "0.1.114"
+    "@jskit-ai/http-runtime": "0.1.104",
+    "@jskit-ai/kernel": "0.1.106",
+    "@jskit-ai/realtime": "0.1.104",
+    "@jskit-ai/shell-web": "0.1.105",
+    "@jskit-ai/uploads-image-web": "0.1.83",
+    "@jskit-ai/users-core": "0.1.115"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/workspaces-core/package.descriptor.mjs
+++ b/packages/workspaces-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-core",
-  version: "0.1.80",
+  version: "0.1.81",
   kind: "runtime",
   description: "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
   dependsOn: [
@@ -142,10 +142,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/json-rest-api-core": "0.1.49",
-        "@jskit-ai/resource-core": "0.1.49",
-        "@jskit-ai/resource-crud-core": "0.1.49",
-        "@jskit-ai/users-core": "0.1.114"
+        "@jskit-ai/json-rest-api-core": "0.1.50",
+        "@jskit-ai/resource-core": "0.1.50",
+        "@jskit-ai/resource-crud-core": "0.1.50",
+        "@jskit-ai/users-core": "0.1.115"
       },
       dev: {}
     },

--- a/packages/workspaces-core/package.json
+++ b/packages/workspaces-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-core",
-  "version": "0.1.80",
+  "version": "0.1.81",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -18,14 +18,14 @@
     "./shared/resources/workspaceSettingsResource": "./src/shared/resources/workspaceSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.103",
-    "@jskit-ai/database-runtime": "0.1.104",
-    "@jskit-ai/http-runtime": "0.1.103",
-    "@jskit-ai/json-rest-api-core": "0.1.49",
-    "@jskit-ai/kernel": "0.1.105",
-    "@jskit-ai/resource-crud-core": "0.1.49",
-    "@jskit-ai/resource-core": "0.1.49",
-    "@jskit-ai/users-core": "0.1.114",
+    "@jskit-ai/auth-core": "0.1.104",
+    "@jskit-ai/database-runtime": "0.1.105",
+    "@jskit-ai/http-runtime": "0.1.104",
+    "@jskit-ai/json-rest-api-core": "0.1.50",
+    "@jskit-ai/kernel": "0.1.106",
+    "@jskit-ai/resource-crud-core": "0.1.50",
+    "@jskit-ai/resource-core": "0.1.50",
+    "@jskit-ai/users-core": "0.1.115",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/workspaces-web/package.descriptor.mjs
+++ b/packages/workspaces-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-web",
-  version: "0.1.81",
+  version: "0.1.82",
   kind: "runtime",
   description: "Workspace web module: workspace selector, tools widget, workspace surfaces, members UI, and settings hosts.",
   dependsOn: [
@@ -227,8 +227,8 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/workspaces-core": "0.1.80",
-        "@jskit-ai/users-web": "0.1.119"
+        "@jskit-ai/workspaces-core": "0.1.81",
+        "@jskit-ai/users-web": "0.1.120"
       },
       dev: {}
     },

--- a/packages/workspaces-web/package.json
+++ b/packages/workspaces-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-web",
-  "version": "0.1.81",
+  "version": "0.1.82",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -14,12 +14,12 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/http-runtime": "0.1.103",
-    "@jskit-ai/kernel": "0.1.105",
-    "@jskit-ai/shell-web": "0.1.104",
-    "@jskit-ai/users-core": "0.1.114",
-    "@jskit-ai/users-web": "0.1.119",
-    "@jskit-ai/workspaces-core": "0.1.80"
+    "@jskit-ai/http-runtime": "0.1.104",
+    "@jskit-ai/kernel": "0.1.106",
+    "@jskit-ai/shell-web": "0.1.105",
+    "@jskit-ai/users-core": "0.1.115",
+    "@jskit-ai/users-web": "0.1.120",
+    "@jskit-ai/workspaces-core": "0.1.81"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/tooling/config-eslint/package.json
+++ b/tooling/config-eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/config-eslint",
-  "version": "0.1.103",
+  "version": "0.1.104",
   "description": "Shared flat ESLint presets for JSKIT projects.",
   "type": "module",
   "files": [

--- a/tooling/create-app/package.descriptor.mjs
+++ b/tooling/create-app/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/create-app",
-  "version": "0.1.113",
+  "version": "0.1.114",
   "dependsOn": [],
   "capabilities": {
     "provides": [

--- a/tooling/create-app/package.json
+++ b/tooling/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/create-app",
-  "version": "0.1.113",
+  "version": "0.1.114",
   "description": "Scaffold JSKIT app shells.",
   "type": "module",
   "files": [

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -6,11 +6,11 @@
   "packages": [
     {
       "packageId": "@jskit-ai/assistant",
-      "version": "0.1.113",
+      "version": "0.1.114",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant",
-        "version": "0.1.113",
+        "version": "0.1.114",
         "kind": "generator",
         "description": "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
         "options": {
@@ -347,11 +347,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-core",
-      "version": "0.1.80",
+      "version": "0.1.81",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-core",
-        "version": "0.1.80",
+        "version": "0.1.81",
         "kind": "runtime",
         "description": "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
         "dependsOn": [
@@ -399,11 +399,11 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/http-runtime": "0.1.103",
-              "@jskit-ai/kernel": "0.1.105",
-              "@jskit-ai/resource-core": "0.1.49",
-              "@jskit-ai/resource-crud-core": "0.1.49",
-              "@jskit-ai/users-core": "0.1.114",
+              "@jskit-ai/http-runtime": "0.1.104",
+              "@jskit-ai/kernel": "0.1.106",
+              "@jskit-ai/resource-core": "0.1.50",
+              "@jskit-ai/resource-crud-core": "0.1.50",
+              "@jskit-ai/users-core": "0.1.115",
               "dompurify": "^3.3.3",
               "json-rest-schema": "1.x.x",
               "marked": "^17.0.4",
@@ -422,11 +422,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-runtime",
-      "version": "0.1.75",
+      "version": "0.1.76",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-runtime",
-        "version": "0.1.75",
+        "version": "0.1.76",
         "kind": "runtime",
         "description": "Shared assistant runtime with per-surface assistant registration.",
         "dependsOn": [
@@ -522,13 +522,13 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/assistant-core": "0.1.80",
-              "@jskit-ai/database-runtime": "0.1.104",
-              "@jskit-ai/http-runtime": "0.1.103",
-              "@jskit-ai/kernel": "0.1.105",
-              "@jskit-ai/shell-web": "0.1.104",
-              "@jskit-ai/users-core": "0.1.114",
-              "@jskit-ai/users-web": "0.1.119"
+              "@jskit-ai/assistant-core": "0.1.81",
+              "@jskit-ai/database-runtime": "0.1.105",
+              "@jskit-ai/http-runtime": "0.1.104",
+              "@jskit-ai/kernel": "0.1.106",
+              "@jskit-ai/shell-web": "0.1.105",
+              "@jskit-ai/users-core": "0.1.115",
+              "@jskit-ai/users-web": "0.1.120"
             },
             "dev": {}
           },
@@ -583,11 +583,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-core",
-      "version": "0.1.103",
+      "version": "0.1.104",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-core",
-        "version": "0.1.103",
+        "version": "0.1.104",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/value-app-config-shared"
@@ -660,7 +660,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.105",
+              "@jskit-ai/kernel": "0.1.106",
               "@fastify/cookie": "^11.0.2",
               "@fastify/csrf-protection": "^7.1.0",
               "@fastify/rate-limit": "^10.3.0"
@@ -678,11 +678,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-local-core",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-local-core",
-        "version": "0.1.4",
+        "version": "0.1.5",
         "kind": "runtime",
         "description": "Local auth provider with a file backend default and no database requirement.",
         "dependsOn": [
@@ -738,8 +738,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.103",
-              "@jskit-ai/kernel": "0.1.105",
+              "@jskit-ai/auth-core": "0.1.104",
+              "@jskit-ai/kernel": "0.1.106",
               "nodemailer": "^7.0.10",
               "dotenv": "^16.4.5"
             },
@@ -785,11 +785,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.103",
+      "version": "0.1.104",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-supabase-core",
-        "version": "0.1.103",
+        "version": "0.1.104",
         "kind": "runtime",
         "options": {
           "auth-supabase-url": {
@@ -871,8 +871,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.103",
-              "@jskit-ai/kernel": "0.1.105",
+              "@jskit-ai/auth-core": "0.1.104",
+              "@jskit-ai/kernel": "0.1.106",
               "dotenv": "^16.4.5",
               "@supabase/supabase-js": "^2.57.4",
               "jose": "^6.1.0"
@@ -950,11 +950,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-web",
-      "version": "0.1.105",
+      "version": "0.1.106",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-web",
-        "version": "0.1.105",
+        "version": "0.1.106",
         "kind": "runtime",
         "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
         "dependsOn": [
@@ -1223,10 +1223,10 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/auth-core": "0.1.103",
-              "@jskit-ai/http-runtime": "0.1.103",
-              "@jskit-ai/kernel": "0.1.105",
-              "@jskit-ai/shell-web": "0.1.104"
+              "@jskit-ai/auth-core": "0.1.104",
+              "@jskit-ai/http-runtime": "0.1.104",
+              "@jskit-ai/kernel": "0.1.106",
+              "@jskit-ai/shell-web": "0.1.105"
             },
             "dev": {}
           },
@@ -1319,11 +1319,11 @@
     },
     {
       "packageId": "@jskit-ai/console-core",
-      "version": "0.1.67",
+      "version": "0.1.68",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-core",
-        "version": "0.1.67",
+        "version": "0.1.68",
         "kind": "runtime",
         "description": "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
         "dependsOn": [
@@ -1407,12 +1407,12 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.103",
-              "@jskit-ai/database-runtime": "0.1.104",
-              "@jskit-ai/http-runtime": "0.1.103",
-              "@jskit-ai/kernel": "0.1.105",
-              "@jskit-ai/resource-crud-core": "0.1.49",
-              "@jskit-ai/users-core": "0.1.114"
+              "@jskit-ai/auth-core": "0.1.104",
+              "@jskit-ai/database-runtime": "0.1.105",
+              "@jskit-ai/http-runtime": "0.1.104",
+              "@jskit-ai/kernel": "0.1.106",
+              "@jskit-ai/resource-crud-core": "0.1.50",
+              "@jskit-ai/users-core": "0.1.115"
             },
             "dev": {}
           },
@@ -1437,11 +1437,11 @@
     },
     {
       "packageId": "@jskit-ai/console-web",
-      "version": "0.1.72",
+      "version": "0.1.73",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-web",
-        "version": "0.1.72",
+        "version": "0.1.73",
         "kind": "runtime",
         "description": "Authenticated console surface scaffold and surface policy wiring.",
         "dependsOn": [
@@ -1551,9 +1551,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-web": "0.1.105",
-              "@jskit-ai/console-core": "0.1.67",
-              "@jskit-ai/shell-web": "0.1.104"
+              "@jskit-ai/auth-web": "0.1.106",
+              "@jskit-ai/console-core": "0.1.68",
+              "@jskit-ai/shell-web": "0.1.105"
             },
             "dev": {}
           },
@@ -1660,11 +1660,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-core",
-      "version": "0.1.112",
+      "version": "0.1.113",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-core",
-        "version": "0.1.112",
+        "version": "0.1.113",
         "kind": "runtime",
         "description": "Shared CRUD helpers used by CRUD modules.",
         "dependsOn": [
@@ -1693,7 +1693,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/crud-core": "0.1.112"
+              "@jskit-ai/crud-core": "0.1.113"
             },
             "dev": {}
           },
@@ -1707,11 +1707,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-server-generator",
-      "version": "0.1.112",
+      "version": "0.1.113",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-server-generator",
-        "version": "0.1.112",
+        "version": "0.1.113",
         "kind": "generator",
         "description": "CRUD server generator with routes, actions, and persistence scaffolding.",
         "options": {
@@ -1878,14 +1878,14 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.103",
-              "@jskit-ai/crud-core": "0.1.112",
-              "@jskit-ai/database-runtime": "0.1.104",
-              "@jskit-ai/http-runtime": "0.1.103",
-              "@jskit-ai/json-rest-api-core": "0.1.49",
-              "@jskit-ai/kernel": "0.1.105",
-              "@jskit-ai/realtime": "0.1.103",
-              "@jskit-ai/resource-crud-core": "0.1.49",
+              "@jskit-ai/auth-core": "0.1.104",
+              "@jskit-ai/crud-core": "0.1.113",
+              "@jskit-ai/database-runtime": "0.1.105",
+              "@jskit-ai/http-runtime": "0.1.104",
+              "@jskit-ai/json-rest-api-core": "0.1.50",
+              "@jskit-ai/kernel": "0.1.106",
+              "@jskit-ai/realtime": "0.1.104",
+              "@jskit-ai/resource-crud-core": "0.1.50",
               "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}"
             },
             "dev": {}
@@ -2017,11 +2017,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.87",
+      "version": "0.1.88",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-ui-generator",
-        "version": "0.1.87",
+        "version": "0.1.88",
         "kind": "generator",
         "description": "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
         "options": {
@@ -2220,7 +2220,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.119"
+              "@jskit-ai/users-web": "0.1.120"
             },
             "dev": {}
           },
@@ -2479,11 +2479,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime",
-      "version": "0.1.104",
+      "version": "0.1.105",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime",
-        "version": "0.1.104",
+        "version": "0.1.105",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -2540,7 +2540,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.105",
+              "@jskit-ai/kernel": "0.1.106",
               "dotenv": "^16.4.5",
               "knex": "^3.1.0"
             },
@@ -2575,11 +2575,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.103",
+      "version": "0.1.104",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-mysql",
-        "version": "0.1.103",
+        "version": "0.1.104",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -2669,7 +2669,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.104",
+              "@jskit-ai/database-runtime": "0.1.105",
               "mysql2": "^3.11.2"
             },
             "dev": {}
@@ -2740,11 +2740,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.103",
+      "version": "0.1.104",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-postgres",
-        "version": "0.1.103",
+        "version": "0.1.104",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -2834,7 +2834,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.104",
+              "@jskit-ai/database-runtime": "0.1.105",
               "pg": "^8.13.1"
             },
             "dev": {}
@@ -2905,11 +2905,11 @@
     },
     {
       "packageId": "@jskit-ai/feature-server-generator",
-      "version": "0.1.46",
+      "version": "0.1.47",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/feature-server-generator",
-        "version": "0.1.46",
+        "version": "0.1.47",
         "kind": "generator",
         "description": "Scaffold substantial non-CRUD server feature packages with provider, actions, service, and optional persistence seams.",
         "options": {
@@ -3094,7 +3094,7 @@
                   "equals": "json-rest"
                 }
               },
-              "@jskit-ai/kernel": "0.1.105",
+              "@jskit-ai/kernel": "0.1.106",
               "json-rest-schema": "1.x.x",
               "@local/${option:feature-name|kebab}": "file:packages/${option:feature-name|kebab}"
             },
@@ -3207,11 +3207,11 @@
     },
     {
       "packageId": "@jskit-ai/google-rewarded-core",
-      "version": "0.1.41",
+      "version": "0.1.42",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/google-rewarded-core",
-        "version": "0.1.41",
+        "version": "0.1.42",
         "kind": "runtime",
         "description": "Google rewarded workflow runtime plus internal CRUD providers for rules, provider configs, watch sessions, and unlock receipts.",
         "dependsOn": [
@@ -3338,14 +3338,14 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.103",
-              "@jskit-ai/crud-core": "0.1.112",
-              "@jskit-ai/database-runtime": "0.1.104",
-              "@jskit-ai/http-runtime": "0.1.103",
-              "@jskit-ai/json-rest-api-core": "0.1.49",
-              "@jskit-ai/kernel": "0.1.105",
-              "@jskit-ai/resource-crud-core": "0.1.49",
-              "@jskit-ai/workspaces-core": "0.1.80"
+              "@jskit-ai/auth-core": "0.1.104",
+              "@jskit-ai/crud-core": "0.1.113",
+              "@jskit-ai/database-runtime": "0.1.105",
+              "@jskit-ai/http-runtime": "0.1.104",
+              "@jskit-ai/json-rest-api-core": "0.1.50",
+              "@jskit-ai/kernel": "0.1.106",
+              "@jskit-ai/resource-crud-core": "0.1.50",
+              "@jskit-ai/workspaces-core": "0.1.81"
             },
             "dev": {}
           },
@@ -3397,11 +3397,11 @@
     },
     {
       "packageId": "@jskit-ai/google-rewarded-web",
-      "version": "0.1.41",
+      "version": "0.1.42",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/google-rewarded-web",
-        "version": "0.1.41",
+        "version": "0.1.42",
         "kind": "runtime",
         "description": "Google rewarded client runtime with a fullscreen gate host and GPT orchestration.",
         "dependsOn": [
@@ -3448,10 +3448,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/google-rewarded-core": "0.1.41",
-              "@jskit-ai/http-runtime": "0.1.103",
-              "@jskit-ai/kernel": "0.1.105",
-              "@jskit-ai/shell-web": "0.1.104"
+              "@jskit-ai/google-rewarded-core": "0.1.42",
+              "@jskit-ai/http-runtime": "0.1.104",
+              "@jskit-ai/kernel": "0.1.106",
+              "@jskit-ai/shell-web": "0.1.105"
             },
             "dev": {}
           },
@@ -3469,11 +3469,11 @@
     },
     {
       "packageId": "@jskit-ai/http-runtime",
-      "version": "0.1.103",
+      "version": "0.1.104",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/http-runtime",
-        "version": "0.1.103",
+        "version": "0.1.104",
         "kind": "runtime",
         "dependsOn": [],
         "capabilities": {
@@ -3539,7 +3539,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.105"
+              "@jskit-ai/kernel": "0.1.106"
             },
             "dev": {}
           },
@@ -3553,11 +3553,11 @@
     },
     {
       "packageId": "@jskit-ai/json-rest-api-core",
-      "version": "0.1.49",
+      "version": "0.1.50",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/json-rest-api-core",
-        "version": "0.1.49",
+        "version": "0.1.50",
         "kind": "runtime",
         "description": "Shared internal json-rest-api host runtime for JSKIT server packages.",
         "dependsOn": [
@@ -3617,11 +3617,11 @@
     },
     {
       "packageId": "@jskit-ai/mobile-capacitor",
-      "version": "0.1.41",
+      "version": "0.1.42",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/mobile-capacitor",
-        "version": "0.1.41",
+        "version": "0.1.42",
         "kind": "runtime",
         "description": "Thin Capacitor client integration for JSKIT mobile-shell launch routing and auth callback completion.",
         "dependsOn": [
@@ -3684,8 +3684,8 @@
               "@capacitor/app": "^7.1.0",
               "@capacitor/browser": "^7.0.1",
               "@capacitor/core": "^7.4.3",
-              "@jskit-ai/kernel": "0.1.105",
-              "@jskit-ai/shell-web": "0.1.104"
+              "@jskit-ai/kernel": "0.1.106",
+              "@jskit-ai/shell-web": "0.1.105"
             },
             "dev": {
               "@capacitor/cli": "^7.4.3"
@@ -3737,11 +3737,11 @@
     },
     {
       "packageId": "@jskit-ai/realtime",
-      "version": "0.1.103",
+      "version": "0.1.104",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/realtime",
-        "version": "0.1.103",
+        "version": "0.1.104",
         "kind": "runtime",
         "description": "Thin, generic realtime runtime wrappers for socket.io server and client.",
         "options": {
@@ -3837,7 +3837,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.105",
+              "@jskit-ai/kernel": "0.1.106",
               "@socket.io/redis-adapter": "^8.3.0",
               "redis": "^5.8.2",
               "socket.io": "^4.8.3",
@@ -3886,11 +3886,11 @@
     },
     {
       "packageId": "@jskit-ai/resource-core",
-      "version": "0.1.49",
+      "version": "0.1.50",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/resource-core",
-        "version": "0.1.49",
+        "version": "0.1.50",
         "kind": "runtime",
         "description": "Generic resource-definition helpers and schema-definition normalization.",
         "dependsOn": [
@@ -3913,7 +3913,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/resource-core": "0.1.49"
+              "@jskit-ai/resource-core": "0.1.50"
             },
             "dev": {}
           },
@@ -3928,11 +3928,11 @@
     },
     {
       "packageId": "@jskit-ai/resource-crud-core",
-      "version": "0.1.49",
+      "version": "0.1.50",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/resource-crud-core",
-        "version": "0.1.49",
+        "version": "0.1.50",
         "kind": "runtime",
         "description": "CRUD-specific resource-definition helpers and namespace support.",
         "dependsOn": [
@@ -3956,7 +3956,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/resource-crud-core": "0.1.49"
+              "@jskit-ai/resource-crud-core": "0.1.50"
             },
             "dev": {}
           },
@@ -3971,11 +3971,11 @@
     },
     {
       "packageId": "@jskit-ai/shell-web",
-      "version": "0.1.104",
+      "version": "0.1.105",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/shell-web",
-        "version": "0.1.104",
+        "version": "0.1.105",
         "kind": "runtime",
         "description": "Web shell layout runtime with outlet-based placement contributions.",
         "dependsOn": [],
@@ -4317,7 +4317,7 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/kernel": "0.1.105"
+              "@jskit-ai/kernel": "0.1.106"
             },
             "dev": {}
           },
@@ -4524,11 +4524,11 @@
     },
     {
       "packageId": "@jskit-ai/storage-runtime",
-      "version": "0.1.103",
+      "version": "0.1.104",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/storage-runtime",
-        "version": "0.1.103",
+        "version": "0.1.104",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -4577,7 +4577,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.105",
+              "@jskit-ai/kernel": "0.1.106",
               "unstorage": "^1.17.3"
             },
             "dev": {}
@@ -4593,11 +4593,11 @@
     },
     {
       "packageId": "@jskit-ai/ui-generator",
-      "version": "0.1.87",
+      "version": "0.1.88",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/ui-generator",
-        "version": "0.1.87",
+        "version": "0.1.88",
         "kind": "generator",
         "description": "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
         "options": {
@@ -5030,7 +5030,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.119"
+              "@jskit-ai/users-web": "0.1.120"
             },
             "dev": {}
           },
@@ -5045,11 +5045,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-image-web",
-      "version": "0.1.82",
+      "version": "0.1.83",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-image-web",
-        "version": "0.1.82",
+        "version": "0.1.83",
         "kind": "runtime",
         "description": "Reusable client-side image upload runtime with pre-upload image editing.",
         "dependsOn": [
@@ -5113,7 +5113,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/uploads-runtime": "0.1.82",
+              "@jskit-ai/uploads-runtime": "0.1.83",
               "@uppy/compressor": "^3.1.0",
               "@uppy/core": "^5.2.0",
               "@uppy/dashboard": "^5.1.1",
@@ -5133,11 +5133,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-runtime",
-      "version": "0.1.82",
+      "version": "0.1.83",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-runtime",
-        "version": "0.1.82",
+        "version": "0.1.83",
         "kind": "runtime",
         "description": "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
         "dependsOn": [
@@ -5207,7 +5207,7 @@
           "dependencies": {
             "runtime": {
               "@fastify/multipart": "^9.4.0",
-              "@jskit-ai/kernel": "0.1.105"
+              "@jskit-ai/kernel": "0.1.106"
             },
             "dev": {}
           },
@@ -5222,11 +5222,11 @@
     },
     {
       "packageId": "@jskit-ai/users-core",
-      "version": "0.1.114",
+      "version": "0.1.115",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-core",
-        "version": "0.1.114",
+        "version": "0.1.115",
         "kind": "runtime",
         "description": "Users/account runtime plus HTTP routes for account features.",
         "dependsOn": [
@@ -5370,16 +5370,16 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.103",
-              "@jskit-ai/crud-core": "0.1.112",
-              "@jskit-ai/database-runtime": "0.1.104",
-              "@jskit-ai/http-runtime": "0.1.103",
-              "@jskit-ai/json-rest-api-core": "0.1.49",
-              "@jskit-ai/kernel": "0.1.105",
-              "@jskit-ai/resource-core": "0.1.49",
-              "@jskit-ai/resource-crud-core": "0.1.49",
+              "@jskit-ai/auth-core": "0.1.104",
+              "@jskit-ai/crud-core": "0.1.113",
+              "@jskit-ai/database-runtime": "0.1.105",
+              "@jskit-ai/http-runtime": "0.1.104",
+              "@jskit-ai/json-rest-api-core": "0.1.50",
+              "@jskit-ai/kernel": "0.1.106",
+              "@jskit-ai/resource-core": "0.1.50",
+              "@jskit-ai/resource-crud-core": "0.1.50",
               "@local/users": "file:packages/users",
-              "@jskit-ai/uploads-runtime": "0.1.82"
+              "@jskit-ai/uploads-runtime": "0.1.83"
             },
             "dev": {}
           },
@@ -5597,11 +5597,11 @@
     },
     {
       "packageId": "@jskit-ai/users-web",
-      "version": "0.1.119",
+      "version": "0.1.120",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-web",
-        "version": "0.1.119",
+        "version": "0.1.120",
         "kind": "runtime",
         "description": "Users web module: account/profile UI plus shared users web widgets.",
         "dependsOn": [
@@ -5904,12 +5904,12 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/http-runtime": "0.1.103",
-              "@jskit-ai/realtime": "0.1.103",
-              "@jskit-ai/kernel": "0.1.105",
-              "@jskit-ai/shell-web": "0.1.104",
-              "@jskit-ai/uploads-image-web": "0.1.82",
-              "@jskit-ai/users-core": "0.1.114"
+              "@jskit-ai/http-runtime": "0.1.104",
+              "@jskit-ai/realtime": "0.1.104",
+              "@jskit-ai/kernel": "0.1.106",
+              "@jskit-ai/shell-web": "0.1.105",
+              "@jskit-ai/uploads-image-web": "0.1.83",
+              "@jskit-ai/users-core": "0.1.115"
             },
             "dev": {}
           },
@@ -6086,11 +6086,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-core",
-      "version": "0.1.80",
+      "version": "0.1.81",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-core",
-        "version": "0.1.80",
+        "version": "0.1.81",
         "kind": "runtime",
         "description": "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
         "dependsOn": [
@@ -6231,10 +6231,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/json-rest-api-core": "0.1.49",
-              "@jskit-ai/resource-core": "0.1.49",
-              "@jskit-ai/resource-crud-core": "0.1.49",
-              "@jskit-ai/users-core": "0.1.114"
+              "@jskit-ai/json-rest-api-core": "0.1.50",
+              "@jskit-ai/resource-core": "0.1.50",
+              "@jskit-ai/resource-crud-core": "0.1.50",
+              "@jskit-ai/users-core": "0.1.115"
             },
             "dev": {}
           },
@@ -6406,11 +6406,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-web",
-      "version": "0.1.81",
+      "version": "0.1.82",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-web",
-        "version": "0.1.81",
+        "version": "0.1.82",
         "kind": "runtime",
         "description": "Workspace web module: workspace selector, tools widget, workspace surfaces, members UI, and settings hosts.",
         "dependsOn": [
@@ -6662,8 +6662,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/workspaces-core": "0.1.80",
-              "@jskit-ai/users-web": "0.1.119"
+              "@jskit-ai/workspaces-core": "0.1.81",
+              "@jskit-ai/users-web": "0.1.120"
             },
             "dev": {}
           },

--- a/tooling/jskit-catalog/package.json
+++ b/tooling/jskit-catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-catalog",
-  "version": "0.1.112",
+  "version": "0.1.113",
   "description": "Published metadata catalog for JSKIT package descriptors.",
   "type": "module",
   "files": [

--- a/tooling/jskit-cli/package.json
+++ b/tooling/jskit-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-cli",
-  "version": "0.2.117",
+  "version": "0.2.118",
   "description": "Bundle and package orchestration CLI for JSKIT apps.",
   "type": "module",
   "files": [
@@ -20,9 +20,9 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/jskit-catalog": "0.1.112",
-    "@jskit-ai/kernel": "0.1.105",
-    "@jskit-ai/shell-web": "0.1.104",
+    "@jskit-ai/jskit-catalog": "0.1.113",
+    "@jskit-ai/kernel": "0.1.106",
+    "@jskit-ai/shell-web": "0.1.105",
     "@vue/compiler-sfc": "^3.5.29",
     "ts-morph": "^28.0.0"
   },


### PR DESCRIPTION
## Summary
- commit the package descriptor/package.json/package-lock/catalog version updates from the second publish
- keep catalog output regenerated against the new published versions

## Checks
- `TMPDIR=/dev/shm npm run catalog:build`
- `TMPDIR=/dev/shm npm run jskit -- lint-descriptors`
- `TMPDIR=/dev/shm npm run check:runtime-deps`
- `TMPDIR=/dev/shm npm run generated:check`
- `git diff --check`
