### PR TITLE
Require json-rest-api deferred policy fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4304,9 +4304,9 @@
       "license": "MIT"
     },
     "node_modules/json-rest-api": {
-      "version": "1.0.25",
-      "resolved": "https://registry.npmjs.org/json-rest-api/-/json-rest-api-1.0.25.tgz",
-      "integrity": "sha512-chJqFeXYNeNrwJpKROMH1iXDkOlwL6XNNaHFFhNqEDVQqFlpoxYawWxeqPkRh+903xczxnRVBmK8I+XFVHrQsQ==",
+      "version": "1.0.26",
+      "resolved": "https://registry.npmjs.org/json-rest-api/-/json-rest-api-1.0.26.tgz",
+      "integrity": "sha512-bGSRwOW/2jQ6CUhHYC+2Gpgai+IEq2moa56fpx++uPNbn823j5PVD+jFfTMVS96JoWiPkaWDzfkxjgnVn/Nftg==",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "hooked-api": "^1.0.24",
@@ -7960,7 +7960,7 @@
       "dependencies": {
         "@jskit-ai/kernel": "0.1.122",
         "hooked-api": "1.x.x",
-        "json-rest-api": "^1.0.25"
+        "json-rest-api": "^1.0.26"
       }
     },
     "packages/kernel": {

--- a/packages/agent-docs/guide/agent/generators/row-policies.md
+++ b/packages/agent-docs/guide/agent/generators/row-policies.md
@@ -515,7 +515,7 @@ The `json-rest-api` package owns exhaustive framework tests for pagination, coun
 
 ## AnyAPI comes later
 
-`json-rest-api@1.0.25` can apply row policies with `RestApiAnyapiKnexPlugin`. JSKIT's current `internal.json-rest-api` host installs `RestApiKnexPlugin`, so the code in this chapter targets normal tables.
+`json-rest-api@1.0.26` can apply row policies with `RestApiAnyapiKnexPlugin`, including grouped predicates evaluated after the policy hook returns. JSKIT's current `internal.json-rest-api` host installs `RestApiKnexPlugin`, so the code in this chapter targets normal tables.
 
 Do not add backend detection, fallback queries, or an `isAnyApi` branch to the normal-table policy in anticipation of a host that does not exist.
 

--- a/packages/agent-docs/site/guide/generators/row-policies.md
+++ b/packages/agent-docs/site/guide/generators/row-policies.md
@@ -513,7 +513,7 @@ The `json-rest-api` package owns exhaustive framework tests for pagination, coun
 
 ## AnyAPI comes later
 
-`json-rest-api@1.0.25` can apply row policies with `RestApiAnyapiKnexPlugin`. JSKIT's current `internal.json-rest-api` host installs `RestApiKnexPlugin`, so the code in this chapter targets normal tables.
+`json-rest-api@1.0.26` can apply row policies with `RestApiAnyapiKnexPlugin`, including grouped predicates evaluated after the policy hook returns. JSKIT's current `internal.json-rest-api` host installs `RestApiKnexPlugin`, so the code in this chapter targets normal tables.
 
 Do not add backend detection, fallback queries, or an `isAnyApi` branch to the normal-table policy in anticipation of a host that does not exist.
 

--- a/packages/json-rest-api-core/package.json
+++ b/packages/json-rest-api-core/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "hooked-api": "1.x.x",
-    "json-rest-api": "^1.0.25",
+    "json-rest-api": "^1.0.26",
     "@jskit-ai/kernel": "0.1.122"
   }
 }

--- a/packages/json-rest-api-core/test/entrypoints.boundary.test.js
+++ b/packages/json-rest-api-core/test/entrypoints.boundary.test.js
@@ -26,7 +26,7 @@ test("package exports include explicit server jsonRestApiHost entrypoint only", 
   const exportsMap = packageJson && typeof packageJson === "object" ? packageJson.exports : {};
   assert.equal(exportsMap["./server/jsonRestApiHost"], "./src/server/jsonRestApiHost.js");
   assert.equal(exportsMap["./server"], undefined);
-  assert.equal(packageJson.dependencies?.["json-rest-api"], "^1.0.25");
+  assert.equal(packageJson.dependencies?.["json-rest-api"], "^1.0.26");
 });
 
 test("server jsonRestApiHost entrypoint no longer exports host-side JSON:API simplification helpers", async () => {


### PR DESCRIPTION
## Summary
- require json-rest-api 1.0.26 from the shared JSKIT host
- refresh the npm lockfile and dependency-floor contract
- document deferred grouped predicate support in the authored and generated row-policy guide

## Verification
- @jskit-ai/json-rest-api-core: 17 tests passed
- dependency lock resolves json-rest-api 1.0.26
- npm audit: 0 vulnerabilities
- lint, descriptor/runtime audits, generated checks, and completed workspace tests passed before the redundant full run was stopped