### PR TITLE
Fix shell-web Vite cold-start dependency optimization

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -49,8 +49,34 @@ jobs:
           JSKIT_DATABASE_INTEGRATION_DRIVER: ${{ matrix.database }}
         run: node --test tooling/create-app/test/databaseCi.integration.test.js
 
+  vite-cold-start:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Chromium
+        run: npx --yes playwright@1.61.1 install --with-deps chromium
+
+      - name: Verify a cold generated auth app
+        env:
+          JSKIT_VITE_COLD_START_INTEGRATION: "1"
+        run: node --test tooling/create-app/test/viteColdStart.integration.test.js
+
   publish:
-    needs: database-ci
+    needs:
+      - database-ci
+      - vite-cold-start
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -55,11 +55,36 @@ jobs:
           JSKIT_DATABASE_INTEGRATION_DRIVER: ${{ matrix.database }}
         run: node --test tooling/create-app/test/databaseCi.integration.test.js
 
+  vite-cold-start:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Chromium
+        run: npx --yes playwright@1.61.1 install --with-deps chromium
+
+      - name: Verify a cold generated auth app
+        env:
+          JSKIT_VITE_COLD_START_INTEGRATION: "1"
+        run: node --test tooling/create-app/test/viteColdStart.integration.test.js
+
   deploy-docs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs:
       - verify
       - database-ci
+      - vite-cold-start
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/package-lock.json
+++ b/package-lock.json
@@ -6737,6 +6737,21 @@
         "vuetify": "^4.0.0"
       }
     },
+    "packages/assistant-runtime/node_modules/@jskit-ai/shell-web": {
+      "version": "0.1.117",
+      "resolved": "https://registry.npmjs.org/@jskit-ai/shell-web/-/shell-web-0.1.117.tgz",
+      "integrity": "sha512-fnqtdl/sR1QdrWH+ufhrsuaALXgJ8RPxODd9Wds6VJWoVY5GvIM3J2EbDSPmHqbBaliGNF/x9DJQERdUcSMJ9g==",
+      "dependencies": {
+        "@jskit-ai/kernel": "0.1.119",
+        "@mdi/js": "^7.4.47"
+      },
+      "peerDependencies": {
+        "pinia": "^3.0.4",
+        "vue": "^3.5.13",
+        "vue-router": "^5.0.4",
+        "vuetify": "^4.0.0"
+      }
+    },
     "packages/auth-core": {
       "name": "@jskit-ai/auth-core",
       "version": "0.1.116",
@@ -6796,6 +6811,21 @@
         "vuetify": "^4.0.0"
       }
     },
+    "packages/auth-web/node_modules/@jskit-ai/shell-web": {
+      "version": "0.1.117",
+      "resolved": "https://registry.npmjs.org/@jskit-ai/shell-web/-/shell-web-0.1.117.tgz",
+      "integrity": "sha512-fnqtdl/sR1QdrWH+ufhrsuaALXgJ8RPxODd9Wds6VJWoVY5GvIM3J2EbDSPmHqbBaliGNF/x9DJQERdUcSMJ9g==",
+      "dependencies": {
+        "@jskit-ai/kernel": "0.1.119",
+        "@mdi/js": "^7.4.47"
+      },
+      "peerDependencies": {
+        "pinia": "^3.0.4",
+        "vue": "^3.5.13",
+        "vue-router": "^5.0.4",
+        "vuetify": "^4.0.0"
+      }
+    },
     "packages/console-core": {
       "name": "@jskit-ai/console-core",
       "version": "0.1.80",
@@ -6818,6 +6848,21 @@
         "@jskit-ai/shell-web": "0.1.117"
       }
     },
