### PR TITLE
fix(crud): enforce explicit ownership and role grants

### DIFF
--- a/install.txt
+++ b/install.txt
@@ -120,31 +120,31 @@ npx jskit generate @jskit-ai/assistant settings-page help
 ------------------------------
 # CRUDS
 
-npx jskit generate crud-server-generator scaffold --namespace contacts --surface admin --table-name contacts
+npx jskit generate crud-server-generator scaffold --namespace contacts --surface admin --table-name contacts --grant-role member
 npx jskit generate @jskit-ai/crud-ui-generator crud \
   src/pages/w/[workspaceSlug]/admin/contacts \
   --resource-file packages/contacts/src/shared/contactResource.js \
   --id-param contactId
 
-npx jskit generate crud-server-generator scaffold --namespace addresses --surface admin --table-name addresses
+npx jskit generate crud-server-generator scaffold --namespace addresses --surface admin --table-name addresses --grant-role member
 npx jskit generate @jskit-ai/crud-ui-generator crud \
   src/pages/w/[workspaceSlug]/admin/contacts/[contactId]/addresses \
   --resource-file packages/addresses/src/shared/addressResource.js \
   --id-param addressId
 
 
-npx jskit generate crud-server-generator scaffold --namespace vets --surface admin --table-name vets
+npx jskit generate crud-server-generator scaffold --namespace vets --surface admin --table-name vets --grant-role member
 npx jskit generate @jskit-ai/crud-ui-generator crud \
   src/pages/w/[workspaceSlug]/admin/vets \
   --resource-file packages/vets/src/shared/vetResource.js
 
-npx jskit generate crud-server-generator scaffold --namespace contact-categories --surface admin --table-name contact_categories
+npx jskit generate crud-server-generator scaffold --namespace contact-categories --surface admin --table-name contact_categories --grant-role member
 npx jskit generate @jskit-ai/crud-ui-generator crud \
   src/pages/w/[workspaceSlug]/admin/contact-categories \
   --resource-file packages/contact-categories/src/shared/contactCategoryResource.js
 
 
-npx jskit generate crud-server-generator scaffold --namespace addresses --surface admin --table-name addresses
+npx jskit generate crud-server-generator scaffold --namespace addresses --surface admin --table-name addresses --grant-role member
 npx jskit generate @jskit-ai/crud-ui-generator crud \
   src/pages/w/[workspaceSlug]/admin/contacts/[contactId]/addresses \
   --resource-file packages/addresses/src/shared/addressResource.js \
@@ -339,7 +339,7 @@ FIELD ADDING:
 
 
 // ONE LINE
