### PR TITLE
Refresh package release metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6686,28 +6686,28 @@
     },
     "packages/agent-docs": {
       "name": "@jskit-ai/agent-docs",
-      "version": "0.1.79",
+      "version": "0.1.80",
       "engines": {
         "node": ">=20 <23"
       }
     },
     "packages/assistant": {
       "name": "@jskit-ai/assistant",
-      "version": "0.1.125",
+      "version": "0.1.126",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.117"
+        "@jskit-ai/kernel": "0.1.119"
       }
     },
     "packages/assistant-core": {
       "name": "@jskit-ai/assistant-core",
-      "version": "0.1.92",
+      "version": "0.1.93",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.116",
-        "@jskit-ai/http-runtime": "0.1.116",
-        "@jskit-ai/kernel": "0.1.117",
-        "@jskit-ai/resource-core": "0.1.61",
-        "@jskit-ai/resource-crud-core": "0.1.61",
-        "@jskit-ai/users-core": "0.1.126",
+        "@jskit-ai/database-runtime": "0.1.118",
+        "@jskit-ai/http-runtime": "0.1.117",
+        "@jskit-ai/kernel": "0.1.119",
+        "@jskit-ai/resource-core": "0.1.62",
+        "@jskit-ai/resource-crud-core": "0.1.62",
+        "@jskit-ai/users-core": "0.1.127",
         "dompurify": "^3.3.3",
         "json-rest-schema": "1.x.x",
         "marked": "^17.0.4",
@@ -6718,33 +6718,17 @@
         "vuetify": "^4.0.0"
       }
     },
-    "packages/assistant-core/node_modules/@jskit-ai/database-runtime": {
-      "version": "0.1.116",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/database-runtime/-/database-runtime-0.1.116.tgz",
-      "integrity": "sha512-qBqK3FFmmqfQ1uBEljCbzCP+tqEdRefBQy8+Nk15siDBnvUs3ao6zq++sZU4O5g+jzFpvajPNeAAUEyZ50R58w==",
-      "dependencies": {
-        "@jskit-ai/kernel": "0.1.117"
-      }
-    },
-    "packages/assistant-core/node_modules/@jskit-ai/kernel": {
-      "version": "0.1.117",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.117.tgz",
-      "integrity": "sha512-5cBfHmvs0baglsKec5KYZ3uWznTQpju/412yMJe/at4zFavKEZn3Bs+QIupLYQU8Y76oEzu4YLIsS05Frha+wg==",
-      "dependencies": {
-        "json-rest-schema": "1.x.x"
-      }
-    },
     "packages/assistant-runtime": {
       "name": "@jskit-ai/assistant-runtime",
-      "version": "0.1.87",
+      "version": "0.1.88",
       "dependencies": {
-        "@jskit-ai/assistant-core": "0.1.92",
-        "@jskit-ai/database-runtime": "0.1.116",
-        "@jskit-ai/http-runtime": "0.1.116",
-        "@jskit-ai/kernel": "0.1.117",
-        "@jskit-ai/shell-web": "0.1.116",
-        "@jskit-ai/users-core": "0.1.126",
-        "@jskit-ai/users-web": "0.1.132",
+        "@jskit-ai/assistant-core": "0.1.93",
+        "@jskit-ai/database-runtime": "0.1.118",
+        "@jskit-ai/http-runtime": "0.1.117",
+        "@jskit-ai/kernel": "0.1.119",
+        "@jskit-ai/shell-web": "0.1.117",
+        "@jskit-ai/users-core": "0.1.127",
+        "@jskit-ai/users-web": "0.1.133",
         "json-rest-schema": "1.x.x"
       },
       "peerDependencies": {
@@ -6753,95 +6737,55 @@
         "vuetify": "^4.0.0"
       }
     },
-    "packages/assistant-runtime/node_modules/@jskit-ai/database-runtime": {
-      "version": "0.1.116",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/database-runtime/-/database-runtime-0.1.116.tgz",
-      "integrity": "sha512-qBqK3FFmmqfQ1uBEljCbzCP+tqEdRefBQy8+Nk15siDBnvUs3ao6zq++sZU4O5g+jzFpvajPNeAAUEyZ50R58w==",
-      "dependencies": {
-        "@jskit-ai/kernel": "0.1.117"
-      }
-    },
-    "packages/assistant-runtime/node_modules/@jskit-ai/kernel": {
-      "version": "0.1.117",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.117.tgz",
-      "integrity": "sha512-5cBfHmvs0baglsKec5KYZ3uWznTQpju/412yMJe/at4zFavKEZn3Bs+QIupLYQU8Y76oEzu4YLIsS05Frha+wg==",
-      "dependencies": {
-        "json-rest-schema": "1.x.x"
-      }
-    },
-    "packages/assistant/node_modules/@jskit-ai/kernel": {
-      "version": "0.1.117",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.117.tgz",
-      "integrity": "sha512-5cBfHmvs0baglsKec5KYZ3uWznTQpju/412yMJe/at4zFavKEZn3Bs+QIupLYQU8Y76oEzu4YLIsS05Frha+wg==",
-      "dependencies": {
-        "json-rest-schema": "1.x.x"
-      }
-    },
     "packages/auth-core": {
       "name": "@jskit-ai/auth-core",
-      "version": "0.1.115",
+      "version": "0.1.116",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0",
-        "@jskit-ai/kernel": "0.1.117",
-        "json-rest-schema": "1.x.x"
-      }
-    },
-    "packages/auth-core/node_modules/@jskit-ai/kernel": {
-      "version": "0.1.117",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.117.tgz",
-      "integrity": "sha512-5cBfHmvs0baglsKec5KYZ3uWznTQpju/412yMJe/at4zFavKEZn3Bs+QIupLYQU8Y76oEzu4YLIsS05Frha+wg==",
-      "dependencies": {
+        "@jskit-ai/kernel": "0.1.119",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/auth-provider-local-core": {
       "name": "@jskit-ai/auth-provider-local-core",
-      "version": "0.1.17",
+      "version": "0.1.18",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.115",
-        "@jskit-ai/kernel": "0.1.118",
+        "@jskit-ai/auth-core": "0.1.116",
+        "@jskit-ai/kernel": "0.1.119",
         "nodemailer": "^7.0.10"
       }
     },
     "packages/auth-provider-local-db-core": {
       "name": "@jskit-ai/auth-provider-local-db-core",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "dependencies": {
-        "@jskit-ai/auth-provider-local-core": "0.1.17",
-        "@jskit-ai/database-runtime": "0.1.117",
-        "@jskit-ai/kernel": "0.1.118"
+        "@jskit-ai/auth-provider-local-core": "0.1.18",
+        "@jskit-ai/database-runtime": "0.1.118",
+        "@jskit-ai/kernel": "0.1.119"
       }
     },
     "packages/auth-provider-supabase-core": {
       "name": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.115",
+      "version": "0.1.116",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.115",
-        "@jskit-ai/kernel": "0.1.117",
+        "@jskit-ai/auth-core": "0.1.116",
+        "@jskit-ai/kernel": "0.1.119",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0",
         "json-rest-schema": "1.x.x",
         "ws": "^8.18.3"
       }
     },
-    "packages/auth-provider-supabase-core/node_modules/@jskit-ai/kernel": {
-      "version": "0.1.117",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.117.tgz",
-      "integrity": "sha512-5cBfHmvs0baglsKec5KYZ3uWznTQpju/412yMJe/at4zFavKEZn3Bs+QIupLYQU8Y76oEzu4YLIsS05Frha+wg==",
-      "dependencies": {
-        "json-rest-schema": "1.x.x"
-      }
-    },
     "packages/auth-web": {
       "name": "@jskit-ai/auth-web",
-      "version": "0.1.117",
+      "version": "0.1.118",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.115",
-        "@jskit-ai/http-runtime": "0.1.116",
-        "@jskit-ai/kernel": "0.1.117",
-        "@jskit-ai/shell-web": "0.1.116",
+        "@jskit-ai/auth-core": "0.1.116",
+        "@jskit-ai/http-runtime": "0.1.117",
+        "@jskit-ai/kernel": "0.1.119",
+        "@jskit-ai/shell-web": "0.1.117",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -6852,64 +6796,40 @@
         "vuetify": "^4.0.0"
       }
     },
-    "packages/auth-web/node_modules/@jskit-ai/kernel": {
-      "version": "0.1.117",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.117.tgz",
-      "integrity": "sha512-5cBfHmvs0baglsKec5KYZ3uWznTQpju/412yMJe/at4zFavKEZn3Bs+QIupLYQU8Y76oEzu4YLIsS05Frha+wg==",
-      "dependencies": {
-        "json-rest-schema": "1.x.x"
-      }
-    },
     "packages/console-core": {
       "name": "@jskit-ai/console-core",
-      "version": "0.1.79",
+      "version": "0.1.80",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.115",
-        "@jskit-ai/database-runtime": "0.1.116",
-        "@jskit-ai/http-runtime": "0.1.116",
-        "@jskit-ai/kernel": "0.1.117",
-        "@jskit-ai/resource-crud-core": "0.1.61",
-        "@jskit-ai/users-core": "0.1.126",
-        "json-rest-schema": "1.x.x"
-      }
-    },
-    "packages/console-core/node_modules/@jskit-ai/database-runtime": {
-      "version": "0.1.116",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/database-runtime/-/database-runtime-0.1.116.tgz",
-      "integrity": "sha512-qBqK3FFmmqfQ1uBEljCbzCP+tqEdRefBQy8+Nk15siDBnvUs3ao6zq++sZU4O5g+jzFpvajPNeAAUEyZ50R58w==",
-      "dependencies": {
-        "@jskit-ai/kernel": "0.1.117"
-      }
-    },
-    "packages/console-core/node_modules/@jskit-ai/kernel": {
-      "version": "0.1.117",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.117.tgz",
-      "integrity": "sha512-5cBfHmvs0baglsKec5KYZ3uWznTQpju/412yMJe/at4zFavKEZn3Bs+QIupLYQU8Y76oEzu4YLIsS05Frha+wg==",
-      "dependencies": {
+        "@jskit-ai/auth-core": "0.1.116",
+        "@jskit-ai/database-runtime": "0.1.118",
+        "@jskit-ai/http-runtime": "0.1.117",
+        "@jskit-ai/kernel": "0.1.119",
+        "@jskit-ai/resource-crud-core": "0.1.62",
+        "@jskit-ai/users-core": "0.1.127",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/console-web": {
       "name": "@jskit-ai/console-web",
-      "version": "0.1.84",
+      "version": "0.1.85",
       "dependencies": {
-        "@jskit-ai/auth-web": "0.1.117",
-        "@jskit-ai/console-core": "0.1.79",
-        "@jskit-ai/shell-web": "0.1.116"
+        "@jskit-ai/auth-web": "0.1.118",
+        "@jskit-ai/console-core": "0.1.80",
+        "@jskit-ai/shell-web": "0.1.117"
       }
     },
     "packages/crud-core": {
       "name": "@jskit-ai/crud-core",
-      "version": "0.1.124",
+      "version": "0.1.125",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.116",
-        "@jskit-ai/http-runtime": "0.1.116",
-        "@jskit-ai/kernel": "0.1.117",
-        "@jskit-ai/realtime": "0.1.115",
-        "@jskit-ai/resource-crud-core": "0.1.61",
-        "@jskit-ai/shell-web": "0.1.116",
-        "@jskit-ai/users-core": "0.1.126",
-        "@jskit-ai/users-web": "0.1.132",
+        "@jskit-ai/database-runtime": "0.1.118",
+        "@jskit-ai/http-runtime": "0.1.117",
+        "@jskit-ai/kernel": "0.1.119",
+        "@jskit-ai/realtime": "0.1.116",
+        "@jskit-ai/resource-crud-core": "0.1.62",
+        "@jskit-ai/shell-web": "0.1.117",
+        "@jskit-ai/users-core": "0.1.127",
+        "@jskit-ai/users-web": "0.1.133",
         "json-rest-schema": "1.x.x"
       },
       "peerDependencies": {
@@ -6918,180 +6838,100 @@
         "vue-router": "^5.0.4"
       }
     },
