### PR TITLE
fix(users-core): add profile updated_at schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6682,28 +6682,28 @@
     },
     "packages/agent-docs": {
       "name": "@jskit-ai/agent-docs",
-      "version": "0.1.68",
+      "version": "0.1.69",
       "engines": {
         "node": ">=20 <23"
       }
     },
     "packages/assistant": {
       "name": "@jskit-ai/assistant",
-      "version": "0.1.115",
+      "version": "0.1.116",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.107"
+        "@jskit-ai/kernel": "0.1.108"
       }
     },
     "packages/assistant-core": {
       "name": "@jskit-ai/assistant-core",
-      "version": "0.1.82",
+      "version": "0.1.83",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.106",
-        "@jskit-ai/http-runtime": "0.1.105",
-        "@jskit-ai/kernel": "0.1.107",
-        "@jskit-ai/resource-core": "0.1.51",
-        "@jskit-ai/resource-crud-core": "0.1.51",
-        "@jskit-ai/users-core": "0.1.116",
+        "@jskit-ai/database-runtime": "0.1.107",
+        "@jskit-ai/http-runtime": "0.1.106",
+        "@jskit-ai/kernel": "0.1.108",
+        "@jskit-ai/resource-core": "0.1.52",
+        "@jskit-ai/resource-crud-core": "0.1.52",
+        "@jskit-ai/users-core": "0.1.117",
         "dompurify": "^3.3.3",
         "json-rest-schema": "1.x.x",
         "marked": "^17.0.4",
@@ -6716,15 +6716,15 @@
     },
     "packages/assistant-runtime": {
       "name": "@jskit-ai/assistant-runtime",
-      "version": "0.1.77",
+      "version": "0.1.78",
       "dependencies": {
-        "@jskit-ai/assistant-core": "0.1.82",
-        "@jskit-ai/database-runtime": "0.1.106",
-        "@jskit-ai/http-runtime": "0.1.105",
-        "@jskit-ai/kernel": "0.1.107",
-        "@jskit-ai/shell-web": "0.1.106",
-        "@jskit-ai/users-core": "0.1.116",
-        "@jskit-ai/users-web": "0.1.121",
+        "@jskit-ai/assistant-core": "0.1.83",
+        "@jskit-ai/database-runtime": "0.1.107",
+        "@jskit-ai/http-runtime": "0.1.106",
+        "@jskit-ai/kernel": "0.1.108",
+        "@jskit-ai/shell-web": "0.1.107",
+        "@jskit-ai/users-core": "0.1.117",
+        "@jskit-ai/users-web": "0.1.122",
         "json-rest-schema": "1.x.x"
       },
       "peerDependencies": {
@@ -6735,30 +6735,30 @@
     },
     "packages/auth-core": {
       "name": "@jskit-ai/auth-core",
-      "version": "0.1.105",
+      "version": "0.1.106",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0",
-        "@jskit-ai/kernel": "0.1.107",
+        "@jskit-ai/kernel": "0.1.108",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/auth-provider-local-core": {
       "name": "@jskit-ai/auth-provider-local-core",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.105",
-        "@jskit-ai/kernel": "0.1.107",
+        "@jskit-ai/auth-core": "0.1.106",
+        "@jskit-ai/kernel": "0.1.108",
         "nodemailer": "^7.0.10"
       }
     },
     "packages/auth-provider-supabase-core": {
       "name": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.105",
+      "version": "0.1.106",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.105",
-        "@jskit-ai/kernel": "0.1.107",
+        "@jskit-ai/auth-core": "0.1.106",
+        "@jskit-ai/kernel": "0.1.108",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0",
         "json-rest-schema": "1.x.x",
@@ -6767,12 +6767,12 @@
     },
     "packages/auth-web": {
       "name": "@jskit-ai/auth-web",
-      "version": "0.1.107",
+      "version": "0.1.108",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.105",
-        "@jskit-ai/http-runtime": "0.1.105",
-        "@jskit-ai/kernel": "0.1.107",
-        "@jskit-ai/shell-web": "0.1.106",
+        "@jskit-ai/auth-core": "0.1.106",
+        "@jskit-ai/http-runtime": "0.1.106",
+        "@jskit-ai/kernel": "0.1.108",
+        "@jskit-ai/shell-web": "0.1.107",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -6785,38 +6785,38 @@
     },
     "packages/console-core": {
       "name": "@jskit-ai/console-core",
-      "version": "0.1.69",
+      "version": "0.1.70",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.105",
-        "@jskit-ai/database-runtime": "0.1.106",
-        "@jskit-ai/http-runtime": "0.1.105",
-        "@jskit-ai/kernel": "0.1.107",
-        "@jskit-ai/resource-crud-core": "0.1.51",
-        "@jskit-ai/users-core": "0.1.116",
+        "@jskit-ai/auth-core": "0.1.106",
+        "@jskit-ai/database-runtime": "0.1.107",
+        "@jskit-ai/http-runtime": "0.1.106",
+        "@jskit-ai/kernel": "0.1.108",
+        "@jskit-ai/resource-crud-core": "0.1.52",
+        "@jskit-ai/users-core": "0.1.117",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/console-web": {
       "name": "@jskit-ai/console-web",
-      "version": "0.1.74",
+      "version": "0.1.75",
       "dependencies": {
-        "@jskit-ai/auth-web": "0.1.107",
-        "@jskit-ai/console-core": "0.1.69",
-        "@jskit-ai/shell-web": "0.1.106"
+        "@jskit-ai/auth-web": "0.1.108",
+        "@jskit-ai/console-core": "0.1.70",
+        "@jskit-ai/shell-web": "0.1.107"
       }
     },
     "packages/crud-core": {
       "name": "@jskit-ai/crud-core",
-      "version": "0.1.114",
+      "version": "0.1.115",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.106",
-        "@jskit-ai/http-runtime": "0.1.105",
-        "@jskit-ai/kernel": "0.1.107",
-        "@jskit-ai/realtime": "0.1.105",
-        "@jskit-ai/resource-crud-core": "0.1.51",
-        "@jskit-ai/shell-web": "0.1.106",
-        "@jskit-ai/users-core": "0.1.116",
-        "@jskit-ai/users-web": "0.1.121",
+        "@jskit-ai/database-runtime": "0.1.107",
+        "@jskit-ai/http-runtime": "0.1.106",
+        "@jskit-ai/kernel": "0.1.108",
+        "@jskit-ai/realtime": "0.1.106",
+        "@jskit-ai/resource-crud-core": "0.1.52",
+        "@jskit-ai/shell-web": "0.1.107",
+        "@jskit-ai/users-core": "0.1.117",
+        "@jskit-ai/users-web": "0.1.122",
         "json-rest-schema": "1.x.x"
       },
       "peerDependencies": {
@@ -6827,98 +6827,98 @@
     },
     "packages/crud-server-generator": {
       "name": "@jskit-ai/crud-server-generator",
-      "version": "0.1.114",
+      "version": "0.1.115",
       "dependencies": {
         "@babel/parser": "^7.29.2",
-        "@jskit-ai/crud-core": "0.1.114",
-        "@jskit-ai/database-runtime": "0.1.106",
-        "@jskit-ai/http-runtime": "0.1.105",
-        "@jskit-ai/json-rest-api-core": "0.1.51",
-        "@jskit-ai/kernel": "0.1.107",
-        "@jskit-ai/resource-crud-core": "0.1.51",
+        "@jskit-ai/crud-core": "0.1.115",
+        "@jskit-ai/database-runtime": "0.1.107",
+        "@jskit-ai/http-runtime": "0.1.106",
+        "@jskit-ai/json-rest-api-core": "0.1.52",
+        "@jskit-ai/kernel": "0.1.108",
+        "@jskit-ai/resource-crud-core": "0.1.52",
         "recast": "^0.23.11"
       }
     },
     "packages/crud-ui-generator": {
       "name": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.89",
+      "version": "0.1.90",
       "dependencies": {
-        "@jskit-ai/crud-core": "0.1.114",
-        "@jskit-ai/kernel": "0.1.107",
-        "@jskit-ai/resource-crud-core": "0.1.51"
+        "@jskit-ai/crud-core": "0.1.115",
+        "@jskit-ai/kernel": "0.1.108",
+        "@jskit-ai/resource-crud-core": "0.1.52"
       }
     },
     "packages/database-runtime": {
       "name": "@jskit-ai/database-runtime",
-      "version": "0.1.106",
+      "version": "0.1.107",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.107"
+        "@jskit-ai/kernel": "0.1.108"
       }
     },
     "packages/database-runtime-mysql": {
       "name": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.105",
+      "version": "0.1.106",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.106",
-        "@jskit-ai/kernel": "0.1.107"
+        "@jskit-ai/database-runtime": "0.1.107",
+        "@jskit-ai/kernel": "0.1.108"
       }
     },
     "packages/database-runtime-postgres": {
       "name": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.105",
+      "version": "0.1.106",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.106"
+        "@jskit-ai/database-runtime": "0.1.107"
       }
     },
     "packages/feature-server-generator": {
       "name": "@jskit-ai/feature-server-generator",
-      "version": "0.1.48"
+      "version": "0.1.49"
     },
     "packages/google-rewarded-core": {
       "name": "@jskit-ai/google-rewarded-core",
-      "version": "0.1.43"
+      "version": "0.1.44"
     },
     "packages/google-rewarded-web": {
       "name": "@jskit-ai/google-rewarded-web",
-      "version": "0.1.43"
+      "version": "0.1.44"
     },
     "packages/http-runtime": {
       "name": "@jskit-ai/http-runtime",
-      "version": "0.1.105",
+      "version": "0.1.106",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.107",
+        "@jskit-ai/kernel": "0.1.108",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/json-rest-api-core": {
       "name": "@jskit-ai/json-rest-api-core",
-      "version": "0.1.51",
+      "version": "0.1.52",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.107",
+        "@jskit-ai/kernel": "0.1.108",
         "hooked-api": "1.x.x",
         "json-rest-api": "1.x.x"
       }
     },
     "packages/kernel": {
       "name": "@jskit-ai/kernel",
-      "version": "0.1.107",
+      "version": "0.1.108",
       "dependencies": {
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/mobile-capacitor": {
       "name": "@jskit-ai/mobile-capacitor",
-      "version": "0.1.43",
+      "version": "0.1.44",
       "dependencies": {
         "@capacitor/browser": "^7.0.1",
-        "@jskit-ai/kernel": "0.1.107"
+        "@jskit-ai/kernel": "0.1.108"
       }
     },
     "packages/realtime": {
       "name": "@jskit-ai/realtime",
-      "version": "0.1.105",
+      "version": "0.1.106",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.107",
+        "@jskit-ai/kernel": "0.1.108",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",
@@ -6930,24 +6930,24 @@
     },
     "packages/resource-core": {
       "name": "@jskit-ai/resource-core",
-      "version": "0.1.51",
+      "version": "0.1.52",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.107"
+        "@jskit-ai/kernel": "0.1.108"
       }
     },
     "packages/resource-crud-core": {
       "name": "@jskit-ai/resource-crud-core",
-      "version": "0.1.51",
+      "version": "0.1.52",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.107",
-        "@jskit-ai/resource-core": "0.1.51"
+        "@jskit-ai/kernel": "0.1.108",
+        "@jskit-ai/resource-core": "0.1.52"
       }
     },
     "packages/shell-web": {
       "name": "@jskit-ai/shell-web",
-      "version": "0.1.106",
+      "version": "0.1.107",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.107",
+        "@jskit-ai/kernel": "0.1.108",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -6959,25 +6959,25 @@
     },
     "packages/storage-runtime": {
       "name": "@jskit-ai/storage-runtime",
-      "version": "0.1.105",
+      "version": "0.1.106",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.107",
+        "@jskit-ai/kernel": "0.1.108",
         "unstorage": "^1.17.3"
       }
     },
     "packages/ui-generator": {
       "name": "@jskit-ai/ui-generator",
-      "version": "0.1.89",
+      "version": "0.1.90",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.107",
-        "@jskit-ai/shell-web": "0.1.106"
+        "@jskit-ai/kernel": "0.1.108",
+        "@jskit-ai/shell-web": "0.1.107"
       }
     },
     "packages/uploads-image-web": {
       "name": "@jskit-ai/uploads-image-web",
-      "version": "0.1.84",
+      "version": "0.1.85",
       "dependencies": {
-        "@jskit-ai/uploads-runtime": "0.1.84",
+        "@jskit-ai/uploads-runtime": "0.1.85",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",
@@ -6990,37 +6990,37 @@
     },
     "packages/uploads-runtime": {
       "name": "@jskit-ai/uploads-runtime",
-      "version": "0.1.84",
+      "version": "0.1.85",
       "dependencies": {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.107"
+        "@jskit-ai/kernel": "0.1.108"
       }
     },
     "packages/users-core": {
       "name": "@jskit-ai/users-core",
-      "version": "0.1.116",
+      "version": "0.1.117",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.105",
-        "@jskit-ai/database-runtime": "0.1.106",
-        "@jskit-ai/http-runtime": "0.1.105",
-        "@jskit-ai/json-rest-api-core": "0.1.51",
-        "@jskit-ai/kernel": "0.1.107",
-        "@jskit-ai/resource-core": "0.1.51",
-        "@jskit-ai/resource-crud-core": "0.1.51",
-        "@jskit-ai/uploads-runtime": "0.1.84",
+        "@jskit-ai/auth-core": "0.1.106",
+        "@jskit-ai/database-runtime": "0.1.107",
+        "@jskit-ai/http-runtime": "0.1.106",
+        "@jskit-ai/json-rest-api-core": "0.1.52",
+        "@jskit-ai/kernel": "0.1.108",
+        "@jskit-ai/resource-core": "0.1.52",
+        "@jskit-ai/resource-crud-core": "0.1.52",
+        "@jskit-ai/uploads-runtime": "0.1.85",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/users-web": {
       "name": "@jskit-ai/users-web",
-      "version": "0.1.121",
+      "version": "0.1.122",
       "dependencies": {
-        "@jskit-ai/http-runtime": "0.1.105",
-        "@jskit-ai/kernel": "0.1.107",
-        "@jskit-ai/realtime": "0.1.105",
-        "@jskit-ai/shell-web": "0.1.106",
-        "@jskit-ai/uploads-image-web": "0.1.84",
-        "@jskit-ai/users-core": "0.1.116",
+        "@jskit-ai/http-runtime": "0.1.106",
+        "@jskit-ai/kernel": "0.1.108",
+        "@jskit-ai/realtime": "0.1.106",
+        "@jskit-ai/shell-web": "0.1.107",
+        "@jskit-ai/uploads-image-web": "0.1.85",
+        "@jskit-ai/users-core": "0.1.117",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -7032,30 +7032,30 @@
     },
     "packages/workspaces-core": {
       "name": "@jskit-ai/workspaces-core",
-      "version": "0.1.82",
+      "version": "0.1.83",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.105",
-        "@jskit-ai/database-runtime": "0.1.106",
-        "@jskit-ai/http-runtime": "0.1.105",
-        "@jskit-ai/json-rest-api-core": "0.1.51",
-        "@jskit-ai/kernel": "0.1.107",
-        "@jskit-ai/resource-core": "0.1.51",
-        "@jskit-ai/resource-crud-core": "0.1.51",
-        "@jskit-ai/users-core": "0.1.116",
+        "@jskit-ai/auth-core": "0.1.106",
+        "@jskit-ai/database-runtime": "0.1.107",
+        "@jskit-ai/http-runtime": "0.1.106",
+        "@jskit-ai/json-rest-api-core": "0.1.52",
+        "@jskit-ai/kernel": "0.1.108",
+        "@jskit-ai/resource-core": "0.1.52",
+        "@jskit-ai/resource-crud-core": "0.1.52",
+        "@jskit-ai/users-core": "0.1.117",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/workspaces-web": {
       "name": "@jskit-ai/workspaces-web",
-      "version": "0.1.83",
+      "version": "0.1.84",
       "dependencies": {
-        "@jskit-ai/auth-web": "0.1.107",
-        "@jskit-ai/http-runtime": "0.1.105",
-        "@jskit-ai/kernel": "0.1.107",
-        "@jskit-ai/shell-web": "0.1.106",
-        "@jskit-ai/users-core": "0.1.116",
-        "@jskit-ai/users-web": "0.1.121",
-        "@jskit-ai/workspaces-core": "0.1.82",
+        "@jskit-ai/auth-web": "0.1.108",
+        "@jskit-ai/http-runtime": "0.1.106",
+        "@jskit-ai/kernel": "0.1.108",
+        "@jskit-ai/shell-web": "0.1.107",
+        "@jskit-ai/users-core": "0.1.117",
+        "@jskit-ai/users-web": "0.1.122",
+        "@jskit-ai/workspaces-core": "0.1.83",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -7067,7 +7067,7 @@
     },
     "tooling/config-eslint": {
       "name": "@jskit-ai/config-eslint",
-      "version": "0.1.105",
+      "version": "0.1.106",
       "dependencies": {
         "@eslint/js": "^9.39.1",
         "eslint-plugin-vue": "^10.5.1",
@@ -7085,7 +7085,7 @@
     },
     "tooling/create-app": {
       "name": "@jskit-ai/create-app",
-      "version": "0.1.115",
+      "version": "0.1.116",
       "bin": {
         "jskit-create-app": "bin/jskit-create-app.js"
       },
@@ -7095,18 +7095,18 @@
     },
     "tooling/jskit-catalog": {
       "name": "@jskit-ai/jskit-catalog",
-      "version": "0.1.114",
+      "version": "0.1.115",
       "engines": {
         "node": ">=20 <23"
       }
     },
     "tooling/jskit-cli": {
       "name": "@jskit-ai/jskit-cli",
-      "version": "0.2.119",
+      "version": "0.2.120",
       "dependencies": {
-        "@jskit-ai/jskit-catalog": "0.1.114",
-        "@jskit-ai/kernel": "0.1.107",
-        "@jskit-ai/shell-web": "0.1.106",
+        "@jskit-ai/jskit-catalog": "0.1.115",
+        "@jskit-ai/kernel": "0.1.108",
+        "@jskit-ai/shell-web": "0.1.107",
         "@vue/compiler-sfc": "^3.5.29",
         "ts-morph": "^28.0.0"
       },

--- a/packages/agent-docs/guide/agent/app-setup/database-layer.md
+++ b/packages/agent-docs/guide/agent/app-setup/database-layer.md
@@ -58,9 +58,10 @@ The app gets three database scripts in `package.json`:
 ```json
 {
   "scripts": {
-    "db:migrate": "knex --knexfile ./knexfile.js migrate:latest",
+    "db:migrations:sync": "jskit migrations changed",
+    "db:migrate": "npm run db:migrations:sync && knex --knexfile ./knexfile.js migrate:latest",
     "db:migrate:rollback": "knex --knexfile ./knexfile.js migrate:rollback",
-    "db:migrate:status": "knex --knexfile ./knexfile.js migrate:list"
+    "db:migrate:status": "npm run db:migrations:sync && knex --knexfile ./knexfile.js migrate:list"
   }
 }
 ```
@@ -95,12 +96,14 @@ The app has two different migration-related layers:
 
 Those are **not** the same step.
 
+The npm scripts hide the easy-to-miss first step for normal use. `npm run db:migrate` and `npm run db:migrate:status` run `npm run db:migrations:sync` first, then run Knex. That means package upgrades can add new JSKIT-managed migration files before Knex checks what is pending.
+
 ### `jskit migrations ...` writes managed migration files
 
-If you run:
+If you run the sync script directly:
 
 ```bash
-npx jskit migrations changed
+npm run db:migrations:sync
 ```
 
 JSKIT checks the installed package state in `.jskit/lock.json` and materializes any managed migration files that need to exist in `migrations/`.
@@ -538,9 +541,10 @@ After installing the MySQL runtime, the important new pieces in `package.json` l
     "mysql2": "^3.11.2"
   },
   "scripts": {
-    "db:migrate": "knex --knexfile ./knexfile.js migrate:latest",
+    "db:migrations:sync": "jskit migrations changed",
+    "db:migrate": "npm run db:migrations:sync && knex --knexfile ./knexfile.js migrate:latest",
     "db:migrate:rollback": "knex --knexfile ./knexfile.js migrate:rollback",
-    "db:migrate:status": "knex --knexfile ./knexfile.js migrate:list"
+    "db:migrate:status": "npm run db:migrations:sync && knex --knexfile ./knexfile.js migrate:list"
   }
 }
 ```
@@ -552,11 +556,12 @@ Those new dependencies divide into two roles:
 - `knex` is the database toolkit used by both runtime code and migration commands
 - `mysql2` is the actual Node driver that speaks to MySQL
 
-The three new scripts are also worth reading carefully:
+The migration scripts are also worth reading carefully:
 
-- `db:migrate` applies all pending migrations
+- `db:migrations:sync` writes or refreshes JSKIT-managed migration files in `migrations/`
+- `db:migrate` syncs JSKIT-managed migration files, then applies all pending Knex migrations
 - `db:migrate:rollback` rolls back the last migration batch
-- `db:migrate:status` lists applied and pending migrations
+- `db:migrate:status` syncs JSKIT-managed migration files, then lists applied and pending migrations
 
 They are not special JSKIT commands. They are ordinary project scripts, which makes them easy to run in any environment.
 

--- a/packages/agent-docs/package.json
+++ b/packages/agent-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/agent-docs",
-  "version": "0.1.68",
+  "version": "0.1.69",
   "description": "Distributed JSKIT agent references, prompts, guides, and generated reference maps.",
   "type": "module",
   "files": [

--- a/packages/agent-docs/reference/autogen/packages/auth-provider-local-core.md
+++ b/packages/agent-docs/reference/autogen/packages/auth-provider-local-core.md
@@ -62,7 +62,7 @@ Local functions
 
 ### `src/server/lib/service.js`
 Exports
-- `createLocalAuthService({ backend, config, profileProjector = null, passwordStrategy = null })`
+- `createLocalAuthService({ backend, config, profileProjector = null, passwordStrategy = null, invitationContextResolver = null })`
 Local functions
 - `nowSeconds()`
 - `isoFromNow(seconds)`
@@ -75,11 +75,12 @@ Local functions
 - `clearCookieOptions(isProduction)`
 - `buildProfile(user)`
 - `buildActor(user, profile = null)`
-- `buildAuthPayload({ user, session, profileProjector })`
+- `buildAuthPayload({ user, session, profileProjector, profileOptions = {} })`
 - `buildAccessToken({ user, session, secret, ttlSeconds = ACCESS_TTL_SECONDS })`
 - `buildSessionPayload({ user, session, refreshToken, secret })`
 - `validatePasswordInput(password)`
 - `validateEmailInput(email)`
+- `normalizeInvitationInput(value = null)`
 - `maybeSendRecoveryEmail(config, recoveryUrl, email)`
 
 ### `src/server/lib/tokens.js`

--- a/packages/agent-docs/reference/autogen/packages/auth-web.md
+++ b/packages/agent-docs/reference/autogen/packages/auth-web.md
@@ -56,6 +56,9 @@ Exports
 ### `src/client/composables/loginView/useLoginViewState.js`
 Exports
 - `useLoginViewState({ placementContext } = {})`
+Local functions
+- `readWindowSearchParam(name = "")`
+- `resolveInitialMode()`
 
 ### `src/client/composables/loginView/useLoginViewValidation.js`
 Exports

--- a/packages/agent-docs/reference/autogen/packages/users-core.md
+++ b/packages/agent-docs/reference/autogen/packages/users-core.md
@@ -293,6 +293,10 @@ Exports
 Exports
 - None
 
+### `templates/migrations/users_core_profile_updated_at.cjs`
+Exports
+- None
+
 ### `templates/migrations/users_core_profile_username.cjs`
 Exports
 - None

--- a/packages/agent-docs/reference/autogen/packages/workspaces-core.md
+++ b/packages/agent-docs/reference/autogen/packages/workspaces-core.md
@@ -207,11 +207,26 @@ Exports
 Local functions
 - `resolveWorkspaceAggregateRecordId(record = {}, context = {})`
 
+### `src/server/workspaceMembers/defaultWorkspaceInviteEmail.js`
+Exports
+- `renderDefaultWorkspaceInviteEmail({ inviteUrl = "", workspace = {}, inviter = null, roleSid = "member", expiresAt = "" } = {})`
+Local functions
+- `escapeHtml(value = "")`
+
 ### `src/server/workspaceMembers/registerWorkspaceMembers.js`
 Exports
 - `registerWorkspaceMembers(app)`
 Local functions
 - `resolveWorkspaceMembersInviteExpiresInMs(appConfig = {})`
+- `resolveWorkspaceInviteEmailTemplate(scope, appConfig = {})`
+
+### `src/server/workspaceMembers/workspaceInviteUrls.js`
+Exports
+- `buildInvitePath(token, pathTemplate = "/invite/:token")`
+- `createWorkspaceInviteUrlBuilder({ appConfig = {}, env = {} } = {})`
+Local functions
+- `normalizeInvitePathTemplate(value = "")`
+- `normalizeBaseUrl(value = "")`
 
 ### `src/server/workspaceMembers/workspaceMembersActions.js`
 Exports
@@ -219,13 +234,14 @@ Exports
 
 ### `src/server/workspaceMembers/workspaceMembersService.js`
 Exports
-- `createService({ workspaceMembershipsRepository, workspaceInvitesRepository, inviteExpiresInMs, roleCatalog = null, workspaceInvitationsEnabled = true } = {})`
+- `createService({ workspaceMembershipsRepository, workspaceInvitesRepository, inviteExpiresInMs, roleCatalog = null, workspaceInvitationsEnabled = true, inviteUrlBuilder = null, workspaceInviteMailer = null, workspaceInviteEmailTemplate = renderDefaultWorkspaceInviteEmail } = {})`
 
 ### `src/server/workspacePendingInvitations/bootWorkspacePendingInvitations.js`
 Exports
 - `bootWorkspacePendingInvitations(app)`
 Local functions
 - `resolveAuthenticatedUserRecordId(_record, context = {})`
+- `resolveInviteResolutionRecordId(record = {})`
 
 ### `src/server/workspacePendingInvitations/registerWorkspacePendingInvitations.js`
 Exports
@@ -287,6 +303,7 @@ Exports
 - `WORKSPACE_INVITES_TRANSPORT`
 - `WORKSPACE_INVITE_CREATE_TRANSPORT`
 - `WORKSPACE_INVITE_REDEEM_TRANSPORT`
+- `WORKSPACE_INVITATION_RESOLVE_TRANSPORT`
 - `WORKSPACE_PENDING_INVITATIONS_TRANSPORT`
 
 ### `src/shared/operationMessages.js`
@@ -426,6 +443,10 @@ Local functions
 - `hasTable(knex, tableName)`
 - `hasColumn(knex, tableName, columnName)`
 - `normalizeHexColor(value)`
+
+### `templates/packages/main/src/server/email/workspaceInviteEmail.js`
+Exports
+- `renderWorkspaceInviteEmail({ inviteUrl = "", workspace = {}, inviter = null, roleSid = "member", expiresAt = "" } = {})`
 
 ### root
 

--- a/packages/agent-docs/reference/autogen/packages/workspaces-web.md
+++ b/packages/agent-docs/reference/autogen/packages/workspaces-web.md
@@ -39,6 +39,7 @@ Local functions
 - `isRevokeInviteLoading(inviteId)`
 - `isRemoveMemberLoading(memberUserId)`
 - `onSubmitInvite()`
+- `onCopyInviteLink()`
 - `onRevokeInvite(inviteId)`
 - `onMemberRoleUpdate(member, roleSid)`
 - `onRemoveMember(member)`
@@ -73,6 +74,14 @@ Exports
 Exports
 - None
 
+### `src/client/components/WorkspaceInviteLanding.vue`
+Exports
+- None
+Local functions
+- `buildAuthUrl(mode)`
+- `refreshInvite()`
+- `acceptInvite()`
+
 ### `src/client/components/WorkspaceMembersClientElement.vue`
 Exports
 - None
@@ -91,6 +100,7 @@ Local functions
 - `applyWorkspaceSettingsPolicy(payload = {})`
 - `refreshLoad()`
 - `submitInvite()`
+- `copyCreatedInviteLink()`
 - `submitRevokeInvite(inviteId)`
 - `submitMemberRoleUpdate(member, roleSid)`
 - `submitRemoveMember(member)`
@@ -125,6 +135,7 @@ Local functions
 Exports
 - `WorkspacesWebClientProvider`
 - `WorkspaceMembersClientElement`
+- `WorkspaceInviteLanding`
 - `clientProviders`
 
 ### `src/client/lib/bootstrap.js`
@@ -332,6 +343,10 @@ Exports
 - None
 
 ### `templates/src/pages/admin/workspace/settings/index.vue`
+Exports
+- None
+
+### `templates/src/pages/invite/[token].vue`
 Exports
 - None
 

--- a/packages/agent-docs/site/guide/app-setup/database-layer.md
+++ b/packages/agent-docs/site/guide/app-setup/database-layer.md
@@ -107,9 +107,10 @@ The app gets three database scripts in `package.json`:
 ```json
 {
   "scripts": {
-    "db:migrate": "knex --knexfile ./knexfile.js migrate:latest",
+    "db:migrations:sync": "jskit migrations changed",
+    "db:migrate": "npm run db:migrations:sync && knex --knexfile ./knexfile.js migrate:latest",
     "db:migrate:rollback": "knex --knexfile ./knexfile.js migrate:rollback",
-    "db:migrate:status": "knex --knexfile ./knexfile.js migrate:list"
+    "db:migrate:status": "npm run db:migrations:sync && knex --knexfile ./knexfile.js migrate:list"
   }
 }
 ```
@@ -144,12 +145,14 @@ The app has two different migration-related layers:
 
 Those are **not** the same step.
 
+The npm scripts hide the easy-to-miss first step for normal use. `npm run db:migrate` and `npm run db:migrate:status` run `npm run db:migrations:sync` first, then run Knex. That means package upgrades can add new JSKIT-managed migration files before Knex checks what is pending.
+
 ### `jskit migrations ...` writes managed migration files
 
-If you run:
+If you run the sync script directly:
 
 ```bash
-npx jskit migrations changed
+npm run db:migrations:sync
 ```
 
 JSKIT checks the installed package state in `.jskit/lock.json` and materializes any managed migration files that need to exist in `migrations/`.
@@ -587,9 +590,10 @@ After installing the MySQL runtime, the important new pieces in `package.json` l
     "mysql2": "^3.11.2"
   },
   "scripts": {
-    "db:migrate": "knex --knexfile ./knexfile.js migrate:latest",
+    "db:migrations:sync": "jskit migrations changed",
+    "db:migrate": "npm run db:migrations:sync && knex --knexfile ./knexfile.js migrate:latest",
     "db:migrate:rollback": "knex --knexfile ./knexfile.js migrate:rollback",
-    "db:migrate:status": "knex --knexfile ./knexfile.js migrate:list"
+    "db:migrate:status": "npm run db:migrations:sync && knex --knexfile ./knexfile.js migrate:list"
   }
 }
 ```
@@ -601,11 +605,12 @@ Those new dependencies divide into two roles:
 - `knex` is the database toolkit used by both runtime code and migration commands
 - `mysql2` is the actual Node driver that speaks to MySQL
 
-The three new scripts are also worth reading carefully:
+The migration scripts are also worth reading carefully:
 
-- `db:migrate` applies all pending migrations
+- `db:migrations:sync` writes or refreshes JSKIT-managed migration files in `migrations/`
+- `db:migrate` syncs JSKIT-managed migration files, then applies all pending Knex migrations
 - `db:migrate:rollback` rolls back the last migration batch
-- `db:migrate:status` lists applied and pending migrations
+- `db:migrate:status` syncs JSKIT-managed migration files, then lists applied and pending migrations
 
 They are not special JSKIT commands. They are ordinary project scripts, which makes them easy to run in any environment.
 

--- a/packages/assistant-core/package.descriptor.mjs
+++ b/packages/assistant-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-core",
-  version: "0.1.82",
+  version: "0.1.83",
   kind: "runtime",
   description: "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
   dependsOn: [
@@ -47,11 +47,11 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/http-runtime": "0.1.105",
-        "@jskit-ai/kernel": "0.1.107",
-        "@jskit-ai/resource-core": "0.1.51",
-        "@jskit-ai/resource-crud-core": "0.1.51",
-        "@jskit-ai/users-core": "0.1.116",
+        "@jskit-ai/http-runtime": "0.1.106",
+        "@jskit-ai/kernel": "0.1.108",
+        "@jskit-ai/resource-core": "0.1.52",
+        "@jskit-ai/resource-crud-core": "0.1.52",
+        "@jskit-ai/users-core": "0.1.117",
         "dompurify": "^3.3.3",
         "json-rest-schema": "1.x.x",
         "marked": "^17.0.4",

--- a/packages/assistant-core/package.json
+++ b/packages/assistant-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-core",
-  "version": "0.1.82",
+  "version": "0.1.83",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,12 +11,12 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.106",
-    "@jskit-ai/http-runtime": "0.1.105",
-    "@jskit-ai/kernel": "0.1.107",
-    "@jskit-ai/resource-crud-core": "0.1.51",
-    "@jskit-ai/resource-core": "0.1.51",
-    "@jskit-ai/users-core": "0.1.116",
+    "@jskit-ai/database-runtime": "0.1.107",
+    "@jskit-ai/http-runtime": "0.1.106",
+    "@jskit-ai/kernel": "0.1.108",
+    "@jskit-ai/resource-crud-core": "0.1.52",
+    "@jskit-ai/resource-core": "0.1.52",
+    "@jskit-ai/users-core": "0.1.117",
     "dompurify": "^3.3.3",
     "json-rest-schema": "1.x.x",
     "marked": "^17.0.4",

--- a/packages/assistant-runtime/package.descriptor.mjs
+++ b/packages/assistant-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-runtime",
-  version: "0.1.77",
+  version: "0.1.78",
   kind: "runtime",
   description: "Shared assistant runtime with per-surface assistant registration.",
   dependsOn: [
@@ -95,13 +95,13 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/assistant-core": "0.1.82",
-        "@jskit-ai/database-runtime": "0.1.106",
-        "@jskit-ai/http-runtime": "0.1.105",
-        "@jskit-ai/kernel": "0.1.107",
-        "@jskit-ai/shell-web": "0.1.106",
-        "@jskit-ai/users-core": "0.1.116",
-        "@jskit-ai/users-web": "0.1.121"
+        "@jskit-ai/assistant-core": "0.1.83",
+        "@jskit-ai/database-runtime": "0.1.107",
+        "@jskit-ai/http-runtime": "0.1.106",
+        "@jskit-ai/kernel": "0.1.108",
+        "@jskit-ai/shell-web": "0.1.107",
+        "@jskit-ai/users-core": "0.1.117",
+        "@jskit-ai/users-web": "0.1.122"
       },
       dev: {}
     },

--- a/packages/assistant-runtime/package.json
+++ b/packages/assistant-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-runtime",
-  "version": "0.1.77",
+  "version": "0.1.78",
   "type": "module",
   "exports": {
     "./client": "./src/client/index.js",
@@ -8,13 +8,13 @@
     "./server/actionIds": "./src/server/actionIds.js"
   },
   "dependencies": {
-    "@jskit-ai/assistant-core": "0.1.82",
-    "@jskit-ai/database-runtime": "0.1.106",
-    "@jskit-ai/http-runtime": "0.1.105",
-    "@jskit-ai/kernel": "0.1.107",
-    "@jskit-ai/shell-web": "0.1.106",
-    "@jskit-ai/users-core": "0.1.116",
-    "@jskit-ai/users-web": "0.1.121",
+    "@jskit-ai/assistant-core": "0.1.83",
+    "@jskit-ai/database-runtime": "0.1.107",
+    "@jskit-ai/http-runtime": "0.1.106",
+    "@jskit-ai/kernel": "0.1.108",
+    "@jskit-ai/shell-web": "0.1.107",
+    "@jskit-ai/users-core": "0.1.117",
+    "@jskit-ai/users-web": "0.1.122",
     "json-rest-schema": "1.x.x"
   },
   "peerDependencies": {

--- a/packages/assistant/package.descriptor.mjs
+++ b/packages/assistant/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant",
-  version: "0.1.115",
+  version: "0.1.116",
   kind: "generator",
   description: "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
   options: {

--- a/packages/assistant/package.json
+++ b/packages/assistant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant",
-  "version": "0.1.115",
+  "version": "0.1.116",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.107"
+    "@jskit-ai/kernel": "0.1.108"
   }
 }

--- a/packages/auth-core/package.descriptor.mjs
+++ b/packages/auth-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-core",
-  "version": "0.1.105",
+  "version": "0.1.106",
   "kind": "runtime",
   "dependsOn": [
     "@jskit-ai/value-app-config-shared"
@@ -74,7 +74,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.107",
+        "@jskit-ai/kernel": "0.1.108",
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0"

--- a/packages/auth-core/package.json
+++ b/packages/auth-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-core",
-  "version": "0.1.105",
+  "version": "0.1.106",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -54,7 +54,7 @@
     "./shared/commands/authSessionReadCommand": "./src/shared/commands/authSessionReadCommand.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.107",
+    "@jskit-ai/kernel": "0.1.108",
     "@fastify/cookie": "^11.0.2",
     "@fastify/csrf-protection": "^7.1.0",
     "@fastify/rate-limit": "^10.3.0",

--- a/packages/auth-provider-local-core/package.descriptor.mjs
+++ b/packages/auth-provider-local-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-provider-local-core",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "kind": "runtime",
   "description": "Local auth provider with a file backend default and no database requirement.",
   "dependsOn": [
@@ -57,8 +57,8 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/auth-core": "0.1.105",
-        "@jskit-ai/kernel": "0.1.107",
+        "@jskit-ai/auth-core": "0.1.106",
+        "@jskit-ai/kernel": "0.1.108",
         "nodemailer": "^7.0.10",
         "dotenv": "^16.4.5"
       },

--- a/packages/auth-provider-local-core/package.json
+++ b/packages/auth-provider-local-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-local-core",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,8 +11,8 @@
     "./server/lib/index": "./src/server/lib/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.105",
-    "@jskit-ai/kernel": "0.1.107",
+    "@jskit-ai/auth-core": "0.1.106",
+    "@jskit-ai/kernel": "0.1.108",
     "nodemailer": "^7.0.10"
   }
 }

--- a/packages/auth-provider-supabase-core/package.descriptor.mjs
+++ b/packages/auth-provider-supabase-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.105",
+  "version": "0.1.106",
   "kind": "runtime",
   "options": {
     "auth-supabase-url": {
@@ -83,8 +83,8 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/auth-core": "0.1.105",
-        "@jskit-ai/kernel": "0.1.107",
+        "@jskit-ai/auth-core": "0.1.106",
+        "@jskit-ai/kernel": "0.1.108",
         "dotenv": "^16.4.5",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0"

--- a/packages/auth-provider-supabase-core/package.json
+++ b/packages/auth-provider-supabase-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.105",
+  "version": "0.1.106",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,8 +12,8 @@
     "./client": "./src/client/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.105",
-    "@jskit-ai/kernel": "0.1.107",
+    "@jskit-ai/auth-core": "0.1.106",
+    "@jskit-ai/kernel": "0.1.108",
     "json-rest-schema": "1.x.x",
     "jose": "^6.1.0",
     "@supabase/supabase-js": "^2.57.4",

--- a/packages/auth-web/package.descriptor.mjs
+++ b/packages/auth-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-web",
-  "version": "0.1.107",
+  "version": "0.1.108",
   "kind": "runtime",
   "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
   "dependsOn": [
@@ -260,10 +260,10 @@ export default Object.freeze({
     "dependencies": {
       "runtime": {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/auth-core": "0.1.105",
-        "@jskit-ai/http-runtime": "0.1.105",
-        "@jskit-ai/kernel": "0.1.107",
-        "@jskit-ai/shell-web": "0.1.106"
+        "@jskit-ai/auth-core": "0.1.106",
+        "@jskit-ai/http-runtime": "0.1.106",
+        "@jskit-ai/kernel": "0.1.108",
+        "@jskit-ai/shell-web": "0.1.107"
       },
       "dev": {}
     },

--- a/packages/auth-web/package.json
+++ b/packages/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-web",
-  "version": "0.1.107",
+  "version": "0.1.108",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -19,11 +19,11 @@
     "./client/runtime/useSignOut": "./src/client/runtime/useSignOut.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.105",
+    "@jskit-ai/auth-core": "0.1.106",
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/kernel": "0.1.107",
-    "@jskit-ai/shell-web": "0.1.106",
-    "@jskit-ai/http-runtime": "0.1.105"
+    "@jskit-ai/kernel": "0.1.108",
+    "@jskit-ai/shell-web": "0.1.107",
+    "@jskit-ai/http-runtime": "0.1.106"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/console-core/package.descriptor.mjs
+++ b/packages/console-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-core",
-  version: "0.1.69",
+  version: "0.1.70",
   kind: "runtime",
   description: "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
   dependsOn: [
@@ -85,12 +85,12 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.105",
-        "@jskit-ai/database-runtime": "0.1.106",
-        "@jskit-ai/http-runtime": "0.1.105",
-        "@jskit-ai/kernel": "0.1.107",
-        "@jskit-ai/resource-crud-core": "0.1.51",
-        "@jskit-ai/users-core": "0.1.116"
+        "@jskit-ai/auth-core": "0.1.106",
+        "@jskit-ai/database-runtime": "0.1.107",
+        "@jskit-ai/http-runtime": "0.1.106",
+        "@jskit-ai/kernel": "0.1.108",
+        "@jskit-ai/resource-crud-core": "0.1.52",
+        "@jskit-ai/users-core": "0.1.117"
       },
       dev: {}
     },

--- a/packages/console-core/package.json
+++ b/packages/console-core/package.json
@@ -1,17 +1,17 @@
 {
   "name": "@jskit-ai/console-core",
-  "version": "0.1.69",
+  "version": "0.1.70",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.105",
-    "@jskit-ai/database-runtime": "0.1.106",
-    "@jskit-ai/http-runtime": "0.1.105",
-    "@jskit-ai/kernel": "0.1.107",
-    "@jskit-ai/resource-crud-core": "0.1.51",
-    "@jskit-ai/users-core": "0.1.116",
+    "@jskit-ai/auth-core": "0.1.106",
+    "@jskit-ai/database-runtime": "0.1.107",
+    "@jskit-ai/http-runtime": "0.1.106",
+    "@jskit-ai/kernel": "0.1.108",
+    "@jskit-ai/resource-crud-core": "0.1.52",
+    "@jskit-ai/users-core": "0.1.117",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/console-web/package.descriptor.mjs
+++ b/packages/console-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-web",
-  version: "0.1.74",
+  version: "0.1.75",
   kind: "runtime",
   description: "Authenticated console surface scaffold and surface policy wiring.",
   dependsOn: [
@@ -103,9 +103,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-web": "0.1.107",
-        "@jskit-ai/console-core": "0.1.69",
-        "@jskit-ai/shell-web": "0.1.106",
+        "@jskit-ai/auth-web": "0.1.108",
+        "@jskit-ai/console-core": "0.1.70",
+        "@jskit-ai/shell-web": "0.1.107",
       },
       dev: {}
     },

--- a/packages/console-web/package.json
+++ b/packages/console-web/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/console-web",
-  "version": "0.1.74",
+  "version": "0.1.75",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-web": "0.1.107",
-    "@jskit-ai/console-core": "0.1.69",
-    "@jskit-ai/shell-web": "0.1.106"
+    "@jskit-ai/auth-web": "0.1.108",
+    "@jskit-ai/console-core": "0.1.70",
+    "@jskit-ai/shell-web": "0.1.107"
   }
 }

--- a/packages/crud-core/package.descriptor.mjs
+++ b/packages/crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-core",
-  version: "0.1.114",
+  version: "0.1.115",
   kind: "runtime",
   description: "Shared CRUD helpers used by CRUD modules.",
   dependsOn: [
@@ -28,7 +28,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/crud-core": "0.1.114"
+        "@jskit-ai/crud-core": "0.1.115"
       },
       dev: {}
     },

--- a/packages/crud-core/package.json
+++ b/packages/crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-core",
-  "version": "0.1.114",
+  "version": "0.1.115",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -27,15 +27,15 @@
     "./server/routeContracts": "./src/server/routeContracts.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.106",
-    "@jskit-ai/http-runtime": "0.1.105",
-    "@jskit-ai/kernel": "0.1.107",
+    "@jskit-ai/database-runtime": "0.1.107",
+    "@jskit-ai/http-runtime": "0.1.106",
+    "@jskit-ai/kernel": "0.1.108",
     "json-rest-schema": "1.x.x",
-    "@jskit-ai/realtime": "0.1.105",
-    "@jskit-ai/resource-crud-core": "0.1.51",
-    "@jskit-ai/shell-web": "0.1.106",
-    "@jskit-ai/users-core": "0.1.116",
-    "@jskit-ai/users-web": "0.1.121"
+    "@jskit-ai/realtime": "0.1.106",
+    "@jskit-ai/resource-crud-core": "0.1.52",
+    "@jskit-ai/shell-web": "0.1.107",
+    "@jskit-ai/users-core": "0.1.117",
+    "@jskit-ai/users-web": "0.1.122"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/crud-server-generator/package.descriptor.mjs
+++ b/packages/crud-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-server-generator",
-  version: "0.1.114",
+  version: "0.1.115",
   kind: "generator",
   description: "CRUD server generator with routes, actions, and persistence scaffolding.",
   options: {
@@ -160,14 +160,14 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.105",
-        "@jskit-ai/crud-core": "0.1.114",
-        "@jskit-ai/database-runtime": "0.1.106",
-        "@jskit-ai/http-runtime": "0.1.105",
-        "@jskit-ai/json-rest-api-core": "0.1.51",
-        "@jskit-ai/kernel": "0.1.107",
-        "@jskit-ai/realtime": "0.1.105",
-        "@jskit-ai/resource-crud-core": "0.1.51",
+        "@jskit-ai/auth-core": "0.1.106",
+        "@jskit-ai/crud-core": "0.1.115",
+        "@jskit-ai/database-runtime": "0.1.107",
+        "@jskit-ai/http-runtime": "0.1.106",
+        "@jskit-ai/json-rest-api-core": "0.1.52",
+        "@jskit-ai/kernel": "0.1.108",
+        "@jskit-ai/realtime": "0.1.106",
+        "@jskit-ai/resource-crud-core": "0.1.52",
         "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}"
       },
       dev: {}

--- a/packages/crud-server-generator/package.json
+++ b/packages/crud-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-server-generator",
-  "version": "0.1.114",
+  "version": "0.1.115",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,12 +13,12 @@
   },
   "dependencies": {
     "@babel/parser": "^7.29.2",
-    "@jskit-ai/crud-core": "0.1.114",
-    "@jskit-ai/database-runtime": "0.1.106",
-    "@jskit-ai/http-runtime": "0.1.105",
-    "@jskit-ai/json-rest-api-core": "0.1.51",
-    "@jskit-ai/kernel": "0.1.107",
-    "@jskit-ai/resource-crud-core": "0.1.51",
+    "@jskit-ai/crud-core": "0.1.115",
+    "@jskit-ai/database-runtime": "0.1.107",
+    "@jskit-ai/http-runtime": "0.1.106",
+    "@jskit-ai/json-rest-api-core": "0.1.52",
+    "@jskit-ai/kernel": "0.1.108",
+    "@jskit-ai/resource-crud-core": "0.1.52",
     "recast": "^0.23.11"
   }
 }

--- a/packages/crud-ui-generator/package.descriptor.mjs
+++ b/packages/crud-ui-generator/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { GENERATED_UI_NAVIGATION_ROLE_OPTION } from "@jskit-ai/kernel/shared/sup
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-ui-generator",
-  version: "0.1.89",
+  version: "0.1.90",
   kind: "generator",
   description: "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
   options: {
@@ -175,7 +175,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.121"
+        "@jskit-ai/users-web": "0.1.122"
       },
       dev: {}
     },