-npx jskit generate crud-server-generator scaffold --namespace contacts --surface admin --table-name contacts;npx jskit generate @jskit-ai/crud-ui-generator crud src/pages/w/[workspaceSlug]/admin/contacts --resource-file packages/contacts/src/shared/contactResource.js;npx jskit generate crud-server-generator scaffold --namespace vets --surface admin --table-name vets;npx jskit generate @jskit-ai/crud-ui-generator crud src/pages/w/[workspaceSlug]/admin/vets --resource-file packages/vets/src/shared/vetResource.js
+npx jskit generate crud-server-generator scaffold --namespace contacts --surface admin --table-name contacts --grant-role member;npx jskit generate @jskit-ai/crud-ui-generator crud src/pages/w/[workspaceSlug]/admin/contacts --resource-file packages/contacts/src/shared/contactResource.js;npx jskit generate crud-server-generator scaffold --namespace vets --surface admin --table-name vets --grant-role member;npx jskit generate @jskit-ai/crud-ui-generator crud src/pages/w/[workspaceSlug]/admin/vets --resource-file packages/vets/src/shared/vetResource.js
 
 npm install --verbose
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7737,28 +7737,28 @@
     },
     "packages/agent-docs": {
       "name": "@jskit-ai/agent-docs",
-      "version": "0.1.88",
+      "version": "0.1.90",
       "engines": {
         "node": "^22.12.0 || ^24.0.0 || ^26.0.0"
       }
     },
     "packages/assistant": {
       "name": "@jskit-ai/assistant",
-      "version": "0.1.132",
+      "version": "0.1.133",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.123"
+        "@jskit-ai/kernel": "0.1.124"
       }
     },
     "packages/assistant-core": {
       "name": "@jskit-ai/assistant-core",
-      "version": "0.1.100",
+      "version": "0.1.101",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.122",
-        "@jskit-ai/http-runtime": "0.1.121",
-        "@jskit-ai/kernel": "0.1.123",
-        "@jskit-ai/resource-core": "0.1.66",
-        "@jskit-ai/resource-crud-core": "0.1.66",
-        "@jskit-ai/users-core": "0.1.133",
+        "@jskit-ai/database-runtime": "0.1.123",
+        "@jskit-ai/http-runtime": "0.1.122",
+        "@jskit-ai/kernel": "0.1.124",
+        "@jskit-ai/resource-core": "0.1.67",
+        "@jskit-ai/resource-crud-core": "0.1.67",
+        "@jskit-ai/users-core": "0.1.134",
         "dompurify": "^3.4.12",
         "json-rest-schema": "1.x.x",
         "marked": "^17.0.4",
@@ -7771,15 +7771,15 @@
     },
     "packages/assistant-runtime": {
       "name": "@jskit-ai/assistant-runtime",
-      "version": "0.1.95",
+      "version": "0.1.96",
       "dependencies": {
-        "@jskit-ai/assistant-core": "0.1.100",
-        "@jskit-ai/database-runtime": "0.1.122",
-        "@jskit-ai/http-runtime": "0.1.121",
-        "@jskit-ai/kernel": "0.1.123",
-        "@jskit-ai/shell-web": "0.1.124",
-        "@jskit-ai/users-core": "0.1.133",
-        "@jskit-ai/users-web": "0.1.139",
+        "@jskit-ai/assistant-core": "0.1.101",
+        "@jskit-ai/database-runtime": "0.1.123",
+        "@jskit-ai/http-runtime": "0.1.122",
+        "@jskit-ai/kernel": "0.1.124",
+        "@jskit-ai/shell-web": "0.1.125",
+        "@jskit-ai/users-core": "0.1.134",
+        "@jskit-ai/users-web": "0.1.140",
         "json-rest-schema": "1.x.x"
       },
       "peerDependencies": {
@@ -7790,39 +7790,39 @@
     },
     "packages/auth-core": {
       "name": "@jskit-ai/auth-core",
-      "version": "0.1.120",
+      "version": "0.1.121",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0",
-        "@jskit-ai/kernel": "0.1.123",
+        "@jskit-ai/kernel": "0.1.124",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/auth-provider-local-core": {
       "name": "@jskit-ai/auth-provider-local-core",
-      "version": "0.1.24",
+      "version": "0.1.25",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.120",
-        "@jskit-ai/kernel": "0.1.123",
+        "@jskit-ai/auth-core": "0.1.121",
+        "@jskit-ai/kernel": "0.1.124",
         "nodemailer": "^9.0.3"
       }
     },
     "packages/auth-provider-local-db-core": {
       "name": "@jskit-ai/auth-provider-local-db-core",
-      "version": "0.1.15",
+      "version": "0.1.16",
       "dependencies": {
-        "@jskit-ai/auth-provider-local-core": "0.1.24",
-        "@jskit-ai/database-runtime": "0.1.122",
-        "@jskit-ai/kernel": "0.1.123"
+        "@jskit-ai/auth-provider-local-core": "0.1.25",
+        "@jskit-ai/database-runtime": "0.1.123",
+        "@jskit-ai/kernel": "0.1.124"
       }
     },
     "packages/auth-provider-supabase-core": {
       "name": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.121",
+      "version": "0.1.122",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.120",
-        "@jskit-ai/kernel": "0.1.123",
+        "@jskit-ai/auth-core": "0.1.121",
+        "@jskit-ai/kernel": "0.1.124",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0",
         "json-rest-schema": "1.x.x",
@@ -7831,12 +7831,12 @@
     },
     "packages/auth-web": {
       "name": "@jskit-ai/auth-web",
-      "version": "0.1.123",
+      "version": "0.1.124",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.120",
-        "@jskit-ai/http-runtime": "0.1.121",
-        "@jskit-ai/kernel": "0.1.123",
-        "@jskit-ai/shell-web": "0.1.124",
+        "@jskit-ai/auth-core": "0.1.121",
+        "@jskit-ai/http-runtime": "0.1.122",
+        "@jskit-ai/kernel": "0.1.124",
+        "@jskit-ai/shell-web": "0.1.125",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -7849,38 +7849,38 @@
     },
     "packages/console-core": {
       "name": "@jskit-ai/console-core",
-      "version": "0.1.86",
+      "version": "0.1.87",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.120",
-        "@jskit-ai/database-runtime": "0.1.122",
-        "@jskit-ai/http-runtime": "0.1.121",
-        "@jskit-ai/kernel": "0.1.123",
-        "@jskit-ai/resource-crud-core": "0.1.66",
-        "@jskit-ai/users-core": "0.1.133",
+        "@jskit-ai/auth-core": "0.1.121",
+        "@jskit-ai/database-runtime": "0.1.123",
+        "@jskit-ai/http-runtime": "0.1.122",
+        "@jskit-ai/kernel": "0.1.124",
+        "@jskit-ai/resource-crud-core": "0.1.67",
+        "@jskit-ai/users-core": "0.1.134",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/console-web": {
       "name": "@jskit-ai/console-web",
-      "version": "0.1.91",
+      "version": "0.1.92",
       "dependencies": {
-        "@jskit-ai/auth-web": "0.1.123",
-        "@jskit-ai/console-core": "0.1.86",
-        "@jskit-ai/shell-web": "0.1.124"
+        "@jskit-ai/auth-web": "0.1.124",
+        "@jskit-ai/console-core": "0.1.87",
+        "@jskit-ai/shell-web": "0.1.125"
       }
     },
     "packages/crud-core": {
       "name": "@jskit-ai/crud-core",
-      "version": "0.1.131",
+      "version": "0.1.132",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.122",
-        "@jskit-ai/http-runtime": "0.1.121",
-        "@jskit-ai/kernel": "0.1.123",
-        "@jskit-ai/realtime": "0.1.120",
-        "@jskit-ai/resource-crud-core": "0.1.66",
-        "@jskit-ai/shell-web": "0.1.124",
-        "@jskit-ai/users-core": "0.1.133",
-        "@jskit-ai/users-web": "0.1.139",
+        "@jskit-ai/database-runtime": "0.1.123",
+        "@jskit-ai/http-runtime": "0.1.122",
+        "@jskit-ai/kernel": "0.1.124",
+        "@jskit-ai/realtime": "0.1.121",
+        "@jskit-ai/resource-crud-core": "0.1.67",
+        "@jskit-ai/shell-web": "0.1.125",
+        "@jskit-ai/users-core": "0.1.134",
+        "@jskit-ai/users-web": "0.1.140",
         "json-rest-schema": "1.x.x"
       },
       "peerDependencies": {
@@ -7891,98 +7891,98 @@
     },
     "packages/crud-server-generator": {
       "name": "@jskit-ai/crud-server-generator",
-      "version": "0.1.131",
+      "version": "0.1.133",
       "dependencies": {
         "@babel/parser": "^7.29.2",
-        "@jskit-ai/crud-core": "0.1.131",
-        "@jskit-ai/database-runtime": "0.1.122",
-        "@jskit-ai/http-runtime": "0.1.121",
-        "@jskit-ai/json-rest-api-core": "0.1.67",
-        "@jskit-ai/kernel": "0.1.123",
-        "@jskit-ai/resource-crud-core": "0.1.66",
+        "@jskit-ai/crud-core": "0.1.132",
+        "@jskit-ai/database-runtime": "0.1.123",
+        "@jskit-ai/http-runtime": "0.1.122",
+        "@jskit-ai/json-rest-api-core": "0.1.68",
+        "@jskit-ai/kernel": "0.1.124",
+        "@jskit-ai/resource-crud-core": "0.1.67",
         "recast": "^0.23.11"
       }
     },
     "packages/crud-ui-generator": {
       "name": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.106",
+      "version": "0.1.107",
       "dependencies": {
-        "@jskit-ai/crud-core": "0.1.131",
-        "@jskit-ai/kernel": "0.1.123",
-        "@jskit-ai/resource-crud-core": "0.1.66"
+        "@jskit-ai/crud-core": "0.1.132",
+        "@jskit-ai/kernel": "0.1.124",
+        "@jskit-ai/resource-crud-core": "0.1.67"
       }
     },
     "packages/database-runtime": {
       "name": "@jskit-ai/database-runtime",
-      "version": "0.1.122",
+      "version": "0.1.123",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.123"
+        "@jskit-ai/kernel": "0.1.124"
       }
     },
     "packages/database-runtime-mysql": {
       "name": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.121",
+      "version": "0.1.122",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.122",
-        "@jskit-ai/kernel": "0.1.123"
+        "@jskit-ai/database-runtime": "0.1.123",
+        "@jskit-ai/kernel": "0.1.124"
       }
     },
     "packages/database-runtime-postgres": {
       "name": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.120",
+      "version": "0.1.121",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.122"
+        "@jskit-ai/database-runtime": "0.1.123"
       }
     },
     "packages/feature-server-generator": {
       "name": "@jskit-ai/feature-server-generator",
-      "version": "0.1.65"
+      "version": "0.1.66"
     },
     "packages/google-rewarded-core": {
       "name": "@jskit-ai/google-rewarded-core",
-      "version": "0.1.60"
+      "version": "0.1.61"
     },
     "packages/google-rewarded-web": {
       "name": "@jskit-ai/google-rewarded-web",
-      "version": "0.1.60"
+      "version": "0.1.61"
     },
     "packages/http-runtime": {
       "name": "@jskit-ai/http-runtime",
-      "version": "0.1.121",
+      "version": "0.1.122",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.123",
+        "@jskit-ai/kernel": "0.1.124",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/json-rest-api-core": {
       "name": "@jskit-ai/json-rest-api-core",
-      "version": "0.1.67",
+      "version": "0.1.68",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.123",
+        "@jskit-ai/kernel": "0.1.124",
         "hooked-api": "1.x.x",
         "json-rest-api": "^1.0.26"
       }
     },
     "packages/kernel": {
       "name": "@jskit-ai/kernel",
-      "version": "0.1.123",
+      "version": "0.1.124",
       "dependencies": {
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/mobile-capacitor": {
       "name": "@jskit-ai/mobile-capacitor",
-      "version": "0.1.59",
+      "version": "0.1.60",
       "dependencies": {
         "@capacitor/browser": "^7.0.1",
-        "@jskit-ai/kernel": "0.1.123"
+        "@jskit-ai/kernel": "0.1.124"
       }
     },
     "packages/realtime": {
       "name": "@jskit-ai/realtime",
-      "version": "0.1.120",
+      "version": "0.1.121",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.123",
+        "@jskit-ai/kernel": "0.1.124",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",
@@ -7994,24 +7994,24 @@
     },
     "packages/resource-core": {
       "name": "@jskit-ai/resource-core",
-      "version": "0.1.66",
+      "version": "0.1.67",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.123"
+        "@jskit-ai/kernel": "0.1.124"
       }
     },
     "packages/resource-crud-core": {
       "name": "@jskit-ai/resource-crud-core",
-      "version": "0.1.66",
+      "version": "0.1.67",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.123",
-        "@jskit-ai/resource-core": "0.1.66"
+        "@jskit-ai/kernel": "0.1.124",
+        "@jskit-ai/resource-core": "0.1.67"
       }
     },
     "packages/shell-web": {
       "name": "@jskit-ai/shell-web",
-      "version": "0.1.124",
+      "version": "0.1.125",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.123",
+        "@jskit-ai/kernel": "0.1.124",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -8023,25 +8023,25 @@
     },
     "packages/storage-runtime": {
       "name": "@jskit-ai/storage-runtime",
-      "version": "0.1.121",
+      "version": "0.1.122",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.123",
+        "@jskit-ai/kernel": "0.1.124",
         "unstorage": "^1.17.5"
       }
     },
     "packages/ui-generator": {
       "name": "@jskit-ai/ui-generator",
-      "version": "0.1.106",
+      "version": "0.1.107",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.123",
-        "@jskit-ai/shell-web": "0.1.124"
+        "@jskit-ai/kernel": "0.1.124",
+        "@jskit-ai/shell-web": "0.1.125"
       }
     },
     "packages/uploads-image-web": {
       "name": "@jskit-ai/uploads-image-web",
-      "version": "0.1.99",
+      "version": "0.1.100",
       "dependencies": {
-        "@jskit-ai/uploads-runtime": "0.1.99",
+        "@jskit-ai/uploads-runtime": "0.1.100",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",
@@ -8054,37 +8054,37 @@
     },
     "packages/uploads-runtime": {
       "name": "@jskit-ai/uploads-runtime",
-      "version": "0.1.99",
+      "version": "0.1.100",
       "dependencies": {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.123"
+        "@jskit-ai/kernel": "0.1.124"
       }
     },
     "packages/users-core": {
       "name": "@jskit-ai/users-core",
-      "version": "0.1.133",
+      "version": "0.1.134",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.120",
-        "@jskit-ai/database-runtime": "0.1.122",
-        "@jskit-ai/http-runtime": "0.1.121",
-        "@jskit-ai/json-rest-api-core": "0.1.67",
-        "@jskit-ai/kernel": "0.1.123",
-        "@jskit-ai/resource-core": "0.1.66",
-        "@jskit-ai/resource-crud-core": "0.1.66",
-        "@jskit-ai/uploads-runtime": "0.1.99",
+        "@jskit-ai/auth-core": "0.1.121",
+        "@jskit-ai/database-runtime": "0.1.123",
+        "@jskit-ai/http-runtime": "0.1.122",
+        "@jskit-ai/json-rest-api-core": "0.1.68",
+        "@jskit-ai/kernel": "0.1.124",
+        "@jskit-ai/resource-core": "0.1.67",
+        "@jskit-ai/resource-crud-core": "0.1.67",
+        "@jskit-ai/uploads-runtime": "0.1.100",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/users-web": {
       "name": "@jskit-ai/users-web",
-      "version": "0.1.139",
+      "version": "0.1.140",
       "dependencies": {
-        "@jskit-ai/http-runtime": "0.1.121",
-        "@jskit-ai/kernel": "0.1.123",
-        "@jskit-ai/realtime": "0.1.120",
-        "@jskit-ai/shell-web": "0.1.124",
-        "@jskit-ai/uploads-image-web": "0.1.99",
-        "@jskit-ai/users-core": "0.1.133",
+        "@jskit-ai/http-runtime": "0.1.122",
+        "@jskit-ai/kernel": "0.1.124",
+        "@jskit-ai/realtime": "0.1.121",
+        "@jskit-ai/shell-web": "0.1.125",
+        "@jskit-ai/uploads-image-web": "0.1.100",
+        "@jskit-ai/users-core": "0.1.134",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -8096,30 +8096,30 @@
     },
     "packages/workspaces-core": {
       "name": "@jskit-ai/workspaces-core",
-      "version": "0.1.99",
+      "version": "0.1.100",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.120",
-        "@jskit-ai/database-runtime": "0.1.122",
-        "@jskit-ai/http-runtime": "0.1.121",
-        "@jskit-ai/json-rest-api-core": "0.1.67",
-        "@jskit-ai/kernel": "0.1.123",
-        "@jskit-ai/resource-core": "0.1.66",
-        "@jskit-ai/resource-crud-core": "0.1.66",
-        "@jskit-ai/users-core": "0.1.133",
+        "@jskit-ai/auth-core": "0.1.121",
+        "@jskit-ai/database-runtime": "0.1.123",
+        "@jskit-ai/http-runtime": "0.1.122",
+        "@jskit-ai/json-rest-api-core": "0.1.68",
+        "@jskit-ai/kernel": "0.1.124",
+        "@jskit-ai/resource-core": "0.1.67",
+        "@jskit-ai/resource-crud-core": "0.1.67",
+        "@jskit-ai/users-core": "0.1.134",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/workspaces-web": {
       "name": "@jskit-ai/workspaces-web",
-      "version": "0.1.100",
+      "version": "0.1.101",
       "dependencies": {
-        "@jskit-ai/auth-web": "0.1.123",
-        "@jskit-ai/http-runtime": "0.1.121",
-        "@jskit-ai/kernel": "0.1.123",
-        "@jskit-ai/shell-web": "0.1.124",
-        "@jskit-ai/users-core": "0.1.133",
-        "@jskit-ai/users-web": "0.1.139",
-        "@jskit-ai/workspaces-core": "0.1.99",
+        "@jskit-ai/auth-web": "0.1.124",
+        "@jskit-ai/http-runtime": "0.1.122",
+        "@jskit-ai/kernel": "0.1.124",
+        "@jskit-ai/shell-web": "0.1.125",
+        "@jskit-ai/users-core": "0.1.134",
+        "@jskit-ai/users-web": "0.1.140",
+        "@jskit-ai/workspaces-core": "0.1.100",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -8131,7 +8131,7 @@
     },
     "tooling/config-eslint": {
       "name": "@jskit-ai/config-eslint",
-      "version": "0.1.121",
+      "version": "0.1.122",
       "dependencies": {
         "@eslint/js": "^9.39.4",
         "eslint-plugin-vue": "^10.5.1",
@@ -8149,9 +8149,9 @@
     },
     "tooling/create-app": {
       "name": "@jskit-ai/create-app",
-      "version": "0.1.137",
+      "version": "0.1.139",
       "dependencies": {
-        "@jskit-ai/jskit-cli": "0.2.140"
+        "@jskit-ai/jskit-cli": "0.2.142"
       },
       "bin": {
         "jskit-create-app": "bin/jskit-create-app.js"
@@ -8162,18 +8162,18 @@
     },
     "tooling/jskit-catalog": {
       "name": "@jskit-ai/jskit-catalog",
-      "version": "0.1.135",
+      "version": "0.1.137",
       "engines": {
         "node": "^22.12.0 || ^24.0.0 || ^26.0.0"
       }
     },
     "tooling/jskit-cli": {
       "name": "@jskit-ai/jskit-cli",
-      "version": "0.2.140",
+      "version": "0.2.142",
       "dependencies": {
-        "@jskit-ai/jskit-catalog": "0.1.135",
-        "@jskit-ai/kernel": "0.1.123",
-        "@jskit-ai/shell-web": "0.1.124",
+        "@jskit-ai/jskit-catalog": "0.1.137",
+        "@jskit-ai/kernel": "0.1.124",
+        "@jskit-ai/shell-web": "0.1.125",
         "@vue/compiler-sfc": "^3.5.29",
         "ts-morph": "^28.0.0",
         "yaml": "^2.8.3"

--- a/packages/agent-docs/guide/agent/app-setup/database-layer.md
+++ b/packages/agent-docs/guide/agent/app-setup/database-layer.md
@@ -197,11 +197,15 @@ In JSKIT persistence code, **visibility** means "which rows should this request 
 - `public`
   - the record is not scoped by owner columns
 - `workspace`
-  - the record belongs to one workspace, usually through `workspace_id`
+  - the record belongs to one workspace through the exact reserved column `workspace_id`
 - `user`
-  - the record belongs to one user, usually through `user_id`
+  - the record belongs to one user through the exact reserved column `user_id`
 - `workspace_user`
-  - the record belongs to one workspace and one user together
+  - the record belongs to one workspace and one user through both reserved columns
+
+Only `workspace_id` and `user_id` carry this standard ownership contract. Specifically named foreign keys such as `recipient_user_id`, `created_by_user_id`, and `assignee_user_id` describe domain relationships; they are not alternate owner columns. Keep both fields when a row has an owner and a separate related actor, and never rename the relationship to an owner column merely to make a tool accept the schema.
+
+The selected ownership filter must match the direct reserved columns exactly. A table with only `workspace_id` is `workspace`; a table with only `user_id` is `user`; and a table with both is `workspace_user`. A declaration cannot override or ignore either column.
 
 That is why the shared helpers exist. Repositories should not have to re-implement the same ownership rules by hand every time they filter a query or build an insert payload.
 

--- a/packages/agent-docs/guide/agent/generators/advanced-cruds.md
+++ b/packages/agent-docs/guide/agent/generators/advanced-cruds.md
@@ -33,7 +33,8 @@ npx jskit generate crud-server-generator scaffold \
   --namespace contacts \
   --surface admin \
   --ownership-filter workspace \
-  --table-name contacts
+  --table-name contacts \
+  --grant-role member
 
 npx jskit generate crud-ui-generator crud \
   w/[workspaceSlug]/admin/contacts \
@@ -140,12 +141,20 @@ So the distinction is:
 
 That is why `--internal` is not a permissions shortcut and not a UI setting. It is a server-route exposure choice on top of the same CRUD ownership model.
 
+The workspace role-grant decision is separate too. Every workspace-required generation must choose `--grant-role <role-id>` or `--no-role-grant`; there is no implicit role. An application that assigns generated CRUD permissions to `member` uses `--grant-role member`. In particular, `--internal` does not imply `--no-role-grant`.
+
 ### Ownership controls which owner columns are expected
 
 The repository layer ultimately applies visibility through the standard owner columns:
 
 - `workspace_id`
 - `user_id`
+
+Those names are exact and reserved. `workspace_id` is workspace ownership; `user_id` is user ownership; both together are workspace-user ownership. Other foreign keys such as `recipient_user_id`, `created_by_user_id`, and `assignee_user_id` remain domain relationships and must not be treated as ownership aliases.
+
+The generated ownership filter must match that exact set of reserved columns. Neither an explicit filter nor generated metadata can override what those direct columns mean.
+
+If a row is workspace-owned but refers to a recipient, keep both concepts explicit: use `workspace_id` for ownership and `recipient_user_id` for the relationship. Renaming the relationship to `user_id` would opt the field into JSKIT's hidden owner-field and user-filtering behavior.
 
 That means the generated CRUD behaves like this:
 

--- a/packages/agent-docs/guide/agent/generators/crud-generators.md
+++ b/packages/agent-docs/guide/agent/generators/crud-generators.md
@@ -99,6 +99,27 @@ The supported values are:
 | `workspace` | rows belong to one workspace | `workspace_id` |
 | `workspace_user` | rows belong to one workspace and one user together | `workspace_id` and `user_id` |
 
+### Ownership column names are exact and reserved
+
+JSKIT ownership is explicit and materialized. Only these exact database columns carry the standard generated ownership contract:
+
+- `workspace_id`
+- `user_id`
+
+They are not ordinary foreign-key names. Generated CRUD infrastructure uses them for visibility filtering, create-time owner stamping, and hidden owner-field handling.
+
+Other foreign keys are domain relationships, even when their names end in `_user_id` or `_workspace_id`. For example:
+
+- `recipient_user_id` identifies a recipient
+- `created_by_user_id` records an author
+- `assignee_user_id` identifies an assignee
+
+Those fields do not become ownership aliases merely because they point to a user-owned table.
+
+The ownership filter must match the direct reserved columns exactly. A table with only `workspace_id` is `workspace`; one with only `user_id` is `user`; and one with both is `workspace_user`. Neither the CLI declaration nor generated metadata overrides those columns.
+
+Decide ownership first, select the matching ownership filter, and then model other actors with specifically named foreign keys. A workspace-owned notification outbox item that targets a user normally has `workspace_id` for ownership and `recipient_user_id` for the recipient relationship. Do not rename `recipient_user_id` to `user_id` merely to satisfy a generator or Doctor check; that would change the resource's ownership semantics.
+
 ### What each value means
 
 #### `public`
@@ -257,7 +278,8 @@ npx jskit generate crud-server-generator scaffold \
   --namespace contacts \
   --surface admin \
   --ownership-filter workspace \
-  --table-name contacts
+  --table-name contacts \
+  --grant-role member
 ```
 
 This creates an app-local package under `packages/contacts/`.
@@ -277,6 +299,46 @@ Use that when:
 - you are not ready to expose list/view/create/update/delete URLs yet
 
 Do **not** use `--internal` as a substitute for ownership or permissions design. It is only about whether the public HTTP CRUD routes exist.
+
+### Choose workspace role grants explicitly
+
+Workspace-required CRUD actions use the normal named permission ids:
+
+- `crud.<namespace>.list`
+- `crud.<namespace>.view`
+- `crud.<namespace>.create`
+- `crud.<namespace>.update`
+- `crud.<namespace>.delete`
+
+The generator never guesses which role should receive all five permissions. Every workspace-required CRUD command must choose one of these options:
+
+```bash
+--grant-role administrator
+```
+
+or:
+
+```bash
+--no-role-grant
+```
+
+`--grant-role` must name a configured role. `--no-role-grant` keeps the generated actions and their permission requirements but leaves the app's role catalog unchanged. The options are mutually exclusive.
+
+To assign the generated permissions to `member`, make that decision explicit:
+
+```bash
+--grant-role member
+```
+
+This decision is independent of `--internal`. For an internal, workspace-owned persistence resource whose generated actions should not be assigned to any actor role, use both:
+
+```bash
+--ownership-filter workspace \
+--internal \
+--no-role-grant
+```
+
+If neither explicit grant option is supplied, generation fails during preflight before writing files, even when a `member` role exists.
 
 Before generating anything, decide these with the developer:
 
@@ -420,7 +482,8 @@ npx jskit generate crud-server-generator scaffold \
   --namespace addresses \
   --surface admin \
   --ownership-filter workspace \
-  --table-name addresses
+  --table-name addresses \
+  --grant-role member
 ```
 
 Then install the generated local package:
@@ -596,7 +659,8 @@ npx jskit generate crud-server-generator scaffold \
   --namespace comments \
   --surface admin \
   --ownership-filter workspace \
-  --table-name comments
+  --table-name comments \
+  --grant-role member
 ```
 
 Then install the generated local package:

--- a/packages/agent-docs/package.json
+++ b/packages/agent-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/agent-docs",
-  "version": "0.1.88",
+  "version": "0.1.90",
   "description": "Distributed JSKIT agent references, prompts, guides, and generated reference maps.",
   "type": "module",
   "files": [

--- a/packages/agent-docs/patterns/crud-scaffolding.md
+++ b/packages/agent-docs/patterns/crud-scaffolding.md
@@ -24,6 +24,9 @@ Rules:
 - If `crud-server-generator` is going to own the CRUD, do not hand-write a separate CRUD migration for that table. The generator installs and manages the CRUD migration scaffold itself.
 - Do not scaffold CRUD UI, hand-build CRUD routes, or hand-build CRUD endpoints before the server CRUD package and shared resource file exist.
 - Treat the generated shared resource file as the canonical CRUD contract for later UI scaffolding and CRUD behavior changes.
+- Treat the exact columns `workspace_id` and `user_id` as reserved JSKIT ownership columns. They are the only standard columns used for generated ownership filtering and create-time owner stamping.
+- Treat other foreign keys such as `recipient_user_id`, `created_by_user_id`, `assignee_user_id`, and similarly specific names as domain relationships, not ownership aliases. Do not rename a relationship to `user_id` or `workspace_id` merely to satisfy tooling.
+- Require the resolved ownership filter to match the reserved columns exactly: neither the filter nor the schema may silently add or omit `workspace_id` or `user_id` ownership.
 - `feature-server-generator` is not the default lane for ordinary persisted entities. Use it for workflows or orchestration that sit on top of CRUD-owned tables, or for rare explicit non-CRUD exceptions.
 - Generated CRUD UI must be compact-first. Lists need searchable cards on compact widths and tables only for medium/expanded layouts.
 - Generated CRUD list screens need real loading, empty, and error states. Empty copy should name the resource, such as "No customers yet", and offer the create action when available.
@@ -41,6 +44,14 @@ Meaning of `--internal`:
 - it keeps the generated repository, service, actions, provider, resource, and CRUD migration ownership chain
 - it only suppresses public HTTP CRUD route registration
 - it is not a substitute for ownership columns or action/route permissions
+- it does not suppress generated action permission ids or decide which role receives them
+
+Workspace role grants:
+
+- every workspace-required CRUD generation must explicitly choose `--grant-role <role-id>` or `--no-role-grant`
+- applications that assign generated CRUD permissions to `member` must say `--grant-role member`; fixed-role applications must name one of their real roles or choose no automatic grant
+- `--grant-role` and `--no-role-grant` are permission-design choices independent of `--internal`
+- never invent a `member` role only to satisfy the generator
 
 When a weird-custom persistence lane is proposed:
 

--- a/packages/agent-docs/reference/autogen/packages/crud-server-generator.md
+++ b/packages/agent-docs/reference/autogen/packages/crud-server-generator.md
@@ -21,13 +21,16 @@ Exports
 - `resolveGenerationSnapshot({ appRoot, tableName, idColumnOption } = {})`
 - `renderCanonicalResourceFieldSchema(column, { fieldContractEntry = null } = {})`
 - `buildFieldContractEntries({ outputColumns = [], writableColumns = [], snapshot = {} } = {})`
-- `resolveCrudGenerationSurfaceId({ appRoot, options } = {})`
+- `resolveCrudGenerationSurfaceId({ appRoot, options, appConfig = null } = {})`
+- `prepareInstallHook({ appRoot, packageOptions = {} } = {})`
 - `__testables`
 Local functions
 - `resolveAllowedValues(schema = {}, fallbackValues = [])`
 - `resolveGlobalScaffoldCache()`
 - `asRecord(value)`
+- `resolveBooleanFlagOption(options = {}, optionName = "")`
 - `resolveInternalRouteOption(options = {})`
+- `resolveNoRoleGrantOption(options = {})`
 - `normalizeRequestedOwnershipFilter(value, { strict = false } = {})`
 - `inferOwnershipFilterFromSnapshot(snapshot)`
 - `assertOwnershipColumnsForFilter(snapshot, filter)`
@@ -36,7 +39,7 @@ Local functions
 - `loadEnvFromApp(appRoot)`
 - `createAppRequire(appRoot)`
 - `importModuleFromApp(appRequire, moduleId, contextLabel)`
-- `resolveCrudSurfaceRequiresWorkspace({ appRoot, options, surface = "" } = {})`
+- `resolveCrudSurfaceRequiresWorkspace({ appRoot, options, surface = "", appConfig = null } = {})`
 - `loadCrudAppConfig(appRoot = "")`
 - `resolveSurfaceDefinitions(appConfig = {})`
 - `resolveDefaultCrudSurfaceIdFromAppConfig(appConfig = {})`
@@ -84,8 +87,11 @@ Local functions
 - `normalizeFieldMetaUiOptions(rawOptions = [])`
 - `resolveEnumFieldMetaUiOptions(enumValues = [])`
 - `buildCrudPermissionIds(namespace = "")`
+- `resolveConfiguredRoleEntries(appConfig = {})`
+- `formatAvailableRoleIds(roleEntries = [])`
+- `resolveCrudPermissionGrantRole(appConfig = {}, options = {}, { requiresNamedPermissions = true } = {})`
 - `normalizeCrudOperation(operation = "", context = "CRUD operation")`
-- `renderRoleCatalogPermissionGrants(namespace = "", { requiresNamedPermissions = true } = {})`
+- `renderRoleCatalogPermissionGrants(namespace = "", { requiresNamedPermissions = true, grantRoleId = "" } = {})`
 - `renderActionPermissionSupport(namespace = "", { requiresNamedPermissions = true } = {})`
 - `renderActionPermissionExpression(operation = "", { requiresNamedPermissions = true } = {})`
 - `renderRouteWorkspaceSupportImports({ surfaceRequiresWorkspace = true } = {})`
@@ -96,7 +102,7 @@ Local functions
 - `renderObjectSchemaDefinition(lines = [], { mode = "patch" } = {})`
 - `renderActionInputExpressions({ surfaceRequiresWorkspace = true } = {})`
 - `renderRouteValidatorConstants({ surfaceRequiresWorkspace = true } = {})`
-- `buildReplacementsFromSnapshot({ namespace = "", snapshot, resolvedOwnershipFilter, surfaceRequiresWorkspace = true, surfaceId = "", routeInternal = false })`
+- `buildReplacementsFromSnapshot({ namespace = "", snapshot, resolvedOwnershipFilter, surfaceRequiresWorkspace = true, surfaceId = "", routeInternal = false, permissionGrantRoleId = "" })`
 - `resolveCrudGenerationTableName(options = {})`
 - `createCacheKey({ appRoot, options })`
 - `buildCrudTemplateContext(input = {})`

--- a/packages/agent-docs/site/guide/app-setup/database-layer.md
+++ b/packages/agent-docs/site/guide/app-setup/database-layer.md
@@ -246,11 +246,15 @@ In JSKIT persistence code, **visibility** means "which rows should this request 
 - `public`
   - the record is not scoped by owner columns
 - `workspace`
-  - the record belongs to one workspace, usually through `workspace_id`
+  - the record belongs to one workspace through the exact reserved column `workspace_id`
 - `user`
-  - the record belongs to one user, usually through `user_id`
+  - the record belongs to one user through the exact reserved column `user_id`
 - `workspace_user`
-  - the record belongs to one workspace and one user together
+  - the record belongs to one workspace and one user through both reserved columns
+
+Only `workspace_id` and `user_id` carry this standard ownership contract. Specifically named foreign keys such as `recipient_user_id`, `created_by_user_id`, and `assignee_user_id` describe domain relationships; they are not alternate owner columns. Keep both fields when a row has an owner and a separate related actor, and never rename the relationship to an owner column merely to make a tool accept the schema.
+
+The selected ownership filter must match the direct reserved columns exactly. A table with only `workspace_id` is `workspace`; a table with only `user_id` is `user`; and a table with both is `workspace_user`. A declaration cannot override or ignore either column.
 
 That is why the shared helpers exist. Repositories should not have to re-implement the same ownership rules by hand every time they filter a query or build an insert payload.
 

--- a/packages/agent-docs/site/guide/generators/advanced-cruds.md
+++ b/packages/agent-docs/site/guide/generators/advanced-cruds.md
@@ -31,7 +31,8 @@ npx jskit generate crud-server-generator scaffold \
   --namespace contacts \
   --surface admin \
   --ownership-filter workspace \
-  --table-name contacts
+  --table-name contacts \
+  --grant-role member
 
 npx jskit generate crud-ui-generator crud \
   w/[workspaceSlug]/admin/contacts \
@@ -138,12 +139,20 @@ So the distinction is:
 
 That is why `--internal` is not a permissions shortcut and not a UI setting. It is a server-route exposure choice on top of the same CRUD ownership model.
 
+The workspace role-grant decision is separate too. Every workspace-required generation must choose `--grant-role <role-id>` or `--no-role-grant`; there is no implicit role. An application that assigns generated CRUD permissions to `member` uses `--grant-role member`. In particular, `--internal` does not imply `--no-role-grant`.
+
 ### Ownership controls which owner columns are expected
 
 The repository layer ultimately applies visibility through the standard owner columns:
 
 - `workspace_id`
 - `user_id`
+
+Those names are exact and reserved. `workspace_id` is workspace ownership; `user_id` is user ownership; both together are workspace-user ownership. Other foreign keys such as `recipient_user_id`, `created_by_user_id`, and `assignee_user_id` remain domain relationships and must not be treated as ownership aliases.
+
+The generated ownership filter must match that exact set of reserved columns. Neither an explicit filter nor generated metadata can override what those direct columns mean.
+
+If a row is workspace-owned but refers to a recipient, keep both concepts explicit: use `workspace_id` for ownership and `recipient_user_id` for the relationship. Renaming the relationship to `user_id` would opt the field into JSKIT's hidden owner-field and user-filtering behavior.
 
 That means the generated CRUD behaves like this:
 

--- a/packages/agent-docs/site/guide/generators/crud-generators.md
+++ b/packages/agent-docs/site/guide/generators/crud-generators.md
@@ -97,6 +97,27 @@ The supported values are:
 | `workspace` | rows belong to one workspace | `workspace_id` |
 | `workspace_user` | rows belong to one workspace and one user together | `workspace_id` and `user_id` |
 
+### Ownership column names are exact and reserved
+
+JSKIT ownership is explicit and materialized. Only these exact database columns carry the standard generated ownership contract:
+
+- `workspace_id`
+- `user_id`
+
+They are not ordinary foreign-key names. Generated CRUD infrastructure uses them for visibility filtering, create-time owner stamping, and hidden owner-field handling.
+
+Other foreign keys are domain relationships, even when their names end in `_user_id` or `_workspace_id`. For example:
+
+- `recipient_user_id` identifies a recipient
+- `created_by_user_id` records an author
+- `assignee_user_id` identifies an assignee
+
+Those fields do not become ownership aliases merely because they point to a user-owned table.
+
+The ownership filter must match the direct reserved columns exactly. A table with only `workspace_id` is `workspace`; one with only `user_id` is `user`; and one with both is `workspace_user`. Neither the CLI declaration nor generated metadata overrides those columns.
+
+Decide ownership first, select the matching ownership filter, and then model other actors with specifically named foreign keys. A workspace-owned notification outbox item that targets a user normally has `workspace_id` for ownership and `recipient_user_id` for the recipient relationship. Do not rename `recipient_user_id` to `user_id` merely to satisfy a generator or Doctor check; that would change the resource's ownership semantics.
+
 ### What each value means
 
 #### `public`
@@ -255,7 +276,8 @@ npx jskit generate crud-server-generator scaffold \
   --namespace contacts \
   --surface admin \
   --ownership-filter workspace \
-  --table-name contacts
+  --table-name contacts \
+  --grant-role member
 ```
 
 This creates an app-local package under `packages/contacts/`.
@@ -275,6 +297,46 @@ Use that when:
 - you are not ready to expose list/view/create/update/delete URLs yet
 
 Do **not** use `--internal` as a substitute for ownership or permissions design. It is only about whether the public HTTP CRUD routes exist.
+
+### Choose workspace role grants explicitly
+
+Workspace-required CRUD actions use the normal named permission ids:
+
+- `crud.<namespace>.list`
+- `crud.<namespace>.view`
+- `crud.<namespace>.create`
+- `crud.<namespace>.update`
+- `crud.<namespace>.delete`
+
+The generator never guesses which role should receive all five permissions. Every workspace-required CRUD command must choose one of these options:
+
+```bash
+--grant-role administrator
+```
+
+or:
+
+```bash
+--no-role-grant
+```
+
+`--grant-role` must name a configured role. `--no-role-grant` keeps the generated actions and their permission requirements but leaves the app's role catalog unchanged. The options are mutually exclusive.
+
+To assign the generated permissions to `member`, make that decision explicit:
+
+```bash
+--grant-role member
+```
+
+This decision is independent of `--internal`. For an internal, workspace-owned persistence resource whose generated actions should not be assigned to any actor role, use both:
+
+```bash
+--ownership-filter workspace \
+--internal \
+--no-role-grant
+```
+
+If neither explicit grant option is supplied, generation fails during preflight before writing files, even when a `member` role exists.
 
 Before generating anything, decide these with the developer:
 
@@ -418,7 +480,8 @@ npx jskit generate crud-server-generator scaffold \
   --namespace addresses \
   --surface admin \
   --ownership-filter workspace \
-  --table-name addresses
+  --table-name addresses \
+  --grant-role member
 ```
 
 Then install the generated local package:
@@ -594,7 +657,8 @@ npx jskit generate crud-server-generator scaffold \
   --namespace comments \
   --surface admin \
   --ownership-filter workspace \
-  --table-name comments
+  --table-name comments \
+  --grant-role member
 ```
 
 Then install the generated local package:

--- a/packages/agent-docs/test/crudGuidance.test.js
+++ b/packages/agent-docs/test/crudGuidance.test.js
@@ -29,3 +29,23 @@ test("crud scaffolding pattern requires approval for weird custom persistence la
   assert.match(pattern, /Record the exact approval and the approved exception in `.jskit\/WORKBOARD.md` before coding/);
   assert.match(pattern, /Without that explicit approval record, do not take the weird-custom persistence path/);
 });
+
+test("crud guidance keeps canonical ownership columns distinct from domain relationships", async () => {
+  const pattern = await readFile(path.join(packageRoot, "patterns/crud-scaffolding.md"), "utf8");
+  const generatorGuide = await readFile(path.join(packageRoot, "site/guide/generators/crud-generators.md"), "utf8");
+  const advancedGuide = await readFile(path.join(packageRoot, "site/guide/generators/advanced-cruds.md"), "utf8");
+
+  for (const source of [pattern, generatorGuide, advancedGuide]) {
+    assert.match(source, /exact.*`workspace_id`.*`user_id`|`workspace_id`.*`user_id`.*exact/s);
+    assert.match(source, /`recipient_user_id`/);
+    assert.match(source, /domain relationship/);
+  }
+
+  assert.match(pattern, /`--grant-role <role-id>`/);
+  assert.match(pattern, /`--no-role-grant`/);
+  assert.match(pattern, /every workspace-required CRUD generation must explicitly choose/);
+  assert.match(generatorGuide, /even when a `member` role exists/);
+  assert.match(generatorGuide, /ownership filter must match the direct reserved columns exactly/);
+  assert.doesNotMatch(generatorGuide, /historical|former|Migrating commands created before/);
+  assert.match(generatorGuide, /`--internal` does not imply `--no-role-grant`|This decision is independent of `--internal`/);
+});

--- a/packages/assistant-core/package.descriptor.mjs
+++ b/packages/assistant-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-core",
-  version: "0.1.100",
+  version: "0.1.101",
   kind: "runtime",
   description: "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
   dependsOn: [
@@ -47,11 +47,11 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/http-runtime": "0.1.121",
-        "@jskit-ai/kernel": "0.1.123",
-        "@jskit-ai/resource-core": "0.1.66",
-        "@jskit-ai/resource-crud-core": "0.1.66",
-        "@jskit-ai/users-core": "0.1.133",
+        "@jskit-ai/http-runtime": "0.1.122",
+        "@jskit-ai/kernel": "0.1.124",
+        "@jskit-ai/resource-core": "0.1.67",
+        "@jskit-ai/resource-crud-core": "0.1.67",
+        "@jskit-ai/users-core": "0.1.134",
         "dompurify": "^3.3.3",
         "json-rest-schema": "1.x.x",
         "marked": "^17.0.4",

--- a/packages/assistant-core/package.json
+++ b/packages/assistant-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-core",
-  "version": "0.1.100",
+  "version": "0.1.101",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,12 +11,12 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.122",
-    "@jskit-ai/http-runtime": "0.1.121",
-    "@jskit-ai/kernel": "0.1.123",
-    "@jskit-ai/resource-crud-core": "0.1.66",
-    "@jskit-ai/resource-core": "0.1.66",
-    "@jskit-ai/users-core": "0.1.133",
+    "@jskit-ai/database-runtime": "0.1.123",
+    "@jskit-ai/http-runtime": "0.1.122",
+    "@jskit-ai/kernel": "0.1.124",
+    "@jskit-ai/resource-crud-core": "0.1.67",
+    "@jskit-ai/resource-core": "0.1.67",
+    "@jskit-ai/users-core": "0.1.134",
     "dompurify": "^3.4.12",
     "json-rest-schema": "1.x.x",
     "marked": "^17.0.4",

--- a/packages/assistant-runtime/package.descriptor.mjs
+++ b/packages/assistant-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-runtime",
-  version: "0.1.95",
+  version: "0.1.96",
   kind: "runtime",
   description: "Shared assistant runtime with per-surface assistant registration.",
   dependsOn: [
@@ -95,13 +95,13 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/assistant-core": "0.1.100",
-        "@jskit-ai/database-runtime": "0.1.122",
-        "@jskit-ai/http-runtime": "0.1.121",
-        "@jskit-ai/kernel": "0.1.123",
-        "@jskit-ai/shell-web": "0.1.124",
-        "@jskit-ai/users-core": "0.1.133",
-        "@jskit-ai/users-web": "0.1.139"
+        "@jskit-ai/assistant-core": "0.1.101",
+        "@jskit-ai/database-runtime": "0.1.123",
+        "@jskit-ai/http-runtime": "0.1.122",
+        "@jskit-ai/kernel": "0.1.124",
+        "@jskit-ai/shell-web": "0.1.125",
+        "@jskit-ai/users-core": "0.1.134",
+        "@jskit-ai/users-web": "0.1.140"
       },
       dev: {}
     },

--- a/packages/assistant-runtime/package.json
+++ b/packages/assistant-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-runtime",
-  "version": "0.1.95",
+  "version": "0.1.96",
   "type": "module",
   "exports": {
     "./client": "./src/client/index.js",
@@ -8,13 +8,13 @@
     "./server/actionIds": "./src/server/actionIds.js"
   },
   "dependencies": {
-    "@jskit-ai/assistant-core": "0.1.100",
-    "@jskit-ai/database-runtime": "0.1.122",
-    "@jskit-ai/http-runtime": "0.1.121",
-    "@jskit-ai/kernel": "0.1.123",
-    "@jskit-ai/shell-web": "0.1.124",
-    "@jskit-ai/users-core": "0.1.133",
-    "@jskit-ai/users-web": "0.1.139",
+    "@jskit-ai/assistant-core": "0.1.101",
+    "@jskit-ai/database-runtime": "0.1.123",
+    "@jskit-ai/http-runtime": "0.1.122",
+    "@jskit-ai/kernel": "0.1.124",
+    "@jskit-ai/shell-web": "0.1.125",
+    "@jskit-ai/users-core": "0.1.134",
+    "@jskit-ai/users-web": "0.1.140",
     "json-rest-schema": "1.x.x"
   },
   "peerDependencies": {

--- a/packages/assistant/package.descriptor.mjs
+++ b/packages/assistant/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant",
-  version: "0.1.132",
+  version: "0.1.133",
   kind: "generator",
   description: "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
   options: {

--- a/packages/assistant/package.json
+++ b/packages/assistant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant",
-  "version": "0.1.132",
+  "version": "0.1.133",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.123"
+    "@jskit-ai/kernel": "0.1.124"
   }
 }

--- a/packages/auth-core/package.descriptor.mjs
+++ b/packages/auth-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-core",
-  "version": "0.1.120",
+  "version": "0.1.121",
   "kind": "runtime",
   "dependsOn": [
     "@jskit-ai/value-app-config-shared"
@@ -74,7 +74,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.123",
+        "@jskit-ai/kernel": "0.1.124",
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0"

--- a/packages/auth-core/package.json
+++ b/packages/auth-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-core",
-  "version": "0.1.120",
+  "version": "0.1.121",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -56,7 +56,7 @@
     "./shared/commands/authSessionReadCommand": "./src/shared/commands/authSessionReadCommand.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.123",
+    "@jskit-ai/kernel": "0.1.124",
     "@fastify/cookie": "^11.0.2",
     "@fastify/csrf-protection": "^7.1.0",
     "@fastify/rate-limit": "^10.3.0",

--- a/packages/auth-provider-local-core/package.descriptor.mjs
+++ b/packages/auth-provider-local-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-provider-local-core",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "kind": "runtime",
   "description": "Local auth provider with a file backend default and no database requirement.",
   "dependsOn": [
@@ -64,8 +64,8 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/auth-core": "0.1.120",
-        "@jskit-ai/kernel": "0.1.123",
+        "@jskit-ai/auth-core": "0.1.121",
+        "@jskit-ai/kernel": "0.1.124",
         "nodemailer": "^9.0.3",
         "dotenv": "^16.4.5"
       },

--- a/packages/auth-provider-local-core/package.json
+++ b/packages/auth-provider-local-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-local-core",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,8 +11,8 @@
     "./server/lib/index": "./src/server/lib/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.120",
-    "@jskit-ai/kernel": "0.1.123",
+    "@jskit-ai/auth-core": "0.1.121",
+    "@jskit-ai/kernel": "0.1.124",
     "nodemailer": "^9.0.3"
   }
 }

--- a/packages/auth-provider-local-db-core/package.descriptor.mjs
+++ b/packages/auth-provider-local-db-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/auth-provider-local-db-core",
-  version: "0.1.15",
+  version: "0.1.16",
   kind: "runtime",
   description: "Database-backed local auth storage backend for JSKIT local auth.",
   dependsOn: [
@@ -80,9 +80,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-provider-local-core": "0.1.24",
-        "@jskit-ai/database-runtime": "0.1.122",
-        "@jskit-ai/kernel": "0.1.123"
+        "@jskit-ai/auth-provider-local-core": "0.1.25",
+        "@jskit-ai/database-runtime": "0.1.123",
+        "@jskit-ai/kernel": "0.1.124"
       },
       dev: {}
     },

--- a/packages/auth-provider-local-db-core/package.json
+++ b/packages/auth-provider-local-db-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-local-db-core",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,8 +10,8 @@
     "./server/lib/index": "./src/server/lib/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-provider-local-core": "0.1.24",
-    "@jskit-ai/database-runtime": "0.1.122",
-    "@jskit-ai/kernel": "0.1.123"
+    "@jskit-ai/auth-provider-local-core": "0.1.25",
+    "@jskit-ai/database-runtime": "0.1.123",
+    "@jskit-ai/kernel": "0.1.124"
   }
 }

--- a/packages/auth-provider-supabase-core/package.descriptor.mjs
+++ b/packages/auth-provider-supabase-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.121",
+  "version": "0.1.122",
   "kind": "runtime",
   "options": {
     "auth-supabase-url": {
@@ -83,8 +83,8 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/auth-core": "0.1.120",
-        "@jskit-ai/kernel": "0.1.123",
+        "@jskit-ai/auth-core": "0.1.121",
+        "@jskit-ai/kernel": "0.1.124",
         "dotenv": "^16.4.5",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0"

--- a/packages/auth-provider-supabase-core/package.json
+++ b/packages/auth-provider-supabase-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.121",
+  "version": "0.1.122",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,8 +12,8 @@
     "./client": "./src/client/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.120",
-    "@jskit-ai/kernel": "0.1.123",
+    "@jskit-ai/auth-core": "0.1.121",
+    "@jskit-ai/kernel": "0.1.124",
     "json-rest-schema": "1.x.x",
     "jose": "^6.1.0",
     "@supabase/supabase-js": "^2.57.4",

--- a/packages/auth-web/package.descriptor.mjs
+++ b/packages/auth-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-web",
-  "version": "0.1.123",
+  "version": "0.1.124",
   "kind": "runtime",
   "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
   "dependsOn": [
@@ -264,10 +264,10 @@ export default Object.freeze({
     "dependencies": {
       "runtime": {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/auth-core": "0.1.120",
-        "@jskit-ai/http-runtime": "0.1.121",
-        "@jskit-ai/kernel": "0.1.123",
-        "@jskit-ai/shell-web": "0.1.124"
+        "@jskit-ai/auth-core": "0.1.121",
+        "@jskit-ai/http-runtime": "0.1.122",
+        "@jskit-ai/kernel": "0.1.124",
+        "@jskit-ai/shell-web": "0.1.125"
       },
       "dev": {}
     },

--- a/packages/auth-web/package.json
+++ b/packages/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-web",
-  "version": "0.1.123",
+  "version": "0.1.124",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -20,11 +20,11 @@
     "./test/playwright": "./src/test/playwright.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.120",
+    "@jskit-ai/auth-core": "0.1.121",
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/kernel": "0.1.123",
-    "@jskit-ai/shell-web": "0.1.124",
-    "@jskit-ai/http-runtime": "0.1.121"
+    "@jskit-ai/kernel": "0.1.124",
+    "@jskit-ai/shell-web": "0.1.125",
+    "@jskit-ai/http-runtime": "0.1.122"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/console-core/package.descriptor.mjs
+++ b/packages/console-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-core",
-  version: "0.1.86",
+  version: "0.1.87",
   kind: "runtime",
   description: "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
   dependsOn: [
@@ -85,12 +85,12 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.120",
-        "@jskit-ai/database-runtime": "0.1.122",
-        "@jskit-ai/http-runtime": "0.1.121",
-        "@jskit-ai/kernel": "0.1.123",
-        "@jskit-ai/resource-crud-core": "0.1.66",
-        "@jskit-ai/users-core": "0.1.133"
+        "@jskit-ai/auth-core": "0.1.121",
+        "@jskit-ai/database-runtime": "0.1.123",
+        "@jskit-ai/http-runtime": "0.1.122",
+        "@jskit-ai/kernel": "0.1.124",
+        "@jskit-ai/resource-crud-core": "0.1.67",
+        "@jskit-ai/users-core": "0.1.134"
       },
       dev: {}
     },

--- a/packages/console-core/package.json
+++ b/packages/console-core/package.json
@@ -1,17 +1,17 @@
 {
   "name": "@jskit-ai/console-core",
-  "version": "0.1.86",
+  "version": "0.1.87",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.120",
-    "@jskit-ai/database-runtime": "0.1.122",
-    "@jskit-ai/http-runtime": "0.1.121",
-    "@jskit-ai/kernel": "0.1.123",
-    "@jskit-ai/resource-crud-core": "0.1.66",
-    "@jskit-ai/users-core": "0.1.133",
+    "@jskit-ai/auth-core": "0.1.121",
+    "@jskit-ai/database-runtime": "0.1.123",
+    "@jskit-ai/http-runtime": "0.1.122",
+    "@jskit-ai/kernel": "0.1.124",
+    "@jskit-ai/resource-crud-core": "0.1.67",
+    "@jskit-ai/users-core": "0.1.134",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/console-web/package.descriptor.mjs
+++ b/packages/console-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-web",
-  version: "0.1.91",
+  version: "0.1.92",
   kind: "runtime",
   description: "Authenticated console surface scaffold and surface policy wiring.",
   dependsOn: [
@@ -103,9 +103,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-web": "0.1.123",
-        "@jskit-ai/console-core": "0.1.86",
-        "@jskit-ai/shell-web": "0.1.124",
+        "@jskit-ai/auth-web": "0.1.124",
+        "@jskit-ai/console-core": "0.1.87",
+        "@jskit-ai/shell-web": "0.1.125",
       },
       dev: {}
     },

--- a/packages/console-web/package.json
+++ b/packages/console-web/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/console-web",
-  "version": "0.1.91",
+  "version": "0.1.92",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-web": "0.1.123",
-    "@jskit-ai/console-core": "0.1.86",
-    "@jskit-ai/shell-web": "0.1.124"
+    "@jskit-ai/auth-web": "0.1.124",
+    "@jskit-ai/console-core": "0.1.87",
+    "@jskit-ai/shell-web": "0.1.125"
   }
 }

--- a/packages/crud-core/package.descriptor.mjs
+++ b/packages/crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-core",
-  version: "0.1.131",
+  version: "0.1.132",
   kind: "runtime",
   description: "Shared CRUD helpers used by CRUD modules.",
   dependsOn: [
@@ -28,7 +28,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/crud-core": "0.1.131"
+        "@jskit-ai/crud-core": "0.1.132"
       },
       dev: {}
     },

--- a/packages/crud-core/package.json
+++ b/packages/crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-core",
-  "version": "0.1.131",
+  "version": "0.1.132",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -27,15 +27,15 @@
     "./server/routeContracts": "./src/server/routeContracts.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.122",
-    "@jskit-ai/http-runtime": "0.1.121",
-    "@jskit-ai/kernel": "0.1.123",
+    "@jskit-ai/database-runtime": "0.1.123",
+    "@jskit-ai/http-runtime": "0.1.122",
+    "@jskit-ai/kernel": "0.1.124",
     "json-rest-schema": "1.x.x",
-    "@jskit-ai/realtime": "0.1.120",
-    "@jskit-ai/resource-crud-core": "0.1.66",
-    "@jskit-ai/shell-web": "0.1.124",
-    "@jskit-ai/users-core": "0.1.133",
-    "@jskit-ai/users-web": "0.1.139"
+    "@jskit-ai/realtime": "0.1.121",
+    "@jskit-ai/resource-crud-core": "0.1.67",
+    "@jskit-ai/shell-web": "0.1.125",
+    "@jskit-ai/users-core": "0.1.134",
+    "@jskit-ai/users-web": "0.1.140"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/crud-server-generator/package.descriptor.mjs
+++ b/packages/crud-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-server-generator",
-  version: "0.1.131",
+  version: "0.1.133",
   kind: "generator",
   description: "CRUD server generator with routes, actions, and persistence scaffolding.",
   options: {
@@ -63,6 +63,20 @@ export default Object.freeze({
       defaultValue: "",
       promptLabel: "Internal HTTP routes",
       promptHint: "Mark generated CRUD HTTP routes as internal-only so they are not publicly registered."
+    },
+    "grant-role": {
+      required: false,
+      inputType: "text",
+      defaultValue: "",
+      promptLabel: "CRUD permission grant role",
+      promptHint: "Configured workspace role that receives generated CRUD permissions; choose this or --no-role-grant."
+    },
+    "no-role-grant": {
+      required: false,
+      inputType: "flag",
+      defaultValue: "",
+      promptLabel: "Skip automatic role grant",
+      promptHint: "Generate normal CRUD permissions without assigning them to a workspace role."
     }
   },
   optionPolicies: {
@@ -98,6 +112,14 @@ export default Object.freeze({
       ]
     }
   },
+  lifecycle: {
+    install: {
+      prepare: {
+        entrypoint: "src/server/buildTemplateContext.js",
+        export: "prepareInstallHook"
+      }
+    }
+  },
   metadata: {
     generatorPrimarySubcommand: "scaffold",
     generatorSubcommands: {
@@ -111,7 +133,9 @@ export default Object.freeze({
           "id-column",
           "directory-prefix",
           "force",
-          "internal"
+          "internal",
+          "grant-role",
+          "no-role-grant"
         ],
         createTarget: {
           pathTemplate: "packages/${option:namespace|kebab}",
@@ -160,14 +184,14 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.120",
-        "@jskit-ai/crud-core": "0.1.131",
-        "@jskit-ai/database-runtime": "0.1.122",
-        "@jskit-ai/http-runtime": "0.1.121",
-        "@jskit-ai/json-rest-api-core": "0.1.67",
-        "@jskit-ai/kernel": "0.1.123",
-        "@jskit-ai/realtime": "0.1.120",
-        "@jskit-ai/resource-crud-core": "0.1.66",
+        "@jskit-ai/auth-core": "0.1.121",
+        "@jskit-ai/crud-core": "0.1.132",
+        "@jskit-ai/database-runtime": "0.1.123",
+        "@jskit-ai/http-runtime": "0.1.122",
+        "@jskit-ai/json-rest-api-core": "0.1.68",
+        "@jskit-ai/kernel": "0.1.124",
+        "@jskit-ai/realtime": "0.1.121",
+        "@jskit-ai/resource-crud-core": "0.1.67",
         "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}"
       },
       dev: {}
@@ -285,7 +309,7 @@ export default Object.freeze({
         position: "bottom",
         skipIfContains: "\"crud.${option:namespace|snake}.list\"",
         value: "__JSKIT_CRUD_ROLE_CATALOG_PERMISSION_GRANTS__",
-        reason: "Grant generated CRUD action permissions to the default member role in the app-owned role catalog.",
+        reason: "Grant generated CRUD action permissions to the selected role in the app-owned role catalog.",
         category: "crud",
         id: "crud-role-catalog-permissions-${option:namespace|snake}",
         templateContext: {

--- a/packages/crud-server-generator/package.json
+++ b/packages/crud-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-server-generator",
-  "version": "0.1.131",
+  "version": "0.1.133",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,12 +13,12 @@
   },
   "dependencies": {
     "@babel/parser": "^7.29.2",
-    "@jskit-ai/crud-core": "0.1.131",
-    "@jskit-ai/database-runtime": "0.1.122",
-    "@jskit-ai/http-runtime": "0.1.121",
-    "@jskit-ai/json-rest-api-core": "0.1.67",
-    "@jskit-ai/kernel": "0.1.123",
-    "@jskit-ai/resource-crud-core": "0.1.66",
+    "@jskit-ai/crud-core": "0.1.132",
+    "@jskit-ai/database-runtime": "0.1.123",
+    "@jskit-ai/http-runtime": "0.1.122",
+    "@jskit-ai/json-rest-api-core": "0.1.68",
+    "@jskit-ai/kernel": "0.1.124",
+    "@jskit-ai/resource-crud-core": "0.1.67",
     "recast": "^0.23.11"
   }
 }

--- a/packages/crud-server-generator/src/server/buildTemplateContext.js
+++ b/packages/crud-server-generator/src/server/buildTemplateContext.js
@@ -82,17 +82,27 @@ function asRecord(value) {
   return value;
 }
 
-function resolveInternalRouteOption(options = {}) {
-  if (!Object.prototype.hasOwnProperty.call(options, "internal")) {
+function resolveBooleanFlagOption(options = {}, optionName = "") {
+  const normalizedOptionName = normalizeText(optionName);
+  if (!normalizedOptionName || !Object.prototype.hasOwnProperty.call(options, normalizedOptionName)) {
     return false;
   }
-  if (options.internal === undefined || options.internal === true) {
+  const value = options[normalizedOptionName];
+  if (value === undefined || value === true) {
     return true;
   }
-  if (options.internal === "" || options.internal == null || options.internal === false) {
+  if (value === "" || value == null || value === false) {
     return false;
   }
-  return normalizeBoolean(options.internal);
+  return normalizeBoolean(value);
+}
+
+function resolveInternalRouteOption(options = {}) {
+  return resolveBooleanFlagOption(options, "internal");
+}
+
+function resolveNoRoleGrantOption(options = {}) {
+  return resolveBooleanFlagOption(options, "no-role-grant");
 }
 
 function normalizeRequestedOwnershipFilter(value, { strict = false } = {}) {
@@ -126,9 +136,6 @@ function inferOwnershipFilterFromSnapshot(snapshot) {
 function assertOwnershipColumnsForFilter(snapshot, filter) {
   const hasWorkspace = snapshot?.hasWorkspaceIdColumn === true;
   const hasUser = snapshot?.hasUserIdColumn === true;
-  if (filter === "public") {
-    return;
-  }
   if (filter === "workspace" && !hasWorkspace) {
     throw new Error(
       'Ownership filter "workspace" requires column "workspace_id".'
@@ -142,6 +149,20 @@ function assertOwnershipColumnsForFilter(snapshot, filter) {
   if (filter === "workspace_user" && (!hasWorkspace || !hasUser)) {
     throw new Error(
       'Ownership filter "workspace_user" requires both columns "workspace_id" and "user_id".'
+    );
+  }
+
+  const inferredFilter = inferOwnershipFilterFromSnapshot(snapshot);
+  if (filter !== inferredFilter) {
+    const directOwnerColumns = [
+      ...(hasWorkspace ? ["workspace_id"] : []),
+      ...(hasUser ? ["user_id"] : [])
+    ];
+    throw new Error(
+      `Ownership filter "${filter}" conflicts with the table's reserved ownership columns ` +
+        `${directOwnerColumns.length > 0 ? directOwnerColumns.map((columnName) => `"${columnName}"`).join(", ") : "(none)"}. ` +
+        `Use ownership filter "${inferredFilter}". The exact columns "workspace_id" and "user_id" define JSKIT ownership; ` +
+        "rename domain relationships to a specific foreign-key name instead of using a reserved ownership column."
     );
   }
 }
@@ -246,7 +267,8 @@ async function importModuleFromApp(appRequire, moduleId, contextLabel) {
 async function resolveCrudSurfaceRequiresWorkspace({
   appRoot,
   options,
-  surface = ""
+  surface = "",
+  appConfig = null
 } = {}) {
   const namespace = normalizeText(options?.namespace);
   const resolvedSurface = normalizeText(surface || options?.surface);
@@ -257,14 +279,16 @@ async function resolveCrudSurfaceRequiresWorkspace({
     throw new Error('crud template context requires option "surface".');
   }
 
-  const appConfig = await loadCrudAppConfig(appRoot);
+  const resolvedAppConfig = appConfig && typeof appConfig === "object"
+    ? appConfig
+    : await loadCrudAppConfig(appRoot);
   const crudPolicy = resolveCrudSurfacePolicyFromAppConfig(
     {
       namespace,
       surface: resolvedSurface,
       ownershipFilter: options?.["ownership-filter"]
     },
-    appConfig,
+    resolvedAppConfig,
     {
       context: "crud template context"
     }
@@ -318,15 +342,18 @@ function resolveDefaultCrudSurfaceIdFromAppConfig(appConfig = {}) {
 
 async function resolveCrudGenerationSurfaceId({
   appRoot,
-  options
+  options,
+  appConfig = null
 } = {}) {
   const explicitSurface = normalizeText(options?.surface).toLowerCase();
   if (explicitSurface) {
     return explicitSurface;
   }
 
-  const appConfig = await loadCrudAppConfig(appRoot);
-  const defaultSurface = resolveDefaultCrudSurfaceIdFromAppConfig(appConfig);
+  const resolvedAppConfig = appConfig && typeof appConfig === "object"
+    ? appConfig
+    : await loadCrudAppConfig(appRoot);
+  const defaultSurface = resolveDefaultCrudSurfaceIdFromAppConfig(resolvedAppConfig);
   if (defaultSurface) {
     return defaultSurface;
   }
@@ -1645,6 +1672,87 @@ function buildCrudPermissionIds(namespace = "") {
   );
 }
 
+function resolveConfiguredRoleEntries(appConfig = {}) {
+  const configuredRoles = asRecord(appConfig?.roleCatalog?.roles);
+  return Object.entries(configuredRoles)
+    .map(([roleId, definition]) => ({
+      configuredRoleId: roleId,
+      normalizedRoleId: normalizeText(roleId).toLowerCase(),
+      definition: asRecord(definition)
+    }))
+    .filter((entry) => entry.normalizedRoleId);
+}
+
+function formatAvailableRoleIds(roleEntries = []) {
+  const roleIds = (Array.isArray(roleEntries) ? roleEntries : [])
+    .map((entry) => normalizeText(entry?.normalizedRoleId))
+    .filter(Boolean)
+    .sort((left, right) => left.localeCompare(right));
+  return roleIds.length > 0 ? roleIds.join(", ") : "(none)";
+}
+
+function resolveCrudPermissionGrantRole(
+  appConfig = {},
+  options = {},
+  { requiresNamedPermissions = true } = {}
+) {
+  const requestedRoleId = normalizeText(options?.["grant-role"]).toLowerCase();
+  const noRoleGrant = resolveNoRoleGrantOption(options);
+
+  if (requestedRoleId && noRoleGrant) {
+    throw new Error('CRUD generation options "--grant-role" and "--no-role-grant" cannot be used together.');
+  }
+
+  if (!requiresNamedPermissions) {
+    if (requestedRoleId || noRoleGrant) {
+      throw new Error(
+        'CRUD generation options "--grant-role" and "--no-role-grant" apply only to surfaces that require a workspace.'
+      );
+    }
+    return "";
+  }
+
+  if (noRoleGrant) {
+    return "";
+  }
+
+  const roleEntries = resolveConfiguredRoleEntries(appConfig);
+  const availableRoleIds = formatAvailableRoleIds(roleEntries);
+  if (!requestedRoleId) {
+    throw new Error(
+      "Workspace CRUD generation requires an explicit permission grant policy. " +
+        'Use "--grant-role <role-id>" or "--no-role-grant". ' +
+        `Available roles: ${availableRoleIds}.`
+    );
+  }
+
+  const roleEntryById = new Map(
+    roleEntries.map((entry) => [entry.normalizedRoleId, entry])
+  );
+  const targetRole = roleEntryById.get(requestedRoleId) || null;
+
+  if (!targetRole) {
+    throw new Error(
+      `CRUD permission grant role "${requestedRoleId}" is not configured in roleCatalog.roles. ` +
+        `Available roles: ${availableRoleIds}.`
+    );
+  }
+
+  if (!Array.isArray(targetRole.definition.permissions)) {
+    throw new Error(
+      `roleCatalog.roles.${targetRole.normalizedRoleId}.permissions must be an array before CRUD permissions can be granted.`
+    );
+  }
+  if (!Object.isExtensible(targetRole.definition.permissions)) {
+    throw new Error(
+      `roleCatalog.roles.${targetRole.normalizedRoleId}.permissions must be mutable before CRUD permissions can be granted. ` +
+        'Use "--no-role-grant" when the role catalog must remain immutable.'
+    );
+  }
+
+  return targetRole.configuredRoleId;
+}
+
 function normalizeCrudOperation(operation = "", context = "CRUD operation") {
   const normalizedOperation = normalizeText(operation).toLowerCase();
   if (!CRUD_PERMISSION_OPERATIONS.includes(normalizedOperation)) {
@@ -1653,14 +1761,20 @@ function normalizeCrudOperation(operation = "", context = "CRUD operation") {
   return normalizedOperation;
 }
 
-function renderRoleCatalogPermissionGrants(namespace = "", { requiresNamedPermissions = true } = {}) {
+function renderRoleCatalogPermissionGrants(
+  namespace = "",
+  { requiresNamedPermissions = true, grantRoleId = "" } = {}
+) {
   const permissionIds = buildCrudPermissionIds(namespace);
-  if (!requiresNamedPermissions || !permissionIds) {
+  const normalizedGrantRoleId = normalizeText(grantRoleId);
+  if (!requiresNamedPermissions || !permissionIds || !normalizedGrantRoleId) {
     return "";
   }
 
+  const rolePermissionsExpression = `roleCatalog.roles[${JSON.stringify(normalizedGrantRoleId)}].permissions`;
+
   return [
-    "roleCatalog.roles.member.permissions.push(",
+    `${rolePermissionsExpression}.push(`,
     `  ${JSON.stringify(permissionIds.list)},`,
     `  ${JSON.stringify(permissionIds.view)},`,
     `  ${JSON.stringify(permissionIds.create)},`,
@@ -1866,9 +1980,11 @@ function buildReplacementsFromSnapshot({
   resolvedOwnershipFilter,
   surfaceRequiresWorkspace = true,
   surfaceId = "",
-  routeInternal = false
+  routeInternal = false,
+  permissionGrantRoleId = ""
 }) {
   const requiresNamedPermissions = surfaceRequiresWorkspace === true;
+  const resolvedPermissionGrantRoleId = normalizeText(permissionGrantRoleId);
   const scaffoldColumns = resolveScaffoldColumns(snapshot);
   const outputColumns = scaffoldColumns.filter((column) => !column.isOwnerColumn);
   const writableColumns = scaffoldColumns.filter((column) => column.writable);
@@ -1924,7 +2040,8 @@ function buildReplacementsFromSnapshot({
       requiresNamedPermissions
     }),
     __JSKIT_CRUD_ROLE_CATALOG_PERMISSION_GRANTS__: renderRoleCatalogPermissionGrants(namespace, {
-      requiresNamedPermissions
+      requiresNamedPermissions,
+      grantRoleId: resolvedPermissionGrantRoleId
     }),
     __JSKIT_CRUD_ROUTE_SURFACE_REQUIRES_WORKSPACE__: String(surfaceRequiresWorkspace === true),
     __JSKIT_CRUD_ROUTE_BASE__: JSON.stringify(surfaceRequiresWorkspace === true ? "/w/:workspaceSlug" : "/"),
@@ -2024,7 +2141,9 @@ function createCacheKey({ appRoot, options }) {
       ownershipFilter: normalizeText(options?.["ownership-filter"]),
       tableName: normalizeText(options?.["table-name"]),
       idColumn: normalizeText(options?.["id-column"]),
-      internal: resolveInternalRouteOption(options)
+      internal: resolveInternalRouteOption(options),
+      grantRole: normalizeText(options?.["grant-role"]).toLowerCase(),
+      noRoleGrant: resolveNoRoleGrantOption(options)
     }
   };
 
@@ -2043,16 +2162,26 @@ async function buildCrudTemplateContext(input = {}) {
   if (!tableName) {
     throw new Error('crud template context requires option "table-name".');
   }
+  const appConfig = await loadCrudAppConfig(appRoot);
   const resolvedSurface = await resolveCrudGenerationSurfaceId({
     appRoot,
-    options
+    options,
+    appConfig
+  });
+  const surfaceRequiresWorkspace = await resolveCrudSurfaceRequiresWorkspace({
+    appRoot,
+    options,
+    surface: resolvedSurface,
+    appConfig
+  });
+  const permissionGrantRoleId = resolveCrudPermissionGrantRole(appConfig, options, {
+    requiresNamedPermissions: surfaceRequiresWorkspace
   });
   const snapshot = await resolveGenerationSnapshot({
     appRoot,
     tableName,
     idColumnOption: options["id-column"]
   });
-
   const resolvedOwnershipFilter = resolveOwnershipFilterForGeneration(
     snapshot,
     options["ownership-filter"],
@@ -2060,11 +2189,6 @@ async function buildCrudTemplateContext(input = {}) {
       enforceTableColumns: true
     }
   );
-  const surfaceRequiresWorkspace = await resolveCrudSurfaceRequiresWorkspace({
-    appRoot,
-    options,
-    surface: resolvedSurface
-  });
   const routeInternal = resolveInternalRouteOption(options);
 
   return buildReplacementsFromSnapshot({
@@ -2073,8 +2197,38 @@ async function buildCrudTemplateContext(input = {}) {
     resolvedOwnershipFilter,
     surfaceRequiresWorkspace,
     surfaceId: resolvedSurface,
-    routeInternal
+    routeInternal,
+    permissionGrantRoleId
   });
+}
+
+async function prepareInstallHook({
+  appRoot,
+  packageOptions = {}
+} = {}) {
+  const options = asRecord(packageOptions);
+  const namespace = normalizeText(options.namespace);
+  if (!namespace) {
+    throw new Error('crud install preflight requires option "namespace".');
+  }
+
+  const appConfig = await loadCrudAppConfig(appRoot);
+  const resolvedSurface = await resolveCrudGenerationSurfaceId({
+    appRoot,
+    options,
+    appConfig
+  });
+  const surfaceRequiresWorkspace = await resolveCrudSurfaceRequiresWorkspace({
+    appRoot,
+    options,
+    surface: resolvedSurface,
+    appConfig
+  });
+  resolveCrudPermissionGrantRole(appConfig, options, {
+    requiresNamedPermissions: surfaceRequiresWorkspace
+  });
+
+  return {};
 }
 
 async function buildTemplateContext(input = {}) {
@@ -2108,6 +2262,7 @@ const __testables = Object.freeze({
   resolveDefaultCrudSurfaceIdFromAppConfig,
   resolveCrudGenerationSurfaceId,
   resolveCrudSurfaceRequiresWorkspace,
+  resolveCrudPermissionGrantRole,
   buildCrudPermissionIds,
   renderRoleCatalogPermissionGrants,
   renderActionPermissionSupport,
@@ -2116,7 +2271,8 @@ const __testables = Object.freeze({
   renderRouteValidatorConstants,
   renderRouteParamsValidatorLine,
   renderRouteInputLines,
-  resolveInternalRouteOption
+  resolveInternalRouteOption,
+  resolveNoRoleGrantOption
 });
 
 export {
@@ -2126,5 +2282,6 @@ export {
   renderCanonicalResourceFieldSchema,
   buildFieldContractEntries,
   resolveCrudGenerationSurfaceId,
+  prepareInstallHook,
   __testables
 };

--- a/packages/crud-server-generator/test/buildTemplateContext.test.js
+++ b/packages/crud-server-generator/test/buildTemplateContext.test.js
@@ -5,7 +5,10 @@ import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 
-import { __testables } from "../src/server/buildTemplateContext.js";
+import {
+  __testables,
+  prepareInstallHook
+} from "../src/server/buildTemplateContext.js";
 
 function createSnapshot({
   tableName = "contacts",
@@ -235,6 +238,32 @@ test("resolveOwnershipFilterForGeneration rejects explicit ownership filters whe
   );
 });
 
+test("resolveOwnershipFilterForGeneration requires explicit filters to match reserved owner columns exactly", () => {
+  const snapshotBoth = createSnapshot({
+    hasWorkspaceIdColumn: true,
+    hasUserIdColumn: true
+  });
+  const snapshotWorkspaceOnly = createSnapshot({
+    hasWorkspaceIdColumn: true,
+    hasUserIdColumn: false
+  });
+
+  assert.throws(
+    () =>
+      __testables.resolveOwnershipFilterForGeneration(snapshotBoth, "workspace", {
+        enforceTableColumns: true
+      }),
+    /conflicts with the table's reserved ownership columns.*"workspace_id", "user_id".*Use ownership filter "workspace_user"/s
+  );
+  assert.throws(
+    () =>
+      __testables.resolveOwnershipFilterForGeneration(snapshotWorkspaceOnly, "public", {
+        enforceTableColumns: true
+      }),
+    /conflicts with the table's reserved ownership columns.*"workspace_id".*Use ownership filter "workspace"/s
+  );
+});
+
 test("buildReplacementsFromSnapshot renders an internal route line only when requested", () => {
   const snapshot = createSnapshot();
 
@@ -244,7 +273,8 @@ test("buildReplacementsFromSnapshot renders an internal route line only when req
     resolvedOwnershipFilter: "workspace_user",
     surfaceRequiresWorkspace: true,
     surfaceId: "admin",
-    routeInternal: false
+    routeInternal: false,
+    permissionGrantRoleId: "administrator"
   });
   const internalReplacements = __testables.buildReplacementsFromSnapshot({
     namespace: "customers",
@@ -252,11 +282,20 @@ test("buildReplacementsFromSnapshot renders an internal route line only when req
     resolvedOwnershipFilter: "workspace_user",
     surfaceRequiresWorkspace: true,
     surfaceId: "admin",
-    routeInternal: true
+    routeInternal: true,
+    permissionGrantRoleId: "administrator"
   });
 
   assert.equal(publicReplacements.__JSKIT_CRUD_ROUTE_INTERNAL_LINE__, "");
   assert.equal(internalReplacements.__JSKIT_CRUD_ROUTE_INTERNAL_LINE__, "\n      internal: true,");
+  assert.equal(
+    internalReplacements.__JSKIT_CRUD_ROLE_CATALOG_PERMISSION_GRANTS__,
+    publicReplacements.__JSKIT_CRUD_ROLE_CATALOG_PERMISSION_GRANTS__
+  );
+  assert.match(
+    internalReplacements.__JSKIT_CRUD_ROLE_CATALOG_PERMISSION_GRANTS__,
+    /roleCatalog\.roles\["administrator"\]\.permissions\.push\(/
+  );
   assert.equal(publicReplacements.__JSKIT_CRUD_LIST_ROUTE_PARAMS_VALIDATOR_LINE__, "\n      params: routeParamsValidator,");
 });
 
@@ -275,6 +314,190 @@ test("resolveInternalRouteOption does not confuse descriptor defaults with expli
   assert.equal(__testables.resolveInternalRouteOption({ internal: true }), true);
   assert.equal(__testables.resolveInternalRouteOption({ internal: "true" }), true);
   assert.equal(__testables.resolveInternalRouteOption({ internal: "false" }), false);
+});
+
+test("resolveCrudPermissionGrantRole requires an explicit policy and supports configured roles", () => {
+  const appConfig = {
+    roleCatalog: {
+      roles: {
+        owner: { permissions: ["*"] },
+        member: { permissions: ["workspace.settings.view"] },
+        administrator: { permissions: ["workspace.settings.update"] }
+      }
+    }
+  };
+
+  assert.throws(
+    () => __testables.resolveCrudPermissionGrantRole(appConfig, {}, {
+      requiresNamedPermissions: true
+    }),
+    /requires an explicit permission grant policy.*--grant-role <role-id>.*--no-role-grant.*administrator.*member.*owner/s
+  );
+  assert.equal(
+    __testables.resolveCrudPermissionGrantRole(appConfig, {
+      "grant-role": "member"
+    }, {
+      requiresNamedPermissions: true
+    }),
+    "member"
+  );
+  assert.equal(
+    __testables.resolveCrudPermissionGrantRole(appConfig, {
+      "grant-role": "ADMINISTRATOR"
+    }, {
+      requiresNamedPermissions: true
+    }),
+    "administrator"
+  );
+  assert.equal(
+    __testables.resolveCrudPermissionGrantRole(appConfig, {
+      "no-role-grant": "true"
+    }, {
+      requiresNamedPermissions: true
+    }),
+    ""
+  );
+});
+
+test("resolveCrudPermissionGrantRole rejects missing, conflicting, and malformed role grants", () => {
+  const customRoleCatalog = {
+    roleCatalog: {
+      roles: {
+        owner: { permissions: ["*"] },
+        administrator: { permissions: [] },
+        worker: {},
+        frozen: { permissions: Object.freeze([]) }
+      }
+    }
+  };
+
+  assert.throws(
+    () => __testables.resolveCrudPermissionGrantRole(customRoleCatalog, {}, {
+      requiresNamedPermissions: true
+    }),
+    /requires an explicit permission grant policy.*--grant-role <role-id>.*--no-role-grant.*administrator.*frozen.*owner.*worker/s
+  );
+  assert.throws(
+    () => __testables.resolveCrudPermissionGrantRole(customRoleCatalog, {
+      "grant-role": "safety_manager"
+    }, {
+      requiresNamedPermissions: true
+    }),
+    /grant role "safety_manager" is not configured/
+  );
+  assert.throws(
+    () => __testables.resolveCrudPermissionGrantRole(customRoleCatalog, {
+      "grant-role": "worker"
+    }, {
+      requiresNamedPermissions: true
+    }),
+    /roleCatalog\.roles\.worker\.permissions must be an array/
+  );
+  assert.throws(
+    () => __testables.resolveCrudPermissionGrantRole(customRoleCatalog, {
+      "grant-role": "frozen"
+    }, {
+      requiresNamedPermissions: true
+    }),
+    /roleCatalog\.roles\.frozen\.permissions must be mutable.*--no-role-grant/s
+  );
+  assert.throws(
+    () => __testables.resolveCrudPermissionGrantRole(customRoleCatalog, {
+      "grant-role": "administrator",
+      "no-role-grant": true
+    }, {
+      requiresNamedPermissions: true
+    }),
+    /cannot be used together/
+  );
+  assert.throws(
+    () => __testables.resolveCrudPermissionGrantRole(customRoleCatalog, {
+      "no-role-grant": true
+    }, {
+      requiresNamedPermissions: false
+    }),
+    /apply only to surfaces that require a workspace/
+  );
+});
+
+test("renderRoleCatalogPermissionGrants targets explicit roles or suppresses only the catalog mutation", () => {
+  const customRoleGrant = __testables.renderRoleCatalogPermissionGrants("contacts", {
+    requiresNamedPermissions: true,
+    grantRoleId: "administrator"
+  });
+  const noRoleGrant = __testables.renderRoleCatalogPermissionGrants("contacts", {
+    requiresNamedPermissions: true,
+    grantRoleId: ""
+  });
+
+  assert.match(customRoleGrant, /roleCatalog\.roles\["administrator"\]\.permissions\.push\(/);
+  assert.match(customRoleGrant, /"crud\.contacts\.delete"/);
+  assert.equal(noRoleGrant, "");
+
+  const replacements = __testables.buildReplacementsFromSnapshot({
+    namespace: "contacts",
+    snapshot: createSnapshot(),
+    resolvedOwnershipFilter: "workspace",
+    surfaceRequiresWorkspace: true,
+    routeInternal: true,
+    permissionGrantRoleId: ""
+  });
+  assert.equal(replacements.__JSKIT_CRUD_ROLE_CATALOG_PERMISSION_GRANTS__, "");
+  assert.match(replacements.__JSKIT_CRUD_ACTION_PERMISSION_SUPPORT__, /"crud\.contacts\.create"/);
+  assert.equal(
+    replacements.__JSKIT_CRUD_CREATE_ACTION_PERMISSION__,
+    '{ require: "all", permissions: [actionPermissions.create] }'
+  );
+  assert.equal(replacements.__JSKIT_CRUD_ROUTE_INTERNAL_LINE__, "\n      internal: true,");
+});
+
+test("prepareInstallHook requires an explicit grant policy before generation", async () => {
+  const publicConfigSource = `export const config = {
+  surfaceDefinitions: {
+    app: { id: "app", enabled: true, requiresAuth: true, requiresWorkspace: true }
+  },
+  roleCatalog: {
+    roles: {
+      owner: { permissions: ["*"] },
+      administrator: { permissions: [] },
+      safety_manager: { permissions: [] },
+      worker: { permissions: [] }
+    }
+  }
+};
+`;
+
+  await withTempApp(
+    async (appRoot) => {
+      await assert.rejects(
+        prepareInstallHook({
+          appRoot,
+          packageOptions: {
+            namespace: "notification_outbox_items",
+            surface: "app",
+            "ownership-filter": "workspace",
+            internal: "true"
+          }
+        }),
+        /requires an explicit permission grant policy/
+      );
+
+      assert.deepEqual(
+        await prepareInstallHook({
+          appRoot,
+          packageOptions: {
+            namespace: "notification_outbox_items",
+            surface: "app",
+            "ownership-filter": "workspace",
+            internal: "true",
+            "no-role-grant": "true"
+          }
+        }),
+        {}
+      );
+    },
+    publicConfigSource
+  );
 });
 
 test("resolveCrudGenerationTableName defaults table-name from namespace", () => {
@@ -299,7 +522,8 @@ test("buildReplacementsFromSnapshot builds deterministic template replacement pa
     namespace: "contacts",
     snapshot,
     resolvedOwnershipFilter: "workspace_user",
-    surfaceRequiresWorkspace: true
+    surfaceRequiresWorkspace: true,
+    permissionGrantRoleId: "member"
   });
 
   assert.equal(replacements.__JSKIT_CRUD_TABLE_NAME__, "\"contacts\"");
@@ -339,7 +563,7 @@ test("buildReplacementsFromSnapshot builds deterministic template replacement pa
   );
   assert.match(
     replacements.__JSKIT_CRUD_ROLE_CATALOG_PERMISSION_GRANTS__,
-    /roleCatalog\.roles\.member\.permissions\.push\(/
+    /roleCatalog\.roles\["member"\]\.permissions\.push\(/
   );
   assert.match(
     replacements.__JSKIT_CRUD_ROLE_CATALOG_PERMISSION_GRANTS__,

--- a/packages/crud-server-generator/test/packageDescriptor.test.js
+++ b/packages/crud-server-generator/test/packageDescriptor.test.js
@@ -17,10 +17,19 @@ test("crud-server-generator surface option validates against enabled surface ids
     "${option:namespace}"
   );
   assert.equal(descriptor.options?.internal?.inputType, "flag");
+  assert.equal(descriptor.options?.["grant-role"]?.inputType, "text");
+  assert.match(descriptor.options?.["grant-role"]?.promptHint || "", /choose this or --no-role-grant/);
+  assert.equal(descriptor.options?.["no-role-grant"]?.inputType, "flag");
   assert.equal(descriptor.metadata?.generatorSubcommands?.scaffold?.optionNames?.includes("surface"), true);
   assert.equal(descriptor.metadata?.generatorSubcommands?.scaffold?.optionNames?.includes("force"), true);
   assert.equal(descriptor.metadata?.generatorSubcommands?.scaffold?.optionNames?.includes("internal"), true);
+  assert.equal(descriptor.metadata?.generatorSubcommands?.scaffold?.optionNames?.includes("grant-role"), true);
+  assert.equal(descriptor.metadata?.generatorSubcommands?.scaffold?.optionNames?.includes("no-role-grant"), true);
   assert.equal(descriptor.metadata?.generatorSubcommands?.scaffold?.createTarget?.pathTemplate, "packages/${option:namespace|kebab}");
+  assert.deepEqual(descriptor.lifecycle?.install?.prepare, {
+    entrypoint: "src/server/buildTemplateContext.js",
+    export: "prepareInstallHook"
+  });
 });
 
 test("crud-server-generator no longer installs a separate jsonRestResource server template", () => {

--- a/packages/crud-ui-generator/package.descriptor.mjs
+++ b/packages/crud-ui-generator/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { GENERATED_UI_NAVIGATION_ROLE_OPTION } from "@jskit-ai/kernel/shared/sup
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-ui-generator",
-  version: "0.1.106",
+  version: "0.1.107",
   kind: "generator",
   description: "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
   options: {
@@ -175,7 +175,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.139"
+        "@jskit-ai/users-web": "0.1.140"
       },
       dev: {}
     },

--- a/packages/crud-ui-generator/package.json
+++ b/packages/crud-ui-generator/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@jskit-ai/crud-ui-generator",
-  "version": "0.1.106",
+  "version": "0.1.107",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/crud-core": "0.1.131",
-    "@jskit-ai/kernel": "0.1.123",
-    "@jskit-ai/resource-crud-core": "0.1.66"
+    "@jskit-ai/crud-core": "0.1.132",
+    "@jskit-ai/kernel": "0.1.124",
+    "@jskit-ai/resource-crud-core": "0.1.67"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/database-runtime-mysql/package.descriptor.mjs
+++ b/packages/database-runtime-mysql/package.descriptor.mjs
@@ -13,7 +13,7 @@ const CI_DATABASE = Object.freeze({
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-mysql",
-  version: "0.1.121",
+  version: "0.1.122",
   kind: "runtime",
   options: {
     "db-host": {
@@ -133,7 +133,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.122",
+        "@jskit-ai/database-runtime": "0.1.123",
         "mysql2": "^3.11.2"
       },
       dev: {}

--- a/packages/database-runtime-mysql/package.json
+++ b/packages/database-runtime-mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-mysql",
-  "version": "0.1.121",
+  "version": "0.1.122",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,7 +12,7 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.122",
-    "@jskit-ai/kernel": "0.1.123"
+    "@jskit-ai/database-runtime": "0.1.123",
+    "@jskit-ai/kernel": "0.1.124"
   }
 }

--- a/packages/database-runtime-postgres/package.descriptor.mjs
+++ b/packages/database-runtime-postgres/package.descriptor.mjs
@@ -12,7 +12,7 @@ const CI_DATABASE = Object.freeze({
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-postgres",
-  version: "0.1.120",
+  version: "0.1.121",
   kind: "runtime",
   options: {
     "db-host": {
@@ -131,7 +131,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.122",
+        "@jskit-ai/database-runtime": "0.1.123",
         "pg": "^8.13.1"
       },
       dev: {}

--- a/packages/database-runtime-postgres/package.json
+++ b/packages/database-runtime-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-postgres",
-  "version": "0.1.120",
+  "version": "0.1.121",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,6 +12,6 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.122"
+    "@jskit-ai/database-runtime": "0.1.123"
   }
 }

--- a/packages/database-runtime/package.descriptor.mjs
+++ b/packages/database-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime",
-  version: "0.1.122",
+  version: "0.1.123",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -70,7 +70,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.123",
+        "@jskit-ai/kernel": "0.1.124",
         "dotenv": "^16.4.5",
         "knex": "^3.1.0"
       },

--- a/packages/database-runtime/package.json
+++ b/packages/database-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime",
-  "version": "0.1.122",
+  "version": "0.1.123",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -25,6 +25,6 @@
     "./shared/transactions": "./src/shared/transactions.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.123"
+    "@jskit-ai/kernel": "0.1.124"
   }
 }

--- a/packages/feature-server-generator/package.descriptor.mjs
+++ b/packages/feature-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/feature-server-generator",
-  version: "0.1.65",
+  version: "0.1.66",
   kind: "generator",
   description: "Scaffold substantial non-CRUD server feature packages with provider, actions, service, and optional persistence seams.",
   options: {
@@ -154,27 +154,27 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@jskit-ai/database-runtime": {
-          version: "0.1.122",
+          version: "0.1.123",
           when: {
             option: "mode",
             notEquals: "orchestrator"
           }
         },
         "@jskit-ai/database-runtime-mysql": {
-          version: "0.1.121",
+          version: "0.1.122",
           when: {
             option: "mode",
             notEquals: "orchestrator"
           }
         },
         "@jskit-ai/json-rest-api-core": {
-          version: "0.1.67",
+          version: "0.1.68",
           when: {
             option: "mode",
             equals: "json-rest"
           }
         },
-        "@jskit-ai/kernel": "0.1.123",
+        "@jskit-ai/kernel": "0.1.124",
         "json-rest-schema": "1.x.x",
         "@local/${option:feature-name|kebab}": "file:packages/${option:feature-name|kebab}"
       },

--- a/packages/feature-server-generator/package.json
+++ b/packages/feature-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/feature-server-generator",
-  "version": "0.1.65",
+  "version": "0.1.66",
   "type": "module",
   "scripts": {
     "test": "node --test"

--- a/packages/google-rewarded-core/package.descriptor.mjs
+++ b/packages/google-rewarded-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/google-rewarded-core",
-  version: "0.1.60",
+  version: "0.1.61",
   kind: "runtime",
   description: "Google rewarded workflow runtime plus internal CRUD providers for rules, provider configs, watch sessions, and unlock receipts.",
   dependsOn: [
@@ -128,14 +128,14 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.120",
-        "@jskit-ai/crud-core": "0.1.131",
-        "@jskit-ai/database-runtime": "0.1.122",
-        "@jskit-ai/http-runtime": "0.1.121",
-        "@jskit-ai/json-rest-api-core": "0.1.67",
-        "@jskit-ai/kernel": "0.1.123",
-        "@jskit-ai/resource-crud-core": "0.1.66",
-        "@jskit-ai/workspaces-core": "0.1.99"
+        "@jskit-ai/auth-core": "0.1.121",
+        "@jskit-ai/crud-core": "0.1.132",
+        "@jskit-ai/database-runtime": "0.1.123",
+        "@jskit-ai/http-runtime": "0.1.122",
+        "@jskit-ai/json-rest-api-core": "0.1.68",
+        "@jskit-ai/kernel": "0.1.124",
+        "@jskit-ai/resource-crud-core": "0.1.67",
+        "@jskit-ai/workspaces-core": "0.1.100"
       },
       dev: {}
     },

--- a/packages/google-rewarded-core/package.json
+++ b/packages/google-rewarded-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/google-rewarded-core",
-  "version": "0.1.60",
+  "version": "0.1.61",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/google-rewarded-web/package.descriptor.mjs
+++ b/packages/google-rewarded-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/google-rewarded-web",
-  version: "0.1.60",
+  version: "0.1.61",
   kind: "runtime",
   description: "Google rewarded client runtime with a fullscreen gate host and GPT orchestration.",
   dependsOn: [
@@ -46,10 +46,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/google-rewarded-core": "0.1.60",
-        "@jskit-ai/http-runtime": "0.1.121",
-        "@jskit-ai/kernel": "0.1.123",
-        "@jskit-ai/shell-web": "0.1.124"
+        "@jskit-ai/google-rewarded-core": "0.1.61",
+        "@jskit-ai/http-runtime": "0.1.122",
+        "@jskit-ai/kernel": "0.1.124",
+        "@jskit-ai/shell-web": "0.1.125"
       },
       dev: {}
     },

--- a/packages/google-rewarded-web/package.json
+++ b/packages/google-rewarded-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/google-rewarded-web",
-  "version": "0.1.60",
+  "version": "0.1.61",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/http-runtime/package.descriptor.mjs
+++ b/packages/http-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/http-runtime",
-  "version": "0.1.121",
+  "version": "0.1.122",
   "kind": "runtime",
   "dependsOn": [],
   "capabilities": {
@@ -67,7 +67,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.123"
+        "@jskit-ai/kernel": "0.1.124"
       },
       "dev": {}
     },

--- a/packages/http-runtime/package.json
+++ b/packages/http-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/http-runtime",
-  "version": "0.1.121",
+  "version": "0.1.122",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -18,7 +18,7 @@
     "./shared/validators/operationValidation": "./src/shared/validators/operationValidation.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.123",
+    "@jskit-ai/kernel": "0.1.124",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/json-rest-api-core/package.descriptor.mjs
+++ b/packages/json-rest-api-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/json-rest-api-core",
-  version: "0.1.67",
+  version: "0.1.68",
   kind: "runtime",
   description: "Shared internal json-rest-api host runtime with autofilter, query-projection, and row-policy support.",
   dependsOn: [

--- a/packages/json-rest-api-core/package.json
+++ b/packages/json-rest-api-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/json-rest-api-core",
-  "version": "0.1.67",
+  "version": "0.1.68",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,6 +11,6 @@
   "dependencies": {
     "hooked-api": "1.x.x",
     "json-rest-api": "^1.0.26",
-    "@jskit-ai/kernel": "0.1.123"
+    "@jskit-ai/kernel": "0.1.124"
   }
 }

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/kernel",
-  "version": "0.1.123",
+  "version": "0.1.124",
   "type": "module",
   "dependencies": {
     "json-rest-schema": "1.x.x"

--- a/packages/mobile-capacitor/package.descriptor.mjs
+++ b/packages/mobile-capacitor/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/mobile-capacitor",
-  version: "0.1.59",
+  version: "0.1.60",
   kind: "runtime",
   description: "Thin Capacitor client integration for JSKIT mobile-shell launch routing and auth callback completion.",
   dependsOn: [
@@ -62,8 +62,8 @@ export default Object.freeze({
         "@capacitor/app": "^7.1.0",
         "@capacitor/browser": "^7.0.1",
         "@capacitor/core": "^7.4.3",
-        "@jskit-ai/kernel": "0.1.123",
-        "@jskit-ai/shell-web": "0.1.124"
+        "@jskit-ai/kernel": "0.1.124",
+        "@jskit-ai/shell-web": "0.1.125"
       },
       dev: {
         "@capacitor/cli": "^7.4.3"

--- a/packages/mobile-capacitor/package.json
+++ b/packages/mobile-capacitor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/mobile-capacitor",
-  "version": "0.1.59",
+  "version": "0.1.60",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,6 +12,6 @@
   },
   "dependencies": {
     "@capacitor/browser": "^7.0.1",
-    "@jskit-ai/kernel": "0.1.123"
+    "@jskit-ai/kernel": "0.1.124"
   }
 }

--- a/packages/realtime/package.descriptor.mjs
+++ b/packages/realtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/realtime",
-  version: "0.1.120",
+  version: "0.1.121",
   kind: "runtime",
   description: "Thin, generic realtime runtime wrappers for socket.io server and client.",
   options: {
@@ -95,7 +95,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.123",
+        "@jskit-ai/kernel": "0.1.124",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/realtime",
-  "version": "0.1.120",
+  "version": "0.1.121",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@socket.io/redis-adapter": "^8.3.0",
-    "@jskit-ai/kernel": "0.1.123",
+    "@jskit-ai/kernel": "0.1.124",
     "redis": "^5.8.2",
     "socket.io": "^4.8.3",
     "socket.io-client": "^4.8.3"

--- a/packages/resource-core/package.descriptor.mjs
+++ b/packages/resource-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/resource-core",
-  version: "0.1.66",
+  version: "0.1.67",
   kind: "runtime",
   description: "Generic resource-definition helpers and schema-definition normalization.",
   dependsOn: [
@@ -22,7 +22,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/resource-core": "0.1.66"
+        "@jskit-ai/resource-core": "0.1.67"
       },
       dev: {}
     },

--- a/packages/resource-core/package.json
+++ b/packages/resource-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/resource-core",
-  "version": "0.1.66",
+  "version": "0.1.67",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./shared/resource": "./src/shared/resource.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.123"
+    "@jskit-ai/kernel": "0.1.124"
   }
 }

--- a/packages/resource-crud-core/package.descriptor.mjs
+++ b/packages/resource-crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/resource-crud-core",
-  version: "0.1.66",
+  version: "0.1.67",
   kind: "runtime",
   description: "CRUD-specific resource-definition helpers and namespace support.",
   dependsOn: [
@@ -23,7 +23,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/resource-crud-core": "0.1.66"
+        "@jskit-ai/resource-crud-core": "0.1.67"
       },
       dev: {}
     },

--- a/packages/resource-crud-core/package.json
+++ b/packages/resource-crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/resource-crud-core",
-  "version": "0.1.66",
+  "version": "0.1.67",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./shared/crudResource": "./src/shared/crudResource.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.123",
-    "@jskit-ai/resource-core": "0.1.66"
+    "@jskit-ai/kernel": "0.1.124",
+    "@jskit-ai/resource-core": "0.1.67"
   }
 }

--- a/packages/shell-web/package.descriptor.mjs
+++ b/packages/shell-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/shell-web",
-  version: "0.1.124",
+  version: "0.1.125",
   kind: "runtime",
   description: "Web shell layout runtime with outlet-based placement contributions.",
   dependsOn: [],
@@ -311,7 +311,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/kernel": "0.1.123"
+        "@jskit-ai/kernel": "0.1.124"
       },
       dev: {
         "@playwright/test": "1.61.1"

--- a/packages/shell-web/package.json
+++ b/packages/shell-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/shell-web",
-  "version": "0.1.124",
+  "version": "0.1.125",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/kernel": "0.1.123"
+    "@jskit-ai/kernel": "0.1.124"
   },
   "peerDependencies": {
     "pinia": "^3.0.4",

--- a/packages/storage-runtime/package.descriptor.mjs
+++ b/packages/storage-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/storage-runtime",
-  version: "0.1.121",
+  version: "0.1.122",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -50,7 +50,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.123",
+        "@jskit-ai/kernel": "0.1.124",
         "unstorage": "^1.17.3"
       },
       dev: {}

--- a/packages/storage-runtime/package.json
+++ b/packages/storage-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/storage-runtime",
-  "version": "0.1.121",
+  "version": "0.1.122",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./server/providers/StorageRuntimeServiceProvider": "./src/server/providers/StorageRuntimeServiceProvider.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.123",
+    "@jskit-ai/kernel": "0.1.124",
     "unstorage": "^1.17.5"
   }
 }

--- a/packages/ui-generator/package.descriptor.mjs
+++ b/packages/ui-generator/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { GENERATED_UI_NAVIGATION_ROLE_OPTION } from "@jskit-ai/kernel/shared/sup
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/ui-generator",
-  version: "0.1.106",
+  version: "0.1.107",
   kind: "generator",
   description: "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
   options: {
@@ -371,7 +371,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.139"
+        "@jskit-ai/users-web": "0.1.140"
       },
       dev: {}
     },

--- a/packages/ui-generator/package.json
+++ b/packages/ui-generator/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/ui-generator",
-  "version": "0.1.106",
+  "version": "0.1.107",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.123",
-    "@jskit-ai/shell-web": "0.1.124"
+    "@jskit-ai/kernel": "0.1.124",
+    "@jskit-ai/shell-web": "0.1.125"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/uploads-image-web/package.descriptor.mjs
+++ b/packages/uploads-image-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-image-web",
-  version: "0.1.99",
+  version: "0.1.100",
   kind: "runtime",
   description: "Reusable client-side image upload runtime with pre-upload image editing.",
   dependsOn: [
@@ -65,7 +65,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/uploads-runtime": "0.1.99",
+        "@jskit-ai/uploads-runtime": "0.1.100",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-image-web/package.json
+++ b/packages/uploads-image-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-image-web",
-  "version": "0.1.99",
+  "version": "0.1.100",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,7 +13,7 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/uploads-runtime": "0.1.99",
+    "@jskit-ai/uploads-runtime": "0.1.100",
     "@uppy/compressor": "^3.1.0",
     "@uppy/core": "^5.2.0",
     "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-runtime/package.descriptor.mjs
+++ b/packages/uploads-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-runtime",
-  version: "0.1.99",
+  version: "0.1.100",
   kind: "runtime",
   description: "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
   dependsOn: [
@@ -71,7 +71,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.123"
+        "@jskit-ai/kernel": "0.1.124"
       },
       dev: {}
     },

--- a/packages/uploads-runtime/package.json
+++ b/packages/uploads-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-runtime",
-  "version": "0.1.99",
+  "version": "0.1.100",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,6 +16,6 @@
   },
   "dependencies": {
     "@fastify/multipart": "^9.4.0",
-    "@jskit-ai/kernel": "0.1.123"
+    "@jskit-ai/kernel": "0.1.124"
   }
 }

--- a/packages/users-core/package.descriptor.mjs
+++ b/packages/users-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-core",
-  version: "0.1.133",
+  version: "0.1.134",
   kind: "runtime",
   description: "Users/account runtime plus HTTP routes for account features.",
   dependsOn: [
@@ -146,16 +146,16 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.120",
-        "@jskit-ai/crud-core": "0.1.131",
-        "@jskit-ai/database-runtime": "0.1.122",
-        "@jskit-ai/http-runtime": "0.1.121",
-        "@jskit-ai/json-rest-api-core": "0.1.67",
-        "@jskit-ai/kernel": "0.1.123",
-        "@jskit-ai/resource-core": "0.1.66",
-        "@jskit-ai/resource-crud-core": "0.1.66",
+        "@jskit-ai/auth-core": "0.1.121",
+        "@jskit-ai/crud-core": "0.1.132",
+        "@jskit-ai/database-runtime": "0.1.123",
+        "@jskit-ai/http-runtime": "0.1.122",
+        "@jskit-ai/json-rest-api-core": "0.1.68",
+        "@jskit-ai/kernel": "0.1.124",
+        "@jskit-ai/resource-core": "0.1.67",
+        "@jskit-ai/resource-crud-core": "0.1.67",
         "@local/users": "file:packages/users",
-        "@jskit-ai/uploads-runtime": "0.1.99"
+        "@jskit-ai/uploads-runtime": "0.1.100"
       },
       dev: {}
     },

--- a/packages/users-core/package.json
+++ b/packages/users-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-core",
-  "version": "0.1.133",
+  "version": "0.1.134",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,14 +11,14 @@
     "./shared/resources/userSettingsResource": "./src/shared/resources/userSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.120",
-    "@jskit-ai/database-runtime": "0.1.122",
-    "@jskit-ai/http-runtime": "0.1.121",
-    "@jskit-ai/json-rest-api-core": "0.1.67",
-    "@jskit-ai/kernel": "0.1.123",
-    "@jskit-ai/resource-crud-core": "0.1.66",
-    "@jskit-ai/resource-core": "0.1.66",
-    "@jskit-ai/uploads-runtime": "0.1.99",
+    "@jskit-ai/auth-core": "0.1.121",
+    "@jskit-ai/database-runtime": "0.1.123",
+    "@jskit-ai/http-runtime": "0.1.122",
+    "@jskit-ai/json-rest-api-core": "0.1.68",
+    "@jskit-ai/kernel": "0.1.124",
+    "@jskit-ai/resource-crud-core": "0.1.67",
+    "@jskit-ai/resource-core": "0.1.67",
+    "@jskit-ai/uploads-runtime": "0.1.100",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/users-web/package.descriptor.mjs
+++ b/packages/users-web/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { HOME_COG_OUTLET } from "./src/shared/toolsOutletContracts.js";
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-web",
-  version: "0.1.139",
+  version: "0.1.140",
   kind: "runtime",
   description: "Users web module: account/profile UI plus shared users web widgets.",
   dependsOn: [
@@ -286,12 +286,12 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/http-runtime": "0.1.121",
-        "@jskit-ai/realtime": "0.1.120",
-        "@jskit-ai/kernel": "0.1.123",
-        "@jskit-ai/shell-web": "0.1.124",
-        "@jskit-ai/uploads-image-web": "0.1.99",
-        "@jskit-ai/users-core": "0.1.133"
+        "@jskit-ai/http-runtime": "0.1.122",
+        "@jskit-ai/realtime": "0.1.121",
+        "@jskit-ai/kernel": "0.1.124",
+        "@jskit-ai/shell-web": "0.1.125",
+        "@jskit-ai/uploads-image-web": "0.1.100",
+        "@jskit-ai/users-core": "0.1.134"
       },
       dev: {}
     },

--- a/packages/users-web/package.json
+++ b/packages/users-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-web",
-  "version": "0.1.139",
+  "version": "0.1.140",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -46,12 +46,12 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/http-runtime": "0.1.121",
-    "@jskit-ai/kernel": "0.1.123",
-    "@jskit-ai/realtime": "0.1.120",
-    "@jskit-ai/shell-web": "0.1.124",
-    "@jskit-ai/uploads-image-web": "0.1.99",
-    "@jskit-ai/users-core": "0.1.133"
+    "@jskit-ai/http-runtime": "0.1.122",
+    "@jskit-ai/kernel": "0.1.124",
+    "@jskit-ai/realtime": "0.1.121",
+    "@jskit-ai/shell-web": "0.1.125",
+    "@jskit-ai/uploads-image-web": "0.1.100",
+    "@jskit-ai/users-core": "0.1.134"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/workspaces-core/package.descriptor.mjs
+++ b/packages/workspaces-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-core",
-  version: "0.1.99",
+  version: "0.1.100",
   kind: "runtime",
   description: "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
   dependsOn: [
@@ -147,10 +147,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/json-rest-api-core": "0.1.67",
-        "@jskit-ai/resource-core": "0.1.66",
-        "@jskit-ai/resource-crud-core": "0.1.66",
-        "@jskit-ai/users-core": "0.1.133"
+        "@jskit-ai/json-rest-api-core": "0.1.68",
+        "@jskit-ai/resource-core": "0.1.67",
+        "@jskit-ai/resource-crud-core": "0.1.67",
+        "@jskit-ai/users-core": "0.1.134"
       },
       dev: {}
     },

--- a/packages/workspaces-core/package.json
+++ b/packages/workspaces-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-core",
-  "version": "0.1.99",
+  "version": "0.1.100",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -17,14 +17,14 @@
     "./shared/resources/workspaceSettingsResource": "./src/shared/resources/workspaceSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.120",
-    "@jskit-ai/database-runtime": "0.1.122",
-    "@jskit-ai/http-runtime": "0.1.121",
-    "@jskit-ai/json-rest-api-core": "0.1.67",
-    "@jskit-ai/kernel": "0.1.123",
-    "@jskit-ai/resource-crud-core": "0.1.66",
-    "@jskit-ai/resource-core": "0.1.66",
-    "@jskit-ai/users-core": "0.1.133",
+    "@jskit-ai/auth-core": "0.1.121",
+    "@jskit-ai/database-runtime": "0.1.123",
+    "@jskit-ai/http-runtime": "0.1.122",
+    "@jskit-ai/json-rest-api-core": "0.1.68",
+    "@jskit-ai/kernel": "0.1.124",
+    "@jskit-ai/resource-crud-core": "0.1.67",
+    "@jskit-ai/resource-core": "0.1.67",
+    "@jskit-ai/users-core": "0.1.134",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/workspaces-web/package.descriptor.mjs
+++ b/packages/workspaces-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-web",
-  version: "0.1.100",
+  version: "0.1.101",
   kind: "runtime",
   description: "Workspace web module: workspace selector, tools widget, workspace surfaces, members UI, and settings hosts.",
   dependsOn: [
@@ -232,9 +232,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-web": "0.1.123",
-        "@jskit-ai/workspaces-core": "0.1.99",
-        "@jskit-ai/users-web": "0.1.139"
+        "@jskit-ai/auth-web": "0.1.124",
+        "@jskit-ai/workspaces-core": "0.1.100",
+        "@jskit-ai/users-web": "0.1.140"
       },
       dev: {}
     },

--- a/packages/workspaces-web/package.json
+++ b/packages/workspaces-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-web",
-  "version": "0.1.100",
+  "version": "0.1.101",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -15,13 +15,13 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/auth-web": "0.1.123",
-    "@jskit-ai/http-runtime": "0.1.121",
-    "@jskit-ai/kernel": "0.1.123",
-    "@jskit-ai/shell-web": "0.1.124",
-    "@jskit-ai/users-core": "0.1.133",
-    "@jskit-ai/users-web": "0.1.139",
-    "@jskit-ai/workspaces-core": "0.1.99"
+    "@jskit-ai/auth-web": "0.1.124",
+    "@jskit-ai/http-runtime": "0.1.122",
+    "@jskit-ai/kernel": "0.1.124",
+    "@jskit-ai/shell-web": "0.1.125",
+    "@jskit-ai/users-core": "0.1.134",
+    "@jskit-ai/users-web": "0.1.140",
+    "@jskit-ai/workspaces-core": "0.1.100"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/tooling/config-eslint/package.json
+++ b/tooling/config-eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/config-eslint",
-  "version": "0.1.121",
+  "version": "0.1.122",
   "description": "Shared flat ESLint presets for JSKIT projects.",
   "type": "module",
   "files": [

--- a/tooling/create-app/package.descriptor.mjs
+++ b/tooling/create-app/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/create-app",
-  "version": "0.1.137",
+  "version": "0.1.139",
   "dependsOn": [],
   "capabilities": {
     "provides": [

--- a/tooling/create-app/package.json
+++ b/tooling/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/create-app",
-  "version": "0.1.137",
+  "version": "0.1.139",
   "description": "Scaffold JSKIT app shells.",
   "type": "module",
   "files": [
@@ -20,7 +20,7 @@
     "./client": "./src/client/index.js"
   },
   "dependencies": {
-    "@jskit-ai/jskit-cli": "0.2.140"
+    "@jskit-ai/jskit-cli": "0.2.142"
   },
   "engines": {
     "node": "^22.12.0 || ^24.0.0 || ^26.0.0"

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -6,11 +6,11 @@
   "packages": [
     {
       "packageId": "@jskit-ai/assistant",
-      "version": "0.1.132",
+      "version": "0.1.133",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant",
-        "version": "0.1.132",
+        "version": "0.1.133",
         "kind": "generator",
         "description": "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
         "options": {
@@ -347,11 +347,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-core",
-      "version": "0.1.100",
+      "version": "0.1.101",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-core",
-        "version": "0.1.100",
+        "version": "0.1.101",
         "kind": "runtime",
         "description": "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
         "dependsOn": [
@@ -399,11 +399,11 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/http-runtime": "0.1.121",
-              "@jskit-ai/kernel": "0.1.123",
-              "@jskit-ai/resource-core": "0.1.66",
-              "@jskit-ai/resource-crud-core": "0.1.66",
-              "@jskit-ai/users-core": "0.1.133",
+              "@jskit-ai/http-runtime": "0.1.122",
+              "@jskit-ai/kernel": "0.1.124",
+              "@jskit-ai/resource-core": "0.1.67",
+              "@jskit-ai/resource-crud-core": "0.1.67",
+              "@jskit-ai/users-core": "0.1.134",
               "dompurify": "^3.3.3",
               "json-rest-schema": "1.x.x",
               "marked": "^17.0.4",
@@ -422,11 +422,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-runtime",
-      "version": "0.1.95",
+      "version": "0.1.96",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-runtime",
-        "version": "0.1.95",
+        "version": "0.1.96",
         "kind": "runtime",
         "description": "Shared assistant runtime with per-surface assistant registration.",
         "dependsOn": [
@@ -522,13 +522,13 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/assistant-core": "0.1.100",
-              "@jskit-ai/database-runtime": "0.1.122",
-              "@jskit-ai/http-runtime": "0.1.121",
-              "@jskit-ai/kernel": "0.1.123",
-              "@jskit-ai/shell-web": "0.1.124",
-              "@jskit-ai/users-core": "0.1.133",
-              "@jskit-ai/users-web": "0.1.139"
+              "@jskit-ai/assistant-core": "0.1.101",
+              "@jskit-ai/database-runtime": "0.1.123",
+              "@jskit-ai/http-runtime": "0.1.122",
+              "@jskit-ai/kernel": "0.1.124",
+              "@jskit-ai/shell-web": "0.1.125",
+              "@jskit-ai/users-core": "0.1.134",
+              "@jskit-ai/users-web": "0.1.140"
             },
             "dev": {}
           },
@@ -583,11 +583,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-core",
-      "version": "0.1.120",
+      "version": "0.1.121",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-core",
-        "version": "0.1.120",
+        "version": "0.1.121",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/value-app-config-shared"
@@ -660,7 +660,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.123",
+              "@jskit-ai/kernel": "0.1.124",
               "@fastify/cookie": "^11.0.2",
               "@fastify/csrf-protection": "^7.1.0",
               "@fastify/rate-limit": "^10.3.0"
@@ -678,11 +678,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-local-core",
-      "version": "0.1.24",
+      "version": "0.1.25",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-local-core",
-        "version": "0.1.24",
+        "version": "0.1.25",
         "kind": "runtime",
         "description": "Local auth provider with a file backend default and no database requirement.",
         "dependsOn": [
@@ -745,8 +745,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.120",
-              "@jskit-ai/kernel": "0.1.123",
+              "@jskit-ai/auth-core": "0.1.121",
+              "@jskit-ai/kernel": "0.1.124",
               "nodemailer": "^9.0.3",
               "dotenv": "^16.4.5"
             },
@@ -792,11 +792,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-local-db-core",
-      "version": "0.1.15",
+      "version": "0.1.16",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-local-db-core",
-        "version": "0.1.15",
+        "version": "0.1.16",
         "kind": "runtime",
         "description": "Database-backed local auth storage backend for JSKIT local auth.",
         "dependsOn": [
@@ -875,9 +875,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-provider-local-core": "0.1.24",
-              "@jskit-ai/database-runtime": "0.1.122",
-              "@jskit-ai/kernel": "0.1.123"
+              "@jskit-ai/auth-provider-local-core": "0.1.25",
+              "@jskit-ai/database-runtime": "0.1.123",
+              "@jskit-ai/kernel": "0.1.124"
             },
             "dev": {}
           },
@@ -912,11 +912,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.121",
+      "version": "0.1.122",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-supabase-core",
-        "version": "0.1.121",
+        "version": "0.1.122",
         "kind": "runtime",
         "options": {
           "auth-supabase-url": {
@@ -998,8 +998,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.120",
-              "@jskit-ai/kernel": "0.1.123",
+              "@jskit-ai/auth-core": "0.1.121",
+              "@jskit-ai/kernel": "0.1.124",
               "dotenv": "^16.4.5",
               "@supabase/supabase-js": "^2.57.4",
               "jose": "^6.1.0"
@@ -1077,11 +1077,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-web",
-      "version": "0.1.123",
+      "version": "0.1.124",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-web",
-        "version": "0.1.123",
+        "version": "0.1.124",
         "kind": "runtime",
         "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
         "dependsOn": [
@@ -1354,10 +1354,10 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/auth-core": "0.1.120",
-              "@jskit-ai/http-runtime": "0.1.121",
-              "@jskit-ai/kernel": "0.1.123",
-              "@jskit-ai/shell-web": "0.1.124"
+              "@jskit-ai/auth-core": "0.1.121",
+              "@jskit-ai/http-runtime": "0.1.122",
+              "@jskit-ai/kernel": "0.1.124",
+              "@jskit-ai/shell-web": "0.1.125"
             },
             "dev": {}
           },
@@ -1450,11 +1450,11 @@
     },
     {
       "packageId": "@jskit-ai/console-core",
-      "version": "0.1.86",
+      "version": "0.1.87",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-core",
-        "version": "0.1.86",
+        "version": "0.1.87",
         "kind": "runtime",
         "description": "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
         "dependsOn": [
@@ -1538,12 +1538,12 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.120",
-              "@jskit-ai/database-runtime": "0.1.122",
-              "@jskit-ai/http-runtime": "0.1.121",
-              "@jskit-ai/kernel": "0.1.123",
-              "@jskit-ai/resource-crud-core": "0.1.66",
-              "@jskit-ai/users-core": "0.1.133"
+              "@jskit-ai/auth-core": "0.1.121",
+              "@jskit-ai/database-runtime": "0.1.123",
+              "@jskit-ai/http-runtime": "0.1.122",
+              "@jskit-ai/kernel": "0.1.124",
+              "@jskit-ai/resource-crud-core": "0.1.67",
+              "@jskit-ai/users-core": "0.1.134"
             },
             "dev": {}
           },
@@ -1568,11 +1568,11 @@
     },
     {
       "packageId": "@jskit-ai/console-web",
-      "version": "0.1.91",
+      "version": "0.1.92",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-web",
-        "version": "0.1.91",
+        "version": "0.1.92",
         "kind": "runtime",
         "description": "Authenticated console surface scaffold and surface policy wiring.",
         "dependsOn": [
@@ -1682,9 +1682,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-web": "0.1.123",
-              "@jskit-ai/console-core": "0.1.86",
-              "@jskit-ai/shell-web": "0.1.124"
+              "@jskit-ai/auth-web": "0.1.124",
+              "@jskit-ai/console-core": "0.1.87",
+              "@jskit-ai/shell-web": "0.1.125"
             },
             "dev": {}
           },
@@ -1791,11 +1791,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-core",
-      "version": "0.1.131",
+      "version": "0.1.132",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-core",
-        "version": "0.1.131",
+        "version": "0.1.132",
         "kind": "runtime",
         "description": "Shared CRUD helpers used by CRUD modules.",
         "dependsOn": [
@@ -1824,7 +1824,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/crud-core": "0.1.131"
+              "@jskit-ai/crud-core": "0.1.132"
             },
             "dev": {}
           },
@@ -1838,11 +1838,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-server-generator",
-      "version": "0.1.131",
+      "version": "0.1.133",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-server-generator",
-        "version": "0.1.131",
+        "version": "0.1.133",
         "kind": "generator",
         "description": "CRUD server generator with routes, actions, and persistence scaffolding.",
         "options": {
@@ -1910,6 +1910,20 @@
             "defaultValue": "",
             "promptLabel": "Internal HTTP routes",
             "promptHint": "Mark generated CRUD HTTP routes as internal-only so they are not publicly registered."
+          },
+          "grant-role": {
+            "required": false,
+            "inputType": "text",
+            "defaultValue": "",
+            "promptLabel": "CRUD permission grant role",
+            "promptHint": "Configured workspace role that receives generated CRUD permissions; choose this or --no-role-grant."
+          },
+          "no-role-grant": {
+            "required": false,
+            "inputType": "flag",
+            "defaultValue": "",
+            "promptLabel": "Skip automatic role grant",
+            "promptHint": "Generate normal CRUD permissions without assigning them to a workspace role."
           }
         },
         "optionPolicies": {
@@ -1947,6 +1961,14 @@
             ]
           }
         },
+        "lifecycle": {
+          "install": {
+            "prepare": {
+              "entrypoint": "src/server/buildTemplateContext.js",
+              "export": "prepareInstallHook"
+            }
+          }
+        },
         "metadata": {
           "generatorPrimarySubcommand": "scaffold",
           "generatorSubcommands": {
@@ -1960,7 +1982,9 @@
                 "id-column",
                 "directory-prefix",
                 "force",
-                "internal"
+                "internal",
+                "grant-role",
+                "no-role-grant"
               ],
               "createTarget": {
                 "pathTemplate": "packages/${option:namespace|kebab}",
@@ -2009,14 +2033,14 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.120",
-              "@jskit-ai/crud-core": "0.1.131",
-              "@jskit-ai/database-runtime": "0.1.122",
-              "@jskit-ai/http-runtime": "0.1.121",
-              "@jskit-ai/json-rest-api-core": "0.1.67",
-              "@jskit-ai/kernel": "0.1.123",
-              "@jskit-ai/realtime": "0.1.120",
-              "@jskit-ai/resource-crud-core": "0.1.66",
+              "@jskit-ai/auth-core": "0.1.121",
+              "@jskit-ai/crud-core": "0.1.132",
+              "@jskit-ai/database-runtime": "0.1.123",
+              "@jskit-ai/http-runtime": "0.1.122",
+              "@jskit-ai/json-rest-api-core": "0.1.68",
+              "@jskit-ai/kernel": "0.1.124",
+              "@jskit-ai/realtime": "0.1.121",
+              "@jskit-ai/resource-crud-core": "0.1.67",
               "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}"
             },
             "dev": {}
@@ -2134,7 +2158,7 @@
               "position": "bottom",
               "skipIfContains": "\"crud.${option:namespace|snake}.list\"",
               "value": "__JSKIT_CRUD_ROLE_CATALOG_PERMISSION_GRANTS__",
-              "reason": "Grant generated CRUD action permissions to the default member role in the app-owned role catalog.",
+              "reason": "Grant generated CRUD action permissions to the selected role in the app-owned role catalog.",
               "category": "crud",
               "id": "crud-role-catalog-permissions-${option:namespace|snake}",
               "templateContext": {
@@ -2148,11 +2172,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.106",
+      "version": "0.1.107",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-ui-generator",
-        "version": "0.1.106",
+        "version": "0.1.107",
         "kind": "generator",
         "description": "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
         "options": {
@@ -2351,7 +2375,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.139"
+              "@jskit-ai/users-web": "0.1.140"
             },
             "dev": {}
           },
@@ -2610,11 +2634,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime",
-      "version": "0.1.122",
+      "version": "0.1.123",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime",
-        "version": "0.1.122",
+        "version": "0.1.123",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -2683,7 +2707,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.123",
+              "@jskit-ai/kernel": "0.1.124",
               "dotenv": "^16.4.5",
               "knex": "^3.1.0"
             },
@@ -2719,11 +2743,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.121",
+      "version": "0.1.122",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-mysql",
-        "version": "0.1.121",
+        "version": "0.1.122",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -2845,7 +2869,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.122",
+              "@jskit-ai/database-runtime": "0.1.123",
               "mysql2": "^3.11.2"
             },
             "dev": {}
@@ -2916,11 +2940,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.120",
+      "version": "0.1.121",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-postgres",
-        "version": "0.1.120",
+        "version": "0.1.121",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -3041,7 +3065,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.122",
+              "@jskit-ai/database-runtime": "0.1.123",
               "pg": "^8.13.1"
             },
             "dev": {}
@@ -3112,11 +3136,11 @@
     },
     {
       "packageId": "@jskit-ai/feature-server-generator",
-      "version": "0.1.65",
+      "version": "0.1.66",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/feature-server-generator",
-        "version": "0.1.65",
+        "version": "0.1.66",
         "kind": "generator",
         "description": "Scaffold substantial non-CRUD server feature packages with provider, actions, service, and optional persistence seams.",
         "options": {
@@ -3281,27 +3305,27 @@
           "dependencies": {
             "runtime": {
               "@jskit-ai/database-runtime": {
-                "version": "0.1.122",
+                "version": "0.1.123",
                 "when": {
                   "option": "mode",
                   "notEquals": "orchestrator"
                 }
               },
               "@jskit-ai/database-runtime-mysql": {
-                "version": "0.1.121",
+                "version": "0.1.122",
                 "when": {
                   "option": "mode",
                   "notEquals": "orchestrator"
                 }
               },
               "@jskit-ai/json-rest-api-core": {
-                "version": "0.1.67",
+                "version": "0.1.68",
                 "when": {
                   "option": "mode",
                   "equals": "json-rest"
                 }
               },
-              "@jskit-ai/kernel": "0.1.123",
+              "@jskit-ai/kernel": "0.1.124",
               "json-rest-schema": "1.x.x",
               "@local/${option:feature-name|kebab}": "file:packages/${option:feature-name|kebab}"
             },
@@ -3414,11 +3438,11 @@
     },
     {
       "packageId": "@jskit-ai/google-rewarded-core",
-      "version": "0.1.60",
+      "version": "0.1.61",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/google-rewarded-core",
-        "version": "0.1.60",
+        "version": "0.1.61",
         "kind": "runtime",
         "description": "Google rewarded workflow runtime plus internal CRUD providers for rules, provider configs, watch sessions, and unlock receipts.",
         "dependsOn": [
@@ -3545,14 +3569,14 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.120",
-              "@jskit-ai/crud-core": "0.1.131",
-              "@jskit-ai/database-runtime": "0.1.122",
-              "@jskit-ai/http-runtime": "0.1.121",
-              "@jskit-ai/json-rest-api-core": "0.1.67",
-              "@jskit-ai/kernel": "0.1.123",
-              "@jskit-ai/resource-crud-core": "0.1.66",
-              "@jskit-ai/workspaces-core": "0.1.99"
+              "@jskit-ai/auth-core": "0.1.121",
+              "@jskit-ai/crud-core": "0.1.132",
+              "@jskit-ai/database-runtime": "0.1.123",
+              "@jskit-ai/http-runtime": "0.1.122",
+              "@jskit-ai/json-rest-api-core": "0.1.68",
+              "@jskit-ai/kernel": "0.1.124",
+              "@jskit-ai/resource-crud-core": "0.1.67",
+              "@jskit-ai/workspaces-core": "0.1.100"
             },
             "dev": {}
           },
@@ -3604,11 +3628,11 @@
     },
     {
       "packageId": "@jskit-ai/google-rewarded-web",
-      "version": "0.1.60",
+      "version": "0.1.61",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/google-rewarded-web",
-        "version": "0.1.60",
+        "version": "0.1.61",
         "kind": "runtime",
         "description": "Google rewarded client runtime with a fullscreen gate host and GPT orchestration.",
         "dependsOn": [
@@ -3655,10 +3679,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/google-rewarded-core": "0.1.60",
-              "@jskit-ai/http-runtime": "0.1.121",
-              "@jskit-ai/kernel": "0.1.123",
-              "@jskit-ai/shell-web": "0.1.124"
+              "@jskit-ai/google-rewarded-core": "0.1.61",
+              "@jskit-ai/http-runtime": "0.1.122",
+              "@jskit-ai/kernel": "0.1.124",
+              "@jskit-ai/shell-web": "0.1.125"
             },
             "dev": {}
           },
@@ -3676,11 +3700,11 @@
     },
     {
       "packageId": "@jskit-ai/http-runtime",
-      "version": "0.1.121",
+      "version": "0.1.122",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/http-runtime",
-        "version": "0.1.121",
+        "version": "0.1.122",
         "kind": "runtime",
         "dependsOn": [],
         "capabilities": {
@@ -3746,7 +3770,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.123"
+              "@jskit-ai/kernel": "0.1.124"
             },
             "dev": {}
           },
@@ -3760,11 +3784,11 @@
     },
     {
       "packageId": "@jskit-ai/json-rest-api-core",
-      "version": "0.1.67",
+      "version": "0.1.68",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/json-rest-api-core",
-        "version": "0.1.67",
+        "version": "0.1.68",
         "kind": "runtime",
         "description": "Shared internal json-rest-api host runtime with autofilter, query-projection, and row-policy support.",
         "dependsOn": [
@@ -3824,11 +3848,11 @@
     },
     {
       "packageId": "@jskit-ai/mobile-capacitor",
-      "version": "0.1.59",
+      "version": "0.1.60",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/mobile-capacitor",
-        "version": "0.1.59",
+        "version": "0.1.60",
         "kind": "runtime",
         "description": "Thin Capacitor client integration for JSKIT mobile-shell launch routing and auth callback completion.",
         "dependsOn": [
@@ -3891,8 +3915,8 @@
               "@capacitor/app": "^7.1.0",
               "@capacitor/browser": "^7.0.1",
               "@capacitor/core": "^7.4.3",
-              "@jskit-ai/kernel": "0.1.123",
-              "@jskit-ai/shell-web": "0.1.124"
+              "@jskit-ai/kernel": "0.1.124",
+              "@jskit-ai/shell-web": "0.1.125"
             },
             "dev": {
               "@capacitor/cli": "^7.4.3"
@@ -3944,11 +3968,11 @@
     },
     {
       "packageId": "@jskit-ai/realtime",
-      "version": "0.1.120",
+      "version": "0.1.121",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/realtime",
-        "version": "0.1.120",
+        "version": "0.1.121",
         "kind": "runtime",
         "description": "Thin, generic realtime runtime wrappers for socket.io server and client.",
         "options": {
@@ -4044,7 +4068,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.123",
+              "@jskit-ai/kernel": "0.1.124",
               "@socket.io/redis-adapter": "^8.3.0",
               "redis": "^5.8.2",
               "socket.io": "^4.8.3",
@@ -4093,11 +4117,11 @@
     },
     {
       "packageId": "@jskit-ai/resource-core",
-      "version": "0.1.66",
+      "version": "0.1.67",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/resource-core",
-        "version": "0.1.66",
+        "version": "0.1.67",
         "kind": "runtime",
         "description": "Generic resource-definition helpers and schema-definition normalization.",
         "dependsOn": [
@@ -4120,7 +4144,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/resource-core": "0.1.66"
+              "@jskit-ai/resource-core": "0.1.67"
             },
             "dev": {}
           },
@@ -4135,11 +4159,11 @@
     },
     {
       "packageId": "@jskit-ai/resource-crud-core",
-      "version": "0.1.66",
+      "version": "0.1.67",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/resource-crud-core",
-        "version": "0.1.66",
+        "version": "0.1.67",
         "kind": "runtime",
         "description": "CRUD-specific resource-definition helpers and namespace support.",
         "dependsOn": [
@@ -4163,7 +4187,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/resource-crud-core": "0.1.66"
+              "@jskit-ai/resource-crud-core": "0.1.67"
             },
             "dev": {}
           },
@@ -4178,11 +4202,11 @@
     },
     {
       "packageId": "@jskit-ai/shell-web",
-      "version": "0.1.124",
+      "version": "0.1.125",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/shell-web",
-        "version": "0.1.124",
+        "version": "0.1.125",
         "kind": "runtime",
         "description": "Web shell layout runtime with outlet-based placement contributions.",
         "dependsOn": [],
@@ -4528,7 +4552,7 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/kernel": "0.1.123"
+              "@jskit-ai/kernel": "0.1.124"
             },
             "dev": {
               "@playwright/test": "1.61.1"
@@ -4757,11 +4781,11 @@
     },
     {
       "packageId": "@jskit-ai/storage-runtime",
-      "version": "0.1.121",
+      "version": "0.1.122",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/storage-runtime",
-        "version": "0.1.121",
+        "version": "0.1.122",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -4810,7 +4834,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.123",
+              "@jskit-ai/kernel": "0.1.124",
               "unstorage": "^1.17.3"
             },
             "dev": {}
@@ -4826,11 +4850,11 @@
     },
     {
       "packageId": "@jskit-ai/ui-generator",
-      "version": "0.1.106",
+      "version": "0.1.107",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/ui-generator",
-        "version": "0.1.106",
+        "version": "0.1.107",
         "kind": "generator",
         "description": "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
         "options": {
@@ -5263,7 +5287,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.139"
+              "@jskit-ai/users-web": "0.1.140"
             },
             "dev": {}
           },
@@ -5278,11 +5302,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-image-web",
-      "version": "0.1.99",
+      "version": "0.1.100",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-image-web",
-        "version": "0.1.99",
+        "version": "0.1.100",
         "kind": "runtime",
         "description": "Reusable client-side image upload runtime with pre-upload image editing.",
         "dependsOn": [
@@ -5346,7 +5370,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/uploads-runtime": "0.1.99",
+              "@jskit-ai/uploads-runtime": "0.1.100",
               "@uppy/compressor": "^3.1.0",
               "@uppy/core": "^5.2.0",
               "@uppy/dashboard": "^5.1.1",
@@ -5366,11 +5390,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-runtime",
-      "version": "0.1.99",
+      "version": "0.1.100",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-runtime",
-        "version": "0.1.99",
+        "version": "0.1.100",
         "kind": "runtime",
         "description": "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
         "dependsOn": [
@@ -5440,7 +5464,7 @@
           "dependencies": {
             "runtime": {
               "@fastify/multipart": "^9.4.0",
-              "@jskit-ai/kernel": "0.1.123"
+              "@jskit-ai/kernel": "0.1.124"
             },
             "dev": {}
           },
@@ -5455,11 +5479,11 @@
     },
     {
       "packageId": "@jskit-ai/users-core",
-      "version": "0.1.133",
+      "version": "0.1.134",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-core",
-        "version": "0.1.133",
+        "version": "0.1.134",
         "kind": "runtime",
         "description": "Users/account runtime plus HTTP routes for account features.",
         "dependsOn": [
@@ -5603,16 +5627,16 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.120",
-              "@jskit-ai/crud-core": "0.1.131",
-              "@jskit-ai/database-runtime": "0.1.122",
-              "@jskit-ai/http-runtime": "0.1.121",
-              "@jskit-ai/json-rest-api-core": "0.1.67",
-              "@jskit-ai/kernel": "0.1.123",
-              "@jskit-ai/resource-core": "0.1.66",
-              "@jskit-ai/resource-crud-core": "0.1.66",
+              "@jskit-ai/auth-core": "0.1.121",
+              "@jskit-ai/crud-core": "0.1.132",
+              "@jskit-ai/database-runtime": "0.1.123",
+              "@jskit-ai/http-runtime": "0.1.122",
+              "@jskit-ai/json-rest-api-core": "0.1.68",
+              "@jskit-ai/kernel": "0.1.124",
+              "@jskit-ai/resource-core": "0.1.67",
+              "@jskit-ai/resource-crud-core": "0.1.67",
               "@local/users": "file:packages/users",
-              "@jskit-ai/uploads-runtime": "0.1.99"
+              "@jskit-ai/uploads-runtime": "0.1.100"
             },
             "dev": {}
           },
@@ -5839,11 +5863,11 @@
     },
     {
       "packageId": "@jskit-ai/users-web",
-      "version": "0.1.139",
+      "version": "0.1.140",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-web",
-        "version": "0.1.139",
+        "version": "0.1.140",
         "kind": "runtime",
         "description": "Users web module: account/profile UI plus shared users web widgets.",
         "dependsOn": [
@@ -6146,12 +6170,12 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/http-runtime": "0.1.121",
-              "@jskit-ai/realtime": "0.1.120",
-              "@jskit-ai/kernel": "0.1.123",
-              "@jskit-ai/shell-web": "0.1.124",
-              "@jskit-ai/uploads-image-web": "0.1.99",
-              "@jskit-ai/users-core": "0.1.133"
+              "@jskit-ai/http-runtime": "0.1.122",
+              "@jskit-ai/realtime": "0.1.121",
+              "@jskit-ai/kernel": "0.1.124",
+              "@jskit-ai/shell-web": "0.1.125",
+              "@jskit-ai/uploads-image-web": "0.1.100",
+              "@jskit-ai/users-core": "0.1.134"
             },
             "dev": {}
           },
@@ -6328,11 +6352,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-core",
-      "version": "0.1.99",
+      "version": "0.1.100",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-core",
-        "version": "0.1.99",
+        "version": "0.1.100",
         "kind": "runtime",
         "description": "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
         "dependsOn": [
@@ -6478,10 +6502,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/json-rest-api-core": "0.1.67",
-              "@jskit-ai/resource-core": "0.1.66",
-              "@jskit-ai/resource-crud-core": "0.1.66",
-              "@jskit-ai/users-core": "0.1.133"
+              "@jskit-ai/json-rest-api-core": "0.1.68",
+              "@jskit-ai/resource-core": "0.1.67",
+              "@jskit-ai/resource-crud-core": "0.1.67",
+              "@jskit-ai/users-core": "0.1.134"
             },
             "dev": {}
           },
@@ -6684,11 +6708,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-web",
-      "version": "0.1.100",
+      "version": "0.1.101",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-web",
-        "version": "0.1.100",
+        "version": "0.1.101",
         "kind": "runtime",
         "description": "Workspace web module: workspace selector, tools widget, workspace surfaces, members UI, and settings hosts.",
         "dependsOn": [
@@ -6945,9 +6969,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-web": "0.1.123",
-              "@jskit-ai/workspaces-core": "0.1.99",
-              "@jskit-ai/users-web": "0.1.139"
+              "@jskit-ai/auth-web": "0.1.124",
+              "@jskit-ai/workspaces-core": "0.1.100",
+              "@jskit-ai/users-web": "0.1.140"
             },
             "dev": {}
           },

--- a/tooling/jskit-catalog/package.json
+++ b/tooling/jskit-catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-catalog",
-  "version": "0.1.135",
+  "version": "0.1.137",
   "description": "Published metadata catalog for JSKIT package descriptors.",
   "type": "module",
   "files": [

--- a/tooling/jskit-cli/package.json
+++ b/tooling/jskit-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-cli",
-  "version": "0.2.140",
+  "version": "0.2.142",
   "description": "Bundle and package orchestration CLI for JSKIT apps.",
   "type": "module",
   "files": [
@@ -21,9 +21,9 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/jskit-catalog": "0.1.135",
-    "@jskit-ai/kernel": "0.1.123",
-    "@jskit-ai/shell-web": "0.1.124",
+    "@jskit-ai/jskit-catalog": "0.1.137",
+    "@jskit-ai/kernel": "0.1.124",
+    "@jskit-ai/shell-web": "0.1.125",
     "@vue/compiler-sfc": "^3.5.29",
     "ts-morph": "^28.0.0",
     "yaml": "^2.8.3"

--- a/tooling/jskit-cli/src/server/commandHandlers/health.js
+++ b/tooling/jskit-cli/src/server/commandHandlers/health.js
@@ -1659,11 +1659,22 @@ function createHealthCommands(ctx = {}) {
       const crudOwnership = crudOwnershipByTable.get(tableName) || null;
       if (crudOwnership) {
         const missingRequiredOwnerKinds = subtractStringSet(crudOwnership.requiredOwnerKinds, directOwnerKinds);
+        const unexpectedOwnerKinds = subtractStringSet(directOwnerKinds, crudOwnership.requiredOwnerKinds);
         if (missingRequiredOwnerKinds.size > 0) {
           issues.push(
             `${crudOwnership.providerPath}: [crud-ownership:missing-owner-columns] ownershipFilter "${crudOwnership.ownershipFilter}" requires live table "${tableName}" to carry direct owner column(s) ${formatOwnerColumns(missingRequiredOwnerKinds)}. JSKIT CRUD ownership must be materialized on the row, not recovered through joins.`
           );
         }
+        if (unexpectedOwnerKinds.size > 0) {
+          issues.push(
+            `${crudOwnership.providerPath}: [crud-ownership:unexpected-owner-columns] ownershipFilter "${crudOwnership.ownershipFilter}" conflicts with reserved owner column(s) ${formatOwnerColumns(unexpectedOwnerKinds)} on live table "${tableName}". The exact direct columns "workspace_id" and "user_id" define JSKIT ownership; change the filter to match, or rename a domain relationship to a specific foreign-key name.`
+          );
+        }
+
+        // Direct workspace_id and user_id columns define this CRUD's ownership, and the checks
+        // above require its filter to agree. Foreign-key reachability through domain relationships
+        // such as recipient_user_id and created_by_user_id does not add another owner.
+        continue;
       }
 
       if (inheritedOwnerKinds.size < 1 || allowsAuxiliaryInheritedOwnership) {

--- a/tooling/jskit-cli/src/server/prompts/app_blueprint.md
+++ b/tooling/jskit-cli/src/server/prompts/app_blueprint.md
@@ -33,7 +33,7 @@ Cover:
 - The role of each surface: app, admin, console, settings, public, workspace, or any app-specific surface from the brief.
 - Global view of the main product areas and navigation destinations.
 - Key domain concepts and data objects, without inventing database schemas unless the brief clearly requires them.
-- Ownership model per persistent entity when it is already clear: public, user, workspace, or workspace_user.
+- Ownership model per persistent entity when it is already clear: public, user, workspace, or workspace_user. Treat only the exact columns `workspace_id` and `user_id` as standard JSKIT ownership, and require the selected ownership filter to match those columns exactly. Treat specific foreign keys such as `recipient_user_id`, `created_by_user_id`, and `assignee_user_id` as domain relationships, not ownership aliases. Never rename a domain relationship to an ownership column to satisfy tooling.
 - Baseline JSKIT package workflows to accept as defaults and any intended overrides.
 - Package install, generator, and custom-code areas at a high level.
 - CRUDs likely to need server ownership, and any narrow exceptions that should be called out later.

--- a/tooling/jskit-cli/test/appBlueprintPrompt.test.js
+++ b/tooling/jskit-cli/test/appBlueprintPrompt.test.js
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+test("app blueprint prompt distinguishes canonical ownership from domain relationships", async () => {
+  const prompt = await readFile(
+    path.join(packageRoot, "src/server/prompts/app_blueprint.md"),
+    "utf8"
+  );
+
+  assert.match(prompt, /exact columns `workspace_id` and `user_id` as standard JSKIT ownership/);
+  assert.match(prompt, /require the selected ownership filter to match those columns exactly/);
+  assert.match(prompt, /`recipient_user_id`/);
+  assert.match(prompt, /domain relationships, not ownership aliases/);
+  assert.match(prompt, /Never rename a domain relationship to an ownership column to satisfy tooling/);
+});

--- a/tooling/jskit-cli/test/crudServerGeneratorGrantPolicy.test.js
+++ b/tooling/jskit-cli/test/crudServerGeneratorGrantPolicy.test.js
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+import {
+  mkdir,
+  readFile,
+  stat,
+  writeFile
+} from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { createCliRunner } from "../../testUtils/runCli.js";
+import { withTempDir } from "../../testUtils/tempDir.mjs";
+
+const CLI_PATH = fileURLToPath(new URL("../bin/jskit.js", import.meta.url));
+const runCli = createCliRunner(CLI_PATH);
+
+async function fileExists(filePath) {
+  try {
+    await stat(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function createCustomRoleApp(appRoot) {
+  await mkdir(path.join(appRoot, "config"), { recursive: true });
+  await mkdir(path.join(appRoot, ".jskit"), { recursive: true });
+  const packageJsonSource = `${JSON.stringify(
+    {
+      name: "custom-role-crud-app",
+      version: "0.1.0",
+      private: true,
+      type: "module",
+      workspaces: ["packages/*"]
+    },
+    null,
+    2
+  )}\n`;
+  const rolesSource = `export const roleCatalog = {
+  workspace: {
+    defaultInviteRole: "worker"
+  },
+  roles: {
+    owner: { assignable: false, permissions: ["*"] },
+    member: { assignable: true, permissions: ["workspace.settings.view"] },
+    administrator: { assignable: true, permissions: [] },
+    safety_manager: { assignable: true, permissions: [] },
+    worker: { assignable: true, permissions: [] }
+  }
+};
+`;
+  const publicConfigSource = `import { roleCatalog } from "./roles.js";
+
+export const config = {
+  surfaceDefinitions: {
+    app: { id: "app", enabled: true, requiresAuth: true, requiresWorkspace: true }
+  },
+  roleCatalog
+};
+`;
+  const lockSource = `${JSON.stringify(
+    {
+      lockVersion: 1,
+      installedPackages: {
+        "@jskit-ai/auth-provider-local-core": { version: "0.1.24" },
+        "@jskit-ai/database-runtime-mysql": { version: "0.1.121" }
+      }
+    },
+    null,
+    2
+  )}\n`;
+
+  await writeFile(path.join(appRoot, "package.json"), packageJsonSource, "utf8");
+  await writeFile(path.join(appRoot, "config", "roles.js"), rolesSource, "utf8");
+  await writeFile(path.join(appRoot, "config", "public.js"), publicConfigSource, "utf8");
+  await writeFile(path.join(appRoot, ".jskit", "lock.json"), lockSource, "utf8");
+
+  return {
+    packageJsonSource,
+    rolesSource,
+    publicConfigSource,
+    lockSource
+  };
+}
+
+test("crud generator requires an explicit grant policy before touching app files", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "app");
+    const original = await createCustomRoleApp(appRoot);
+
+    const result = runCli({
+      cwd: appRoot,
+      args: [
+        "generate",
+        "crud-server-generator",
+        "scaffold",
+        "--namespace",
+        "notification_outbox_items",
+        "--surface",
+        "app",
+        "--ownership-filter",
+        "workspace",
+        "--table-name",
+        "notification_outbox_items",
+        "--internal"
+      ]
+    });
+
+    assert.equal(result.status, 1, String(result.stdout || ""));
+    assert.match(
+      String(result.stderr || ""),
+      /requires an explicit permission grant policy.*--grant-role <role-id>.*--no-role-grant/s
+    );
+    assert.equal(await readFile(path.join(appRoot, "package.json"), "utf8"), original.packageJsonSource);
+    assert.equal(await readFile(path.join(appRoot, "config", "roles.js"), "utf8"), original.rolesSource);
+    assert.equal(await readFile(path.join(appRoot, "config", "public.js"), "utf8"), original.publicConfigSource);
+    assert.equal(await readFile(path.join(appRoot, ".jskit", "lock.json"), "utf8"), original.lockSource);
+    assert.equal(await fileExists(path.join(appRoot, "packages")), false);
+    assert.equal(await fileExists(path.join(appRoot, "migrations")), false);
+  });
+});

--- a/tooling/jskit-cli/test/doctorTableOwnershipValidation.test.js
+++ b/tooling/jskit-cli/test/doctorTableOwnershipValidation.test.js
@@ -478,14 +478,14 @@ test("doctor flags direct knex in app-owned packages outside explicit exception 
   });
 });
 
-test("doctor flags CRUD tables whose ownership filter requires a direct owner column", async () => {
+test("doctor requires CRUD ownership filters to match direct reserved owner columns exactly", async () => {
   await withTempDir(async (cwd) => {
     const appRoot = path.join(cwd, "doctor-crud-missing-owner-column-app");
     await createMinimalApp(appRoot, { name: "doctor-crud-missing-owner-column-app" });
     await installFakeKnex(appRoot, {
       tables: ["contacts"],
       columns: {
-        contacts: ["id", "name"]
+        contacts: ["id", "user_id", "name"]
       }
     });
     await writeKnexfile(appRoot);
@@ -547,6 +547,110 @@ test("doctor flags CRUD tables whose ownership filter requires a direct owner co
       payload.issues.join("\n"),
       /ContactsProvider\.js: \[crud-ownership:missing-owner-columns\] ownershipFilter "workspace" requires live table "contacts" to carry direct owner column\(s\) "workspace_id"/
     );
+    assert.match(
+      payload.issues.join("\n"),
+      /ContactsProvider\.js: \[crud-ownership:unexpected-owner-columns\] ownershipFilter "workspace" conflicts with reserved owner column\(s\) "user_id".*exact direct columns "workspace_id" and "user_id" define JSKIT ownership/s
+    );
+  });
+});
+
+test("doctor keeps noncanonical user foreign keys as domain relationships for explicitly owned CRUD tables", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "doctor-crud-domain-user-relationship-app");
+    await createMinimalApp(appRoot, { name: "doctor-crud-domain-user-relationship-app" });
+    await installFakeKnex(appRoot, {
+      tables: ["user_profiles", "notification_outbox_items"],
+      columns: {
+        user_profiles: ["id", "user_id"],
+        notification_outbox_items: ["id", "workspace_id", "recipient_user_id"]
+      },
+      foreignKeys: [
+        {
+          tableName: "notification_outbox_items",
+          columnName: "recipient_user_id",
+          referencedTableName: "user_profiles",
+          referencedColumnName: "user_id"
+        }
+      ]
+    });
+    await writeKnexfile(appRoot);
+    await writeLockFile(appRoot, ["@local/notification-outbox-items"]);
+
+    await writePackageDescriptor(
+      appRoot,
+      "notification-outbox-items",
+      `export default Object.freeze({
+  packageId: "@local/notification-outbox-items",
+  version: "0.1.0",
+  kind: "runtime",
+  capabilities: {
+    provides: ["crud.notification-outbox-items"],
+    requires: []
+  },
+  runtime: {
+    server: {
+      providers: [
+        {
+          entrypoint: "src/server/NotificationOutboxItemsProvider.js",
+          export: "NotificationOutboxItemsProvider"
+        }
+      ]
+    }
+  },
+  metadata: {
+    jskit: {
+      scaffoldShape: "crud-server-v1",
+      tableOwnership: {
+        tables: [
+          {
+            tableName: "notification_outbox_items",
+            provenance: "crud-server-generator",
+            ownerKind: "crud-package"
+          }
+        ]
+      }
+    }
+  },
+  mutations: {
+    files: []
+  }
+});
+`,
+      {
+        "src/server/NotificationOutboxItemsProvider.js": createCrudProviderStub(
+          "workspace",
+          "NotificationOutboxItemsProvider"
+        )
+      }
+    );
+    await writeAppFile(
+      appRoot,
+      ".jskit/table-ownership.json",
+      `${JSON.stringify(
+        {
+          version: 1,
+          exceptions: [
+            {
+              tableName: "user_profiles",
+              category: "projection-cache",
+              owner: "packages/users",
+              reason: "User profile fixture referenced by the outbox recipient relationship."
+            }
+          ]
+        },
+        null,
+        2
+      )}\n`
+    );
+
+    const doctorResult = runCli({
+      cwd: appRoot,
+      args: ["doctor", "--json"]
+    });
+
+    assert.equal(doctorResult.status, 0, String(doctorResult.stderr || ""));
+    const payload = JSON.parse(String(doctorResult.stdout || "{}"));
+    assert.deepEqual(payload.issues, []);
   });
 });
 


### PR DESCRIPTION
## Summary

- require generated CRUD ownership filters to match the exact reserved `workspace_id` and `user_id` columns
- require an explicit `--grant-role <role-id>` or `--no-role-grant` policy for workspace CRUD generation before files are written
- align Doctor checks, app blueprint guidance, distributed docs, generated artifacts, tests, and release-updated package metadata

## Verification

- `npm run verify`