### PR TITLE
Fix provider-neutral profile email hint

### DIFF
--- a/packages/users-web/src/client/components/ProfileClientElement.vue
+++ b/packages/users-web/src/client/components/ProfileClientElement.vue
@@ -102,7 +102,7 @@ const DEFAULT_COPY = Object.freeze({
   selectedFilePrefix: "Selected file:",
   displayName: "Display name",
   email: "Email",
-  emailHint: "Managed by Supabase Auth",
+  emailHint: "Managed by your sign-in account",
   saveProfile: "Save profile"
 });
 

--- a/packages/users-web/templates/src/components/account/settings/AccountSettingsProfileSection.vue
+++ b/packages/users-web/templates/src/components/account/settings/AccountSettingsProfileSection.vue
@@ -73,7 +73,7 @@ const profile = props.runtime.profile;
               variant="outlined"
               density="comfortable"
               readonly
-              hint="Managed by Supabase Auth"
+              hint="Managed by your sign-in account"
               persistent-hint
             />
           </v-col>

--- a/packages/users-web/test/settingsPlacementContract.test.js
+++ b/packages/users-web/test/settingsPlacementContract.test.js
@@ -160,6 +160,19 @@ test("users-web profile form element uses a direct panel instead of card scaffol
   assert.doesNotMatch(source, /<v-card\b|v-card-title|v-card-subtitle|v-card-text|v-card-item/);
 });
 
+test("users-web profile email ownership copy is provider-neutral", async () => {
+  const sourcePaths = [
+    path.join("src", "client", "components", "ProfileClientElement.vue"),
+    path.join("templates", "src", "components", "account", "settings", "AccountSettingsProfileSection.vue")
+  ];
+
+  for (const sourcePath of sourcePaths) {
+    const source = await readFile(path.join(PACKAGE_DIR, sourcePath), "utf8");
+    assert.match(source, /Managed by your sign-in account/);
+    assert.doesNotMatch(source, /Managed by Supabase Auth/);
+  }
+});
+
 test("users-web account settings section templates use direct settings panels", async () => {
   for (const relativePath of [
     path.join("templates", "src", "components", "account", "settings", "AccountSettingsProfileSection.vue"),


### PR DESCRIPTION
## Summary
- replace the Supabase-specific profile email hint with provider-neutral wording
- keep the packaged component and generated account-settings template aligned
- add a contract test preventing provider-specific default copy from returning

## Verification
- npm test --workspace @jskit-ai/users-web
- npx eslint packages/users-web/src/client/components/ProfileClientElement.vue packages/users-web/test/settingsPlacementContract.test.js
- npx eslint --no-ignore packages/users-web/templates/src/components/account/settings/AccountSettingsProfileSection.vue
- git diff --check