### PR TITLE
Release JSKIT packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7737,28 +7737,28 @@
     },
     "packages/agent-docs": {
       "name": "@jskit-ai/agent-docs",
-      "version": "0.1.90",
+      "version": "0.1.91",
       "engines": {
         "node": "^22.12.0 || ^24.0.0 || ^26.0.0"
       }
     },
     "packages/assistant": {
       "name": "@jskit-ai/assistant",
-      "version": "0.1.133",
+      "version": "0.1.134",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.124"
+        "@jskit-ai/kernel": "0.1.125"
       }
     },
     "packages/assistant-core": {
       "name": "@jskit-ai/assistant-core",
-      "version": "0.1.101",
+      "version": "0.1.102",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.123",
-        "@jskit-ai/http-runtime": "0.1.122",
-        "@jskit-ai/kernel": "0.1.124",
-        "@jskit-ai/resource-core": "0.1.67",
-        "@jskit-ai/resource-crud-core": "0.1.67",
-        "@jskit-ai/users-core": "0.1.134",
+        "@jskit-ai/database-runtime": "0.1.124",
+        "@jskit-ai/http-runtime": "0.1.123",
+        "@jskit-ai/kernel": "0.1.125",
+        "@jskit-ai/resource-core": "0.1.68",
+        "@jskit-ai/resource-crud-core": "0.1.68",
+        "@jskit-ai/users-core": "0.1.135",
         "dompurify": "^3.4.12",
         "json-rest-schema": "1.x.x",
         "marked": "^17.0.4",
@@ -7771,15 +7771,15 @@
     },
     "packages/assistant-runtime": {
       "name": "@jskit-ai/assistant-runtime",
-      "version": "0.1.96",
+      "version": "0.1.97",
       "dependencies": {
-        "@jskit-ai/assistant-core": "0.1.101",
-        "@jskit-ai/database-runtime": "0.1.123",
-        "@jskit-ai/http-runtime": "0.1.122",
-        "@jskit-ai/kernel": "0.1.124",
-        "@jskit-ai/shell-web": "0.1.125",
-        "@jskit-ai/users-core": "0.1.134",
-        "@jskit-ai/users-web": "0.1.140",
+        "@jskit-ai/assistant-core": "0.1.102",
+        "@jskit-ai/database-runtime": "0.1.124",
+        "@jskit-ai/http-runtime": "0.1.123",
+        "@jskit-ai/kernel": "0.1.125",
+        "@jskit-ai/shell-web": "0.1.126",
+        "@jskit-ai/users-core": "0.1.135",
+        "@jskit-ai/users-web": "0.1.141",
         "json-rest-schema": "1.x.x"
       },
       "peerDependencies": {
@@ -7790,39 +7790,39 @@
     },
     "packages/auth-core": {
       "name": "@jskit-ai/auth-core",
-      "version": "0.1.121",
+      "version": "0.1.122",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0",
-        "@jskit-ai/kernel": "0.1.124",
+        "@jskit-ai/kernel": "0.1.125",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/auth-provider-local-core": {
       "name": "@jskit-ai/auth-provider-local-core",
-      "version": "0.1.25",
+      "version": "0.1.26",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.121",
-        "@jskit-ai/kernel": "0.1.124",
+        "@jskit-ai/auth-core": "0.1.122",
+        "@jskit-ai/kernel": "0.1.125",
         "nodemailer": "^9.0.3"
       }
     },
     "packages/auth-provider-local-db-core": {
       "name": "@jskit-ai/auth-provider-local-db-core",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "dependencies": {
-        "@jskit-ai/auth-provider-local-core": "0.1.25",
-        "@jskit-ai/database-runtime": "0.1.123",
-        "@jskit-ai/kernel": "0.1.124"
+        "@jskit-ai/auth-provider-local-core": "0.1.26",
+        "@jskit-ai/database-runtime": "0.1.124",
+        "@jskit-ai/kernel": "0.1.125"
       }
     },
     "packages/auth-provider-supabase-core": {
       "name": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.122",
+      "version": "0.1.123",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.121",
-        "@jskit-ai/kernel": "0.1.124",
+        "@jskit-ai/auth-core": "0.1.122",
+        "@jskit-ai/kernel": "0.1.125",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0",
         "json-rest-schema": "1.x.x",
@@ -7831,12 +7831,12 @@
     },
     "packages/auth-web": {
       "name": "@jskit-ai/auth-web",
-      "version": "0.1.124",
+      "version": "0.1.125",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.121",
-        "@jskit-ai/http-runtime": "0.1.122",
-        "@jskit-ai/kernel": "0.1.124",
-        "@jskit-ai/shell-web": "0.1.125",
+        "@jskit-ai/auth-core": "0.1.122",
+        "@jskit-ai/http-runtime": "0.1.123",
+        "@jskit-ai/kernel": "0.1.125",
+        "@jskit-ai/shell-web": "0.1.126",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -7849,38 +7849,38 @@
     },
     "packages/console-core": {
       "name": "@jskit-ai/console-core",
-      "version": "0.1.88",
+      "version": "0.1.89",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.121",
-        "@jskit-ai/database-runtime": "0.1.123",
-        "@jskit-ai/http-runtime": "0.1.122",
-        "@jskit-ai/kernel": "0.1.124",
-        "@jskit-ai/resource-crud-core": "0.1.67",
-        "@jskit-ai/users-core": "0.1.134",
+        "@jskit-ai/auth-core": "0.1.122",
+        "@jskit-ai/database-runtime": "0.1.124",
+        "@jskit-ai/http-runtime": "0.1.123",
+        "@jskit-ai/kernel": "0.1.125",
+        "@jskit-ai/resource-crud-core": "0.1.68",
+        "@jskit-ai/users-core": "0.1.135",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/console-web": {
       "name": "@jskit-ai/console-web",
-      "version": "0.1.93",
+      "version": "0.1.94",
       "dependencies": {
-        "@jskit-ai/auth-web": "0.1.124",
-        "@jskit-ai/console-core": "0.1.88",
-        "@jskit-ai/shell-web": "0.1.125"
+        "@jskit-ai/auth-web": "0.1.125",
+        "@jskit-ai/console-core": "0.1.89",
+        "@jskit-ai/shell-web": "0.1.126"
       }
     },
     "packages/crud-core": {
       "name": "@jskit-ai/crud-core",
-      "version": "0.1.132",
+      "version": "0.1.133",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.123",
-        "@jskit-ai/http-runtime": "0.1.122",
-        "@jskit-ai/kernel": "0.1.124",
-        "@jskit-ai/realtime": "0.1.121",
-        "@jskit-ai/resource-crud-core": "0.1.67",
-        "@jskit-ai/shell-web": "0.1.125",
-        "@jskit-ai/users-core": "0.1.134",
-        "@jskit-ai/users-web": "0.1.140",
+        "@jskit-ai/database-runtime": "0.1.124",
+        "@jskit-ai/http-runtime": "0.1.123",
+        "@jskit-ai/kernel": "0.1.125",
+        "@jskit-ai/realtime": "0.1.122",
+        "@jskit-ai/resource-crud-core": "0.1.68",
+        "@jskit-ai/shell-web": "0.1.126",
+        "@jskit-ai/users-core": "0.1.135",
+        "@jskit-ai/users-web": "0.1.141",
         "json-rest-schema": "1.x.x"
       },
       "peerDependencies": {
@@ -7891,98 +7891,98 @@
     },
     "packages/crud-server-generator": {
       "name": "@jskit-ai/crud-server-generator",
-      "version": "0.1.133",
+      "version": "0.1.134",
       "dependencies": {
         "@babel/parser": "^7.29.2",
-        "@jskit-ai/crud-core": "0.1.132",
-        "@jskit-ai/database-runtime": "0.1.123",
-        "@jskit-ai/http-runtime": "0.1.122",
-        "@jskit-ai/json-rest-api-core": "0.1.68",
-        "@jskit-ai/kernel": "0.1.124",
-        "@jskit-ai/resource-crud-core": "0.1.67",
+        "@jskit-ai/crud-core": "0.1.133",
+        "@jskit-ai/database-runtime": "0.1.124",
+        "@jskit-ai/http-runtime": "0.1.123",
+        "@jskit-ai/json-rest-api-core": "0.1.69",
+        "@jskit-ai/kernel": "0.1.125",
+        "@jskit-ai/resource-crud-core": "0.1.68",
         "recast": "^0.23.11"
       }
     },
     "packages/crud-ui-generator": {
       "name": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.107",
+      "version": "0.1.108",
       "dependencies": {
-        "@jskit-ai/crud-core": "0.1.132",
-        "@jskit-ai/kernel": "0.1.124",
-        "@jskit-ai/resource-crud-core": "0.1.67"
+        "@jskit-ai/crud-core": "0.1.133",
+        "@jskit-ai/kernel": "0.1.125",
+        "@jskit-ai/resource-crud-core": "0.1.68"
       }
     },
     "packages/database-runtime": {
       "name": "@jskit-ai/database-runtime",
-      "version": "0.1.123",
+      "version": "0.1.124",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.124"
+        "@jskit-ai/kernel": "0.1.125"
       }
     },
     "packages/database-runtime-mysql": {
       "name": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.122",
+      "version": "0.1.123",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.123",
-        "@jskit-ai/kernel": "0.1.124"
+        "@jskit-ai/database-runtime": "0.1.124",
+        "@jskit-ai/kernel": "0.1.125"
       }
     },
     "packages/database-runtime-postgres": {
       "name": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.121",
+      "version": "0.1.122",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.123"
+        "@jskit-ai/database-runtime": "0.1.124"
       }
     },
     "packages/feature-server-generator": {
       "name": "@jskit-ai/feature-server-generator",
-      "version": "0.1.66"
+      "version": "0.1.67"
     },
     "packages/google-rewarded-core": {
       "name": "@jskit-ai/google-rewarded-core",
-      "version": "0.1.61"
+      "version": "0.1.62"
     },
     "packages/google-rewarded-web": {
       "name": "@jskit-ai/google-rewarded-web",
-      "version": "0.1.61"
+      "version": "0.1.62"
     },
     "packages/http-runtime": {
       "name": "@jskit-ai/http-runtime",
-      "version": "0.1.122",
+      "version": "0.1.123",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.124",
+        "@jskit-ai/kernel": "0.1.125",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/json-rest-api-core": {
       "name": "@jskit-ai/json-rest-api-core",
-      "version": "0.1.68",
+      "version": "0.1.69",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.124",
+        "@jskit-ai/kernel": "0.1.125",
         "hooked-api": "1.x.x",
         "json-rest-api": "^1.0.26"
       }
     },
     "packages/kernel": {
       "name": "@jskit-ai/kernel",
-      "version": "0.1.124",
+      "version": "0.1.125",
       "dependencies": {
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/mobile-capacitor": {
       "name": "@jskit-ai/mobile-capacitor",
-      "version": "0.1.60",
+      "version": "0.1.61",
       "dependencies": {
         "@capacitor/browser": "^7.0.1",
-        "@jskit-ai/kernel": "0.1.124"
+        "@jskit-ai/kernel": "0.1.125"
       }
     },
     "packages/realtime": {
       "name": "@jskit-ai/realtime",
-      "version": "0.1.121",
+      "version": "0.1.122",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.124",
+        "@jskit-ai/kernel": "0.1.125",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",
@@ -7994,24 +7994,24 @@
     },
     "packages/resource-core": {
       "name": "@jskit-ai/resource-core",
-      "version": "0.1.67",
+      "version": "0.1.68",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.124"
+        "@jskit-ai/kernel": "0.1.125"
       }
     },
     "packages/resource-crud-core": {
       "name": "@jskit-ai/resource-crud-core",
-      "version": "0.1.67",
+      "version": "0.1.68",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.124",
-        "@jskit-ai/resource-core": "0.1.67"
+        "@jskit-ai/kernel": "0.1.125",
+        "@jskit-ai/resource-core": "0.1.68"
       }
     },
     "packages/shell-web": {
       "name": "@jskit-ai/shell-web",
-      "version": "0.1.125",
+      "version": "0.1.126",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.124",
+        "@jskit-ai/kernel": "0.1.125",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -8023,25 +8023,25 @@
     },
     "packages/storage-runtime": {
       "name": "@jskit-ai/storage-runtime",
-      "version": "0.1.122",
+      "version": "0.1.123",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.124",
+        "@jskit-ai/kernel": "0.1.125",
         "unstorage": "^1.17.5"
       }
     },
     "packages/ui-generator": {
       "name": "@jskit-ai/ui-generator",
-      "version": "0.1.107",
+      "version": "0.1.108",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.124",
-        "@jskit-ai/shell-web": "0.1.125"
+        "@jskit-ai/kernel": "0.1.125",
+        "@jskit-ai/shell-web": "0.1.126"
       }
     },
     "packages/uploads-image-web": {
       "name": "@jskit-ai/uploads-image-web",
-      "version": "0.1.100",
+      "version": "0.1.101",
       "dependencies": {
-        "@jskit-ai/uploads-runtime": "0.1.100",
+        "@jskit-ai/uploads-runtime": "0.1.101",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",
@@ -8054,37 +8054,37 @@
     },
     "packages/uploads-runtime": {
       "name": "@jskit-ai/uploads-runtime",
-      "version": "0.1.100",
+      "version": "0.1.101",
       "dependencies": {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.124"
+        "@jskit-ai/kernel": "0.1.125"
       }
     },
     "packages/users-core": {
       "name": "@jskit-ai/users-core",
-      "version": "0.1.134",
+      "version": "0.1.135",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.121",
-        "@jskit-ai/database-runtime": "0.1.123",
-        "@jskit-ai/http-runtime": "0.1.122",
-        "@jskit-ai/json-rest-api-core": "0.1.68",
-        "@jskit-ai/kernel": "0.1.124",
-        "@jskit-ai/resource-core": "0.1.67",
-        "@jskit-ai/resource-crud-core": "0.1.67",
-        "@jskit-ai/uploads-runtime": "0.1.100",
+        "@jskit-ai/auth-core": "0.1.122",
+        "@jskit-ai/database-runtime": "0.1.124",
+        "@jskit-ai/http-runtime": "0.1.123",
+        "@jskit-ai/json-rest-api-core": "0.1.69",
+        "@jskit-ai/kernel": "0.1.125",
+        "@jskit-ai/resource-core": "0.1.68",
+        "@jskit-ai/resource-crud-core": "0.1.68",
+        "@jskit-ai/uploads-runtime": "0.1.101",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/users-web": {
       "name": "@jskit-ai/users-web",
-      "version": "0.1.140",
+      "version": "0.1.141",
       "dependencies": {
-        "@jskit-ai/http-runtime": "0.1.122",
-        "@jskit-ai/kernel": "0.1.124",
-        "@jskit-ai/realtime": "0.1.121",
-        "@jskit-ai/shell-web": "0.1.125",
-        "@jskit-ai/uploads-image-web": "0.1.100",
-        "@jskit-ai/users-core": "0.1.134",
+        "@jskit-ai/http-runtime": "0.1.123",
+        "@jskit-ai/kernel": "0.1.125",
+        "@jskit-ai/realtime": "0.1.122",
+        "@jskit-ai/shell-web": "0.1.126",
+        "@jskit-ai/uploads-image-web": "0.1.101",
+        "@jskit-ai/users-core": "0.1.135",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -8096,30 +8096,30 @@
     },
     "packages/workspaces-core": {
       "name": "@jskit-ai/workspaces-core",
-      "version": "0.1.101",
+      "version": "0.1.102",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.121",
-        "@jskit-ai/database-runtime": "0.1.123",
-        "@jskit-ai/http-runtime": "0.1.122",
-        "@jskit-ai/json-rest-api-core": "0.1.68",
-        "@jskit-ai/kernel": "0.1.124",
-        "@jskit-ai/resource-core": "0.1.67",
-        "@jskit-ai/resource-crud-core": "0.1.67",
-        "@jskit-ai/users-core": "0.1.134",
+        "@jskit-ai/auth-core": "0.1.122",
+        "@jskit-ai/database-runtime": "0.1.124",
+        "@jskit-ai/http-runtime": "0.1.123",
+        "@jskit-ai/json-rest-api-core": "0.1.69",
+        "@jskit-ai/kernel": "0.1.125",
+        "@jskit-ai/resource-core": "0.1.68",
+        "@jskit-ai/resource-crud-core": "0.1.68",
+        "@jskit-ai/users-core": "0.1.135",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/workspaces-web": {
       "name": "@jskit-ai/workspaces-web",
-      "version": "0.1.102",
+      "version": "0.1.103",
       "dependencies": {
-        "@jskit-ai/auth-web": "0.1.124",
-        "@jskit-ai/http-runtime": "0.1.122",
-        "@jskit-ai/kernel": "0.1.124",
-        "@jskit-ai/shell-web": "0.1.125",
-        "@jskit-ai/users-core": "0.1.134",
-        "@jskit-ai/users-web": "0.1.140",
-        "@jskit-ai/workspaces-core": "0.1.101",
+        "@jskit-ai/auth-web": "0.1.125",
+        "@jskit-ai/http-runtime": "0.1.123",
+        "@jskit-ai/kernel": "0.1.125",
+        "@jskit-ai/shell-web": "0.1.126",
+        "@jskit-ai/users-core": "0.1.135",
+        "@jskit-ai/users-web": "0.1.141",
+        "@jskit-ai/workspaces-core": "0.1.102",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -8131,7 +8131,7 @@
     },
     "tooling/config-eslint": {
       "name": "@jskit-ai/config-eslint",
-      "version": "0.1.122",
+      "version": "0.1.123",
       "dependencies": {
         "@eslint/js": "^9.39.4",
         "eslint-plugin-vue": "^10.5.1",
@@ -8149,9 +8149,9 @@
     },
     "tooling/create-app": {
       "name": "@jskit-ai/create-app",
-      "version": "0.1.141",
+      "version": "0.1.142",
       "dependencies": {
-        "@jskit-ai/jskit-cli": "0.2.144"
+        "@jskit-ai/jskit-cli": "0.2.145"
       },
       "bin": {
         "jskit-create-app": "bin/jskit-create-app.js"
@@ -8162,18 +8162,18 @@
     },
     "tooling/jskit-catalog": {
       "name": "@jskit-ai/jskit-catalog",
-      "version": "0.1.138",
+      "version": "0.1.139",
       "engines": {
         "node": "^22.12.0 || ^24.0.0 || ^26.0.0"
       }
     },
     "tooling/jskit-cli": {
       "name": "@jskit-ai/jskit-cli",
-      "version": "0.2.144",
+      "version": "0.2.145",
       "dependencies": {
-        "@jskit-ai/jskit-catalog": "0.1.138",
-        "@jskit-ai/kernel": "0.1.124",
-        "@jskit-ai/shell-web": "0.1.125",
+        "@jskit-ai/jskit-catalog": "0.1.139",
+        "@jskit-ai/kernel": "0.1.125",
+        "@jskit-ai/shell-web": "0.1.126",
         "@vue/compiler-sfc": "^3.5.29",
         "ts-morph": "^28.0.0",
         "yaml": "^2.8.3"

--- a/packages/agent-docs/package.json
+++ b/packages/agent-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/agent-docs",
-  "version": "0.1.90",
+  "version": "0.1.91",
   "description": "Distributed JSKIT agent references, prompts, guides, and generated reference maps.",
   "type": "module",
   "files": [

--- a/packages/assistant-core/package.descriptor.mjs
+++ b/packages/assistant-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-core",
-  version: "0.1.101",
+  version: "0.1.102",
   kind: "runtime",
   description: "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
   dependsOn: [
@@ -47,11 +47,11 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/http-runtime": "0.1.122",
-        "@jskit-ai/kernel": "0.1.124",
-        "@jskit-ai/resource-core": "0.1.67",
-        "@jskit-ai/resource-crud-core": "0.1.67",
-        "@jskit-ai/users-core": "0.1.134",
+        "@jskit-ai/http-runtime": "0.1.123",
+        "@jskit-ai/kernel": "0.1.125",
+        "@jskit-ai/resource-core": "0.1.68",
+        "@jskit-ai/resource-crud-core": "0.1.68",
+        "@jskit-ai/users-core": "0.1.135",
         "dompurify": "^3.3.3",
         "json-rest-schema": "1.x.x",
         "marked": "^17.0.4",

--- a/packages/assistant-core/package.json
+++ b/packages/assistant-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-core",
-  "version": "0.1.101",
+  "version": "0.1.102",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,12 +11,12 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.123",
-    "@jskit-ai/http-runtime": "0.1.122",
-    "@jskit-ai/kernel": "0.1.124",
-    "@jskit-ai/resource-crud-core": "0.1.67",
-    "@jskit-ai/resource-core": "0.1.67",
-    "@jskit-ai/users-core": "0.1.134",
+    "@jskit-ai/database-runtime": "0.1.124",
+    "@jskit-ai/http-runtime": "0.1.123",
+    "@jskit-ai/kernel": "0.1.125",
+    "@jskit-ai/resource-crud-core": "0.1.68",
+    "@jskit-ai/resource-core": "0.1.68",
+    "@jskit-ai/users-core": "0.1.135",
     "dompurify": "^3.4.12",
     "json-rest-schema": "1.x.x",
     "marked": "^17.0.4",

--- a/packages/assistant-runtime/package.descriptor.mjs
+++ b/packages/assistant-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-runtime",
-  version: "0.1.96",
+  version: "0.1.97",
   kind: "runtime",
   description: "Shared assistant runtime with per-surface assistant registration.",
   dependsOn: [
@@ -95,13 +95,13 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/assistant-core": "0.1.101",
-        "@jskit-ai/database-runtime": "0.1.123",
-        "@jskit-ai/http-runtime": "0.1.122",
-        "@jskit-ai/kernel": "0.1.124",
-        "@jskit-ai/shell-web": "0.1.125",
-        "@jskit-ai/users-core": "0.1.134",
-        "@jskit-ai/users-web": "0.1.140"
+        "@jskit-ai/assistant-core": "0.1.102",
+        "@jskit-ai/database-runtime": "0.1.124",
+        "@jskit-ai/http-runtime": "0.1.123",
+        "@jskit-ai/kernel": "0.1.125",
+        "@jskit-ai/shell-web": "0.1.126",
+        "@jskit-ai/users-core": "0.1.135",
+        "@jskit-ai/users-web": "0.1.141"
       },
       dev: {}
     },

--- a/packages/assistant-runtime/package.json
+++ b/packages/assistant-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-runtime",
-  "version": "0.1.96",
+  "version": "0.1.97",
   "type": "module",
   "exports": {
     "./client": "./src/client/index.js",
@@ -8,13 +8,13 @@
     "./server/actionIds": "./src/server/actionIds.js"
   },
   "dependencies": {
-    "@jskit-ai/assistant-core": "0.1.101",
-    "@jskit-ai/database-runtime": "0.1.123",
-    "@jskit-ai/http-runtime": "0.1.122",
-    "@jskit-ai/kernel": "0.1.124",
-    "@jskit-ai/shell-web": "0.1.125",
-    "@jskit-ai/users-core": "0.1.134",
-    "@jskit-ai/users-web": "0.1.140",
+    "@jskit-ai/assistant-core": "0.1.102",
+    "@jskit-ai/database-runtime": "0.1.124",
+    "@jskit-ai/http-runtime": "0.1.123",
+    "@jskit-ai/kernel": "0.1.125",
+    "@jskit-ai/shell-web": "0.1.126",
+    "@jskit-ai/users-core": "0.1.135",
+    "@jskit-ai/users-web": "0.1.141",
     "json-rest-schema": "1.x.x"
   },
   "peerDependencies": {

--- a/packages/assistant/package.descriptor.mjs
+++ b/packages/assistant/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant",
-  version: "0.1.133",
+  version: "0.1.134",
   kind: "generator",
   description: "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
   options: {

--- a/packages/assistant/package.json
+++ b/packages/assistant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant",
-  "version": "0.1.133",
+  "version": "0.1.134",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.124"
+    "@jskit-ai/kernel": "0.1.125"
   }
 }

--- a/packages/auth-core/package.descriptor.mjs
+++ b/packages/auth-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-core",
-  "version": "0.1.121",
+  "version": "0.1.122",
   "kind": "runtime",
   "dependsOn": [
     "@jskit-ai/value-app-config-shared"
@@ -74,7 +74,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.124",
+        "@jskit-ai/kernel": "0.1.125",
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0"

--- a/packages/auth-core/package.json
+++ b/packages/auth-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-core",
-  "version": "0.1.121",
+  "version": "0.1.122",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -56,7 +56,7 @@
     "./shared/commands/authSessionReadCommand": "./src/shared/commands/authSessionReadCommand.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.124",
+    "@jskit-ai/kernel": "0.1.125",
     "@fastify/cookie": "^11.0.2",
     "@fastify/csrf-protection": "^7.1.0",
     "@fastify/rate-limit": "^10.3.0",

--- a/packages/auth-provider-local-core/package.descriptor.mjs
+++ b/packages/auth-provider-local-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-provider-local-core",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "kind": "runtime",
   "description": "Local auth provider with a file backend default and no database requirement.",
   "dependsOn": [
@@ -64,8 +64,8 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/auth-core": "0.1.121",
-        "@jskit-ai/kernel": "0.1.124",
+        "@jskit-ai/auth-core": "0.1.122",
+        "@jskit-ai/kernel": "0.1.125",
         "nodemailer": "^9.0.3",
         "dotenv": "^16.4.5"
       },

--- a/packages/auth-provider-local-core/package.json
+++ b/packages/auth-provider-local-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-local-core",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,8 +11,8 @@
     "./server/lib/index": "./src/server/lib/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.121",
-    "@jskit-ai/kernel": "0.1.124",
+    "@jskit-ai/auth-core": "0.1.122",
+    "@jskit-ai/kernel": "0.1.125",
     "nodemailer": "^9.0.3"
   }
 }

--- a/packages/auth-provider-local-db-core/package.descriptor.mjs
+++ b/packages/auth-provider-local-db-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/auth-provider-local-db-core",
-  version: "0.1.16",
+  version: "0.1.17",
   kind: "runtime",
   description: "Database-backed local auth storage backend for JSKIT local auth.",
   dependsOn: [
@@ -80,9 +80,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-provider-local-core": "0.1.25",
-        "@jskit-ai/database-runtime": "0.1.123",
-        "@jskit-ai/kernel": "0.1.124"
+        "@jskit-ai/auth-provider-local-core": "0.1.26",
+        "@jskit-ai/database-runtime": "0.1.124",
+        "@jskit-ai/kernel": "0.1.125"
       },
       dev: {}
     },

--- a/packages/auth-provider-local-db-core/package.json
+++ b/packages/auth-provider-local-db-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-local-db-core",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,8 +10,8 @@
     "./server/lib/index": "./src/server/lib/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-provider-local-core": "0.1.25",
-    "@jskit-ai/database-runtime": "0.1.123",
-    "@jskit-ai/kernel": "0.1.124"
+    "@jskit-ai/auth-provider-local-core": "0.1.26",
+    "@jskit-ai/database-runtime": "0.1.124",
+    "@jskit-ai/kernel": "0.1.125"
   }
 }

--- a/packages/auth-provider-supabase-core/package.descriptor.mjs
+++ b/packages/auth-provider-supabase-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.122",
+  "version": "0.1.123",
   "kind": "runtime",
   "options": {
     "auth-supabase-url": {
@@ -83,8 +83,8 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/auth-core": "0.1.121",
-        "@jskit-ai/kernel": "0.1.124",
+        "@jskit-ai/auth-core": "0.1.122",
+        "@jskit-ai/kernel": "0.1.125",
         "dotenv": "^16.4.5",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0"

--- a/packages/auth-provider-supabase-core/package.json
+++ b/packages/auth-provider-supabase-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.122",
+  "version": "0.1.123",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,8 +12,8 @@
     "./client": "./src/client/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.121",
-    "@jskit-ai/kernel": "0.1.124",
+    "@jskit-ai/auth-core": "0.1.122",
+    "@jskit-ai/kernel": "0.1.125",
     "json-rest-schema": "1.x.x",
     "jose": "^6.1.0",
     "@supabase/supabase-js": "^2.57.4",

--- a/packages/auth-web/package.descriptor.mjs
+++ b/packages/auth-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-web",
-  "version": "0.1.124",
+  "version": "0.1.125",
   "kind": "runtime",
   "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
   "dependsOn": [
@@ -264,10 +264,10 @@ export default Object.freeze({
     "dependencies": {
       "runtime": {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/auth-core": "0.1.121",
-        "@jskit-ai/http-runtime": "0.1.122",
-        "@jskit-ai/kernel": "0.1.124",
-        "@jskit-ai/shell-web": "0.1.125"
+        "@jskit-ai/auth-core": "0.1.122",
+        "@jskit-ai/http-runtime": "0.1.123",
+        "@jskit-ai/kernel": "0.1.125",
+        "@jskit-ai/shell-web": "0.1.126"
       },
       "dev": {}
     },

--- a/packages/auth-web/package.json
+++ b/packages/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-web",
-  "version": "0.1.124",
+  "version": "0.1.125",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -20,11 +20,11 @@
     "./test/playwright": "./src/test/playwright.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.121",
+    "@jskit-ai/auth-core": "0.1.122",
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/kernel": "0.1.124",
-    "@jskit-ai/shell-web": "0.1.125",
-    "@jskit-ai/http-runtime": "0.1.122"
+    "@jskit-ai/kernel": "0.1.125",
+    "@jskit-ai/shell-web": "0.1.126",
+    "@jskit-ai/http-runtime": "0.1.123"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/console-core/package.descriptor.mjs
+++ b/packages/console-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-core",
-  version: "0.1.88",
+  version: "0.1.89",
   kind: "runtime",
   description: "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
   dependsOn: [
@@ -85,12 +85,12 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.121",
-        "@jskit-ai/database-runtime": "0.1.123",
-        "@jskit-ai/http-runtime": "0.1.122",
-        "@jskit-ai/kernel": "0.1.124",
-        "@jskit-ai/resource-crud-core": "0.1.67",
-        "@jskit-ai/users-core": "0.1.134"
+        "@jskit-ai/auth-core": "0.1.122",
+        "@jskit-ai/database-runtime": "0.1.124",
+        "@jskit-ai/http-runtime": "0.1.123",
+        "@jskit-ai/kernel": "0.1.125",
+        "@jskit-ai/resource-crud-core": "0.1.68",
+        "@jskit-ai/users-core": "0.1.135"
       },
       dev: {}
     },

--- a/packages/console-core/package.json
+++ b/packages/console-core/package.json
@@ -1,17 +1,17 @@
 {
   "name": "@jskit-ai/console-core",
-  "version": "0.1.88",
+  "version": "0.1.89",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.121",
-    "@jskit-ai/database-runtime": "0.1.123",
-    "@jskit-ai/http-runtime": "0.1.122",
-    "@jskit-ai/kernel": "0.1.124",
-    "@jskit-ai/resource-crud-core": "0.1.67",
-    "@jskit-ai/users-core": "0.1.134",
+    "@jskit-ai/auth-core": "0.1.122",
+    "@jskit-ai/database-runtime": "0.1.124",
+    "@jskit-ai/http-runtime": "0.1.123",
+    "@jskit-ai/kernel": "0.1.125",
+    "@jskit-ai/resource-crud-core": "0.1.68",
+    "@jskit-ai/users-core": "0.1.135",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/console-web/package.descriptor.mjs
+++ b/packages/console-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-web",
-  version: "0.1.93",
+  version: "0.1.94",
   kind: "runtime",
   description: "Authenticated console surface scaffold and surface policy wiring.",
   dependsOn: [
@@ -103,9 +103,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-web": "0.1.124",
-        "@jskit-ai/console-core": "0.1.88",
-        "@jskit-ai/shell-web": "0.1.125",
+        "@jskit-ai/auth-web": "0.1.125",
+        "@jskit-ai/console-core": "0.1.89",
+        "@jskit-ai/shell-web": "0.1.126",
       },
       dev: {}
     },

--- a/packages/console-web/package.json
+++ b/packages/console-web/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/console-web",
-  "version": "0.1.93",
+  "version": "0.1.94",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-web": "0.1.124",
-    "@jskit-ai/console-core": "0.1.88",
-    "@jskit-ai/shell-web": "0.1.125"
+    "@jskit-ai/auth-web": "0.1.125",
+    "@jskit-ai/console-core": "0.1.89",
+    "@jskit-ai/shell-web": "0.1.126"
   }
 }

--- a/packages/crud-core/package.descriptor.mjs
+++ b/packages/crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-core",
-  version: "0.1.132",
+  version: "0.1.133",
   kind: "runtime",
   description: "Shared CRUD helpers used by CRUD modules.",
   dependsOn: [
@@ -28,7 +28,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/crud-core": "0.1.132"
+        "@jskit-ai/crud-core": "0.1.133"
       },
       dev: {}
     },

--- a/packages/crud-core/package.json
+++ b/packages/crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-core",
-  "version": "0.1.132",
+  "version": "0.1.133",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -27,15 +27,15 @@
     "./server/routeContracts": "./src/server/routeContracts.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.123",
-    "@jskit-ai/http-runtime": "0.1.122",
-    "@jskit-ai/kernel": "0.1.124",
+    "@jskit-ai/database-runtime": "0.1.124",
+    "@jskit-ai/http-runtime": "0.1.123",
+    "@jskit-ai/kernel": "0.1.125",
     "json-rest-schema": "1.x.x",
-    "@jskit-ai/realtime": "0.1.121",
-    "@jskit-ai/resource-crud-core": "0.1.67",
-    "@jskit-ai/shell-web": "0.1.125",
-    "@jskit-ai/users-core": "0.1.134",
-    "@jskit-ai/users-web": "0.1.140"
+    "@jskit-ai/realtime": "0.1.122",
+    "@jskit-ai/resource-crud-core": "0.1.68",
+    "@jskit-ai/shell-web": "0.1.126",
+    "@jskit-ai/users-core": "0.1.135",
+    "@jskit-ai/users-web": "0.1.141"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/crud-server-generator/package.descriptor.mjs
+++ b/packages/crud-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-server-generator",
-  version: "0.1.133",
+  version: "0.1.134",
   kind: "generator",
   description: "CRUD server generator with routes, actions, and persistence scaffolding.",
   options: {
@@ -184,14 +184,14 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.121",
-        "@jskit-ai/crud-core": "0.1.132",
-        "@jskit-ai/database-runtime": "0.1.123",
-        "@jskit-ai/http-runtime": "0.1.122",
-        "@jskit-ai/json-rest-api-core": "0.1.68",
-        "@jskit-ai/kernel": "0.1.124",
-        "@jskit-ai/realtime": "0.1.121",
-        "@jskit-ai/resource-crud-core": "0.1.67",
+        "@jskit-ai/auth-core": "0.1.122",
+        "@jskit-ai/crud-core": "0.1.133",
+        "@jskit-ai/database-runtime": "0.1.124",
+        "@jskit-ai/http-runtime": "0.1.123",
+        "@jskit-ai/json-rest-api-core": "0.1.69",
+        "@jskit-ai/kernel": "0.1.125",
+        "@jskit-ai/realtime": "0.1.122",
+        "@jskit-ai/resource-crud-core": "0.1.68",
         "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}"
       },
       dev: {}

--- a/packages/crud-server-generator/package.json
+++ b/packages/crud-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-server-generator",
-  "version": "0.1.133",
+  "version": "0.1.134",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,12 +13,12 @@
   },
   "dependencies": {
     "@babel/parser": "^7.29.2",
-    "@jskit-ai/crud-core": "0.1.132",
-    "@jskit-ai/database-runtime": "0.1.123",
-    "@jskit-ai/http-runtime": "0.1.122",
-    "@jskit-ai/json-rest-api-core": "0.1.68",
-    "@jskit-ai/kernel": "0.1.124",
-    "@jskit-ai/resource-crud-core": "0.1.67",
+    "@jskit-ai/crud-core": "0.1.133",
+    "@jskit-ai/database-runtime": "0.1.124",
+    "@jskit-ai/http-runtime": "0.1.123",
+    "@jskit-ai/json-rest-api-core": "0.1.69",
+    "@jskit-ai/kernel": "0.1.125",
+    "@jskit-ai/resource-crud-core": "0.1.68",
     "recast": "^0.23.11"
   }
 }

--- a/packages/crud-ui-generator/package.descriptor.mjs
+++ b/packages/crud-ui-generator/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { GENERATED_UI_NAVIGATION_ROLE_OPTION } from "@jskit-ai/kernel/shared/sup
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-ui-generator",
-  version: "0.1.107",
+  version: "0.1.108",
   kind: "generator",
   description: "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
   options: {
@@ -175,7 +175,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.140"
+        "@jskit-ai/users-web": "0.1.141"
       },
       dev: {}
     },

--- a/packages/crud-ui-generator/package.json
+++ b/packages/crud-ui-generator/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@jskit-ai/crud-ui-generator",
-  "version": "0.1.107",
+  "version": "0.1.108",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/crud-core": "0.1.132",
-    "@jskit-ai/kernel": "0.1.124",
-    "@jskit-ai/resource-crud-core": "0.1.67"
+    "@jskit-ai/crud-core": "0.1.133",
+    "@jskit-ai/kernel": "0.1.125",
+    "@jskit-ai/resource-crud-core": "0.1.68"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/database-runtime-mysql/package.descriptor.mjs
+++ b/packages/database-runtime-mysql/package.descriptor.mjs
@@ -13,7 +13,7 @@ const CI_DATABASE = Object.freeze({
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-mysql",
-  version: "0.1.122",
+  version: "0.1.123",
   kind: "runtime",
   options: {
     "db-host": {
@@ -133,7 +133,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.123",
+        "@jskit-ai/database-runtime": "0.1.124",
         "mysql2": "^3.11.2"
       },
       dev: {}

--- a/packages/database-runtime-mysql/package.json
+++ b/packages/database-runtime-mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-mysql",
-  "version": "0.1.122",
+  "version": "0.1.123",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,7 +12,7 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.123",
-    "@jskit-ai/kernel": "0.1.124"
+    "@jskit-ai/database-runtime": "0.1.124",
+    "@jskit-ai/kernel": "0.1.125"
   }
 }

--- a/packages/database-runtime-postgres/package.descriptor.mjs
+++ b/packages/database-runtime-postgres/package.descriptor.mjs
@@ -12,7 +12,7 @@ const CI_DATABASE = Object.freeze({
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-postgres",
-  version: "0.1.121",
+  version: "0.1.122",
   kind: "runtime",
   options: {
     "db-host": {
@@ -131,7 +131,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.123",
+        "@jskit-ai/database-runtime": "0.1.124",
         "pg": "^8.13.1"
       },
       dev: {}

--- a/packages/database-runtime-postgres/package.json
+++ b/packages/database-runtime-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-postgres",
-  "version": "0.1.121",
+  "version": "0.1.122",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,6 +12,6 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.123"
+    "@jskit-ai/database-runtime": "0.1.124"
   }
 }

--- a/packages/database-runtime/package.descriptor.mjs
+++ b/packages/database-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime",
-  version: "0.1.123",
+  version: "0.1.124",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -70,7 +70,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.124",
+        "@jskit-ai/kernel": "0.1.125",
         "dotenv": "^16.4.5",
         "knex": "^3.1.0"
       },

--- a/packages/database-runtime/package.json
+++ b/packages/database-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime",
-  "version": "0.1.123",
+  "version": "0.1.124",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -25,6 +25,6 @@
     "./shared/transactions": "./src/shared/transactions.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.124"
+    "@jskit-ai/kernel": "0.1.125"
   }
 }

--- a/packages/feature-server-generator/package.descriptor.mjs
+++ b/packages/feature-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/feature-server-generator",
-  version: "0.1.66",
+  version: "0.1.67",
   kind: "generator",
   description: "Scaffold substantial non-CRUD server feature packages with provider, actions, service, and optional persistence seams.",
   options: {
@@ -154,27 +154,27 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@jskit-ai/database-runtime": {
-          version: "0.1.123",
+          version: "0.1.124",
           when: {
             option: "mode",
             notEquals: "orchestrator"
           }
         },
         "@jskit-ai/database-runtime-mysql": {
-          version: "0.1.122",
+          version: "0.1.123",
           when: {
             option: "mode",
             notEquals: "orchestrator"
           }
         },
         "@jskit-ai/json-rest-api-core": {
-          version: "0.1.68",
+          version: "0.1.69",
           when: {
             option: "mode",
             equals: "json-rest"
           }
         },
-        "@jskit-ai/kernel": "0.1.124",
+        "@jskit-ai/kernel": "0.1.125",
         "json-rest-schema": "1.x.x",
         "@local/${option:feature-name|kebab}": "file:packages/${option:feature-name|kebab}"
       },

