### PR TITLE
Make generated Playwright tests file-addressable

### DIFF
--- a/packages/shell-web/src/test/adaptiveShellSmoke.js
+++ b/packages/shell-web/src/test/adaptiveShellSmoke.js
@@ -68,6 +68,48 @@ async function isElementVisibleInViewport(page, testId) {
   });
 }
 
+async function runAdaptiveShellSmokeCase({
+  page,
+  expect,
+  smokePath = DEFAULT_SMOKE_PATH,
+  viewport
+} = {}) {
+  if (!page || !expect || !viewport) {
+    throw new Error("runAdaptiveShellSmokeCase requires page, expect, and viewport.");
+  }
+
+  await page.setViewportSize({ width: viewport.width, height: viewport.height });
+  await page.goto(smokePath);
+  await expect(page.locator("body")).toBeVisible();
+  await expectGeneratedScreenContract(page, expect);
+  await expectNoHorizontalOverflow(page, expect);
+
+  if (viewport.name === "compact") {
+    let bootstrapRequests = 0;
+    await page.route("**/api/bootstrap**", async (route) => {
+      bootstrapRequests += 1;
+      await route.continue();
+    });
+    const bootstrapRequestsBeforePull = bootstrapRequests;
+
+    await expect(page.getByTestId("jskit-shell-bottom-nav")).toBeVisible();
+    expect(await isElementVisibleInViewport(page, "jskit-shell-drawer")).toBe(false);
+
+    const navButtonHeights = await page.getByTestId("jskit-shell-bottom-nav").locator(".v-btn").evaluateAll((buttons) =>
+      buttons.map((button) => button.getBoundingClientRect().height)
+    );
+    expect(navButtonHeights.length).toBeGreaterThan(0);
+    for (const height of navButtonHeights) {
+      expect(height).toBeGreaterThanOrEqual(48);
+    }
+
+    await pullToRefresh(page, expect);
+    await expect.poll(() => bootstrapRequests).toBeGreaterThan(bootstrapRequestsBeforePull);
+  } else {
+    await expect(page.getByTestId("jskit-shell-drawer")).toBeVisible();
+  }
+}
+
 function runAdaptiveShellSmoke({
   test,
   expect,
@@ -81,39 +123,10 @@ function runAdaptiveShellSmoke({
   test.describe("generated adaptive shell smoke", () => {
     for (const viewport of viewports) {
       test(`${viewport.name} layout has reachable navigation and no horizontal overflow`, async ({ page }) => {
-        await page.setViewportSize({ width: viewport.width, height: viewport.height });
-        await page.goto(smokePath);
-        await expect(page.locator("body")).toBeVisible();
-        await expectGeneratedScreenContract(page, expect);
-        await expectNoHorizontalOverflow(page, expect);
-
-        if (viewport.name === "compact") {
-          let bootstrapRequests = 0;
-          await page.route("**/api/bootstrap**", async (route) => {
-            bootstrapRequests += 1;
-            await route.continue();
-          });
-          const bootstrapRequestsBeforePull = bootstrapRequests;
-
-          await expect(page.getByTestId("jskit-shell-bottom-nav")).toBeVisible();
-          expect(await isElementVisibleInViewport(page, "jskit-shell-drawer")).toBe(false);
-
-          const navButtonHeights = await page.getByTestId("jskit-shell-bottom-nav").locator(".v-btn").evaluateAll((buttons) =>
-            buttons.map((button) => button.getBoundingClientRect().height)
-          );
-          expect(navButtonHeights.length).toBeGreaterThan(0);
-          for (const height of navButtonHeights) {
-            expect(height).toBeGreaterThanOrEqual(48);
-          }
-
-          await pullToRefresh(page, expect);
-          await expect.poll(() => bootstrapRequests).toBeGreaterThan(bootstrapRequestsBeforePull);
-        } else {
-          await expect(page.getByTestId("jskit-shell-drawer")).toBeVisible();
-        }
+        await runAdaptiveShellSmokeCase({ page, expect, smokePath, viewport });
       });
     }
   });
 }
 
-export { DEFAULT_VIEWPORTS, runAdaptiveShellSmoke };
+export { DEFAULT_VIEWPORTS, runAdaptiveShellSmoke, runAdaptiveShellSmokeCase };

--- a/packages/shell-web/templates/tests/e2e/adaptive-shell.spec.ts
+++ b/packages/shell-web/templates/tests/e2e/adaptive-shell.spec.ts
@@ -1,4 +1,10 @@
 import { expect, test } from "@playwright/test";
-import { runAdaptiveShellSmoke } from "@jskit-ai/shell-web/test/adaptiveShellSmoke";
+import { DEFAULT_VIEWPORTS, runAdaptiveShellSmokeCase } from "@jskit-ai/shell-web/test/adaptiveShellSmoke";
 
-runAdaptiveShellSmoke({ test, expect });
+test.describe("generated adaptive shell smoke", () => {
+  for (const viewport of DEFAULT_VIEWPORTS) {
+    test(`${viewport.name} layout has reachable navigation and no horizontal overflow`, async ({ page }) => {
+      await runAdaptiveShellSmokeCase({ page, expect, viewport });
+    });
+  }
+});

--- a/packages/shell-web/test/settingsPlacementContract.test.js
+++ b/packages/shell-web/test/settingsPlacementContract.test.js
@@ -140,7 +140,10 @@ test("shell-web installs generated adaptive shell Playwright smoke coverage", as
     profile: "responsive-smoke",
     sourceName: "adaptiveShellSmoke.js"
   });
-  assert.match(source, /runAdaptiveShellSmoke/);
+  assert.match(source, /DEFAULT_VIEWPORTS, runAdaptiveShellSmokeCase/);
+  assert.match(source, /test\(`/);
+  assert.match(source, /runAdaptiveShellSmokeCase\(\{ page, expect, viewport \}\)/);
+  assert.doesNotMatch(source, /runAdaptiveShellSmoke\(\{/);
   assert.match(source, /@jskit-ai\/shell-web\/test\/adaptiveShellSmoke/);
   assert.match(helperSource, /generated adaptive shell smoke/);
   assert.match(helperSource, /390/);

--- a/tooling/create-app/templates/base-shell/tests/e2e/adaptive-shell.spec.ts
+++ b/tooling/create-app/templates/base-shell/tests/e2e/adaptive-shell.spec.ts
@@ -1,4 +1,10 @@
 import { expect, test } from "@playwright/test";
-import { runAdaptiveShellSmoke } from "@jskit-ai/shell-web/test/adaptiveShellSmoke";
+import { DEFAULT_VIEWPORTS, runAdaptiveShellSmokeCase } from "@jskit-ai/shell-web/test/adaptiveShellSmoke";
 
-runAdaptiveShellSmoke({ test, expect });
+test.describe("generated adaptive shell smoke", () => {
+  for (const viewport of DEFAULT_VIEWPORTS) {
+    test(`${viewport.name} layout has reachable navigation and no horizontal overflow`, async ({ page }) => {
+      await runAdaptiveShellSmokeCase({ page, expect, viewport });
+    });
+  }
+});

--- a/tooling/create-app/templates/base-shell/tests/e2e/base-shell.spec.ts
+++ b/tooling/create-app/templates/base-shell/tests/e2e/base-shell.spec.ts
@@ -1,4 +1,10 @@
 import { expect, test } from "@playwright/test";
-import { runGeneratedAppSmoke } from "@jskit-ai/jskit-cli/test/playwright";
+import { DEFAULT_VIEWPORTS, runGeneratedAppSmokeCase } from "@jskit-ai/jskit-cli/test/playwright";
 
-runGeneratedAppSmoke({ test, expect, expectedText: "Ready" });
+test.describe("generated app responsive smoke", () => {
+  for (const viewport of DEFAULT_VIEWPORTS) {
+    test(`${viewport.name} home route renders without horizontal overflow`, async ({ page }) => {
+      await runGeneratedAppSmokeCase({ page, expect, expectedText: "Ready", viewport });
+    });
+  }
+});

--- a/tooling/create-app/templates/minimal-shell/tests/e2e/base-shell.spec.ts
+++ b/tooling/create-app/templates/minimal-shell/tests/e2e/base-shell.spec.ts
@@ -1,4 +1,10 @@
 import { expect, test } from "@playwright/test";
-import { runGeneratedAppSmoke } from "@jskit-ai/jskit-cli/test/playwright";
+import { DEFAULT_VIEWPORTS, runGeneratedAppSmokeCase } from "@jskit-ai/jskit-cli/test/playwright";
 
-runGeneratedAppSmoke({ test, expect, expectedText: "Home base" });
+test.describe("generated app responsive smoke", () => {
+  for (const viewport of DEFAULT_VIEWPORTS) {
+    test(`${viewport.name} home route renders without horizontal overflow`, async ({ page }) => {
+      await runGeneratedAppSmokeCase({ page, expect, expectedText: "Home base", viewport });
+    });
+  }
+});

--- a/tooling/create-app/test/createApp.test.js
+++ b/tooling/create-app/test/createApp.test.js
@@ -214,12 +214,18 @@ test("create-app scaffolds the base shell with placeholder replacements", async 
     assert.match(clientSmoke, /sample-app client smoke/);
     const e2eSmoke = await readFile(path.join(appRoot, "tests/e2e/base-shell.spec.ts"), "utf8");
     assert.match(e2eSmoke, /@jskit-ai\/jskit-cli\/test\/playwright/u);
-    assert.match(e2eSmoke, /runGeneratedAppSmoke\(\{ test, expect, expectedText: "Ready" \}\)/u);
+    assert.match(e2eSmoke, /DEFAULT_VIEWPORTS, runGeneratedAppSmokeCase/u);
+    assert.match(e2eSmoke, /test\(`\$\{viewport\.name\} home route renders without horizontal overflow`/u);
+    assert.match(e2eSmoke, /runGeneratedAppSmokeCase\(\{ page, expect, expectedText: "Ready", viewport \}\)/u);
+    assert.doesNotMatch(e2eSmoke, /runGeneratedAppSmoke\(\{/u);
     assert.doesNotMatch(e2eSmoke, /PLAYWRIGHT_BASE_URL|scrollWidth|390|768|1280/u);
 
     const adaptiveShellSmoke = await readFile(path.join(appRoot, "tests/e2e/adaptive-shell.spec.ts"), "utf8");
     assert.match(adaptiveShellSmoke, /@jskit-ai\/shell-web\/test\/adaptiveShellSmoke/u);
-    assert.match(adaptiveShellSmoke, /runAdaptiveShellSmoke\(\{ test, expect \}\)/u);
+    assert.match(adaptiveShellSmoke, /DEFAULT_VIEWPORTS, runAdaptiveShellSmokeCase/u);
+    assert.match(adaptiveShellSmoke, /test\(`\$\{viewport\.name\} layout has reachable navigation and no horizontal overflow`/u);
+    assert.match(adaptiveShellSmoke, /runAdaptiveShellSmokeCase\(\{ page, expect, viewport \}\)/u);
+    assert.doesNotMatch(adaptiveShellSmoke, /runAdaptiveShellSmoke\(\{/u);
 
     const playwrightConfig = await readFile(path.join(appRoot, "playwright.config.mjs"), "utf8");
     assert.match(playwrightConfig, /@jskit-ai\/jskit-cli\/test\/playwright/u);
@@ -771,7 +777,8 @@ test("create-app minimal mode keeps the bare scaffold and can still install shel
     assert.match(playwrightConfigBefore, /defineConfig\(createJskitPlaywrightConfig\(\)\)/u);
     assert.doesNotMatch(playwrightConfigBefore, /PLAYWRIGHT_BASE_URL|webServer|4173/u);
     const e2eSmokeBefore = await readFile(path.join(appRoot, "tests/e2e/base-shell.spec.ts"), "utf8");
-    assert.match(e2eSmokeBefore, /runGeneratedAppSmoke/u);
+    assert.match(e2eSmokeBefore, /runGeneratedAppSmokeCase/u);
+    assert.match(e2eSmokeBefore, /test\(`/u);
     assert.match(e2eSmokeBefore, /expectedText: "Home base"/u);
     assert.doesNotMatch(e2eSmokeBefore, /PLAYWRIGHT_BASE_URL|scrollWidth|390|768|1280/u);
     const homeViewBefore = await readFile(path.join(appRoot, "src/pages/home/index.vue"), "utf8");

--- a/tooling/jskit-cli/src/test/playwright.js
+++ b/tooling/jskit-cli/src/test/playwright.js
@@ -65,6 +65,26 @@ async function expectVisibleTapTargets(page, expect) {
   }
 }
 
+async function runGeneratedAppSmokeCase({
+  page,
+  expect,
+  expectedText,
+  viewport,
+  smokePath = String(process.env.JSKIT_PLAYWRIGHT_SMOKE_PATH || DEFAULT_SMOKE_PATH)
+} = {}) {
+  if (!page || !expect || !String(expectedText || "").trim() || !viewport) {
+    throw new Error("runGeneratedAppSmokeCase requires page, expect, expectedText, and viewport.");
+  }
+
+  await page.setViewportSize({ width: viewport.width, height: viewport.height });
+  await page.goto(smokePath);
+  await expect(page.locator("body")).toBeVisible();
+  await expect(page.getByText(expectedText)).toBeVisible();
+  await expect(page.locator(".generated-ui-screen").first()).toBeVisible();
+  await expectVisibleTapTargets(page, expect);
+  await expectNoHorizontalOverflow(page, expect);
+}
+
 function runGeneratedAppSmoke({ test, expect, expectedText } = {}) {
   if (!test || !expect || !String(expectedText || "").trim()) {
     throw new Error("runGeneratedAppSmoke requires Playwright test, expect, and expectedText.");
@@ -75,13 +95,7 @@ function runGeneratedAppSmoke({ test, expect, expectedText } = {}) {
   test.describe("generated app responsive smoke", () => {
     for (const viewport of DEFAULT_VIEWPORTS) {
       test(`${viewport.name} home route renders without horizontal overflow`, async ({ page }) => {
-        await page.setViewportSize({ width: viewport.width, height: viewport.height });
-        await page.goto(smokePath);
-        await expect(page.locator("body")).toBeVisible();
-        await expect(page.getByText(expectedText)).toBeVisible();
-        await expect(page.locator(".generated-ui-screen").first()).toBeVisible();
-        await expectVisibleTapTargets(page, expect);
-        await expectNoHorizontalOverflow(page, expect);
+        await runGeneratedAppSmokeCase({ page, expect, expectedText, viewport, smokePath });
       });
     }
   });
@@ -91,5 +105,6 @@ export {
   createJskitPlaywrightConfig,
   DEFAULT_LOCAL_BASE_URL,
   DEFAULT_VIEWPORTS,
-  runGeneratedAppSmoke
+  runGeneratedAppSmoke,
+  runGeneratedAppSmokeCase
 };


### PR DESCRIPTION
Generated smoke specs now declare their Playwright tests in the app-owned spec file while reusing package-owned case runners. This preserves shared assertions and makes commands such as `vibe64-playwright test tests/e2e/base-shell.spec.ts` discover the expected tests.\n\nValidation: root lint, create-app tests, and the shell-web smoke scaffold contract test pass.