-    "packages/crud-core/node_modules/@jskit-ai/database-runtime": {
-      "version": "0.1.116",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/database-runtime/-/database-runtime-0.1.116.tgz",
-      "integrity": "sha512-qBqK3FFmmqfQ1uBEljCbzCP+tqEdRefBQy8+Nk15siDBnvUs3ao6zq++sZU4O5g+jzFpvajPNeAAUEyZ50R58w==",
-      "dependencies": {
-        "@jskit-ai/kernel": "0.1.117"
-      }
-    },
-    "packages/crud-core/node_modules/@jskit-ai/kernel": {
-      "version": "0.1.117",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.117.tgz",
-      "integrity": "sha512-5cBfHmvs0baglsKec5KYZ3uWznTQpju/412yMJe/at4zFavKEZn3Bs+QIupLYQU8Y76oEzu4YLIsS05Frha+wg==",
-      "dependencies": {
-        "json-rest-schema": "1.x.x"
-      }
-    },
     "packages/crud-server-generator": {
       "name": "@jskit-ai/crud-server-generator",
-      "version": "0.1.124",
+      "version": "0.1.125",
       "dependencies": {
         "@babel/parser": "^7.29.2",
-        "@jskit-ai/crud-core": "0.1.124",
-        "@jskit-ai/database-runtime": "0.1.116",
-        "@jskit-ai/http-runtime": "0.1.116",
-        "@jskit-ai/json-rest-api-core": "0.1.61",
-        "@jskit-ai/kernel": "0.1.117",
-        "@jskit-ai/resource-crud-core": "0.1.61",
+        "@jskit-ai/crud-core": "0.1.125",
+        "@jskit-ai/database-runtime": "0.1.118",
+        "@jskit-ai/http-runtime": "0.1.117",
+        "@jskit-ai/json-rest-api-core": "0.1.62",
+        "@jskit-ai/kernel": "0.1.119",
+        "@jskit-ai/resource-crud-core": "0.1.62",
         "recast": "^0.23.11"
-      }
-    },
-    "packages/crud-server-generator/node_modules/@jskit-ai/database-runtime": {
-      "version": "0.1.116",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/database-runtime/-/database-runtime-0.1.116.tgz",
-      "integrity": "sha512-qBqK3FFmmqfQ1uBEljCbzCP+tqEdRefBQy8+Nk15siDBnvUs3ao6zq++sZU4O5g+jzFpvajPNeAAUEyZ50R58w==",
-      "dependencies": {
-        "@jskit-ai/kernel": "0.1.117"
-      }
-    },
-    "packages/crud-server-generator/node_modules/@jskit-ai/kernel": {
-      "version": "0.1.117",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.117.tgz",
-      "integrity": "sha512-5cBfHmvs0baglsKec5KYZ3uWznTQpju/412yMJe/at4zFavKEZn3Bs+QIupLYQU8Y76oEzu4YLIsS05Frha+wg==",
-      "dependencies": {
-        "json-rest-schema": "1.x.x"
       }
     },
     "packages/crud-ui-generator": {
       "name": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.99",
+      "version": "0.1.100",
       "dependencies": {
-        "@jskit-ai/crud-core": "0.1.124",
-        "@jskit-ai/kernel": "0.1.117",
-        "@jskit-ai/resource-crud-core": "0.1.61"
-      }
-    },
-    "packages/crud-ui-generator/node_modules/@jskit-ai/kernel": {
-      "version": "0.1.117",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.117.tgz",
-      "integrity": "sha512-5cBfHmvs0baglsKec5KYZ3uWznTQpju/412yMJe/at4zFavKEZn3Bs+QIupLYQU8Y76oEzu4YLIsS05Frha+wg==",
-      "dependencies": {
-        "json-rest-schema": "1.x.x"
+        "@jskit-ai/crud-core": "0.1.125",
+        "@jskit-ai/kernel": "0.1.119",
+        "@jskit-ai/resource-crud-core": "0.1.62"
       }
     },
     "packages/database-runtime": {
       "name": "@jskit-ai/database-runtime",
-      "version": "0.1.117",
+      "version": "0.1.118",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.118"
+        "@jskit-ai/kernel": "0.1.119"
       }
     },
     "packages/database-runtime-mysql": {
       "name": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.116",
+      "version": "0.1.117",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.117",
-        "@jskit-ai/kernel": "0.1.118"
+        "@jskit-ai/database-runtime": "0.1.118",
+        "@jskit-ai/kernel": "0.1.119"
       }
     },
     "packages/database-runtime-postgres": {
       "name": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.115",
-      "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.116"
-      }
-    },
-    "packages/database-runtime-postgres/node_modules/@jskit-ai/database-runtime": {
       "version": "0.1.116",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/database-runtime/-/database-runtime-0.1.116.tgz",
-      "integrity": "sha512-qBqK3FFmmqfQ1uBEljCbzCP+tqEdRefBQy8+Nk15siDBnvUs3ao6zq++sZU4O5g+jzFpvajPNeAAUEyZ50R58w==",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.117"
-      }
-    },
-    "packages/database-runtime-postgres/node_modules/@jskit-ai/kernel": {
-      "version": "0.1.117",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.117.tgz",
-      "integrity": "sha512-5cBfHmvs0baglsKec5KYZ3uWznTQpju/412yMJe/at4zFavKEZn3Bs+QIupLYQU8Y76oEzu4YLIsS05Frha+wg==",
-      "dependencies": {
-        "json-rest-schema": "1.x.x"
+        "@jskit-ai/database-runtime": "0.1.118"
       }
     },
     "packages/feature-server-generator": {
       "name": "@jskit-ai/feature-server-generator",
-      "version": "0.1.59"
+      "version": "0.1.60"
     },
     "packages/google-rewarded-core": {
       "name": "@jskit-ai/google-rewarded-core",
-      "version": "0.1.53"
+      "version": "0.1.54"
     },
     "packages/google-rewarded-web": {
       "name": "@jskit-ai/google-rewarded-web",
-      "version": "0.1.53"
+      "version": "0.1.54"
     },
     "packages/http-runtime": {
       "name": "@jskit-ai/http-runtime",
-      "version": "0.1.116",
-      "dependencies": {
-        "@jskit-ai/kernel": "0.1.117",
-        "json-rest-schema": "1.x.x"
-      }
-    },
-    "packages/http-runtime/node_modules/@jskit-ai/kernel": {
       "version": "0.1.117",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.117.tgz",
-      "integrity": "sha512-5cBfHmvs0baglsKec5KYZ3uWznTQpju/412yMJe/at4zFavKEZn3Bs+QIupLYQU8Y76oEzu4YLIsS05Frha+wg==",
       "dependencies": {
+        "@jskit-ai/kernel": "0.1.119",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/json-rest-api-core": {
       "name": "@jskit-ai/json-rest-api-core",
-      "version": "0.1.61",
+      "version": "0.1.62",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.117",
+        "@jskit-ai/kernel": "0.1.119",
         "hooked-api": "1.x.x",
         "json-rest-api": "1.x.x"
       }
     },
-    "packages/json-rest-api-core/node_modules/@jskit-ai/kernel": {
-      "version": "0.1.117",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.117.tgz",
-      "integrity": "sha512-5cBfHmvs0baglsKec5KYZ3uWznTQpju/412yMJe/at4zFavKEZn3Bs+QIupLYQU8Y76oEzu4YLIsS05Frha+wg==",
-      "dependencies": {
-        "json-rest-schema": "1.x.x"
-      }
-    },
     "packages/kernel": {
       "name": "@jskit-ai/kernel",
-      "version": "0.1.118",
+      "version": "0.1.119",
       "dependencies": {
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/mobile-capacitor": {
       "name": "@jskit-ai/mobile-capacitor",
-      "version": "0.1.53",
+      "version": "0.1.54",
       "dependencies": {
         "@capacitor/browser": "^7.0.1",
-        "@jskit-ai/kernel": "0.1.117"
-      }
-    },
-    "packages/mobile-capacitor/node_modules/@jskit-ai/kernel": {
-      "version": "0.1.117",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.117.tgz",
-      "integrity": "sha512-5cBfHmvs0baglsKec5KYZ3uWznTQpju/412yMJe/at4zFavKEZn3Bs+QIupLYQU8Y76oEzu4YLIsS05Frha+wg==",
-      "dependencies": {
-        "json-rest-schema": "1.x.x"
+        "@jskit-ai/kernel": "0.1.119"
       }
     },
     "packages/realtime": {
       "name": "@jskit-ai/realtime",
-      "version": "0.1.115",
+      "version": "0.1.116",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.117",
+        "@jskit-ai/kernel": "0.1.119",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",
@@ -7101,50 +6941,26 @@
         "vue": "^3.5.13"
       }
     },
-    "packages/realtime/node_modules/@jskit-ai/kernel": {
-      "version": "0.1.117",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.117.tgz",
-      "integrity": "sha512-5cBfHmvs0baglsKec5KYZ3uWznTQpju/412yMJe/at4zFavKEZn3Bs+QIupLYQU8Y76oEzu4YLIsS05Frha+wg==",
-      "dependencies": {
-        "json-rest-schema": "1.x.x"
-      }
-    },
     "packages/resource-core": {
       "name": "@jskit-ai/resource-core",
-      "version": "0.1.61",
+      "version": "0.1.62",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.117"
-      }
-    },
-    "packages/resource-core/node_modules/@jskit-ai/kernel": {
-      "version": "0.1.117",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.117.tgz",
-      "integrity": "sha512-5cBfHmvs0baglsKec5KYZ3uWznTQpju/412yMJe/at4zFavKEZn3Bs+QIupLYQU8Y76oEzu4YLIsS05Frha+wg==",
-      "dependencies": {
-        "json-rest-schema": "1.x.x"
+        "@jskit-ai/kernel": "0.1.119"
       }
     },
     "packages/resource-crud-core": {
       "name": "@jskit-ai/resource-crud-core",
-      "version": "0.1.61",
+      "version": "0.1.62",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.117",
-        "@jskit-ai/resource-core": "0.1.61"
-      }
-    },
-    "packages/resource-crud-core/node_modules/@jskit-ai/kernel": {
-      "version": "0.1.117",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.117.tgz",
-      "integrity": "sha512-5cBfHmvs0baglsKec5KYZ3uWznTQpju/412yMJe/at4zFavKEZn3Bs+QIupLYQU8Y76oEzu4YLIsS05Frha+wg==",
-      "dependencies": {
-        "json-rest-schema": "1.x.x"
+        "@jskit-ai/kernel": "0.1.119",
+        "@jskit-ai/resource-core": "0.1.62"
       }
     },
     "packages/shell-web": {
       "name": "@jskit-ai/shell-web",
-      "version": "0.1.116",
+      "version": "0.1.117",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.117",
+        "@jskit-ai/kernel": "0.1.119",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -7154,51 +6970,27 @@
         "vuetify": "^4.0.0"
       }
     },