--- a/packages/crud-ui-generator/package.json
+++ b/packages/crud-ui-generator/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@jskit-ai/crud-ui-generator",
-  "version": "0.1.89",
+  "version": "0.1.90",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/crud-core": "0.1.114",
-    "@jskit-ai/kernel": "0.1.107",
-    "@jskit-ai/resource-crud-core": "0.1.51"
+    "@jskit-ai/crud-core": "0.1.115",
+    "@jskit-ai/kernel": "0.1.108",
+    "@jskit-ai/resource-crud-core": "0.1.52"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/database-runtime-mysql/package.descriptor.mjs
+++ b/packages/database-runtime-mysql/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-mysql",
-  version: "0.1.105",
+  version: "0.1.106",
   kind: "runtime",
   options: {
     "db-host": {
@@ -91,7 +91,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.106",
+        "@jskit-ai/database-runtime": "0.1.107",
         "mysql2": "^3.11.2"
       },
       dev: {}

--- a/packages/database-runtime-mysql/package.json
+++ b/packages/database-runtime-mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-mysql",
-  "version": "0.1.105",
+  "version": "0.1.106",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,7 +12,7 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.106",
-    "@jskit-ai/kernel": "0.1.107"
+    "@jskit-ai/database-runtime": "0.1.107",
+    "@jskit-ai/kernel": "0.1.108"
   }
 }