+    "packages/console-web/node_modules/@jskit-ai/shell-web": {
+      "version": "0.1.117",
+      "resolved": "https://registry.npmjs.org/@jskit-ai/shell-web/-/shell-web-0.1.117.tgz",
+      "integrity": "sha512-fnqtdl/sR1QdrWH+ufhrsuaALXgJ8RPxODd9Wds6VJWoVY5GvIM3J2EbDSPmHqbBaliGNF/x9DJQERdUcSMJ9g==",
+      "dependencies": {
+        "@jskit-ai/kernel": "0.1.119",
+        "@mdi/js": "^7.4.47"
+      },
+      "peerDependencies": {
+        "pinia": "^3.0.4",
+        "vue": "^3.5.13",
+        "vue-router": "^5.0.4",
+        "vuetify": "^4.0.0"
+      }
+    },
     "packages/crud-core": {
       "name": "@jskit-ai/crud-core",
       "version": "0.1.125",
@@ -6836,6 +6881,21 @@
         "@tanstack/vue-query": "^5.90.5",
         "vue": "^3.5.13",
         "vue-router": "^5.0.4"
+      }
+    },
+    "packages/crud-core/node_modules/@jskit-ai/shell-web": {
+      "version": "0.1.117",
+      "resolved": "https://registry.npmjs.org/@jskit-ai/shell-web/-/shell-web-0.1.117.tgz",
+      "integrity": "sha512-fnqtdl/sR1QdrWH+ufhrsuaALXgJ8RPxODd9Wds6VJWoVY5GvIM3J2EbDSPmHqbBaliGNF/x9DJQERdUcSMJ9g==",
+      "dependencies": {
+        "@jskit-ai/kernel": "0.1.119",
+        "@mdi/js": "^7.4.47"
+      },
+      "peerDependencies": {
+        "pinia": "^3.0.4",
+        "vue": "^3.5.13",
+        "vue-router": "^5.0.4",
+        "vuetify": "^4.0.0"
       }
     },
     "packages/crud-server-generator": {
@@ -6958,7 +7018,7 @@
     },
     "packages/shell-web": {
       "name": "@jskit-ai/shell-web",
-      "version": "0.1.117",
+      "version": "0.1.118",
       "dependencies": {
         "@jskit-ai/kernel": "0.1.119",
         "@mdi/js": "^7.4.47"
@@ -6984,6 +7044,21 @@
       "dependencies": {
         "@jskit-ai/kernel": "0.1.119",
         "@jskit-ai/shell-web": "0.1.117"
+      }
+    },
+    "packages/ui-generator/node_modules/@jskit-ai/shell-web": {
+      "version": "0.1.117",
+      "resolved": "https://registry.npmjs.org/@jskit-ai/shell-web/-/shell-web-0.1.117.tgz",
+      "integrity": "sha512-fnqtdl/sR1QdrWH+ufhrsuaALXgJ8RPxODd9Wds6VJWoVY5GvIM3J2EbDSPmHqbBaliGNF/x9DJQERdUcSMJ9g==",
+      "dependencies": {
+        "@jskit-ai/kernel": "0.1.119",
+        "@mdi/js": "^7.4.47"
+      },
+      "peerDependencies": {
+        "pinia": "^3.0.4",
+        "vue": "^3.5.13",
+        "vue-router": "^5.0.4",
+        "vuetify": "^4.0.0"
       }
     },
     "packages/uploads-image-web": {
@@ -7043,6 +7118,21 @@
         "vuetify": "^4.0.0"
       }
     },
+    "packages/users-web/node_modules/@jskit-ai/shell-web": {
+      "version": "0.1.117",
+      "resolved": "https://registry.npmjs.org/@jskit-ai/shell-web/-/shell-web-0.1.117.tgz",
+      "integrity": "sha512-fnqtdl/sR1QdrWH+ufhrsuaALXgJ8RPxODd9Wds6VJWoVY5GvIM3J2EbDSPmHqbBaliGNF/x9DJQERdUcSMJ9g==",
+      "dependencies": {
+        "@jskit-ai/kernel": "0.1.119",
+        "@mdi/js": "^7.4.47"
+      },
+      "peerDependencies": {
+        "pinia": "^3.0.4",
+        "vue": "^3.5.13",
+        "vue-router": "^5.0.4",
+        "vuetify": "^4.0.0"
+      }
+    },
     "packages/workspaces-core": {
       "name": "@jskit-ai/workspaces-core",
       "version": "0.1.93",
@@ -7078,6 +7168,21 @@
         "vuetify": "^4.0.0"
       }
     },