--- a/packages/feature-server-generator/package.json
+++ b/packages/feature-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/feature-server-generator",
-  "version": "0.1.66",
+  "version": "0.1.67",
   "type": "module",
   "scripts": {
     "test": "node --test"

--- a/packages/google-rewarded-core/package.descriptor.mjs
+++ b/packages/google-rewarded-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/google-rewarded-core",
-  version: "0.1.61",
+  version: "0.1.62",
   kind: "runtime",
   description: "Google rewarded workflow runtime plus internal CRUD providers for rules, provider configs, watch sessions, and unlock receipts.",
   dependsOn: [
@@ -128,14 +128,14 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.121",
-        "@jskit-ai/crud-core": "0.1.132",
-        "@jskit-ai/database-runtime": "0.1.123",
-        "@jskit-ai/http-runtime": "0.1.122",
-        "@jskit-ai/json-rest-api-core": "0.1.68",
-        "@jskit-ai/kernel": "0.1.124",
-        "@jskit-ai/resource-crud-core": "0.1.67",
-        "@jskit-ai/workspaces-core": "0.1.100"
+        "@jskit-ai/auth-core": "0.1.122",
+        "@jskit-ai/crud-core": "0.1.133",
+        "@jskit-ai/database-runtime": "0.1.124",
+        "@jskit-ai/http-runtime": "0.1.123",
+        "@jskit-ai/json-rest-api-core": "0.1.69",
+        "@jskit-ai/kernel": "0.1.125",
+        "@jskit-ai/resource-crud-core": "0.1.68",
+        "@jskit-ai/workspaces-core": "0.1.102"
       },
       dev: {}
     },