--- a/packages/database-runtime-postgres/package.descriptor.mjs
+++ b/packages/database-runtime-postgres/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-postgres",
-  version: "0.1.105",
+  version: "0.1.106",
   kind: "runtime",
   options: {
     "db-host": {
@@ -91,7 +91,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.106",
+        "@jskit-ai/database-runtime": "0.1.107",
         "pg": "^8.13.1"
       },
       dev: {}

--- a/packages/database-runtime-postgres/package.json
+++ b/packages/database-runtime-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-postgres",
-  "version": "0.1.105",
+  "version": "0.1.106",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,6 +12,6 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.106"
+    "@jskit-ai/database-runtime": "0.1.107"
   }
 }

--- a/packages/database-runtime/package.descriptor.mjs
+++ b/packages/database-runtime/package.descriptor.mjs
@@ -66,9 +66,10 @@ export default Object.freeze({
     },
     packageJson: {
       scripts: {
-        "db:migrate": "knex --knexfile ./knexfile.js migrate:latest",
+        "db:migrations:sync": "jskit migrations changed",
+        "db:migrate": "npm run db:migrations:sync && knex --knexfile ./knexfile.js migrate:latest",
         "db:migrate:rollback": "knex --knexfile ./knexfile.js migrate:rollback",
-        "db:migrate:status": "knex --knexfile ./knexfile.js migrate:list"
+        "db:migrate:status": "npm run db:migrations:sync && knex --knexfile ./knexfile.js migrate:list"
       }
     },
     procfile: {},

--- a/packages/database-runtime/package.descriptor.mjs
+++ b/packages/database-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime",
-  version: "0.1.106",
+  version: "0.1.107",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -58,7 +58,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.107",
+        "@jskit-ai/kernel": "0.1.108",
         "dotenv": "^16.4.5",
         "knex": "^3.1.0"
       },

