### PR TITLE
chore(release): publish managed Playwright support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7737,28 +7737,28 @@
     },
     "packages/agent-docs": {
       "name": "@jskit-ai/agent-docs",
-      "version": "0.1.84",
+      "version": "0.1.85",
       "engines": {
         "node": "^22.12.0 || ^24.0.0 || ^26.0.0"
       }
     },
     "packages/assistant": {
       "name": "@jskit-ai/assistant",
-      "version": "0.1.129",
+      "version": "0.1.130",
       "dependencies": {
         "@jskit-ai/kernel": "0.1.121"
       }
     },
     "packages/assistant-core": {
       "name": "@jskit-ai/assistant-core",
-      "version": "0.1.97",
+      "version": "0.1.98",
       "dependencies": {
         "@jskit-ai/database-runtime": "0.1.120",
         "@jskit-ai/http-runtime": "0.1.119",
         "@jskit-ai/kernel": "0.1.121",
         "@jskit-ai/resource-core": "0.1.64",
         "@jskit-ai/resource-crud-core": "0.1.64",
-        "@jskit-ai/users-core": "0.1.130",
+        "@jskit-ai/users-core": "0.1.131",
         "dompurify": "^3.4.12",
         "json-rest-schema": "1.x.x",
         "marked": "^17.0.4",
@@ -7771,15 +7771,15 @@
     },
     "packages/assistant-runtime": {
       "name": "@jskit-ai/assistant-runtime",
-      "version": "0.1.92",
+      "version": "0.1.93",
       "dependencies": {
-        "@jskit-ai/assistant-core": "0.1.97",
+        "@jskit-ai/assistant-core": "0.1.98",
         "@jskit-ai/database-runtime": "0.1.120",
         "@jskit-ai/http-runtime": "0.1.119",
         "@jskit-ai/kernel": "0.1.121",
-        "@jskit-ai/shell-web": "0.1.120",
-        "@jskit-ai/users-core": "0.1.130",
-        "@jskit-ai/users-web": "0.1.136",
+        "@jskit-ai/shell-web": "0.1.121",
+        "@jskit-ai/users-core": "0.1.131",
+        "@jskit-ai/users-web": "0.1.137",
         "json-rest-schema": "1.x.x"
       },
       "peerDependencies": {
@@ -7831,12 +7831,12 @@
     },
     "packages/auth-web": {
       "name": "@jskit-ai/auth-web",
-      "version": "0.1.120",
+      "version": "0.1.121",
       "dependencies": {
         "@jskit-ai/auth-core": "0.1.118",
         "@jskit-ai/http-runtime": "0.1.119",
         "@jskit-ai/kernel": "0.1.121",
-        "@jskit-ai/shell-web": "0.1.120",
+        "@jskit-ai/shell-web": "0.1.121",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -7849,38 +7849,38 @@
     },
     "packages/console-core": {
       "name": "@jskit-ai/console-core",
-      "version": "0.1.83",
+      "version": "0.1.84",
       "dependencies": {
         "@jskit-ai/auth-core": "0.1.118",
         "@jskit-ai/database-runtime": "0.1.120",
         "@jskit-ai/http-runtime": "0.1.119",
         "@jskit-ai/kernel": "0.1.121",
         "@jskit-ai/resource-crud-core": "0.1.64",
-        "@jskit-ai/users-core": "0.1.130",
+        "@jskit-ai/users-core": "0.1.131",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/console-web": {
       "name": "@jskit-ai/console-web",
-      "version": "0.1.88",
+      "version": "0.1.89",
       "dependencies": {
-        "@jskit-ai/auth-web": "0.1.120",
-        "@jskit-ai/console-core": "0.1.83",
-        "@jskit-ai/shell-web": "0.1.120"
+        "@jskit-ai/auth-web": "0.1.121",
+        "@jskit-ai/console-core": "0.1.84",
+        "@jskit-ai/shell-web": "0.1.121"
       }
     },
     "packages/crud-core": {
       "name": "@jskit-ai/crud-core",
-      "version": "0.1.128",
+      "version": "0.1.129",
       "dependencies": {
         "@jskit-ai/database-runtime": "0.1.120",
         "@jskit-ai/http-runtime": "0.1.119",
         "@jskit-ai/kernel": "0.1.121",
         "@jskit-ai/realtime": "0.1.118",
         "@jskit-ai/resource-crud-core": "0.1.64",
-        "@jskit-ai/shell-web": "0.1.120",
-        "@jskit-ai/users-core": "0.1.130",
-        "@jskit-ai/users-web": "0.1.136",
+        "@jskit-ai/shell-web": "0.1.121",
+        "@jskit-ai/users-core": "0.1.131",
+        "@jskit-ai/users-web": "0.1.137",
         "json-rest-schema": "1.x.x"
       },
       "peerDependencies": {
@@ -7891,10 +7891,10 @@
     },
     "packages/crud-server-generator": {
       "name": "@jskit-ai/crud-server-generator",
-      "version": "0.1.128",
+      "version": "0.1.129",
       "dependencies": {
         "@babel/parser": "^7.29.2",
-        "@jskit-ai/crud-core": "0.1.128",
+        "@jskit-ai/crud-core": "0.1.129",
         "@jskit-ai/database-runtime": "0.1.120",
         "@jskit-ai/http-runtime": "0.1.119",
         "@jskit-ai/json-rest-api-core": "0.1.65",
@@ -7905,9 +7905,9 @@
     },
     "packages/crud-ui-generator": {
       "name": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.103",
+      "version": "0.1.104",
       "dependencies": {
-        "@jskit-ai/crud-core": "0.1.128",
+        "@jskit-ai/crud-core": "0.1.129",
         "@jskit-ai/kernel": "0.1.121",
         "@jskit-ai/resource-crud-core": "0.1.64"
       }
@@ -7940,11 +7940,11 @@
     },
     "packages/google-rewarded-core": {
       "name": "@jskit-ai/google-rewarded-core",
-      "version": "0.1.57"
+      "version": "0.1.58"
     },
     "packages/google-rewarded-web": {
       "name": "@jskit-ai/google-rewarded-web",
-      "version": "0.1.57"
+      "version": "0.1.58"
     },
     "packages/http-runtime": {
       "name": "@jskit-ai/http-runtime",
@@ -7972,7 +7972,7 @@
     },
     "packages/mobile-capacitor": {
       "name": "@jskit-ai/mobile-capacitor",
-      "version": "0.1.56",
+      "version": "0.1.57",
       "dependencies": {
         "@capacitor/browser": "^7.0.1",
         "@jskit-ai/kernel": "0.1.121"
@@ -8009,7 +8009,7 @@
     },
     "packages/shell-web": {
       "name": "@jskit-ai/shell-web",
-      "version": "0.1.120",
+      "version": "0.1.121",
       "dependencies": {
         "@jskit-ai/kernel": "0.1.121",
         "@mdi/js": "^7.4.47"
@@ -8031,10 +8031,10 @@
     },
     "packages/ui-generator": {
       "name": "@jskit-ai/ui-generator",
-      "version": "0.1.103",
+      "version": "0.1.104",
       "dependencies": {
         "@jskit-ai/kernel": "0.1.121",
-        "@jskit-ai/shell-web": "0.1.120"
+        "@jskit-ai/shell-web": "0.1.121"
       }
     },
     "packages/uploads-image-web": {
@@ -8062,7 +8062,7 @@
     },
     "packages/users-core": {
       "name": "@jskit-ai/users-core",
-      "version": "0.1.130",
+      "version": "0.1.131",
       "dependencies": {
         "@jskit-ai/auth-core": "0.1.118",
         "@jskit-ai/database-runtime": "0.1.120",
@@ -8077,14 +8077,14 @@
     },
     "packages/users-web": {
       "name": "@jskit-ai/users-web",
-      "version": "0.1.136",
+      "version": "0.1.137",
       "dependencies": {
         "@jskit-ai/http-runtime": "0.1.119",
         "@jskit-ai/kernel": "0.1.121",
         "@jskit-ai/realtime": "0.1.118",
-        "@jskit-ai/shell-web": "0.1.120",
+        "@jskit-ai/shell-web": "0.1.121",
         "@jskit-ai/uploads-image-web": "0.1.97",
-        "@jskit-ai/users-core": "0.1.130",
+        "@jskit-ai/users-core": "0.1.131",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -8096,7 +8096,7 @@
     },
     "packages/workspaces-core": {
       "name": "@jskit-ai/workspaces-core",
-      "version": "0.1.96",
+      "version": "0.1.97",
       "dependencies": {
         "@jskit-ai/auth-core": "0.1.118",
         "@jskit-ai/database-runtime": "0.1.120",
@@ -8105,21 +8105,21 @@
         "@jskit-ai/kernel": "0.1.121",
         "@jskit-ai/resource-core": "0.1.64",
         "@jskit-ai/resource-crud-core": "0.1.64",
-        "@jskit-ai/users-core": "0.1.130",
+        "@jskit-ai/users-core": "0.1.131",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/workspaces-web": {
       "name": "@jskit-ai/workspaces-web",
-      "version": "0.1.97",
+      "version": "0.1.98",
       "dependencies": {
-        "@jskit-ai/auth-web": "0.1.120",
+        "@jskit-ai/auth-web": "0.1.121",
         "@jskit-ai/http-runtime": "0.1.119",
         "@jskit-ai/kernel": "0.1.121",
-        "@jskit-ai/shell-web": "0.1.120",
-        "@jskit-ai/users-core": "0.1.130",
-        "@jskit-ai/users-web": "0.1.136",
-        "@jskit-ai/workspaces-core": "0.1.96",
+        "@jskit-ai/shell-web": "0.1.121",
+        "@jskit-ai/users-core": "0.1.131",
+        "@jskit-ai/users-web": "0.1.137",
+        "@jskit-ai/workspaces-core": "0.1.97",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -8149,9 +8149,9 @@
     },
     "tooling/create-app": {
       "name": "@jskit-ai/create-app",
-      "version": "0.1.133",
+      "version": "0.1.134",
       "dependencies": {
-        "@jskit-ai/jskit-cli": "0.2.136"
+        "@jskit-ai/jskit-cli": "0.2.137"
       },
       "bin": {
         "jskit-create-app": "bin/jskit-create-app.js"
@@ -8162,18 +8162,18 @@
     },
     "tooling/jskit-catalog": {
       "name": "@jskit-ai/jskit-catalog",
-      "version": "0.1.131",
+      "version": "0.1.132",
       "engines": {
         "node": "^22.12.0 || ^24.0.0 || ^26.0.0"
       }
     },
     "tooling/jskit-cli": {
       "name": "@jskit-ai/jskit-cli",
-      "version": "0.2.136",
+      "version": "0.2.137",
       "dependencies": {
-        "@jskit-ai/jskit-catalog": "0.1.131",
+        "@jskit-ai/jskit-catalog": "0.1.132",
         "@jskit-ai/kernel": "0.1.121",
-        "@jskit-ai/shell-web": "0.1.120",
+        "@jskit-ai/shell-web": "0.1.121",
         "@vue/compiler-sfc": "^3.5.29",
         "ts-morph": "^28.0.0",
         "yaml": "^2.8.3"

--- a/packages/agent-docs/package.json
+++ b/packages/agent-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/agent-docs",
-  "version": "0.1.84",
+  "version": "0.1.85",
   "description": "Distributed JSKIT agent references, prompts, guides, and generated reference maps.",
   "type": "module",
   "files": [

--- a/packages/assistant-core/package.descriptor.mjs
+++ b/packages/assistant-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-core",
-  version: "0.1.97",
+  version: "0.1.98",
   kind: "runtime",
   description: "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
   dependsOn: [
@@ -51,7 +51,7 @@ export default Object.freeze({
         "@jskit-ai/kernel": "0.1.121",
         "@jskit-ai/resource-core": "0.1.64",
         "@jskit-ai/resource-crud-core": "0.1.64",
-        "@jskit-ai/users-core": "0.1.130",
+        "@jskit-ai/users-core": "0.1.131",
         "dompurify": "^3.3.3",
         "json-rest-schema": "1.x.x",
         "marked": "^17.0.4",

--- a/packages/assistant-core/package.json
+++ b/packages/assistant-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-core",
-  "version": "0.1.97",
+  "version": "0.1.98",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,7 +16,7 @@
     "@jskit-ai/kernel": "0.1.121",
     "@jskit-ai/resource-crud-core": "0.1.64",
     "@jskit-ai/resource-core": "0.1.64",
-    "@jskit-ai/users-core": "0.1.130",
+    "@jskit-ai/users-core": "0.1.131",
     "dompurify": "^3.4.12",
     "json-rest-schema": "1.x.x",
     "marked": "^17.0.4",

--- a/packages/assistant-runtime/package.descriptor.mjs
+++ b/packages/assistant-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-runtime",
-  version: "0.1.92",
+  version: "0.1.93",
   kind: "runtime",
   description: "Shared assistant runtime with per-surface assistant registration.",
   dependsOn: [
@@ -95,13 +95,13 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/assistant-core": "0.1.97",
+        "@jskit-ai/assistant-core": "0.1.98",
         "@jskit-ai/database-runtime": "0.1.120",
         "@jskit-ai/http-runtime": "0.1.119",
         "@jskit-ai/kernel": "0.1.121",
-        "@jskit-ai/shell-web": "0.1.120",
-        "@jskit-ai/users-core": "0.1.130",
-        "@jskit-ai/users-web": "0.1.136"
+        "@jskit-ai/shell-web": "0.1.121",
+        "@jskit-ai/users-core": "0.1.131",
+        "@jskit-ai/users-web": "0.1.137"
       },
       dev: {}
     },

--- a/packages/assistant-runtime/package.json
+++ b/packages/assistant-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-runtime",
-  "version": "0.1.92",
+  "version": "0.1.93",
   "type": "module",
   "exports": {
     "./client": "./src/client/index.js",
@@ -8,13 +8,13 @@
     "./server/actionIds": "./src/server/actionIds.js"
   },
   "dependencies": {
-    "@jskit-ai/assistant-core": "0.1.97",
+    "@jskit-ai/assistant-core": "0.1.98",
     "@jskit-ai/database-runtime": "0.1.120",
     "@jskit-ai/http-runtime": "0.1.119",
     "@jskit-ai/kernel": "0.1.121",
-    "@jskit-ai/shell-web": "0.1.120",
-    "@jskit-ai/users-core": "0.1.130",
-    "@jskit-ai/users-web": "0.1.136",
+    "@jskit-ai/shell-web": "0.1.121",
+    "@jskit-ai/users-core": "0.1.131",
+    "@jskit-ai/users-web": "0.1.137",
     "json-rest-schema": "1.x.x"
   },
   "peerDependencies": {

--- a/packages/assistant/package.descriptor.mjs
+++ b/packages/assistant/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant",
-  version: "0.1.129",
+  version: "0.1.130",
   kind: "generator",
   description: "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
   options: {

--- a/packages/assistant/package.json
+++ b/packages/assistant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant",
-  "version": "0.1.129",
+  "version": "0.1.130",
   "type": "module",
   "scripts": {
     "test": "node --test"

--- a/packages/auth-web/package.descriptor.mjs
+++ b/packages/auth-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-web",
-  "version": "0.1.120",
+  "version": "0.1.121",
   "kind": "runtime",
   "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
   "dependsOn": [
@@ -267,7 +267,7 @@ export default Object.freeze({
         "@jskit-ai/auth-core": "0.1.118",
         "@jskit-ai/http-runtime": "0.1.119",
         "@jskit-ai/kernel": "0.1.121",
-        "@jskit-ai/shell-web": "0.1.120"
+        "@jskit-ai/shell-web": "0.1.121"
       },
       "dev": {}
     },

--- a/packages/auth-web/package.json
+++ b/packages/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-web",
-  "version": "0.1.120",
+  "version": "0.1.121",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -23,7 +23,7 @@
     "@jskit-ai/auth-core": "0.1.118",
     "@mdi/js": "^7.4.47",
     "@jskit-ai/kernel": "0.1.121",
-    "@jskit-ai/shell-web": "0.1.120",
+    "@jskit-ai/shell-web": "0.1.121",
     "@jskit-ai/http-runtime": "0.1.119"
   },
   "peerDependencies": {

--- a/packages/console-core/package.descriptor.mjs
+++ b/packages/console-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-core",
-  version: "0.1.83",
+  version: "0.1.84",
   kind: "runtime",
   description: "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
   dependsOn: [
@@ -90,7 +90,7 @@ export default Object.freeze({
         "@jskit-ai/http-runtime": "0.1.119",
         "@jskit-ai/kernel": "0.1.121",
         "@jskit-ai/resource-crud-core": "0.1.64",
-        "@jskit-ai/users-core": "0.1.130"
+        "@jskit-ai/users-core": "0.1.131"
       },
       dev: {}
     },

--- a/packages/console-core/package.json
+++ b/packages/console-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/console-core",
-  "version": "0.1.83",
+  "version": "0.1.84",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,7 +11,7 @@
     "@jskit-ai/http-runtime": "0.1.119",
     "@jskit-ai/kernel": "0.1.121",
     "@jskit-ai/resource-crud-core": "0.1.64",
-    "@jskit-ai/users-core": "0.1.130",
+    "@jskit-ai/users-core": "0.1.131",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/console-web/package.descriptor.mjs
+++ b/packages/console-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-web",
-  version: "0.1.88",
+  version: "0.1.89",
   kind: "runtime",
   description: "Authenticated console surface scaffold and surface policy wiring.",
   dependsOn: [
@@ -103,9 +103,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-web": "0.1.120",
-        "@jskit-ai/console-core": "0.1.83",
-        "@jskit-ai/shell-web": "0.1.120",
+        "@jskit-ai/auth-web": "0.1.121",
+        "@jskit-ai/console-core": "0.1.84",
+        "@jskit-ai/shell-web": "0.1.121",
       },
       dev: {}
     },

--- a/packages/console-web/package.json
+++ b/packages/console-web/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/console-web",
-  "version": "0.1.88",
+  "version": "0.1.89",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-web": "0.1.120",
-    "@jskit-ai/console-core": "0.1.83",
-    "@jskit-ai/shell-web": "0.1.120"
+    "@jskit-ai/auth-web": "0.1.121",
+    "@jskit-ai/console-core": "0.1.84",
+    "@jskit-ai/shell-web": "0.1.121"
   }
 }

--- a/packages/crud-core/package.descriptor.mjs
+++ b/packages/crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-core",
-  version: "0.1.128",
+  version: "0.1.129",
   kind: "runtime",
   description: "Shared CRUD helpers used by CRUD modules.",
   dependsOn: [
@@ -28,7 +28,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/crud-core": "0.1.128"
+        "@jskit-ai/crud-core": "0.1.129"
       },
       dev: {}
     },

--- a/packages/crud-core/package.json
+++ b/packages/crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-core",
-  "version": "0.1.128",
+  "version": "0.1.129",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -33,9 +33,9 @@
     "json-rest-schema": "1.x.x",
     "@jskit-ai/realtime": "0.1.118",
     "@jskit-ai/resource-crud-core": "0.1.64",
-    "@jskit-ai/shell-web": "0.1.120",
-    "@jskit-ai/users-core": "0.1.130",
-    "@jskit-ai/users-web": "0.1.136"
+    "@jskit-ai/shell-web": "0.1.121",
+    "@jskit-ai/users-core": "0.1.131",
+    "@jskit-ai/users-web": "0.1.137"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/crud-server-generator/package.descriptor.mjs
+++ b/packages/crud-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-server-generator",
-  version: "0.1.128",
+  version: "0.1.129",
   kind: "generator",
   description: "CRUD server generator with routes, actions, and persistence scaffolding.",
   options: {
@@ -161,7 +161,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@jskit-ai/auth-core": "0.1.118",
-        "@jskit-ai/crud-core": "0.1.128",
+        "@jskit-ai/crud-core": "0.1.129",
         "@jskit-ai/database-runtime": "0.1.120",
         "@jskit-ai/http-runtime": "0.1.119",
         "@jskit-ai/json-rest-api-core": "0.1.65",

--- a/packages/crud-server-generator/package.json
+++ b/packages/crud-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-server-generator",
-  "version": "0.1.128",
+  "version": "0.1.129",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@babel/parser": "^7.29.2",
-    "@jskit-ai/crud-core": "0.1.128",
+    "@jskit-ai/crud-core": "0.1.129",
     "@jskit-ai/database-runtime": "0.1.120",
     "@jskit-ai/http-runtime": "0.1.119",
     "@jskit-ai/json-rest-api-core": "0.1.65",

--- a/packages/crud-ui-generator/package.descriptor.mjs
+++ b/packages/crud-ui-generator/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { GENERATED_UI_NAVIGATION_ROLE_OPTION } from "@jskit-ai/kernel/shared/sup
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-ui-generator",
-  version: "0.1.103",
+  version: "0.1.104",
   kind: "generator",
   description: "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
   options: {
@@ -175,7 +175,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.136"
+        "@jskit-ai/users-web": "0.1.137"
       },
       dev: {}
     },

--- a/packages/crud-ui-generator/package.json
+++ b/packages/crud-ui-generator/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@jskit-ai/crud-ui-generator",
-  "version": "0.1.103",
+  "version": "0.1.104",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/crud-core": "0.1.128",
+    "@jskit-ai/crud-core": "0.1.129",
     "@jskit-ai/kernel": "0.1.121",
     "@jskit-ai/resource-crud-core": "0.1.64"
   },

--- a/packages/google-rewarded-core/package.descriptor.mjs
+++ b/packages/google-rewarded-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/google-rewarded-core",
-  version: "0.1.57",
+  version: "0.1.58",
   kind: "runtime",
   description: "Google rewarded workflow runtime plus internal CRUD providers for rules, provider configs, watch sessions, and unlock receipts.",
   dependsOn: [
@@ -129,13 +129,13 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@jskit-ai/auth-core": "0.1.118",
-        "@jskit-ai/crud-core": "0.1.128",
+        "@jskit-ai/crud-core": "0.1.129",
         "@jskit-ai/database-runtime": "0.1.120",
         "@jskit-ai/http-runtime": "0.1.119",
         "@jskit-ai/json-rest-api-core": "0.1.65",
         "@jskit-ai/kernel": "0.1.121",
         "@jskit-ai/resource-crud-core": "0.1.64",
-        "@jskit-ai/workspaces-core": "0.1.96"
+        "@jskit-ai/workspaces-core": "0.1.97"
       },
       dev: {}
     },

--- a/packages/google-rewarded-core/package.json
+++ b/packages/google-rewarded-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/google-rewarded-core",
-  "version": "0.1.57",
+  "version": "0.1.58",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/google-rewarded-web/package.descriptor.mjs
+++ b/packages/google-rewarded-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/google-rewarded-web",
-  version: "0.1.57",
+  version: "0.1.58",
   kind: "runtime",
   description: "Google rewarded client runtime with a fullscreen gate host and GPT orchestration.",
   dependsOn: [
@@ -46,10 +46,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/google-rewarded-core": "0.1.57",
+        "@jskit-ai/google-rewarded-core": "0.1.58",
         "@jskit-ai/http-runtime": "0.1.119",
         "@jskit-ai/kernel": "0.1.121",
-        "@jskit-ai/shell-web": "0.1.120"
+        "@jskit-ai/shell-web": "0.1.121"
       },
       dev: {}
     },

--- a/packages/google-rewarded-web/package.json
+++ b/packages/google-rewarded-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/google-rewarded-web",
-  "version": "0.1.57",
+  "version": "0.1.58",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/mobile-capacitor/package.descriptor.mjs
+++ b/packages/mobile-capacitor/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/mobile-capacitor",
-  version: "0.1.56",
+  version: "0.1.57",
   kind: "runtime",
   description: "Thin Capacitor client integration for JSKIT mobile-shell launch routing and auth callback completion.",
   dependsOn: [
@@ -63,7 +63,7 @@ export default Object.freeze({
         "@capacitor/browser": "^7.0.1",
         "@capacitor/core": "^7.4.3",
         "@jskit-ai/kernel": "0.1.121",
-        "@jskit-ai/shell-web": "0.1.120"
+        "@jskit-ai/shell-web": "0.1.121"
       },
       dev: {
         "@capacitor/cli": "^7.4.3"

--- a/packages/mobile-capacitor/package.json
+++ b/packages/mobile-capacitor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/mobile-capacitor",
-  "version": "0.1.56",
+  "version": "0.1.57",
   "type": "module",
   "scripts": {
     "test": "node --test"

--- a/packages/shell-web/package.descriptor.mjs
+++ b/packages/shell-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/shell-web",
-  version: "0.1.120",
+  version: "0.1.121",
   kind: "runtime",
   description: "Web shell layout runtime with outlet-based placement contributions.",
   dependsOn: [],

--- a/packages/shell-web/package.json
+++ b/packages/shell-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/shell-web",
-  "version": "0.1.120",
+  "version": "0.1.121",
   "type": "module",
   "scripts": {
     "test": "node --test"

--- a/packages/ui-generator/package.descriptor.mjs
+++ b/packages/ui-generator/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { GENERATED_UI_NAVIGATION_ROLE_OPTION } from "@jskit-ai/kernel/shared/sup
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/ui-generator",
-  version: "0.1.103",
+  version: "0.1.104",
   kind: "generator",
   description: "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
   options: {
@@ -371,7 +371,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.136"
+        "@jskit-ai/users-web": "0.1.137"
       },
       dev: {}
     },

--- a/packages/ui-generator/package.json
+++ b/packages/ui-generator/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/ui-generator",
-  "version": "0.1.103",
+  "version": "0.1.104",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
     "@jskit-ai/kernel": "0.1.121",
-    "@jskit-ai/shell-web": "0.1.120"
+    "@jskit-ai/shell-web": "0.1.121"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/users-core/package.descriptor.mjs
+++ b/packages/users-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-core",
-  version: "0.1.130",
+  version: "0.1.131",
   kind: "runtime",
   description: "Users/account runtime plus HTTP routes for account features.",
   dependsOn: [
@@ -147,7 +147,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@jskit-ai/auth-core": "0.1.118",
-        "@jskit-ai/crud-core": "0.1.128",
+        "@jskit-ai/crud-core": "0.1.129",
         "@jskit-ai/database-runtime": "0.1.120",
         "@jskit-ai/http-runtime": "0.1.119",
         "@jskit-ai/json-rest-api-core": "0.1.65",

--- a/packages/users-core/package.json
+++ b/packages/users-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-core",
-  "version": "0.1.130",
+  "version": "0.1.131",
   "type": "module",
   "scripts": {
     "test": "node --test"

--- a/packages/users-web/package.descriptor.mjs
+++ b/packages/users-web/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { HOME_COG_OUTLET } from "./src/shared/toolsOutletContracts.js";
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-web",
-  version: "0.1.136",
+  version: "0.1.137",
   kind: "runtime",
   description: "Users web module: account/profile UI plus shared users web widgets.",
   dependsOn: [
@@ -289,9 +289,9 @@ export default Object.freeze({
         "@jskit-ai/http-runtime": "0.1.119",
         "@jskit-ai/realtime": "0.1.118",
         "@jskit-ai/kernel": "0.1.121",
-        "@jskit-ai/shell-web": "0.1.120",
+        "@jskit-ai/shell-web": "0.1.121",
         "@jskit-ai/uploads-image-web": "0.1.97",
-        "@jskit-ai/users-core": "0.1.130"
+        "@jskit-ai/users-core": "0.1.131"
       },
       dev: {}
     },

--- a/packages/users-web/package.json
+++ b/packages/users-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-web",
-  "version": "0.1.136",
+  "version": "0.1.137",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -49,9 +49,9 @@
     "@jskit-ai/http-runtime": "0.1.119",
     "@jskit-ai/kernel": "0.1.121",
     "@jskit-ai/realtime": "0.1.118",
-    "@jskit-ai/shell-web": "0.1.120",
+    "@jskit-ai/shell-web": "0.1.121",
     "@jskit-ai/uploads-image-web": "0.1.97",
-    "@jskit-ai/users-core": "0.1.130"
+    "@jskit-ai/users-core": "0.1.131"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/workspaces-core/package.descriptor.mjs
+++ b/packages/workspaces-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-core",
-  version: "0.1.96",
+  version: "0.1.97",
   kind: "runtime",
   description: "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
   dependsOn: [
@@ -150,7 +150,7 @@ export default Object.freeze({
         "@jskit-ai/json-rest-api-core": "0.1.65",
         "@jskit-ai/resource-core": "0.1.64",
         "@jskit-ai/resource-crud-core": "0.1.64",
-        "@jskit-ai/users-core": "0.1.130"
+        "@jskit-ai/users-core": "0.1.131"
       },
       dev: {}
     },

--- a/packages/workspaces-core/package.json
+++ b/packages/workspaces-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-core",
-  "version": "0.1.96",
+  "version": "0.1.97",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -24,7 +24,7 @@
     "@jskit-ai/kernel": "0.1.121",
     "@jskit-ai/resource-crud-core": "0.1.64",
     "@jskit-ai/resource-core": "0.1.64",
-    "@jskit-ai/users-core": "0.1.130",
+    "@jskit-ai/users-core": "0.1.131",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/workspaces-web/package.descriptor.mjs
+++ b/packages/workspaces-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-web",
-  version: "0.1.97",
+  version: "0.1.98",
   kind: "runtime",
   description: "Workspace web module: workspace selector, tools widget, workspace surfaces, members UI, and settings hosts.",
   dependsOn: [
@@ -232,9 +232,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-web": "0.1.120",
-        "@jskit-ai/workspaces-core": "0.1.96",
-        "@jskit-ai/users-web": "0.1.136"
+        "@jskit-ai/auth-web": "0.1.121",
+        "@jskit-ai/workspaces-core": "0.1.97",
+        "@jskit-ai/users-web": "0.1.137"
       },
       dev: {}
     },

--- a/packages/workspaces-web/package.json
+++ b/packages/workspaces-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-web",
-  "version": "0.1.97",
+  "version": "0.1.98",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -15,13 +15,13 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/auth-web": "0.1.120",
+    "@jskit-ai/auth-web": "0.1.121",
     "@jskit-ai/http-runtime": "0.1.119",
     "@jskit-ai/kernel": "0.1.121",
-    "@jskit-ai/shell-web": "0.1.120",
-    "@jskit-ai/users-core": "0.1.130",
-    "@jskit-ai/users-web": "0.1.136",
-    "@jskit-ai/workspaces-core": "0.1.96"
+    "@jskit-ai/shell-web": "0.1.121",
+    "@jskit-ai/users-core": "0.1.131",
+    "@jskit-ai/users-web": "0.1.137",
+    "@jskit-ai/workspaces-core": "0.1.97"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/tooling/create-app/package.descriptor.mjs
+++ b/tooling/create-app/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/create-app",
-  "version": "0.1.133",
+  "version": "0.1.134",
   "dependsOn": [],
   "capabilities": {
     "provides": [

--- a/tooling/create-app/package.json
+++ b/tooling/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/create-app",
-  "version": "0.1.133",
+  "version": "0.1.134",
   "description": "Scaffold JSKIT app shells.",
   "type": "module",
   "files": [
@@ -20,7 +20,7 @@
     "./client": "./src/client/index.js"
   },
   "dependencies": {
-    "@jskit-ai/jskit-cli": "0.2.136"
+    "@jskit-ai/jskit-cli": "0.2.137"
   },
   "engines": {
     "node": "^22.12.0 || ^24.0.0 || ^26.0.0"

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -6,11 +6,11 @@
   "packages": [
     {
       "packageId": "@jskit-ai/assistant",
-      "version": "0.1.129",
+      "version": "0.1.130",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant",
-        "version": "0.1.129",
+        "version": "0.1.130",
         "kind": "generator",
         "description": "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
         "options": {
@@ -347,11 +347,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-core",
-      "version": "0.1.97",
+      "version": "0.1.98",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-core",
-        "version": "0.1.97",
+        "version": "0.1.98",
         "kind": "runtime",
         "description": "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
         "dependsOn": [
@@ -403,7 +403,7 @@
               "@jskit-ai/kernel": "0.1.121",
               "@jskit-ai/resource-core": "0.1.64",
               "@jskit-ai/resource-crud-core": "0.1.64",
-              "@jskit-ai/users-core": "0.1.130",
+              "@jskit-ai/users-core": "0.1.131",
               "dompurify": "^3.3.3",
               "json-rest-schema": "1.x.x",
               "marked": "^17.0.4",
@@ -422,11 +422,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-runtime",
-      "version": "0.1.92",
+      "version": "0.1.93",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-runtime",
-        "version": "0.1.92",
+        "version": "0.1.93",
         "kind": "runtime",
         "description": "Shared assistant runtime with per-surface assistant registration.",
         "dependsOn": [
@@ -522,13 +522,13 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/assistant-core": "0.1.97",
+              "@jskit-ai/assistant-core": "0.1.98",
               "@jskit-ai/database-runtime": "0.1.120",
               "@jskit-ai/http-runtime": "0.1.119",
               "@jskit-ai/kernel": "0.1.121",
-              "@jskit-ai/shell-web": "0.1.120",
-              "@jskit-ai/users-core": "0.1.130",
-              "@jskit-ai/users-web": "0.1.136"
+              "@jskit-ai/shell-web": "0.1.121",
+              "@jskit-ai/users-core": "0.1.131",
+              "@jskit-ai/users-web": "0.1.137"
             },
             "dev": {}
           },
@@ -1077,11 +1077,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-web",
-      "version": "0.1.120",
+      "version": "0.1.121",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-web",
-        "version": "0.1.120",
+        "version": "0.1.121",
         "kind": "runtime",
         "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
         "dependsOn": [
@@ -1357,7 +1357,7 @@
               "@jskit-ai/auth-core": "0.1.118",
               "@jskit-ai/http-runtime": "0.1.119",
               "@jskit-ai/kernel": "0.1.121",
-              "@jskit-ai/shell-web": "0.1.120"
+              "@jskit-ai/shell-web": "0.1.121"
             },
             "dev": {}
           },
@@ -1450,11 +1450,11 @@
     },
     {
       "packageId": "@jskit-ai/console-core",
-      "version": "0.1.83",
+      "version": "0.1.84",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-core",
-        "version": "0.1.83",
+        "version": "0.1.84",
         "kind": "runtime",
         "description": "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
         "dependsOn": [
@@ -1543,7 +1543,7 @@
               "@jskit-ai/http-runtime": "0.1.119",
               "@jskit-ai/kernel": "0.1.121",
               "@jskit-ai/resource-crud-core": "0.1.64",
-              "@jskit-ai/users-core": "0.1.130"
+              "@jskit-ai/users-core": "0.1.131"
             },
             "dev": {}
           },
@@ -1568,11 +1568,11 @@
     },
     {
       "packageId": "@jskit-ai/console-web",
-      "version": "0.1.88",
+      "version": "0.1.89",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-web",
-        "version": "0.1.88",
+        "version": "0.1.89",
         "kind": "runtime",
         "description": "Authenticated console surface scaffold and surface policy wiring.",
         "dependsOn": [
@@ -1682,9 +1682,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-web": "0.1.120",
-              "@jskit-ai/console-core": "0.1.83",
-              "@jskit-ai/shell-web": "0.1.120"
+              "@jskit-ai/auth-web": "0.1.121",
+              "@jskit-ai/console-core": "0.1.84",
+              "@jskit-ai/shell-web": "0.1.121"
             },
             "dev": {}
           },
@@ -1791,11 +1791,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-core",
-      "version": "0.1.128",
+      "version": "0.1.129",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-core",
-        "version": "0.1.128",
+        "version": "0.1.129",
         "kind": "runtime",
         "description": "Shared CRUD helpers used by CRUD modules.",
         "dependsOn": [
@@ -1824,7 +1824,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/crud-core": "0.1.128"
+              "@jskit-ai/crud-core": "0.1.129"
             },
             "dev": {}
           },
@@ -1838,11 +1838,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-server-generator",
-      "version": "0.1.128",
+      "version": "0.1.129",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-server-generator",
-        "version": "0.1.128",
+        "version": "0.1.129",
         "kind": "generator",
         "description": "CRUD server generator with routes, actions, and persistence scaffolding.",
         "options": {
@@ -2010,7 +2010,7 @@
           "dependencies": {
             "runtime": {
               "@jskit-ai/auth-core": "0.1.118",
-              "@jskit-ai/crud-core": "0.1.128",
+              "@jskit-ai/crud-core": "0.1.129",
               "@jskit-ai/database-runtime": "0.1.120",
               "@jskit-ai/http-runtime": "0.1.119",
               "@jskit-ai/json-rest-api-core": "0.1.65",
@@ -2148,11 +2148,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.103",
+      "version": "0.1.104",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-ui-generator",
-        "version": "0.1.103",
+        "version": "0.1.104",
         "kind": "generator",
         "description": "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
         "options": {
@@ -2351,7 +2351,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.136"
+              "@jskit-ai/users-web": "0.1.137"
             },
             "dev": {}
           },
@@ -3414,11 +3414,11 @@
     },
     {
       "packageId": "@jskit-ai/google-rewarded-core",
-      "version": "0.1.57",
+      "version": "0.1.58",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/google-rewarded-core",
-        "version": "0.1.57",
+        "version": "0.1.58",
         "kind": "runtime",
         "description": "Google rewarded workflow runtime plus internal CRUD providers for rules, provider configs, watch sessions, and unlock receipts.",
         "dependsOn": [
@@ -3546,13 +3546,13 @@
           "dependencies": {
             "runtime": {
               "@jskit-ai/auth-core": "0.1.118",
-              "@jskit-ai/crud-core": "0.1.128",
+              "@jskit-ai/crud-core": "0.1.129",
               "@jskit-ai/database-runtime": "0.1.120",
               "@jskit-ai/http-runtime": "0.1.119",
               "@jskit-ai/json-rest-api-core": "0.1.65",
               "@jskit-ai/kernel": "0.1.121",
               "@jskit-ai/resource-crud-core": "0.1.64",
-              "@jskit-ai/workspaces-core": "0.1.96"
+              "@jskit-ai/workspaces-core": "0.1.97"
             },
             "dev": {}
           },
@@ -3604,11 +3604,11 @@
     },
     {
       "packageId": "@jskit-ai/google-rewarded-web",
-      "version": "0.1.57",
+      "version": "0.1.58",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/google-rewarded-web",
-        "version": "0.1.57",
+        "version": "0.1.58",
         "kind": "runtime",
         "description": "Google rewarded client runtime with a fullscreen gate host and GPT orchestration.",
         "dependsOn": [
@@ -3655,10 +3655,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/google-rewarded-core": "0.1.57",
+              "@jskit-ai/google-rewarded-core": "0.1.58",
               "@jskit-ai/http-runtime": "0.1.119",
               "@jskit-ai/kernel": "0.1.121",
-              "@jskit-ai/shell-web": "0.1.120"
+              "@jskit-ai/shell-web": "0.1.121"
             },
             "dev": {}
           },
@@ -3824,11 +3824,11 @@
     },
     {
       "packageId": "@jskit-ai/mobile-capacitor",
-      "version": "0.1.56",
+      "version": "0.1.57",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/mobile-capacitor",
-        "version": "0.1.56",
+        "version": "0.1.57",
         "kind": "runtime",
         "description": "Thin Capacitor client integration for JSKIT mobile-shell launch routing and auth callback completion.",
         "dependsOn": [
@@ -3892,7 +3892,7 @@
               "@capacitor/browser": "^7.0.1",
               "@capacitor/core": "^7.4.3",
               "@jskit-ai/kernel": "0.1.121",
-              "@jskit-ai/shell-web": "0.1.120"
+              "@jskit-ai/shell-web": "0.1.121"
             },
             "dev": {
               "@capacitor/cli": "^7.4.3"
@@ -4178,11 +4178,11 @@
     },
     {
       "packageId": "@jskit-ai/shell-web",
-      "version": "0.1.120",
+      "version": "0.1.121",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/shell-web",
-        "version": "0.1.120",
+        "version": "0.1.121",
         "kind": "runtime",
         "description": "Web shell layout runtime with outlet-based placement contributions.",
         "dependsOn": [],
@@ -4806,11 +4806,11 @@
     },
     {
       "packageId": "@jskit-ai/ui-generator",
-      "version": "0.1.103",
+      "version": "0.1.104",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/ui-generator",
-        "version": "0.1.103",
+        "version": "0.1.104",
         "kind": "generator",
         "description": "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
         "options": {
@@ -5243,7 +5243,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.136"
+              "@jskit-ai/users-web": "0.1.137"
             },
             "dev": {}
           },
@@ -5435,11 +5435,11 @@
     },
     {
       "packageId": "@jskit-ai/users-core",
-      "version": "0.1.130",
+      "version": "0.1.131",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-core",
-        "version": "0.1.130",
+        "version": "0.1.131",
         "kind": "runtime",
         "description": "Users/account runtime plus HTTP routes for account features.",
         "dependsOn": [
@@ -5584,7 +5584,7 @@
           "dependencies": {
             "runtime": {
               "@jskit-ai/auth-core": "0.1.118",
-              "@jskit-ai/crud-core": "0.1.128",
+              "@jskit-ai/crud-core": "0.1.129",
               "@jskit-ai/database-runtime": "0.1.120",
               "@jskit-ai/http-runtime": "0.1.119",
               "@jskit-ai/json-rest-api-core": "0.1.65",
@@ -5819,11 +5819,11 @@
     },
     {
       "packageId": "@jskit-ai/users-web",
-      "version": "0.1.136",
+      "version": "0.1.137",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-web",
-        "version": "0.1.136",
+        "version": "0.1.137",
         "kind": "runtime",
         "description": "Users web module: account/profile UI plus shared users web widgets.",
         "dependsOn": [
@@ -6129,9 +6129,9 @@
               "@jskit-ai/http-runtime": "0.1.119",
               "@jskit-ai/realtime": "0.1.118",
               "@jskit-ai/kernel": "0.1.121",
-              "@jskit-ai/shell-web": "0.1.120",
+              "@jskit-ai/shell-web": "0.1.121",
               "@jskit-ai/uploads-image-web": "0.1.97",
-              "@jskit-ai/users-core": "0.1.130"
+              "@jskit-ai/users-core": "0.1.131"
             },
             "dev": {}
           },
@@ -6308,11 +6308,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-core",
-      "version": "0.1.96",
+      "version": "0.1.97",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-core",
-        "version": "0.1.96",
+        "version": "0.1.97",
         "kind": "runtime",
         "description": "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
         "dependsOn": [
@@ -6461,7 +6461,7 @@
               "@jskit-ai/json-rest-api-core": "0.1.65",
               "@jskit-ai/resource-core": "0.1.64",
               "@jskit-ai/resource-crud-core": "0.1.64",
-              "@jskit-ai/users-core": "0.1.130"
+              "@jskit-ai/users-core": "0.1.131"
             },
             "dev": {}
           },
@@ -6664,11 +6664,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-web",
-      "version": "0.1.97",
+      "version": "0.1.98",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-web",
-        "version": "0.1.97",
+        "version": "0.1.98",
         "kind": "runtime",
         "description": "Workspace web module: workspace selector, tools widget, workspace surfaces, members UI, and settings hosts.",
         "dependsOn": [
@@ -6925,9 +6925,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-web": "0.1.120",
-              "@jskit-ai/workspaces-core": "0.1.96",
-              "@jskit-ai/users-web": "0.1.136"
+              "@jskit-ai/auth-web": "0.1.121",
+              "@jskit-ai/workspaces-core": "0.1.97",
+              "@jskit-ai/users-web": "0.1.137"
             },
             "dev": {}
           },

--- a/tooling/jskit-catalog/package.json
+++ b/tooling/jskit-catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-catalog",
-  "version": "0.1.131",
+  "version": "0.1.132",
   "description": "Published metadata catalog for JSKIT package descriptors.",
   "type": "module",
   "files": [

--- a/tooling/jskit-cli/package.json
+++ b/tooling/jskit-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-cli",
-  "version": "0.2.136",
+  "version": "0.2.137",
   "description": "Bundle and package orchestration CLI for JSKIT apps.",
   "type": "module",
   "files": [
@@ -21,9 +21,9 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/jskit-catalog": "0.1.131",
+    "@jskit-ai/jskit-catalog": "0.1.132",
     "@jskit-ai/kernel": "0.1.121",
-    "@jskit-ai/shell-web": "0.1.120",
+    "@jskit-ai/shell-web": "0.1.121",
     "@vue/compiler-sfc": "^3.5.29",
     "ts-morph": "^28.0.0",
     "yaml": "^2.8.3"


### PR DESCRIPTION
Records the npm release closure for the forward-owned Playwright configuration, smoke helpers, and auth test helper delivered in #355.

Published and registry-verified under Node 26.5.0. Generated outputs are current.