--- a/packages/google-rewarded-core/package.json
+++ b/packages/google-rewarded-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/google-rewarded-core",
-  "version": "0.1.61",
+  "version": "0.1.62",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/google-rewarded-web/package.descriptor.mjs
+++ b/packages/google-rewarded-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/google-rewarded-web",
-  version: "0.1.61",
+  version: "0.1.62",
   kind: "runtime",
   description: "Google rewarded client runtime with a fullscreen gate host and GPT orchestration.",
   dependsOn: [
@@ -46,10 +46,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/google-rewarded-core": "0.1.61",
-        "@jskit-ai/http-runtime": "0.1.122",
-        "@jskit-ai/kernel": "0.1.124",
-        "@jskit-ai/shell-web": "0.1.125"
+        "@jskit-ai/google-rewarded-core": "0.1.62",
+        "@jskit-ai/http-runtime": "0.1.123",
+        "@jskit-ai/kernel": "0.1.125",
+        "@jskit-ai/shell-web": "0.1.126"
       },
       dev: {}
     },

--- a/packages/google-rewarded-web/package.json
+++ b/packages/google-rewarded-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/google-rewarded-web",
-  "version": "0.1.61",
+  "version": "0.1.62",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/http-runtime/package.descriptor.mjs
+++ b/packages/http-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/http-runtime",
-  "version": "0.1.122",
+  "version": "0.1.123",
   "kind": "runtime",
   "dependsOn": [],
   "capabilities": {
@@ -67,7 +67,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.124"
+        "@jskit-ai/kernel": "0.1.125"
       },
       "dev": {}
     },