--- a/packages/database-runtime/package.json
+++ b/packages/database-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime",
-  "version": "0.1.106",
+  "version": "0.1.107",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -25,6 +25,6 @@
     "./shared/transactions": "./src/shared/transactions.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.107"
+    "@jskit-ai/kernel": "0.1.108"
   }
 }

--- a/packages/database-runtime/test/packageDescriptor.test.js
+++ b/packages/database-runtime/test/packageDescriptor.test.js
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import descriptor from "../package.descriptor.mjs";
+
+test("database-runtime db migrate scripts sync JSKIT-managed migrations before Knex reads them", () => {
+  const scripts = descriptor.mutations.packageJson.scripts;
+
+  assert.equal(scripts["db:migrations:sync"], "jskit migrations changed");
+  assert.equal(
+    scripts["db:migrate"],
+    "npm run db:migrations:sync && knex --knexfile ./knexfile.js migrate:latest"
+  );
+  assert.equal(
+    scripts["db:migrate:status"],
+    "npm run db:migrations:sync && knex --knexfile ./knexfile.js migrate:list"
+  );
+  assert.equal(
+    scripts["db:migrate:rollback"],
+    "knex --knexfile ./knexfile.js migrate:rollback"
+  );
+});

--- a/packages/feature-server-generator/package.descriptor.mjs
+++ b/packages/feature-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/feature-server-generator",
-  version: "0.1.48",
+  version: "0.1.49",
   kind: "generator",
   description: "Scaffold substantial non-CRUD server feature packages with provider, actions, service, and optional persistence seams.",
   options: {
@@ -174,7 +174,7 @@ export default Object.freeze({
             equals: "json-rest"
           }
         },
-        "@jskit-ai/kernel": "0.1.107",
+        "@jskit-ai/kernel": "0.1.108",
         "json-rest-schema": "1.x.x",
         "@local/${option:feature-name|kebab}": "file:packages/${option:feature-name|kebab}"
       },

--- a/packages/feature-server-generator/package.json
+++ b/packages/feature-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/feature-server-generator",
-  "version": "0.1.48",
+  "version": "0.1.49",
   "type": "module",
   "scripts": {
     "test": "node --test"

--- a/packages/google-rewarded-core/package.descriptor.mjs
+++ b/packages/google-rewarded-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/google-rewarded-core",
-  version: "0.1.43",
+  version: "0.1.44",
   kind: "runtime",
   description: "Google rewarded workflow runtime plus internal CRUD providers for rules, provider configs, watch sessions, and unlock receipts.",
   dependsOn: [
@@ -128,14 +128,14 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.105",
-        "@jskit-ai/crud-core": "0.1.114",
-        "@jskit-ai/database-runtime": "0.1.106",
-        "@jskit-ai/http-runtime": "0.1.105",
-        "@jskit-ai/json-rest-api-core": "0.1.51",
-        "@jskit-ai/kernel": "0.1.107",
-        "@jskit-ai/resource-crud-core": "0.1.51",
-        "@jskit-ai/workspaces-core": "0.1.82"
+        "@jskit-ai/auth-core": "0.1.106",
+        "@jskit-ai/crud-core": "0.1.115",
+        "@jskit-ai/database-runtime": "0.1.107",
+        "@jskit-ai/http-runtime": "0.1.106",
+        "@jskit-ai/json-rest-api-core": "0.1.52",
+        "@jskit-ai/kernel": "0.1.108",
+        "@jskit-ai/resource-crud-core": "0.1.52",
+        "@jskit-ai/workspaces-core": "0.1.83"
       },
       dev: {}
     },

--- a/packages/google-rewarded-core/package.json
+++ b/packages/google-rewarded-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/google-rewarded-core",
-  "version": "0.1.43",
+  "version": "0.1.44",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/google-rewarded-web/package.descriptor.mjs
+++ b/packages/google-rewarded-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/google-rewarded-web",
-  version: "0.1.43",
+  version: "0.1.44",
   kind: "runtime",
   description: "Google rewarded client runtime with a fullscreen gate host and GPT orchestration.",
   dependsOn: [
@@ -46,10 +46,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/google-rewarded-core": "0.1.43",
-        "@jskit-ai/http-runtime": "0.1.105",
-        "@jskit-ai/kernel": "0.1.107",
-        "@jskit-ai/shell-web": "0.1.106"
+        "@jskit-ai/google-rewarded-core": "0.1.44",
+        "@jskit-ai/http-runtime": "0.1.106",
+        "@jskit-ai/kernel": "0.1.108",
+        "@jskit-ai/shell-web": "0.1.107"
       },
       dev: {}
     },

--- a/packages/google-rewarded-web/package.json
+++ b/packages/google-rewarded-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/google-rewarded-web",
-  "version": "0.1.43",
+  "version": "0.1.44",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/http-runtime/package.descriptor.mjs
+++ b/packages/http-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/http-runtime",
-  "version": "0.1.105",
+  "version": "0.1.106",
   "kind": "runtime",
   "dependsOn": [],
   "capabilities": {
@@ -67,7 +67,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.107"
+        "@jskit-ai/kernel": "0.1.108"
       },
       "dev": {}
     },

--- a/packages/http-runtime/package.json
+++ b/packages/http-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/http-runtime",
-  "version": "0.1.105",
+  "version": "0.1.106",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -18,7 +18,7 @@
     "./shared/validators/operationValidation": "./src/shared/validators/operationValidation.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.107",
