### PR TITLE
Honor generated shell tap targets

### DIFF
--- a/packages/auth-web/src/client/views/AuthProfileWidget.vue
+++ b/packages/auth-web/src/client/views/AuthProfileWidget.vue
@@ -63,7 +63,7 @@ const placementContext = computed(() => {
 <template>
   <v-menu location="bottom end" offset="10">
     <template #activator="{ props }">
-      <v-btn v-bind="props" variant="text" class="text-none pl-1 pr-2">
+      <v-btn v-bind="props" variant="text" class="auth-profile-widget__activator text-none pl-1 pr-2">
         <v-avatar size="32" color="primary" variant="tonal">
           <v-img v-if="avatarUrl" :src="avatarUrl" cover />
           <span v-else class="text-caption font-weight-medium">{{ initials }}</span>
@@ -80,3 +80,9 @@ const placementContext = computed(() => {
     </v-list>
   </v-menu>
 </template>
+
+<style scoped>
+.auth-profile-widget__activator {
+  min-height: 48px;
+}
+</style>

--- a/packages/auth-web/test/clientSurface.test.js
+++ b/packages/auth-web/test/clientSurface.test.js
@@ -78,6 +78,14 @@ test("auth-web client provider registers a mobile auth callback completion token
   assert.match(providerSource, /completeOAuthCallbackFromUrl/);
 });
 
+test("auth profile activator preserves the generated tap-target contract", () => {
+  const widgetPath = fileURLToPath(new URL("../src/client/views/AuthProfileWidget.vue", import.meta.url));
+  const widgetSource = readFileSync(widgetPath, "utf8");
+
+  assert.match(widgetSource, /class="auth-profile-widget__activator text-none pl-1 pr-2"/);
+  assert.match(widgetSource, /\.auth-profile-widget__activator\s*\{[\s\S]*min-height:\s*48px;/);
+});
+
 test("default login view owns the viewport and becomes a full-screen mobile screen", () => {
   const viewPath = fileURLToPath(new URL("../src/client/views/DefaultLoginView.vue", import.meta.url));
   const viewSource = readFileSync(viewPath, "utf8");

--- a/packages/shell-web/src/client/components/ShellLayout.vue
+++ b/packages/shell-web/src/client/components/ShellLayout.vue
@@ -490,6 +490,11 @@ function touchListIncludesActiveTouch(touchList) {
   min-width: 0;
 }
 
+.shell-layout__nav-toggle {
+  min-height: 48px;
+  min-width: 48px;
+}
+
 .shell-layout__top-right {
   max-width: min(45vw, 18rem);
   overflow: hidden;

--- a/packages/shell-web/test/settingsPlacementContract.test.js
+++ b/packages/shell-web/test/settingsPlacementContract.test.js
@@ -77,6 +77,7 @@ test("shell-web shell layout registers navigation at the app layout level", asyn
   assert.match(source, /<ShellRouteTransition>[\s\S]*<slot \/>[\s\S]*<\/ShellRouteTransition>/);
   assert.match(source, /data-testid="jskit-shell-app-bar"/);
   assert.match(source, /:density="isCompactLayout \? 'compact' : 'comfortable'"/);
+  assert.match(source, /\.shell-layout__nav-toggle\s*\{[\s\S]*min-height:\s*48px;[\s\S]*min-width:\s*48px;/);
   assert.match(source, /shell-layout__surface-label/);
   assert.doesNotMatch(source, /shell-layout__surface-chip/);
   assert.doesNotMatch(source, /<v-chip[^>]*resolvedSurfaceLabel/);


### PR DESCRIPTION
Ensures the compact shell navigation toggle and account profile activator meet the 48px tap-target contract enforced by generated Playwright smoke tests.\n\nFocused shell-web and auth-web contract tests and ESLint pass.