### PR TITLE
Fix CRUD list rendering and generator flags

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6686,28 +6686,28 @@
     },
     "packages/agent-docs": {
       "name": "@jskit-ai/agent-docs",
-      "version": "0.1.74",
+      "version": "0.1.75",
       "engines": {
         "node": ">=20 <23"
       }
     },
     "packages/assistant": {
       "name": "@jskit-ai/assistant",
-      "version": "0.1.121",
+      "version": "0.1.122",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.113"
+        "@jskit-ai/kernel": "0.1.114"
       }
     },
     "packages/assistant-core": {
       "name": "@jskit-ai/assistant-core",
-      "version": "0.1.88",
+      "version": "0.1.89",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.112",
-        "@jskit-ai/http-runtime": "0.1.111",
-        "@jskit-ai/kernel": "0.1.113",
-        "@jskit-ai/resource-core": "0.1.57",
-        "@jskit-ai/resource-crud-core": "0.1.57",
-        "@jskit-ai/users-core": "0.1.122",
+        "@jskit-ai/database-runtime": "0.1.113",
+        "@jskit-ai/http-runtime": "0.1.112",
+        "@jskit-ai/kernel": "0.1.114",
+        "@jskit-ai/resource-core": "0.1.58",
+        "@jskit-ai/resource-crud-core": "0.1.58",
+        "@jskit-ai/users-core": "0.1.123",
         "dompurify": "^3.3.3",
         "json-rest-schema": "1.x.x",
         "marked": "^17.0.4",
@@ -6720,15 +6720,15 @@
     },
     "packages/assistant-runtime": {
       "name": "@jskit-ai/assistant-runtime",
-      "version": "0.1.83",
+      "version": "0.1.84",
       "dependencies": {
-        "@jskit-ai/assistant-core": "0.1.88",
-        "@jskit-ai/database-runtime": "0.1.112",
-        "@jskit-ai/http-runtime": "0.1.111",
-        "@jskit-ai/kernel": "0.1.113",
-        "@jskit-ai/shell-web": "0.1.112",
-        "@jskit-ai/users-core": "0.1.122",
-        "@jskit-ai/users-web": "0.1.127",
+        "@jskit-ai/assistant-core": "0.1.89",
+        "@jskit-ai/database-runtime": "0.1.113",
+        "@jskit-ai/http-runtime": "0.1.112",
+        "@jskit-ai/kernel": "0.1.114",
+        "@jskit-ai/shell-web": "0.1.113",
+        "@jskit-ai/users-core": "0.1.123",
+        "@jskit-ai/users-web": "0.1.128",
         "json-rest-schema": "1.x.x"
       },
       "peerDependencies": {
@@ -6739,39 +6739,39 @@
     },
     "packages/auth-core": {
       "name": "@jskit-ai/auth-core",
-      "version": "0.1.111",
+      "version": "0.1.112",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0",
-        "@jskit-ai/kernel": "0.1.113",
+        "@jskit-ai/kernel": "0.1.114",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/auth-provider-local-core": {
       "name": "@jskit-ai/auth-provider-local-core",
-      "version": "0.1.12",
+      "version": "0.1.13",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.111",
-        "@jskit-ai/kernel": "0.1.113",
+        "@jskit-ai/auth-core": "0.1.112",
+        "@jskit-ai/kernel": "0.1.114",
         "nodemailer": "^7.0.10"
       }
     },
     "packages/auth-provider-local-db-core": {
       "name": "@jskit-ai/auth-provider-local-db-core",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "dependencies": {
-        "@jskit-ai/auth-provider-local-core": "0.1.12",
-        "@jskit-ai/database-runtime": "0.1.112",
-        "@jskit-ai/kernel": "0.1.113"
+        "@jskit-ai/auth-provider-local-core": "0.1.13",
+        "@jskit-ai/database-runtime": "0.1.113",
+        "@jskit-ai/kernel": "0.1.114"
       }
     },
     "packages/auth-provider-supabase-core": {
       "name": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.111",
+      "version": "0.1.112",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.111",
-        "@jskit-ai/kernel": "0.1.113",
+        "@jskit-ai/auth-core": "0.1.112",
+        "@jskit-ai/kernel": "0.1.114",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0",
         "json-rest-schema": "1.x.x",
@@ -6780,12 +6780,12 @@
     },
     "packages/auth-web": {
       "name": "@jskit-ai/auth-web",
-      "version": "0.1.113",
+      "version": "0.1.114",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.111",
-        "@jskit-ai/http-runtime": "0.1.111",
-        "@jskit-ai/kernel": "0.1.113",
-        "@jskit-ai/shell-web": "0.1.112",
+        "@jskit-ai/auth-core": "0.1.112",
+        "@jskit-ai/http-runtime": "0.1.112",
+        "@jskit-ai/kernel": "0.1.114",
+        "@jskit-ai/shell-web": "0.1.113",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -6798,38 +6798,38 @@
     },
     "packages/console-core": {
       "name": "@jskit-ai/console-core",
-      "version": "0.1.75",
+      "version": "0.1.76",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.111",
-        "@jskit-ai/database-runtime": "0.1.112",
-        "@jskit-ai/http-runtime": "0.1.111",
-        "@jskit-ai/kernel": "0.1.113",
-        "@jskit-ai/resource-crud-core": "0.1.57",
-        "@jskit-ai/users-core": "0.1.122",
+        "@jskit-ai/auth-core": "0.1.112",
+        "@jskit-ai/database-runtime": "0.1.113",
+        "@jskit-ai/http-runtime": "0.1.112",
+        "@jskit-ai/kernel": "0.1.114",
+        "@jskit-ai/resource-crud-core": "0.1.58",
+        "@jskit-ai/users-core": "0.1.123",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/console-web": {
       "name": "@jskit-ai/console-web",
-      "version": "0.1.80",
+      "version": "0.1.81",
       "dependencies": {
-        "@jskit-ai/auth-web": "0.1.113",
-        "@jskit-ai/console-core": "0.1.75",
-        "@jskit-ai/shell-web": "0.1.112"
+        "@jskit-ai/auth-web": "0.1.114",
+        "@jskit-ai/console-core": "0.1.76",
+        "@jskit-ai/shell-web": "0.1.113"
       }
     },
     "packages/crud-core": {
       "name": "@jskit-ai/crud-core",
-      "version": "0.1.120",
+      "version": "0.1.121",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.112",
-        "@jskit-ai/http-runtime": "0.1.111",
-        "@jskit-ai/kernel": "0.1.113",
-        "@jskit-ai/realtime": "0.1.111",
-        "@jskit-ai/resource-crud-core": "0.1.57",
-        "@jskit-ai/shell-web": "0.1.112",
-        "@jskit-ai/users-core": "0.1.122",
-        "@jskit-ai/users-web": "0.1.127",
+        "@jskit-ai/database-runtime": "0.1.113",
+        "@jskit-ai/http-runtime": "0.1.112",
+        "@jskit-ai/kernel": "0.1.114",
+        "@jskit-ai/realtime": "0.1.112",
+        "@jskit-ai/resource-crud-core": "0.1.58",
+        "@jskit-ai/shell-web": "0.1.113",
+        "@jskit-ai/users-core": "0.1.123",
+        "@jskit-ai/users-web": "0.1.128",
         "json-rest-schema": "1.x.x"
       },
       "peerDependencies": {
@@ -6840,98 +6840,98 @@
     },
     "packages/crud-server-generator": {
       "name": "@jskit-ai/crud-server-generator",
-      "version": "0.1.120",
+      "version": "0.1.121",
       "dependencies": {
         "@babel/parser": "^7.29.2",
-        "@jskit-ai/crud-core": "0.1.120",
-        "@jskit-ai/database-runtime": "0.1.112",
-        "@jskit-ai/http-runtime": "0.1.111",
-        "@jskit-ai/json-rest-api-core": "0.1.57",
-        "@jskit-ai/kernel": "0.1.113",
-        "@jskit-ai/resource-crud-core": "0.1.57",
+        "@jskit-ai/crud-core": "0.1.121",
+        "@jskit-ai/database-runtime": "0.1.113",
+        "@jskit-ai/http-runtime": "0.1.112",
+        "@jskit-ai/json-rest-api-core": "0.1.58",
+        "@jskit-ai/kernel": "0.1.114",
+        "@jskit-ai/resource-crud-core": "0.1.58",
         "recast": "^0.23.11"
       }
     },
     "packages/crud-ui-generator": {
       "name": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.95",
+      "version": "0.1.96",
       "dependencies": {
-        "@jskit-ai/crud-core": "0.1.120",
-        "@jskit-ai/kernel": "0.1.113",
-        "@jskit-ai/resource-crud-core": "0.1.57"
+        "@jskit-ai/crud-core": "0.1.121",
+        "@jskit-ai/kernel": "0.1.114",
+        "@jskit-ai/resource-crud-core": "0.1.58"
       }
     },
     "packages/database-runtime": {
       "name": "@jskit-ai/database-runtime",
-      "version": "0.1.112",
+      "version": "0.1.113",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.113"
+        "@jskit-ai/kernel": "0.1.114"
       }
     },
     "packages/database-runtime-mysql": {
       "name": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.111",
+      "version": "0.1.112",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.112",
-        "@jskit-ai/kernel": "0.1.113"
+        "@jskit-ai/database-runtime": "0.1.113",
+        "@jskit-ai/kernel": "0.1.114"
       }
     },
     "packages/database-runtime-postgres": {
       "name": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.111",
+      "version": "0.1.112",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.112"
+        "@jskit-ai/database-runtime": "0.1.113"
       }
     },
     "packages/feature-server-generator": {
       "name": "@jskit-ai/feature-server-generator",
-      "version": "0.1.54"
+      "version": "0.1.55"
     },
     "packages/google-rewarded-core": {
       "name": "@jskit-ai/google-rewarded-core",
-      "version": "0.1.49"
+      "version": "0.1.50"
     },
     "packages/google-rewarded-web": {
       "name": "@jskit-ai/google-rewarded-web",
-      "version": "0.1.49"
+      "version": "0.1.50"
     },
     "packages/http-runtime": {
       "name": "@jskit-ai/http-runtime",
-      "version": "0.1.111",
+      "version": "0.1.112",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.113",
+        "@jskit-ai/kernel": "0.1.114",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/json-rest-api-core": {
       "name": "@jskit-ai/json-rest-api-core",
-      "version": "0.1.57",
+      "version": "0.1.58",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.113",
+        "@jskit-ai/kernel": "0.1.114",
         "hooked-api": "1.x.x",
         "json-rest-api": "1.x.x"
       }
     },
     "packages/kernel": {
       "name": "@jskit-ai/kernel",
-      "version": "0.1.113",
+      "version": "0.1.114",
       "dependencies": {
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/mobile-capacitor": {
       "name": "@jskit-ai/mobile-capacitor",
-      "version": "0.1.49",
+      "version": "0.1.50",
       "dependencies": {
         "@capacitor/browser": "^7.0.1",
-        "@jskit-ai/kernel": "0.1.113"
+        "@jskit-ai/kernel": "0.1.114"
       }
     },
     "packages/realtime": {
       "name": "@jskit-ai/realtime",
-      "version": "0.1.111",
+      "version": "0.1.112",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.113",
+        "@jskit-ai/kernel": "0.1.114",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",
@@ -6943,24 +6943,24 @@
     },
     "packages/resource-core": {
       "name": "@jskit-ai/resource-core",
-      "version": "0.1.57",
+      "version": "0.1.58",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.113"
+        "@jskit-ai/kernel": "0.1.114"
       }
     },
     "packages/resource-crud-core": {
       "name": "@jskit-ai/resource-crud-core",
-      "version": "0.1.57",
+      "version": "0.1.58",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.113",
-        "@jskit-ai/resource-core": "0.1.57"
+        "@jskit-ai/kernel": "0.1.114",
+        "@jskit-ai/resource-core": "0.1.58"
       }
     },
     "packages/shell-web": {
       "name": "@jskit-ai/shell-web",
-      "version": "0.1.112",
+      "version": "0.1.113",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.113",
+        "@jskit-ai/kernel": "0.1.114",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -6972,25 +6972,25 @@
     },
     "packages/storage-runtime": {
       "name": "@jskit-ai/storage-runtime",
-      "version": "0.1.111",
+      "version": "0.1.112",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.113",
+        "@jskit-ai/kernel": "0.1.114",
         "unstorage": "^1.17.3"
       }
     },
     "packages/ui-generator": {
       "name": "@jskit-ai/ui-generator",
-      "version": "0.1.95",
+      "version": "0.1.96",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.113",
-        "@jskit-ai/shell-web": "0.1.112"
+        "@jskit-ai/kernel": "0.1.114",
+        "@jskit-ai/shell-web": "0.1.113"
       }
     },
     "packages/uploads-image-web": {
       "name": "@jskit-ai/uploads-image-web",
-      "version": "0.1.90",
+      "version": "0.1.91",
       "dependencies": {
-        "@jskit-ai/uploads-runtime": "0.1.90",
+        "@jskit-ai/uploads-runtime": "0.1.91",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",
@@ -7003,37 +7003,37 @@
     },
     "packages/uploads-runtime": {
       "name": "@jskit-ai/uploads-runtime",
-      "version": "0.1.90",
+      "version": "0.1.91",
       "dependencies": {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.113"
+        "@jskit-ai/kernel": "0.1.114"
       }
     },
     "packages/users-core": {
       "name": "@jskit-ai/users-core",
-      "version": "0.1.122",
+      "version": "0.1.123",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.111",
-        "@jskit-ai/database-runtime": "0.1.112",
-        "@jskit-ai/http-runtime": "0.1.111",
-        "@jskit-ai/json-rest-api-core": "0.1.57",
-        "@jskit-ai/kernel": "0.1.113",
-        "@jskit-ai/resource-core": "0.1.57",
-        "@jskit-ai/resource-crud-core": "0.1.57",
-        "@jskit-ai/uploads-runtime": "0.1.90",
+        "@jskit-ai/auth-core": "0.1.112",
+        "@jskit-ai/database-runtime": "0.1.113",
+        "@jskit-ai/http-runtime": "0.1.112",
+        "@jskit-ai/json-rest-api-core": "0.1.58",
+        "@jskit-ai/kernel": "0.1.114",
+        "@jskit-ai/resource-core": "0.1.58",
+        "@jskit-ai/resource-crud-core": "0.1.58",
+        "@jskit-ai/uploads-runtime": "0.1.91",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/users-web": {
       "name": "@jskit-ai/users-web",
-      "version": "0.1.127",
+      "version": "0.1.128",
       "dependencies": {
-        "@jskit-ai/http-runtime": "0.1.111",
-        "@jskit-ai/kernel": "0.1.113",
-        "@jskit-ai/realtime": "0.1.111",
-        "@jskit-ai/shell-web": "0.1.112",
-        "@jskit-ai/uploads-image-web": "0.1.90",
-        "@jskit-ai/users-core": "0.1.122",
+        "@jskit-ai/http-runtime": "0.1.112",
+        "@jskit-ai/kernel": "0.1.114",
+        "@jskit-ai/realtime": "0.1.112",
+        "@jskit-ai/shell-web": "0.1.113",
+        "@jskit-ai/uploads-image-web": "0.1.91",
+        "@jskit-ai/users-core": "0.1.123",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -7045,30 +7045,30 @@
     },
     "packages/workspaces-core": {
       "name": "@jskit-ai/workspaces-core",
-      "version": "0.1.88",
+      "version": "0.1.89",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.111",
-        "@jskit-ai/database-runtime": "0.1.112",
-        "@jskit-ai/http-runtime": "0.1.111",
-        "@jskit-ai/json-rest-api-core": "0.1.57",
-        "@jskit-ai/kernel": "0.1.113",
-        "@jskit-ai/resource-core": "0.1.57",
-        "@jskit-ai/resource-crud-core": "0.1.57",
-        "@jskit-ai/users-core": "0.1.122",
+        "@jskit-ai/auth-core": "0.1.112",
+        "@jskit-ai/database-runtime": "0.1.113",
+        "@jskit-ai/http-runtime": "0.1.112",
+        "@jskit-ai/json-rest-api-core": "0.1.58",
+        "@jskit-ai/kernel": "0.1.114",
+        "@jskit-ai/resource-core": "0.1.58",
+        "@jskit-ai/resource-crud-core": "0.1.58",
+        "@jskit-ai/users-core": "0.1.123",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/workspaces-web": {
       "name": "@jskit-ai/workspaces-web",
-      "version": "0.1.89",
+      "version": "0.1.90",
       "dependencies": {
-        "@jskit-ai/auth-web": "0.1.113",
-        "@jskit-ai/http-runtime": "0.1.111",
-        "@jskit-ai/kernel": "0.1.113",
-        "@jskit-ai/shell-web": "0.1.112",
-        "@jskit-ai/users-core": "0.1.122",
-        "@jskit-ai/users-web": "0.1.127",
-        "@jskit-ai/workspaces-core": "0.1.88",
+        "@jskit-ai/auth-web": "0.1.114",
+        "@jskit-ai/http-runtime": "0.1.112",
+        "@jskit-ai/kernel": "0.1.114",
+        "@jskit-ai/shell-web": "0.1.113",
+        "@jskit-ai/users-core": "0.1.123",
+        "@jskit-ai/users-web": "0.1.128",
+        "@jskit-ai/workspaces-core": "0.1.89",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -7080,7 +7080,7 @@
     },
     "tooling/config-eslint": {
       "name": "@jskit-ai/config-eslint",
-      "version": "0.1.111",
+      "version": "0.1.112",
       "dependencies": {
         "@eslint/js": "^9.39.1",
         "eslint-plugin-vue": "^10.5.1",
@@ -7098,7 +7098,7 @@
     },
     "tooling/create-app": {
       "name": "@jskit-ai/create-app",
-      "version": "0.1.121",
+      "version": "0.1.122",
       "bin": {
         "jskit-create-app": "bin/jskit-create-app.js"
       },
@@ -7108,18 +7108,18 @@
     },
     "tooling/jskit-catalog": {
       "name": "@jskit-ai/jskit-catalog",
-      "version": "0.1.120",
+      "version": "0.1.121",
       "engines": {
         "node": ">=20 <23"
       }
     },
     "tooling/jskit-cli": {
       "name": "@jskit-ai/jskit-cli",
-      "version": "0.2.125",
+      "version": "0.2.126",
       "dependencies": {
-        "@jskit-ai/jskit-catalog": "0.1.120",
-        "@jskit-ai/kernel": "0.1.113",
-        "@jskit-ai/shell-web": "0.1.112",
+        "@jskit-ai/jskit-catalog": "0.1.121",
+        "@jskit-ai/kernel": "0.1.114",
+        "@jskit-ai/shell-web": "0.1.113",
         "@vue/compiler-sfc": "^3.5.29",
         "ts-morph": "^28.0.0"
       },

--- a/packages/agent-docs/package.json
+++ b/packages/agent-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/agent-docs",
-  "version": "0.1.74",
+  "version": "0.1.75",
   "description": "Distributed JSKIT agent references, prompts, guides, and generated reference maps.",
   "type": "module",
   "files": [

--- a/packages/assistant-core/package.descriptor.mjs
+++ b/packages/assistant-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-core",
-  version: "0.1.88",
+  version: "0.1.89",
   kind: "runtime",
   description: "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
   dependsOn: [
@@ -47,11 +47,11 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/http-runtime": "0.1.111",
-        "@jskit-ai/kernel": "0.1.113",
-        "@jskit-ai/resource-core": "0.1.57",
-        "@jskit-ai/resource-crud-core": "0.1.57",
-        "@jskit-ai/users-core": "0.1.122",
+        "@jskit-ai/http-runtime": "0.1.112",
+        "@jskit-ai/kernel": "0.1.114",
+        "@jskit-ai/resource-core": "0.1.58",
+        "@jskit-ai/resource-crud-core": "0.1.58",
+        "@jskit-ai/users-core": "0.1.123",
         "dompurify": "^3.3.3",
         "json-rest-schema": "1.x.x",
         "marked": "^17.0.4",

--- a/packages/assistant-core/package.json
+++ b/packages/assistant-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-core",
-  "version": "0.1.88",
+  "version": "0.1.89",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,12 +11,12 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.112",
-    "@jskit-ai/http-runtime": "0.1.111",
-    "@jskit-ai/kernel": "0.1.113",
-    "@jskit-ai/resource-crud-core": "0.1.57",
-    "@jskit-ai/resource-core": "0.1.57",
-    "@jskit-ai/users-core": "0.1.122",
+    "@jskit-ai/database-runtime": "0.1.113",
+    "@jskit-ai/http-runtime": "0.1.112",
+    "@jskit-ai/kernel": "0.1.114",
+    "@jskit-ai/resource-crud-core": "0.1.58",
+    "@jskit-ai/resource-core": "0.1.58",
+    "@jskit-ai/users-core": "0.1.123",
     "dompurify": "^3.3.3",
     "json-rest-schema": "1.x.x",
     "marked": "^17.0.4",

--- a/packages/assistant-runtime/package.descriptor.mjs
+++ b/packages/assistant-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-runtime",
-  version: "0.1.83",
+  version: "0.1.84",
   kind: "runtime",
   description: "Shared assistant runtime with per-surface assistant registration.",
   dependsOn: [
@@ -95,13 +95,13 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/assistant-core": "0.1.88",
-        "@jskit-ai/database-runtime": "0.1.112",
-        "@jskit-ai/http-runtime": "0.1.111",
-        "@jskit-ai/kernel": "0.1.113",
-        "@jskit-ai/shell-web": "0.1.112",
-        "@jskit-ai/users-core": "0.1.122",
-        "@jskit-ai/users-web": "0.1.127"
+        "@jskit-ai/assistant-core": "0.1.89",
+        "@jskit-ai/database-runtime": "0.1.113",
+        "@jskit-ai/http-runtime": "0.1.112",
+        "@jskit-ai/kernel": "0.1.114",
+        "@jskit-ai/shell-web": "0.1.113",
+        "@jskit-ai/users-core": "0.1.123",
+        "@jskit-ai/users-web": "0.1.128"
       },
       dev: {}
     },

--- a/packages/assistant-runtime/package.json
+++ b/packages/assistant-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-runtime",
-  "version": "0.1.83",
+  "version": "0.1.84",
   "type": "module",
   "exports": {
     "./client": "./src/client/index.js",
@@ -8,13 +8,13 @@
     "./server/actionIds": "./src/server/actionIds.js"
   },
   "dependencies": {
-    "@jskit-ai/assistant-core": "0.1.88",
-    "@jskit-ai/database-runtime": "0.1.112",
-    "@jskit-ai/http-runtime": "0.1.111",
-    "@jskit-ai/kernel": "0.1.113",
-    "@jskit-ai/shell-web": "0.1.112",
-    "@jskit-ai/users-core": "0.1.122",
-    "@jskit-ai/users-web": "0.1.127",
+    "@jskit-ai/assistant-core": "0.1.89",
+    "@jskit-ai/database-runtime": "0.1.113",
+    "@jskit-ai/http-runtime": "0.1.112",
+    "@jskit-ai/kernel": "0.1.114",
+    "@jskit-ai/shell-web": "0.1.113",
+    "@jskit-ai/users-core": "0.1.123",
+    "@jskit-ai/users-web": "0.1.128",
     "json-rest-schema": "1.x.x"
   },
   "peerDependencies": {

--- a/packages/assistant/package.descriptor.mjs
+++ b/packages/assistant/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant",
-  version: "0.1.121",
+  version: "0.1.122",
   kind: "generator",
   description: "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
   options: {

--- a/packages/assistant/package.json
+++ b/packages/assistant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant",
-  "version": "0.1.121",
+  "version": "0.1.122",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.113"
+    "@jskit-ai/kernel": "0.1.114"
   }
 }

--- a/packages/auth-core/package.descriptor.mjs
+++ b/packages/auth-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-core",
-  "version": "0.1.111",
+  "version": "0.1.112",
   "kind": "runtime",
   "dependsOn": [
     "@jskit-ai/value-app-config-shared"
@@ -74,7 +74,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.113",
+        "@jskit-ai/kernel": "0.1.114",
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0"

--- a/packages/auth-core/package.json
+++ b/packages/auth-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-core",
-  "version": "0.1.111",
+  "version": "0.1.112",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -54,7 +54,7 @@
     "./shared/commands/authSessionReadCommand": "./src/shared/commands/authSessionReadCommand.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.113",
+    "@jskit-ai/kernel": "0.1.114",
     "@fastify/cookie": "^11.0.2",
     "@fastify/csrf-protection": "^7.1.0",
     "@fastify/rate-limit": "^10.3.0",

--- a/packages/auth-provider-local-core/package.descriptor.mjs
+++ b/packages/auth-provider-local-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-provider-local-core",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "kind": "runtime",
   "description": "Local auth provider with a file backend default and no database requirement.",
   "dependsOn": [
@@ -57,8 +57,8 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/auth-core": "0.1.111",
-        "@jskit-ai/kernel": "0.1.113",
+        "@jskit-ai/auth-core": "0.1.112",
+        "@jskit-ai/kernel": "0.1.114",
         "nodemailer": "^7.0.10",
         "dotenv": "^16.4.5"
       },

--- a/packages/auth-provider-local-core/package.json
+++ b/packages/auth-provider-local-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-local-core",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,8 +11,8 @@
     "./server/lib/index": "./src/server/lib/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.111",
-    "@jskit-ai/kernel": "0.1.113",
+    "@jskit-ai/auth-core": "0.1.112",
+    "@jskit-ai/kernel": "0.1.114",
     "nodemailer": "^7.0.10"
   }
 }

--- a/packages/auth-provider-local-db-core/package.descriptor.mjs
+++ b/packages/auth-provider-local-db-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/auth-provider-local-db-core",
-  version: "0.1.4",
+  version: "0.1.5",
   kind: "runtime",
   description: "Database-backed local auth storage backend for JSKIT local auth.",
   dependsOn: [
@@ -73,9 +73,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-provider-local-core": "0.1.12",
-        "@jskit-ai/database-runtime": "0.1.112",
-        "@jskit-ai/kernel": "0.1.113"
+        "@jskit-ai/auth-provider-local-core": "0.1.13",
+        "@jskit-ai/database-runtime": "0.1.113",
+        "@jskit-ai/kernel": "0.1.114"
       },
       dev: {}
     },

--- a/packages/auth-provider-local-db-core/package.json
+++ b/packages/auth-provider-local-db-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-local-db-core",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,8 +10,8 @@
     "./server/lib/index": "./src/server/lib/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-provider-local-core": "0.1.12",
-    "@jskit-ai/database-runtime": "0.1.112",
-    "@jskit-ai/kernel": "0.1.113"
+    "@jskit-ai/auth-provider-local-core": "0.1.13",
+    "@jskit-ai/database-runtime": "0.1.113",
+    "@jskit-ai/kernel": "0.1.114"
   }
 }

--- a/packages/auth-provider-supabase-core/package.descriptor.mjs
+++ b/packages/auth-provider-supabase-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.111",
+  "version": "0.1.112",
   "kind": "runtime",
   "options": {
     "auth-supabase-url": {
@@ -83,8 +83,8 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/auth-core": "0.1.111",
-        "@jskit-ai/kernel": "0.1.113",
+        "@jskit-ai/auth-core": "0.1.112",
+        "@jskit-ai/kernel": "0.1.114",
         "dotenv": "^16.4.5",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0"

--- a/packages/auth-provider-supabase-core/package.json
+++ b/packages/auth-provider-supabase-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.111",
+  "version": "0.1.112",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,8 +12,8 @@
     "./client": "./src/client/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.111",
-    "@jskit-ai/kernel": "0.1.113",
+    "@jskit-ai/auth-core": "0.1.112",
+    "@jskit-ai/kernel": "0.1.114",
     "json-rest-schema": "1.x.x",
     "jose": "^6.1.0",
     "@supabase/supabase-js": "^2.57.4",

--- a/packages/auth-web/package.descriptor.mjs
+++ b/packages/auth-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-web",
-  "version": "0.1.113",
+  "version": "0.1.114",
   "kind": "runtime",
   "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
   "dependsOn": [
@@ -260,10 +260,10 @@ export default Object.freeze({
     "dependencies": {
       "runtime": {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/auth-core": "0.1.111",
-        "@jskit-ai/http-runtime": "0.1.111",
-        "@jskit-ai/kernel": "0.1.113",
-        "@jskit-ai/shell-web": "0.1.112"
+        "@jskit-ai/auth-core": "0.1.112",
+        "@jskit-ai/http-runtime": "0.1.112",
+        "@jskit-ai/kernel": "0.1.114",
+        "@jskit-ai/shell-web": "0.1.113"
       },
       "dev": {}
     },

--- a/packages/auth-web/package.json
+++ b/packages/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-web",
-  "version": "0.1.113",
+  "version": "0.1.114",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -19,11 +19,11 @@
     "./client/runtime/useSignOut": "./src/client/runtime/useSignOut.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.111",
+    "@jskit-ai/auth-core": "0.1.112",
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/kernel": "0.1.113",
-    "@jskit-ai/shell-web": "0.1.112",
-    "@jskit-ai/http-runtime": "0.1.111"
+    "@jskit-ai/kernel": "0.1.114",
+    "@jskit-ai/shell-web": "0.1.113",
+    "@jskit-ai/http-runtime": "0.1.112"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/console-core/package.descriptor.mjs
+++ b/packages/console-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-core",
-  version: "0.1.75",
+  version: "0.1.76",
   kind: "runtime",
   description: "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
   dependsOn: [
@@ -85,12 +85,12 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.111",
-        "@jskit-ai/database-runtime": "0.1.112",
-        "@jskit-ai/http-runtime": "0.1.111",
-        "@jskit-ai/kernel": "0.1.113",
-        "@jskit-ai/resource-crud-core": "0.1.57",
-        "@jskit-ai/users-core": "0.1.122"
+        "@jskit-ai/auth-core": "0.1.112",
+        "@jskit-ai/database-runtime": "0.1.113",
+        "@jskit-ai/http-runtime": "0.1.112",
+        "@jskit-ai/kernel": "0.1.114",
+        "@jskit-ai/resource-crud-core": "0.1.58",
+        "@jskit-ai/users-core": "0.1.123"
       },
       dev: {}
     },

--- a/packages/console-core/package.json
+++ b/packages/console-core/package.json
@@ -1,17 +1,17 @@
 {
   "name": "@jskit-ai/console-core",
-  "version": "0.1.75",
+  "version": "0.1.76",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.111",
-    "@jskit-ai/database-runtime": "0.1.112",
-    "@jskit-ai/http-runtime": "0.1.111",
-    "@jskit-ai/kernel": "0.1.113",
-    "@jskit-ai/resource-crud-core": "0.1.57",
-    "@jskit-ai/users-core": "0.1.122",
+    "@jskit-ai/auth-core": "0.1.112",
+    "@jskit-ai/database-runtime": "0.1.113",
+    "@jskit-ai/http-runtime": "0.1.112",
+    "@jskit-ai/kernel": "0.1.114",
+    "@jskit-ai/resource-crud-core": "0.1.58",
+    "@jskit-ai/users-core": "0.1.123",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/console-web/package.descriptor.mjs
+++ b/packages/console-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-web",
-  version: "0.1.80",
+  version: "0.1.81",
   kind: "runtime",
   description: "Authenticated console surface scaffold and surface policy wiring.",
   dependsOn: [
@@ -103,9 +103,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-web": "0.1.113",
-        "@jskit-ai/console-core": "0.1.75",
-        "@jskit-ai/shell-web": "0.1.112",
+        "@jskit-ai/auth-web": "0.1.114",
+        "@jskit-ai/console-core": "0.1.76",
+        "@jskit-ai/shell-web": "0.1.113",
       },
       dev: {}
     },

--- a/packages/console-web/package.json
+++ b/packages/console-web/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/console-web",
-  "version": "0.1.80",
+  "version": "0.1.81",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-web": "0.1.113",
-    "@jskit-ai/console-core": "0.1.75",
-    "@jskit-ai/shell-web": "0.1.112"
+    "@jskit-ai/auth-web": "0.1.114",
+    "@jskit-ai/console-core": "0.1.76",
+    "@jskit-ai/shell-web": "0.1.113"
   }
 }

--- a/packages/crud-core/package.descriptor.mjs
+++ b/packages/crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-core",
-  version: "0.1.120",
+  version: "0.1.121",
   kind: "runtime",
   description: "Shared CRUD helpers used by CRUD modules.",
   dependsOn: [
@@ -28,7 +28,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/crud-core": "0.1.120"
+        "@jskit-ai/crud-core": "0.1.121"
       },
       dev: {}
     },

--- a/packages/crud-core/package.json
+++ b/packages/crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-core",
-  "version": "0.1.120",
+  "version": "0.1.121",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -27,15 +27,15 @@
     "./server/routeContracts": "./src/server/routeContracts.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.112",
-    "@jskit-ai/http-runtime": "0.1.111",
-    "@jskit-ai/kernel": "0.1.113",
+    "@jskit-ai/database-runtime": "0.1.113",
+    "@jskit-ai/http-runtime": "0.1.112",
+    "@jskit-ai/kernel": "0.1.114",
     "json-rest-schema": "1.x.x",
-    "@jskit-ai/realtime": "0.1.111",
-    "@jskit-ai/resource-crud-core": "0.1.57",
-    "@jskit-ai/shell-web": "0.1.112",
-    "@jskit-ai/users-core": "0.1.122",
-    "@jskit-ai/users-web": "0.1.127"
+    "@jskit-ai/realtime": "0.1.112",
+    "@jskit-ai/resource-crud-core": "0.1.58",
+    "@jskit-ai/shell-web": "0.1.113",
+    "@jskit-ai/users-core": "0.1.123",
+    "@jskit-ai/users-web": "0.1.128"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/crud-server-generator/package.descriptor.mjs
+++ b/packages/crud-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-server-generator",
-  version: "0.1.120",
+  version: "0.1.121",
   kind: "generator",
   description: "CRUD server generator with routes, actions, and persistence scaffolding.",
   options: {
@@ -160,14 +160,14 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.111",
-        "@jskit-ai/crud-core": "0.1.120",
-        "@jskit-ai/database-runtime": "0.1.112",
-        "@jskit-ai/http-runtime": "0.1.111",
-        "@jskit-ai/json-rest-api-core": "0.1.57",
-        "@jskit-ai/kernel": "0.1.113",
-        "@jskit-ai/realtime": "0.1.111",
-        "@jskit-ai/resource-crud-core": "0.1.57",
+        "@jskit-ai/auth-core": "0.1.112",
+        "@jskit-ai/crud-core": "0.1.121",
+        "@jskit-ai/database-runtime": "0.1.113",
+        "@jskit-ai/http-runtime": "0.1.112",
+        "@jskit-ai/json-rest-api-core": "0.1.58",
+        "@jskit-ai/kernel": "0.1.114",
+        "@jskit-ai/realtime": "0.1.112",
+        "@jskit-ai/resource-crud-core": "0.1.58",
         "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}"
       },
       dev: {}

--- a/packages/crud-server-generator/package.json
+++ b/packages/crud-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-server-generator",
-  "version": "0.1.120",
+  "version": "0.1.121",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,12 +13,12 @@
   },
   "dependencies": {
     "@babel/parser": "^7.29.2",
-    "@jskit-ai/crud-core": "0.1.120",
-    "@jskit-ai/database-runtime": "0.1.112",
-    "@jskit-ai/http-runtime": "0.1.111",
-    "@jskit-ai/json-rest-api-core": "0.1.57",
-    "@jskit-ai/kernel": "0.1.113",
-    "@jskit-ai/resource-crud-core": "0.1.57",
+    "@jskit-ai/crud-core": "0.1.121",
+    "@jskit-ai/database-runtime": "0.1.113",
+    "@jskit-ai/http-runtime": "0.1.112",
+    "@jskit-ai/json-rest-api-core": "0.1.58",
+    "@jskit-ai/kernel": "0.1.114",
+    "@jskit-ai/resource-crud-core": "0.1.58",
     "recast": "^0.23.11"
   }
 }

--- a/packages/crud-server-generator/src/server/buildTemplateContext.js
+++ b/packages/crud-server-generator/src/server/buildTemplateContext.js
@@ -86,10 +86,10 @@ function resolveInternalRouteOption(options = {}) {
   if (!Object.prototype.hasOwnProperty.call(options, "internal")) {
     return false;
   }
-  if (options.internal === "" || options.internal === true) {
+  if (options.internal === undefined || options.internal === true) {
     return true;
   }
-  if (options.internal === false) {
+  if (options.internal === "" || options.internal == null || options.internal === false) {
     return false;
   }
   return normalizeBoolean(options.internal);
@@ -1736,6 +1736,11 @@ function renderRouteParamsValidatorLine(operation = "", { surfaceRequiresWorkspa
   return "      params: recordRouteParamsValidator,";
 }
 
+function renderOptionalTemplateLine(line = "") {
+  const renderedLine = String(line || "").trimEnd();
+  return renderedLine ? `\n${renderedLine}` : "";
+}
+
 function renderRouteInputLines(operation = "", { surfaceRequiresWorkspace = true } = {}) {
   const normalizedOperation = normalizeCrudOperation(operation, "CRUD route input operation");
   const lines = [];
@@ -1926,26 +1931,36 @@ function buildReplacementsFromSnapshot({
     __JSKIT_CRUD_ROUTE_WORKSPACE_SUPPORT_IMPORTS__: renderRouteWorkspaceSupportImports({
       surfaceRequiresWorkspace
     }),
-    __JSKIT_CRUD_ROUTE_INTERNAL_LINE__: routeInternal === true ? "      internal: true," : "",
+    __JSKIT_CRUD_ROUTE_INTERNAL_LINE__: routeInternal === true ? "\n      internal: true," : "",
     __JSKIT_CRUD_ROUTE_CONTRACTS_RESOURCE_ARGS__: surfaceRequiresWorkspace ? ",\n  routeParamsValidator" : "",
     __JSKIT_CRUD_ROUTE_VALIDATOR_CONSTANTS__: renderRouteValidatorConstants({
       surfaceRequiresWorkspace
     }),
-    __JSKIT_CRUD_LIST_ROUTE_PARAMS_VALIDATOR_LINE__: renderRouteParamsValidatorLine("list", {
-      surfaceRequiresWorkspace
-    }),
-    __JSKIT_CRUD_VIEW_ROUTE_PARAMS_VALIDATOR_LINE__: renderRouteParamsValidatorLine("view", {
-      surfaceRequiresWorkspace
-    }),
-    __JSKIT_CRUD_CREATE_ROUTE_PARAMS_VALIDATOR_LINE__: renderRouteParamsValidatorLine("create", {
-      surfaceRequiresWorkspace
-    }),
-    __JSKIT_CRUD_UPDATE_ROUTE_PARAMS_VALIDATOR_LINE__: renderRouteParamsValidatorLine("update", {
-      surfaceRequiresWorkspace
-    }),
-    __JSKIT_CRUD_DELETE_ROUTE_PARAMS_VALIDATOR_LINE__: renderRouteParamsValidatorLine("delete", {
-      surfaceRequiresWorkspace
-    }),
+    __JSKIT_CRUD_LIST_ROUTE_PARAMS_VALIDATOR_LINE__: renderOptionalTemplateLine(
+      renderRouteParamsValidatorLine("list", {
+        surfaceRequiresWorkspace
+      })
+    ),
+    __JSKIT_CRUD_VIEW_ROUTE_PARAMS_VALIDATOR_LINE__: renderOptionalTemplateLine(
+      renderRouteParamsValidatorLine("view", {
+        surfaceRequiresWorkspace
+      })
+    ),
+    __JSKIT_CRUD_CREATE_ROUTE_PARAMS_VALIDATOR_LINE__: renderOptionalTemplateLine(
+      renderRouteParamsValidatorLine("create", {
+        surfaceRequiresWorkspace
+      })
+    ),
+    __JSKIT_CRUD_UPDATE_ROUTE_PARAMS_VALIDATOR_LINE__: renderOptionalTemplateLine(
+      renderRouteParamsValidatorLine("update", {
+        surfaceRequiresWorkspace
+      })
+    ),
+    __JSKIT_CRUD_DELETE_ROUTE_PARAMS_VALIDATOR_LINE__: renderOptionalTemplateLine(
+      renderRouteParamsValidatorLine("delete", {
+        surfaceRequiresWorkspace
+      })
+    ),
     __JSKIT_CRUD_LIST_ROUTE_INPUT_LINES__: renderRouteInputLines("list", {
       surfaceRequiresWorkspace
     }),

--- a/packages/crud-server-generator/templates/src/local-package/server/registerRoutes.js
+++ b/packages/crud-server-generator/templates/src/local-package/server/registerRoutes.js
@@ -37,15 +37,13 @@ function registerRoutes(
     routeBase,
     {
       auth: "required",
-      surface: normalizedRouteSurface,
-__JSKIT_CRUD_ROUTE_INTERNAL_LINE__
+      surface: normalizedRouteSurface,__JSKIT_CRUD_ROUTE_INTERNAL_LINE__
       visibility: checkRouteVisibility(routeOwnershipFilter),
       meta: {
         tags: ["crud"],
         summary: "List records."
       },
-      ...listRouteContract,
-__JSKIT_CRUD_LIST_ROUTE_PARAMS_VALIDATOR_LINE__
+      ...listRouteContract,__JSKIT_CRUD_LIST_ROUTE_PARAMS_VALIDATOR_LINE__
     },
     async function (request, reply) {
       const listInput = {
@@ -64,15 +62,13 @@ __JSKIT_CRUD_LIST_ROUTE_INPUT_LINES__
     `${routeBase}/:recordId`,
     {
       auth: "required",
-      surface: normalizedRouteSurface,
-__JSKIT_CRUD_ROUTE_INTERNAL_LINE__
+      surface: normalizedRouteSurface,__JSKIT_CRUD_ROUTE_INTERNAL_LINE__
       visibility: checkRouteVisibility(routeOwnershipFilter),
       meta: {
         tags: ["crud"],
         summary: "View a record."
       },
-      ...viewRouteContract,
-__JSKIT_CRUD_VIEW_ROUTE_PARAMS_VALIDATOR_LINE__
+      ...viewRouteContract,__JSKIT_CRUD_VIEW_ROUTE_PARAMS_VALIDATOR_LINE__
     },
     async function (request, reply) {
       const response = await request.executeAction({
@@ -90,15 +86,13 @@ __JSKIT_CRUD_VIEW_ROUTE_INPUT_LINES__
     routeBase,
     {
       auth: "required",
-      surface: normalizedRouteSurface,
-__JSKIT_CRUD_ROUTE_INTERNAL_LINE__
+      surface: normalizedRouteSurface,__JSKIT_CRUD_ROUTE_INTERNAL_LINE__
       visibility: checkRouteVisibility(routeOwnershipFilter),
       meta: {
         tags: ["crud"],
         summary: "Create a record."
       },
-      ...createRouteContract,
-__JSKIT_CRUD_CREATE_ROUTE_PARAMS_VALIDATOR_LINE__
+      ...createRouteContract,__JSKIT_CRUD_CREATE_ROUTE_PARAMS_VALIDATOR_LINE__
     },
     async function (request, reply) {
       const response = await request.executeAction({
@@ -116,15 +110,13 @@ __JSKIT_CRUD_CREATE_ROUTE_INPUT_LINES__
     `${routeBase}/:recordId`,
     {
       auth: "required",
-      surface: normalizedRouteSurface,
-__JSKIT_CRUD_ROUTE_INTERNAL_LINE__
+      surface: normalizedRouteSurface,__JSKIT_CRUD_ROUTE_INTERNAL_LINE__
       visibility: checkRouteVisibility(routeOwnershipFilter),
       meta: {
         tags: ["crud"],
         summary: "Update a record."
       },
-      ...updateRouteContract,
-__JSKIT_CRUD_UPDATE_ROUTE_PARAMS_VALIDATOR_LINE__
+      ...updateRouteContract,__JSKIT_CRUD_UPDATE_ROUTE_PARAMS_VALIDATOR_LINE__
     },
     async function (request, reply) {
       const response = await request.executeAction({
@@ -142,15 +134,13 @@ __JSKIT_CRUD_UPDATE_ROUTE_INPUT_LINES__
     `${routeBase}/:recordId`,
     {
       auth: "required",
-      surface: normalizedRouteSurface,
-__JSKIT_CRUD_ROUTE_INTERNAL_LINE__
+      surface: normalizedRouteSurface,__JSKIT_CRUD_ROUTE_INTERNAL_LINE__
       visibility: checkRouteVisibility(routeOwnershipFilter),
       meta: {
         tags: ["crud"],
         summary: "Delete a record."
       },
-      ...deleteRouteContract,
-__JSKIT_CRUD_DELETE_ROUTE_PARAMS_VALIDATOR_LINE__
+      ...deleteRouteContract,__JSKIT_CRUD_DELETE_ROUTE_PARAMS_VALIDATOR_LINE__
     },
     async function (request, reply) {
       const response = await request.executeAction({

--- a/packages/crud-server-generator/test/buildTemplateContext.test.js
+++ b/packages/crud-server-generator/test/buildTemplateContext.test.js
@@ -256,7 +256,8 @@ test("buildReplacementsFromSnapshot renders an internal route line only when req
   });
 
   assert.equal(publicReplacements.__JSKIT_CRUD_ROUTE_INTERNAL_LINE__, "");
-  assert.equal(internalReplacements.__JSKIT_CRUD_ROUTE_INTERNAL_LINE__, "      internal: true,");
+  assert.equal(internalReplacements.__JSKIT_CRUD_ROUTE_INTERNAL_LINE__, "\n      internal: true,");
+  assert.equal(publicReplacements.__JSKIT_CRUD_LIST_ROUTE_PARAMS_VALIDATOR_LINE__, "\n      params: routeParamsValidator,");
 });
 
 test("resolveInternalRouteOption rejects invalid internal flag values instead of silently generating public routes", () => {
@@ -266,8 +267,12 @@ test("resolveInternalRouteOption rejects invalid internal flag values instead of
   );
 });
 
-test("resolveInternalRouteOption treats an empty-string flag presence as true", () => {
-  assert.equal(__testables.resolveInternalRouteOption({ internal: "" }), true);
+test("resolveInternalRouteOption does not confuse descriptor defaults with explicit internal flags", () => {
+  assert.equal(__testables.resolveInternalRouteOption({}), false);
+  assert.equal(__testables.resolveInternalRouteOption({ internal: "" }), false);
+  assert.equal(__testables.resolveInternalRouteOption({ internal: false }), false);
+  assert.equal(__testables.resolveInternalRouteOption({ internal: undefined }), true);
+  assert.equal(__testables.resolveInternalRouteOption({ internal: true }), true);
   assert.equal(__testables.resolveInternalRouteOption({ internal: "true" }), true);
   assert.equal(__testables.resolveInternalRouteOption({ internal: "false" }), false);
 });
@@ -326,7 +331,7 @@ test("buildReplacementsFromSnapshot builds deterministic template replacement pa
   assert.match(replacements.__JSKIT_CRUD_LIST_ACTION_INPUT__, /workspaceSlugParamsValidator,/);
   assert.equal(
     replacements.__JSKIT_CRUD_VIEW_ROUTE_PARAMS_VALIDATOR_LINE__,
-    "      params: recordRouteParamsValidator,"
+    "\n      params: recordRouteParamsValidator,"
   );
   assert.match(
     replacements.__JSKIT_CRUD_ROUTE_VALIDATOR_CONSTANTS__,
@@ -402,7 +407,7 @@ test("buildReplacementsFromSnapshot omits named permissions and role grants when
   assert.equal(replacements.__JSKIT_CRUD_LIST_ROUTE_PARAMS_VALIDATOR_LINE__, "");
   assert.equal(
     replacements.__JSKIT_CRUD_VIEW_ROUTE_PARAMS_VALIDATOR_LINE__,
-    "      params: recordRouteParamsValidator,"
+    "\n      params: recordRouteParamsValidator,"
   );
   assert.equal(
     replacements.__JSKIT_CRUD_VIEW_ROUTE_INPUT_LINES__,
@@ -1057,6 +1062,9 @@ test("crud actions and routes templates derive cursor validation and route contr
   assert.match(registerRoutesTemplateSource, /createCrudJsonApiRouteContracts/);
   assert.match(registerRoutesTemplateSource, /const \{\s+listRouteContract,\s+viewRouteContract,\s+createRouteContract,\s+updateRouteContract,\s+deleteRouteContract,\s+recordRouteParamsValidator\s+\} = createCrudJsonApiRouteContracts\(\{/s);
   assert.match(registerRoutesTemplateSource, /resource__JSKIT_CRUD_ROUTE_CONTRACTS_RESOURCE_ARGS__/);
+  assert.match(registerRoutesTemplateSource, /surface: normalizedRouteSurface,__JSKIT_CRUD_ROUTE_INTERNAL_LINE__\n      visibility:/);
+  assert.match(registerRoutesTemplateSource, /\.\.\.listRouteContract,__JSKIT_CRUD_LIST_ROUTE_PARAMS_VALIDATOR_LINE__\n    \},/);
+  assert.doesNotMatch(registerRoutesTemplateSource, /surface: normalizedRouteSurface,\n__JSKIT_CRUD_ROUTE_INTERNAL_LINE__/);
   assert.doesNotMatch(registerRoutesTemplateSource, /wrapResponse/);
   assert.match(registerRoutesTemplateSource, /reply\.code\(204\)\.send\(response\);/);
   assert.doesNotMatch(registerRoutesTemplateSource, /withStandardErrorResponses/);

--- a/packages/crud-ui-generator/package.descriptor.mjs
+++ b/packages/crud-ui-generator/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { GENERATED_UI_NAVIGATION_ROLE_OPTION } from "@jskit-ai/kernel/shared/sup
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-ui-generator",
-  version: "0.1.95",
+  version: "0.1.96",
   kind: "generator",
   description: "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
   options: {
@@ -175,7 +175,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.127"
+        "@jskit-ai/users-web": "0.1.128"
       },
       dev: {}
     },

--- a/packages/crud-ui-generator/package.json
+++ b/packages/crud-ui-generator/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@jskit-ai/crud-ui-generator",
-  "version": "0.1.95",
+  "version": "0.1.96",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/crud-core": "0.1.120",
-    "@jskit-ai/kernel": "0.1.113",
-    "@jskit-ai/resource-crud-core": "0.1.57"
+    "@jskit-ai/crud-core": "0.1.121",
+    "@jskit-ai/kernel": "0.1.114",
+    "@jskit-ai/resource-crud-core": "0.1.58"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/database-runtime-mysql/package.descriptor.mjs
+++ b/packages/database-runtime-mysql/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-mysql",
-  version: "0.1.111",
+  version: "0.1.112",
   kind: "runtime",
   options: {
     "db-host": {
@@ -91,7 +91,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.112",
+        "@jskit-ai/database-runtime": "0.1.113",
         "mysql2": "^3.11.2"
       },
       dev: {}

--- a/packages/database-runtime-mysql/package.json
+++ b/packages/database-runtime-mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-mysql",
-  "version": "0.1.111",
+  "version": "0.1.112",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,7 +12,7 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.112",
-    "@jskit-ai/kernel": "0.1.113"
+    "@jskit-ai/database-runtime": "0.1.113",
+    "@jskit-ai/kernel": "0.1.114"
   }
 }

--- a/packages/database-runtime-postgres/package.descriptor.mjs
+++ b/packages/database-runtime-postgres/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-postgres",
-  version: "0.1.111",
+  version: "0.1.112",
   kind: "runtime",
   options: {
     "db-host": {
@@ -91,7 +91,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.112",
+        "@jskit-ai/database-runtime": "0.1.113",
         "pg": "^8.13.1"
       },
       dev: {}

--- a/packages/database-runtime-postgres/package.json
+++ b/packages/database-runtime-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-postgres",
-  "version": "0.1.111",
+  "version": "0.1.112",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,6 +12,6 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.112"
+    "@jskit-ai/database-runtime": "0.1.113"
   }
 }

--- a/packages/database-runtime/package.descriptor.mjs
+++ b/packages/database-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime",
-  version: "0.1.112",
+  version: "0.1.113",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -58,7 +58,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.113",
+        "@jskit-ai/kernel": "0.1.114",
         "dotenv": "^16.4.5",
         "knex": "^3.1.0"
       },

--- a/packages/database-runtime/package.json
+++ b/packages/database-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime",
-  "version": "0.1.112",
+  "version": "0.1.113",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -25,6 +25,6 @@
     "./shared/transactions": "./src/shared/transactions.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.113"
+    "@jskit-ai/kernel": "0.1.114"
   }
 }

--- a/packages/feature-server-generator/package.descriptor.mjs
+++ b/packages/feature-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/feature-server-generator",
-  version: "0.1.54",
+  version: "0.1.55",
   kind: "generator",
   description: "Scaffold substantial non-CRUD server feature packages with provider, actions, service, and optional persistence seams.",
   options: {
@@ -174,7 +174,7 @@ export default Object.freeze({
             equals: "json-rest"
           }
         },
-        "@jskit-ai/kernel": "0.1.113",
+        "@jskit-ai/kernel": "0.1.114",
         "json-rest-schema": "1.x.x",
         "@local/${option:feature-name|kebab}": "file:packages/${option:feature-name|kebab}"
       },

--- a/packages/feature-server-generator/package.json
+++ b/packages/feature-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/feature-server-generator",
-  "version": "0.1.54",
+  "version": "0.1.55",
   "type": "module",
   "scripts": {
     "test": "node --test"

--- a/packages/google-rewarded-core/package.descriptor.mjs
+++ b/packages/google-rewarded-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/google-rewarded-core",
-  version: "0.1.49",
+  version: "0.1.50",
   kind: "runtime",
   description: "Google rewarded workflow runtime plus internal CRUD providers for rules, provider configs, watch sessions, and unlock receipts.",
   dependsOn: [
@@ -128,14 +128,14 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.111",
-        "@jskit-ai/crud-core": "0.1.120",
-        "@jskit-ai/database-runtime": "0.1.112",
-        "@jskit-ai/http-runtime": "0.1.111",
-        "@jskit-ai/json-rest-api-core": "0.1.57",
-        "@jskit-ai/kernel": "0.1.113",
-        "@jskit-ai/resource-crud-core": "0.1.57",
-        "@jskit-ai/workspaces-core": "0.1.88"
+        "@jskit-ai/auth-core": "0.1.112",
+        "@jskit-ai/crud-core": "0.1.121",
+        "@jskit-ai/database-runtime": "0.1.113",
+        "@jskit-ai/http-runtime": "0.1.112",
+        "@jskit-ai/json-rest-api-core": "0.1.58",
+        "@jskit-ai/kernel": "0.1.114",
+        "@jskit-ai/resource-crud-core": "0.1.58",
+        "@jskit-ai/workspaces-core": "0.1.89"
       },
       dev: {}
     },

--- a/packages/google-rewarded-core/package.json
+++ b/packages/google-rewarded-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/google-rewarded-core",
-  "version": "0.1.49",
+  "version": "0.1.50",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/google-rewarded-web/package.descriptor.mjs
+++ b/packages/google-rewarded-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/google-rewarded-web",
-  version: "0.1.49",
+  version: "0.1.50",
   kind: "runtime",
   description: "Google rewarded client runtime with a fullscreen gate host and GPT orchestration.",
   dependsOn: [
@@ -46,10 +46,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/google-rewarded-core": "0.1.49",
-        "@jskit-ai/http-runtime": "0.1.111",
-        "@jskit-ai/kernel": "0.1.113",
-        "@jskit-ai/shell-web": "0.1.112"
+        "@jskit-ai/google-rewarded-core": "0.1.50",
+        "@jskit-ai/http-runtime": "0.1.112",
+        "@jskit-ai/kernel": "0.1.114",
+        "@jskit-ai/shell-web": "0.1.113"
       },
       dev: {}
     },

--- a/packages/google-rewarded-web/package.json
+++ b/packages/google-rewarded-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/google-rewarded-web",
-  "version": "0.1.49",
+  "version": "0.1.50",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/http-runtime/package.descriptor.mjs
+++ b/packages/http-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/http-runtime",
-  "version": "0.1.111",
+  "version": "0.1.112",
   "kind": "runtime",
   "dependsOn": [],
   "capabilities": {
@@ -67,7 +67,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.113"
+        "@jskit-ai/kernel": "0.1.114"
       },
       "dev": {}
     },

--- a/packages/http-runtime/package.json
+++ b/packages/http-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/http-runtime",
-  "version": "0.1.111",
+  "version": "0.1.112",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -18,7 +18,7 @@
     "./shared/validators/operationValidation": "./src/shared/validators/operationValidation.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.113",
+    "@jskit-ai/kernel": "0.1.114",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/json-rest-api-core/package.descriptor.mjs
+++ b/packages/json-rest-api-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/json-rest-api-core",
-  version: "0.1.57",
+  version: "0.1.58",
   kind: "runtime",
   description: "Shared internal json-rest-api host runtime for JSKIT server packages.",
   dependsOn: [

--- a/packages/json-rest-api-core/package.json
+++ b/packages/json-rest-api-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/json-rest-api-core",
-  "version": "0.1.57",
+  "version": "0.1.58",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,6 +11,6 @@
   "dependencies": {
     "hooked-api": "1.x.x",
     "json-rest-api": "1.x.x",
-    "@jskit-ai/kernel": "0.1.113"
+    "@jskit-ai/kernel": "0.1.114"
   }
 }

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/kernel",
-  "version": "0.1.113",
+  "version": "0.1.114",
   "type": "module",
   "dependencies": {
     "json-rest-schema": "1.x.x"

--- a/packages/mobile-capacitor/package.descriptor.mjs
+++ b/packages/mobile-capacitor/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/mobile-capacitor",
-  version: "0.1.49",
+  version: "0.1.50",
   kind: "runtime",
   description: "Thin Capacitor client integration for JSKIT mobile-shell launch routing and auth callback completion.",
   dependsOn: [
@@ -62,8 +62,8 @@ export default Object.freeze({
         "@capacitor/app": "^7.1.0",
         "@capacitor/browser": "^7.0.1",
         "@capacitor/core": "^7.4.3",
-        "@jskit-ai/kernel": "0.1.113",
-        "@jskit-ai/shell-web": "0.1.112"
+        "@jskit-ai/kernel": "0.1.114",
+        "@jskit-ai/shell-web": "0.1.113"
       },
       dev: {
         "@capacitor/cli": "^7.4.3"

--- a/packages/mobile-capacitor/package.json
+++ b/packages/mobile-capacitor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/mobile-capacitor",
-  "version": "0.1.49",
+  "version": "0.1.50",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,6 +12,6 @@
   },
   "dependencies": {
     "@capacitor/browser": "^7.0.1",
-    "@jskit-ai/kernel": "0.1.113"
+    "@jskit-ai/kernel": "0.1.114"
   }
 }

--- a/packages/realtime/package.descriptor.mjs
+++ b/packages/realtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/realtime",
-  version: "0.1.111",
+  version: "0.1.112",
   kind: "runtime",
   description: "Thin, generic realtime runtime wrappers for socket.io server and client.",
   options: {
@@ -95,7 +95,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.113",
+        "@jskit-ai/kernel": "0.1.114",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/realtime",
-  "version": "0.1.111",
+  "version": "0.1.112",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@socket.io/redis-adapter": "^8.3.0",
-    "@jskit-ai/kernel": "0.1.113",
+    "@jskit-ai/kernel": "0.1.114",
     "redis": "^5.8.2",
     "socket.io": "^4.8.3",
     "socket.io-client": "^4.8.3"

--- a/packages/resource-core/package.descriptor.mjs
+++ b/packages/resource-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/resource-core",
-  version: "0.1.57",
+  version: "0.1.58",
   kind: "runtime",
   description: "Generic resource-definition helpers and schema-definition normalization.",
   dependsOn: [
@@ -22,7 +22,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/resource-core": "0.1.57"
+        "@jskit-ai/resource-core": "0.1.58"
       },
       dev: {}
     },

--- a/packages/resource-core/package.json
+++ b/packages/resource-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/resource-core",
-  "version": "0.1.57",
+  "version": "0.1.58",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./shared/resource": "./src/shared/resource.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.113"
+    "@jskit-ai/kernel": "0.1.114"
   }
 }

--- a/packages/resource-crud-core/package.descriptor.mjs
+++ b/packages/resource-crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/resource-crud-core",
-  version: "0.1.57",
+  version: "0.1.58",
   kind: "runtime",
   description: "CRUD-specific resource-definition helpers and namespace support.",
   dependsOn: [
@@ -23,7 +23,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/resource-crud-core": "0.1.57"
+        "@jskit-ai/resource-crud-core": "0.1.58"
       },
       dev: {}
     },

--- a/packages/resource-crud-core/package.json
+++ b/packages/resource-crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/resource-crud-core",
-  "version": "0.1.57",
+  "version": "0.1.58",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./shared/crudResource": "./src/shared/crudResource.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.113",
-    "@jskit-ai/resource-core": "0.1.57"
+    "@jskit-ai/kernel": "0.1.114",
+    "@jskit-ai/resource-core": "0.1.58"
   }
 }

--- a/packages/shell-web/package.descriptor.mjs
+++ b/packages/shell-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/shell-web",
-  version: "0.1.112",
+  version: "0.1.113",
   kind: "runtime",
   description: "Web shell layout runtime with outlet-based placement contributions.",
   dependsOn: [],
@@ -307,7 +307,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/kernel": "0.1.113"
+        "@jskit-ai/kernel": "0.1.114"
       },
       dev: {}
     },

--- a/packages/shell-web/package.json
+++ b/packages/shell-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/shell-web",
-  "version": "0.1.112",
+  "version": "0.1.113",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/kernel": "0.1.113"
+    "@jskit-ai/kernel": "0.1.114"
   },
   "peerDependencies": {
     "pinia": "^3.0.4",

--- a/packages/storage-runtime/package.descriptor.mjs
+++ b/packages/storage-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/storage-runtime",
-  version: "0.1.111",
+  version: "0.1.112",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -50,7 +50,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.113",
+        "@jskit-ai/kernel": "0.1.114",
         "unstorage": "^1.17.3"
       },
       dev: {}

--- a/packages/storage-runtime/package.json
+++ b/packages/storage-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/storage-runtime",
-  "version": "0.1.111",
+  "version": "0.1.112",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./server/providers/StorageRuntimeServiceProvider": "./src/server/providers/StorageRuntimeServiceProvider.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.113",
+    "@jskit-ai/kernel": "0.1.114",
     "unstorage": "^1.17.3"
   }
 }

--- a/packages/ui-generator/package.descriptor.mjs
+++ b/packages/ui-generator/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { GENERATED_UI_NAVIGATION_ROLE_OPTION } from "@jskit-ai/kernel/shared/sup
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/ui-generator",
-  version: "0.1.95",
+  version: "0.1.96",
   kind: "generator",
   description: "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
   options: {
@@ -371,7 +371,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.127"
+        "@jskit-ai/users-web": "0.1.128"
       },
       dev: {}
     },

--- a/packages/ui-generator/package.json
+++ b/packages/ui-generator/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/ui-generator",
-  "version": "0.1.95",
+  "version": "0.1.96",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.113",
-    "@jskit-ai/shell-web": "0.1.112"
+    "@jskit-ai/kernel": "0.1.114",
+    "@jskit-ai/shell-web": "0.1.113"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/uploads-image-web/package.descriptor.mjs
+++ b/packages/uploads-image-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-image-web",
-  version: "0.1.90",
+  version: "0.1.91",
   kind: "runtime",
   description: "Reusable client-side image upload runtime with pre-upload image editing.",
   dependsOn: [
@@ -65,7 +65,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/uploads-runtime": "0.1.90",
+        "@jskit-ai/uploads-runtime": "0.1.91",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-image-web/package.json
+++ b/packages/uploads-image-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-image-web",
-  "version": "0.1.90",
+  "version": "0.1.91",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,7 +13,7 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/uploads-runtime": "0.1.90",
+    "@jskit-ai/uploads-runtime": "0.1.91",
     "@uppy/compressor": "^3.1.0",
     "@uppy/core": "^5.2.0",
     "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-runtime/package.descriptor.mjs
+++ b/packages/uploads-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-runtime",
-  version: "0.1.90",
+  version: "0.1.91",
   kind: "runtime",
   description: "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
   dependsOn: [
@@ -71,7 +71,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.113"
+        "@jskit-ai/kernel": "0.1.114"
       },
       dev: {}
     },

--- a/packages/uploads-runtime/package.json
+++ b/packages/uploads-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-runtime",
-  "version": "0.1.90",
+  "version": "0.1.91",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,6 +16,6 @@
   },
   "dependencies": {
     "@fastify/multipart": "^9.4.0",
-    "@jskit-ai/kernel": "0.1.113"
+    "@jskit-ai/kernel": "0.1.114"
   }
 }

--- a/packages/users-core/package.descriptor.mjs
+++ b/packages/users-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-core",
-  version: "0.1.122",
+  version: "0.1.123",
   kind: "runtime",
   description: "Users/account runtime plus HTTP routes for account features.",
   dependsOn: [
@@ -146,16 +146,16 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.111",
-        "@jskit-ai/crud-core": "0.1.120",
-        "@jskit-ai/database-runtime": "0.1.112",
-        "@jskit-ai/http-runtime": "0.1.111",
-        "@jskit-ai/json-rest-api-core": "0.1.57",
-        "@jskit-ai/kernel": "0.1.113",
-        "@jskit-ai/resource-core": "0.1.57",
-        "@jskit-ai/resource-crud-core": "0.1.57",
+        "@jskit-ai/auth-core": "0.1.112",
+        "@jskit-ai/crud-core": "0.1.121",
+        "@jskit-ai/database-runtime": "0.1.113",
+        "@jskit-ai/http-runtime": "0.1.112",
+        "@jskit-ai/json-rest-api-core": "0.1.58",
+        "@jskit-ai/kernel": "0.1.114",
+        "@jskit-ai/resource-core": "0.1.58",
+        "@jskit-ai/resource-crud-core": "0.1.58",
         "@local/users": "file:packages/users",
-        "@jskit-ai/uploads-runtime": "0.1.90"
+        "@jskit-ai/uploads-runtime": "0.1.91"
       },
       dev: {}
     },

--- a/packages/users-core/package.json
+++ b/packages/users-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-core",
-  "version": "0.1.122",
+  "version": "0.1.123",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,14 +12,14 @@
     "./shared/resources/userSettingsResource": "./src/shared/resources/userSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.111",
-    "@jskit-ai/database-runtime": "0.1.112",
-    "@jskit-ai/http-runtime": "0.1.111",
-    "@jskit-ai/json-rest-api-core": "0.1.57",
-    "@jskit-ai/kernel": "0.1.113",
-    "@jskit-ai/resource-crud-core": "0.1.57",
-    "@jskit-ai/resource-core": "0.1.57",
-    "@jskit-ai/uploads-runtime": "0.1.90",
+    "@jskit-ai/auth-core": "0.1.112",
+    "@jskit-ai/database-runtime": "0.1.113",
+    "@jskit-ai/http-runtime": "0.1.112",
+    "@jskit-ai/json-rest-api-core": "0.1.58",
+    "@jskit-ai/kernel": "0.1.114",
+    "@jskit-ai/resource-crud-core": "0.1.58",
+    "@jskit-ai/resource-core": "0.1.58",
+    "@jskit-ai/uploads-runtime": "0.1.91",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/users-web/package.descriptor.mjs
+++ b/packages/users-web/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { HOME_COG_OUTLET } from "./src/shared/toolsOutletContracts.js";
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-web",
-  version: "0.1.127",
+  version: "0.1.128",
   kind: "runtime",
   description: "Users web module: account/profile UI plus shared users web widgets.",
   dependsOn: [
@@ -286,12 +286,12 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/http-runtime": "0.1.111",
-        "@jskit-ai/realtime": "0.1.111",
-        "@jskit-ai/kernel": "0.1.113",
-        "@jskit-ai/shell-web": "0.1.112",
-        "@jskit-ai/uploads-image-web": "0.1.90",
-        "@jskit-ai/users-core": "0.1.122"
+        "@jskit-ai/http-runtime": "0.1.112",
+        "@jskit-ai/realtime": "0.1.112",
+        "@jskit-ai/kernel": "0.1.114",
+        "@jskit-ai/shell-web": "0.1.113",
+        "@jskit-ai/uploads-image-web": "0.1.91",
+        "@jskit-ai/users-core": "0.1.123"
       },
       dev: {}
     },

--- a/packages/users-web/package.json
+++ b/packages/users-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-web",
-  "version": "0.1.127",
+  "version": "0.1.128",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -46,12 +46,12 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/http-runtime": "0.1.111",
-    "@jskit-ai/kernel": "0.1.113",
-    "@jskit-ai/realtime": "0.1.111",
-    "@jskit-ai/shell-web": "0.1.112",
-    "@jskit-ai/uploads-image-web": "0.1.90",
-    "@jskit-ai/users-core": "0.1.122"
+    "@jskit-ai/http-runtime": "0.1.112",
+    "@jskit-ai/kernel": "0.1.114",
+    "@jskit-ai/realtime": "0.1.112",
+    "@jskit-ai/shell-web": "0.1.113",
+    "@jskit-ai/uploads-image-web": "0.1.91",
+    "@jskit-ai/users-core": "0.1.123"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/users-web/src/client/components/CrudListScreen.vue
+++ b/packages/users-web/src/client/components/CrudListScreen.vue
@@ -191,7 +191,7 @@ function setSelectableRowsSelected(selected = true) {
         </div>
 
         <template v-else>
-          <div class="ui-generator-list-cards d-md-none">
+          <div class="ui-generator-list-cards">
             <v-sheet
               v-for="row in displayRows"
               :key="row.key"
@@ -237,7 +237,7 @@ function setSelectableRowsSelected(selected = true) {
             </v-sheet>
           </div>
 
-          <div class="ui-generator-list-table d-none d-md-block">
+          <div class="ui-generator-list-table">
             <v-table density="comfortable">
               <thead>
                 <tr>
@@ -325,7 +325,7 @@ function setSelectableRowsSelected(selected = true) {
 
     <v-btn
       v-if="listPrimaryAction"
-      class="ui-generator-list-fab d-md-none"
+      class="ui-generator-list-fab"
       color="primary"
       variant="flat"
       :to="listPrimaryAction"
@@ -447,6 +447,7 @@ function setSelectableRowsSelected(selected = true) {
 }
 
 .ui-generator-list-table {
+  display: none;
   overflow-x: auto;
 }
 
@@ -456,9 +457,24 @@ function setSelectableRowsSelected(selected = true) {
 
 .ui-generator-list-fab {
   bottom: calc(5rem + env(safe-area-inset-bottom, 0px));
+  display: flex;
   position: fixed;
   right: 1rem;
   z-index: 6;
+}
+
+@media (min-width: 960px) {
+  .ui-generator-list-cards {
+    display: none;
+  }
+
+  .ui-generator-list-table {
+    display: block;
+  }
+
+  .ui-generator-list-fab {
+    display: none;
+  }
 }
 
 @media (max-width: 960px) {

--- a/packages/users-web/test/crudScreenComponents.test.js
+++ b/packages/users-web/test/crudScreenComponents.test.js
@@ -23,9 +23,17 @@ test("CRUD screen components own generated list/view/form chrome centrally", asy
   assert.match(listSource, /CrudListBulkActionSurface/);
   assert.match(listSource, /CrudListFilterSurface/);
   assert.match(listSource, /CrudListRecordActionMenu/);
-  assert.match(listSource, /ui-generator-list-cards d-md-none/);
-  assert.match(listSource, /ui-generator-list-table d-none d-md-block/);
-  assert.match(listSource, /class="ui-generator-list-fab d-md-none"/);
+  assert.match(listSource, /class="ui-generator-list-cards"/);
+  assert.match(listSource, /class="ui-generator-list-table"/);
+  assert.match(listSource, /class="ui-generator-list-fab"/);
+  assert.doesNotMatch(listSource, /ui-generator-list-cards d-md-none/);
+  assert.doesNotMatch(listSource, /ui-generator-list-table d-none d-md-block/);
+  assert.doesNotMatch(listSource, /class="ui-generator-list-fab d-md-none"/);
+  assert.match(listSource, /\.ui-generator-list-table\s*\{\s*display:\s*none;/);
+  assert.match(
+    listSource,
+    /@media \(min-width: 960px\)[\s\S]*\.ui-generator-list-cards\s*\{\s*display:\s*none;[\s\S]*\.ui-generator-list-table\s*\{\s*display:\s*block;[\s\S]*\.ui-generator-list-fab\s*\{\s*display:\s*none;/
+  );
   assert.match(listSource, /button-label="More"/);
   assert.match(listSource, /selectableRows/);
   assert.match(listSource, /min-height:\s*48px/);

--- a/packages/workspaces-core/package.descriptor.mjs
+++ b/packages/workspaces-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-core",
-  version: "0.1.88",
+  version: "0.1.89",
   kind: "runtime",
   description: "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
   dependsOn: [
@@ -147,10 +147,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/json-rest-api-core": "0.1.57",
-        "@jskit-ai/resource-core": "0.1.57",
-        "@jskit-ai/resource-crud-core": "0.1.57",
-        "@jskit-ai/users-core": "0.1.122"
+        "@jskit-ai/json-rest-api-core": "0.1.58",
+        "@jskit-ai/resource-core": "0.1.58",
+        "@jskit-ai/resource-crud-core": "0.1.58",
+        "@jskit-ai/users-core": "0.1.123"
       },
       dev: {}
     },

--- a/packages/workspaces-core/package.json
+++ b/packages/workspaces-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-core",
-  "version": "0.1.88",
+  "version": "0.1.89",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -18,14 +18,14 @@
     "./shared/resources/workspaceSettingsResource": "./src/shared/resources/workspaceSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.111",
-    "@jskit-ai/database-runtime": "0.1.112",
-    "@jskit-ai/http-runtime": "0.1.111",
-    "@jskit-ai/json-rest-api-core": "0.1.57",
-    "@jskit-ai/kernel": "0.1.113",
-    "@jskit-ai/resource-crud-core": "0.1.57",
-    "@jskit-ai/resource-core": "0.1.57",
-    "@jskit-ai/users-core": "0.1.122",
+    "@jskit-ai/auth-core": "0.1.112",
+    "@jskit-ai/database-runtime": "0.1.113",
+    "@jskit-ai/http-runtime": "0.1.112",
+    "@jskit-ai/json-rest-api-core": "0.1.58",
+    "@jskit-ai/kernel": "0.1.114",
+    "@jskit-ai/resource-crud-core": "0.1.58",
+    "@jskit-ai/resource-core": "0.1.58",
+    "@jskit-ai/users-core": "0.1.123",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/workspaces-web/package.descriptor.mjs
+++ b/packages/workspaces-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-web",
-  version: "0.1.89",
+  version: "0.1.90",
   kind: "runtime",
   description: "Workspace web module: workspace selector, tools widget, workspace surfaces, members UI, and settings hosts.",
   dependsOn: [
@@ -232,9 +232,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-web": "0.1.113",
-        "@jskit-ai/workspaces-core": "0.1.88",
-        "@jskit-ai/users-web": "0.1.127"
+        "@jskit-ai/auth-web": "0.1.114",
+        "@jskit-ai/workspaces-core": "0.1.89",
+        "@jskit-ai/users-web": "0.1.128"
       },
       dev: {}
     },

--- a/packages/workspaces-web/package.json
+++ b/packages/workspaces-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-web",
-  "version": "0.1.89",
+  "version": "0.1.90",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -15,13 +15,13 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/auth-web": "0.1.113",
-    "@jskit-ai/http-runtime": "0.1.111",
-    "@jskit-ai/kernel": "0.1.113",
-    "@jskit-ai/shell-web": "0.1.112",
-    "@jskit-ai/users-core": "0.1.122",
-    "@jskit-ai/users-web": "0.1.127",
-    "@jskit-ai/workspaces-core": "0.1.88"
+    "@jskit-ai/auth-web": "0.1.114",
+    "@jskit-ai/http-runtime": "0.1.112",
+    "@jskit-ai/kernel": "0.1.114",
+    "@jskit-ai/shell-web": "0.1.113",
+    "@jskit-ai/users-core": "0.1.123",
+    "@jskit-ai/users-web": "0.1.128",
+    "@jskit-ai/workspaces-core": "0.1.89"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/tooling/config-eslint/package.json
+++ b/tooling/config-eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/config-eslint",
-  "version": "0.1.111",
+  "version": "0.1.112",
   "description": "Shared flat ESLint presets for JSKIT projects.",
   "type": "module",
   "files": [

--- a/tooling/create-app/package.descriptor.mjs
+++ b/tooling/create-app/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/create-app",
-  "version": "0.1.121",
+  "version": "0.1.122",
   "dependsOn": [],
   "capabilities": {
     "provides": [

--- a/tooling/create-app/package.json
+++ b/tooling/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/create-app",
-  "version": "0.1.121",
+  "version": "0.1.122",
   "description": "Scaffold JSKIT app shells.",
   "type": "module",
   "files": [

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -6,11 +6,11 @@
   "packages": [
     {
       "packageId": "@jskit-ai/assistant",
-      "version": "0.1.121",
+      "version": "0.1.122",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant",
-        "version": "0.1.121",
+        "version": "0.1.122",
         "kind": "generator",
         "description": "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
         "options": {
@@ -347,11 +347,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-core",
-      "version": "0.1.88",
+      "version": "0.1.89",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-core",
-        "version": "0.1.88",
+        "version": "0.1.89",
         "kind": "runtime",
         "description": "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
         "dependsOn": [
@@ -399,11 +399,11 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/http-runtime": "0.1.111",
-              "@jskit-ai/kernel": "0.1.113",
-              "@jskit-ai/resource-core": "0.1.57",
-              "@jskit-ai/resource-crud-core": "0.1.57",
-              "@jskit-ai/users-core": "0.1.122",
+              "@jskit-ai/http-runtime": "0.1.112",
+              "@jskit-ai/kernel": "0.1.114",
+              "@jskit-ai/resource-core": "0.1.58",
+              "@jskit-ai/resource-crud-core": "0.1.58",
+              "@jskit-ai/users-core": "0.1.123",
               "dompurify": "^3.3.3",
               "json-rest-schema": "1.x.x",
               "marked": "^17.0.4",
@@ -422,11 +422,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-runtime",
-      "version": "0.1.83",
+      "version": "0.1.84",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-runtime",
-        "version": "0.1.83",
+        "version": "0.1.84",
         "kind": "runtime",
         "description": "Shared assistant runtime with per-surface assistant registration.",
         "dependsOn": [
@@ -522,13 +522,13 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/assistant-core": "0.1.88",
-              "@jskit-ai/database-runtime": "0.1.112",
-              "@jskit-ai/http-runtime": "0.1.111",
-              "@jskit-ai/kernel": "0.1.113",
-              "@jskit-ai/shell-web": "0.1.112",
-              "@jskit-ai/users-core": "0.1.122",
-              "@jskit-ai/users-web": "0.1.127"
+              "@jskit-ai/assistant-core": "0.1.89",
+              "@jskit-ai/database-runtime": "0.1.113",
+              "@jskit-ai/http-runtime": "0.1.112",
+              "@jskit-ai/kernel": "0.1.114",
+              "@jskit-ai/shell-web": "0.1.113",
+              "@jskit-ai/users-core": "0.1.123",
+              "@jskit-ai/users-web": "0.1.128"
             },
             "dev": {}
           },
@@ -583,11 +583,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-core",
-      "version": "0.1.111",
+      "version": "0.1.112",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-core",
-        "version": "0.1.111",
+        "version": "0.1.112",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/value-app-config-shared"
@@ -660,7 +660,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.113",
+              "@jskit-ai/kernel": "0.1.114",
               "@fastify/cookie": "^11.0.2",
               "@fastify/csrf-protection": "^7.1.0",
               "@fastify/rate-limit": "^10.3.0"
@@ -678,11 +678,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-local-core",
-      "version": "0.1.12",
+      "version": "0.1.13",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-local-core",
-        "version": "0.1.12",
+        "version": "0.1.13",
         "kind": "runtime",
         "description": "Local auth provider with a file backend default and no database requirement.",
         "dependsOn": [
@@ -738,8 +738,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.111",
-              "@jskit-ai/kernel": "0.1.113",
+              "@jskit-ai/auth-core": "0.1.112",
+              "@jskit-ai/kernel": "0.1.114",
               "nodemailer": "^7.0.10",
               "dotenv": "^16.4.5"
             },
@@ -785,11 +785,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-local-db-core",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-local-db-core",
-        "version": "0.1.4",
+        "version": "0.1.5",
         "kind": "runtime",
         "description": "Database-backed local auth storage backend for JSKIT local auth.",
         "dependsOn": [
@@ -861,9 +861,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-provider-local-core": "0.1.12",
-              "@jskit-ai/database-runtime": "0.1.112",
-              "@jskit-ai/kernel": "0.1.113"
+              "@jskit-ai/auth-provider-local-core": "0.1.13",
+              "@jskit-ai/database-runtime": "0.1.113",
+              "@jskit-ai/kernel": "0.1.114"
             },
             "dev": {}
           },
@@ -898,11 +898,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.111",
+      "version": "0.1.112",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-supabase-core",
-        "version": "0.1.111",
+        "version": "0.1.112",
         "kind": "runtime",
         "options": {
           "auth-supabase-url": {
@@ -984,8 +984,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.111",
-              "@jskit-ai/kernel": "0.1.113",
+              "@jskit-ai/auth-core": "0.1.112",
+              "@jskit-ai/kernel": "0.1.114",
               "dotenv": "^16.4.5",
               "@supabase/supabase-js": "^2.57.4",
               "jose": "^6.1.0"
@@ -1063,11 +1063,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-web",
-      "version": "0.1.113",
+      "version": "0.1.114",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-web",
-        "version": "0.1.113",
+        "version": "0.1.114",
         "kind": "runtime",
         "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
         "dependsOn": [
@@ -1336,10 +1336,10 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/auth-core": "0.1.111",
-              "@jskit-ai/http-runtime": "0.1.111",
-              "@jskit-ai/kernel": "0.1.113",
-              "@jskit-ai/shell-web": "0.1.112"
+              "@jskit-ai/auth-core": "0.1.112",
+              "@jskit-ai/http-runtime": "0.1.112",
+              "@jskit-ai/kernel": "0.1.114",
+              "@jskit-ai/shell-web": "0.1.113"
             },
             "dev": {}
           },
@@ -1432,11 +1432,11 @@
     },
     {
       "packageId": "@jskit-ai/console-core",
-      "version": "0.1.75",
+      "version": "0.1.76",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-core",
-        "version": "0.1.75",
+        "version": "0.1.76",
         "kind": "runtime",
         "description": "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
         "dependsOn": [
@@ -1520,12 +1520,12 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.111",
-              "@jskit-ai/database-runtime": "0.1.112",
-              "@jskit-ai/http-runtime": "0.1.111",
-              "@jskit-ai/kernel": "0.1.113",
-              "@jskit-ai/resource-crud-core": "0.1.57",
-              "@jskit-ai/users-core": "0.1.122"
+              "@jskit-ai/auth-core": "0.1.112",
+              "@jskit-ai/database-runtime": "0.1.113",
+              "@jskit-ai/http-runtime": "0.1.112",
+              "@jskit-ai/kernel": "0.1.114",
+              "@jskit-ai/resource-crud-core": "0.1.58",
+              "@jskit-ai/users-core": "0.1.123"
             },
             "dev": {}
           },
@@ -1550,11 +1550,11 @@
     },
     {
       "packageId": "@jskit-ai/console-web",
-      "version": "0.1.80",
+      "version": "0.1.81",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-web",
-        "version": "0.1.80",
+        "version": "0.1.81",
         "kind": "runtime",
         "description": "Authenticated console surface scaffold and surface policy wiring.",
         "dependsOn": [
@@ -1664,9 +1664,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-web": "0.1.113",
-              "@jskit-ai/console-core": "0.1.75",
-              "@jskit-ai/shell-web": "0.1.112"
+              "@jskit-ai/auth-web": "0.1.114",
+              "@jskit-ai/console-core": "0.1.76",
+              "@jskit-ai/shell-web": "0.1.113"
             },
             "dev": {}
           },
@@ -1773,11 +1773,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-core",
-      "version": "0.1.120",
+      "version": "0.1.121",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-core",
-        "version": "0.1.120",
+        "version": "0.1.121",
         "kind": "runtime",
         "description": "Shared CRUD helpers used by CRUD modules.",
         "dependsOn": [
@@ -1806,7 +1806,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/crud-core": "0.1.120"
+              "@jskit-ai/crud-core": "0.1.121"
             },
             "dev": {}
           },
@@ -1820,11 +1820,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-server-generator",
-      "version": "0.1.120",
+      "version": "0.1.121",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-server-generator",
-        "version": "0.1.120",
+        "version": "0.1.121",
         "kind": "generator",
         "description": "CRUD server generator with routes, actions, and persistence scaffolding.",
         "options": {
@@ -1991,14 +1991,14 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.111",
-              "@jskit-ai/crud-core": "0.1.120",
-              "@jskit-ai/database-runtime": "0.1.112",
-              "@jskit-ai/http-runtime": "0.1.111",
-              "@jskit-ai/json-rest-api-core": "0.1.57",
-              "@jskit-ai/kernel": "0.1.113",
-              "@jskit-ai/realtime": "0.1.111",
-              "@jskit-ai/resource-crud-core": "0.1.57",
+              "@jskit-ai/auth-core": "0.1.112",
+              "@jskit-ai/crud-core": "0.1.121",
+              "@jskit-ai/database-runtime": "0.1.113",
+              "@jskit-ai/http-runtime": "0.1.112",
+              "@jskit-ai/json-rest-api-core": "0.1.58",
+              "@jskit-ai/kernel": "0.1.114",
+              "@jskit-ai/realtime": "0.1.112",
+              "@jskit-ai/resource-crud-core": "0.1.58",
               "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}"
             },
             "dev": {}
@@ -2130,11 +2130,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.95",
+      "version": "0.1.96",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-ui-generator",
-        "version": "0.1.95",
+        "version": "0.1.96",
         "kind": "generator",
         "description": "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
         "options": {
@@ -2333,7 +2333,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.127"
+              "@jskit-ai/users-web": "0.1.128"
             },
             "dev": {}
           },
@@ -2592,11 +2592,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime",
-      "version": "0.1.112",
+      "version": "0.1.113",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime",
-        "version": "0.1.112",
+        "version": "0.1.113",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -2653,7 +2653,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.113",
+              "@jskit-ai/kernel": "0.1.114",
               "dotenv": "^16.4.5",
               "knex": "^3.1.0"
             },
@@ -2689,11 +2689,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.111",
+      "version": "0.1.112",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-mysql",
-        "version": "0.1.111",
+        "version": "0.1.112",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -2783,7 +2783,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.112",
+              "@jskit-ai/database-runtime": "0.1.113",
               "mysql2": "^3.11.2"
             },
             "dev": {}
@@ -2854,11 +2854,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.111",
+      "version": "0.1.112",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-postgres",
-        "version": "0.1.111",
+        "version": "0.1.112",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -2948,7 +2948,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.112",
+              "@jskit-ai/database-runtime": "0.1.113",
               "pg": "^8.13.1"
             },
             "dev": {}
@@ -3019,11 +3019,11 @@
     },
     {
       "packageId": "@jskit-ai/feature-server-generator",
-      "version": "0.1.54",
+      "version": "0.1.55",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/feature-server-generator",
-        "version": "0.1.54",
+        "version": "0.1.55",
         "kind": "generator",
         "description": "Scaffold substantial non-CRUD server feature packages with provider, actions, service, and optional persistence seams.",
         "options": {
@@ -3208,7 +3208,7 @@
                   "equals": "json-rest"
                 }
               },
-              "@jskit-ai/kernel": "0.1.113",
+              "@jskit-ai/kernel": "0.1.114",
               "json-rest-schema": "1.x.x",
               "@local/${option:feature-name|kebab}": "file:packages/${option:feature-name|kebab}"
             },
@@ -3321,11 +3321,11 @@
     },
     {
       "packageId": "@jskit-ai/google-rewarded-core",
-      "version": "0.1.49",
+      "version": "0.1.50",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/google-rewarded-core",
-        "version": "0.1.49",
+        "version": "0.1.50",
         "kind": "runtime",
         "description": "Google rewarded workflow runtime plus internal CRUD providers for rules, provider configs, watch sessions, and unlock receipts.",
         "dependsOn": [
@@ -3452,14 +3452,14 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.111",
-              "@jskit-ai/crud-core": "0.1.120",
-              "@jskit-ai/database-runtime": "0.1.112",
-              "@jskit-ai/http-runtime": "0.1.111",
-              "@jskit-ai/json-rest-api-core": "0.1.57",
-              "@jskit-ai/kernel": "0.1.113",
-              "@jskit-ai/resource-crud-core": "0.1.57",
-              "@jskit-ai/workspaces-core": "0.1.88"
+              "@jskit-ai/auth-core": "0.1.112",
+              "@jskit-ai/crud-core": "0.1.121",
+              "@jskit-ai/database-runtime": "0.1.113",
+              "@jskit-ai/http-runtime": "0.1.112",
+              "@jskit-ai/json-rest-api-core": "0.1.58",
+              "@jskit-ai/kernel": "0.1.114",
+              "@jskit-ai/resource-crud-core": "0.1.58",
+              "@jskit-ai/workspaces-core": "0.1.89"
             },
             "dev": {}
           },
@@ -3511,11 +3511,11 @@
     },
     {
       "packageId": "@jskit-ai/google-rewarded-web",
-      "version": "0.1.49",
+      "version": "0.1.50",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/google-rewarded-web",
-        "version": "0.1.49",
+        "version": "0.1.50",
         "kind": "runtime",
         "description": "Google rewarded client runtime with a fullscreen gate host and GPT orchestration.",
         "dependsOn": [
@@ -3562,10 +3562,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/google-rewarded-core": "0.1.49",
-              "@jskit-ai/http-runtime": "0.1.111",
-              "@jskit-ai/kernel": "0.1.113",
-              "@jskit-ai/shell-web": "0.1.112"
+              "@jskit-ai/google-rewarded-core": "0.1.50",
+              "@jskit-ai/http-runtime": "0.1.112",
+              "@jskit-ai/kernel": "0.1.114",
+              "@jskit-ai/shell-web": "0.1.113"
             },
             "dev": {}
           },
@@ -3583,11 +3583,11 @@
     },
     {
       "packageId": "@jskit-ai/http-runtime",
-      "version": "0.1.111",
+      "version": "0.1.112",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/http-runtime",
-        "version": "0.1.111",
+        "version": "0.1.112",
         "kind": "runtime",
         "dependsOn": [],
         "capabilities": {
@@ -3653,7 +3653,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.113"
+              "@jskit-ai/kernel": "0.1.114"
             },
             "dev": {}
           },
@@ -3667,11 +3667,11 @@
     },
     {
       "packageId": "@jskit-ai/json-rest-api-core",
-      "version": "0.1.57",
+      "version": "0.1.58",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/json-rest-api-core",
-        "version": "0.1.57",
+        "version": "0.1.58",
         "kind": "runtime",
         "description": "Shared internal json-rest-api host runtime for JSKIT server packages.",
         "dependsOn": [
@@ -3731,11 +3731,11 @@
     },
     {
       "packageId": "@jskit-ai/mobile-capacitor",
-      "version": "0.1.49",
+      "version": "0.1.50",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/mobile-capacitor",
-        "version": "0.1.49",
+        "version": "0.1.50",
         "kind": "runtime",
         "description": "Thin Capacitor client integration for JSKIT mobile-shell launch routing and auth callback completion.",
         "dependsOn": [
@@ -3798,8 +3798,8 @@
               "@capacitor/app": "^7.1.0",
               "@capacitor/browser": "^7.0.1",
               "@capacitor/core": "^7.4.3",
-              "@jskit-ai/kernel": "0.1.113",
-              "@jskit-ai/shell-web": "0.1.112"
+              "@jskit-ai/kernel": "0.1.114",
+              "@jskit-ai/shell-web": "0.1.113"
             },
             "dev": {
               "@capacitor/cli": "^7.4.3"
@@ -3851,11 +3851,11 @@
     },
     {
       "packageId": "@jskit-ai/realtime",
-      "version": "0.1.111",
+      "version": "0.1.112",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/realtime",
-        "version": "0.1.111",
+        "version": "0.1.112",
         "kind": "runtime",
         "description": "Thin, generic realtime runtime wrappers for socket.io server and client.",
         "options": {
@@ -3951,7 +3951,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.113",
+              "@jskit-ai/kernel": "0.1.114",
               "@socket.io/redis-adapter": "^8.3.0",
               "redis": "^5.8.2",
               "socket.io": "^4.8.3",
@@ -4000,11 +4000,11 @@
     },
     {
       "packageId": "@jskit-ai/resource-core",
-      "version": "0.1.57",
+      "version": "0.1.58",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/resource-core",
-        "version": "0.1.57",
+        "version": "0.1.58",
         "kind": "runtime",
         "description": "Generic resource-definition helpers and schema-definition normalization.",
         "dependsOn": [
@@ -4027,7 +4027,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/resource-core": "0.1.57"
+              "@jskit-ai/resource-core": "0.1.58"
             },
             "dev": {}
           },
@@ -4042,11 +4042,11 @@
     },
     {
       "packageId": "@jskit-ai/resource-crud-core",
-      "version": "0.1.57",
+      "version": "0.1.58",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/resource-crud-core",
-        "version": "0.1.57",
+        "version": "0.1.58",
         "kind": "runtime",
         "description": "CRUD-specific resource-definition helpers and namespace support.",
         "dependsOn": [
@@ -4070,7 +4070,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/resource-crud-core": "0.1.57"
+              "@jskit-ai/resource-crud-core": "0.1.58"
             },
             "dev": {}
           },
@@ -4085,11 +4085,11 @@
     },
     {
       "packageId": "@jskit-ai/shell-web",
-      "version": "0.1.112",
+      "version": "0.1.113",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/shell-web",
-        "version": "0.1.112",
+        "version": "0.1.113",
         "kind": "runtime",
         "description": "Web shell layout runtime with outlet-based placement contributions.",
         "dependsOn": [],
@@ -4431,7 +4431,7 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/kernel": "0.1.113"
+              "@jskit-ai/kernel": "0.1.114"
             },
             "dev": {}
           },
@@ -4638,11 +4638,11 @@
     },
     {
       "packageId": "@jskit-ai/storage-runtime",
-      "version": "0.1.111",
+      "version": "0.1.112",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/storage-runtime",
-        "version": "0.1.111",
+        "version": "0.1.112",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -4691,7 +4691,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.113",
+              "@jskit-ai/kernel": "0.1.114",
               "unstorage": "^1.17.3"
             },
             "dev": {}
@@ -4707,11 +4707,11 @@
     },
     {
       "packageId": "@jskit-ai/ui-generator",
-      "version": "0.1.95",
+      "version": "0.1.96",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/ui-generator",
-        "version": "0.1.95",
+        "version": "0.1.96",
         "kind": "generator",
         "description": "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
         "options": {
@@ -5144,7 +5144,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.127"
+              "@jskit-ai/users-web": "0.1.128"
             },
             "dev": {}
           },
@@ -5159,11 +5159,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-image-web",
-      "version": "0.1.90",
+      "version": "0.1.91",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-image-web",
-        "version": "0.1.90",
+        "version": "0.1.91",
         "kind": "runtime",
         "description": "Reusable client-side image upload runtime with pre-upload image editing.",
         "dependsOn": [
@@ -5227,7 +5227,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/uploads-runtime": "0.1.90",
+              "@jskit-ai/uploads-runtime": "0.1.91",
               "@uppy/compressor": "^3.1.0",
               "@uppy/core": "^5.2.0",
               "@uppy/dashboard": "^5.1.1",
@@ -5247,11 +5247,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-runtime",
-      "version": "0.1.90",
+      "version": "0.1.91",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-runtime",
-        "version": "0.1.90",
+        "version": "0.1.91",
         "kind": "runtime",
         "description": "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
         "dependsOn": [
@@ -5321,7 +5321,7 @@
           "dependencies": {
             "runtime": {
               "@fastify/multipart": "^9.4.0",
-              "@jskit-ai/kernel": "0.1.113"
+              "@jskit-ai/kernel": "0.1.114"
             },
             "dev": {}
           },
@@ -5336,11 +5336,11 @@
     },
     {
       "packageId": "@jskit-ai/users-core",
-      "version": "0.1.122",
+      "version": "0.1.123",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-core",
-        "version": "0.1.122",
+        "version": "0.1.123",
         "kind": "runtime",
         "description": "Users/account runtime plus HTTP routes for account features.",
         "dependsOn": [
@@ -5484,16 +5484,16 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.111",
-              "@jskit-ai/crud-core": "0.1.120",
-              "@jskit-ai/database-runtime": "0.1.112",
-              "@jskit-ai/http-runtime": "0.1.111",
-              "@jskit-ai/json-rest-api-core": "0.1.57",
-              "@jskit-ai/kernel": "0.1.113",
-              "@jskit-ai/resource-core": "0.1.57",
-              "@jskit-ai/resource-crud-core": "0.1.57",
+              "@jskit-ai/auth-core": "0.1.112",
+              "@jskit-ai/crud-core": "0.1.121",
+              "@jskit-ai/database-runtime": "0.1.113",
+              "@jskit-ai/http-runtime": "0.1.112",
+              "@jskit-ai/json-rest-api-core": "0.1.58",
+              "@jskit-ai/kernel": "0.1.114",
+              "@jskit-ai/resource-core": "0.1.58",
+              "@jskit-ai/resource-crud-core": "0.1.58",
               "@local/users": "file:packages/users",
-              "@jskit-ai/uploads-runtime": "0.1.90"
+              "@jskit-ai/uploads-runtime": "0.1.91"
             },
             "dev": {}
           },
@@ -5720,11 +5720,11 @@
     },
     {
       "packageId": "@jskit-ai/users-web",
-      "version": "0.1.127",
+      "version": "0.1.128",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-web",
-        "version": "0.1.127",
+        "version": "0.1.128",
         "kind": "runtime",
         "description": "Users web module: account/profile UI plus shared users web widgets.",
         "dependsOn": [
@@ -6027,12 +6027,12 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/http-runtime": "0.1.111",
-              "@jskit-ai/realtime": "0.1.111",
-              "@jskit-ai/kernel": "0.1.113",
-              "@jskit-ai/shell-web": "0.1.112",
-              "@jskit-ai/uploads-image-web": "0.1.90",
-              "@jskit-ai/users-core": "0.1.122"
+              "@jskit-ai/http-runtime": "0.1.112",
+              "@jskit-ai/realtime": "0.1.112",
+              "@jskit-ai/kernel": "0.1.114",
+              "@jskit-ai/shell-web": "0.1.113",
+              "@jskit-ai/uploads-image-web": "0.1.91",
+              "@jskit-ai/users-core": "0.1.123"
             },
             "dev": {}
           },
@@ -6209,11 +6209,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-core",
-      "version": "0.1.88",
+      "version": "0.1.89",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-core",
-        "version": "0.1.88",
+        "version": "0.1.89",
         "kind": "runtime",
         "description": "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
         "dependsOn": [
@@ -6359,10 +6359,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/json-rest-api-core": "0.1.57",
-              "@jskit-ai/resource-core": "0.1.57",
-              "@jskit-ai/resource-crud-core": "0.1.57",
-              "@jskit-ai/users-core": "0.1.122"
+              "@jskit-ai/json-rest-api-core": "0.1.58",
+              "@jskit-ai/resource-core": "0.1.58",
+              "@jskit-ai/resource-crud-core": "0.1.58",
+              "@jskit-ai/users-core": "0.1.123"
             },
             "dev": {}
           },
@@ -6564,11 +6564,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-web",
-      "version": "0.1.89",
+      "version": "0.1.90",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-web",
-        "version": "0.1.89",
+        "version": "0.1.90",
         "kind": "runtime",
         "description": "Workspace web module: workspace selector, tools widget, workspace surfaces, members UI, and settings hosts.",
         "dependsOn": [
@@ -6825,9 +6825,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-web": "0.1.113",
-              "@jskit-ai/workspaces-core": "0.1.88",
-              "@jskit-ai/users-web": "0.1.127"
+              "@jskit-ai/auth-web": "0.1.114",
+              "@jskit-ai/workspaces-core": "0.1.89",
+              "@jskit-ai/users-web": "0.1.128"
             },
             "dev": {}
           },

--- a/tooling/jskit-catalog/package.json
+++ b/tooling/jskit-catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-catalog",
-  "version": "0.1.120",
+  "version": "0.1.121",
   "description": "Published metadata catalog for JSKIT package descriptors.",
   "type": "module",
   "files": [

--- a/tooling/jskit-cli/package.json
+++ b/tooling/jskit-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-cli",
-  "version": "0.2.125",
+  "version": "0.2.126",
   "description": "Bundle and package orchestration CLI for JSKIT apps.",
   "type": "module",
   "files": [
@@ -20,9 +20,9 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/jskit-catalog": "0.1.120",
-    "@jskit-ai/kernel": "0.1.113",
-    "@jskit-ai/shell-web": "0.1.112",
+    "@jskit-ai/jskit-catalog": "0.1.121",
+    "@jskit-ai/kernel": "0.1.114",
+    "@jskit-ai/shell-web": "0.1.113",
     "@vue/compiler-sfc": "^3.5.29",
     "ts-morph": "^28.0.0"
   },

--- a/tooling/jskit-cli/src/server/cliRuntime/packageOptions.js
+++ b/tooling/jskit-cli/src/server/cliRuntime/packageOptions.js
@@ -106,6 +106,10 @@ function normalizeResolvedOptionValue(value = "") {
   return String(value || "").trim().toLowerCase();
 }
 
+function isFlagOptionSchema(schema = {}) {
+  return normalizeResolvedOptionValue(schema?.inputType) === "flag";
+}
+
 function normalizeResolvedOptionSchemaValue({
   packageEntry,
   optionName = "",
@@ -475,6 +479,7 @@ async function resolvePackageOptions(packageEntry, inlineOptions, io, { appRoot 
   for (const optionName of optionNames) {
     const schema = ensureObject(optionSchemas[optionName]);
     const allowEmpty = schema.allowEmpty === true;
+    const isFlagOption = isFlagOptionSchema(schema);
     const assignResolvedOption = (rawValue = "") => {
       const normalizedOptionValue = normalizeResolvedOptionSchemaValue({
         packageEntry,
@@ -489,7 +494,12 @@ async function resolvePackageOptions(packageEntry, inlineOptions, io, { appRoot 
       return false;
     };
     if (hasInlineOption(optionName)) {
-      const inlineValue = String(inlineOptionValues[optionName] || "").trim();
+      const rawInlineValue = inlineOptionValues[optionName];
+      const inlineValue = String(rawInlineValue ?? "").trim();
+      if (isFlagOption) {
+        assignResolvedOption(inlineValue || "true");
+        continue;
+      }
       if (inlineValue || allowEmpty) {
         assignResolvedOption(inlineValue);
         continue;
@@ -519,6 +529,11 @@ async function resolvePackageOptions(packageEntry, inlineOptions, io, { appRoot 
 
     if (typeof schema.defaultValue === "string" && schema.defaultValue.trim()) {
       assignResolvedOption(schema.defaultValue.trim());
+      continue;
+    }
+
+    if (isFlagOption) {
+      resolved[optionName] = "false";
       continue;
     }
 

--- a/tooling/jskit-cli/test/packageOptionEnumValidation.test.js
+++ b/tooling/jskit-cli/test/packageOptionEnumValidation.test.js
@@ -73,6 +73,37 @@ test("validateInlineOptionValuesForPackage rejects unsupported enum and csv-enum
   );
 });
 
+test("resolvePackageOptions normalizes descriptor flag options without empty-string ambiguity", async () => {
+  const packageEntry = {
+    packageId: "@demo/flag-generator",
+    descriptor: {
+      options: {
+        force: {
+          required: false,
+          inputType: "flag",
+          defaultValue: ""
+        },
+        internal: {
+          required: false,
+          inputType: "flag",
+          defaultValue: ""
+        }
+      }
+    }
+  };
+
+  assert.deepEqual(
+    await resolvePackageOptions(packageEntry, {}, {}, {}),
+    {
+      force: "false",
+      internal: "false"
+    }
+  );
+  assert.equal((await resolvePackageOptions(packageEntry, { internal: undefined }, {}, {})).internal, "true");
+  assert.equal((await resolvePackageOptions(packageEntry, { internal: "" }, {}, {})).internal, "true");
+  assert.equal((await resolvePackageOptions(packageEntry, { internal: "false" }, {}, {})).internal, "false");
+});
+
 test("resolvePackageOptions offers descriptor-backed choices for required enum options", async () => {
   const stdin = new PassThrough();
   stdin.isTTY = true;


### PR DESCRIPTION
## Summary
- make CrudListScreen own mutually exclusive card/table/FAB responsive display
- fix descriptor flag option resolution so omitted flags are false and bare flags are true
- keep generated CRUD routes public unless --internal is requested, with clean optional-line output
- include the published npm version metadata updates

## Tests
- npm test --workspace @jskit-ai/users-web
- npm test --workspace @jskit-ai/crud-server-generator
- npm test --workspace @jskit-ai/jskit-cli

## Manual verification
- linked local packages into the temp DB-auth app
- regenerated tasks CRUD
- confirmed generated routes no longer emit internal: true by default
- created a task through the generated UI
- verified desktop list shows only table rows and compact list shows only cards