+    "@jskit-ai/kernel": "0.1.108",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/json-rest-api-core/package.descriptor.mjs
+++ b/packages/json-rest-api-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/json-rest-api-core",
-  version: "0.1.51",
+  version: "0.1.52",
   kind: "runtime",
   description: "Shared internal json-rest-api host runtime for JSKIT server packages.",
   dependsOn: [

--- a/packages/json-rest-api-core/package.json
+++ b/packages/json-rest-api-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/json-rest-api-core",
-  "version": "0.1.51",
+  "version": "0.1.52",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,6 +11,6 @@
   "dependencies": {
     "hooked-api": "1.x.x",
     "json-rest-api": "1.x.x",
-    "@jskit-ai/kernel": "0.1.107"
+    "@jskit-ai/kernel": "0.1.108"
   }
 }

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/kernel",
-  "version": "0.1.107",
+  "version": "0.1.108",
   "type": "module",
   "dependencies": {
     "json-rest-schema": "1.x.x"

--- a/packages/mobile-capacitor/package.descriptor.mjs
+++ b/packages/mobile-capacitor/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/mobile-capacitor",
-  version: "0.1.43",
+  version: "0.1.44",
   kind: "runtime",
   description: "Thin Capacitor client integration for JSKIT mobile-shell launch routing and auth callback completion.",
   dependsOn: [
@@ -62,8 +62,8 @@ export default Object.freeze({
         "@capacitor/app": "^7.1.0",
         "@capacitor/browser": "^7.0.1",
         "@capacitor/core": "^7.4.3",
-        "@jskit-ai/kernel": "0.1.107",
-        "@jskit-ai/shell-web": "0.1.106"
+        "@jskit-ai/kernel": "0.1.108",
+        "@jskit-ai/shell-web": "0.1.107"
       },
       dev: {
         "@capacitor/cli": "^7.4.3"

--- a/packages/mobile-capacitor/package.json
+++ b/packages/mobile-capacitor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/mobile-capacitor",
-  "version": "0.1.43",
+  "version": "0.1.44",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,6 +12,6 @@
   },
   "dependencies": {
     "@capacitor/browser": "^7.0.1",
-    "@jskit-ai/kernel": "0.1.107"
+    "@jskit-ai/kernel": "0.1.108"
   }
 }

--- a/packages/realtime/package.descriptor.mjs
+++ b/packages/realtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/realtime",
-  version: "0.1.105",
+  version: "0.1.106",
   kind: "runtime",
   description: "Thin, generic realtime runtime wrappers for socket.io server and client.",
   options: {
@@ -95,7 +95,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.107",
+        "@jskit-ai/kernel": "0.1.108",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/realtime",
-  "version": "0.1.105",
+  "version": "0.1.106",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@socket.io/redis-adapter": "^8.3.0",
-    "@jskit-ai/kernel": "0.1.107",
+    "@jskit-ai/kernel": "0.1.108",
     "redis": "^5.8.2",
     "socket.io": "^4.8.3",
     "socket.io-client": "^4.8.3"

--- a/packages/resource-core/package.descriptor.mjs
+++ b/packages/resource-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/resource-core",
-  version: "0.1.51",
+  version: "0.1.52",
   kind: "runtime",
   description: "Generic resource-definition helpers and schema-definition normalization.",
   dependsOn: [
@@ -22,7 +22,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/resource-core": "0.1.51"
+        "@jskit-ai/resource-core": "0.1.52"
       },
       dev: {}
     },

--- a/packages/resource-core/package.json
+++ b/packages/resource-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/resource-core",
-  "version": "0.1.51",
+  "version": "0.1.52",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./shared/resource": "./src/shared/resource.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.107"
+    "@jskit-ai/kernel": "0.1.108"
   }
 }

--- a/packages/resource-crud-core/package.descriptor.mjs
+++ b/packages/resource-crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/resource-crud-core",
-  version: "0.1.51",
+  version: "0.1.52",
   kind: "runtime",
   description: "CRUD-specific resource-definition helpers and namespace support.",
   dependsOn: [
@@ -23,7 +23,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/resource-crud-core": "0.1.51"
+        "@jskit-ai/resource-crud-core": "0.1.52"
       },
       dev: {}
     },

--- a/packages/resource-crud-core/package.json
+++ b/packages/resource-crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/resource-crud-core",
-  "version": "0.1.51",
+  "version": "0.1.52",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./shared/crudResource": "./src/shared/crudResource.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.107",
-    "@jskit-ai/resource-core": "0.1.51"
+    "@jskit-ai/kernel": "0.1.108",
+    "@jskit-ai/resource-core": "0.1.52"
   }
 }

--- a/packages/shell-web/package.descriptor.mjs
+++ b/packages/shell-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/shell-web",
-  version: "0.1.106",
+  version: "0.1.107",
   kind: "runtime",
   description: "Web shell layout runtime with outlet-based placement contributions.",
   dependsOn: [],
@@ -307,7 +307,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/kernel": "0.1.107"
+        "@jskit-ai/kernel": "0.1.108"
       },
       dev: {}
     },

--- a/packages/shell-web/package.json
+++ b/packages/shell-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/shell-web",
-  "version": "0.1.106",
+  "version": "0.1.107",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/kernel": "0.1.107"
+    "@jskit-ai/kernel": "0.1.108"
   },
   "peerDependencies": {
     "pinia": "^3.0.4",

--- a/packages/storage-runtime/package.descriptor.mjs
+++ b/packages/storage-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/storage-runtime",
-  version: "0.1.105",
+  version: "0.1.106",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -50,7 +50,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.107",
+        "@jskit-ai/kernel": "0.1.108",
         "unstorage": "^1.17.3"
       },
       dev: {}

--- a/packages/storage-runtime/package.json
+++ b/packages/storage-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/storage-runtime",
-  "version": "0.1.105",
+  "version": "0.1.106",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./server/providers/StorageRuntimeServiceProvider": "./src/server/providers/StorageRuntimeServiceProvider.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.107",
+    "@jskit-ai/kernel": "0.1.108",
     "unstorage": "^1.17.3"
   }
 }

--- a/packages/ui-generator/package.descriptor.mjs
+++ b/packages/ui-generator/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { GENERATED_UI_NAVIGATION_ROLE_OPTION } from "@jskit-ai/kernel/shared/sup
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/ui-generator",
-  version: "0.1.89",
+  version: "0.1.90",
   kind: "generator",
   description: "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
   options: {
@@ -371,7 +371,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.121"
+        "@jskit-ai/users-web": "0.1.122"
       },
       dev: {}
     },

--- a/packages/ui-generator/package.json
+++ b/packages/ui-generator/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/ui-generator",
-  "version": "0.1.89",
+  "version": "0.1.90",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.107",
-    "@jskit-ai/shell-web": "0.1.106"
+    "@jskit-ai/kernel": "0.1.108",
+    "@jskit-ai/shell-web": "0.1.107"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/uploads-image-web/package.descriptor.mjs
+++ b/packages/uploads-image-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-image-web",
-  version: "0.1.84",
+  version: "0.1.85",
   kind: "runtime",
   description: "Reusable client-side image upload runtime with pre-upload image editing.",
   dependsOn: [
@@ -65,7 +65,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/uploads-runtime": "0.1.84",
+        "@jskit-ai/uploads-runtime": "0.1.85",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-image-web/package.json
+++ b/packages/uploads-image-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-image-web",
-  "version": "0.1.84",
+  "version": "0.1.85",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,7 +13,7 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/uploads-runtime": "0.1.84",
+    "@jskit-ai/uploads-runtime": "0.1.85",
     "@uppy/compressor": "^3.1.0",
     "@uppy/core": "^5.2.0",
     "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-runtime/package.descriptor.mjs
+++ b/packages/uploads-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-runtime",
-  version: "0.1.84",
+  version: "0.1.85",
   kind: "runtime",
   description: "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
   dependsOn: [
@@ -71,7 +71,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.107"
+        "@jskit-ai/kernel": "0.1.108"
       },
       dev: {}
     },

--- a/packages/uploads-runtime/package.json
+++ b/packages/uploads-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-runtime",
-  "version": "0.1.84",
+  "version": "0.1.85",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,6 +16,6 @@
   },
   "dependencies": {
     "@fastify/multipart": "^9.4.0",
-    "@jskit-ai/kernel": "0.1.107"
+    "@jskit-ai/kernel": "0.1.108"
   }
 }

--- a/packages/users-core/package.descriptor.mjs
+++ b/packages/users-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-core",
-  version: "0.1.116",
+  version: "0.1.117",
   kind: "runtime",
   description: "Users/account runtime plus HTTP routes for account features.",
   dependsOn: [
@@ -146,16 +146,16 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.105",
-        "@jskit-ai/crud-core": "0.1.114",
-        "@jskit-ai/database-runtime": "0.1.106",
-        "@jskit-ai/http-runtime": "0.1.105",
-        "@jskit-ai/json-rest-api-core": "0.1.51",
-        "@jskit-ai/kernel": "0.1.107",
-        "@jskit-ai/resource-core": "0.1.51",
-        "@jskit-ai/resource-crud-core": "0.1.51",
+        "@jskit-ai/auth-core": "0.1.106",
+        "@jskit-ai/crud-core": "0.1.115",
+        "@jskit-ai/database-runtime": "0.1.107",
+        "@jskit-ai/http-runtime": "0.1.106",
+        "@jskit-ai/json-rest-api-core": "0.1.52",
+        "@jskit-ai/kernel": "0.1.108",
+        "@jskit-ai/resource-core": "0.1.52",
+        "@jskit-ai/resource-crud-core": "0.1.52",
         "@local/users": "file:packages/users",
-        "@jskit-ai/uploads-runtime": "0.1.84"
+        "@jskit-ai/uploads-runtime": "0.1.85"
       },
       dev: {}
     },
@@ -181,6 +181,15 @@ export default Object.freeze({
         reason: "Install users profile username migration.",
         category: "migration",
         id: "users-core-profile-username-schema"
+      },
+      {
+        op: "install-migration",
+        from: "templates/migrations/users_core_profile_updated_at.cjs",
+        toDir: "migrations",
+        extension: ".cjs",
+        reason: "Install users profile updated-at migration.",
+        category: "migration",
+        id: "users-core-profile-updated-at-schema"
       },
       {
         from: "templates/packages/users/package.json",

--- a/packages/users-core/package.json
+++ b/packages/users-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-core",
-  "version": "0.1.116",
+  "version": "0.1.117",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,14 +12,14 @@
     "./shared/resources/userSettingsResource": "./src/shared/resources/userSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.105",
-    "@jskit-ai/database-runtime": "0.1.106",
-    "@jskit-ai/http-runtime": "0.1.105",
-    "@jskit-ai/json-rest-api-core": "0.1.51",
-    "@jskit-ai/kernel": "0.1.107",
-    "@jskit-ai/resource-crud-core": "0.1.51",
-    "@jskit-ai/resource-core": "0.1.51",
-    "@jskit-ai/uploads-runtime": "0.1.84",
+    "@jskit-ai/auth-core": "0.1.106",
+    "@jskit-ai/database-runtime": "0.1.107",
+    "@jskit-ai/http-runtime": "0.1.106",
+    "@jskit-ai/json-rest-api-core": "0.1.52",
+    "@jskit-ai/kernel": "0.1.108",
+    "@jskit-ai/resource-crud-core": "0.1.52",
+    "@jskit-ai/resource-core": "0.1.52",
+    "@jskit-ai/uploads-runtime": "0.1.85",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/users-core/src/server/common/repositories/userProfilesRepository.js
+++ b/packages/users-core/src/server/common/repositories/userProfilesRepository.js
@@ -58,7 +58,8 @@ function normalizeProfileRecord(payload = null) {
     avatarStorageKey: normalizeNullableString(payload.avatarStorageKey),
     avatarVersion: normalizeNullableVersion(payload.avatarVersion),
     avatarUpdatedAt: payload.avatarUpdatedAt ? toIsoString(payload.avatarUpdatedAt) : null,
-    createdAt: payload.createdAt ? toIsoString(payload.createdAt) : null
+    createdAt: payload.createdAt ? toIsoString(payload.createdAt) : null,
+    updatedAt: payload.updatedAt ? toIsoString(payload.updatedAt) : null
   };
 }
 

--- a/packages/users-core/src/shared/resources/userProfileResource.js
+++ b/packages/users-core/src/shared/resources/userProfileResource.js
@@ -150,6 +150,14 @@ const userProfileResource = defineCrudResource({
         column: "created_at",
         writeSerializer: "datetime-utc"
       }
+    },
+    updatedAt: {
+      type: "dateTime",
+      default: "now()",
+      storage: {
+        column: "updated_at",
+        writeSerializer: "datetime-utc"
+      }
     }
   },
   messages: USER_PROFILE_OPERATION_MESSAGES,