--- a/packages/http-runtime/package.json
+++ b/packages/http-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/http-runtime",
-  "version": "0.1.122",
+  "version": "0.1.123",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -18,7 +18,7 @@
     "./shared/validators/operationValidation": "./src/shared/validators/operationValidation.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.124",
+    "@jskit-ai/kernel": "0.1.125",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/json-rest-api-core/package.descriptor.mjs
+++ b/packages/json-rest-api-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/json-rest-api-core",
-  version: "0.1.68",
+  version: "0.1.69",
   kind: "runtime",
   description: "Shared internal json-rest-api host runtime with autofilter, query-projection, and row-policy support.",
   dependsOn: [

--- a/packages/json-rest-api-core/package.json
+++ b/packages/json-rest-api-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/json-rest-api-core",
-  "version": "0.1.68",
+  "version": "0.1.69",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,6 +11,6 @@
   "dependencies": {
     "hooked-api": "1.x.x",
     "json-rest-api": "^1.0.26",
-    "@jskit-ai/kernel": "0.1.124"
+    "@jskit-ai/kernel": "0.1.125"
   }
 }

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/kernel",
-  "version": "0.1.124",
+  "version": "0.1.125",
   "type": "module",
   "dependencies": {
     "json-rest-schema": "1.x.x"

--- a/packages/mobile-capacitor/package.descriptor.mjs
+++ b/packages/mobile-capacitor/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/mobile-capacitor",
-  version: "0.1.60",
+  version: "0.1.61",
   kind: "runtime",
   description: "Thin Capacitor client integration for JSKIT mobile-shell launch routing and auth callback completion.",
   dependsOn: [
@@ -62,8 +62,8 @@ export default Object.freeze({
         "@capacitor/app": "^7.1.0",
         "@capacitor/browser": "^7.0.1",
         "@capacitor/core": "^7.4.3",
-        "@jskit-ai/kernel": "0.1.124",
-        "@jskit-ai/shell-web": "0.1.125"
+        "@jskit-ai/kernel": "0.1.125",
+        "@jskit-ai/shell-web": "0.1.126"
       },
       dev: {
         "@capacitor/cli": "^7.4.3"

--- a/packages/mobile-capacitor/package.json
+++ b/packages/mobile-capacitor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/mobile-capacitor",
-  "version": "0.1.60",
+  "version": "0.1.61",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,6 +12,6 @@
   },
   "dependencies": {
     "@capacitor/browser": "^7.0.1",
-    "@jskit-ai/kernel": "0.1.124"
+    "@jskit-ai/kernel": "0.1.125"
   }
 }

--- a/packages/realtime/package.descriptor.mjs
+++ b/packages/realtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/realtime",
-  version: "0.1.121",
+  version: "0.1.122",
   kind: "runtime",
   description: "Thin, generic realtime runtime wrappers for socket.io server and client.",
   options: {
@@ -95,7 +95,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.124",
+        "@jskit-ai/kernel": "0.1.125",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/realtime",
-  "version": "0.1.121",
+  "version": "0.1.122",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@socket.io/redis-adapter": "^8.3.0",
-    "@jskit-ai/kernel": "0.1.124",
+    "@jskit-ai/kernel": "0.1.125",
     "redis": "^5.8.2",
     "socket.io": "^4.8.3",
     "socket.io-client": "^4.8.3"

--- a/packages/resource-core/package.descriptor.mjs
+++ b/packages/resource-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/resource-core",
-  version: "0.1.67",
+  version: "0.1.68",
   kind: "runtime",
   description: "Generic resource-definition helpers and schema-definition normalization.",
   dependsOn: [
@@ -22,7 +22,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/resource-core": "0.1.67"
+        "@jskit-ai/resource-core": "0.1.68"
       },
       dev: {}
     },

--- a/packages/resource-core/package.json
+++ b/packages/resource-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/resource-core",
-  "version": "0.1.67",
+  "version": "0.1.68",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./shared/resource": "./src/shared/resource.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.124"
+    "@jskit-ai/kernel": "0.1.125"
   }
 }