-    "packages/shell-web/node_modules/@jskit-ai/kernel": {
-      "version": "0.1.117",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.117.tgz",
-      "integrity": "sha512-5cBfHmvs0baglsKec5KYZ3uWznTQpju/412yMJe/at4zFavKEZn3Bs+QIupLYQU8Y76oEzu4YLIsS05Frha+wg==",
-      "dependencies": {
-        "json-rest-schema": "1.x.x"
-      }
-    },
     "packages/storage-runtime": {
       "name": "@jskit-ai/storage-runtime",
-      "version": "0.1.115",
+      "version": "0.1.116",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.117",
+        "@jskit-ai/kernel": "0.1.119",
         "unstorage": "^1.17.3"
-      }
-    },
-    "packages/storage-runtime/node_modules/@jskit-ai/kernel": {
-      "version": "0.1.117",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.117.tgz",
-      "integrity": "sha512-5cBfHmvs0baglsKec5KYZ3uWznTQpju/412yMJe/at4zFavKEZn3Bs+QIupLYQU8Y76oEzu4YLIsS05Frha+wg==",
-      "dependencies": {
-        "json-rest-schema": "1.x.x"
       }
     },
     "packages/ui-generator": {
       "name": "@jskit-ai/ui-generator",
-      "version": "0.1.99",
+      "version": "0.1.100",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.117",
-        "@jskit-ai/shell-web": "0.1.116"
-      }
-    },
-    "packages/ui-generator/node_modules/@jskit-ai/kernel": {
-      "version": "0.1.117",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.117.tgz",
-      "integrity": "sha512-5cBfHmvs0baglsKec5KYZ3uWznTQpju/412yMJe/at4zFavKEZn3Bs+QIupLYQU8Y76oEzu4YLIsS05Frha+wg==",
-      "dependencies": {
-        "json-rest-schema": "1.x.x"
+        "@jskit-ai/kernel": "0.1.119",
+        "@jskit-ai/shell-web": "0.1.117"
       }
     },
     "packages/uploads-image-web": {
       "name": "@jskit-ai/uploads-image-web",
-      "version": "0.1.94",
+      "version": "0.1.95",
       "dependencies": {
-        "@jskit-ai/uploads-runtime": "0.1.94",
+        "@jskit-ai/uploads-runtime": "0.1.95",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",
@@ -7211,61 +7003,37 @@
     },
     "packages/uploads-runtime": {
       "name": "@jskit-ai/uploads-runtime",
-      "version": "0.1.94",
+      "version": "0.1.95",
       "dependencies": {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.117"
-      }
-    },
-    "packages/uploads-runtime/node_modules/@jskit-ai/kernel": {
-      "version": "0.1.117",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.117.tgz",
-      "integrity": "sha512-5cBfHmvs0baglsKec5KYZ3uWznTQpju/412yMJe/at4zFavKEZn3Bs+QIupLYQU8Y76oEzu4YLIsS05Frha+wg==",
-      "dependencies": {
-        "json-rest-schema": "1.x.x"
+        "@jskit-ai/kernel": "0.1.119"
       }
     },
     "packages/users-core": {
       "name": "@jskit-ai/users-core",
-      "version": "0.1.126",
+      "version": "0.1.127",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.115",
-        "@jskit-ai/database-runtime": "0.1.116",
-        "@jskit-ai/http-runtime": "0.1.116",
-        "@jskit-ai/json-rest-api-core": "0.1.61",
-        "@jskit-ai/kernel": "0.1.117",
-        "@jskit-ai/resource-core": "0.1.61",
-        "@jskit-ai/resource-crud-core": "0.1.61",
-        "@jskit-ai/uploads-runtime": "0.1.94",
-        "json-rest-schema": "1.x.x"
-      }
-    },
-    "packages/users-core/node_modules/@jskit-ai/database-runtime": {
-      "version": "0.1.116",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/database-runtime/-/database-runtime-0.1.116.tgz",
-      "integrity": "sha512-qBqK3FFmmqfQ1uBEljCbzCP+tqEdRefBQy8+Nk15siDBnvUs3ao6zq++sZU4O5g+jzFpvajPNeAAUEyZ50R58w==",
-      "dependencies": {
-        "@jskit-ai/kernel": "0.1.117"
-      }
-    },
-    "packages/users-core/node_modules/@jskit-ai/kernel": {
-      "version": "0.1.117",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.117.tgz",
-      "integrity": "sha512-5cBfHmvs0baglsKec5KYZ3uWznTQpju/412yMJe/at4zFavKEZn3Bs+QIupLYQU8Y76oEzu4YLIsS05Frha+wg==",
-      "dependencies": {
+        "@jskit-ai/auth-core": "0.1.116",
+        "@jskit-ai/database-runtime": "0.1.118",
+        "@jskit-ai/http-runtime": "0.1.117",
+        "@jskit-ai/json-rest-api-core": "0.1.62",
+        "@jskit-ai/kernel": "0.1.119",
+        "@jskit-ai/resource-core": "0.1.62",
+        "@jskit-ai/resource-crud-core": "0.1.62",
+        "@jskit-ai/uploads-runtime": "0.1.95",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/users-web": {
       "name": "@jskit-ai/users-web",
-      "version": "0.1.132",
+      "version": "0.1.133",
       "dependencies": {
-        "@jskit-ai/http-runtime": "0.1.116",
-        "@jskit-ai/kernel": "0.1.117",
-        "@jskit-ai/realtime": "0.1.115",
-        "@jskit-ai/shell-web": "0.1.116",
-        "@jskit-ai/uploads-image-web": "0.1.94",
-        "@jskit-ai/users-core": "0.1.126",
+        "@jskit-ai/http-runtime": "0.1.117",
+        "@jskit-ai/kernel": "0.1.119",
+        "@jskit-ai/realtime": "0.1.116",
+        "@jskit-ai/shell-web": "0.1.117",
+        "@jskit-ai/uploads-image-web": "0.1.95",
+        "@jskit-ai/users-core": "0.1.127",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -7275,56 +7043,32 @@
         "vuetify": "^4.0.0"
       }
     },
-    "packages/users-web/node_modules/@jskit-ai/kernel": {
-      "version": "0.1.117",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.117.tgz",
-      "integrity": "sha512-5cBfHmvs0baglsKec5KYZ3uWznTQpju/412yMJe/at4zFavKEZn3Bs+QIupLYQU8Y76oEzu4YLIsS05Frha+wg==",
-      "dependencies": {
-        "json-rest-schema": "1.x.x"
-      }
-    },
     "packages/workspaces-core": {
       "name": "@jskit-ai/workspaces-core",
-      "version": "0.1.92",
+      "version": "0.1.93",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.115",
-        "@jskit-ai/database-runtime": "0.1.116",
-        "@jskit-ai/http-runtime": "0.1.116",
-        "@jskit-ai/json-rest-api-core": "0.1.61",
-        "@jskit-ai/kernel": "0.1.117",
-        "@jskit-ai/resource-core": "0.1.61",
-        "@jskit-ai/resource-crud-core": "0.1.61",
-        "@jskit-ai/users-core": "0.1.126",
-        "json-rest-schema": "1.x.x"
-      }
-    },
-    "packages/workspaces-core/node_modules/@jskit-ai/database-runtime": {
-      "version": "0.1.116",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/database-runtime/-/database-runtime-0.1.116.tgz",
-      "integrity": "sha512-qBqK3FFmmqfQ1uBEljCbzCP+tqEdRefBQy8+Nk15siDBnvUs3ao6zq++sZU4O5g+jzFpvajPNeAAUEyZ50R58w==",
-      "dependencies": {
-        "@jskit-ai/kernel": "0.1.117"
-      }
-    },
-    "packages/workspaces-core/node_modules/@jskit-ai/kernel": {
-      "version": "0.1.117",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.117.tgz",
-      "integrity": "sha512-5cBfHmvs0baglsKec5KYZ3uWznTQpju/412yMJe/at4zFavKEZn3Bs+QIupLYQU8Y76oEzu4YLIsS05Frha+wg==",
-      "dependencies": {
+        "@jskit-ai/auth-core": "0.1.116",
+        "@jskit-ai/database-runtime": "0.1.118",
+        "@jskit-ai/http-runtime": "0.1.117",
+        "@jskit-ai/json-rest-api-core": "0.1.62",
+        "@jskit-ai/kernel": "0.1.119",
+        "@jskit-ai/resource-core": "0.1.62",
+        "@jskit-ai/resource-crud-core": "0.1.62",
+        "@jskit-ai/users-core": "0.1.127",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/workspaces-web": {
       "name": "@jskit-ai/workspaces-web",
-      "version": "0.1.93",
+      "version": "0.1.94",
       "dependencies": {
-        "@jskit-ai/auth-web": "0.1.117",
-        "@jskit-ai/http-runtime": "0.1.116",
-        "@jskit-ai/kernel": "0.1.117",
-        "@jskit-ai/shell-web": "0.1.116",
-        "@jskit-ai/users-core": "0.1.126",
-        "@jskit-ai/users-web": "0.1.132",
-        "@jskit-ai/workspaces-core": "0.1.92",
+        "@jskit-ai/auth-web": "0.1.118",
+        "@jskit-ai/http-runtime": "0.1.117",
+        "@jskit-ai/kernel": "0.1.119",
+        "@jskit-ai/shell-web": "0.1.117",
+        "@jskit-ai/users-core": "0.1.127",
+        "@jskit-ai/users-web": "0.1.133",
+        "@jskit-ai/workspaces-core": "0.1.93",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -7334,17 +7078,9 @@
         "vuetify": "^4.0.0"
       }
     },
-    "packages/workspaces-web/node_modules/@jskit-ai/kernel": {
-      "version": "0.1.117",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/kernel/-/kernel-0.1.117.tgz",
-      "integrity": "sha512-5cBfHmvs0baglsKec5KYZ3uWznTQpju/412yMJe/at4zFavKEZn3Bs+QIupLYQU8Y76oEzu4YLIsS05Frha+wg==",
-      "dependencies": {
-        "json-rest-schema": "1.x.x"
-      }
-    },
     "tooling/config-eslint": {
       "name": "@jskit-ai/config-eslint",
-      "version": "0.1.115",
+      "version": "0.1.116",
       "dependencies": {
         "@eslint/js": "^9.39.1",
         "eslint-plugin-vue": "^10.5.1",
@@ -7362,9 +7098,9 @@
     },
     "tooling/create-app": {
       "name": "@jskit-ai/create-app",
-      "version": "0.1.127",
+      "version": "0.1.128",
       "dependencies": {
-        "@jskit-ai/jskit-cli": "0.2.130"
+        "@jskit-ai/jskit-cli": "0.2.131"
       },
       "bin": {
         "jskit-create-app": "bin/jskit-create-app.js"
@@ -7375,18 +7111,18 @@
     },
     "tooling/jskit-catalog": {
       "name": "@jskit-ai/jskit-catalog",
-      "version": "0.1.125",
+      "version": "0.1.126",
       "engines": {
         "node": ">=20 <23"
       }
     },
     "tooling/jskit-cli": {
       "name": "@jskit-ai/jskit-cli",
-      "version": "0.2.130",
+      "version": "0.2.131",
       "dependencies": {
-        "@jskit-ai/jskit-catalog": "0.1.125",
-        "@jskit-ai/kernel": "0.1.118",
-        "@jskit-ai/shell-web": "0.1.116",
+        "@jskit-ai/jskit-catalog": "0.1.126",
+        "@jskit-ai/kernel": "0.1.119",
+        "@jskit-ai/shell-web": "0.1.117",
         "@vue/compiler-sfc": "^3.5.29",
         "ts-morph": "^28.0.0",
         "yaml": "^2.8.3"

--- a/packages/agent-docs/package.json
+++ b/packages/agent-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/agent-docs",
-  "version": "0.1.79",
+  "version": "0.1.80",
   "description": "Distributed JSKIT agent references, prompts, guides, and generated reference maps.",
   "type": "module",
   "files": [

--- a/packages/assistant-core/package.descriptor.mjs
+++ b/packages/assistant-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-core",
-  version: "0.1.92",
+  version: "0.1.93",
   kind: "runtime",
   description: "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
   dependsOn: [
@@ -47,11 +47,11 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/http-runtime": "0.1.116",
-        "@jskit-ai/kernel": "0.1.117",
-        "@jskit-ai/resource-core": "0.1.61",
-        "@jskit-ai/resource-crud-core": "0.1.61",
-        "@jskit-ai/users-core": "0.1.126",
+        "@jskit-ai/http-runtime": "0.1.117",
+        "@jskit-ai/kernel": "0.1.119",
+        "@jskit-ai/resource-core": "0.1.62",
+        "@jskit-ai/resource-crud-core": "0.1.62",
+        "@jskit-ai/users-core": "0.1.127",
         "dompurify": "^3.3.3",
         "json-rest-schema": "1.x.x",
         "marked": "^17.0.4",

--- a/packages/assistant-core/package.json
+++ b/packages/assistant-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-core",
-  "version": "0.1.92",
+  "version": "0.1.93",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,12 +11,12 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.116",
-    "@jskit-ai/http-runtime": "0.1.116",
-    "@jskit-ai/kernel": "0.1.117",
-    "@jskit-ai/resource-crud-core": "0.1.61",
-    "@jskit-ai/resource-core": "0.1.61",
-    "@jskit-ai/users-core": "0.1.126",
+    "@jskit-ai/database-runtime": "0.1.118",
+    "@jskit-ai/http-runtime": "0.1.117",
+    "@jskit-ai/kernel": "0.1.119",
+    "@jskit-ai/resource-crud-core": "0.1.62",
+    "@jskit-ai/resource-core": "0.1.62",
+    "@jskit-ai/users-core": "0.1.127",
     "dompurify": "^3.3.3",
     "json-rest-schema": "1.x.x",
     "marked": "^17.0.4",

--- a/packages/assistant-runtime/package.descriptor.mjs
+++ b/packages/assistant-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-runtime",
-  version: "0.1.87",
+  version: "0.1.88",
   kind: "runtime",
   description: "Shared assistant runtime with per-surface assistant registration.",
   dependsOn: [
@@ -95,13 +95,13 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/assistant-core": "0.1.92",
-        "@jskit-ai/database-runtime": "0.1.116",
-        "@jskit-ai/http-runtime": "0.1.116",
-        "@jskit-ai/kernel": "0.1.117",
-        "@jskit-ai/shell-web": "0.1.116",
-        "@jskit-ai/users-core": "0.1.126",
-        "@jskit-ai/users-web": "0.1.132"
+        "@jskit-ai/assistant-core": "0.1.93",
+        "@jskit-ai/database-runtime": "0.1.118",
+        "@jskit-ai/http-runtime": "0.1.117",
+        "@jskit-ai/kernel": "0.1.119",
+        "@jskit-ai/shell-web": "0.1.117",
+        "@jskit-ai/users-core": "0.1.127",
+        "@jskit-ai/users-web": "0.1.133"
       },
       dev: {}
     },

--- a/packages/assistant-runtime/package.json
+++ b/packages/assistant-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-runtime",
-  "version": "0.1.87",
+  "version": "0.1.88",
   "type": "module",
   "exports": {
     "./client": "./src/client/index.js",
@@ -8,13 +8,13 @@
     "./server/actionIds": "./src/server/actionIds.js"
   },
   "dependencies": {
-    "@jskit-ai/assistant-core": "0.1.92",
-    "@jskit-ai/database-runtime": "0.1.116",
-    "@jskit-ai/http-runtime": "0.1.116",
-    "@jskit-ai/kernel": "0.1.117",
-    "@jskit-ai/shell-web": "0.1.116",
-    "@jskit-ai/users-core": "0.1.126",
-    "@jskit-ai/users-web": "0.1.132",
+    "@jskit-ai/assistant-core": "0.1.93",
+    "@jskit-ai/database-runtime": "0.1.118",
+    "@jskit-ai/http-runtime": "0.1.117",
+    "@jskit-ai/kernel": "0.1.119",
+    "@jskit-ai/shell-web": "0.1.117",
+    "@jskit-ai/users-core": "0.1.127",
+    "@jskit-ai/users-web": "0.1.133",
     "json-rest-schema": "1.x.x"
   },
   "peerDependencies": {

--- a/packages/assistant/package.descriptor.mjs
+++ b/packages/assistant/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant",
-  version: "0.1.125",
+  version: "0.1.126",
   kind: "generator",
   description: "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
   options: {

--- a/packages/assistant/package.json
+++ b/packages/assistant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant",
-  "version": "0.1.125",
+  "version": "0.1.126",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.117"
+    "@jskit-ai/kernel": "0.1.119"
   }
 }

--- a/packages/auth-core/package.descriptor.mjs
+++ b/packages/auth-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-core",
-  "version": "0.1.115",
+  "version": "0.1.116",
   "kind": "runtime",
   "dependsOn": [
     "@jskit-ai/value-app-config-shared"
@@ -74,7 +74,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.117",
+        "@jskit-ai/kernel": "0.1.119",
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0"

--- a/packages/auth-core/package.json
+++ b/packages/auth-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-core",
-  "version": "0.1.115",
+  "version": "0.1.116",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -56,7 +56,7 @@
     "./shared/commands/authSessionReadCommand": "./src/shared/commands/authSessionReadCommand.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.117",
+    "@jskit-ai/kernel": "0.1.119",
     "@fastify/cookie": "^11.0.2",
     "@fastify/csrf-protection": "^7.1.0",
     "@fastify/rate-limit": "^10.3.0",

--- a/packages/auth-provider-local-core/package.descriptor.mjs
+++ b/packages/auth-provider-local-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-provider-local-core",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "kind": "runtime",
   "description": "Local auth provider with a file backend default and no database requirement.",
   "dependsOn": [
@@ -64,8 +64,8 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/auth-core": "0.1.115",
-        "@jskit-ai/kernel": "0.1.118",
+        "@jskit-ai/auth-core": "0.1.116",
+        "@jskit-ai/kernel": "0.1.119",
         "nodemailer": "^7.0.10",
         "dotenv": "^16.4.5"
       },

--- a/packages/auth-provider-local-core/package.json
+++ b/packages/auth-provider-local-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-local-core",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,8 +11,8 @@
     "./server/lib/index": "./src/server/lib/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.115",
-    "@jskit-ai/kernel": "0.1.118",
+    "@jskit-ai/auth-core": "0.1.116",
+    "@jskit-ai/kernel": "0.1.119",
     "nodemailer": "^7.0.10"
   }
 }

--- a/packages/auth-provider-local-db-core/package.descriptor.mjs
+++ b/packages/auth-provider-local-db-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/auth-provider-local-db-core",
-  version: "0.1.9",
+  version: "0.1.10",
   kind: "runtime",
   description: "Database-backed local auth storage backend for JSKIT local auth.",
   dependsOn: [
@@ -80,9 +80,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-provider-local-core": "0.1.17",
-        "@jskit-ai/database-runtime": "0.1.117",
-        "@jskit-ai/kernel": "0.1.118"
+        "@jskit-ai/auth-provider-local-core": "0.1.18",
+        "@jskit-ai/database-runtime": "0.1.118",
+        "@jskit-ai/kernel": "0.1.119"
       },
       dev: {}
     },

--- a/packages/auth-provider-local-db-core/package.json
+++ b/packages/auth-provider-local-db-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-local-db-core",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,8 +10,8 @@
     "./server/lib/index": "./src/server/lib/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-provider-local-core": "0.1.17",
-    "@jskit-ai/database-runtime": "0.1.117",
-    "@jskit-ai/kernel": "0.1.118"
+    "@jskit-ai/auth-provider-local-core": "0.1.18",
+    "@jskit-ai/database-runtime": "0.1.118",
+    "@jskit-ai/kernel": "0.1.119"
   }
 }

--- a/packages/auth-provider-supabase-core/package.descriptor.mjs
+++ b/packages/auth-provider-supabase-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.115",
+  "version": "0.1.116",
   "kind": "runtime",
   "options": {
     "auth-supabase-url": {
@@ -83,8 +83,8 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/auth-core": "0.1.115",
-        "@jskit-ai/kernel": "0.1.117",
+        "@jskit-ai/auth-core": "0.1.116",
+        "@jskit-ai/kernel": "0.1.119",
         "dotenv": "^16.4.5",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0"

--- a/packages/auth-provider-supabase-core/package.json
+++ b/packages/auth-provider-supabase-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.115",
+  "version": "0.1.116",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,8 +12,8 @@
     "./client": "./src/client/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.115",
-    "@jskit-ai/kernel": "0.1.117",
+    "@jskit-ai/auth-core": "0.1.116",
+    "@jskit-ai/kernel": "0.1.119",
     "json-rest-schema": "1.x.x",
     "jose": "^6.1.0",
     "@supabase/supabase-js": "^2.57.4",

--- a/packages/auth-web/package.descriptor.mjs
+++ b/packages/auth-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-web",
-  "version": "0.1.117",
+  "version": "0.1.118",
   "kind": "runtime",
   "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
   "dependsOn": [
@@ -260,10 +260,10 @@ export default Object.freeze({
     "dependencies": {
       "runtime": {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/auth-core": "0.1.115",
-        "@jskit-ai/http-runtime": "0.1.116",
-        "@jskit-ai/kernel": "0.1.117",
-        "@jskit-ai/shell-web": "0.1.116"
+        "@jskit-ai/auth-core": "0.1.116",
+        "@jskit-ai/http-runtime": "0.1.117",
+        "@jskit-ai/kernel": "0.1.119",
+        "@jskit-ai/shell-web": "0.1.117"
       },
       "dev": {}
     },

--- a/packages/auth-web/package.json
+++ b/packages/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-web",
-  "version": "0.1.117",
+  "version": "0.1.118",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -19,11 +19,11 @@
     "./client/runtime/useSignOut": "./src/client/runtime/useSignOut.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.115",
+    "@jskit-ai/auth-core": "0.1.116",
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/kernel": "0.1.117",
-    "@jskit-ai/shell-web": "0.1.116",
-    "@jskit-ai/http-runtime": "0.1.116"
+    "@jskit-ai/kernel": "0.1.119",
+    "@jskit-ai/shell-web": "0.1.117",
+    "@jskit-ai/http-runtime": "0.1.117"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/console-core/package.descriptor.mjs
+++ b/packages/console-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-core",
-  version: "0.1.79",
+  version: "0.1.80",
   kind: "runtime",
   description: "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
   dependsOn: [
@@ -85,12 +85,12 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.115",
-        "@jskit-ai/database-runtime": "0.1.116",
-        "@jskit-ai/http-runtime": "0.1.116",
-        "@jskit-ai/kernel": "0.1.117",
-        "@jskit-ai/resource-crud-core": "0.1.61",
-        "@jskit-ai/users-core": "0.1.126"
+        "@jskit-ai/auth-core": "0.1.116",
+        "@jskit-ai/database-runtime": "0.1.118",
+        "@jskit-ai/http-runtime": "0.1.117",
+        "@jskit-ai/kernel": "0.1.119",
+        "@jskit-ai/resource-crud-core": "0.1.62",
+        "@jskit-ai/users-core": "0.1.127"
       },
       dev: {}
     },

--- a/packages/console-core/package.json
+++ b/packages/console-core/package.json
@@ -1,17 +1,17 @@
 {
   "name": "@jskit-ai/console-core",
-  "version": "0.1.79",
+  "version": "0.1.80",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.115",
-    "@jskit-ai/database-runtime": "0.1.116",
-    "@jskit-ai/http-runtime": "0.1.116",
-    "@jskit-ai/kernel": "0.1.117",
-    "@jskit-ai/resource-crud-core": "0.1.61",
-    "@jskit-ai/users-core": "0.1.126",
+    "@jskit-ai/auth-core": "0.1.116",
+    "@jskit-ai/database-runtime": "0.1.118",
+    "@jskit-ai/http-runtime": "0.1.117",
+    "@jskit-ai/kernel": "0.1.119",
+    "@jskit-ai/resource-crud-core": "0.1.62",
+    "@jskit-ai/users-core": "0.1.127",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/console-web/package.descriptor.mjs
+++ b/packages/console-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-web",
-  version: "0.1.84",
+  version: "0.1.85",
   kind: "runtime",
   description: "Authenticated console surface scaffold and surface policy wiring.",
   dependsOn: [
@@ -103,9 +103,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-web": "0.1.117",
-        "@jskit-ai/console-core": "0.1.79",
-        "@jskit-ai/shell-web": "0.1.116",
+        "@jskit-ai/auth-web": "0.1.118",
+        "@jskit-ai/console-core": "0.1.80",
+        "@jskit-ai/shell-web": "0.1.117",
       },
       dev: {}
     },

--- a/packages/console-web/package.json
+++ b/packages/console-web/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/console-web",
-  "version": "0.1.84",
+  "version": "0.1.85",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-web": "0.1.117",
-    "@jskit-ai/console-core": "0.1.79",
-    "@jskit-ai/shell-web": "0.1.116"
+    "@jskit-ai/auth-web": "0.1.118",
+    "@jskit-ai/console-core": "0.1.80",
+    "@jskit-ai/shell-web": "0.1.117"
   }
 }

--- a/packages/crud-core/package.descriptor.mjs
+++ b/packages/crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-core",
-  version: "0.1.124",
+  version: "0.1.125",
   kind: "runtime",
   description: "Shared CRUD helpers used by CRUD modules.",
   dependsOn: [
@@ -28,7 +28,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/crud-core": "0.1.124"
+        "@jskit-ai/crud-core": "0.1.125"
       },
       dev: {}
     },

--- a/packages/crud-core/package.json
+++ b/packages/crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-core",
-  "version": "0.1.124",
+  "version": "0.1.125",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -27,15 +27,15 @@
     "./server/routeContracts": "./src/server/routeContracts.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.116",
-    "@jskit-ai/http-runtime": "0.1.116",
-    "@jskit-ai/kernel": "0.1.117",
+    "@jskit-ai/database-runtime": "0.1.118",
+    "@jskit-ai/http-runtime": "0.1.117",
+    "@jskit-ai/kernel": "0.1.119",
     "json-rest-schema": "1.x.x",
-    "@jskit-ai/realtime": "0.1.115",
-    "@jskit-ai/resource-crud-core": "0.1.61",
-    "@jskit-ai/shell-web": "0.1.116",
-    "@jskit-ai/users-core": "0.1.126",
-    "@jskit-ai/users-web": "0.1.132"
+    "@jskit-ai/realtime": "0.1.116",
+    "@jskit-ai/resource-crud-core": "0.1.62",
+    "@jskit-ai/shell-web": "0.1.117",
+    "@jskit-ai/users-core": "0.1.127",
+    "@jskit-ai/users-web": "0.1.133"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/crud-server-generator/package.descriptor.mjs
+++ b/packages/crud-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-server-generator",
-  version: "0.1.124",
+  version: "0.1.125",
   kind: "generator",
   description: "CRUD server generator with routes, actions, and persistence scaffolding.",
   options: {
@@ -160,14 +160,14 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.115",
-        "@jskit-ai/crud-core": "0.1.124",
-        "@jskit-ai/database-runtime": "0.1.116",
-        "@jskit-ai/http-runtime": "0.1.116",
-        "@jskit-ai/json-rest-api-core": "0.1.61",
-        "@jskit-ai/kernel": "0.1.117",
-        "@jskit-ai/realtime": "0.1.115",
-        "@jskit-ai/resource-crud-core": "0.1.61",
+        "@jskit-ai/auth-core": "0.1.116",
+        "@jskit-ai/crud-core": "0.1.125",
+        "@jskit-ai/database-runtime": "0.1.118",
+        "@jskit-ai/http-runtime": "0.1.117",
+        "@jskit-ai/json-rest-api-core": "0.1.62",
+        "@jskit-ai/kernel": "0.1.119",
+        "@jskit-ai/realtime": "0.1.116",
+        "@jskit-ai/resource-crud-core": "0.1.62",
         "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}"
       },
       dev: {}

--- a/packages/crud-server-generator/package.json
+++ b/packages/crud-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-server-generator",
-  "version": "0.1.124",
+  "version": "0.1.125",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,12 +13,12 @@
   },
   "dependencies": {
     "@babel/parser": "^7.29.2",
-    "@jskit-ai/crud-core": "0.1.124",
-    "@jskit-ai/database-runtime": "0.1.116",
-    "@jskit-ai/http-runtime": "0.1.116",
-    "@jskit-ai/json-rest-api-core": "0.1.61",
-    "@jskit-ai/kernel": "0.1.117",
-    "@jskit-ai/resource-crud-core": "0.1.61",
+    "@jskit-ai/crud-core": "0.1.125",
+    "@jskit-ai/database-runtime": "0.1.118",
+    "@jskit-ai/http-runtime": "0.1.117",
+    "@jskit-ai/json-rest-api-core": "0.1.62",
+    "@jskit-ai/kernel": "0.1.119",
+    "@jskit-ai/resource-crud-core": "0.1.62",
     "recast": "^0.23.11"
   }
 }

--- a/packages/crud-ui-generator/package.descriptor.mjs
+++ b/packages/crud-ui-generator/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { GENERATED_UI_NAVIGATION_ROLE_OPTION } from "@jskit-ai/kernel/shared/sup
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-ui-generator",
-  version: "0.1.99",
+  version: "0.1.100",
   kind: "generator",
   description: "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
   options: {
@@ -175,7 +175,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.132"
+        "@jskit-ai/users-web": "0.1.133"
       },
       dev: {}
     },