--- a/packages/users-core/templates/migrations/users_core_generic_initial.cjs
+++ b/packages/users-core/templates/migrations/users_core_generic_initial.cjs
@@ -15,7 +15,6 @@ exports.up = async function up(knex) {
       table.string("avatar_version", 64).nullable();
       table.timestamp("avatar_updated_at", { useTz: false }).nullable();
       table.timestamp("created_at", { useTz: false }).notNullable().defaultTo(knex.fn.now());
-      table.timestamp("updated_at", { useTz: false }).notNullable().defaultTo(knex.fn.now());
       table.unique(["auth_provider", "auth_provider_user_sid"], "uq_users_identity");
       table.unique(["email"], "uq_users_email");
       table.unique(["username"], "uq_users_username");

--- a/packages/users-core/templates/migrations/users_core_generic_initial.cjs
+++ b/packages/users-core/templates/migrations/users_core_generic_initial.cjs
@@ -15,6 +15,7 @@ exports.up = async function up(knex) {
       table.string("avatar_version", 64).nullable();
       table.timestamp("avatar_updated_at", { useTz: false }).nullable();
       table.timestamp("created_at", { useTz: false }).notNullable().defaultTo(knex.fn.now());
+      table.timestamp("updated_at", { useTz: false }).notNullable().defaultTo(knex.fn.now());
       table.unique(["auth_provider", "auth_provider_user_sid"], "uq_users_identity");
       table.unique(["email"], "uq_users_email");
       table.unique(["username"], "uq_users_username");

--- a/packages/users-core/templates/migrations/users_core_profile_updated_at.cjs
+++ b/packages/users-core/templates/migrations/users_core_profile_updated_at.cjs
@@ -1,0 +1,48 @@
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function up(knex) {
+  const hasUsersTable = await knex.schema.hasTable("users");
+  if (!hasUsersTable) {
+    return;
+  }
+
+  const hasUpdatedAt = await knex.schema.hasColumn("users", "updated_at");
+  if (hasUpdatedAt) {
+    return;
+  }
+
+  await knex.schema.alterTable("users", (table) => {
+    table.timestamp("updated_at", { useTz: false }).nullable();
+  });
+
+  const hasCreatedAt = await knex.schema.hasColumn("users", "created_at");
+  await knex("users").whereNull("updated_at").update({
+    updated_at: hasCreatedAt
+      ? knex.raw("COALESCE(??, CURRENT_TIMESTAMP)", ["created_at"])
+      : knex.raw("CURRENT_TIMESTAMP")
+  });
+
+  await knex.schema.alterTable("users", (table) => {
+    table.timestamp("updated_at", { useTz: false }).notNullable().defaultTo(knex.fn.now()).alter();
+  });
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function down(knex) {
+  const hasUsersTable = await knex.schema.hasTable("users");
+  if (!hasUsersTable) {
+    return;
+  }
+
+  const hasUpdatedAt = await knex.schema.hasColumn("users", "updated_at");
+  if (!hasUpdatedAt) {
+    return;
+  }
+
+  await knex.schema.alterTable("users", (table) => {
+    table.dropColumn("updated_at");
+  });
+};

--- a/packages/users-core/templates/packages/users/src/shared/userResource.js
+++ b/packages/users-core/templates/packages/users/src/shared/userResource.js
@@ -39,6 +39,14 @@ const resource = defineCrudResource({
       operations: {
         output: { required: true }
       }
+    },
+    updatedAt: {
+      type: "dateTime",
+      required: true,
+      storage: { writeSerializer: "datetime-utc" },
+      operations: {
+        output: { required: true }
+      }
     }
   },
   searchSchema: {

--- a/packages/users-core/test/repositoryContracts.test.js
+++ b/packages/users-core/test/repositoryContracts.test.js
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { DEFAULT_USER_SETTINGS } from "../src/shared/settings.js";
+import { userProfileResource } from "../src/shared/resources/userProfileResource.js";
 import { createRepository as createUserProfilesRepository } from "../src/server/common/repositories/userProfilesRepository.js";
 import { createRepository as createUserSettingsRepository } from "../src/server/common/repositories/userSettingsRepository.js";
 
@@ -172,6 +173,133 @@ test("userProfilesRepository.upsert sends native JSON:API write documents with t
   assert.equal(postParams?.inputRecord?.data?.type, "userProfiles");
   assert.equal(postParams?.inputRecord?.data?.attributes?.authProvider, "supabase");
   assert.equal(record?.id, "11");
+});
+
+test("userProfilesRepository.upsert patches existing profiles with resource-backed updatedAt", async () => {
+  const trx = { trxId: "trx-1" };
+  const existingRecord = {
+    id: "7",
+    authProvider: "local",
+    authProviderUserSid: "local-user-7",
+    email: "ada@example.com",
+    username: "ada",
+    displayName: "Ada Example",
+    avatarStorageKey: null,
+    avatarVersion: null,
+    avatarUpdatedAt: null,
+    createdAt: "2026-04-20T00:00:00.000Z",
+    updatedAt: "2026-04-20T00:00:00.000Z"
+  };
+  let patchParams = null;
+  const repository = createUserProfilesRepository({
+    knex: createKnexStub(),
+    api: {
+      resources: {
+        userProfiles: {
+          async query({ queryParams }) {
+            const filters = queryParams?.filters || {};
+            if (Object.hasOwn(filters, "authProvider") || Object.hasOwn(filters, "authProviderUserSid")) {
+              return asCollectionDocument([existingRecord]);
+            }
+            if (Object.hasOwn(filters, "username")) {
+              return asCollectionDocument([]);
+            }
+            return asCollectionDocument([]);
+          },
+          async patch(params) {
+            patchParams = params;
+            const attributes = params.inputRecord?.data?.attributes || {};
+            return {
+              ...existingRecord,
+              ...attributes
+            };
+          }
+        }
+      }
+    }
+  });
+
+  const record = await repository.upsert({
+    authProvider: "local",
+    authProviderUserSid: "local-user-7",
+    email: " ADA.RENAMED@EXAMPLE.COM ",
+    displayName: "Ada Renamed"
+  }, { trx });
+
+  const attributes = patchParams?.inputRecord?.data?.attributes || {};
+  assert.equal(userProfileResource.schema.updatedAt?.type, "dateTime");
+  assert.equal(userProfileResource.schema.updatedAt?.storage?.column, "updated_at");
+  assert.equal(userProfileResource.schema.updatedAt?.storage?.writeSerializer, "datetime-utc");
+  assert.equal(patchParams?.transaction, trx);
+  assert.deepEqual(Object.keys(attributes).sort(), ["displayName", "email", "updatedAt", "username"]);
+  assert.equal(attributes.email, "ada.renamed@example.com");
+  assert.equal(attributes.displayName, "Ada Renamed");
+  assert.equal(attributes.username, "ada");
+  assert.ok(attributes.updatedAt instanceof Date);
+  assert.equal(record?.id, "7");
+  assert.equal(record?.updatedAt, attributes.updatedAt.toISOString());
+});
+
+test("userProfilesRepository profile patch helpers stamp updatedAt through the resource contract", async () => {
+  const trx = { trxId: "trx-1" };
+  const calls = [];
+  const repository = createUserProfilesRepository({
+    knex: createKnexStub(),
+    api: {
+      resources: {
+        userProfiles: {
+          async query() {
+            return asCollectionDocument([]);
+          },
+          async patch(params) {
+            calls.push(params);
+            const attributes = params.inputRecord?.data?.attributes || {};
+            return {
+              id: params.inputRecord?.data?.id || "7",
+              authProvider: "local",
+              authProviderUserSid: "local-user-7",
+              email: "ada@example.com",
+              username: "ada",
+              displayName: attributes.displayName || "Ada Example",
+              avatarStorageKey: attributes.avatarStorageKey ?? null,
+              avatarVersion: attributes.avatarVersion ?? null,
+              avatarUpdatedAt: attributes.avatarUpdatedAt ?? null,
+              createdAt: "2026-04-20T00:00:00.000Z",
+              updatedAt: attributes.updatedAt
+            };
+          }
+        }
+      }
+    }
+  });
+  const avatarUpdatedAt = new Date("2026-04-21T12:00:00.000Z");
+
+  await repository.updateDisplayNameById("7", "Ada Updated", { trx });
+  await repository.updateAvatarById("7", {
+    avatarStorageKey: "avatars/7.png",
+    avatarVersion: "v1",
+    avatarUpdatedAt
+  }, { trx });
+  await repository.clearAvatarById("7", { trx });
+
+  assert.equal(calls.length, 3);
+  for (const call of calls) {
+    assert.equal(call.transaction, trx);
+    assert.ok(call.inputRecord?.data?.attributes?.updatedAt instanceof Date);
+  }
+  assert.deepEqual(Object.keys(calls[0].inputRecord.data.attributes).sort(), ["displayName", "updatedAt"]);
+  assert.deepEqual(Object.keys(calls[1].inputRecord.data.attributes).sort(), [
+    "avatarStorageKey",
+    "avatarUpdatedAt",
+    "avatarVersion",
+    "updatedAt"
+  ]);
+  assert.equal(calls[1].inputRecord.data.attributes.avatarStorageKey, "avatars/7.png");
+  assert.equal(calls[1].inputRecord.data.attributes.avatarVersion, "v1");
+  assert.equal(calls[1].inputRecord.data.attributes.avatarUpdatedAt, avatarUpdatedAt);
+  assert.deepEqual(calls[2].inputRecord.data.attributes.avatarStorageKey, null);
+  assert.deepEqual(calls[2].inputRecord.data.attributes.avatarVersion, null);
+  assert.deepEqual(calls[2].inputRecord.data.attributes.avatarUpdatedAt, null);
 });
 
 test("userProfilesRepository.findByEmail normalizes email lookup", async () => {

--- a/packages/users-core/test/resourcesCanonical.test.js
+++ b/packages/users-core/test/resourcesCanonical.test.js
@@ -38,6 +38,15 @@ test("users-core resources expose messages for all operations", () => {
   }
 });
 
+test("user profile resource exposes managed timestamps used by JSON REST writes", () => {
+  assert.equal(userProfileResource.schema.createdAt?.type, "dateTime");
+  assert.equal(userProfileResource.schema.createdAt?.storage?.column, "created_at");
+  assert.equal(userProfileResource.schema.createdAt?.storage?.writeSerializer, "datetime-utc");
+  assert.equal(userProfileResource.schema.updatedAt?.type, "dateTime");
+  assert.equal(userProfileResource.schema.updatedAt?.storage?.column, "updated_at");
+  assert.equal(userProfileResource.schema.updatedAt?.storage?.writeSerializer, "datetime-utc");
+});
+
 test("users-core specialized resource operations expose messages and validators", () => {
   const operationSpecs = [
     { label: "userProfile.avatarUpload", operation: userProfileResource.operations.avatarUpload },

--- a/packages/users-core/test/usersPackageScaffoldContract.test.js
+++ b/packages/users-core/test/usersPackageScaffoldContract.test.js
@@ -49,6 +49,37 @@ test("users-core installs the app-local users package scaffold", () => {
   }
 });
 
+test("users-core installs all users profile schema migrations", async () => {
+  const expectedMigrationIds = [
+    "users-core-generic-initial-schema",
+    "users-core-profile-username-schema",
+    "users-core-profile-updated-at-schema"
+  ];
+
+  for (const migrationId of expectedMigrationIds) {
+    const mutation = readFileMutationById(migrationId);
+    assert.ok(mutation, `Missing users-core migration mutation ${migrationId}.`);
+    assert.equal(mutation.op, "install-migration", `${migrationId} must install a migration.`);
+    assert.equal(mutation.toDir, "migrations", `${migrationId} must target app migrations.`);
+    assert.equal(mutation.category, "migration", `${migrationId} must be categorized as a migration.`);
+    assert.ok(mutation.from, `${migrationId} must define a migration template source.`);
+    assert.ok(mutation.reason, `${migrationId} must document why it exists.`);
+  }
+
+  const initialMigrationSource = await readFile(
+    path.join(PACKAGE_ROOT, "templates/migrations/users_core_generic_initial.cjs"),
+    "utf8"
+  );
+  const updatedAtMigrationSource = await readFile(
+    path.join(PACKAGE_ROOT, "templates/migrations/users_core_profile_updated_at.cjs"),
+    "utf8"
+  );
+
+  assert.match(initialMigrationSource, /table\.timestamp\("updated_at"/);
+  assert.match(updatedAtMigrationSource, /hasColumn\("users", "updated_at"\)/);
+  assert.match(updatedAtMigrationSource, /COALESCE\(\?\?, CURRENT_TIMESTAMP\)/);
+});
+
 test("users-core base users package templates stay aligned with non-workspace apps", async () => {
   const packageDescriptorSource = await readFile(
     path.join(PACKAGE_ROOT, "templates/packages/users/package.descriptor.mjs"),
@@ -181,4 +212,6 @@ test("users-core local users resource scaffold stays read-only and canonical", a
   assert.equal(typeof resource, "object");
   assert.deepEqual(Object.keys(resource.operations), ["list", "view"]);
   assert.equal(Object.hasOwn(resource.operations, "create"), false);
+  assert.equal(resource.schema.updatedAt?.type, "dateTime");
+  assert.equal(resource.schema.updatedAt?.storage?.writeSerializer, "datetime-utc");
 });

--- a/packages/users-core/test/usersPackageScaffoldContract.test.js
+++ b/packages/users-core/test/usersPackageScaffoldContract.test.js
@@ -66,16 +66,17 @@ test("users-core installs all users profile schema migrations", async () => {
     assert.ok(mutation.reason, `${migrationId} must document why it exists.`);
   }
 
-  const initialMigrationSource = await readFile(
-    path.join(PACKAGE_ROOT, "templates/migrations/users_core_generic_initial.cjs"),
-    "utf8"
-  );
   const updatedAtMigrationSource = await readFile(
     path.join(PACKAGE_ROOT, "templates/migrations/users_core_profile_updated_at.cjs"),
     "utf8"
   );
+  const initialMigrationSource = await readFile(
+    path.join(PACKAGE_ROOT, "templates/migrations/users_core_generic_initial.cjs"),
+    "utf8"
+  );
+  const usersTableSection = initialMigrationSource.split("const hasUserSettingsTable")[0] || "";
 
-  assert.match(initialMigrationSource, /table\.timestamp\("updated_at"/);
+  assert.doesNotMatch(usersTableSection, /table\.timestamp\("updated_at"/);
   assert.match(updatedAtMigrationSource, /hasColumn\("users", "updated_at"\)/);
   assert.match(updatedAtMigrationSource, /COALESCE\(\?\?, CURRENT_TIMESTAMP\)/);
 });

--- a/packages/users-web/package.descriptor.mjs
+++ b/packages/users-web/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { HOME_COG_OUTLET } from "./src/shared/toolsOutletContracts.js";
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-web",
-  version: "0.1.121",
+  version: "0.1.122",
   kind: "runtime",
   description: "Users web module: account/profile UI plus shared users web widgets.",
   dependsOn: [
@@ -286,12 +286,12 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/http-runtime": "0.1.105",
-        "@jskit-ai/realtime": "0.1.105",
-        "@jskit-ai/kernel": "0.1.107",
-        "@jskit-ai/shell-web": "0.1.106",
-        "@jskit-ai/uploads-image-web": "0.1.84",
-        "@jskit-ai/users-core": "0.1.116"
+        "@jskit-ai/http-runtime": "0.1.106",
+        "@jskit-ai/realtime": "0.1.106",
+        "@jskit-ai/kernel": "0.1.108",
+        "@jskit-ai/shell-web": "0.1.107",
+        "@jskit-ai/uploads-image-web": "0.1.85",
+        "@jskit-ai/users-core": "0.1.117"
       },
       dev: {}
     },

--- a/packages/users-web/package.json
+++ b/packages/users-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-web",
-  "version": "0.1.121",
+  "version": "0.1.122",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -46,12 +46,12 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/http-runtime": "0.1.105",
-    "@jskit-ai/kernel": "0.1.107",
-    "@jskit-ai/realtime": "0.1.105",
-    "@jskit-ai/shell-web": "0.1.106",
-    "@jskit-ai/uploads-image-web": "0.1.84",
-    "@jskit-ai/users-core": "0.1.116"
+    "@jskit-ai/http-runtime": "0.1.106",
+    "@jskit-ai/kernel": "0.1.108",
+    "@jskit-ai/realtime": "0.1.106",
+    "@jskit-ai/shell-web": "0.1.107",
+    "@jskit-ai/uploads-image-web": "0.1.85",
+    "@jskit-ai/users-core": "0.1.117"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/workspaces-core/package.descriptor.mjs
+++ b/packages/workspaces-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-core",
-  version: "0.1.82",
+  version: "0.1.83",
   kind: "runtime",
   description: "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
   dependsOn: [
@@ -147,10 +147,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/json-rest-api-core": "0.1.51",
-        "@jskit-ai/resource-core": "0.1.51",
-        "@jskit-ai/resource-crud-core": "0.1.51",
-        "@jskit-ai/users-core": "0.1.116"
+        "@jskit-ai/json-rest-api-core": "0.1.52",
+        "@jskit-ai/resource-core": "0.1.52",
+        "@jskit-ai/resource-crud-core": "0.1.52",
+        "@jskit-ai/users-core": "0.1.117"
       },
       dev: {}
     },

--- a/packages/workspaces-core/package.json
+++ b/packages/workspaces-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-core",
-  "version": "0.1.82",
+  "version": "0.1.83",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -18,14 +18,14 @@
     "./shared/resources/workspaceSettingsResource": "./src/shared/resources/workspaceSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.105",
-    "@jskit-ai/database-runtime": "0.1.106",
-    "@jskit-ai/http-runtime": "0.1.105",
-    "@jskit-ai/json-rest-api-core": "0.1.51",
-    "@jskit-ai/kernel": "0.1.107",
-    "@jskit-ai/resource-crud-core": "0.1.51",
-    "@jskit-ai/resource-core": "0.1.51",
-    "@jskit-ai/users-core": "0.1.116",
+    "@jskit-ai/auth-core": "0.1.106",
+    "@jskit-ai/database-runtime": "0.1.107",
+    "@jskit-ai/http-runtime": "0.1.106",
+    "@jskit-ai/json-rest-api-core": "0.1.52",
+    "@jskit-ai/kernel": "0.1.108",
+    "@jskit-ai/resource-crud-core": "0.1.52",
+    "@jskit-ai/resource-core": "0.1.52",
+    "@jskit-ai/users-core": "0.1.117",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/workspaces-web/package.descriptor.mjs
+++ b/packages/workspaces-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-web",
-  version: "0.1.83",
+  version: "0.1.84",
   kind: "runtime",
   description: "Workspace web module: workspace selector, tools widget, workspace surfaces, members UI, and settings hosts.",
   dependsOn: [
@@ -232,9 +232,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-web": "0.1.107",
-        "@jskit-ai/workspaces-core": "0.1.82",
-        "@jskit-ai/users-web": "0.1.121"
+        "@jskit-ai/auth-web": "0.1.108",
+        "@jskit-ai/workspaces-core": "0.1.83",
+        "@jskit-ai/users-web": "0.1.122"
       },
       dev: {}
     },

--- a/packages/workspaces-web/package.json
+++ b/packages/workspaces-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-web",
-  "version": "0.1.83",
+  "version": "0.1.84",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -15,13 +15,13 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/auth-web": "0.1.107",
-    "@jskit-ai/http-runtime": "0.1.105",
-    "@jskit-ai/kernel": "0.1.107",
-    "@jskit-ai/shell-web": "0.1.106",
-    "@jskit-ai/users-core": "0.1.116",
-    "@jskit-ai/users-web": "0.1.121",
-    "@jskit-ai/workspaces-core": "0.1.82"
+    "@jskit-ai/auth-web": "0.1.108",
+    "@jskit-ai/http-runtime": "0.1.106",
+    "@jskit-ai/kernel": "0.1.108",
+    "@jskit-ai/shell-web": "0.1.107",
+    "@jskit-ai/users-core": "0.1.117",
+    "@jskit-ai/users-web": "0.1.122",
+    "@jskit-ai/workspaces-core": "0.1.83"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/tooling/config-eslint/package.json
+++ b/tooling/config-eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/config-eslint",
-  "version": "0.1.105",
+  "version": "0.1.106",
   "description": "Shared flat ESLint presets for JSKIT projects.",
   "type": "module",
   "files": [

--- a/tooling/create-app/package.descriptor.mjs
+++ b/tooling/create-app/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/create-app",
-  "version": "0.1.115",
+  "version": "0.1.116",
   "dependsOn": [],
   "capabilities": {
     "provides": [

--- a/tooling/create-app/package.json
+++ b/tooling/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/create-app",
-  "version": "0.1.115",
+  "version": "0.1.116",
   "description": "Scaffold JSKIT app shells.",
   "type": "module",
   "files": [

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -6,11 +6,11 @@
   "packages": [
     {
       "packageId": "@jskit-ai/assistant",
-      "version": "0.1.115",
+      "version": "0.1.116",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant",
-        "version": "0.1.115",
+        "version": "0.1.116",
         "kind": "generator",
         "description": "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
         "options": {
@@ -347,11 +347,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-core",
-      "version": "0.1.82",
+      "version": "0.1.83",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-core",
-        "version": "0.1.82",
+        "version": "0.1.83",
         "kind": "runtime",
         "description": "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
         "dependsOn": [
@@ -399,11 +399,11 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/http-runtime": "0.1.105",
-              "@jskit-ai/kernel": "0.1.107",
-              "@jskit-ai/resource-core": "0.1.51",
-              "@jskit-ai/resource-crud-core": "0.1.51",
-              "@jskit-ai/users-core": "0.1.116",
+              "@jskit-ai/http-runtime": "0.1.106",
+              "@jskit-ai/kernel": "0.1.108",
+              "@jskit-ai/resource-core": "0.1.52",
+              "@jskit-ai/resource-crud-core": "0.1.52",
+              "@jskit-ai/users-core": "0.1.117",
               "dompurify": "^3.3.3",
               "json-rest-schema": "1.x.x",
               "marked": "^17.0.4",
@@ -422,11 +422,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-runtime",
-      "version": "0.1.77",
+      "version": "0.1.78",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-runtime",
-        "version": "0.1.77",
+        "version": "0.1.78",
         "kind": "runtime",
         "description": "Shared assistant runtime with per-surface assistant registration.",
         "dependsOn": [
@@ -522,13 +522,13 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/assistant-core": "0.1.82",
-              "@jskit-ai/database-runtime": "0.1.106",
-              "@jskit-ai/http-runtime": "0.1.105",
-              "@jskit-ai/kernel": "0.1.107",
-              "@jskit-ai/shell-web": "0.1.106",
-              "@jskit-ai/users-core": "0.1.116",
-              "@jskit-ai/users-web": "0.1.121"
+              "@jskit-ai/assistant-core": "0.1.83",
+              "@jskit-ai/database-runtime": "0.1.107",
+              "@jskit-ai/http-runtime": "0.1.106",
+              "@jskit-ai/kernel": "0.1.108",
+              "@jskit-ai/shell-web": "0.1.107",
+              "@jskit-ai/users-core": "0.1.117",
+              "@jskit-ai/users-web": "0.1.122"
             },
             "dev": {}
           },
@@ -583,11 +583,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-core",
-      "version": "0.1.105",
+      "version": "0.1.106",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-core",
-        "version": "0.1.105",
+        "version": "0.1.106",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/value-app-config-shared"
@@ -660,7 +660,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.107",
+              "@jskit-ai/kernel": "0.1.108",
               "@fastify/cookie": "^11.0.2",
               "@fastify/csrf-protection": "^7.1.0",
               "@fastify/rate-limit": "^10.3.0"
@@ -678,11 +678,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-local-core",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-local-core",
-        "version": "0.1.6",
+        "version": "0.1.7",
         "kind": "runtime",
         "description": "Local auth provider with a file backend default and no database requirement.",
         "dependsOn": [
@@ -738,8 +738,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.105",
-              "@jskit-ai/kernel": "0.1.107",
+              "@jskit-ai/auth-core": "0.1.106",
+              "@jskit-ai/kernel": "0.1.108",
               "nodemailer": "^7.0.10",
               "dotenv": "^16.4.5"
             },
@@ -785,11 +785,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.105",
+      "version": "0.1.106",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-supabase-core",
-        "version": "0.1.105",
+        "version": "0.1.106",
         "kind": "runtime",
         "options": {
           "auth-supabase-url": {
@@ -871,8 +871,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.105",
-              "@jskit-ai/kernel": "0.1.107",
+              "@jskit-ai/auth-core": "0.1.106",
+              "@jskit-ai/kernel": "0.1.108",
               "dotenv": "^16.4.5",
               "@supabase/supabase-js": "^2.57.4",
               "jose": "^6.1.0"
@@ -950,11 +950,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-web",
-      "version": "0.1.107",
+      "version": "0.1.108",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-web",
-        "version": "0.1.107",
+        "version": "0.1.108",
         "kind": "runtime",
         "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
         "dependsOn": [
@@ -1223,10 +1223,10 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/auth-core": "0.1.105",
-              "@jskit-ai/http-runtime": "0.1.105",
-              "@jskit-ai/kernel": "0.1.107",
-              "@jskit-ai/shell-web": "0.1.106"
+              "@jskit-ai/auth-core": "0.1.106",
+              "@jskit-ai/http-runtime": "0.1.106",
+              "@jskit-ai/kernel": "0.1.108",
+              "@jskit-ai/shell-web": "0.1.107"
             },
             "dev": {}
           },
@@ -1319,11 +1319,11 @@
     },
     {
       "packageId": "@jskit-ai/console-core",
-      "version": "0.1.69",
+      "version": "0.1.70",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-core",
-        "version": "0.1.69",
+        "version": "0.1.70",
         "kind": "runtime",
         "description": "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
         "dependsOn": [
@@ -1407,12 +1407,12 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.105",
-              "@jskit-ai/database-runtime": "0.1.106",
-              "@jskit-ai/http-runtime": "0.1.105",
-              "@jskit-ai/kernel": "0.1.107",
-              "@jskit-ai/resource-crud-core": "0.1.51",
-              "@jskit-ai/users-core": "0.1.116"
+              "@jskit-ai/auth-core": "0.1.106",
+              "@jskit-ai/database-runtime": "0.1.107",
+              "@jskit-ai/http-runtime": "0.1.106",
+              "@jskit-ai/kernel": "0.1.108",
+              "@jskit-ai/resource-crud-core": "0.1.52",
+              "@jskit-ai/users-core": "0.1.117"
             },
             "dev": {}
           },
@@ -1437,11 +1437,11 @@
     },
     {
       "packageId": "@jskit-ai/console-web",
-      "version": "0.1.74",
+      "version": "0.1.75",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-web",
-        "version": "0.1.74",
+        "version": "0.1.75",
         "kind": "runtime",
         "description": "Authenticated console surface scaffold and surface policy wiring.",
         "dependsOn": [
@@ -1551,9 +1551,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-web": "0.1.107",
-              "@jskit-ai/console-core": "0.1.69",
-              "@jskit-ai/shell-web": "0.1.106"
+              "@jskit-ai/auth-web": "0.1.108",
+              "@jskit-ai/console-core": "0.1.70",
+              "@jskit-ai/shell-web": "0.1.107"
             },
             "dev": {}
           },
@@ -1660,11 +1660,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-core",
-      "version": "0.1.114",
+      "version": "0.1.115",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-core",
-        "version": "0.1.114",
+        "version": "0.1.115",
         "kind": "runtime",
         "description": "Shared CRUD helpers used by CRUD modules.",
         "dependsOn": [
@@ -1693,7 +1693,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/crud-core": "0.1.114"
+              "@jskit-ai/crud-core": "0.1.115"
             },
             "dev": {}
           },
@@ -1707,11 +1707,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-server-generator",
-      "version": "0.1.114",
+      "version": "0.1.115",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-server-generator",
-        "version": "0.1.114",
+        "version": "0.1.115",
         "kind": "generator",
         "description": "CRUD server generator with routes, actions, and persistence scaffolding.",
         "options": {
@@ -1878,14 +1878,14 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.105",
-              "@jskit-ai/crud-core": "0.1.114",
-              "@jskit-ai/database-runtime": "0.1.106",
-              "@jskit-ai/http-runtime": "0.1.105",
-              "@jskit-ai/json-rest-api-core": "0.1.51",
-              "@jskit-ai/kernel": "0.1.107",
-              "@jskit-ai/realtime": "0.1.105",
-              "@jskit-ai/resource-crud-core": "0.1.51",
+              "@jskit-ai/auth-core": "0.1.106",
+              "@jskit-ai/crud-core": "0.1.115",
+              "@jskit-ai/database-runtime": "0.1.107",
+              "@jskit-ai/http-runtime": "0.1.106",
+              "@jskit-ai/json-rest-api-core": "0.1.52",
+              "@jskit-ai/kernel": "0.1.108",
+              "@jskit-ai/realtime": "0.1.106",
+              "@jskit-ai/resource-crud-core": "0.1.52",
               "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}"
             },
             "dev": {}
@@ -2017,11 +2017,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.89",
+      "version": "0.1.90",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-ui-generator",
-        "version": "0.1.89",
+        "version": "0.1.90",
         "kind": "generator",
         "description": "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
         "options": {
@@ -2220,7 +2220,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.121"
+              "@jskit-ai/users-web": "0.1.122"
             },
             "dev": {}
           },
@@ -2479,11 +2479,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime",
-      "version": "0.1.106",
+      "version": "0.1.107",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime",
-        "version": "0.1.106",
+        "version": "0.1.107",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -2540,7 +2540,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.107",
+              "@jskit-ai/kernel": "0.1.108",
               "dotenv": "^16.4.5",
               "knex": "^3.1.0"
             },
@@ -2575,11 +2575,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.105",
+      "version": "0.1.106",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-mysql",
-        "version": "0.1.105",
+        "version": "0.1.106",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -2669,7 +2669,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.106",
+              "@jskit-ai/database-runtime": "0.1.107",
               "mysql2": "^3.11.2"
             },
             "dev": {}
@@ -2740,11 +2740,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.105",
+      "version": "0.1.106",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-postgres",
-        "version": "0.1.105",
+        "version": "0.1.106",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -2834,7 +2834,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.106",
+              "@jskit-ai/database-runtime": "0.1.107",
               "pg": "^8.13.1"
             },
             "dev": {}
@@ -2905,11 +2905,11 @@
     },
     {
       "packageId": "@jskit-ai/feature-server-generator",
-      "version": "0.1.48",
+      "version": "0.1.49",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/feature-server-generator",
-        "version": "0.1.48",
+        "version": "0.1.49",
         "kind": "generator",
         "description": "Scaffold substantial non-CRUD server feature packages with provider, actions, service, and optional persistence seams.",
         "options": {
@@ -3094,7 +3094,7 @@
                   "equals": "json-rest"
                 }
               },
-              "@jskit-ai/kernel": "0.1.107",
+              "@jskit-ai/kernel": "0.1.108",
               "json-rest-schema": "1.x.x",
               "@local/${option:feature-name|kebab}": "file:packages/${option:feature-name|kebab}"
             },
@@ -3207,11 +3207,11 @@
     },
     {
       "packageId": "@jskit-ai/google-rewarded-core",
-      "version": "0.1.43",
+      "version": "0.1.44",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/google-rewarded-core",
-        "version": "0.1.43",
+        "version": "0.1.44",
         "kind": "runtime",
         "description": "Google rewarded workflow runtime plus internal CRUD providers for rules, provider configs, watch sessions, and unlock receipts.",
         "dependsOn": [
@@ -3338,14 +3338,14 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.105",
-              "@jskit-ai/crud-core": "0.1.114",
-              "@jskit-ai/database-runtime": "0.1.106",
-              "@jskit-ai/http-runtime": "0.1.105",
-              "@jskit-ai/json-rest-api-core": "0.1.51",
-              "@jskit-ai/kernel": "0.1.107",
-              "@jskit-ai/resource-crud-core": "0.1.51",
-              "@jskit-ai/workspaces-core": "0.1.82"
+              "@jskit-ai/auth-core": "0.1.106",
+              "@jskit-ai/crud-core": "0.1.115",
+              "@jskit-ai/database-runtime": "0.1.107",
+              "@jskit-ai/http-runtime": "0.1.106",
+              "@jskit-ai/json-rest-api-core": "0.1.52",
+              "@jskit-ai/kernel": "0.1.108",
+              "@jskit-ai/resource-crud-core": "0.1.52",
+              "@jskit-ai/workspaces-core": "0.1.83"
             },
             "dev": {}
           },
@@ -3397,11 +3397,11 @@
     },
     {
       "packageId": "@jskit-ai/google-rewarded-web",
-      "version": "0.1.43",
+      "version": "0.1.44",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/google-rewarded-web",
-        "version": "0.1.43",
+        "version": "0.1.44",
         "kind": "runtime",
         "description": "Google rewarded client runtime with a fullscreen gate host and GPT orchestration.",
         "dependsOn": [
@@ -3448,10 +3448,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/google-rewarded-core": "0.1.43",
-              "@jskit-ai/http-runtime": "0.1.105",
-              "@jskit-ai/kernel": "0.1.107",
-              "@jskit-ai/shell-web": "0.1.106"
+              "@jskit-ai/google-rewarded-core": "0.1.44",
+              "@jskit-ai/http-runtime": "0.1.106",
+              "@jskit-ai/kernel": "0.1.108",
+              "@jskit-ai/shell-web": "0.1.107"
             },
             "dev": {}
           },
@@ -3469,11 +3469,11 @@
     },
     {
       "packageId": "@jskit-ai/http-runtime",
-      "version": "0.1.105",
+      "version": "0.1.106",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/http-runtime",
-        "version": "0.1.105",
+        "version": "0.1.106",
         "kind": "runtime",
         "dependsOn": [],
         "capabilities": {
@@ -3539,7 +3539,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.107"
+              "@jskit-ai/kernel": "0.1.108"
             },
             "dev": {}
           },
@@ -3553,11 +3553,11 @@
     },
     {
       "packageId": "@jskit-ai/json-rest-api-core",
-      "version": "0.1.51",
+      "version": "0.1.52",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/json-rest-api-core",
-        "version": "0.1.51",
+        "version": "0.1.52",
         "kind": "runtime",
         "description": "Shared internal json-rest-api host runtime for JSKIT server packages.",
         "dependsOn": [
@@ -3617,11 +3617,11 @@
     },
     {
       "packageId": "@jskit-ai/mobile-capacitor",
-      "version": "0.1.43",
+      "version": "0.1.44",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/mobile-capacitor",
-        "version": "0.1.43",
+        "version": "0.1.44",
         "kind": "runtime",
         "description": "Thin Capacitor client integration for JSKIT mobile-shell launch routing and auth callback completion.",
         "dependsOn": [
@@ -3684,8 +3684,8 @@
               "@capacitor/app": "^7.1.0",
               "@capacitor/browser": "^7.0.1",
               "@capacitor/core": "^7.4.3",
-              "@jskit-ai/kernel": "0.1.107",
-              "@jskit-ai/shell-web": "0.1.106"
+              "@jskit-ai/kernel": "0.1.108",
+              "@jskit-ai/shell-web": "0.1.107"
             },
             "dev": {
               "@capacitor/cli": "^7.4.3"
@@ -3737,11 +3737,11 @@
     },
     {
       "packageId": "@jskit-ai/realtime",
-      "version": "0.1.105",
+      "version": "0.1.106",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/realtime",
-        "version": "0.1.105",
+        "version": "0.1.106",
         "kind": "runtime",
         "description": "Thin, generic realtime runtime wrappers for socket.io server and client.",
         "options": {
@@ -3837,7 +3837,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.107",
+              "@jskit-ai/kernel": "0.1.108",
               "@socket.io/redis-adapter": "^8.3.0",
               "redis": "^5.8.2",
               "socket.io": "^4.8.3",
@@ -3886,11 +3886,11 @@
     },
     {
       "packageId": "@jskit-ai/resource-core",
-      "version": "0.1.51",
+      "version": "0.1.52",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/resource-core",
-        "version": "0.1.51",
+        "version": "0.1.52",
         "kind": "runtime",
         "description": "Generic resource-definition helpers and schema-definition normalization.",
         "dependsOn": [
@@ -3913,7 +3913,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/resource-core": "0.1.51"
+              "@jskit-ai/resource-core": "0.1.52"
             },
             "dev": {}
           },
@@ -3928,11 +3928,11 @@
     },
     {
       "packageId": "@jskit-ai/resource-crud-core",
-      "version": "0.1.51",
+      "version": "0.1.52",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/resource-crud-core",
-        "version": "0.1.51",
+        "version": "0.1.52",
         "kind": "runtime",
         "description": "CRUD-specific resource-definition helpers and namespace support.",
         "dependsOn": [
@@ -3956,7 +3956,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/resource-crud-core": "0.1.51"
+              "@jskit-ai/resource-crud-core": "0.1.52"
             },
             "dev": {}
           },
@@ -3971,11 +3971,11 @@
     },
     {
       "packageId": "@jskit-ai/shell-web",
-      "version": "0.1.106",
+      "version": "0.1.107",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/shell-web",
-        "version": "0.1.106",
+        "version": "0.1.107",
         "kind": "runtime",
         "description": "Web shell layout runtime with outlet-based placement contributions.",
         "dependsOn": [],
@@ -4317,7 +4317,7 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/kernel": "0.1.107"
+              "@jskit-ai/kernel": "0.1.108"
             },
             "dev": {}
           },
@@ -4524,11 +4524,11 @@
     },
     {
       "packageId": "@jskit-ai/storage-runtime",
-      "version": "0.1.105",
+      "version": "0.1.106",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/storage-runtime",
-        "version": "0.1.105",
+        "version": "0.1.106",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -4577,7 +4577,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.107",
+              "@jskit-ai/kernel": "0.1.108",
               "unstorage": "^1.17.3"
             },
             "dev": {}
@@ -4593,11 +4593,11 @@
     },
     {
       "packageId": "@jskit-ai/ui-generator",
-      "version": "0.1.89",
+      "version": "0.1.90",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/ui-generator",
-        "version": "0.1.89",
+        "version": "0.1.90",
         "kind": "generator",
         "description": "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
         "options": {
@@ -5030,7 +5030,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.121"
+              "@jskit-ai/users-web": "0.1.122"
             },
             "dev": {}
           },