--- a/packages/resource-crud-core/package.descriptor.mjs
+++ b/packages/resource-crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/resource-crud-core",
-  version: "0.1.67",
+  version: "0.1.68",
   kind: "runtime",
   description: "CRUD-specific resource-definition helpers and namespace support.",
   dependsOn: [
@@ -23,7 +23,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/resource-crud-core": "0.1.67"
+        "@jskit-ai/resource-crud-core": "0.1.68"
       },
       dev: {}
     },

--- a/packages/resource-crud-core/package.json
+++ b/packages/resource-crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/resource-crud-core",
-  "version": "0.1.67",
+  "version": "0.1.68",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./shared/crudResource": "./src/shared/crudResource.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.124",
-    "@jskit-ai/resource-core": "0.1.67"
+    "@jskit-ai/kernel": "0.1.125",
+    "@jskit-ai/resource-core": "0.1.68"
   }
 }

--- a/packages/shell-web/package.descriptor.mjs
+++ b/packages/shell-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/shell-web",
-  version: "0.1.125",
+  version: "0.1.126",
   kind: "runtime",
   description: "Web shell layout runtime with outlet-based placement contributions.",
   dependsOn: [],
@@ -311,7 +311,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/kernel": "0.1.124"
+        "@jskit-ai/kernel": "0.1.125"
       },
       dev: {
         "@playwright/test": "1.61.1"

--- a/packages/shell-web/package.json
+++ b/packages/shell-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/shell-web",
-  "version": "0.1.125",
+  "version": "0.1.126",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/kernel": "0.1.124"
+    "@jskit-ai/kernel": "0.1.125"
   },
   "peerDependencies": {
     "pinia": "^3.0.4",

--- a/packages/storage-runtime/package.descriptor.mjs
+++ b/packages/storage-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/storage-runtime",
-  version: "0.1.122",
+  version: "0.1.123",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -50,7 +50,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.124",
+        "@jskit-ai/kernel": "0.1.125",
         "unstorage": "^1.17.3"
       },
       dev: {}

--- a/packages/storage-runtime/package.json
+++ b/packages/storage-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/storage-runtime",
-  "version": "0.1.122",
+  "version": "0.1.123",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./server/providers/StorageRuntimeServiceProvider": "./src/server/providers/StorageRuntimeServiceProvider.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.124",
+    "@jskit-ai/kernel": "0.1.125",
     "unstorage": "^1.17.5"
   }
 }

--- a/packages/ui-generator/package.descriptor.mjs
+++ b/packages/ui-generator/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { GENERATED_UI_NAVIGATION_ROLE_OPTION } from "@jskit-ai/kernel/shared/sup
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/ui-generator",
-  version: "0.1.107",
+  version: "0.1.108",
   kind: "generator",
   description: "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
   options: {
@@ -371,7 +371,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.140"
+        "@jskit-ai/users-web": "0.1.141"
       },
       dev: {}
     },

--- a/packages/ui-generator/package.json
+++ b/packages/ui-generator/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/ui-generator",
-  "version": "0.1.107",
+  "version": "0.1.108",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.124",
-    "@jskit-ai/shell-web": "0.1.125"
+    "@jskit-ai/kernel": "0.1.125",
+    "@jskit-ai/shell-web": "0.1.126"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/uploads-image-web/package.descriptor.mjs
+++ b/packages/uploads-image-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-image-web",
-  version: "0.1.100",
+  version: "0.1.101",
   kind: "runtime",
   description: "Reusable client-side image upload runtime with pre-upload image editing.",
   dependsOn: [
@@ -65,7 +65,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/uploads-runtime": "0.1.100",
+        "@jskit-ai/uploads-runtime": "0.1.101",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-image-web/package.json
+++ b/packages/uploads-image-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-image-web",
-  "version": "0.1.100",
+  "version": "0.1.101",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,7 +13,7 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/uploads-runtime": "0.1.100",
+    "@jskit-ai/uploads-runtime": "0.1.101",
     "@uppy/compressor": "^3.1.0",
     "@uppy/core": "^5.2.0",
     "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-runtime/package.descriptor.mjs
+++ b/packages/uploads-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-runtime",
-  version: "0.1.100",
+  version: "0.1.101",
   kind: "runtime",
   description: "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
   dependsOn: [
@@ -71,7 +71,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.124"
+        "@jskit-ai/kernel": "0.1.125"
       },
       dev: {}
     },

--- a/packages/uploads-runtime/package.json
+++ b/packages/uploads-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-runtime",
-  "version": "0.1.100",
+  "version": "0.1.101",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,6 +16,6 @@
   },
   "dependencies": {
     "@fastify/multipart": "^9.4.0",
-    "@jskit-ai/kernel": "0.1.124"
+    "@jskit-ai/kernel": "0.1.125"
   }
 }

--- a/packages/users-core/package.descriptor.mjs
+++ b/packages/users-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-core",
-  version: "0.1.134",
+  version: "0.1.135",
   kind: "runtime",
   description: "Users/account runtime plus HTTP routes for account features.",
   dependsOn: [
@@ -146,16 +146,16 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.121",
-        "@jskit-ai/crud-core": "0.1.132",
-        "@jskit-ai/database-runtime": "0.1.123",
-        "@jskit-ai/http-runtime": "0.1.122",
-        "@jskit-ai/json-rest-api-core": "0.1.68",
-        "@jskit-ai/kernel": "0.1.124",
-        "@jskit-ai/resource-core": "0.1.67",
-        "@jskit-ai/resource-crud-core": "0.1.67",
+        "@jskit-ai/auth-core": "0.1.122",
+        "@jskit-ai/crud-core": "0.1.133",
+        "@jskit-ai/database-runtime": "0.1.124",
+        "@jskit-ai/http-runtime": "0.1.123",
+        "@jskit-ai/json-rest-api-core": "0.1.69",
+        "@jskit-ai/kernel": "0.1.125",
+        "@jskit-ai/resource-core": "0.1.68",
+        "@jskit-ai/resource-crud-core": "0.1.68",
         "@local/users": "file:packages/users",
-        "@jskit-ai/uploads-runtime": "0.1.100"
+        "@jskit-ai/uploads-runtime": "0.1.101"
       },
       dev: {}
     },

--- a/packages/users-core/package.json
+++ b/packages/users-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-core",
-  "version": "0.1.134",
+  "version": "0.1.135",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,14 +11,14 @@
     "./shared/resources/userSettingsResource": "./src/shared/resources/userSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.121",
