### PR TITLE
chore: record published Node compatibility releases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6828,7 +6828,7 @@
     },
     "packages/agent-docs": {
       "name": "@jskit-ai/agent-docs",
-      "version": "0.1.80",
+      "version": "0.1.81",
       "engines": {
         "node": "^22.12.0 || ^24.0.0 || ^26.0.0"
       }
@@ -6842,7 +6842,7 @@
     },
     "packages/assistant-core": {
       "name": "@jskit-ai/assistant-core",
-      "version": "0.1.93",
+      "version": "0.1.94",
       "dependencies": {
         "@jskit-ai/database-runtime": "0.1.118",
         "@jskit-ai/http-runtime": "0.1.117",
@@ -6862,13 +6862,13 @@
     },
     "packages/assistant-runtime": {
       "name": "@jskit-ai/assistant-runtime",
-      "version": "0.1.88",
+      "version": "0.1.89",
       "dependencies": {
-        "@jskit-ai/assistant-core": "0.1.93",
+        "@jskit-ai/assistant-core": "0.1.94",
         "@jskit-ai/database-runtime": "0.1.118",
         "@jskit-ai/http-runtime": "0.1.117",
         "@jskit-ai/kernel": "0.1.119",
-        "@jskit-ai/shell-web": "0.1.117",
+        "@jskit-ai/shell-web": "0.1.118",
         "@jskit-ai/users-core": "0.1.127",
         "@jskit-ai/users-web": "0.1.133",
         "json-rest-schema": "1.x.x"
@@ -6876,21 +6876,6 @@
       "peerDependencies": {
         "@tanstack/vue-query": "^5.90.5",
         "vue": "^3.5.13",
-        "vuetify": "^4.0.0"
-      }
-    },
-    "packages/assistant-runtime/node_modules/@jskit-ai/shell-web": {
-      "version": "0.1.117",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/shell-web/-/shell-web-0.1.117.tgz",
-      "integrity": "sha512-fnqtdl/sR1QdrWH+ufhrsuaALXgJ8RPxODd9Wds6VJWoVY5GvIM3J2EbDSPmHqbBaliGNF/x9DJQERdUcSMJ9g==",
-      "dependencies": {
-        "@jskit-ai/kernel": "0.1.119",
-        "@mdi/js": "^7.4.47"
-      },
-      "peerDependencies": {
-        "pinia": "^3.0.4",
-        "vue": "^3.5.13",
-        "vue-router": "^5.0.4",
         "vuetify": "^4.0.0"
       }
     },
@@ -6907,7 +6892,7 @@
     },
     "packages/auth-provider-local-core": {
       "name": "@jskit-ai/auth-provider-local-core",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "dependencies": {
         "@jskit-ai/auth-core": "0.1.116",
         "@jskit-ai/kernel": "0.1.119",
@@ -6916,16 +6901,16 @@
     },
     "packages/auth-provider-local-db-core": {
       "name": "@jskit-ai/auth-provider-local-db-core",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "dependencies": {
-        "@jskit-ai/auth-provider-local-core": "0.1.18",
+        "@jskit-ai/auth-provider-local-core": "0.1.19",
         "@jskit-ai/database-runtime": "0.1.118",
         "@jskit-ai/kernel": "0.1.119"
       }
     },
     "packages/auth-provider-supabase-core": {
       "name": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.116",
+      "version": "0.1.117",
       "dependencies": {
         "@jskit-ai/auth-core": "0.1.116",
         "@jskit-ai/kernel": "0.1.119",
@@ -7174,7 +7159,7 @@
     },
     "packages/storage-runtime": {
       "name": "@jskit-ai/storage-runtime",
-      "version": "0.1.116",
+      "version": "0.1.117",
       "dependencies": {
         "@jskit-ai/kernel": "0.1.119",
         "unstorage": "^1.17.5"
@@ -7327,7 +7312,7 @@
     },
     "tooling/config-eslint": {
       "name": "@jskit-ai/config-eslint",
-      "version": "0.1.116",
+      "version": "0.1.117",
       "dependencies": {
         "@eslint/js": "^9.39.4",
         "eslint-plugin-vue": "^10.5.1",
@@ -7345,9 +7330,9 @@
     },
     "tooling/create-app": {
       "name": "@jskit-ai/create-app",
-      "version": "0.1.129",
+      "version": "0.1.130",
       "dependencies": {
-        "@jskit-ai/jskit-cli": "0.2.132"
+        "@jskit-ai/jskit-cli": "0.2.133"
       },
       "bin": {
         "jskit-create-app": "bin/jskit-create-app.js"
@@ -7358,16 +7343,16 @@
     },
     "tooling/jskit-catalog": {
       "name": "@jskit-ai/jskit-catalog",
-      "version": "0.1.127",
+      "version": "0.1.128",
       "engines": {
         "node": "^22.12.0 || ^24.0.0 || ^26.0.0"
       }
     },
     "tooling/jskit-cli": {
       "name": "@jskit-ai/jskit-cli",
-      "version": "0.2.132",
+      "version": "0.2.133",
       "dependencies": {
-        "@jskit-ai/jskit-catalog": "0.1.127",
+        "@jskit-ai/jskit-catalog": "0.1.128",
         "@jskit-ai/kernel": "0.1.119",
         "@jskit-ai/shell-web": "0.1.118",
         "@vue/compiler-sfc": "^3.5.29",

--- a/packages/agent-docs/package.json
+++ b/packages/agent-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/agent-docs",
-  "version": "0.1.80",
+  "version": "0.1.81",
   "description": "Distributed JSKIT agent references, prompts, guides, and generated reference maps.",
   "type": "module",
   "files": [

--- a/packages/assistant-core/package.descriptor.mjs
+++ b/packages/assistant-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-core",
-  version: "0.1.93",
+  version: "0.1.94",
   kind: "runtime",
   description: "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
   dependsOn: [

--- a/packages/assistant-core/package.json
+++ b/packages/assistant-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-core",
-  "version": "0.1.93",
+  "version": "0.1.94",
   "type": "module",
   "scripts": {
     "test": "node --test"

--- a/packages/assistant-runtime/package.descriptor.mjs
+++ b/packages/assistant-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-runtime",
-  version: "0.1.88",
+  version: "0.1.89",
   kind: "runtime",
   description: "Shared assistant runtime with per-surface assistant registration.",
   dependsOn: [
@@ -95,11 +95,11 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/assistant-core": "0.1.93",
+        "@jskit-ai/assistant-core": "0.1.94",
         "@jskit-ai/database-runtime": "0.1.118",
         "@jskit-ai/http-runtime": "0.1.117",
         "@jskit-ai/kernel": "0.1.119",
-        "@jskit-ai/shell-web": "0.1.117",
+        "@jskit-ai/shell-web": "0.1.118",
         "@jskit-ai/users-core": "0.1.127",
         "@jskit-ai/users-web": "0.1.133"
       },

--- a/packages/assistant-runtime/package.json
+++ b/packages/assistant-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-runtime",
-  "version": "0.1.88",
+  "version": "0.1.89",
   "type": "module",
   "exports": {
     "./client": "./src/client/index.js",
@@ -8,11 +8,11 @@
     "./server/actionIds": "./src/server/actionIds.js"
   },
   "dependencies": {
-    "@jskit-ai/assistant-core": "0.1.93",
+    "@jskit-ai/assistant-core": "0.1.94",
     "@jskit-ai/database-runtime": "0.1.118",
     "@jskit-ai/http-runtime": "0.1.117",
     "@jskit-ai/kernel": "0.1.119",
-    "@jskit-ai/shell-web": "0.1.117",
+    "@jskit-ai/shell-web": "0.1.118",
     "@jskit-ai/users-core": "0.1.127",
     "@jskit-ai/users-web": "0.1.133",
     "json-rest-schema": "1.x.x"

--- a/packages/auth-provider-local-core/package.descriptor.mjs
+++ b/packages/auth-provider-local-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-provider-local-core",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "kind": "runtime",
   "description": "Local auth provider with a file backend default and no database requirement.",
   "dependsOn": [

--- a/packages/auth-provider-local-core/package.json
+++ b/packages/auth-provider-local-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-local-core",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "type": "module",
   "scripts": {
     "test": "node --test"

--- a/packages/auth-provider-local-db-core/package.descriptor.mjs
+++ b/packages/auth-provider-local-db-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/auth-provider-local-db-core",
-  version: "0.1.10",
+  version: "0.1.11",
   kind: "runtime",
   description: "Database-backed local auth storage backend for JSKIT local auth.",
   dependsOn: [
@@ -80,7 +80,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-provider-local-core": "0.1.18",
+        "@jskit-ai/auth-provider-local-core": "0.1.19",
         "@jskit-ai/database-runtime": "0.1.118",
         "@jskit-ai/kernel": "0.1.119"
       },

--- a/packages/auth-provider-local-db-core/package.json
+++ b/packages/auth-provider-local-db-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-local-db-core",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./server/lib/index": "./src/server/lib/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-provider-local-core": "0.1.18",
+    "@jskit-ai/auth-provider-local-core": "0.1.19",
     "@jskit-ai/database-runtime": "0.1.118",
     "@jskit-ai/kernel": "0.1.119"
   }

--- a/packages/auth-provider-supabase-core/package.descriptor.mjs
+++ b/packages/auth-provider-supabase-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.116",
+  "version": "0.1.117",
   "kind": "runtime",
   "options": {
     "auth-supabase-url": {

--- a/packages/auth-provider-supabase-core/package.json
+++ b/packages/auth-provider-supabase-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.116",
+  "version": "0.1.117",
   "type": "module",
   "scripts": {
     "test": "node --test"

--- a/packages/storage-runtime/package.descriptor.mjs
+++ b/packages/storage-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/storage-runtime",
-  version: "0.1.116",
+  version: "0.1.117",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"

--- a/packages/storage-runtime/package.json
+++ b/packages/storage-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/storage-runtime",
-  "version": "0.1.116",
+  "version": "0.1.117",
   "type": "module",
   "scripts": {
     "test": "node --test"

--- a/tooling/config-eslint/package.json
+++ b/tooling/config-eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/config-eslint",
-  "version": "0.1.116",
+  "version": "0.1.117",
   "description": "Shared flat ESLint presets for JSKIT projects.",
   "type": "module",
   "files": [

--- a/tooling/create-app/package.descriptor.mjs
+++ b/tooling/create-app/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/create-app",
-  "version": "0.1.129",
+  "version": "0.1.130",
   "dependsOn": [],
   "capabilities": {
     "provides": [

--- a/tooling/create-app/package.json
+++ b/tooling/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/create-app",
-  "version": "0.1.129",
+  "version": "0.1.130",
   "description": "Scaffold JSKIT app shells.",
   "type": "module",
   "files": [
@@ -20,7 +20,7 @@
     "./client": "./src/client/index.js"
   },
   "dependencies": {
-    "@jskit-ai/jskit-cli": "0.2.132"
+    "@jskit-ai/jskit-cli": "0.2.133"
   },
   "engines": {
     "node": "^22.12.0 || ^24.0.0 || ^26.0.0"

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -347,11 +347,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-core",
-      "version": "0.1.93",
+      "version": "0.1.94",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-core",
-        "version": "0.1.93",
+        "version": "0.1.94",
         "kind": "runtime",
         "description": "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
         "dependsOn": [
@@ -422,11 +422,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-runtime",
-      "version": "0.1.88",
+      "version": "0.1.89",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-runtime",
-        "version": "0.1.88",
+        "version": "0.1.89",
         "kind": "runtime",
         "description": "Shared assistant runtime with per-surface assistant registration.",
         "dependsOn": [
@@ -522,11 +522,11 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/assistant-core": "0.1.93",
+              "@jskit-ai/assistant-core": "0.1.94",
               "@jskit-ai/database-runtime": "0.1.118",
               "@jskit-ai/http-runtime": "0.1.117",
               "@jskit-ai/kernel": "0.1.119",
-              "@jskit-ai/shell-web": "0.1.117",
+              "@jskit-ai/shell-web": "0.1.118",
               "@jskit-ai/users-core": "0.1.127",
               "@jskit-ai/users-web": "0.1.133"
             },
@@ -678,11 +678,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-local-core",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-local-core",
-        "version": "0.1.18",
+        "version": "0.1.19",
         "kind": "runtime",
         "description": "Local auth provider with a file backend default and no database requirement.",
         "dependsOn": [
@@ -792,11 +792,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-local-db-core",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-local-db-core",
-        "version": "0.1.10",
+        "version": "0.1.11",
         "kind": "runtime",
         "description": "Database-backed local auth storage backend for JSKIT local auth.",
         "dependsOn": [
@@ -875,7 +875,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-provider-local-core": "0.1.18",
+              "@jskit-ai/auth-provider-local-core": "0.1.19",
               "@jskit-ai/database-runtime": "0.1.118",
               "@jskit-ai/kernel": "0.1.119"
             },
@@ -912,11 +912,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.116",
+      "version": "0.1.117",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-supabase-core",
-        "version": "0.1.116",
+        "version": "0.1.117",
         "kind": "runtime",
         "options": {
           "auth-supabase-url": {
@@ -4731,11 +4731,11 @@
     },
     {
       "packageId": "@jskit-ai/storage-runtime",
-      "version": "0.1.116",
+      "version": "0.1.117",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/storage-runtime",
-        "version": "0.1.116",
+        "version": "0.1.117",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"

--- a/tooling/jskit-catalog/package.json
+++ b/tooling/jskit-catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-catalog",
-  "version": "0.1.127",
+  "version": "0.1.128",
   "description": "Published metadata catalog for JSKIT package descriptors.",
   "type": "module",
   "files": [

--- a/tooling/jskit-cli/package.json
+++ b/tooling/jskit-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-cli",
-  "version": "0.2.132",
+  "version": "0.2.133",
   "description": "Bundle and package orchestration CLI for JSKIT apps.",
   "type": "module",
   "files": [
@@ -20,7 +20,7 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/jskit-catalog": "0.1.127",
+    "@jskit-ai/jskit-catalog": "0.1.128",
     "@jskit-ai/kernel": "0.1.119",
     "@jskit-ai/shell-web": "0.1.118",
     "@vue/compiler-sfc": "^3.5.29",


### PR DESCRIPTION
Records the package versions and generated catalog produced by the successful npm run release following PR #351.

Published packages: agent-docs 0.1.81, assistant-core 0.1.94, assistant-runtime 0.1.89, auth-provider-local-core 0.1.19, auth-provider-local-db-core 0.1.11, auth-provider-supabase-core 0.1.117, config-eslint 0.1.117, jskit-catalog 0.1.128, jskit-cli 0.2.133, create-app 0.1.130, and storage-runtime 0.1.117.

Registry verification: published base and minimal apps install and verify on Node 26 with zero audit findings.