@@ -5045,11 +5045,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-image-web",
-      "version": "0.1.84",
+      "version": "0.1.85",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-image-web",
-        "version": "0.1.84",
+        "version": "0.1.85",
         "kind": "runtime",
         "description": "Reusable client-side image upload runtime with pre-upload image editing.",
         "dependsOn": [
@@ -5113,7 +5113,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/uploads-runtime": "0.1.84",
+              "@jskit-ai/uploads-runtime": "0.1.85",
               "@uppy/compressor": "^3.1.0",
               "@uppy/core": "^5.2.0",
               "@uppy/dashboard": "^5.1.1",
@@ -5133,11 +5133,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-runtime",
-      "version": "0.1.84",
+      "version": "0.1.85",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-runtime",
-        "version": "0.1.84",
+        "version": "0.1.85",
         "kind": "runtime",
         "description": "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
         "dependsOn": [
@@ -5207,7 +5207,7 @@
           "dependencies": {
             "runtime": {
               "@fastify/multipart": "^9.4.0",
-              "@jskit-ai/kernel": "0.1.107"
+              "@jskit-ai/kernel": "0.1.108"
             },
             "dev": {}
           },
@@ -5222,11 +5222,11 @@
     },
     {
       "packageId": "@jskit-ai/users-core",
-      "version": "0.1.116",
+      "version": "0.1.117",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-core",
-        "version": "0.1.116",
+        "version": "0.1.117",
         "kind": "runtime",
         "description": "Users/account runtime plus HTTP routes for account features.",
         "dependsOn": [
@@ -5370,16 +5370,16 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.105",
-              "@jskit-ai/crud-core": "0.1.114",
-              "@jskit-ai/database-runtime": "0.1.106",
-              "@jskit-ai/http-runtime": "0.1.105",
-              "@jskit-ai/json-rest-api-core": "0.1.51",
-              "@jskit-ai/kernel": "0.1.107",
-              "@jskit-ai/resource-core": "0.1.51",
-              "@jskit-ai/resource-crud-core": "0.1.51",
+              "@jskit-ai/auth-core": "0.1.106",
+              "@jskit-ai/crud-core": "0.1.115",
+              "@jskit-ai/database-runtime": "0.1.107",
+              "@jskit-ai/http-runtime": "0.1.106",
+              "@jskit-ai/json-rest-api-core": "0.1.52",
+              "@jskit-ai/kernel": "0.1.108",
+              "@jskit-ai/resource-core": "0.1.52",
+              "@jskit-ai/resource-crud-core": "0.1.52",
               "@local/users": "file:packages/users",
-              "@jskit-ai/uploads-runtime": "0.1.84"
+              "@jskit-ai/uploads-runtime": "0.1.85"
             },
             "dev": {}
           },
@@ -5405,6 +5405,15 @@
               "reason": "Install users profile username migration.",
               "category": "migration",
               "id": "users-core-profile-username-schema"
+            },
+            {
+              "op": "install-migration",
+              "from": "templates/migrations/users_core_profile_updated_at.cjs",
+              "toDir": "migrations",
+              "extension": ".cjs",
+              "reason": "Install users profile updated-at migration.",
+              "category": "migration",
+              "id": "users-core-profile-updated-at-schema"
             },
             {
               "from": "templates/packages/users/package.json",
@@ -5597,11 +5606,11 @@
     },
     {
       "packageId": "@jskit-ai/users-web",
-      "version": "0.1.121",
+      "version": "0.1.122",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-web",
-        "version": "0.1.121",
+        "version": "0.1.122",
         "kind": "runtime",
         "description": "Users web module: account/profile UI plus shared users web widgets.",
         "dependsOn": [
@@ -5904,12 +5913,12 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/http-runtime": "0.1.105",
-              "@jskit-ai/realtime": "0.1.105",
-              "@jskit-ai/kernel": "0.1.107",
-              "@jskit-ai/shell-web": "0.1.106",
-              "@jskit-ai/uploads-image-web": "0.1.84",
-              "@jskit-ai/users-core": "0.1.116"
+              "@jskit-ai/http-runtime": "0.1.106",
+              "@jskit-ai/realtime": "0.1.106",
+              "@jskit-ai/kernel": "0.1.108",
+              "@jskit-ai/shell-web": "0.1.107",
+              "@jskit-ai/uploads-image-web": "0.1.85",
+              "@jskit-ai/users-core": "0.1.117"
             },
             "dev": {}
           },