--- a/packages/crud-ui-generator/package.json
+++ b/packages/crud-ui-generator/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@jskit-ai/crud-ui-generator",
-  "version": "0.1.99",
+  "version": "0.1.100",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/crud-core": "0.1.124",
-    "@jskit-ai/kernel": "0.1.117",
-    "@jskit-ai/resource-crud-core": "0.1.61"
+    "@jskit-ai/crud-core": "0.1.125",
+    "@jskit-ai/kernel": "0.1.119",
+    "@jskit-ai/resource-crud-core": "0.1.62"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/database-runtime-mysql/package.descriptor.mjs
+++ b/packages/database-runtime-mysql/package.descriptor.mjs
@@ -13,7 +13,7 @@ const CI_DATABASE = Object.freeze({
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-mysql",
-  version: "0.1.116",
+  version: "0.1.117",
   kind: "runtime",
   options: {
     "db-host": {
@@ -133,7 +133,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.117",
+        "@jskit-ai/database-runtime": "0.1.118",
         "mysql2": "^3.11.2"
       },
       dev: {}

--- a/packages/database-runtime-mysql/package.json
+++ b/packages/database-runtime-mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-mysql",
-  "version": "0.1.116",
+  "version": "0.1.117",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,7 +12,7 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.117",
-    "@jskit-ai/kernel": "0.1.118"
+    "@jskit-ai/database-runtime": "0.1.118",
+    "@jskit-ai/kernel": "0.1.119"
   }
 }

--- a/packages/database-runtime-postgres/package.descriptor.mjs
+++ b/packages/database-runtime-postgres/package.descriptor.mjs
@@ -12,7 +12,7 @@ const CI_DATABASE = Object.freeze({
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-postgres",
-  version: "0.1.115",
+  version: "0.1.116",
   kind: "runtime",
   options: {
     "db-host": {
@@ -131,7 +131,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.116",
+        "@jskit-ai/database-runtime": "0.1.118",
         "pg": "^8.13.1"
       },
       dev: {}

--- a/packages/database-runtime-postgres/package.json
+++ b/packages/database-runtime-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-postgres",
-  "version": "0.1.115",
+  "version": "0.1.116",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,6 +12,6 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.116"
+    "@jskit-ai/database-runtime": "0.1.118"
   }
 }

--- a/packages/database-runtime/package.descriptor.mjs
+++ b/packages/database-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime",
-  version: "0.1.117",
+  version: "0.1.118",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -70,7 +70,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.118",
+        "@jskit-ai/kernel": "0.1.119",
         "dotenv": "^16.4.5",
         "knex": "^3.1.0"
       },

--- a/packages/database-runtime/package.json
+++ b/packages/database-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime",
-  "version": "0.1.117",
+  "version": "0.1.118",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -25,6 +25,6 @@
     "./shared/transactions": "./src/shared/transactions.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.118"
+    "@jskit-ai/kernel": "0.1.119"
   }
 }

