### PR TITLE
fix(crud-generator): satisfy regex lint rules

### DIFF
--- a/packages/agent-docs/reference/autogen/packages/crud-server-generator.md
+++ b/packages/agent-docs/reference/autogen/packages/crud-server-generator.md
@@ -91,6 +91,7 @@ Local functions
 - `renderRouteWorkspaceSupportImports({ surfaceRequiresWorkspace = true } = {})`
 - `renderActionWorkspaceValidatorImport({ surfaceRequiresWorkspace = true } = {})`
 - `renderRouteParamsValidatorLine(operation = "", { surfaceRequiresWorkspace = true } = {})`
+- `renderOptionalTemplateLine(line = "")`
 - `renderRouteInputLines(operation = "", { surfaceRequiresWorkspace = true } = {})`
 - `renderObjectSchemaDefinition(lines = [], { mode = "patch" } = {})`
 - `renderActionInputExpressions({ surfaceRequiresWorkspace = true } = {})`

--- a/packages/agent-docs/reference/autogen/tooling/jskit-cli.md
+++ b/packages/agent-docs/reference/autogen/tooling/jskit-cli.md
@@ -344,6 +344,7 @@ Local functions
 - `resolveSurfaceVisibilityOptionPolicy(packageEntry = {})`
 - `resolveSurfaceDefinitionsForOptionPolicy(configContext = {})`
 - `normalizeResolvedOptionValue(value = "")`
+- `isFlagOptionSchema(schema = {})`
 - `normalizeResolvedOptionSchemaValue({ packageEntry, optionName = "", schema = {}, value = "" } = {})`
 - `resolveSchemaValidatedOptionNames(packageEntry = {}, validationType = "", { optionNames = null } = {})`
 - `resolveAllowedValuesForSchema(schema = {})`
@@ -387,6 +388,25 @@ Local functions
 - `resolvePackageRootFromNodeModules({ appRoot, packageId })`
 - `loadLocalWorkspacePackageIdIndex()`
 - `resolvePackageRootFromLocalWorkspace({ packageId })`
+
+### `src/server/cliRuntime/sensitiveLockState.js`
+Exports
+- `collectOptionReferences(value = "")`
+- `isSensitiveEnvKey(key = "")`
+- `isSensitiveManagedTextRecord({ packageEntry = {}, record = {} } = {})`
+- `isSensitivePackageOption(packageEntry = {}, optionName = "")`
+- `isSensitiveTextMutation({ packageEntry = {}, mutation = {}, resolvedKey = "" } = {})`
+- `resolveSensitiveOptionEnvFallbacks({ packageEntry = {}, appRoot = "", optionInput = {}, readFileBufferIfExists } = {})`
+- `sanitizeInstalledPackageRecordForLock(record = {}, packageEntry = {})`
+- `sanitizeLockSecretsForWrite(lock = {}, packageRegistry = null)`
+- `sanitizeManagedTextForLock(packageEntry = {}, managedText = {})`
+- `sanitizePackageOptionsForLock(packageEntry = {}, options = {})`
+- `sanitizePackageOptionsForResolve(packageEntry = {}, options = {})`
+Local functions
+- `isSensitiveName(value = "")`
+- `textValueReferencesSensitiveOption(packageEntry = {}, value = "")`
+- `isExactOptionReference(value = "", optionName = "")`
+- `readEnvValue(content = "", key = "")`
 
 ### `src/server/cliRuntime/viteProxy.js`
 Exports
@@ -658,6 +678,7 @@ Local functions
 - `renderWrappedShellCommand(binaryName, args = [], { maxWidth = 100, continuationIndent = " " } = {})`
 - `runLocalProjectBinary(binaryName, args = [], { appRoot, io, pathModule = path, createCliError, explanation = "", dryRun = false } = {})`
 - `installAppDependenciesForHook({ appRoot, appPackageJson, io, pathModule = path, createCliError, dryRun = false, runDevlinks = false } = {})`
+- `resolvePackageOptionInputForInstall({ packageEntry, existingInstall, packageInlineOptions, appRoot, readFileBufferIfExists })`
 - `validateHookResult(result = {}, { packageId = "", hookLabel = "" } = {})`
 - `loadInstallHook({ packageEntry, appRoot, hookSpec, hookLabel = "" } = {})`
 - `createInstallHookHelpers({ ctx, appRoot, io, appPackageJson, commandOptions = {} } = {})`
@@ -896,6 +917,7 @@ Exports
 - `appendTextSnippet(content, snippet, position = "bottom")`
 - `escapeRegExp(value)`
 - `interpolateOptionValue(rawValue, options, ownerId, key)`
+- `isSecretOptionInput(optionSchema)`
 - `normalizeSkipChecks(value)`
 - `promptForRequiredOption({ ownerType, ownerId, optionName, optionSchema, promptChoices = [], stdin = process.stdin, stdout = process.stdout })`
 Local functions
@@ -915,7 +937,6 @@ Local functions
 - `parseTransformSpec(transform)`
 - `applyOptionTransform(value, transform, ownerId, key, optionName)`
 - `applyOptionTransformPipeline(rawValue, rawPipeline, ownerId, key, optionName)`
-- `isSecretOptionInput(optionSchema)`
 - `createMutedReadlineOutput(stdout)`
 
 ### `src/server/shared/outputFormatting.js`

--- a/packages/crud-server-generator/test/buildTemplateContext.test.js
+++ b/packages/crud-server-generator/test/buildTemplateContext.test.js
@@ -1062,8 +1062,8 @@ test("crud actions and routes templates derive cursor validation and route contr
   assert.match(registerRoutesTemplateSource, /createCrudJsonApiRouteContracts/);
   assert.match(registerRoutesTemplateSource, /const \{\s+listRouteContract,\s+viewRouteContract,\s+createRouteContract,\s+updateRouteContract,\s+deleteRouteContract,\s+recordRouteParamsValidator\s+\} = createCrudJsonApiRouteContracts\(\{/s);
   assert.match(registerRoutesTemplateSource, /resource__JSKIT_CRUD_ROUTE_CONTRACTS_RESOURCE_ARGS__/);
-  assert.match(registerRoutesTemplateSource, /surface: normalizedRouteSurface,__JSKIT_CRUD_ROUTE_INTERNAL_LINE__\n      visibility:/);
-  assert.match(registerRoutesTemplateSource, /\.\.\.listRouteContract,__JSKIT_CRUD_LIST_ROUTE_PARAMS_VALIDATOR_LINE__\n    \},/);
+  assert.match(registerRoutesTemplateSource, /surface: normalizedRouteSurface,__JSKIT_CRUD_ROUTE_INTERNAL_LINE__\n {6}visibility:/);
+  assert.match(registerRoutesTemplateSource, /\.\.\.listRouteContract,__JSKIT_CRUD_LIST_ROUTE_PARAMS_VALIDATOR_LINE__\n {4}\},/);
   assert.doesNotMatch(registerRoutesTemplateSource, /surface: normalizedRouteSurface,\n__JSKIT_CRUD_ROUTE_INTERNAL_LINE__/);
   assert.doesNotMatch(registerRoutesTemplateSource, /wrapResponse/);
   assert.match(registerRoutesTemplateSource, /reply\.code\(204\)\.send\(response\);/);


### PR DESCRIPTION
## Summary

- replace counted literal spaces in two CRUD generator regex assertions with explicit quantifiers
- preserve the exact indentation assertions while satisfying `no-regex-spaces`

## Verification

- `npm run lint`
- `node --test packages/crud-server-generator/test/buildTemplateContext.test.js` (28 passing)
- `git diff --check`