@@ -6086,11 +6095,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-core",
-      "version": "0.1.82",
+      "version": "0.1.83",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-core",
-        "version": "0.1.82",
+        "version": "0.1.83",
         "kind": "runtime",
         "description": "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
         "dependsOn": [
@@ -6236,10 +6245,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/json-rest-api-core": "0.1.51",
-              "@jskit-ai/resource-core": "0.1.51",
-              "@jskit-ai/resource-crud-core": "0.1.51",
-              "@jskit-ai/users-core": "0.1.116"
+              "@jskit-ai/json-rest-api-core": "0.1.52",
+              "@jskit-ai/resource-core": "0.1.52",
+              "@jskit-ai/resource-crud-core": "0.1.52",
+              "@jskit-ai/users-core": "0.1.117"
             },
             "dev": {}
           },
@@ -6441,11 +6450,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-web",
-      "version": "0.1.83",
+      "version": "0.1.84",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-web",
-        "version": "0.1.83",
+        "version": "0.1.84",
         "kind": "runtime",
         "description": "Workspace web module: workspace selector, tools widget, workspace surfaces, members UI, and settings hosts.",
         "dependsOn": [
@@ -6702,9 +6711,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-web": "0.1.107",
-              "@jskit-ai/workspaces-core": "0.1.82",
-              "@jskit-ai/users-web": "0.1.121"
+              "@jskit-ai/auth-web": "0.1.108",
+              "@jskit-ai/workspaces-core": "0.1.83",
+              "@jskit-ai/users-web": "0.1.122"
             },
             "dev": {}
           },

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -2548,9 +2548,10 @@
           },
           "packageJson": {
             "scripts": {
-              "db:migrate": "knex --knexfile ./knexfile.js migrate:latest",
+              "db:migrations:sync": "jskit migrations changed",
+              "db:migrate": "npm run db:migrations:sync && knex --knexfile ./knexfile.js migrate:latest",
               "db:migrate:rollback": "knex --knexfile ./knexfile.js migrate:rollback",
-              "db:migrate:status": "knex --knexfile ./knexfile.js migrate:list"
+              "db:migrate:status": "npm run db:migrations:sync && knex --knexfile ./knexfile.js migrate:list"
             }
           },
           "procfile": {},

--- a/tooling/jskit-catalog/package.json
+++ b/tooling/jskit-catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-catalog",
-  "version": "0.1.114",
+  "version": "0.1.115",
   "description": "Published metadata catalog for JSKIT package descriptors.",
   "type": "module",
   "files": [

--- a/tooling/jskit-cli/package.json
+++ b/tooling/jskit-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-cli",
-  "version": "0.2.119",
+  "version": "0.2.120",
   "description": "Bundle and package orchestration CLI for JSKIT apps.",
   "type": "module",
   "files": [
@@ -20,9 +20,9 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/jskit-catalog": "0.1.114",
-    "@jskit-ai/kernel": "0.1.107",
-    "@jskit-ai/shell-web": "0.1.106",
+    "@jskit-ai/jskit-catalog": "0.1.115",
+    "@jskit-ai/kernel": "0.1.108",
+    "@jskit-ai/shell-web": "0.1.107",
     "@vue/compiler-sfc": "^3.5.29",
     "ts-morph": "^28.0.0"
   },


### PR DESCRIPTION
## Summary
- Add users.profile updatedAt to the userProfiles resource contract and normalized repository records.
- Add users.updated_at to the initial users migration plus an idempotent follow-up migration for existing dev apps.
- Update the app-owned users scaffold, catalog metadata, and regression tests for existing-profile sync/patch paths.
- Include release version/catalog updates already present in the working tree.

## Verification
- npm run jskit -- lint-descriptors
- npm run check:runtime-deps
- npm test --workspace packages/users-core
- git diff --check