--- a/packages/feature-server-generator/package.descriptor.mjs
+++ b/packages/feature-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/feature-server-generator",
-  version: "0.1.59",
+  version: "0.1.60",
   kind: "generator",
   description: "Scaffold substantial non-CRUD server feature packages with provider, actions, service, and optional persistence seams.",
   options: {
@@ -174,7 +174,7 @@ export default Object.freeze({
             equals: "json-rest"
           }
         },
-        "@jskit-ai/kernel": "0.1.118",
+        "@jskit-ai/kernel": "0.1.119",
         "json-rest-schema": "1.x.x",
         "@local/${option:feature-name|kebab}": "file:packages/${option:feature-name|kebab}"
       },

--- a/packages/feature-server-generator/package.json
+++ b/packages/feature-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/feature-server-generator",
-  "version": "0.1.59",
+  "version": "0.1.60",
   "type": "module",
   "scripts": {
     "test": "node --test"

--- a/packages/google-rewarded-core/package.descriptor.mjs
+++ b/packages/google-rewarded-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/google-rewarded-core",
-  version: "0.1.53",
+  version: "0.1.54",
   kind: "runtime",
   description: "Google rewarded workflow runtime plus internal CRUD providers for rules, provider configs, watch sessions, and unlock receipts.",
   dependsOn: [
@@ -128,14 +128,14 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.115",
-        "@jskit-ai/crud-core": "0.1.124",
-        "@jskit-ai/database-runtime": "0.1.116",
-        "@jskit-ai/http-runtime": "0.1.116",
-        "@jskit-ai/json-rest-api-core": "0.1.61",
-        "@jskit-ai/kernel": "0.1.117",
-        "@jskit-ai/resource-crud-core": "0.1.61",
-        "@jskit-ai/workspaces-core": "0.1.92"
+        "@jskit-ai/auth-core": "0.1.116",
+        "@jskit-ai/crud-core": "0.1.125",
+        "@jskit-ai/database-runtime": "0.1.118",
+        "@jskit-ai/http-runtime": "0.1.117",
+        "@jskit-ai/json-rest-api-core": "0.1.62",
+        "@jskit-ai/kernel": "0.1.119",
+        "@jskit-ai/resource-crud-core": "0.1.62",
+        "@jskit-ai/workspaces-core": "0.1.93"
       },
       dev: {}
     },

--- a/packages/google-rewarded-core/package.json
+++ b/packages/google-rewarded-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/google-rewarded-core",
-  "version": "0.1.53",
+  "version": "0.1.54",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/google-rewarded-web/package.descriptor.mjs
+++ b/packages/google-rewarded-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/google-rewarded-web",
-  version: "0.1.53",
+  version: "0.1.54",
   kind: "runtime",
   description: "Google rewarded client runtime with a fullscreen gate host and GPT orchestration.",
   dependsOn: [
@@ -46,10 +46,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/google-rewarded-core": "0.1.53",
-        "@jskit-ai/http-runtime": "0.1.116",
-        "@jskit-ai/kernel": "0.1.117",
-        "@jskit-ai/shell-web": "0.1.116"
+        "@jskit-ai/google-rewarded-core": "0.1.54",
+        "@jskit-ai/http-runtime": "0.1.117",
+        "@jskit-ai/kernel": "0.1.119",
+        "@jskit-ai/shell-web": "0.1.117"
       },
       dev: {}
     },

--- a/packages/google-rewarded-web/package.json
+++ b/packages/google-rewarded-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/google-rewarded-web",
-  "version": "0.1.53",
+  "version": "0.1.54",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/http-runtime/package.descriptor.mjs
+++ b/packages/http-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/http-runtime",
-  "version": "0.1.116",
+  "version": "0.1.117",
   "kind": "runtime",
   "dependsOn": [],
   "capabilities": {
@@ -67,7 +67,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.117"
+        "@jskit-ai/kernel": "0.1.119"
       },
       "dev": {}
     },

--- a/packages/http-runtime/package.json
+++ b/packages/http-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/http-runtime",
-  "version": "0.1.116",
+  "version": "0.1.117",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -18,7 +18,7 @@
     "./shared/validators/operationValidation": "./src/shared/validators/operationValidation.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.117",
+    "@jskit-ai/kernel": "0.1.119",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/json-rest-api-core/package.descriptor.mjs
+++ b/packages/json-rest-api-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/json-rest-api-core",
-  version: "0.1.61",
+  version: "0.1.62",
   kind: "runtime",
   description: "Shared internal json-rest-api host runtime for JSKIT server packages.",
   dependsOn: [

--- a/packages/json-rest-api-core/package.json
+++ b/packages/json-rest-api-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/json-rest-api-core",
-  "version": "0.1.61",
+  "version": "0.1.62",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,6 +11,6 @@
   "dependencies": {
     "hooked-api": "1.x.x",
     "json-rest-api": "1.x.x",
-    "@jskit-ai/kernel": "0.1.117"
+    "@jskit-ai/kernel": "0.1.119"
   }
 }

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/kernel",
-  "version": "0.1.118",
+  "version": "0.1.119",
   "type": "module",
   "dependencies": {
     "json-rest-schema": "1.x.x"

--- a/packages/mobile-capacitor/package.descriptor.mjs
+++ b/packages/mobile-capacitor/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/mobile-capacitor",
-  version: "0.1.53",
+  version: "0.1.54",
   kind: "runtime",
   description: "Thin Capacitor client integration for JSKIT mobile-shell launch routing and auth callback completion.",
   dependsOn: [
@@ -62,8 +62,8 @@ export default Object.freeze({
         "@capacitor/app": "^7.1.0",
         "@capacitor/browser": "^7.0.1",
         "@capacitor/core": "^7.4.3",
-        "@jskit-ai/kernel": "0.1.117",
-        "@jskit-ai/shell-web": "0.1.116"
+        "@jskit-ai/kernel": "0.1.119",
+        "@jskit-ai/shell-web": "0.1.117"
       },
       dev: {
         "@capacitor/cli": "^7.4.3"

--- a/packages/mobile-capacitor/package.json
+++ b/packages/mobile-capacitor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/mobile-capacitor",
-  "version": "0.1.53",
+  "version": "0.1.54",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,6 +12,6 @@
   },
   "dependencies": {
     "@capacitor/browser": "^7.0.1",
-    "@jskit-ai/kernel": "0.1.117"
+    "@jskit-ai/kernel": "0.1.119"
   }
 }

--- a/packages/realtime/package.descriptor.mjs
+++ b/packages/realtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/realtime",
-  version: "0.1.115",
+  version: "0.1.116",
   kind: "runtime",
   description: "Thin, generic realtime runtime wrappers for socket.io server and client.",
   options: {
@@ -95,7 +95,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.117",
+        "@jskit-ai/kernel": "0.1.119",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/realtime",
-  "version": "0.1.115",
+  "version": "0.1.116",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@socket.io/redis-adapter": "^8.3.0",
-    "@jskit-ai/kernel": "0.1.117",
+    "@jskit-ai/kernel": "0.1.119",
     "redis": "^5.8.2",
     "socket.io": "^4.8.3",
     "socket.io-client": "^4.8.3"

--- a/packages/resource-core/package.descriptor.mjs
+++ b/packages/resource-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/resource-core",
-  version: "0.1.61",
+  version: "0.1.62",
   kind: "runtime",
   description: "Generic resource-definition helpers and schema-definition normalization.",
   dependsOn: [
@@ -22,7 +22,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/resource-core": "0.1.61"
+        "@jskit-ai/resource-core": "0.1.62"
       },
       dev: {}
     },

--- a/packages/resource-core/package.json
+++ b/packages/resource-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/resource-core",
-  "version": "0.1.61",
+  "version": "0.1.62",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./shared/resource": "./src/shared/resource.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.117"
+    "@jskit-ai/kernel": "0.1.119"
   }
 }

--- a/packages/resource-crud-core/package.descriptor.mjs
+++ b/packages/resource-crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/resource-crud-core",
-  version: "0.1.61",
+  version: "0.1.62",
   kind: "runtime",
   description: "CRUD-specific resource-definition helpers and namespace support.",
   dependsOn: [
@@ -23,7 +23,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/resource-crud-core": "0.1.61"
+        "@jskit-ai/resource-crud-core": "0.1.62"
       },
       dev: {}
     },

--- a/packages/resource-crud-core/package.json
+++ b/packages/resource-crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/resource-crud-core",
-  "version": "0.1.61",
+  "version": "0.1.62",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./shared/crudResource": "./src/shared/crudResource.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.117",
-    "@jskit-ai/resource-core": "0.1.61"
+    "@jskit-ai/kernel": "0.1.119",
+    "@jskit-ai/resource-core": "0.1.62"
   }
 }