-    "@jskit-ai/database-runtime": "0.1.123",
-    "@jskit-ai/http-runtime": "0.1.122",
-    "@jskit-ai/json-rest-api-core": "0.1.68",
-    "@jskit-ai/kernel": "0.1.124",
-    "@jskit-ai/resource-crud-core": "0.1.67",
-    "@jskit-ai/resource-core": "0.1.67",
-    "@jskit-ai/uploads-runtime": "0.1.100",
+    "@jskit-ai/auth-core": "0.1.122",
+    "@jskit-ai/database-runtime": "0.1.124",
+    "@jskit-ai/http-runtime": "0.1.123",
+    "@jskit-ai/json-rest-api-core": "0.1.69",
+    "@jskit-ai/kernel": "0.1.125",
+    "@jskit-ai/resource-crud-core": "0.1.68",
+    "@jskit-ai/resource-core": "0.1.68",
+    "@jskit-ai/uploads-runtime": "0.1.101",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/users-web/package.descriptor.mjs
+++ b/packages/users-web/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { HOME_COG_OUTLET } from "./src/shared/toolsOutletContracts.js";
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-web",
-  version: "0.1.140",
+  version: "0.1.141",
   kind: "runtime",
   description: "Users web module: account/profile UI plus shared users web widgets.",
   dependsOn: [
@@ -286,12 +286,12 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/http-runtime": "0.1.122",
-        "@jskit-ai/realtime": "0.1.121",
-        "@jskit-ai/kernel": "0.1.124",
-        "@jskit-ai/shell-web": "0.1.125",
-        "@jskit-ai/uploads-image-web": "0.1.100",
-        "@jskit-ai/users-core": "0.1.134"
+        "@jskit-ai/http-runtime": "0.1.123",
+        "@jskit-ai/realtime": "0.1.122",
+        "@jskit-ai/kernel": "0.1.125",
+        "@jskit-ai/shell-web": "0.1.126",
+        "@jskit-ai/uploads-image-web": "0.1.101",
+        "@jskit-ai/users-core": "0.1.135"
       },
       dev: {}
     },

--- a/packages/users-web/package.json
+++ b/packages/users-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-web",
-  "version": "0.1.140",
+  "version": "0.1.141",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -46,12 +46,12 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/http-runtime": "0.1.122",
-    "@jskit-ai/kernel": "0.1.124",
-    "@jskit-ai/realtime": "0.1.121",
-    "@jskit-ai/shell-web": "0.1.125",
-    "@jskit-ai/uploads-image-web": "0.1.100",
-    "@jskit-ai/users-core": "0.1.134"
+    "@jskit-ai/http-runtime": "0.1.123",
+    "@jskit-ai/kernel": "0.1.125",
+    "@jskit-ai/realtime": "0.1.122",
+    "@jskit-ai/shell-web": "0.1.126",
+    "@jskit-ai/uploads-image-web": "0.1.101",
+    "@jskit-ai/users-core": "0.1.135"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/workspaces-core/package.descriptor.mjs
+++ b/packages/workspaces-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-core",
-  version: "0.1.101",
+  version: "0.1.102",
   kind: "runtime",
   description: "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
   dependsOn: [
@@ -147,10 +147,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/json-rest-api-core": "0.1.68",
-        "@jskit-ai/resource-core": "0.1.67",
-        "@jskit-ai/resource-crud-core": "0.1.67",
-        "@jskit-ai/users-core": "0.1.134"
+        "@jskit-ai/json-rest-api-core": "0.1.69",
+        "@jskit-ai/resource-core": "0.1.68",
+        "@jskit-ai/resource-crud-core": "0.1.68",
+        "@jskit-ai/users-core": "0.1.135"
       },
       dev: {}
     },

--- a/packages/workspaces-core/package.json
+++ b/packages/workspaces-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-core",
-  "version": "0.1.101",
+  "version": "0.1.102",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -17,14 +17,14 @@
     "./shared/resources/workspaceSettingsResource": "./src/shared/resources/workspaceSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.121",
-    "@jskit-ai/database-runtime": "0.1.123",
-    "@jskit-ai/http-runtime": "0.1.122",
-    "@jskit-ai/json-rest-api-core": "0.1.68",
-    "@jskit-ai/kernel": "0.1.124",
-    "@jskit-ai/resource-crud-core": "0.1.67",
-    "@jskit-ai/resource-core": "0.1.67",
-    "@jskit-ai/users-core": "0.1.134",
+    "@jskit-ai/auth-core": "0.1.122",
+    "@jskit-ai/database-runtime": "0.1.124",
+    "@jskit-ai/http-runtime": "0.1.123",
+    "@jskit-ai/json-rest-api-core": "0.1.69",
+    "@jskit-ai/kernel": "0.1.125",
+    "@jskit-ai/resource-crud-core": "0.1.68",
+    "@jskit-ai/resource-core": "0.1.68",
+    "@jskit-ai/users-core": "0.1.135",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/workspaces-web/package.descriptor.mjs
+++ b/packages/workspaces-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-web",
-  version: "0.1.102",
+  version: "0.1.103",
   kind: "runtime",
   description: "Workspace web module: workspace selector, tools widget, workspace surfaces, members UI, and settings hosts.",
   dependsOn: [
@@ -232,9 +232,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-web": "0.1.124",
-        "@jskit-ai/workspaces-core": "0.1.101",
-        "@jskit-ai/users-web": "0.1.140"
+        "@jskit-ai/auth-web": "0.1.125",
+        "@jskit-ai/workspaces-core": "0.1.102",
+        "@jskit-ai/users-web": "0.1.141"
       },
       dev: {}
     },

