### PR TITLE
Fix immutable console auth decoration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7849,7 +7849,7 @@
     },
     "packages/console-core": {
       "name": "@jskit-ai/console-core",
-      "version": "0.1.87",
+      "version": "0.1.88",
       "dependencies": {
         "@jskit-ai/auth-core": "0.1.121",
         "@jskit-ai/database-runtime": "0.1.123",
@@ -7862,10 +7862,10 @@
     },
     "packages/console-web": {
       "name": "@jskit-ai/console-web",
-      "version": "0.1.92",
+      "version": "0.1.93",
       "dependencies": {
         "@jskit-ai/auth-web": "0.1.124",
-        "@jskit-ai/console-core": "0.1.87",
+        "@jskit-ai/console-core": "0.1.88",
         "@jskit-ai/shell-web": "0.1.125"
       }
     },
@@ -8096,7 +8096,7 @@
     },
     "packages/workspaces-core": {
       "name": "@jskit-ai/workspaces-core",
-      "version": "0.1.100",
+      "version": "0.1.101",
       "dependencies": {
         "@jskit-ai/auth-core": "0.1.121",
         "@jskit-ai/database-runtime": "0.1.123",
@@ -8111,7 +8111,7 @@
     },
     "packages/workspaces-web": {
       "name": "@jskit-ai/workspaces-web",
-      "version": "0.1.101",
+      "version": "0.1.102",
       "dependencies": {
         "@jskit-ai/auth-web": "0.1.124",
         "@jskit-ai/http-runtime": "0.1.122",
@@ -8119,7 +8119,7 @@
         "@jskit-ai/shell-web": "0.1.125",
         "@jskit-ai/users-core": "0.1.134",
         "@jskit-ai/users-web": "0.1.140",
-        "@jskit-ai/workspaces-core": "0.1.100",
+        "@jskit-ai/workspaces-core": "0.1.101",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -8149,9 +8149,9 @@
     },
     "tooling/create-app": {
       "name": "@jskit-ai/create-app",
-      "version": "0.1.139",
+      "version": "0.1.140",
       "dependencies": {
-        "@jskit-ai/jskit-cli": "0.2.142"
+        "@jskit-ai/jskit-cli": "0.2.143"
       },
       "bin": {
         "jskit-create-app": "bin/jskit-create-app.js"
@@ -8162,16 +8162,16 @@
     },
     "tooling/jskit-catalog": {
       "name": "@jskit-ai/jskit-catalog",
-      "version": "0.1.137",
+      "version": "0.1.138",
       "engines": {
         "node": "^22.12.0 || ^24.0.0 || ^26.0.0"
       }
     },
     "tooling/jskit-cli": {
       "name": "@jskit-ai/jskit-cli",
-      "version": "0.2.142",
+      "version": "0.2.143",
       "dependencies": {
-        "@jskit-ai/jskit-catalog": "0.1.137",
+        "@jskit-ai/jskit-catalog": "0.1.138",
         "@jskit-ai/kernel": "0.1.124",
         "@jskit-ai/shell-web": "0.1.125",
         "@vue/compiler-sfc": "^3.5.29",

--- a/packages/console-core/package.descriptor.mjs
+++ b/packages/console-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-core",
-  version: "0.1.87",
+  version: "0.1.88",
   kind: "runtime",
   description: "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
   dependsOn: [

--- a/packages/console-core/package.json
+++ b/packages/console-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/console-core",
-  "version": "0.1.87",
+  "version": "0.1.88",
   "type": "module",
   "scripts": {
     "test": "node --test"

--- a/packages/console-core/src/server/consoleAuthServiceDecorator.js
+++ b/packages/console-core/src/server/consoleAuthServiceDecorator.js
@@ -40,8 +40,9 @@ function createConsoleAuthServiceDecorator({ consoleService } = {}) {
       }
 
       return Object.freeze(
-        Object.assign(Object.create(authService), {
-          async authenticateRequest(request, ...args) {
+        Object.defineProperty(Object.create(authService), "authenticateRequest", {
+          enumerable: true,
+          value: async function authenticateRequest(request, ...args) {
             const authResult = await authService.authenticateRequest(request, ...args);
             if (consoleOwnerInitialized) {
               return authResult;

--- a/packages/console-core/test/consoleAuthServiceDecorator.test.js
+++ b/packages/console-core/test/consoleAuthServiceDecorator.test.js
@@ -63,3 +63,56 @@ test("console auth service decorator leaves unauthenticated session reads alone"
 
   assert.equal(result.authenticated, false);
 });
+
+test("console auth service decorator safely shadows authenticateRequest on a frozen service", async () => {
+  const calls = [];
+  const ownerSeeds = [];
+  const originalAuthenticateRequest = async function authenticateRequest(request, ...args) {
+    calls.push({ request, args });
+    return {
+      authenticated: true,
+      profile: {
+        id: request.profileId
+      }
+    };
+  };
+  const originalAuthService = Object.freeze({
+    authenticateRequest: originalAuthenticateRequest,
+    readMarker() {
+      return "original-service";
+    }
+  });
+  const decorator = createConsoleAuthServiceDecorator({
+    consoleService: {
+      async ensureInitialConsoleMember(userId) {
+        ownerSeeds.push(String(userId || ""));
+        return String(userId || "");
+      }
+    }
+  });
+
+  const decoratedAuthService = decorator.decorateAuthService(originalAuthService);
+  const result = await decoratedAuthService.authenticateRequest(
+    {
+      profileId: "42",
+      url: "/api/session"
+    },
+    "forwarded-argument"
+  );
+
+  assert.equal(Object.isFrozen(originalAuthService), true);
+  assert.equal(Object.isFrozen(decoratedAuthService), true);
+  assert.equal(Object.getPrototypeOf(decoratedAuthService), originalAuthService);
+  assert.equal(originalAuthService.authenticateRequest, originalAuthenticateRequest);
+  assert.equal(decoratedAuthService.readMarker(), "original-service");
+  assert.equal(result.profile.id, "42");
+  assert.deepEqual(ownerSeeds, ["42"]);
+  assert.equal(calls.length, 1);
+  assert.deepEqual(calls[0].args, ["forwarded-argument"]);
+  assert.deepEqual(Object.getOwnPropertyDescriptor(decoratedAuthService, "authenticateRequest"), {
+    configurable: false,
+    enumerable: true,
+    value: decoratedAuthService.authenticateRequest,
+    writable: false
+  });
+});

--- a/packages/console-web/package.descriptor.mjs
+++ b/packages/console-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-web",
-  version: "0.1.92",
+  version: "0.1.93",
   kind: "runtime",
   description: "Authenticated console surface scaffold and surface policy wiring.",
   dependsOn: [
@@ -104,7 +104,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@jskit-ai/auth-web": "0.1.124",
-        "@jskit-ai/console-core": "0.1.87",
+        "@jskit-ai/console-core": "0.1.88",
         "@jskit-ai/shell-web": "0.1.125",
       },
       dev: {}

--- a/packages/console-web/package.json
+++ b/packages/console-web/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/console-web",
-  "version": "0.1.92",
+  "version": "0.1.93",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
     "@jskit-ai/auth-web": "0.1.124",
-    "@jskit-ai/console-core": "0.1.87",
+    "@jskit-ai/console-core": "0.1.88",
     "@jskit-ai/shell-web": "0.1.125"
   }
 }

--- a/packages/workspaces-core/package.descriptor.mjs
+++ b/packages/workspaces-core/package.descriptor.mjs
@@ -192,6 +192,7 @@ export default Object.freeze({
       {
         from: "templates/config/roles.js",
         to: "config/roles.js",
+        ownership: "app",
         preserveOnRemove: true,
         reason: "Install app-owned role catalog in a dedicated config file.",
         category: "workspaces-core",

--- a/packages/workspaces-core/package.descriptor.mjs
+++ b/packages/workspaces-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-core",
-  version: "0.1.100",
+  version: "0.1.101",
   kind: "runtime",
   description: "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
   dependsOn: [

--- a/packages/workspaces-core/package.json
+++ b/packages/workspaces-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-core",
-  "version": "0.1.100",
+  "version": "0.1.101",
   "type": "module",
   "scripts": {
     "test": "node --test"

--- a/packages/workspaces-core/test/packageDescriptor.test.js
+++ b/packages/workspaces-core/test/packageDescriptor.test.js
@@ -37,6 +37,21 @@ test("workspaces-core descriptor advertises public invite resolution route metad
   });
 });
 
+test("workspaces-core installs an app-owned editable role catalog", async () => {
+  const source = await readFile(path.join(PACKAGE_DIR, "templates", "config", "roles.js"), "utf8");
+
+  assert.match(source, /export const roleCatalog/);
+  assert.deepEqual(findFileMutation("users-core-app-owned-role-catalog-config"), {
+    from: "templates/config/roles.js",
+    to: "config/roles.js",
+    ownership: "app",
+    preserveOnRemove: true,
+    reason: "Install app-owned role catalog in a dedicated config file.",
+    category: "workspaces-core",
+    id: "users-core-app-owned-role-catalog-config"
+  });
+});
+
 test("workspaces-core installs an app-owned editable workspace invite email template", async () => {
   const source = await readFile(
     path.join(PACKAGE_DIR, "templates", "packages", "main", "src", "server", "email", "workspaceInviteEmail.js"),

--- a/packages/workspaces-web/package.descriptor.mjs
+++ b/packages/workspaces-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-web",
-  version: "0.1.101",
+  version: "0.1.102",
   kind: "runtime",
   description: "Workspace web module: workspace selector, tools widget, workspace surfaces, members UI, and settings hosts.",
   dependsOn: [
@@ -233,7 +233,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@jskit-ai/auth-web": "0.1.124",
-        "@jskit-ai/workspaces-core": "0.1.100",
+        "@jskit-ai/workspaces-core": "0.1.101",
         "@jskit-ai/users-web": "0.1.140"
       },
       dev: {}

--- a/packages/workspaces-web/package.json
+++ b/packages/workspaces-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-web",
-  "version": "0.1.101",
+  "version": "0.1.102",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -21,7 +21,7 @@
     "@jskit-ai/shell-web": "0.1.125",
     "@jskit-ai/users-core": "0.1.134",
     "@jskit-ai/users-web": "0.1.140",
-    "@jskit-ai/workspaces-core": "0.1.100"
+    "@jskit-ai/workspaces-core": "0.1.101"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/tooling/create-app/package.descriptor.mjs
+++ b/tooling/create-app/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/create-app",
-  "version": "0.1.139",
+  "version": "0.1.140",
   "dependsOn": [],
   "capabilities": {
     "provides": [

--- a/tooling/create-app/package.json
+++ b/tooling/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/create-app",
-  "version": "0.1.139",
+  "version": "0.1.140",
   "description": "Scaffold JSKIT app shells.",
   "type": "module",
   "files": [
@@ -20,7 +20,7 @@
     "./client": "./src/client/index.js"
   },
   "dependencies": {
-    "@jskit-ai/jskit-cli": "0.2.142"
+    "@jskit-ai/jskit-cli": "0.2.143"
   },
   "engines": {
     "node": "^22.12.0 || ^24.0.0 || ^26.0.0"

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -6547,6 +6547,7 @@
             {
               "from": "templates/config/roles.js",
               "to": "config/roles.js",
+              "ownership": "app",
               "preserveOnRemove": true,
               "reason": "Install app-owned role catalog in a dedicated config file.",
               "category": "workspaces-core",

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -1450,11 +1450,11 @@
     },
     {
       "packageId": "@jskit-ai/console-core",
-      "version": "0.1.87",
+      "version": "0.1.88",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-core",
-        "version": "0.1.87",
+        "version": "0.1.88",
         "kind": "runtime",
         "description": "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
         "dependsOn": [
@@ -1568,11 +1568,11 @@
     },
     {
       "packageId": "@jskit-ai/console-web",
-      "version": "0.1.92",
+      "version": "0.1.93",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-web",
-        "version": "0.1.92",
+        "version": "0.1.93",
         "kind": "runtime",
         "description": "Authenticated console surface scaffold and surface policy wiring.",
         "dependsOn": [
@@ -1683,7 +1683,7 @@
           "dependencies": {
             "runtime": {
               "@jskit-ai/auth-web": "0.1.124",
-              "@jskit-ai/console-core": "0.1.87",
+              "@jskit-ai/console-core": "0.1.88",
               "@jskit-ai/shell-web": "0.1.125"
             },
             "dev": {}
@@ -6352,11 +6352,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-core",
-      "version": "0.1.100",
+      "version": "0.1.101",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-core",
-        "version": "0.1.100",
+        "version": "0.1.101",
         "kind": "runtime",
         "description": "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
         "dependsOn": [
@@ -6709,11 +6709,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-web",
-      "version": "0.1.101",
+      "version": "0.1.102",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-web",
-        "version": "0.1.101",
+        "version": "0.1.102",
         "kind": "runtime",
         "description": "Workspace web module: workspace selector, tools widget, workspace surfaces, members UI, and settings hosts.",
         "dependsOn": [
@@ -6971,7 +6971,7 @@
           "dependencies": {
             "runtime": {
               "@jskit-ai/auth-web": "0.1.124",
-              "@jskit-ai/workspaces-core": "0.1.100",
+              "@jskit-ai/workspaces-core": "0.1.101",
               "@jskit-ai/users-web": "0.1.140"
             },
             "dev": {}

--- a/tooling/jskit-catalog/package.json
+++ b/tooling/jskit-catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-catalog",
-  "version": "0.1.137",
+  "version": "0.1.138",
   "description": "Published metadata catalog for JSKIT package descriptors.",
   "type": "module",
   "files": [

--- a/tooling/jskit-cli/package.json
+++ b/tooling/jskit-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-cli",
-  "version": "0.2.142",
+  "version": "0.2.143",
   "description": "Bundle and package orchestration CLI for JSKIT apps.",
   "type": "module",
   "files": [
@@ -21,7 +21,7 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/jskit-catalog": "0.1.137",
+    "@jskit-ai/jskit-catalog": "0.1.138",
     "@jskit-ai/kernel": "0.1.124",
     "@jskit-ai/shell-web": "0.1.125",
     "@vue/compiler-sfc": "^3.5.29",


### PR DESCRIPTION
## Summary
- preserve app-owned workspace role catalogs during package updates
- decorate frozen auth services with an own property instead of assignment
- add regression coverage for frozen base services and retained service behavior
- publish the corrected JSKIT package closure

## Verification
- npm run verify
- registry versions verified for console-core 0.1.88 and the dependent release set