--- a/packages/shell-web/package.descriptor.mjs
+++ b/packages/shell-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/shell-web",
-  version: "0.1.116",
+  version: "0.1.117",
   kind: "runtime",
   description: "Web shell layout runtime with outlet-based placement contributions.",
   dependsOn: [],
@@ -307,7 +307,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/kernel": "0.1.117"
+        "@jskit-ai/kernel": "0.1.119"
       },
       dev: {}
     },

--- a/packages/shell-web/package.json
+++ b/packages/shell-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/shell-web",
-  "version": "0.1.116",
+  "version": "0.1.117",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/kernel": "0.1.117"
+    "@jskit-ai/kernel": "0.1.119"
   },
   "peerDependencies": {
     "pinia": "^3.0.4",

--- a/packages/storage-runtime/package.descriptor.mjs
+++ b/packages/storage-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/storage-runtime",
-  version: "0.1.115",
+  version: "0.1.116",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -50,7 +50,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.117",
+        "@jskit-ai/kernel": "0.1.119",
         "unstorage": "^1.17.3"
       },
       dev: {}

--- a/packages/storage-runtime/package.json
+++ b/packages/storage-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/storage-runtime",
-  "version": "0.1.115",
+  "version": "0.1.116",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./server/providers/StorageRuntimeServiceProvider": "./src/server/providers/StorageRuntimeServiceProvider.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.117",
+    "@jskit-ai/kernel": "0.1.119",
     "unstorage": "^1.17.3"
   }
 }

--- a/packages/ui-generator/package.descriptor.mjs
+++ b/packages/ui-generator/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { GENERATED_UI_NAVIGATION_ROLE_OPTION } from "@jskit-ai/kernel/shared/sup
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/ui-generator",
-  version: "0.1.99",
+  version: "0.1.100",
   kind: "generator",
   description: "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
   options: {
@@ -371,7 +371,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.132"
+        "@jskit-ai/users-web": "0.1.133"
       },
       dev: {}
     },

--- a/packages/ui-generator/package.json
+++ b/packages/ui-generator/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/ui-generator",
-  "version": "0.1.99",
+  "version": "0.1.100",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.117",
-    "@jskit-ai/shell-web": "0.1.116"
+    "@jskit-ai/kernel": "0.1.119",
+    "@jskit-ai/shell-web": "0.1.117"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/uploads-image-web/package.descriptor.mjs
+++ b/packages/uploads-image-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-image-web",
-  version: "0.1.94",
+  version: "0.1.95",
   kind: "runtime",
   description: "Reusable client-side image upload runtime with pre-upload image editing.",
   dependsOn: [
@@ -65,7 +65,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/uploads-runtime": "0.1.94",
+        "@jskit-ai/uploads-runtime": "0.1.95",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-image-web/package.json
+++ b/packages/uploads-image-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-image-web",
-  "version": "0.1.94",
+  "version": "0.1.95",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,7 +13,7 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/uploads-runtime": "0.1.94",
+    "@jskit-ai/uploads-runtime": "0.1.95",
     "@uppy/compressor": "^3.1.0",
     "@uppy/core": "^5.2.0",
     "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-runtime/package.descriptor.mjs
+++ b/packages/uploads-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-runtime",
-  version: "0.1.94",
+  version: "0.1.95",
   kind: "runtime",
   description: "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
   dependsOn: [
@@ -71,7 +71,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.117"
+        "@jskit-ai/kernel": "0.1.119"
       },
       dev: {}
     },

--- a/packages/uploads-runtime/package.json
+++ b/packages/uploads-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-runtime",
-  "version": "0.1.94",
+  "version": "0.1.95",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,6 +16,6 @@
   },
   "dependencies": {
     "@fastify/multipart": "^9.4.0",
-    "@jskit-ai/kernel": "0.1.117"
+    "@jskit-ai/kernel": "0.1.119"
   }
 }

--- a/packages/users-core/package.descriptor.mjs
+++ b/packages/users-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-core",
-  version: "0.1.126",
+  version: "0.1.127",
   kind: "runtime",
   description: "Users/account runtime plus HTTP routes for account features.",
   dependsOn: [
@@ -146,16 +146,16 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.115",
-        "@jskit-ai/crud-core": "0.1.124",
-        "@jskit-ai/database-runtime": "0.1.116",
-        "@jskit-ai/http-runtime": "0.1.116",
-        "@jskit-ai/json-rest-api-core": "0.1.61",
-        "@jskit-ai/kernel": "0.1.117",
-        "@jskit-ai/resource-core": "0.1.61",
-        "@jskit-ai/resource-crud-core": "0.1.61",
+        "@jskit-ai/auth-core": "0.1.116",
+        "@jskit-ai/crud-core": "0.1.125",
+        "@jskit-ai/database-runtime": "0.1.118",
+        "@jskit-ai/http-runtime": "0.1.117",
+        "@jskit-ai/json-rest-api-core": "0.1.62",
+        "@jskit-ai/kernel": "0.1.119",
+        "@jskit-ai/resource-core": "0.1.62",
+        "@jskit-ai/resource-crud-core": "0.1.62",
         "@local/users": "file:packages/users",
-        "@jskit-ai/uploads-runtime": "0.1.94"
+        "@jskit-ai/uploads-runtime": "0.1.95"
       },
       dev: {}
     },

--- a/packages/users-core/package.json
+++ b/packages/users-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-core",
-  "version": "0.1.126",
+  "version": "0.1.127",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,14 +11,14 @@
     "./shared/resources/userSettingsResource": "./src/shared/resources/userSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.115",
-    "@jskit-ai/database-runtime": "0.1.116",
-    "@jskit-ai/http-runtime": "0.1.116",
-    "@jskit-ai/json-rest-api-core": "0.1.61",
-    "@jskit-ai/kernel": "0.1.117",
-    "@jskit-ai/resource-crud-core": "0.1.61",
-    "@jskit-ai/resource-core": "0.1.61",
-    "@jskit-ai/uploads-runtime": "0.1.94",
+    "@jskit-ai/auth-core": "0.1.116",
+    "@jskit-ai/database-runtime": "0.1.118",
+    "@jskit-ai/http-runtime": "0.1.117",
+    "@jskit-ai/json-rest-api-core": "0.1.62",
+    "@jskit-ai/kernel": "0.1.119",
+    "@jskit-ai/resource-crud-core": "0.1.62",
+    "@jskit-ai/resource-core": "0.1.62",
+    "@jskit-ai/uploads-runtime": "0.1.95",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/users-web/package.descriptor.mjs
+++ b/packages/users-web/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { HOME_COG_OUTLET } from "./src/shared/toolsOutletContracts.js";
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-web",
-  version: "0.1.132",
+  version: "0.1.133",
   kind: "runtime",
   description: "Users web module: account/profile UI plus shared users web widgets.",
   dependsOn: [
@@ -286,12 +286,12 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/http-runtime": "0.1.116",
-        "@jskit-ai/realtime": "0.1.115",
-        "@jskit-ai/kernel": "0.1.117",
-        "@jskit-ai/shell-web": "0.1.116",
-        "@jskit-ai/uploads-image-web": "0.1.94",
-        "@jskit-ai/users-core": "0.1.126"
+        "@jskit-ai/http-runtime": "0.1.117",
+        "@jskit-ai/realtime": "0.1.116",
+        "@jskit-ai/kernel": "0.1.119",
+        "@jskit-ai/shell-web": "0.1.117",
+        "@jskit-ai/uploads-image-web": "0.1.95",
+        "@jskit-ai/users-core": "0.1.127"
       },
       dev: {}
     },

--- a/packages/users-web/package.json
+++ b/packages/users-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-web",
-  "version": "0.1.132",
+  "version": "0.1.133",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -46,12 +46,12 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/http-runtime": "0.1.116",
-    "@jskit-ai/kernel": "0.1.117",
-    "@jskit-ai/realtime": "0.1.115",
-    "@jskit-ai/shell-web": "0.1.116",
-    "@jskit-ai/uploads-image-web": "0.1.94",
-    "@jskit-ai/users-core": "0.1.126"
+    "@jskit-ai/http-runtime": "0.1.117",
+    "@jskit-ai/kernel": "0.1.119",
+    "@jskit-ai/realtime": "0.1.116",
+    "@jskit-ai/shell-web": "0.1.117",
+    "@jskit-ai/uploads-image-web": "0.1.95",
+    "@jskit-ai/users-core": "0.1.127"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/workspaces-core/package.descriptor.mjs
+++ b/packages/workspaces-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-core",
-  version: "0.1.92",
+  version: "0.1.93",
   kind: "runtime",
   description: "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
   dependsOn: [
@@ -147,10 +147,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/json-rest-api-core": "0.1.61",
-        "@jskit-ai/resource-core": "0.1.61",
-        "@jskit-ai/resource-crud-core": "0.1.61",
-        "@jskit-ai/users-core": "0.1.126"
+        "@jskit-ai/json-rest-api-core": "0.1.62",
+        "@jskit-ai/resource-core": "0.1.62",
+        "@jskit-ai/resource-crud-core": "0.1.62",
+        "@jskit-ai/users-core": "0.1.127"
       },
       dev: {}
     },

--- a/packages/workspaces-core/package.json
+++ b/packages/workspaces-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-core",
-  "version": "0.1.92",
+  "version": "0.1.93",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -17,14 +17,14 @@
     "./shared/resources/workspaceSettingsResource": "./src/shared/resources/workspaceSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.115",
-    "@jskit-ai/database-runtime": "0.1.116",
-    "@jskit-ai/http-runtime": "0.1.116",
-    "@jskit-ai/json-rest-api-core": "0.1.61",
-    "@jskit-ai/kernel": "0.1.117",
-    "@jskit-ai/resource-crud-core": "0.1.61",
-    "@jskit-ai/resource-core": "0.1.61",
-    "@jskit-ai/users-core": "0.1.126",
+    "@jskit-ai/auth-core": "0.1.116",
+    "@jskit-ai/database-runtime": "0.1.118",
+    "@jskit-ai/http-runtime": "0.1.117",
+    "@jskit-ai/json-rest-api-core": "0.1.62",
+    "@jskit-ai/kernel": "0.1.119",
+    "@jskit-ai/resource-crud-core": "0.1.62",
+    "@jskit-ai/resource-core": "0.1.62",
+    "@jskit-ai/users-core": "0.1.127",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/workspaces-web/package.descriptor.mjs
+++ b/packages/workspaces-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-web",
-  version: "0.1.93",
+  version: "0.1.94",
   kind: "runtime",
   description: "Workspace web module: workspace selector, tools widget, workspace surfaces, members UI, and settings hosts.",
   dependsOn: [
@@ -232,9 +232,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-web": "0.1.117",
-        "@jskit-ai/workspaces-core": "0.1.92",
-        "@jskit-ai/users-web": "0.1.132"
+        "@jskit-ai/auth-web": "0.1.118",
+        "@jskit-ai/workspaces-core": "0.1.93",
+        "@jskit-ai/users-web": "0.1.133"
       },
       dev: {}
     },