--- a/packages/workspaces-web/package.json
+++ b/packages/workspaces-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-web",
-  "version": "0.1.102",
+  "version": "0.1.103",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -15,13 +15,13 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/auth-web": "0.1.124",
-    "@jskit-ai/http-runtime": "0.1.122",
-    "@jskit-ai/kernel": "0.1.124",
-    "@jskit-ai/shell-web": "0.1.125",
-    "@jskit-ai/users-core": "0.1.134",
-    "@jskit-ai/users-web": "0.1.140",
-    "@jskit-ai/workspaces-core": "0.1.101"
+    "@jskit-ai/auth-web": "0.1.125",
+    "@jskit-ai/http-runtime": "0.1.123",
+    "@jskit-ai/kernel": "0.1.125",
+    "@jskit-ai/shell-web": "0.1.126",
+    "@jskit-ai/users-core": "0.1.135",
+    "@jskit-ai/users-web": "0.1.141",
+    "@jskit-ai/workspaces-core": "0.1.102"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/tooling/config-eslint/package.json
+++ b/tooling/config-eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/config-eslint",
-  "version": "0.1.122",
+  "version": "0.1.123",
   "description": "Shared flat ESLint presets for JSKIT projects.",
   "type": "module",
   "files": [

--- a/tooling/create-app/package.descriptor.mjs
+++ b/tooling/create-app/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/create-app",
-  "version": "0.1.141",
+  "version": "0.1.142",
   "dependsOn": [],
   "capabilities": {
     "provides": [

--- a/tooling/create-app/package.json
+++ b/tooling/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/create-app",
-  "version": "0.1.141",
+  "version": "0.1.142",
   "description": "Scaffold JSKIT app shells.",
   "type": "module",
   "files": [
@@ -20,7 +20,7 @@
     "./client": "./src/client/index.js"
   },
   "dependencies": {
-    "@jskit-ai/jskit-cli": "0.2.144"
+    "@jskit-ai/jskit-cli": "0.2.145"
   },
   "engines": {
     "node": "^22.12.0 || ^24.0.0 || ^26.0.0"

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -6,11 +6,11 @@
   "packages": [
     {
       "packageId": "@jskit-ai/assistant",
-      "version": "0.1.133",
+      "version": "0.1.134",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant",
-        "version": "0.1.133",
+        "version": "0.1.134",
         "kind": "generator",
         "description": "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
         "options": {
@@ -347,11 +347,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-core",
-      "version": "0.1.101",
+      "version": "0.1.102",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-core",
-        "version": "0.1.101",
+        "version": "0.1.102",
         "kind": "runtime",
         "description": "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
         "dependsOn": [
@@ -399,11 +399,11 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/http-runtime": "0.1.122",
-              "@jskit-ai/kernel": "0.1.124",
-              "@jskit-ai/resource-core": "0.1.67",
-              "@jskit-ai/resource-crud-core": "0.1.67",
-              "@jskit-ai/users-core": "0.1.134",
+              "@jskit-ai/http-runtime": "0.1.123",
+              "@jskit-ai/kernel": "0.1.125",
+              "@jskit-ai/resource-core": "0.1.68",
+              "@jskit-ai/resource-crud-core": "0.1.68",
+              "@jskit-ai/users-core": "0.1.135",
               "dompurify": "^3.3.3",
               "json-rest-schema": "1.x.x",
               "marked": "^17.0.4",
@@ -422,11 +422,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-runtime",
-      "version": "0.1.96",
+      "version": "0.1.97",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-runtime",
-        "version": "0.1.96",
+        "version": "0.1.97",
         "kind": "runtime",
         "description": "Shared assistant runtime with per-surface assistant registration.",
         "dependsOn": [
@@ -522,13 +522,13 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/assistant-core": "0.1.101",
-              "@jskit-ai/database-runtime": "0.1.123",
-              "@jskit-ai/http-runtime": "0.1.122",
-              "@jskit-ai/kernel": "0.1.124",
-              "@jskit-ai/shell-web": "0.1.125",
-              "@jskit-ai/users-core": "0.1.134",
-              "@jskit-ai/users-web": "0.1.140"
+              "@jskit-ai/assistant-core": "0.1.102",
+              "@jskit-ai/database-runtime": "0.1.124",
+              "@jskit-ai/http-runtime": "0.1.123",
+              "@jskit-ai/kernel": "0.1.125",
+              "@jskit-ai/shell-web": "0.1.126",
+              "@jskit-ai/users-core": "0.1.135",
+              "@jskit-ai/users-web": "0.1.141"
             },
             "dev": {}
           },
@@ -583,11 +583,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-core",
-      "version": "0.1.121",
+      "version": "0.1.122",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-core",
-        "version": "0.1.121",
+        "version": "0.1.122",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/value-app-config-shared"
@@ -660,7 +660,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.124",
+              "@jskit-ai/kernel": "0.1.125",
               "@fastify/cookie": "^11.0.2",
               "@fastify/csrf-protection": "^7.1.0",
               "@fastify/rate-limit": "^10.3.0"
@@ -678,11 +678,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-local-core",
-      "version": "0.1.25",
+      "version": "0.1.26",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-local-core",
-        "version": "0.1.25",
+        "version": "0.1.26",
         "kind": "runtime",
         "description": "Local auth provider with a file backend default and no database requirement.",
         "dependsOn": [
@@ -745,8 +745,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.121",
-              "@jskit-ai/kernel": "0.1.124",
+              "@jskit-ai/auth-core": "0.1.122",
+              "@jskit-ai/kernel": "0.1.125",
               "nodemailer": "^9.0.3",
               "dotenv": "^16.4.5"
             },
@@ -792,11 +792,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-local-db-core",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-local-db-core",
-        "version": "0.1.16",
+        "version": "0.1.17",
         "kind": "runtime",
         "description": "Database-backed local auth storage backend for JSKIT local auth.",
         "dependsOn": [
@@ -875,9 +875,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-provider-local-core": "0.1.25",
-              "@jskit-ai/database-runtime": "0.1.123",
-              "@jskit-ai/kernel": "0.1.124"
+              "@jskit-ai/auth-provider-local-core": "0.1.26",
+              "@jskit-ai/database-runtime": "0.1.124",
+              "@jskit-ai/kernel": "0.1.125"
             },
             "dev": {}
           },
@@ -912,11 +912,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.122",
+      "version": "0.1.123",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-supabase-core",
-        "version": "0.1.122",
+        "version": "0.1.123",
         "kind": "runtime",
         "options": {
           "auth-supabase-url": {
@@ -998,8 +998,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.121",
-              "@jskit-ai/kernel": "0.1.124",
+              "@jskit-ai/auth-core": "0.1.122",
+              "@jskit-ai/kernel": "0.1.125",
               "dotenv": "^16.4.5",
               "@supabase/supabase-js": "^2.57.4",
               "jose": "^6.1.0"
@@ -1077,11 +1077,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-web",
-      "version": "0.1.124",
+      "version": "0.1.125",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-web",
-        "version": "0.1.124",
+        "version": "0.1.125",
         "kind": "runtime",
         "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
         "dependsOn": [
@@ -1354,10 +1354,10 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/auth-core": "0.1.121",
-              "@jskit-ai/http-runtime": "0.1.122",
-              "@jskit-ai/kernel": "0.1.124",
-              "@jskit-ai/shell-web": "0.1.125"
+              "@jskit-ai/auth-core": "0.1.122",
+              "@jskit-ai/http-runtime": "0.1.123",
+              "@jskit-ai/kernel": "0.1.125",
+              "@jskit-ai/shell-web": "0.1.126"
             },
             "dev": {}
           },
@@ -1450,11 +1450,11 @@
     },
     {
       "packageId": "@jskit-ai/console-core",
-      "version": "0.1.88",
+      "version": "0.1.89",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-core",
-        "version": "0.1.88",
+        "version": "0.1.89",
         "kind": "runtime",
         "description": "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
         "dependsOn": [
@@ -1538,12 +1538,12 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.121",
-              "@jskit-ai/database-runtime": "0.1.123",
-              "@jskit-ai/http-runtime": "0.1.122",
-              "@jskit-ai/kernel": "0.1.124",
-              "@jskit-ai/resource-crud-core": "0.1.67",
-              "@jskit-ai/users-core": "0.1.134"
+              "@jskit-ai/auth-core": "0.1.122",
+              "@jskit-ai/database-runtime": "0.1.124",
+              "@jskit-ai/http-runtime": "0.1.123",
+              "@jskit-ai/kernel": "0.1.125",
+              "@jskit-ai/resource-crud-core": "0.1.68",
+              "@jskit-ai/users-core": "0.1.135"
             },
             "dev": {}
           },
@@ -1568,11 +1568,11 @@
     },
     {
       "packageId": "@jskit-ai/console-web",
-      "version": "0.1.93",
+      "version": "0.1.94",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-web",
-        "version": "0.1.93",
+        "version": "0.1.94",
         "kind": "runtime",
         "description": "Authenticated console surface scaffold and surface policy wiring.",
         "dependsOn": [
@@ -1682,9 +1682,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-web": "0.1.124",
-              "@jskit-ai/console-core": "0.1.88",
-              "@jskit-ai/shell-web": "0.1.125"
+              "@jskit-ai/auth-web": "0.1.125",
+              "@jskit-ai/console-core": "0.1.89",
+              "@jskit-ai/shell-web": "0.1.126"
             },
             "dev": {}
           },
@@ -1791,11 +1791,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-core",
-      "version": "0.1.132",
+      "version": "0.1.133",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-core",
-        "version": "0.1.132",
+        "version": "0.1.133",
         "kind": "runtime",
         "description": "Shared CRUD helpers used by CRUD modules.",
         "dependsOn": [
@@ -1824,7 +1824,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/crud-core": "0.1.132"
+              "@jskit-ai/crud-core": "0.1.133"
             },
             "dev": {}
           },
@@ -1838,11 +1838,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-server-generator",
-      "version": "0.1.133",
+      "version": "0.1.134",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-server-generator",
-        "version": "0.1.133",
+        "version": "0.1.134",
         "kind": "generator",
         "description": "CRUD server generator with routes, actions, and persistence scaffolding.",
         "options": {
@@ -2033,14 +2033,14 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.121",
-              "@jskit-ai/crud-core": "0.1.132",
-              "@jskit-ai/database-runtime": "0.1.123",
-              "@jskit-ai/http-runtime": "0.1.122",
-              "@jskit-ai/json-rest-api-core": "0.1.68",
-              "@jskit-ai/kernel": "0.1.124",
-              "@jskit-ai/realtime": "0.1.121",
-              "@jskit-ai/resource-crud-core": "0.1.67",
+              "@jskit-ai/auth-core": "0.1.122",
+              "@jskit-ai/crud-core": "0.1.133",
+              "@jskit-ai/database-runtime": "0.1.124",
+              "@jskit-ai/http-runtime": "0.1.123",
+              "@jskit-ai/json-rest-api-core": "0.1.69",
+              "@jskit-ai/kernel": "0.1.125",
+              "@jskit-ai/realtime": "0.1.122",
+              "@jskit-ai/resource-crud-core": "0.1.68",
               "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}"
             },
             "dev": {}
@@ -2172,11 +2172,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.107",
+      "version": "0.1.108",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-ui-generator",
-        "version": "0.1.107",
+        "version": "0.1.108",
         "kind": "generator",
         "description": "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
         "options": {
@@ -2375,7 +2375,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.140"
+              "@jskit-ai/users-web": "0.1.141"
             },
             "dev": {}
           },
@@ -2634,11 +2634,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime",
-      "version": "0.1.123",
+      "version": "0.1.124",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime",
-        "version": "0.1.123",
+        "version": "0.1.124",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -2707,7 +2707,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.124",
+              "@jskit-ai/kernel": "0.1.125",
               "dotenv": "^16.4.5",
               "knex": "^3.1.0"
             },
@@ -2743,11 +2743,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.122",
+      "version": "0.1.123",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-mysql",
-        "version": "0.1.122",
+        "version": "0.1.123",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -2869,7 +2869,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.123",
+              "@jskit-ai/database-runtime": "0.1.124",
               "mysql2": "^3.11.2"
             },
             "dev": {}
@@ -2940,11 +2940,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.121",
+      "version": "0.1.122",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-postgres",
-        "version": "0.1.121",
+        "version": "0.1.122",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -3065,7 +3065,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.123",
+              "@jskit-ai/database-runtime": "0.1.124",
               "pg": "^8.13.1"
             },
             "dev": {}
@@ -3136,11 +3136,11 @@
     },
     {
       "packageId": "@jskit-ai/feature-server-generator",
-      "version": "0.1.66",
+      "version": "0.1.67",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/feature-server-generator",
-        "version": "0.1.66",
+        "version": "0.1.67",
         "kind": "generator",
         "description": "Scaffold substantial non-CRUD server feature packages with provider, actions, service, and optional persistence seams.",
         "options": {
@@ -3305,27 +3305,27 @@
           "dependencies": {
             "runtime": {
               "@jskit-ai/database-runtime": {
-                "version": "0.1.123",
+                "version": "0.1.124",
                 "when": {
                   "option": "mode",
                   "notEquals": "orchestrator"
                 }
               },
               "@jskit-ai/database-runtime-mysql": {
-                "version": "0.1.122",
+                "version": "0.1.123",
                 "when": {
                   "option": "mode",
                   "notEquals": "orchestrator"
                 }
               },
               "@jskit-ai/json-rest-api-core": {
-                "version": "0.1.68",
+                "version": "0.1.69",
                 "when": {
                   "option": "mode",
                   "equals": "json-rest"
                 }
               },
-              "@jskit-ai/kernel": "0.1.124",
+              "@jskit-ai/kernel": "0.1.125",
               "json-rest-schema": "1.x.x",
               "@local/${option:feature-name|kebab}": "file:packages/${option:feature-name|kebab}"
             },
@@ -3438,11 +3438,11 @@
     },
     {
       "packageId": "@jskit-ai/google-rewarded-core",
-      "version": "0.1.61",
+      "version": "0.1.62",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/google-rewarded-core",
-        "version": "0.1.61",
+        "version": "0.1.62",
         "kind": "runtime",
         "description": "Google rewarded workflow runtime plus internal CRUD providers for rules, provider configs, watch sessions, and unlock receipts.",
         "dependsOn": [
@@ -3569,14 +3569,14 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.121",
-              "@jskit-ai/crud-core": "0.1.132",
-              "@jskit-ai/database-runtime": "0.1.123",
-              "@jskit-ai/http-runtime": "0.1.122",
-              "@jskit-ai/json-rest-api-core": "0.1.68",
-              "@jskit-ai/kernel": "0.1.124",
-              "@jskit-ai/resource-crud-core": "0.1.67",
-              "@jskit-ai/workspaces-core": "0.1.100"
+              "@jskit-ai/auth-core": "0.1.122",
+              "@jskit-ai/crud-core": "0.1.133",
+              "@jskit-ai/database-runtime": "0.1.124",
+              "@jskit-ai/http-runtime": "0.1.123",
+              "@jskit-ai/json-rest-api-core": "0.1.69",
+              "@jskit-ai/kernel": "0.1.125",
+              "@jskit-ai/resource-crud-core": "0.1.68",
+              "@jskit-ai/workspaces-core": "0.1.102"
             },
             "dev": {}
           },
@@ -3628,11 +3628,11 @@
     },
     {
       "packageId": "@jskit-ai/google-rewarded-web",
-      "version": "0.1.61",
+      "version": "0.1.62",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/google-rewarded-web",
-        "version": "0.1.61",
+        "version": "0.1.62",
         "kind": "runtime",
         "description": "Google rewarded client runtime with a fullscreen gate host and GPT orchestration.",
         "dependsOn": [
@@ -3679,10 +3679,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/google-rewarded-core": "0.1.61",
-              "@jskit-ai/http-runtime": "0.1.122",
-              "@jskit-ai/kernel": "0.1.124",
-              "@jskit-ai/shell-web": "0.1.125"
+              "@jskit-ai/google-rewarded-core": "0.1.62",
+              "@jskit-ai/http-runtime": "0.1.123",
+              "@jskit-ai/kernel": "0.1.125",
+              "@jskit-ai/shell-web": "0.1.126"
             },
             "dev": {}
           },
@@ -3700,11 +3700,11 @@
     },
     {
       "packageId": "@jskit-ai/http-runtime",
-      "version": "0.1.122",
+      "version": "0.1.123",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/http-runtime",
-        "version": "0.1.122",
+        "version": "0.1.123",
         "kind": "runtime",
         "dependsOn": [],
         "capabilities": {
@@ -3770,7 +3770,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.124"
+              "@jskit-ai/kernel": "0.1.125"
             },
             "dev": {}
           },
