### PR TITLE
Preserve customized app scaffolds on update

### DIFF
--- a/packages/auth-web/package.descriptor.mjs
+++ b/packages/auth-web/package.descriptor.mjs
@@ -283,6 +283,7 @@ export default Object.freeze({
       {
         "from": "templates/src/views/auth/LoginView.vue",
         "to": "src/views/auth/LoginView.vue",
+        "ownership": "app",
         "reason": "Install minimal login container that renders the module-provided DefaultLoginView by default.",
         "category": "auth-web",
         "id": "auth-view-login"
@@ -290,6 +291,7 @@ export default Object.freeze({
       {
         "from": "templates/src/views/auth/SignOutView.vue",
         "to": "src/views/auth/SignOutView.vue",
+        "ownership": "app",
         "reason": "Install minimal sign-out container that renders the module-provided SignOutView by default (edit the scaffolded file to customize).",
         "category": "auth-web",
         "id": "auth-view-signout"
@@ -297,6 +299,7 @@ export default Object.freeze({
       {
         "from": "templates/src/views/auth/ResetPasswordView.vue",
         "to": "src/views/auth/ResetPasswordView.vue",
+        "ownership": "app",
         "reason": "Install minimal password reset container that renders the module-provided DefaultResetPasswordView by default.",
         "category": "auth-web",
         "id": "auth-view-reset-password"
@@ -304,6 +307,7 @@ export default Object.freeze({
       {
         "from": "templates/src/pages/auth/login.vue",
         "to": "src/pages/auth/login.vue",
+        "ownership": "app",
         "reason": "Provide an auth-surface /auth/login wrapper that renders the package login view.",
         "category": "auth-web",
         "id": "auth-page-login"
@@ -311,6 +315,7 @@ export default Object.freeze({
       {
         "from": "templates/src/pages/auth/signout.vue",
         "to": "src/pages/auth/signout.vue",
+        "ownership": "app",
         "reason": "Provide an auth-surface /auth/signout wrapper that renders the package sign-out view.",
         "category": "auth-web",
         "id": "auth-page-signout"
@@ -318,6 +323,7 @@ export default Object.freeze({
       {
         "from": "templates/src/pages/auth/reset-password.vue",
         "to": "src/pages/auth/reset-password.vue",
+        "ownership": "app",
         "reason": "Provide an auth-surface /auth/reset-password wrapper that renders the package password reset view.",
         "category": "auth-web",
         "id": "auth-page-reset-password"

--- a/packages/auth-web/test/packageDescriptorOwnership.test.js
+++ b/packages/auth-web/test/packageDescriptorOwnership.test.js
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import descriptor from "../package.descriptor.mjs";
+
+test("auth-web leaves its editable view and route scaffolds app-owned", () => {
+  const expectedIds = [
+    "auth-view-login",
+    "auth-view-signout",
+    "auth-view-reset-password",
+    "auth-page-login",
+    "auth-page-signout",
+    "auth-page-reset-password"
+  ];
+
+  for (const id of expectedIds) {
+    const mutation = descriptor.mutations.files.find((entry) => entry.id === id);
+    assert.ok(mutation, `Missing auth-web scaffold mutation ${id}.`);
+    assert.equal(mutation.ownership, "app", `${id} must remain app-owned across package updates.`);
+  }
+});

--- a/packages/users-web/package.descriptor.mjs
+++ b/packages/users-web/package.descriptor.mjs
@@ -307,6 +307,7 @@ export default Object.freeze({
       {
         from: "templates/src/pages/account/index.vue",
         to: "src/pages/account/index.vue",
+        ownership: "app",
         reason: "Install app-owned account surface root page scaffold.",
         category: "users-web",
         id: "users-web-page-account-root"
@@ -314,6 +315,7 @@ export default Object.freeze({
       {
         from: "templates/src/components/account/settings/AccountSettingsProfileSection.vue",
         to: "src/components/account/settings/AccountSettingsProfileSection.vue",
+        ownership: "app",
         reason: "Install app-owned account settings profile section scaffold.",
         category: "users-web",
         id: "users-web-component-account-settings-profile"
@@ -321,6 +323,7 @@ export default Object.freeze({
       {
         from: "templates/src/components/account/settings/AccountSettingsPreferencesSection.vue",
         to: "src/components/account/settings/AccountSettingsPreferencesSection.vue",
+        ownership: "app",
         reason: "Install app-owned account settings preferences section scaffold.",
         category: "users-web",
         id: "users-web-component-account-settings-preferences"
@@ -328,6 +331,7 @@ export default Object.freeze({
       {
         from: "templates/src/components/account/settings/AccountSettingsNotificationsSection.vue",
         to: "src/components/account/settings/AccountSettingsNotificationsSection.vue",
+        ownership: "app",
         reason: "Install app-owned account settings notifications section scaffold.",
         category: "users-web",
         id: "users-web-component-account-settings-notifications"

--- a/packages/users-web/test/packageDescriptorOwnership.test.js
+++ b/packages/users-web/test/packageDescriptorOwnership.test.js
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import descriptor from "../package.descriptor.mjs";
+
+test("users-web leaves account surface scaffolds app-owned", () => {
+  const expectedIds = [
+    "users-web-page-account-root",
+    "users-web-component-account-settings-profile",
+    "users-web-component-account-settings-preferences",
+    "users-web-component-account-settings-notifications"
+  ];
+
+  for (const id of expectedIds) {
+    const mutation = descriptor.mutations.files.find((entry) => entry.id === id);
+    assert.ok(mutation, `Missing users-web scaffold mutation ${id}.`);
+    assert.equal(mutation.ownership, "app", `${id} must remain app-owned across package updates.`);
+  }
+});

--- a/packages/workspaces-web/package.descriptor.mjs
+++ b/packages/workspaces-web/package.descriptor.mjs
@@ -251,6 +251,7 @@ export default Object.freeze({
       {
         from: "templates/packages/main/src/client/components/AccountPendingInvitesCue.vue",
         to: "packages/main/src/client/components/AccountPendingInvitesCue.vue",
+        ownership: "app",
         reason: "Install app-owned account pending invites cue component scaffold.",
         category: "workspaces-web",
         id: "users-web-main-component-account-pending-invites-cue"
@@ -258,6 +259,7 @@ export default Object.freeze({
       {
         from: "templates/packages/main/src/client/components/AccountSettingsInvitesSection.vue",
         to: "packages/main/src/client/components/AccountSettingsInvitesSection.vue",
+        ownership: "app",
         reason: "Install app-owned account invites section scaffold for multihoming account settings.",
         category: "workspaces-web",
         id: "users-web-main-component-account-settings-invites-section"
@@ -265,6 +267,7 @@ export default Object.freeze({
       {
         from: "templates/src/pages/invite/[token].vue",
         to: "src/pages/invite/[token].vue",
+        ownership: "app",
         reason: "Install public workspace invite acceptance route scaffold.",
         category: "workspaces-web",
         id: "workspaces-web-page-public-invite"
@@ -272,6 +275,7 @@ export default Object.freeze({
       {
         from: "templates/src/components/WorkspaceNotFoundCard.vue",
         to: "src/components/WorkspaceNotFoundCard.vue",
+        ownership: "app",
         reason: "Install app-owned workspace not-found card component used by workspace-dependent surfaces.",
         category: "workspaces-web",
         id: "users-web-component-workspace-not-found-card",
@@ -283,6 +287,7 @@ export default Object.freeze({
       {
         from: "templates/src/composables/useWorkspaceNotFoundState.js",
         to: "src/composables/useWorkspaceNotFoundState.js",
+        ownership: "app",
         reason: "Install app-owned workspace bootstrap status composable for workspace-dependent surfaces.",
         category: "workspaces-web",
         id: "users-web-composable-workspace-not-found-state",
@@ -295,6 +300,7 @@ export default Object.freeze({
         from: "templates/src/surfaces/app/root.vue",
         toSurface: "app",
         toSurfaceRoot: true,
+        ownership: "app",
         reason: "Install workspace app surface wrapper shell for workspaces-web.",
         category: "workspaces-web",
         id: "users-web-page-app-wrapper",
@@ -307,6 +313,7 @@ export default Object.freeze({
         from: "templates/src/surfaces/app/index.vue",
         toSurface: "app",
         toSurfacePath: "index.vue",
+        ownership: "app",
         reason: "Install workspace app surface starter page scaffold for workspaces-web.",
         category: "workspaces-web",
         id: "users-web-page-app-index",
@@ -319,6 +326,7 @@ export default Object.freeze({
         from: "templates/src/surfaces/admin/root.vue",
         toSurface: "admin",
         toSurfaceRoot: true,
+        ownership: "app",
         reason: "Install workspace admin surface wrapper shell for workspaces-web.",
         category: "workspaces-web",
         id: "users-web-page-admin-wrapper",
@@ -331,6 +339,7 @@ export default Object.freeze({
         from: "templates/src/surfaces/admin/index.vue",
         toSurface: "admin",
         toSurfacePath: "index.vue",
+        ownership: "app",
         reason: "Install workspace admin surface starter page scaffold for workspaces-web.",
         category: "workspaces-web",
         id: "users-web-page-admin-index",
@@ -343,6 +352,7 @@ export default Object.freeze({
         from: "templates/src/pages/admin/members/index.vue",
         toSurface: "admin",
         toSurfacePath: "members/index.vue",
+        ownership: "app",
         reason: "Install admin members starter page scaffold for workspaces-web members UI.",
         category: "workspaces-web",
         id: "users-web-page-admin-members",
@@ -355,6 +365,7 @@ export default Object.freeze({
         from: "templates/src/pages/admin/workspace/settings.vue",
         toSurface: "admin",
         toSurfacePath: "workspace/settings.vue",
+        ownership: "app",
         reason: "Install workspace settings shell route scaffold for workspaces-web workspace admin UI.",
         category: "workspaces-web",
         id: "users-web-page-admin-workspace-settings-shell",
@@ -367,6 +378,7 @@ export default Object.freeze({
         from: "templates/src/pages/admin/workspace/settings/index.vue",
         toSurface: "admin",
         toSurfacePath: "workspace/settings/index.vue",
+        ownership: "app",
         reason: "Install workspace settings index stub scaffold for app-owned landing or redirect behavior.",
         category: "workspaces-web",
         id: "users-web-page-admin-workspace-settings",

--- a/packages/workspaces-web/test/packageDescriptorOwnership.test.js
+++ b/packages/workspaces-web/test/packageDescriptorOwnership.test.js
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import descriptor from "../package.descriptor.mjs";
+
+test("workspaces-web leaves editable workspace scaffolds app-owned", () => {
+  const fileMutations = descriptor.mutations.files;
+
+  assert.ok(fileMutations.length > 0);
+  for (const mutation of fileMutations) {
+    assert.equal(
+      mutation.ownership,
+      "app",
+      `${mutation.id} must remain app-owned across package updates.`
+    );
+  }
+});


### PR DESCRIPTION
Marks Auth, Users, and Workspaces editable scaffolds as app-owned so package updates refresh untouched defaults while preserving app customizations.\n\nValidation: descriptor ownership tests; existing app-owned update integration suite; focused ESLint; diff check.