--- a/packages/workspaces-web/package.json
+++ b/packages/workspaces-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-web",
-  "version": "0.1.93",
+  "version": "0.1.94",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -15,13 +15,13 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/auth-web": "0.1.117",
-    "@jskit-ai/http-runtime": "0.1.116",
-    "@jskit-ai/kernel": "0.1.117",
-    "@jskit-ai/shell-web": "0.1.116",
-    "@jskit-ai/users-core": "0.1.126",
-    "@jskit-ai/users-web": "0.1.132",
-    "@jskit-ai/workspaces-core": "0.1.92"
+    "@jskit-ai/auth-web": "0.1.118",
+    "@jskit-ai/http-runtime": "0.1.117",
+    "@jskit-ai/kernel": "0.1.119",
+    "@jskit-ai/shell-web": "0.1.117",
+    "@jskit-ai/users-core": "0.1.127",
+    "@jskit-ai/users-web": "0.1.133",
+    "@jskit-ai/workspaces-core": "0.1.93"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/tooling/config-eslint/package.json
+++ b/tooling/config-eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/config-eslint",
-  "version": "0.1.115",
+  "version": "0.1.116",
   "description": "Shared flat ESLint presets for JSKIT projects.",
   "type": "module",
   "files": [

--- a/tooling/create-app/package.descriptor.mjs
+++ b/tooling/create-app/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/create-app",
-  "version": "0.1.127",
+  "version": "0.1.128",
   "dependsOn": [],
   "capabilities": {
     "provides": [

--- a/tooling/create-app/package.json
+++ b/tooling/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/create-app",
-  "version": "0.1.127",
+  "version": "0.1.128",
   "description": "Scaffold JSKIT app shells.",
   "type": "module",
   "files": [
@@ -20,7 +20,7 @@
     "./client": "./src/client/index.js"
   },
   "dependencies": {
-    "@jskit-ai/jskit-cli": "0.2.130"
+    "@jskit-ai/jskit-cli": "0.2.131"
   },
   "engines": {
     "node": ">=20 <23"

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -6,11 +6,11 @@
   "packages": [
     {
       "packageId": "@jskit-ai/assistant",
-      "version": "0.1.125",
+      "version": "0.1.126",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant",
-        "version": "0.1.125",
+        "version": "0.1.126",
         "kind": "generator",
         "description": "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
         "options": {
@@ -347,11 +347,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-core",
-      "version": "0.1.92",
+      "version": "0.1.93",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-core",
-        "version": "0.1.92",
+        "version": "0.1.93",
         "kind": "runtime",
         "description": "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
         "dependsOn": [
@@ -399,11 +399,11 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/http-runtime": "0.1.116",
-              "@jskit-ai/kernel": "0.1.117",
-              "@jskit-ai/resource-core": "0.1.61",
-              "@jskit-ai/resource-crud-core": "0.1.61",
-              "@jskit-ai/users-core": "0.1.126",
+              "@jskit-ai/http-runtime": "0.1.117",
+              "@jskit-ai/kernel": "0.1.119",
+              "@jskit-ai/resource-core": "0.1.62",
+              "@jskit-ai/resource-crud-core": "0.1.62",
+              "@jskit-ai/users-core": "0.1.127",
               "dompurify": "^3.3.3",
               "json-rest-schema": "1.x.x",
               "marked": "^17.0.4",
@@ -422,11 +422,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-runtime",
-      "version": "0.1.87",
+      "version": "0.1.88",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-runtime",
-        "version": "0.1.87",
+        "version": "0.1.88",
         "kind": "runtime",
         "description": "Shared assistant runtime with per-surface assistant registration.",
         "dependsOn": [
@@ -522,13 +522,13 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/assistant-core": "0.1.92",
-              "@jskit-ai/database-runtime": "0.1.116",
-              "@jskit-ai/http-runtime": "0.1.116",
-              "@jskit-ai/kernel": "0.1.117",
-              "@jskit-ai/shell-web": "0.1.116",
-              "@jskit-ai/users-core": "0.1.126",
-              "@jskit-ai/users-web": "0.1.132"
+              "@jskit-ai/assistant-core": "0.1.93",
+              "@jskit-ai/database-runtime": "0.1.118",
+              "@jskit-ai/http-runtime": "0.1.117",
+              "@jskit-ai/kernel": "0.1.119",
+              "@jskit-ai/shell-web": "0.1.117",
+              "@jskit-ai/users-core": "0.1.127",
+              "@jskit-ai/users-web": "0.1.133"
             },
             "dev": {}
           },
@@ -583,11 +583,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-core",
-      "version": "0.1.115",
+      "version": "0.1.116",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-core",
-        "version": "0.1.115",
+        "version": "0.1.116",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/value-app-config-shared"
@@ -660,7 +660,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.117",
+              "@jskit-ai/kernel": "0.1.119",
               "@fastify/cookie": "^11.0.2",
               "@fastify/csrf-protection": "^7.1.0",
               "@fastify/rate-limit": "^10.3.0"
@@ -678,11 +678,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-local-core",
-      "version": "0.1.17",
+      "version": "0.1.18",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-local-core",
-        "version": "0.1.17",
+        "version": "0.1.18",
         "kind": "runtime",
         "description": "Local auth provider with a file backend default and no database requirement.",
         "dependsOn": [
@@ -745,8 +745,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.115",
-              "@jskit-ai/kernel": "0.1.118",
+              "@jskit-ai/auth-core": "0.1.116",
+              "@jskit-ai/kernel": "0.1.119",
               "nodemailer": "^7.0.10",
               "dotenv": "^16.4.5"
             },
@@ -792,11 +792,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-local-db-core",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-local-db-core",
-        "version": "0.1.9",
+        "version": "0.1.10",
         "kind": "runtime",
         "description": "Database-backed local auth storage backend for JSKIT local auth.",
         "dependsOn": [
@@ -875,9 +875,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-provider-local-core": "0.1.17",
-              "@jskit-ai/database-runtime": "0.1.117",
-              "@jskit-ai/kernel": "0.1.118"
+              "@jskit-ai/auth-provider-local-core": "0.1.18",
+              "@jskit-ai/database-runtime": "0.1.118",
+              "@jskit-ai/kernel": "0.1.119"
             },
             "dev": {}
           },
@@ -912,11 +912,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.115",
+      "version": "0.1.116",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-supabase-core",
-        "version": "0.1.115",
+        "version": "0.1.116",
         "kind": "runtime",
         "options": {
           "auth-supabase-url": {
@@ -998,8 +998,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.115",
-              "@jskit-ai/kernel": "0.1.117",
+              "@jskit-ai/auth-core": "0.1.116",
+              "@jskit-ai/kernel": "0.1.119",
               "dotenv": "^16.4.5",
               "@supabase/supabase-js": "^2.57.4",
               "jose": "^6.1.0"
@@ -1077,11 +1077,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-web",
-      "version": "0.1.117",
+      "version": "0.1.118",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-web",
-        "version": "0.1.117",
+        "version": "0.1.118",
         "kind": "runtime",
         "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
         "dependsOn": [
@@ -1350,10 +1350,10 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/auth-core": "0.1.115",
-              "@jskit-ai/http-runtime": "0.1.116",
-              "@jskit-ai/kernel": "0.1.117",
-              "@jskit-ai/shell-web": "0.1.116"
+              "@jskit-ai/auth-core": "0.1.116",
+              "@jskit-ai/http-runtime": "0.1.117",
+              "@jskit-ai/kernel": "0.1.119",
+              "@jskit-ai/shell-web": "0.1.117"
             },
             "dev": {}
           },
@@ -1446,11 +1446,11 @@
     },
     {
       "packageId": "@jskit-ai/console-core",
-      "version": "0.1.79",
+      "version": "0.1.80",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-core",
-        "version": "0.1.79",
+        "version": "0.1.80",
         "kind": "runtime",
         "description": "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
         "dependsOn": [
@@ -1534,12 +1534,12 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.115",
-              "@jskit-ai/database-runtime": "0.1.116",
-              "@jskit-ai/http-runtime": "0.1.116",
-              "@jskit-ai/kernel": "0.1.117",
-              "@jskit-ai/resource-crud-core": "0.1.61",
-              "@jskit-ai/users-core": "0.1.126"
+              "@jskit-ai/auth-core": "0.1.116",
+              "@jskit-ai/database-runtime": "0.1.118",
+              "@jskit-ai/http-runtime": "0.1.117",
+              "@jskit-ai/kernel": "0.1.119",
+              "@jskit-ai/resource-crud-core": "0.1.62",
+              "@jskit-ai/users-core": "0.1.127"
             },
             "dev": {}
           },
@@ -1564,11 +1564,11 @@
     },
     {
       "packageId": "@jskit-ai/console-web",
-      "version": "0.1.84",
+      "version": "0.1.85",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-web",
-        "version": "0.1.84",
+        "version": "0.1.85",
         "kind": "runtime",
         "description": "Authenticated console surface scaffold and surface policy wiring.",
         "dependsOn": [
@@ -1678,9 +1678,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-web": "0.1.117",
-              "@jskit-ai/console-core": "0.1.79",
-              "@jskit-ai/shell-web": "0.1.116"
+              "@jskit-ai/auth-web": "0.1.118",
+              "@jskit-ai/console-core": "0.1.80",
+              "@jskit-ai/shell-web": "0.1.117"
             },
             "dev": {}
           },
@@ -1787,11 +1787,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-core",
-      "version": "0.1.124",
+      "version": "0.1.125",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-core",
-        "version": "0.1.124",
+        "version": "0.1.125",
         "kind": "runtime",
         "description": "Shared CRUD helpers used by CRUD modules.",
         "dependsOn": [
@@ -1820,7 +1820,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/crud-core": "0.1.124"
+              "@jskit-ai/crud-core": "0.1.125"
             },
             "dev": {}
           },
@@ -1834,11 +1834,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-server-generator",
-      "version": "0.1.124",
+      "version": "0.1.125",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-server-generator",
-        "version": "0.1.124",
+        "version": "0.1.125",
         "kind": "generator",
         "description": "CRUD server generator with routes, actions, and persistence scaffolding.",
         "options": {
@@ -2005,14 +2005,14 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.115",
-              "@jskit-ai/crud-core": "0.1.124",
-              "@jskit-ai/database-runtime": "0.1.116",
-              "@jskit-ai/http-runtime": "0.1.116",
-              "@jskit-ai/json-rest-api-core": "0.1.61",
-              "@jskit-ai/kernel": "0.1.117",
-              "@jskit-ai/realtime": "0.1.115",
-              "@jskit-ai/resource-crud-core": "0.1.61",
+              "@jskit-ai/auth-core": "0.1.116",
+              "@jskit-ai/crud-core": "0.1.125",
+              "@jskit-ai/database-runtime": "0.1.118",
+              "@jskit-ai/http-runtime": "0.1.117",
+              "@jskit-ai/json-rest-api-core": "0.1.62",
+              "@jskit-ai/kernel": "0.1.119",
+              "@jskit-ai/realtime": "0.1.116",
+              "@jskit-ai/resource-crud-core": "0.1.62",
               "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}"
             },
             "dev": {}
@@ -2144,11 +2144,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.99",
+      "version": "0.1.100",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-ui-generator",
-        "version": "0.1.99",
+        "version": "0.1.100",
         "kind": "generator",
         "description": "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
         "options": {
@@ -2347,7 +2347,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.132"
+              "@jskit-ai/users-web": "0.1.133"
             },
             "dev": {}
           },
@@ -2606,11 +2606,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime",
-      "version": "0.1.117",
+      "version": "0.1.118",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime",
-        "version": "0.1.117",
+        "version": "0.1.118",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -2679,7 +2679,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.118",
+              "@jskit-ai/kernel": "0.1.119",
               "dotenv": "^16.4.5",
               "knex": "^3.1.0"
             },
@@ -2715,11 +2715,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.116",
+      "version": "0.1.117",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-mysql",
-        "version": "0.1.116",
+        "version": "0.1.117",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -2841,7 +2841,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.117",
+              "@jskit-ai/database-runtime": "0.1.118",
               "mysql2": "^3.11.2"
             },
             "dev": {}
@@ -2912,11 +2912,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.115",
+      "version": "0.1.116",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-postgres",
-        "version": "0.1.115",
+        "version": "0.1.116",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -3037,7 +3037,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.116",
+              "@jskit-ai/database-runtime": "0.1.118",
               "pg": "^8.13.1"
             },
             "dev": {}
@@ -3108,11 +3108,11 @@
     },
     {
       "packageId": "@jskit-ai/feature-server-generator",
-      "version": "0.1.59",
+      "version": "0.1.60",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/feature-server-generator",
-        "version": "0.1.59",
+        "version": "0.1.60",
         "kind": "generator",
         "description": "Scaffold substantial non-CRUD server feature packages with provider, actions, service, and optional persistence seams.",
         "options": {
@@ -3297,7 +3297,7 @@
                   "equals": "json-rest"
                 }
               },
-              "@jskit-ai/kernel": "0.1.118",
+              "@jskit-ai/kernel": "0.1.119",
               "json-rest-schema": "1.x.x",
               "@local/${option:feature-name|kebab}": "file:packages/${option:feature-name|kebab}"
             },
@@ -3410,11 +3410,11 @@
     },
     {
       "packageId": "@jskit-ai/google-rewarded-core",
-      "version": "0.1.53",
+      "version": "0.1.54",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/google-rewarded-core",
-        "version": "0.1.53",
+        "version": "0.1.54",
         "kind": "runtime",
         "description": "Google rewarded workflow runtime plus internal CRUD providers for rules, provider configs, watch sessions, and unlock receipts.",
         "dependsOn": [
@@ -3541,14 +3541,14 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.115",
-              "@jskit-ai/crud-core": "0.1.124",
-              "@jskit-ai/database-runtime": "0.1.116",
-              "@jskit-ai/http-runtime": "0.1.116",
-              "@jskit-ai/json-rest-api-core": "0.1.61",
-              "@jskit-ai/kernel": "0.1.117",
-              "@jskit-ai/resource-crud-core": "0.1.61",
-              "@jskit-ai/workspaces-core": "0.1.92"
+              "@jskit-ai/auth-core": "0.1.116",
+              "@jskit-ai/crud-core": "0.1.125",
+              "@jskit-ai/database-runtime": "0.1.118",
+              "@jskit-ai/http-runtime": "0.1.117",
+              "@jskit-ai/json-rest-api-core": "0.1.62",
+              "@jskit-ai/kernel": "0.1.119",
+              "@jskit-ai/resource-crud-core": "0.1.62",
+              "@jskit-ai/workspaces-core": "0.1.93"
             },
             "dev": {}
           },
