### PR TITLE
Let package updates reuse runtime secrets

### DIFF
--- a/tooling/jskit-cli/src/server/cliRuntime/sensitiveLockState.js
+++ b/tooling/jskit-cli/src/server/cliRuntime/sensitiveLockState.js
@@ -1,4 +1,5 @@
 import path from "node:path";
+import process from "node:process";
 import {
   ensureArray,
   ensureObject
@@ -154,13 +155,15 @@ async function resolveSensitiveOptionEnvFallbacks({
   packageEntry = {},
   appRoot = "",
   optionInput = {},
-  readFileBufferIfExists
+  readFileBufferIfExists,
+  environment = process.env
 } = {}) {
   if (!appRoot || typeof readFileBufferIfExists !== "function") {
     return {};
   }
 
   const fallbacks = {};
+  const runtimeEnvironment = ensureObject(environment);
   const runtimeOptions = ensureObject(optionInput);
   const optionSchemas = ensureObject(packageEntry?.descriptor?.options);
   const textMutations = ensureArray(ensureObject(packageEntry?.descriptor?.mutations).text);
@@ -204,13 +207,21 @@ async function resolveSensitiveOptionEnvFallbacks({
       continue;
     }
 
+    const optionSchema = ensureObject(optionSchemas[optionName]);
+    const environmentValue = Object.prototype.hasOwnProperty.call(runtimeEnvironment, resolvedKey)
+      ? String(runtimeEnvironment[resolvedKey] ?? "")
+      : null;
+    if (environmentValue !== null && (environmentValue || optionSchema.allowEmpty === true)) {
+      fallbacks[optionName] = environmentValue;
+      continue;
+    }
+
     const existing = await readFileBufferIfExists(path.join(appRoot, relativeFile));
     if (!existing.exists) {
       continue;
     }
 
     const envValue = readEnvValue(existing.buffer.toString("utf8"), resolvedKey);
-    const optionSchema = ensureObject(optionSchemas[optionName]);
     if (envValue !== null && (envValue || optionSchema.allowEmpty === true)) {
       fallbacks[optionName] = envValue;
     }

--- a/tooling/jskit-cli/src/server/core/commandCatalog.js
+++ b/tooling/jskit-cli/src/server/core/commandCatalog.js
@@ -538,7 +538,7 @@ const COMMAND_DESCRIPTORS = Object.freeze({
     defaults: Object.freeze([
       "No npm install runs unless --run-npm-install is passed.",
       "Existing non-secret lock options are reused unless overridden inline.",
-      "Secret options are read from current .env values or explicit inline options; they are not stored in the lock.",
+      "Secret options are read from the process environment, current .env values, or explicit inline options; they are not stored in the lock.",
       "update reuses add package flow with forced reapply."
     ]),
     fullUse: "jskit update package <packageId> [--<option> <value>...] [--dry-run] [--run-npm-install] [--json]",

--- a/tooling/jskit-cli/test/completionCommand.test.js
+++ b/tooling/jskit-cli/test/completionCommand.test.js
@@ -91,6 +91,7 @@ test("completion bash __complete__ lists app subcommands and app-specific option
     [
       "adopt-managed-scripts",
       "migrate-source-mutations",
+      "preview-identity",
       "release",
       "sync-ci",
       "update-packages",

--- a/tooling/jskit-cli/test/secretLockRedaction.test.js
+++ b/tooling/jskit-cli/test/secretLockRedaction.test.js
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 import test from "node:test";
@@ -179,6 +179,45 @@ test("package add and update do not persist secret options or env mutation value
     assert.equal(installedAfterUpdate.managed.text[".env::database-password"].sensitive, true);
     assert.equal(Object.prototype.hasOwnProperty.call(installedAfterUpdate.managed.text[".env::database-password"], "value"), false);
     assert.equal(Object.prototype.hasOwnProperty.call(installedAfterUpdate.managed.text[".env::database-password"], "previousValue"), false);
+  });
+});
+
+test("package update restores secret options from the process environment when .env is absent", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "secret-process-env-app");
+    await createMinimalApp(appRoot, { name: "secret-process-env-app" });
+    const packageId = await createSecretRuntimePackage(appRoot);
+    const secretValue = "process-env-only-password";
+
+    const addResult = runCli({
+      cwd: appRoot,
+      args: [
+        "add",
+        "package",
+        packageId,
+        "--db-name",
+        "demo_db",
+        "--db-password",
+        "initial-password"
+      ]
+    });
+    assert.equal(addResult.status, 0, String(addResult.stderr || ""));
+
+    await rm(path.join(appRoot, ".env"));
+    const updateResult = runCli({
+      cwd: appRoot,
+      args: ["update", "package", packageId, "--json"],
+      env: {
+        DB_PASSWORD: secretValue
+      }
+    });
+    assert.equal(updateResult.status, 0, String(updateResult.stderr || ""));
+    assert.doesNotMatch(String(updateResult.stdout || ""), new RegExp(secretValue));
+
+    const envSource = await readFile(path.join(appRoot, ".env"), "utf8");
+    assert.match(envSource, new RegExp(`^DB_PASSWORD=${secretValue}$`, "m"));
+    const lockSource = await readFile(path.join(appRoot, ".jskit", "lock.json"), "utf8");
+    assert.doesNotMatch(lockSource, new RegExp(secretValue));
   });
 });
 


### PR DESCRIPTION
Database-backed apps cannot safely persist sensitive package options in .jskit/lock.json. Allow package reapplication to resolve those values from the current process environment before falling back to .env, so managed app updates work without weakening secret redaction.\n\nAlso aligns the stale shell-completion expectation with the existing preview-identity app command.\n\nVerification: focused secret/completion tests pass; full CLI suite reached 319/320 with only that stale completion assertion, which passes after this change.