+    "packages/workspaces-web/node_modules/@jskit-ai/shell-web": {
+      "version": "0.1.117",
+      "resolved": "https://registry.npmjs.org/@jskit-ai/shell-web/-/shell-web-0.1.117.tgz",
+      "integrity": "sha512-fnqtdl/sR1QdrWH+ufhrsuaALXgJ8RPxODd9Wds6VJWoVY5GvIM3J2EbDSPmHqbBaliGNF/x9DJQERdUcSMJ9g==",
+      "dependencies": {
+        "@jskit-ai/kernel": "0.1.119",
+        "@mdi/js": "^7.4.47"
+      },
+      "peerDependencies": {
+        "pinia": "^3.0.4",
+        "vue": "^3.5.13",
+        "vue-router": "^5.0.4",
+        "vuetify": "^4.0.0"
+      }
+    },
     "tooling/config-eslint": {
       "name": "@jskit-ai/config-eslint",
       "version": "0.1.116",
@@ -7098,9 +7203,9 @@
     },
     "tooling/create-app": {
       "name": "@jskit-ai/create-app",
-      "version": "0.1.128",
+      "version": "0.1.129",
       "dependencies": {
-        "@jskit-ai/jskit-cli": "0.2.131"
+        "@jskit-ai/jskit-cli": "0.2.132"
       },
       "bin": {
         "jskit-create-app": "bin/jskit-create-app.js"
@@ -7111,18 +7216,18 @@
     },
     "tooling/jskit-catalog": {
       "name": "@jskit-ai/jskit-catalog",
-      "version": "0.1.126",
+      "version": "0.1.127",
       "engines": {
         "node": ">=20 <23"
       }
     },
     "tooling/jskit-cli": {
       "name": "@jskit-ai/jskit-cli",
-      "version": "0.2.131",
+      "version": "0.2.132",
       "dependencies": {
-        "@jskit-ai/jskit-catalog": "0.1.126",
+        "@jskit-ai/jskit-catalog": "0.1.127",
         "@jskit-ai/kernel": "0.1.119",
-        "@jskit-ai/shell-web": "0.1.117",
+        "@jskit-ai/shell-web": "0.1.118",
         "@vue/compiler-sfc": "^3.5.29",
         "ts-morph": "^28.0.0",
         "yaml": "^2.8.3"

--- a/packages/shell-web/package.descriptor.mjs
+++ b/packages/shell-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/shell-web",
-  version: "0.1.117",
+  version: "0.1.118",
   kind: "runtime",
   description: "Web shell layout runtime with outlet-based placement contributions.",
   dependsOn: [],
@@ -30,6 +30,10 @@ export default Object.freeze({
   metadata: {
     client: {
       optimizeDeps: {
+        include: [
+          "@jskit-ai/shell-web/client/placement",
+          "@jskit-ai/shell-web/client/error"
+        ],
         exclude: [
           "@jskit-ai/shell-web/client"
         ]

--- a/packages/shell-web/package.json
+++ b/packages/shell-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/shell-web",
-  "version": "0.1.117",
+  "version": "0.1.118",
   "type": "module",
   "scripts": {
     "test": "node --test"

--- a/packages/shell-web/test/settingsPlacementContract.test.js
+++ b/packages/shell-web/test/settingsPlacementContract.test.js
@@ -38,6 +38,13 @@ function readTopology(id = "", owner = "") {
     : [];
 }
 
+function readPackageImportSpecifiers(source = "") {
+  return Array.from(
+    String(source || "").matchAll(/\bfrom\s+["'](@jskit-ai\/[^"']+)["']/gu),
+    (match) => match[1]
+  );
+}
+
 function readClientContainerTokens() {
   const tokens = descriptor?.metadata?.apiSummary?.containerTokens?.client;
   return Array.isArray(tokens) ? tokens : [];
@@ -315,11 +322,43 @@ test("shell-web placement topology seeds global actions as a semantic shell plac
   assert.match(source, /outlet: "shell-layout:supporting-side-panel"/);
 });
 
-test("shell-web descriptor metadata advertises adaptive shell outlets, default links, and installs the scaffold page", () => {
+test("shell-web descriptor pre-optimizes package subpaths reached only through dynamic base-shell modules", async () => {
+  const [providerSource, placementSource, placementTopologySource, errorSource] = await Promise.all([
+    readFile(path.join(PACKAGE_DIR, "src", "client", "providers", "ShellWebClientProvider.js"), "utf8"),
+    readFile(path.join(PACKAGE_DIR, "templates", "src", "placement.js"), "utf8"),
+    readFile(path.join(PACKAGE_DIR, "templates", "src", "placementTopology.js"), "utf8"),
+    readFile(path.join(PACKAGE_DIR, "templates", "src", "error.js"), "utf8")
+  ]);
+
+  assert.deepEqual(
+    Array.from(
+      new Set(
+        Array.from(
+          providerSource.matchAll(/\bimport\(["'](\/src\/[^"']+)["']\)/gu),
+          (match) => match[1]
+        )
+      )
+    ),
+    ["/src/placement.js", "/src/placementTopology.js", "/src/error.js"]
+  );
+  assert.deepEqual(readPackageImportSpecifiers(placementSource), [
+    "@jskit-ai/shell-web/client/placement"
+  ]);
+  assert.deepEqual(readPackageImportSpecifiers(placementTopologySource), []);
+  assert.deepEqual(readPackageImportSpecifiers(errorSource), [
+    "@jskit-ai/shell-web/client/error"
+  ]);
+
+  assert.deepEqual(descriptor?.metadata?.client?.optimizeDeps?.include, [
+    "@jskit-ai/shell-web/client/placement",
+    "@jskit-ai/shell-web/client/error"
+  ]);
   assert.deepEqual(descriptor?.metadata?.client?.optimizeDeps?.exclude, [
     "@jskit-ai/shell-web/client"
   ]);
+});
 
+test("shell-web descriptor metadata advertises adaptive shell outlets, default links, and installs the scaffold page", () => {
   assert.deepEqual(readClientContainerTokens(), [
     "runtime.web-placement.client",
     "runtime.web-bootstrap.client",

--- a/tooling/create-app/package.descriptor.mjs
+++ b/tooling/create-app/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/create-app",
-  "version": "0.1.128",
+  "version": "0.1.129",
   "dependsOn": [],
   "capabilities": {
     "provides": [

--- a/tooling/create-app/package.json
+++ b/tooling/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/create-app",
-  "version": "0.1.128",
+  "version": "0.1.129",
   "description": "Scaffold JSKIT app shells.",
   "type": "module",
   "files": [
@@ -20,7 +20,7 @@
     "./client": "./src/client/index.js"
   },
   "dependencies": {
-    "@jskit-ai/jskit-cli": "0.2.131"
+    "@jskit-ai/jskit-cli": "0.2.132"
   },
   "engines": {
     "node": ">=20 <23"

--- a/tooling/create-app/test/viteColdStart.integration.test.js
+++ b/tooling/create-app/test/viteColdStart.integration.test.js
@@ -1,0 +1,283 @@
+import assert from "node:assert/strict";
+import { spawn, spawnSync } from "node:child_process";
+import { access, readFile, rm, writeFile } from "node:fs/promises";
+import net from "node:net";
+import path from "node:path";
+import process from "node:process";
+import test from "node:test";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { withTempDir } from "../../testUtils/tempDir.mjs";
+
+const CREATE_APP_CLI = fileURLToPath(new URL("../bin/jskit-create-app.js", import.meta.url));
+const JSKIT_CLI = fileURLToPath(new URL("../../jskit-cli/bin/jskit.js", import.meta.url));
+const SHELL_WEB_PACKAGE_ROOT = fileURLToPath(new URL("../../../packages/shell-web", import.meta.url));
+const RUN_COLD_START_INTEGRATION = process.env.JSKIT_VITE_COLD_START_INTEGRATION === "1";
+const OPTIMIZED_SHELL_SUBPATHS = Object.freeze([
+  "@jskit-ai/shell-web/client/placement",
+  "@jskit-ai/shell-web/client/error"
+]);
+
+function runChecked(command, args, { cwd, label = command, timeout = 300_000 } = {}) {
+  const result = spawnSync(command, args, {
+    cwd,
+    encoding: "utf8",
+    timeout,
+    maxBuffer: 20 * 1024 * 1024,
+    env: {
+      ...process.env,
+      NO_COLOR: "1",
+      FORCE_COLOR: "0",
+      PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
+    }
+  });
+  assert.equal(
+    result.status,
+    0,
+    `${label} failed.\nstdout:\n${String(result.stdout || "")}\nstderr:\n${String(result.stderr || "")}`
+  );
+  return result;
+}
+
+function startCapturedProcess(command, args, { cwd, env = {} } = {}) {
+  const child = spawn(command, args, {
+    cwd,
+    stdio: ["ignore", "pipe", "pipe"],
+    env: {
+      ...process.env,
+      NO_COLOR: "1",
+      FORCE_COLOR: "0",
+      ...env
+    }
+  });
+  let output = "";
+  const listeners = new Set();
+
+  function append(chunk) {
+    output += chunk.toString("utf8");
+    for (const listener of listeners) {
+      listener();
+    }
+  }
+
+  child.stdout.on("data", append);
+  child.stderr.on("data", append);
+
+  function waitFor(pattern, timeout = 30_000) {
+    return new Promise((resolve, reject) => {
+      let settled = false;
+      const check = () => {
+        if (pattern.test(output)) {
+          finish(resolve);
+        }
+      };
+      const onExit = (code, signal) => {
+        finish(
+          reject,
+          new Error(
+            `${command} exited before ${pattern} (code=${code}, signal=${signal || "none"}).\n${output}`
+          )
+        );
+      };
+      const timer = setTimeout(() => {
+        finish(reject, new Error(`Timed out waiting for ${pattern}.\n${output}`));
+      }, timeout);
+      const finish = (complete, value) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(timer);
+        listeners.delete(check);
+        child.off("exit", onExit);
+        complete(value);
+      };
+
+      listeners.add(check);
+      child.on("exit", onExit);
+      check();
+    });
+  }
+
+  return Object.freeze({
+    child,
+    readOutput: () => output,
+    waitFor
+  });
+}
+
+async function stopProcess(runtime) {
+  const child = runtime?.child;
+  if (!child || child.exitCode !== null || child.signalCode !== null) {
+    return;
+  }
+
+  await new Promise((resolve) => {
+    const forceTimer = setTimeout(() => {
+      child.kill("SIGKILL");
+    }, 5_000);
+    child.once("exit", () => {
+      clearTimeout(forceTimer);
+      resolve();
+    });
+    child.kill("SIGTERM");
+  });
+}
+
+async function reservePort() {
+  const server = net.createServer();
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+  const port = address.port;
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+  return port;
+}
+
+async function installPackedShellWeb(appRoot, tempRoot) {
+  const packResult = runChecked(
+    "npm",
+    ["pack", SHELL_WEB_PACKAGE_ROOT, "--pack-destination", tempRoot, "--json"],
+    { cwd: tempRoot, label: "pack current shell-web" }
+  );
+  const packPayload = JSON.parse(packResult.stdout);
+  const tarballName = String(packPayload?.[0]?.filename || "").trim();
+  assert.ok(tarballName, `npm pack did not report a tarball.\n${packResult.stdout}`);
+
+  const packageJsonPath = path.join(appRoot, "package.json");
+  const packageJson = JSON.parse(await readFile(packageJsonPath, "utf8"));
+  packageJson.dependencies["@jskit-ai/shell-web"] = `file:${path.join(tempRoot, tarballName)}`;
+  await writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`, "utf8");
+
+  runChecked("npm", ["install", "--no-audit", "--no-fund"], {
+    cwd: appRoot,
+    label: "fresh generated-app npm install"
+  });
+}
+
+async function readOptimizerMetadata(appRoot) {
+  const metadataPath = path.join(appRoot, "node_modules", ".vite", "deps", "_metadata.json");
+  const metadata = JSON.parse(await readFile(metadataPath, "utf8"));
+  return Object.keys(metadata?.optimized || {});
+}
+
+test("fresh generated shell-web/auth app optimizes dynamic shell subpaths before its first browser load", {
+  skip: RUN_COLD_START_INTEGRATION
+    ? false
+    : "set JSKIT_VITE_COLD_START_INTEGRATION=1 to run the browser-backed cold-start regression",
+  timeout: 600_000
+}, async () => {
+  await withTempDir(async (tempRoot) => {
+    const appRoot = path.join(tempRoot, "cold-start-app");
+    let apiRuntime = null;
+    let viteRuntime = null;
+    let browser = null;
+
+    try {
+      runChecked(process.execPath, [
+        CREATE_APP_CLI,
+        "cold-start-app",
+        "--target",
+        appRoot,
+        "--initial-bundles",
+        "auth"
+      ], { cwd: tempRoot, label: "create generated auth app" });
+      runChecked(process.execPath, [JSKIT_CLI, "add", "package", "auth-provider-local-core"], {
+        cwd: appRoot,
+        label: "add local auth provider"
+      });
+      runChecked(process.execPath, [JSKIT_CLI, "add", "package", "auth-web"], {
+        cwd: appRoot,
+        label: "add auth web"
+      });
+      await installPackedShellWeb(appRoot, tempRoot);
+
+      const viteCachePath = path.join(appRoot, "node_modules", ".vite");
+      await rm(viteCachePath, { recursive: true, force: true });
+      await assert.rejects(access(viteCachePath), /ENOENT/u);
+
+      const [apiPort, vitePort] = await Promise.all([reservePort(), reservePort()]);
+      apiRuntime = startCapturedProcess(process.execPath, ["./bin/server.js"], {
+        cwd: appRoot,
+        env: { PORT: String(apiPort) }
+      });
+      await apiRuntime.waitFor(new RegExp(`Server listening at http://127\\.0\\.0\\.1:${apiPort}`));
+
+      viteRuntime = startCapturedProcess(process.execPath, [
+        "./node_modules/vite/bin/vite.js",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        String(vitePort),
+        "--strictPort",
+        "--clearScreen",
+        "false"
+      ], {
+        cwd: appRoot,
+        env: {
+          DEBUG: "vite:deps",
+          VITE_API_PROXY_TARGET: `http://127.0.0.1:${apiPort}`
+        }
+      });
+      await viteRuntime.waitFor(new RegExp(`http://127\\.0\\.0\\.1:${vitePort}/`));
+      await viteRuntime.waitFor(/dependencies optimized/u, 60_000);
+
+      const initiallyOptimized = await readOptimizerMetadata(appRoot);
+      for (const specifier of OPTIMIZED_SHELL_SUBPATHS) {
+        assert.ok(
+          initiallyOptimized.includes(specifier),
+          `Expected ${specifier} in the pre-navigation optimizer metadata.\n${viteRuntime.readOutput()}`
+        );
+      }
+
+      const navigationLogOffset = viteRuntime.readOutput().length;
+      const playwrightUrl = pathToFileURL(
+        path.join(appRoot, "node_modules", "@playwright", "test", "index.mjs")
+      ).href;
+      const { chromium } = await import(playwrightUrl);
+      const chromiumExecutablePath = String(
+        process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH || ""
+      ).trim();
+      browser = await chromium.launch({
+        headless: true,
+        ...(chromiumExecutablePath ? { executablePath: chromiumExecutablePath } : {})
+      });
+      const page = await browser.newPage();
+      const pageErrors = [];
+      page.on("pageerror", (error) => {
+        pageErrors.push(String(error?.message || error));
+      });
+
+      await page.goto(`http://127.0.0.1:${vitePort}/home`, { waitUntil: "domcontentloaded" });
+      await page.getByText("Ready", { exact: true }).waitFor({ state: "visible" });
+      await page.waitForLoadState("networkidle");
+
+      const bodyText = await page.locator("body").innerText();
+      assert.doesNotMatch(
+        bodyText,
+        /did not download\. The app may have been updated, or the network request failed\./u
+      );
+      assert.deepEqual(pageErrors, []);
+
+      const navigationOutput = viteRuntime.readOutput().slice(navigationLogOffset);
+      for (const specifier of OPTIMIZED_SHELL_SUBPATHS) {
+        const escapedSpecifier = specifier.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+        assert.doesNotMatch(
+          navigationOutput,
+          new RegExp(`(?:new dependencies found|dependenc(?:y|ies) optimized)[^\\n]*${escapedSpecifier}`, "u")
+        );
+      }
+      assert.doesNotMatch(navigationOutput, /optimized dependencies changed/u);
+    } finally {
+      if (browser) {
+        await browser.close();
+      }
+      await stopProcess(viteRuntime);
+      await stopProcess(apiRuntime);
+    }
+  }, { prefix: "jskit-vite-cold-start-" });
+});

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -4174,11 +4174,11 @@
     },
     {
       "packageId": "@jskit-ai/shell-web",
-      "version": "0.1.117",
+      "version": "0.1.118",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/shell-web",
-        "version": "0.1.117",
+        "version": "0.1.118",
         "kind": "runtime",
         "description": "Web shell layout runtime with outlet-based placement contributions.",
         "dependsOn": [],
@@ -4207,6 +4207,10 @@
         "metadata": {
           "client": {
             "optimizeDeps": {
+              "include": [
+                "@jskit-ai/shell-web/client/placement",
+                "@jskit-ai/shell-web/client/error"
+              ],
               "exclude": [
                 "@jskit-ai/shell-web/client"
               ]

--- a/tooling/jskit-catalog/package.json
+++ b/tooling/jskit-catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-catalog",
-  "version": "0.1.126",
+  "version": "0.1.127",
   "description": "Published metadata catalog for JSKIT package descriptors.",
   "type": "module",
   "files": [

--- a/tooling/jskit-cli/package.json
+++ b/tooling/jskit-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-cli",
-  "version": "0.2.131",
+  "version": "0.2.132",
   "description": "Bundle and package orchestration CLI for JSKIT apps.",
   "type": "module",
   "files": [
@@ -20,9 +20,9 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/jskit-catalog": "0.1.126",
+    "@jskit-ai/jskit-catalog": "0.1.127",
     "@jskit-ai/kernel": "0.1.119",
-    "@jskit-ai/shell-web": "0.1.117",
+    "@jskit-ai/shell-web": "0.1.118",
     "@vue/compiler-sfc": "^3.5.29",
     "ts-morph": "^28.0.0",
     "yaml": "^2.8.3"


### PR DESCRIPTION
## Summary

- explicitly pre-optimize `@jskit-ai/shell-web/client/placement` and `@jskit-ai/shell-web/client/error` through the shell-web descriptor-owned contract
- preserve the intentional exclusion of the broad `@jskit-ai/shell-web/client` entry
- audit all base-shell modules dynamically loaded by `ShellWebClientProvider`; `placementTopology.js` has no package import, so no additional entry is needed
- add a descriptor contract test and a real freshly generated shell/auth browser regression with the Vite optimizer cache removed
- gate verify and package publishing on the cold-start regression
- refresh and release the shell-web/catalog/CLI/create-app delivery chain

## Ownership

The kernel Vite plugin already owns translating installed descriptor `optimizeDeps.include` and `exclude` metadata into Vite configuration. The failure was missing leaf-subpath metadata in shell-web, not a generated Vite config problem. The broad client barrel remains excluded because the observed cold-start imports are the two dynamically reached leaf modules and the audit found no evidence that optimizing the broader graph is necessary.

## Regression proof

The integration test generates a new auth app, installs the current packed shell-web, deletes `node_modules/.vite`, starts the real API and Vite with optimizer diagnostics, and verifies both leaf subpaths are in optimizer metadata before browser navigation. Chromium then loads `/home`; the test fails on any later discovery/invalidation event for either subpath, any `optimized dependencies changed` reload, any page error, or the async-module recovery banner.

## Validation

- shell-web suite: 98 passing
- kernel Vite-plugin test: 16 passing
- create-app suite: 21 passing, with 3 intentionally gated integrations
- enabled browser-backed cold-start integration: passing
- lint, descriptor lint, runtime dependency audit, generated reference paths, workflow YAML parsing, and `git diff --check`: passing
- post-publish fresh app using `@jskit-ai/create-app@0.1.129`: both dependencies in the initial optimization set, one browser connection, no late optimizer event, no recovery banner

## Releases

Published to npm with the `latest` tag:

- `@jskit-ai/shell-web@0.1.118`
- `@jskit-ai/jskit-catalog@0.1.127`
- `@jskit-ai/jskit-cli@0.2.132`
- `@jskit-ai/create-app@0.1.129`

## Documentation

No authored human documentation changed. `npm run agent-docs:build` was run and produced no tracked documentation diff because this is internal Vite optimization metadata, not a public API, command, or user workflow. The generated package catalog was refreshed and includes the new descriptor metadata.