@@ -3600,11 +3600,11 @@
     },
     {
       "packageId": "@jskit-ai/google-rewarded-web",
-      "version": "0.1.53",
+      "version": "0.1.54",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/google-rewarded-web",
-        "version": "0.1.53",
+        "version": "0.1.54",
         "kind": "runtime",
         "description": "Google rewarded client runtime with a fullscreen gate host and GPT orchestration.",
         "dependsOn": [
@@ -3651,10 +3651,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/google-rewarded-core": "0.1.53",
-              "@jskit-ai/http-runtime": "0.1.116",
-              "@jskit-ai/kernel": "0.1.117",
-              "@jskit-ai/shell-web": "0.1.116"
+              "@jskit-ai/google-rewarded-core": "0.1.54",
+              "@jskit-ai/http-runtime": "0.1.117",
+              "@jskit-ai/kernel": "0.1.119",
+              "@jskit-ai/shell-web": "0.1.117"
             },
             "dev": {}
           },
@@ -3672,11 +3672,11 @@
     },
     {
       "packageId": "@jskit-ai/http-runtime",
-      "version": "0.1.116",
+      "version": "0.1.117",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/http-runtime",
-        "version": "0.1.116",
+        "version": "0.1.117",
         "kind": "runtime",
         "dependsOn": [],
         "capabilities": {
@@ -3742,7 +3742,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.117"
+              "@jskit-ai/kernel": "0.1.119"
             },
             "dev": {}
           },
@@ -3756,11 +3756,11 @@
     },
     {
       "packageId": "@jskit-ai/json-rest-api-core",
-      "version": "0.1.61",
+      "version": "0.1.62",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/json-rest-api-core",
-        "version": "0.1.61",
+        "version": "0.1.62",
         "kind": "runtime",
         "description": "Shared internal json-rest-api host runtime for JSKIT server packages.",
         "dependsOn": [
@@ -3820,11 +3820,11 @@
     },
     {
       "packageId": "@jskit-ai/mobile-capacitor",
-      "version": "0.1.53",
+      "version": "0.1.54",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/mobile-capacitor",
-        "version": "0.1.53",
+        "version": "0.1.54",
         "kind": "runtime",
         "description": "Thin Capacitor client integration for JSKIT mobile-shell launch routing and auth callback completion.",
         "dependsOn": [
@@ -3887,8 +3887,8 @@
               "@capacitor/app": "^7.1.0",
               "@capacitor/browser": "^7.0.1",
               "@capacitor/core": "^7.4.3",
-              "@jskit-ai/kernel": "0.1.117",
-              "@jskit-ai/shell-web": "0.1.116"
+              "@jskit-ai/kernel": "0.1.119",
+              "@jskit-ai/shell-web": "0.1.117"
             },
             "dev": {
               "@capacitor/cli": "^7.4.3"
@@ -3940,11 +3940,11 @@
     },
     {
       "packageId": "@jskit-ai/realtime",
-      "version": "0.1.115",
+      "version": "0.1.116",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/realtime",
-        "version": "0.1.115",
+        "version": "0.1.116",
         "kind": "runtime",
         "description": "Thin, generic realtime runtime wrappers for socket.io server and client.",
         "options": {
@@ -4040,7 +4040,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.117",
+              "@jskit-ai/kernel": "0.1.119",
               "@socket.io/redis-adapter": "^8.3.0",
               "redis": "^5.8.2",
               "socket.io": "^4.8.3",
@@ -4089,11 +4089,11 @@
     },
     {
       "packageId": "@jskit-ai/resource-core",
-      "version": "0.1.61",
+      "version": "0.1.62",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/resource-core",
-        "version": "0.1.61",
+        "version": "0.1.62",
         "kind": "runtime",
         "description": "Generic resource-definition helpers and schema-definition normalization.",
         "dependsOn": [
@@ -4116,7 +4116,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/resource-core": "0.1.61"
+              "@jskit-ai/resource-core": "0.1.62"
             },
             "dev": {}
           },
@@ -4131,11 +4131,11 @@
     },
     {
       "packageId": "@jskit-ai/resource-crud-core",
-      "version": "0.1.61",
+      "version": "0.1.62",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/resource-crud-core",
-        "version": "0.1.61",
+        "version": "0.1.62",
         "kind": "runtime",
         "description": "CRUD-specific resource-definition helpers and namespace support.",
         "dependsOn": [
@@ -4159,7 +4159,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/resource-crud-core": "0.1.61"
+              "@jskit-ai/resource-crud-core": "0.1.62"
             },
             "dev": {}
           },
@@ -4174,11 +4174,11 @@
     },
     {
       "packageId": "@jskit-ai/shell-web",
-      "version": "0.1.116",
+      "version": "0.1.117",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/shell-web",
-        "version": "0.1.116",
+        "version": "0.1.117",
         "kind": "runtime",
         "description": "Web shell layout runtime with outlet-based placement contributions.",
         "dependsOn": [],
@@ -4520,7 +4520,7 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/kernel": "0.1.117"
+              "@jskit-ai/kernel": "0.1.119"
             },
             "dev": {}
           },
@@ -4727,11 +4727,11 @@
     },
     {
       "packageId": "@jskit-ai/storage-runtime",
-      "version": "0.1.115",
+      "version": "0.1.116",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/storage-runtime",
-        "version": "0.1.115",
+        "version": "0.1.116",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -4780,7 +4780,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.117",
+              "@jskit-ai/kernel": "0.1.119",
               "unstorage": "^1.17.3"
             },
             "dev": {}
@@ -4796,11 +4796,11 @@
     },
     {
       "packageId": "@jskit-ai/ui-generator",
-      "version": "0.1.99",
+      "version": "0.1.100",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/ui-generator",
-        "version": "0.1.99",
+        "version": "0.1.100",
         "kind": "generator",
         "description": "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
         "options": {
@@ -5233,7 +5233,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.132"
+              "@jskit-ai/users-web": "0.1.133"
             },
             "dev": {}
           },
@@ -5248,11 +5248,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-image-web",
-      "version": "0.1.94",
+      "version": "0.1.95",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-image-web",
-        "version": "0.1.94",
+        "version": "0.1.95",
         "kind": "runtime",
         "description": "Reusable client-side image upload runtime with pre-upload image editing.",
         "dependsOn": [
@@ -5316,7 +5316,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/uploads-runtime": "0.1.94",
+              "@jskit-ai/uploads-runtime": "0.1.95",
               "@uppy/compressor": "^3.1.0",
               "@uppy/core": "^5.2.0",
               "@uppy/dashboard": "^5.1.1",
@@ -5336,11 +5336,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-runtime",
-      "version": "0.1.94",
+      "version": "0.1.95",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-runtime",
-        "version": "0.1.94",
+        "version": "0.1.95",
         "kind": "runtime",
         "description": "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
         "dependsOn": [
@@ -5410,7 +5410,7 @@
           "dependencies": {
             "runtime": {
               "@fastify/multipart": "^9.4.0",
-              "@jskit-ai/kernel": "0.1.117"
+              "@jskit-ai/kernel": "0.1.119"
             },
             "dev": {}
           },
@@ -5425,11 +5425,11 @@
     },
     {
       "packageId": "@jskit-ai/users-core",
-      "version": "0.1.126",
+      "version": "0.1.127",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-core",
-        "version": "0.1.126",
+        "version": "0.1.127",
         "kind": "runtime",
         "description": "Users/account runtime plus HTTP routes for account features.",
         "dependsOn": [
@@ -5573,16 +5573,16 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.115",
-              "@jskit-ai/crud-core": "0.1.124",
-              "@jskit-ai/database-runtime": "0.1.116",
-              "@jskit-ai/http-runtime": "0.1.116",
-              "@jskit-ai/json-rest-api-core": "0.1.61",
-              "@jskit-ai/kernel": "0.1.117",
-              "@jskit-ai/resource-core": "0.1.61",
-              "@jskit-ai/resource-crud-core": "0.1.61",
+              "@jskit-ai/auth-core": "0.1.116",
+              "@jskit-ai/crud-core": "0.1.125",
+              "@jskit-ai/database-runtime": "0.1.118",
+              "@jskit-ai/http-runtime": "0.1.117",
+              "@jskit-ai/json-rest-api-core": "0.1.62",
+              "@jskit-ai/kernel": "0.1.119",
+              "@jskit-ai/resource-core": "0.1.62",
+              "@jskit-ai/resource-crud-core": "0.1.62",
               "@local/users": "file:packages/users",
-              "@jskit-ai/uploads-runtime": "0.1.94"
+              "@jskit-ai/uploads-runtime": "0.1.95"
             },
             "dev": {}
           },
@@ -5809,11 +5809,11 @@
     },
     {
       "packageId": "@jskit-ai/users-web",
-      "version": "0.1.132",
+      "version": "0.1.133",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-web",
-        "version": "0.1.132",
+        "version": "0.1.133",
         "kind": "runtime",
         "description": "Users web module: account/profile UI plus shared users web widgets.",
         "dependsOn": [
@@ -6116,12 +6116,12 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/http-runtime": "0.1.116",
-              "@jskit-ai/realtime": "0.1.115",
-              "@jskit-ai/kernel": "0.1.117",
-              "@jskit-ai/shell-web": "0.1.116",
-              "@jskit-ai/uploads-image-web": "0.1.94",
-              "@jskit-ai/users-core": "0.1.126"
+              "@jskit-ai/http-runtime": "0.1.117",
+              "@jskit-ai/realtime": "0.1.116",
+              "@jskit-ai/kernel": "0.1.119",
+              "@jskit-ai/shell-web": "0.1.117",
+              "@jskit-ai/uploads-image-web": "0.1.95",
+              "@jskit-ai/users-core": "0.1.127"
             },
             "dev": {}
           },
@@ -6298,11 +6298,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-core",
-      "version": "0.1.92",
+      "version": "0.1.93",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-core",
-        "version": "0.1.92",
+        "version": "0.1.93",
         "kind": "runtime",
         "description": "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
         "dependsOn": [
@@ -6448,10 +6448,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/json-rest-api-core": "0.1.61",
-              "@jskit-ai/resource-core": "0.1.61",
-              "@jskit-ai/resource-crud-core": "0.1.61",
-              "@jskit-ai/users-core": "0.1.126"
+              "@jskit-ai/json-rest-api-core": "0.1.62",
+              "@jskit-ai/resource-core": "0.1.62",
+              "@jskit-ai/resource-crud-core": "0.1.62",
+              "@jskit-ai/users-core": "0.1.127"
             },
             "dev": {}
           },
@@ -6653,11 +6653,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-web",
-      "version": "0.1.93",
+      "version": "0.1.94",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-web",
-        "version": "0.1.93",
+        "version": "0.1.94",
         "kind": "runtime",
         "description": "Workspace web module: workspace selector, tools widget, workspace surfaces, members UI, and settings hosts.",
         "dependsOn": [
@@ -6914,9 +6914,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-web": "0.1.117",
-              "@jskit-ai/workspaces-core": "0.1.92",
-              "@jskit-ai/users-web": "0.1.132"
+              "@jskit-ai/auth-web": "0.1.118",
+              "@jskit-ai/workspaces-core": "0.1.93",
+              "@jskit-ai/users-web": "0.1.133"
             },
             "dev": {}
           },

--- a/tooling/jskit-catalog/package.json
+++ b/tooling/jskit-catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-catalog",
-  "version": "0.1.125",
+  "version": "0.1.126",
   "description": "Published metadata catalog for JSKIT package descriptors.",
   "type": "module",
   "files": [

--- a/tooling/jskit-cli/package.json
+++ b/tooling/jskit-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-cli",
-  "version": "0.2.130",
+  "version": "0.2.131",
   "description": "Bundle and package orchestration CLI for JSKIT apps.",
   "type": "module",
   "files": [
@@ -20,9 +20,9 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/jskit-catalog": "0.1.125",
-    "@jskit-ai/kernel": "0.1.118",
-    "@jskit-ai/shell-web": "0.1.116",
+    "@jskit-ai/jskit-catalog": "0.1.126",
+    "@jskit-ai/kernel": "0.1.119",
+    "@jskit-ai/shell-web": "0.1.117",
     "@vue/compiler-sfc": "^3.5.29",
     "ts-morph": "^28.0.0",
     "yaml": "^2.8.3"


### PR DESCRIPTION
## Summary

- synchronize all published workspace versions with npm
- refresh exact internal JSKIT dependency pins
- regenerate the package lockfile and JSKIT catalog

## Verification

- all 38 publishable workspace package versions match npm latest
- package-lock and catalog regeneration are byte-for-byte stable
- runtime dependency audit passed
- descriptor lint passed
- focused database descriptor and feature-generator tests passed
- git diff check passed
