### PR TITLE
Fix generated workspace admin links

### DIFF
--- a/packages/workspaces-web/templates/src/surfaces/admin/index.vue
+++ b/packages/workspaces-web/templates/src/surfaces/admin/index.vue
@@ -1,8 +1,16 @@
 <script setup>
+import { useRoute } from "vue-router";
 import WorkspaceNotFoundCard from "@/components/WorkspaceNotFoundCard.vue";
 import { useWorkspaceNotFoundState } from "@/composables/useWorkspaceNotFoundState";
 
+const route = useRoute();
 const { workspaceUnavailable, workspaceUnavailableMessage } = useWorkspaceNotFoundState();
+
+function adminChildPath(suffix = "") {
+  const basePath = String(route.path || "").replace(/\/+$/u, "");
+  const childPath = String(suffix || "").replace(/^\/+|\/+$/gu, "");
+  return childPath ? `${basePath}/${childPath}` : basePath;
+}
 </script>
 
 <template>
@@ -19,8 +27,8 @@ const { workspaceUnavailable, workspaceUnavailableMessage } = useWorkspaceNotFou
         <p class="text-body-2 text-medium-emphasis mb-0">Manage members and workspace settings.</p>
       </div>
       <div class="workspace-admin-screen__actions">
-        <v-btn color="primary" variant="flat" to="./members">Members</v-btn>
-        <v-btn color="primary" variant="tonal" to="./workspace/settings">Settings</v-btn>
+        <v-btn color="primary" variant="flat" :to="adminChildPath('members')">Members</v-btn>
+        <v-btn color="primary" variant="tonal" :to="adminChildPath('workspace/settings')">Settings</v-btn>
       </div>
     </header>
 

--- a/packages/workspaces-web/test/settingsPlacementContract.test.js
+++ b/packages/workspaces-web/test/settingsPlacementContract.test.js
@@ -258,20 +258,23 @@ test("workspaces-web starter surfaces avoid instructional placeholder copy", asy
     requiredPatterns: [
       {
         id: "workspace-admin-member-link",
-        pattern: /to="\.\/members"/,
+        pattern: /:to="adminChildPath\('members'\)"/,
         message: "Workspace admin surface needs a direct members action."
       },
       {
         id: "workspace-admin-settings-link",
-        pattern: /to="\.\/workspace\/settings"/,
+        pattern: /:to="adminChildPath\('workspace\/settings'\)"/,
         message: "Workspace admin surface needs a direct settings action."
       }
     ]
   });
   assert.match(appSource, /No workspace activity yet/);
   assert.match(adminSource, /Manage members and workspace settings/);
-  assert.match(adminSource, /to="\.\/members"/);
-  assert.match(adminSource, /to="\.\/workspace\/settings"/);
+  assert.match(adminSource, /const route = useRoute\(\)/);
+  assert.match(adminSource, /function adminChildPath/);
+  assert.match(adminSource, /:to="adminChildPath\('members'\)"/);
+  assert.match(adminSource, /:to="adminChildPath\('workspace\/settings'\)"/);
+  assert.doesNotMatch(adminSource, /to="\.\//);
   assert.doesNotMatch(appSource, /Replace this page|Primary in-workspace surface/);
   assert.doesNotMatch(adminSource, /Use this area|Privileged workspace workflows/);
 });


### PR DESCRIPTION
Fix the generated Workspaces admin Members and Settings actions so they resolve beneath the current admin route instead of escaping to the workspace root.\n\nVerification: workspaces-web tests (48 passed), lint, and fresh seed production build.