@@ -3784,11 +3784,11 @@
     },
     {
       "packageId": "@jskit-ai/json-rest-api-core",
-      "version": "0.1.68",
+      "version": "0.1.69",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/json-rest-api-core",
-        "version": "0.1.68",
+        "version": "0.1.69",
         "kind": "runtime",
         "description": "Shared internal json-rest-api host runtime with autofilter, query-projection, and row-policy support.",
         "dependsOn": [
@@ -3848,11 +3848,11 @@
     },
     {
       "packageId": "@jskit-ai/mobile-capacitor",
-      "version": "0.1.60",
+      "version": "0.1.61",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/mobile-capacitor",
-        "version": "0.1.60",
+        "version": "0.1.61",
         "kind": "runtime",
         "description": "Thin Capacitor client integration for JSKIT mobile-shell launch routing and auth callback completion.",
         "dependsOn": [
@@ -3915,8 +3915,8 @@
               "@capacitor/app": "^7.1.0",
               "@capacitor/browser": "^7.0.1",
               "@capacitor/core": "^7.4.3",
-              "@jskit-ai/kernel": "0.1.124",
-              "@jskit-ai/shell-web": "0.1.125"
+              "@jskit-ai/kernel": "0.1.125",
+              "@jskit-ai/shell-web": "0.1.126"
             },
             "dev": {
               "@capacitor/cli": "^7.4.3"
@@ -3968,11 +3968,11 @@
     },
     {
       "packageId": "@jskit-ai/realtime",
-      "version": "0.1.121",
+      "version": "0.1.122",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/realtime",
-        "version": "0.1.121",
+        "version": "0.1.122",
         "kind": "runtime",
         "description": "Thin, generic realtime runtime wrappers for socket.io server and client.",
         "options": {
@@ -4068,7 +4068,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.124",
+              "@jskit-ai/kernel": "0.1.125",
               "@socket.io/redis-adapter": "^8.3.0",
               "redis": "^5.8.2",
               "socket.io": "^4.8.3",
@@ -4117,11 +4117,11 @@
     },
     {
       "packageId": "@jskit-ai/resource-core",
-      "version": "0.1.67",
+      "version": "0.1.68",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/resource-core",
-        "version": "0.1.67",
+        "version": "0.1.68",
         "kind": "runtime",
         "description": "Generic resource-definition helpers and schema-definition normalization.",
         "dependsOn": [
@@ -4144,7 +4144,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/resource-core": "0.1.67"
+              "@jskit-ai/resource-core": "0.1.68"
             },
             "dev": {}
           },
@@ -4159,11 +4159,11 @@
     },
     {
       "packageId": "@jskit-ai/resource-crud-core",
-      "version": "0.1.67",
+      "version": "0.1.68",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/resource-crud-core",
-        "version": "0.1.67",
+        "version": "0.1.68",
         "kind": "runtime",
         "description": "CRUD-specific resource-definition helpers and namespace support.",
         "dependsOn": [
@@ -4187,7 +4187,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/resource-crud-core": "0.1.67"
+              "@jskit-ai/resource-crud-core": "0.1.68"
             },
             "dev": {}
           },
@@ -4202,11 +4202,11 @@
     },
     {
       "packageId": "@jskit-ai/shell-web",
-      "version": "0.1.125",
+      "version": "0.1.126",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/shell-web",
-        "version": "0.1.125",
+        "version": "0.1.126",
         "kind": "runtime",
         "description": "Web shell layout runtime with outlet-based placement contributions.",
         "dependsOn": [],
@@ -4552,7 +4552,7 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/kernel": "0.1.124"
+              "@jskit-ai/kernel": "0.1.125"
             },
             "dev": {
               "@playwright/test": "1.61.1"
@@ -4781,11 +4781,11 @@
     },
     {
       "packageId": "@jskit-ai/storage-runtime",
-      "version": "0.1.122",
+      "version": "0.1.123",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/storage-runtime",
-        "version": "0.1.122",
+        "version": "0.1.123",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -4834,7 +4834,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.124",
+              "@jskit-ai/kernel": "0.1.125",
               "unstorage": "^1.17.3"
             },
             "dev": {}
@@ -4850,11 +4850,11 @@
     },
     {
       "packageId": "@jskit-ai/ui-generator",
-      "version": "0.1.107",
+      "version": "0.1.108",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/ui-generator",
-        "version": "0.1.107",
+        "version": "0.1.108",
         "kind": "generator",
         "description": "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
         "options": {
@@ -5287,7 +5287,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.140"
+              "@jskit-ai/users-web": "0.1.141"
             },
             "dev": {}
           },
@@ -5302,11 +5302,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-image-web",
-      "version": "0.1.100",
+      "version": "0.1.101",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-image-web",
-        "version": "0.1.100",
+        "version": "0.1.101",
         "kind": "runtime",
         "description": "Reusable client-side image upload runtime with pre-upload image editing.",
         "dependsOn": [
@@ -5370,7 +5370,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/uploads-runtime": "0.1.100",
+              "@jskit-ai/uploads-runtime": "0.1.101",
               "@uppy/compressor": "^3.1.0",
               "@uppy/core": "^5.2.0",
               "@uppy/dashboard": "^5.1.1",
@@ -5390,11 +5390,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-runtime",
-      "version": "0.1.100",
+      "version": "0.1.101",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-runtime",
-        "version": "0.1.100",
+        "version": "0.1.101",
         "kind": "runtime",
         "description": "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
         "dependsOn": [
@@ -5464,7 +5464,7 @@
           "dependencies": {
             "runtime": {
               "@fastify/multipart": "^9.4.0",
-              "@jskit-ai/kernel": "0.1.124"
+              "@jskit-ai/kernel": "0.1.125"
             },
             "dev": {}
           },
@@ -5479,11 +5479,11 @@
     },
     {
       "packageId": "@jskit-ai/users-core",
-      "version": "0.1.134",
+      "version": "0.1.135",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-core",
-        "version": "0.1.134",
+        "version": "0.1.135",
         "kind": "runtime",
         "description": "Users/account runtime plus HTTP routes for account features.",
         "dependsOn": [
@@ -5627,16 +5627,16 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.121",
-              "@jskit-ai/crud-core": "0.1.132",
-              "@jskit-ai/database-runtime": "0.1.123",
-              "@jskit-ai/http-runtime": "0.1.122",
-              "@jskit-ai/json-rest-api-core": "0.1.68",
-              "@jskit-ai/kernel": "0.1.124",
-              "@jskit-ai/resource-core": "0.1.67",
-              "@jskit-ai/resource-crud-core": "0.1.67",
+              "@jskit-ai/auth-core": "0.1.122",
+              "@jskit-ai/crud-core": "0.1.133",
+              "@jskit-ai/database-runtime": "0.1.124",
+              "@jskit-ai/http-runtime": "0.1.123",
+              "@jskit-ai/json-rest-api-core": "0.1.69",
+              "@jskit-ai/kernel": "0.1.125",
+              "@jskit-ai/resource-core": "0.1.68",
+              "@jskit-ai/resource-crud-core": "0.1.68",
               "@local/users": "file:packages/users",
-              "@jskit-ai/uploads-runtime": "0.1.100"
+              "@jskit-ai/uploads-runtime": "0.1.101"
             },
             "dev": {}
           },
@@ -5863,11 +5863,11 @@
     },
     {
       "packageId": "@jskit-ai/users-web",
-      "version": "0.1.140",
+      "version": "0.1.141",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-web",
-        "version": "0.1.140",
+        "version": "0.1.141",
         "kind": "runtime",
         "description": "Users web module: account/profile UI plus shared users web widgets.",
         "dependsOn": [
@@ -6170,12 +6170,12 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/http-runtime": "0.1.122",
-              "@jskit-ai/realtime": "0.1.121",
-              "@jskit-ai/kernel": "0.1.124",
-              "@jskit-ai/shell-web": "0.1.125",
-              "@jskit-ai/uploads-image-web": "0.1.100",
-              "@jskit-ai/users-core": "0.1.134"
+              "@jskit-ai/http-runtime": "0.1.123",
+              "@jskit-ai/realtime": "0.1.122",
+              "@jskit-ai/kernel": "0.1.125",
+              "@jskit-ai/shell-web": "0.1.126",
+              "@jskit-ai/uploads-image-web": "0.1.101",
+              "@jskit-ai/users-core": "0.1.135"
             },
             "dev": {}
           },
@@ -6352,11 +6352,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-core",
-      "version": "0.1.101",
+      "version": "0.1.102",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-core",
-        "version": "0.1.101",
+        "version": "0.1.102",
         "kind": "runtime",
         "description": "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
         "dependsOn": [
@@ -6502,10 +6502,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/json-rest-api-core": "0.1.68",
-              "@jskit-ai/resource-core": "0.1.67",
-              "@jskit-ai/resource-crud-core": "0.1.67",
-              "@jskit-ai/users-core": "0.1.134"
+              "@jskit-ai/json-rest-api-core": "0.1.69",
+              "@jskit-ai/resource-core": "0.1.68",
+              "@jskit-ai/resource-crud-core": "0.1.68",
+              "@jskit-ai/users-core": "0.1.135"
             },
             "dev": {}
           },
@@ -6709,11 +6709,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-web",
-      "version": "0.1.102",
+      "version": "0.1.103",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-web",
-        "version": "0.1.102",
+        "version": "0.1.103",
         "kind": "runtime",
         "description": "Workspace web module: workspace selector, tools widget, workspace surfaces, members UI, and settings hosts.",
         "dependsOn": [
@@ -6970,9 +6970,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-web": "0.1.124",
-              "@jskit-ai/workspaces-core": "0.1.101",
-              "@jskit-ai/users-web": "0.1.140"
+              "@jskit-ai/auth-web": "0.1.125",
+              "@jskit-ai/workspaces-core": "0.1.102",
+              "@jskit-ai/users-web": "0.1.141"
             },
             "dev": {}
           },

--- a/tooling/jskit-catalog/package.json
+++ b/tooling/jskit-catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-catalog",
-  "version": "0.1.138",
+  "version": "0.1.139",
   "description": "Published metadata catalog for JSKIT package descriptors.",
   "type": "module",
   "files": [

--- a/tooling/jskit-cli/package.json
+++ b/tooling/jskit-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-cli",
-  "version": "0.2.144",
+  "version": "0.2.145",
   "description": "Bundle and package orchestration CLI for JSKIT apps.",
   "type": "module",
   "files": [
@@ -21,9 +21,9 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/jskit-catalog": "0.1.138",
-    "@jskit-ai/kernel": "0.1.124",
-    "@jskit-ai/shell-web": "0.1.125",
+    "@jskit-ai/jskit-catalog": "0.1.139",
+    "@jskit-ai/kernel": "0.1.125",
+    "@jskit-ai/shell-web": "0.1.126",
     "@vue/compiler-sfc": "^3.5.29",
     "ts-morph": "^28.0.0",
     "yaml": "^2.8.3"


### PR DESCRIPTION
Publishes the current JSKIT module set after the generated workspace admin-link fix. Includes synchronized package versions, dependency pins, lockfile, and package catalog generated by npm run release.\n\nPublished successfully, including @jskit-ai/workspaces-web@0.1.103, @jskit-ai/create-app@0.1.142, and @jskit-ai/jskit-cli@0.2.145.