### PR TITLE
Add app-owned preview identity contract

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8149,9 +8149,9 @@
     },
     "tooling/create-app": {
       "name": "@jskit-ai/create-app",
-      "version": "0.1.140",
+      "version": "0.1.141",
       "dependencies": {
-        "@jskit-ai/jskit-cli": "0.2.143"
+        "@jskit-ai/jskit-cli": "0.2.144"
       },
       "bin": {
         "jskit-create-app": "bin/jskit-create-app.js"
@@ -8169,7 +8169,7 @@
     },
     "tooling/jskit-cli": {
       "name": "@jskit-ai/jskit-cli",
-      "version": "0.2.143",
+      "version": "0.2.144",
       "dependencies": {
         "@jskit-ai/jskit-catalog": "0.1.138",
         "@jskit-ai/kernel": "0.1.124",

--- a/packages/agent-docs/guide/agent/app-setup/authentication.md
+++ b/packages/agent-docs/guide/agent/app-setup/authentication.md
@@ -974,7 +974,7 @@ The generated `playwright.config.mjs` is a thin delegate to `@jskit-ai/jskit-cli
 
 - without `PLAYWRIGHT_BASE_URL`, it builds the app and starts the local server on `http://127.0.0.1:4173`
 - with `PLAYWRIGHT_BASE_URL`, it uses that managed preview and does not start another server
-- with `JSKIT_PLAYWRIGHT_STORAGE_STATE`, it loads the supplied authenticated state into Playwright contexts
+- with `VIBE64_PLAYWRIGHT_STORAGE_STATE`, it loads the Vibe64-supplied authenticated state into Playwright contexts
 
 Tests should therefore navigate with relative paths such as `page.goto("/w/acme/admin/contacts")`.
 
@@ -1032,7 +1032,7 @@ A managed host authenticates outside the project browser context. It performs it
 
 ```bash
 PLAYWRIGHT_BASE_URL=https://managed-preview.example.test \
-JSKIT_PLAYWRIGHT_STORAGE_STATE=/secure/temp/playwright-state.json \
+VIBE64_PLAYWRIGHT_STORAGE_STATE=/secure/temp/playwright-state.json \
 playwright test tests/e2e/contacts.spec.ts
 ```
 

--- a/packages/agent-docs/guide/agent/app-setup/initial-scaffolding.md
+++ b/packages/agent-docs/guide/agent/app-setup/initial-scaffolding.md
@@ -209,7 +209,7 @@ Published JSKIT libraries and tooling support Node.js 22 from 22.12.0 onward, No
 
 That matters because JSKIT maintenance policy changes over time. If the scaffold copied a large shell script into every app, existing apps would freeze the old behavior forever. By delegating to `jskit app verify`, `jskit app update-packages`, and `jskit app release`, the app keeps the nice `npm run` shortcuts while the maintained behavior stays in the installed CLI package.
 
-The Playwright scaffold follows the same rule. `playwright.config.mjs` delegates to `@jskit-ai/jskit-cli/test/playwright`, and the starter browser specs delegate their shared responsive checks to published JSKIT helpers. The generated files stay small while later JSKIT package updates can change local server startup, managed `PLAYWRIGHT_BASE_URL` handling, and `JSKIT_PLAYWRIGHT_STORAGE_STATE` support without copying that logic into each new app.
+The Playwright scaffold follows the same rule. `playwright.config.mjs` delegates to `@jskit-ai/jskit-cli/test/playwright`, and the starter browser specs delegate their shared responsive checks to published JSKIT helpers. The generated files stay small while later JSKIT package updates can change local server startup, managed `PLAYWRIGHT_BASE_URL` handling, and `VIBE64_PLAYWRIGHT_STORAGE_STATE` support without copying that logic into each new app.
 
 `jskit app verify` is worth noticing specifically. Linting, tests, and builds check your source code and runtime behavior. The JSKIT part of that flow runs `doctor`, which checks JSKIT-managed app state: installed package visibility, lock-file-backed managed files, and other JSKIT-specific health rules. It is there because a JSKIT app is not only code. It is also a descriptor-driven managed project.
 

--- a/packages/agent-docs/guide/agent/app-setup/working-with-the-jskit-cli.md
+++ b/packages/agent-docs/guide/agent/app-setup/working-with-the-jskit-cli.md
@@ -804,7 +804,7 @@ That command does two things:
 - runs the targeted Playwright command you give it
 - writes a receipt describing the verified feature, auth mode, and current dirty UI file set
 
-The auth mode is receipt metadata, not an authentication implementation. `jskit app verify-ui` does not log a user in, inject a secret, or rewrite the Playwright context. A direct local run uses `loginAsExistingUser()` from `@jskit-ai/auth-web/test/playwright`; a managed runner supplies authenticated state through `JSKIT_PLAYWRIGHT_STORAGE_STATE`. The generated `playwright.config.mjs` consumes that state and honors `PLAYWRIGHT_BASE_URL` without starting a second server.
+The auth mode is receipt metadata, not an authentication implementation. `jskit app verify-ui` does not log a user in, inject a secret, or rewrite the Playwright context. A direct local run uses `loginAsExistingUser()` from `@jskit-ai/auth-web/test/playwright`; Vibe64 supplies authenticated state through `VIBE64_PLAYWRIGHT_STORAGE_STATE`. The generated `playwright.config.mjs` consumes that state and honors `PLAYWRIGHT_BASE_URL` without starting a second server.
 
 `doctor` then compares the current changed UI files to that receipt. If you edit the UI again afterwards, the receipt is stale and `doctor` tells you to rerun `jskit app verify-ui`.
 

--- a/packages/agent-docs/patterns/ui-testing.md
+++ b/packages/agent-docs/patterns/ui-testing.md
@@ -16,7 +16,7 @@ Rules:
 - Generated `playwright.config.mjs` delegates to `@jskit-ai/jskit-cli/test/playwright`. Do not copy base-URL, web-server, or storage-state logic into app tests.
 - Use relative paths such as `page.goto("/home")`. The shared config owns the browser base URL.
 - A managed runner supplies `PLAYWRIGHT_BASE_URL`. When it is set, JSKIT does not start another app server.
-- A managed runner supplies an authenticated context through `JSKIT_PLAYWRIGHT_STORAGE_STATE`. Treat that file as a temporary secret: do not commit it, print it, or retain it after the run.
+- Vibe64 supplies an authenticated context through `VIBE64_PLAYWRIGHT_STORAGE_STATE`. Treat that file as a temporary secret: do not commit it, print it, or retain it after the run.
 - Do not install a browser when the environment provides a managed browser runner.
 
 ## Direct local authentication
@@ -61,7 +61,7 @@ A managed preview must not expose `AUTH_DEV_BYPASS_SECRET` to project code or fo
 
 ```bash
 PLAYWRIGHT_BASE_URL=https://managed-preview.example.test \
-JSKIT_PLAYWRIGHT_STORAGE_STATE=/secure/temp/playwright-state.json \
+VIBE64_PLAYWRIGHT_STORAGE_STATE=/secure/temp/playwright-state.json \
 playwright test tests/e2e/contacts.spec.ts
 ```
 

--- a/packages/agent-docs/reference/autogen/tooling/jskit-cli.md
+++ b/packages/agent-docs/reference/autogen/tooling/jskit-cli.md
@@ -534,6 +534,27 @@ Local functions
 - `applyTextReplacements(sourceText = "", replacements = [])`
 - `collectCrudFormFieldCandidateFiles(appRoot = "")`
 
+### `src/server/commandHandlers/appCommands/previewIdentity.js`
+Exports
+- `PREVIEW_IDENTITY_PROTOCOL`
+- `executeJskitPreviewIdentityRequest(value = {}, { env = process.env, fetchImpl = globalThis.fetch } = {})`
+- `runAppPreviewIdentityCommand(_ctx = {}, { env = process.env, fetchImpl = globalThis.fetch, stdin = process.stdin, stdout = process.stdout } = {})`
+Local functions
+- `previewIdentityResponse(requestId = "", values = {})`
+- `previewIdentityFailure(requestId = "", error = {})`
+- `commandError(message = "", code = "jskit_preview_identity_failed", extra = {})`
+- `readInput(stream)`
+- `normalizeRequest(value = {})`
+- `identityFromSubject(subject = {})`
+- `responseSetCookie(response = {})`
+- `cookieHeader(setCookie = [])`
+- `responsePayload(response = {})`
+- `upstreamError(payload = {}, response = {}, extra = {})`
+- `postJson(fetchImpl, href, body, headers = {})`
+- `readSession(fetchImpl, targetOrigin, setCookie = [])`
+- `logout(fetchImpl, targetOrigin, session)`
+- `login(fetchImpl, targetOrigin, identity, secret, session)`
+
 ### `src/server/commandHandlers/appCommands/release.js`
 Exports
 - `runAppReleaseCommand(ctx = {}, { appRoot = "", options = {}, stdout, stderr })`

--- a/packages/agent-docs/site/guide/app-setup/authentication.md
+++ b/packages/agent-docs/site/guide/app-setup/authentication.md
@@ -987,7 +987,7 @@ The generated `playwright.config.mjs` is a thin delegate to `@jskit-ai/jskit-cli
 
 - without `PLAYWRIGHT_BASE_URL`, it builds the app and starts the local server on `http://127.0.0.1:4173`
 - with `PLAYWRIGHT_BASE_URL`, it uses that managed preview and does not start another server
-- with `JSKIT_PLAYWRIGHT_STORAGE_STATE`, it loads the supplied authenticated state into Playwright contexts
+- with `VIBE64_PLAYWRIGHT_STORAGE_STATE`, it loads the Vibe64-supplied authenticated state into Playwright contexts
 
 Tests should therefore navigate with relative paths such as `page.goto("/w/acme/admin/contacts")`.
 
@@ -1045,7 +1045,7 @@ A managed host authenticates outside the project browser context. It performs it
 
 ```bash
 PLAYWRIGHT_BASE_URL=https://managed-preview.example.test \
-JSKIT_PLAYWRIGHT_STORAGE_STATE=/secure/temp/playwright-state.json \
+VIBE64_PLAYWRIGHT_STORAGE_STATE=/secure/temp/playwright-state.json \
 playwright test tests/e2e/contacts.spec.ts
 ```
 

--- a/packages/agent-docs/site/guide/app-setup/initial-scaffolding.md
+++ b/packages/agent-docs/site/guide/app-setup/initial-scaffolding.md
@@ -224,7 +224,7 @@ Published JSKIT libraries and tooling support Node.js 22 from 22.12.0 onward, No
 
 That matters because JSKIT maintenance policy changes over time. If the scaffold copied a large shell script into every app, existing apps would freeze the old behavior forever. By delegating to `jskit app verify`, `jskit app update-packages`, and `jskit app release`, the app keeps the nice `npm run` shortcuts while the maintained behavior stays in the installed CLI package.
 
-The Playwright scaffold follows the same rule. `playwright.config.mjs` delegates to `@jskit-ai/jskit-cli/test/playwright`, and the starter browser specs delegate their shared responsive checks to published JSKIT helpers. The generated files stay small while later JSKIT package updates can change local server startup, managed `PLAYWRIGHT_BASE_URL` handling, and `JSKIT_PLAYWRIGHT_STORAGE_STATE` support without copying that logic into each new app.
+The Playwright scaffold follows the same rule. `playwright.config.mjs` delegates to `@jskit-ai/jskit-cli/test/playwright`, and the starter browser specs delegate their shared responsive checks to published JSKIT helpers. The generated files stay small while later JSKIT package updates can change local server startup, managed `PLAYWRIGHT_BASE_URL` handling, and `VIBE64_PLAYWRIGHT_STORAGE_STATE` support without copying that logic into each new app.
 
 `jskit app verify` is worth noticing specifically. Linting, tests, and builds check your source code and runtime behavior. The JSKIT part of that flow runs `doctor`, which checks JSKIT-managed app state: installed package visibility, lock-file-backed managed files, and other JSKIT-specific health rules. It is there because a JSKIT app is not only code. It is also a descriptor-driven managed project.
 

--- a/packages/agent-docs/site/guide/app-setup/working-with-the-jskit-cli.md
+++ b/packages/agent-docs/site/guide/app-setup/working-with-the-jskit-cli.md
@@ -816,7 +816,7 @@ That command does two things:
 - runs the targeted Playwright command you give it
 - writes a receipt describing the verified feature, auth mode, and current dirty UI file set
 
-The auth mode is receipt metadata, not an authentication implementation. `jskit app verify-ui` does not log a user in, inject a secret, or rewrite the Playwright context. A direct local run uses `loginAsExistingUser()` from `@jskit-ai/auth-web/test/playwright`; a managed runner supplies authenticated state through `JSKIT_PLAYWRIGHT_STORAGE_STATE`. The generated `playwright.config.mjs` consumes that state and honors `PLAYWRIGHT_BASE_URL` without starting a second server.
+The auth mode is receipt metadata, not an authentication implementation. `jskit app verify-ui` does not log a user in, inject a secret, or rewrite the Playwright context. A direct local run uses `loginAsExistingUser()` from `@jskit-ai/auth-web/test/playwright`; Vibe64 supplies authenticated state through `VIBE64_PLAYWRIGHT_STORAGE_STATE`. The generated `playwright.config.mjs` consumes that state and honors `PLAYWRIGHT_BASE_URL` without starting a second server.
 
 `doctor` then compares the current changed UI files to that receipt. If you edit the UI again afterwards, the receipt is stale and `doctor` tells you to rerun `jskit app verify-ui`.
 

--- a/packages/agent-docs/test/uiTestingGuidance.test.js
+++ b/packages/agent-docs/test/uiTestingGuidance.test.js
@@ -21,7 +21,7 @@ test("UI testing guidance uses private local exchange support and managed storag
   for (const source of [pattern, humanGuide, distributedGuide]) {
     assert.match(source, /@jskit-ai\/auth-web\/test\/playwright/u);
     assert.match(source, /x-jskit-dev-auth-secret/u);
-    assert.match(source, /JSKIT_PLAYWRIGHT_STORAGE_STATE/u);
+    assert.match(source, /VIBE64_PLAYWRIGHT_STORAGE_STATE/u);
     assert.doesNotMatch(source, /page\.evaluate\(async/u);
     assert.doesNotMatch(source, /fetch\("\/api\/dev-auth\/login-as"/u);
   }

--- a/tooling/create-app/package.descriptor.mjs
+++ b/tooling/create-app/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/create-app",
-  "version": "0.1.140",
+  "version": "0.1.141",
   "dependsOn": [],
   "capabilities": {
     "provides": [

--- a/tooling/create-app/package.json
+++ b/tooling/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/create-app",
-  "version": "0.1.140",
+  "version": "0.1.141",
   "description": "Scaffold JSKIT app shells.",
   "type": "module",
   "files": [
@@ -20,7 +20,7 @@
     "./client": "./src/client/index.js"
   },
   "dependencies": {
-    "@jskit-ai/jskit-cli": "0.2.143"
+    "@jskit-ai/jskit-cli": "0.2.144"
   },
   "engines": {
     "node": "^22.12.0 || ^24.0.0 || ^26.0.0"

--- a/tooling/create-app/templates/base-shell/.vibe64/bin/preview-identity
+++ b/tooling/create-app/templates/base-shell/.vibe64/bin/preview-identity
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+exec npx --no-install jskit app preview-identity

--- a/tooling/create-app/templates/base-shell/tests/server/minimalShell.validator.test.js
+++ b/tooling/create-app/templates/base-shell/tests/server/minimalShell.validator.test.js
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { access, readdir, readFile } from "node:fs/promises";
+import { access, readdir, readFile, stat } from "node:fs/promises";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -97,6 +97,12 @@ test("latest JSKIT scaffold files are present at the app root", async () => {
   for (const requiredEntry of REQUIRED_TOP_LEVEL_ENTRIES) {
     assert.equal(entries.includes(requiredEntry), true, `Missing top-level scaffold entry: ${requiredEntry}`);
   }
+});
+
+test("latest JSKIT scaffold provides the app-owned Vibe64 preview identity executable", async () => {
+  const executablePath = path.join(APP_ROOT, ".vibe64", "bin", "preview-identity");
+  assert.match(await readFile(executablePath, "utf8"), /npx --no-install jskit app preview-identity/u);
+  assert.notEqual((await stat(executablePath)).mode & 0o111, 0);
 });
 
 test("starter shell keeps one JSKIT-managed hosted CI workflow", async () => {

--- a/tooling/create-app/templates/minimal-shell/.vibe64/bin/preview-identity
+++ b/tooling/create-app/templates/minimal-shell/.vibe64/bin/preview-identity
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+exec npx --no-install jskit app preview-identity

--- a/tooling/create-app/templates/minimal-shell/tests/server/minimalShell.validator.test.js
+++ b/tooling/create-app/templates/minimal-shell/tests/server/minimalShell.validator.test.js
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { access, readdir, readFile } from "node:fs/promises";
+import { access, readdir, readFile, stat } from "node:fs/promises";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -97,6 +97,12 @@ test("latest JSKIT scaffold files are present at the app root", async () => {
   for (const requiredEntry of REQUIRED_TOP_LEVEL_ENTRIES) {
     assert.equal(entries.includes(requiredEntry), true, `Missing top-level scaffold entry: ${requiredEntry}`);
   }
+});
+
+test("latest JSKIT scaffold provides the app-owned Vibe64 preview identity executable", async () => {
+  const executablePath = path.join(APP_ROOT, ".vibe64", "bin", "preview-identity");
+  assert.match(await readFile(executablePath, "utf8"), /npx --no-install jskit app preview-identity/u);
+  assert.notEqual((await stat(executablePath)).mode & 0o111, 0);
 });
 
 test("starter shell keeps one JSKIT-managed hosted CI workflow", async () => {

--- a/tooling/jskit-cli/package.json
+++ b/tooling/jskit-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-cli",
-  "version": "0.2.143",
+  "version": "0.2.144",
   "description": "Bundle and package orchestration CLI for JSKIT apps.",
   "type": "module",
   "files": [

--- a/tooling/jskit-cli/src/server/commandHandlers/app.js
+++ b/tooling/jskit-cli/src/server/commandHandlers/app.js
@@ -10,6 +10,7 @@ import {
 } from "./appCommandCatalog.js";
 import { runAppAdoptManagedScriptsCommand } from "./appCommands/adoptManagedScripts.js";
 import { runAppMigrateSourceMutationsCommand } from "./appCommands/migrateSourceMutations.js";
+import { runAppPreviewIdentityCommand } from "./appCommands/previewIdentity.js";
 import { runAppReleaseCommand } from "./appCommands/release.js";
 import { runAppSyncCiCommand } from "./appCommands/syncCi.js";
 import { runAppUpdatePackagesCommand } from "./appCommands/updatePackages.js";
@@ -83,7 +84,7 @@ function createAppCommands(ctx = {}) {
     resolveAppRootFromCwd
   } = ctx;
 
-  async function commandApp({ positional = [], options = {}, cwd = "", stdout, stderr }) {
+  async function commandApp({ positional = [], options = {}, cwd = "", stdout, stderr, io = {} }) {
     const appRoot = await resolveAppRootFromCwd(cwd);
     const firstToken = String(positional[0] || "").trim();
     const secondToken = String(positional[1] || "").trim();
@@ -136,6 +137,12 @@ function createAppCommands(ctx = {}) {
 
     if (definition.name === "verify") {
       return runAppVerifyCommand(ctx, { appRoot, options, stdout, stderr });
+    }
+    if (definition.name === "preview-identity") {
+      return runAppPreviewIdentityCommand(ctx, {
+        stdin: io.stdin,
+        stdout
+      });
     }
     if (definition.name === "verify-ui") {
       return runAppVerifyUiCommand(ctx, { appRoot, options, stdout, stderr });

--- a/tooling/jskit-cli/src/server/commandHandlers/appCommandCatalog.js
+++ b/tooling/jskit-cli/src/server/commandHandlers/appCommandCatalog.js
@@ -22,6 +22,17 @@ const COPIED_APP_SCRIPT_FILES = Object.freeze([
 ]);
 
 const APP_COMMAND_DEFINITIONS = Object.freeze({
+  "preview-identity": Object.freeze({
+    name: "preview-identity",
+    summary: "Run the app-owned Vibe64 preview-identity command protocol.",
+    usage: "jskit app preview-identity",
+    options: Object.freeze([]),
+    defaults: Object.freeze([
+      "Reads one versioned preview-identity request from stdin and writes one JSON response to stdout.",
+      "Uses the running local JSKIT app to create a native session for an existing user only.",
+      "This machine command is enabled only by the managed development-preview environment."
+    ])
+  }),
   verify: Object.freeze({
     name: "verify",
     summary: "Run the JSKIT baseline app verification flow.",

--- a/tooling/jskit-cli/src/server/commandHandlers/appCommands/previewIdentity.js
+++ b/tooling/jskit-cli/src/server/commandHandlers/appCommands/previewIdentity.js
@@ -1,0 +1,420 @@
+const PREVIEW_IDENTITY_PROTOCOL = "vibe64.preview-identity.command.v1";
+const PREVIEW_IDENTITY_LOGIN_OPERATION = "login-as";
+const PREVIEW_IDENTITY_LOGOUT_OPERATION = "logout";
+const PREVIEW_IDENTITY_INPUT_LIMIT_BYTES = 64 * 1024;
+const PREVIEW_IDENTITY_RESPONSE_LIMIT_BYTES = 64 * 1024;
+const PREVIEW_IDENTITY_ENABLED_ENV = "VIBE64_PREVIEW_IDENTITY_ENABLED";
+const PREVIEW_IDENTITY_SECRET_ENV = "VIBE64_PREVIEW_IDENTITY_SECRET";
+const DEV_AUTH_SECRET_HEADER = "x-jskit-dev-auth-secret";
+const AUTH_PATHS = Object.freeze({
+  devLoginAs: "/api/dev-auth/login-as",
+  logout: "/api/logout",
+  session: "/api/session"
+});
+
+function previewIdentityResponse(requestId = "", values = {}) {
+  return {
+    protocol: PREVIEW_IDENTITY_PROTOCOL,
+    requestId: String(requestId || ""),
+    ...values
+  };
+}
+
+function previewIdentityFailure(requestId = "", error = {}) {
+  return previewIdentityResponse(requestId, {
+    code: String(error.code || "jskit_preview_identity_failed"),
+    error: String(error.message || error || "JSKIT preview identity failed."),
+    ok: false,
+    setCookie: Array.isArray(error.setCookie) ? error.setCookie : [],
+    signedOut: error.signedOut === true,
+    statusCode: Number.isInteger(Number(error.statusCode)) ? Number(error.statusCode) : 400
+  });
+}
+
+function commandError(message = "", code = "jskit_preview_identity_failed", extra = {}) {
+  const error = new Error(message || "JSKIT preview identity failed.");
+  error.code = code;
+  Object.assign(error, extra);
+  return error;
+}
+
+async function readInput(stream) {
+  let bytes = 0;
+  const chunks = [];
+  for await (const chunk of stream) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    bytes += buffer.length;
+    if (bytes > PREVIEW_IDENTITY_INPUT_LIMIT_BYTES) {
+      throw commandError(
+        "Preview identity request is too large.",
+        "jskit_preview_identity_request_too_large",
+        { statusCode: 413 }
+      );
+    }
+    chunks.push(buffer);
+  }
+  try {
+    return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+  } catch {
+    throw commandError(
+      "Preview identity request is invalid JSON.",
+      "jskit_preview_identity_request_invalid"
+    );
+  }
+}
+
+function normalizeRequest(value = {}) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw commandError(
+      "Preview identity request must be an object.",
+      "jskit_preview_identity_request_invalid"
+    );
+  }
+  const requestId = String(value.requestId || "").trim();
+  const operation = String(value.operation || "").trim();
+  if (value.protocol !== PREVIEW_IDENTITY_PROTOCOL || !requestId) {
+    throw commandError(
+      "Preview identity request protocol is invalid.",
+      "jskit_preview_identity_protocol_invalid"
+    );
+  }
+  if (![PREVIEW_IDENTITY_LOGIN_OPERATION, PREVIEW_IDENTITY_LOGOUT_OPERATION].includes(operation)) {
+    throw commandError(
+      "Preview identity operation is invalid.",
+      "jskit_preview_identity_operation_invalid"
+    );
+  }
+  let target;
+  try {
+    target = new URL(String(value.target?.origin || value.target?.href || ""));
+  } catch {
+    throw commandError(
+      "Preview identity target must be a local JSKIT application.",
+      "jskit_preview_identity_target_invalid"
+    );
+  }
+  const hostname = target.hostname.toLowerCase().replace(/^\[|\]$/gu, "");
+  if (
+    target.protocol !== "http:" ||
+    !(
+      hostname === "localhost" ||
+      hostname.endsWith(".localhost") ||
+      /^127(?:\.\d{1,3}){3}$/u.test(hostname) ||
+      hostname === "::1" ||
+      /^vibe64-launch-[a-f0-9]{12}$/u.test(hostname)
+    )
+  ) {
+    throw commandError(
+      "Preview identity target must be a local JSKIT application.",
+      "jskit_preview_identity_target_invalid"
+    );
+  }
+  return {
+    operation,
+    requestId,
+    subject: value.subject,
+    targetOrigin: target.origin
+  };
+}
+
+function identityFromSubject(subject = {}) {
+  const source = subject && typeof subject === "object" && !Array.isArray(subject) ? subject : {};
+  if (source.kind === "selector") {
+    const type = String(source.selector?.type || "").trim();
+    const value = String(source.selector?.value || "").trim();
+    if (type === "email" && value) {
+      return { email: value };
+    }
+    if (type === "user-id" && value) {
+      return { userId: value };
+    }
+  }
+  if (source.kind === "viewer") {
+    const email = (Array.isArray(source.identifiers) ? source.identifiers : [])
+      .find((identifier) => identifier?.type === "email" && String(identifier.value || "").trim());
+    if (email) {
+      return { email: String(email.value).trim() };
+    }
+  }
+  throw commandError(
+    "JSKIT preview identity requires an existing application email or user ID.",
+    "jskit_preview_identity_selector_unsupported"
+  );
+}
+
+function responseSetCookie(response = {}) {
+  if (typeof response.headers?.getSetCookie === "function") {
+    return response.headers.getSetCookie().map(String).filter(Boolean);
+  }
+  const value = String(response.headers?.get?.("set-cookie") || "").trim();
+  return value ? [value] : [];
+}
+
+function cookieHeader(setCookie = []) {
+  const cookies = new Map();
+  for (const entry of Array.isArray(setCookie) ? setCookie : []) {
+    const pair = String(entry || "").split(";", 1)[0].trim();
+    const separatorIndex = pair.indexOf("=");
+    const name = separatorIndex > 0 ? pair.slice(0, separatorIndex).trim() : "";
+    if (name) {
+      cookies.set(name, pair);
+    }
+  }
+  return [...cookies.values()].join("; ");
+}
+
+async function responsePayload(response = {}) {
+  const reader = response.body?.getReader?.();
+  let text = "";
+  if (reader) {
+    const decoder = new TextDecoder();
+    let bytes = 0;
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      bytes += value.byteLength;
+      if (bytes > PREVIEW_IDENTITY_RESPONSE_LIMIT_BYTES) {
+        await reader.cancel();
+        throw commandError(
+          "JSKIT preview identity response is too large.",
+          "jskit_preview_identity_response_too_large",
+          { statusCode: 502 }
+        );
+      }
+      text += decoder.decode(value, { stream: true });
+    }
+    text += decoder.decode();
+  } else {
+    text = await response.text();
+    if (Buffer.byteLength(text) > PREVIEW_IDENTITY_RESPONSE_LIMIT_BYTES) {
+      throw commandError(
+        "JSKIT preview identity response is too large.",
+        "jskit_preview_identity_response_too_large",
+        { statusCode: 502 }
+      );
+    }
+  }
+  if (!text) {
+    return null;
+  }
+  try {
+    const payload = JSON.parse(text);
+    return payload && typeof payload === "object" && !Array.isArray(payload)
+      ? payload
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function upstreamError(payload = {}, response = {}, extra = {}) {
+  const fieldErrors = payload?.details?.fieldErrors || payload?.fieldErrors || {};
+  const fieldMessage = Object.values(
+    fieldErrors && typeof fieldErrors === "object" && !Array.isArray(fieldErrors) ? fieldErrors : {}
+  ).find(Boolean);
+  const firstError = Array.isArray(payload?.errors) ? payload.errors.find(Boolean) : null;
+  return commandError(
+    String(
+      fieldMessage ||
+      firstError?.message ||
+      firstError ||
+      payload?.error ||
+      payload?.message ||
+      "JSKIT preview identity exchange failed."
+    ),
+    String(firstError?.code || payload?.code || "jskit_preview_identity_upstream_rejected"),
+    {
+      ...extra,
+      statusCode: Number(response.status || 502)
+    }
+  );
+}
+
+async function request(fetchImpl, href, options) {
+  try {
+    return await fetchImpl(href, options);
+  } catch {
+    throw commandError(
+      "JSKIT preview identity could not reach the application.",
+      "jskit_preview_identity_unreachable",
+      { statusCode: 502 }
+    );
+  }
+}
+
+function postJson(fetchImpl, href, body, headers = {}) {
+  return request(fetchImpl, href, {
+    body: JSON.stringify(body),
+    headers: {
+      "content-type": "application/json",
+      ...headers
+    },
+    method: "POST",
+    redirect: "manual"
+  });
+}
+
+async function readSession(fetchImpl, targetOrigin) {
+  const response = await request(fetchImpl, `${targetOrigin}${AUTH_PATHS.session}`, {
+    method: "GET",
+    redirect: "manual"
+  });
+  const payload = await responsePayload(response);
+  const responseCookies = responseSetCookie(response);
+  if (!response.ok) {
+    throw upstreamError(payload, response, {
+      setCookie: responseCookies,
+      signedOut: false
+    });
+  }
+  const csrfToken = String(payload?.csrfToken || "").trim();
+  if (!csrfToken) {
+    throw commandError(
+      "JSKIT session bootstrap did not return a CSRF token.",
+      "jskit_preview_identity_csrf_missing",
+      {
+        setCookie: responseCookies,
+        statusCode: 502
+      }
+    );
+  }
+  return {
+    csrfToken,
+    setCookie: responseCookies
+  };
+}
+
+async function logout(fetchImpl, targetOrigin, session) {
+  const response = await postJson(fetchImpl, `${targetOrigin}${AUTH_PATHS.logout}`, {}, {
+    cookie: cookieHeader(session.setCookie),
+    "csrf-token": session.csrfToken
+  });
+  const payload = await responsePayload(response);
+  const setCookie = [...session.setCookie, ...responseSetCookie(response)];
+  if (!response.ok || payload?.ok !== true) {
+    throw upstreamError(payload, response, {
+      setCookie,
+      signedOut: false
+    });
+  }
+  return {
+    csrfToken: session.csrfToken,
+    setCookie
+  };
+}
+
+async function login(fetchImpl, targetOrigin, identity, secret, session) {
+  const loginResponse = await postJson(fetchImpl, `${targetOrigin}${AUTH_PATHS.devLoginAs}`, identity, {
+    cookie: cookieHeader(session.setCookie),
+    "csrf-token": session.csrfToken,
+    [DEV_AUTH_SECRET_HEADER]: secret
+  });
+  const loginPayload = await responsePayload(loginResponse);
+  const loginSetCookie = responseSetCookie(loginResponse);
+  const setCookie = [...session.setCookie, ...loginSetCookie];
+  if (!loginResponse.ok || loginPayload?.ok !== true) {
+    throw upstreamError(loginPayload, loginResponse, {
+      setCookie,
+      signedOut: true
+    });
+  }
+  return {
+    identity: {
+      displayName: String(loginPayload.displayName || loginPayload.username || "").trim(),
+      email: String(loginPayload.email || identity.email || "").trim().toLowerCase(),
+      userId: String(loginPayload.userId || identity.userId || "").trim(),
+      username: String(loginPayload.username || "").trim()
+    },
+    setCookie
+  };
+}
+
+async function executeJskitPreviewIdentityRequest(value = {}, {
+  env = process.env,
+  fetchImpl = globalThis.fetch
+} = {}) {
+  let requestId = String(value?.requestId || "").trim();
+  try {
+    const request = normalizeRequest(value);
+    requestId = request.requestId;
+    if (typeof fetchImpl !== "function") {
+      throw commandError(
+        "JSKIT preview identity requires fetch support.",
+        "jskit_preview_identity_fetch_unavailable",
+        { statusCode: 500 }
+      );
+    }
+    if (String(env[PREVIEW_IDENTITY_ENABLED_ENV] || "").trim().toLowerCase() !== "true") {
+      throw commandError(
+        "JSKIT development identity exchange is not enabled.",
+        "jskit_preview_identity_disabled",
+        { statusCode: 403 }
+      );
+    }
+    const secret = String(env[PREVIEW_IDENTITY_SECRET_ENV] || "").trim();
+    if (!/^[a-f0-9]{64}$/u.test(secret)) {
+      throw commandError(
+        "JSKIT development identity exchange secret is unavailable.",
+        "jskit_preview_identity_secret_missing",
+        { statusCode: 500 }
+      );
+    }
+    const identity = request.operation === PREVIEW_IDENTITY_LOGIN_OPERATION
+      ? identityFromSubject(request.subject)
+      : null;
+    const session = await readSession(fetchImpl, request.targetOrigin);
+    const signedOutSession = await logout(fetchImpl, request.targetOrigin, session);
+    if (request.operation === PREVIEW_IDENTITY_LOGOUT_OPERATION) {
+      return previewIdentityResponse(requestId, {
+        identity: null,
+        ok: true,
+        setCookie: signedOutSession.setCookie,
+        signedOut: true
+      });
+    }
+    const result = await login(
+      fetchImpl,
+      request.targetOrigin,
+      identity,
+      secret,
+      signedOutSession
+    );
+    return previewIdentityResponse(requestId, {
+      identity: result.identity,
+      ok: true,
+      setCookie: result.setCookie,
+      signedOut: false
+    });
+  } catch (error) {
+    return previewIdentityFailure(requestId, error);
+  }
+}
+
+async function runAppPreviewIdentityCommand(_ctx = {}, {
+  env = process.env,
+  fetchImpl = globalThis.fetch,
+  stdin = process.stdin,
+  stdout = process.stdout
+} = {}) {
+  let request;
+  try {
+    request = await readInput(stdin);
+  } catch (error) {
+    stdout.write(`${JSON.stringify(previewIdentityFailure("", error))}\n`);
+    return 0;
+  }
+  const response = await executeJskitPreviewIdentityRequest(request, {
+    env,
+    fetchImpl
+  });
+  stdout.write(`${JSON.stringify(response)}\n`);
+  return 0;
+}
+
+export {
+  PREVIEW_IDENTITY_PROTOCOL,
+  executeJskitPreviewIdentityRequest,
+  runAppPreviewIdentityCommand
+};

--- a/tooling/jskit-cli/src/test/playwright.js
+++ b/tooling/jskit-cli/src/test/playwright.js
@@ -13,7 +13,7 @@ function normalizeBaseUrl(value) {
 function createJskitPlaywrightConfig({ env = process.env } = {}) {
   const managedBaseUrl = normalizeBaseUrl(env.PLAYWRIGHT_BASE_URL);
   const baseURL = managedBaseUrl || DEFAULT_LOCAL_BASE_URL;
-  const storageState = String(env.JSKIT_PLAYWRIGHT_STORAGE_STATE || "").trim();
+  const storageState = String(env.VIBE64_PLAYWRIGHT_STORAGE_STATE || "").trim();
 
   return {
     testDir: "./tests/e2e",

--- a/tooling/jskit-cli/test/playwrightConfig.test.js
+++ b/tooling/jskit-cli/test/playwrightConfig.test.js
@@ -25,7 +25,7 @@ test("Playwright config uses a managed base URL without starting another server"
   const config = createJskitPlaywrightConfig({
     env: {
       PLAYWRIGHT_BASE_URL: "https://preview.example.test/",
-      JSKIT_PLAYWRIGHT_STORAGE_STATE: "/run/jskit/auth-state.json"
+      VIBE64_PLAYWRIGHT_STORAGE_STATE: "/run/jskit/auth-state.json"
     }
   });
 

--- a/tooling/jskit-cli/test/previewIdentity.test.js
+++ b/tooling/jskit-cli/test/previewIdentity.test.js
@@ -1,0 +1,213 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  PREVIEW_IDENTITY_PROTOCOL,
+  executeJskitPreviewIdentityRequest
+} from "../src/server/commandHandlers/appCommands/previewIdentity.js";
+
+const PREVIEW_IDENTITY_ENV = Object.freeze({
+  VIBE64_PREVIEW_IDENTITY_ENABLED: "true",
+  VIBE64_PREVIEW_IDENTITY_SECRET: "a".repeat(64)
+});
+
+function response(payload = {}, {
+  setCookie = [],
+  status = 200
+} = {}) {
+  return {
+    headers: {
+      getSetCookie() {
+        return setCookie;
+      }
+    },
+    ok: status >= 200 && status < 300,
+    status,
+    async text() {
+      return JSON.stringify(payload);
+    }
+  };
+}
+
+function request(overrides = {}) {
+  return {
+    operation: "login-as",
+    protocol: PREVIEW_IDENTITY_PROTOCOL,
+    requestId: "request-1",
+    subject: {
+      identifiers: [
+        {
+          type: "email",
+          value: "ada@example.com"
+        }
+      ],
+      kind: "viewer"
+    },
+    target: {
+      href: "http://127.0.0.1:4100/app",
+      origin: "http://127.0.0.1:4100"
+    },
+    ...overrides
+  };
+}
+
+test("JSKIT preview identity creates a native session for the viewer email", async () => {
+  const calls = [];
+  const replies = [
+    response({ csrfToken: "csrf-1" }, {
+      setCookie: ["csrf=guest; Path=/; HttpOnly"]
+    }),
+    response({ ok: true }, {
+      setCookie: ["access=; Max-Age=0; Path=/", "refresh=; Max-Age=0; Path=/"]
+    }),
+    response({
+      email: "ada@example.com",
+      ok: true,
+      userId: "42",
+      username: "Ada"
+    }, {
+      setCookie: ["access=native-access; Path=/; HttpOnly", "refresh=native-refresh; Path=/; HttpOnly"]
+    })
+  ];
+  const result = await executeJskitPreviewIdentityRequest(request(), {
+    env: PREVIEW_IDENTITY_ENV,
+    fetchImpl: async (href, options = {}) => {
+      calls.push({ href, options });
+      return replies.shift();
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.protocol, PREVIEW_IDENTITY_PROTOCOL);
+  assert.equal(result.identity.email, "ada@example.com");
+  assert.equal(result.identity.userId, "42");
+  assert.equal(result.setCookie.at(-1), "refresh=native-refresh; Path=/; HttpOnly");
+  assert.deepEqual(calls.map((entry) => entry.href), [
+    "http://127.0.0.1:4100/api/session",
+    "http://127.0.0.1:4100/api/logout",
+    "http://127.0.0.1:4100/api/dev-auth/login-as"
+  ]);
+  assert.equal(calls[2].options.headers["x-jskit-dev-auth-secret"], PREVIEW_IDENTITY_ENV.VIBE64_PREVIEW_IDENTITY_SECRET);
+  assert.equal(calls[2].options.headers["csrf-token"], "csrf-1");
+  assert.match(calls[2].options.headers.cookie, /csrf=guest/u);
+  assert.deepEqual(JSON.parse(calls[2].options.body), {
+    email: "ada@example.com"
+  });
+});
+
+test("JSKIT preview identity accepts an explicit existing user ID", async () => {
+  const bodies = [];
+  const replies = [
+    response({ csrfToken: "csrf-2" }),
+    response({ ok: true }, { setCookie: ["access=; Max-Age=0; Path=/"] }),
+    response({ ok: true, userId: "189", username: "Tony" }, {
+      setCookie: ["access=native; Path=/; HttpOnly"]
+    })
+  ];
+  const result = await executeJskitPreviewIdentityRequest(request({
+    subject: {
+      kind: "selector",
+      selector: {
+        type: "user-id",
+        value: "189"
+      }
+    }
+  }), {
+    env: PREVIEW_IDENTITY_ENV,
+    fetchImpl: async (_href, options = {}) => {
+      if (options.body) {
+        bodies.push(JSON.parse(options.body));
+      }
+      return replies.shift();
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.identity.userId, "189");
+  assert.deepEqual(bodies.at(-1), { userId: "189" });
+});
+
+test("JSKIT preview identity reports the application's missing-user error", async () => {
+  const replies = [
+    response({ csrfToken: "csrf-3" }),
+    response({ ok: true }, { setCookie: ["access=; Max-Age=0; Path=/"] }),
+    response({
+      code: "user_not_found",
+      message: "User not found."
+    }, {
+      status: 404
+    })
+  ];
+  const result = await executeJskitPreviewIdentityRequest(request(), {
+    env: PREVIEW_IDENTITY_ENV,
+    fetchImpl: async () => replies.shift()
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "user_not_found");
+  assert.equal(result.error, "User not found.");
+  assert.equal(result.signedOut, true);
+  assert.equal(result.statusCode, 404);
+});
+
+test("JSKIT preview identity logs out through the CSRF-protected application route", async () => {
+  const calls = [];
+  const replies = [
+    response({ csrfToken: "csrf-logout" }, { setCookie: ["csrf=guest; Path=/; HttpOnly"] }),
+    response({ ok: true }, { setCookie: ["access=; Max-Age=0; Path=/"] })
+  ];
+  const result = await executeJskitPreviewIdentityRequest(request({ operation: "logout" }), {
+    env: PREVIEW_IDENTITY_ENV,
+    fetchImpl: async (href, options = {}) => {
+      calls.push({ href, options });
+      return replies.shift();
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.signedOut, true);
+  assert.equal(result.identity, null);
+  assert.deepEqual(calls.map((entry) => entry.href), [
+    "http://127.0.0.1:4100/api/session",
+    "http://127.0.0.1:4100/api/logout"
+  ]);
+  assert.equal(calls[1].options.headers["csrf-token"], "csrf-logout");
+  assert.match(calls[1].options.headers.cookie, /csrf=guest/u);
+});
+
+test("JSKIT preview identity rejects a session response without a CSRF token", async () => {
+  let calls = 0;
+  const result = await executeJskitPreviewIdentityRequest(request(), {
+    env: PREVIEW_IDENTITY_ENV,
+    fetchImpl: async () => {
+      calls += 1;
+      return response({ authenticated: false });
+    }
+  });
+
+  assert.equal(calls, 1);
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "jskit_preview_identity_csrf_missing");
+  assert.equal(result.statusCode, 502);
+});
+
+for (const targetOrigin of ["https://example.com", "http://127.example.com", "not a URL"]) {
+  test(`JSKIT preview identity rejects non-local target ${targetOrigin}`, async () => {
+    let called = false;
+    const result = await executeJskitPreviewIdentityRequest(request({
+      target: {
+        origin: targetOrigin
+      }
+    }), {
+      env: PREVIEW_IDENTITY_ENV,
+      fetchImpl: async () => {
+        called = true;
+        return response({ ok: true });
+      }
+    });
+
+    assert.equal(called, false);
+    assert.equal(result.ok, false);
+    assert.equal(result.code, "jskit_preview_identity_target_invalid");
+  });
+}


### PR DESCRIPTION
Adds the app-owned preview identity command and publishes the corresponding JSKIT CLI/create-app versions.