### PR TITLE
Release shell tap target fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7737,28 +7737,28 @@
     },
     "packages/agent-docs": {
       "name": "@jskit-ai/agent-docs",
-      "version": "0.1.94",
+      "version": "0.1.95",
       "engines": {
         "node": "^22.12.0 || ^24.0.0 || ^26.0.0"
       }
     },
     "packages/assistant": {
       "name": "@jskit-ai/assistant",
-      "version": "0.1.137",
+      "version": "0.1.138",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.128"
+        "@jskit-ai/kernel": "0.1.129"
       }
     },
     "packages/assistant-core": {
       "name": "@jskit-ai/assistant-core",
-      "version": "0.1.105",
+      "version": "0.1.106",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.127",
-        "@jskit-ai/http-runtime": "0.1.126",
-        "@jskit-ai/kernel": "0.1.128",
-        "@jskit-ai/resource-core": "0.1.71",
-        "@jskit-ai/resource-crud-core": "0.1.71",
-        "@jskit-ai/users-core": "0.1.138",
+        "@jskit-ai/database-runtime": "0.1.128",
+        "@jskit-ai/http-runtime": "0.1.127",
+        "@jskit-ai/kernel": "0.1.129",
+        "@jskit-ai/resource-core": "0.1.72",
+        "@jskit-ai/resource-crud-core": "0.1.72",
+        "@jskit-ai/users-core": "0.1.139",
         "dompurify": "^3.4.12",
         "json-rest-schema": "1.x.x",
         "marked": "^17.0.4",
@@ -7771,15 +7771,15 @@
     },
     "packages/assistant-runtime": {
       "name": "@jskit-ai/assistant-runtime",
-      "version": "0.1.100",
+      "version": "0.1.101",
       "dependencies": {
-        "@jskit-ai/assistant-core": "0.1.105",
-        "@jskit-ai/database-runtime": "0.1.127",
-        "@jskit-ai/http-runtime": "0.1.126",
-        "@jskit-ai/kernel": "0.1.128",
-        "@jskit-ai/shell-web": "0.1.129",
-        "@jskit-ai/users-core": "0.1.138",
-        "@jskit-ai/users-web": "0.1.144",
+        "@jskit-ai/assistant-core": "0.1.106",
+        "@jskit-ai/database-runtime": "0.1.128",
+        "@jskit-ai/http-runtime": "0.1.127",
+        "@jskit-ai/kernel": "0.1.129",
+        "@jskit-ai/shell-web": "0.1.130",
+        "@jskit-ai/users-core": "0.1.139",
+        "@jskit-ai/users-web": "0.1.145",
         "json-rest-schema": "1.x.x"
       },
       "peerDependencies": {
@@ -7790,39 +7790,39 @@
     },
     "packages/auth-core": {
       "name": "@jskit-ai/auth-core",
-      "version": "0.1.125",
+      "version": "0.1.126",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0",
-        "@jskit-ai/kernel": "0.1.128",
+        "@jskit-ai/kernel": "0.1.129",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/auth-provider-local-core": {
       "name": "@jskit-ai/auth-provider-local-core",
-      "version": "0.1.29",
+      "version": "0.1.30",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.125",
-        "@jskit-ai/kernel": "0.1.128",
+        "@jskit-ai/auth-core": "0.1.126",
+        "@jskit-ai/kernel": "0.1.129",
         "nodemailer": "^9.0.3"
       }
     },
     "packages/auth-provider-local-db-core": {
       "name": "@jskit-ai/auth-provider-local-db-core",
-      "version": "0.1.20",
+      "version": "0.1.21",
       "dependencies": {
-        "@jskit-ai/auth-provider-local-core": "0.1.29",
-        "@jskit-ai/database-runtime": "0.1.127",
-        "@jskit-ai/kernel": "0.1.128"
+        "@jskit-ai/auth-provider-local-core": "0.1.30",
+        "@jskit-ai/database-runtime": "0.1.128",
+        "@jskit-ai/kernel": "0.1.129"
       }
     },
     "packages/auth-provider-supabase-core": {
       "name": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.126",
+      "version": "0.1.127",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.125",
-        "@jskit-ai/kernel": "0.1.128",
+        "@jskit-ai/auth-core": "0.1.126",
+        "@jskit-ai/kernel": "0.1.129",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0",
         "json-rest-schema": "1.x.x",
@@ -7831,12 +7831,12 @@
     },
     "packages/auth-web": {
       "name": "@jskit-ai/auth-web",
-      "version": "0.1.128",
+      "version": "0.1.129",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.125",
-        "@jskit-ai/http-runtime": "0.1.126",
-        "@jskit-ai/kernel": "0.1.128",
-        "@jskit-ai/shell-web": "0.1.129",
+        "@jskit-ai/auth-core": "0.1.126",
+        "@jskit-ai/http-runtime": "0.1.127",
+        "@jskit-ai/kernel": "0.1.129",
+        "@jskit-ai/shell-web": "0.1.130",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -7849,38 +7849,38 @@
     },
     "packages/console-core": {
       "name": "@jskit-ai/console-core",
-      "version": "0.1.92",
+      "version": "0.1.93",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.125",
-        "@jskit-ai/database-runtime": "0.1.127",
-        "@jskit-ai/http-runtime": "0.1.126",
-        "@jskit-ai/kernel": "0.1.128",
-        "@jskit-ai/resource-crud-core": "0.1.71",
-        "@jskit-ai/users-core": "0.1.138",
+        "@jskit-ai/auth-core": "0.1.126",
+        "@jskit-ai/database-runtime": "0.1.128",
+        "@jskit-ai/http-runtime": "0.1.127",
+        "@jskit-ai/kernel": "0.1.129",
+        "@jskit-ai/resource-crud-core": "0.1.72",
+        "@jskit-ai/users-core": "0.1.139",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/console-web": {
       "name": "@jskit-ai/console-web",
-      "version": "0.1.97",
+      "version": "0.1.98",
       "dependencies": {
-        "@jskit-ai/auth-web": "0.1.128",
-        "@jskit-ai/console-core": "0.1.92",
-        "@jskit-ai/shell-web": "0.1.129"
+        "@jskit-ai/auth-web": "0.1.129",
+        "@jskit-ai/console-core": "0.1.93",
+        "@jskit-ai/shell-web": "0.1.130"
       }
     },
     "packages/crud-core": {
       "name": "@jskit-ai/crud-core",
-      "version": "0.1.136",
+      "version": "0.1.137",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.127",
-        "@jskit-ai/http-runtime": "0.1.126",
-        "@jskit-ai/kernel": "0.1.128",
-        "@jskit-ai/realtime": "0.1.125",
-        "@jskit-ai/resource-crud-core": "0.1.71",
-        "@jskit-ai/shell-web": "0.1.129",
-        "@jskit-ai/users-core": "0.1.138",
-        "@jskit-ai/users-web": "0.1.144",
+        "@jskit-ai/database-runtime": "0.1.128",
+        "@jskit-ai/http-runtime": "0.1.127",
+        "@jskit-ai/kernel": "0.1.129",
+        "@jskit-ai/realtime": "0.1.126",
+        "@jskit-ai/resource-crud-core": "0.1.72",
+        "@jskit-ai/shell-web": "0.1.130",
+        "@jskit-ai/users-core": "0.1.139",
+        "@jskit-ai/users-web": "0.1.145",
         "json-rest-schema": "1.x.x"
       },
       "peerDependencies": {
@@ -7891,98 +7891,98 @@
     },
     "packages/crud-server-generator": {
       "name": "@jskit-ai/crud-server-generator",
-      "version": "0.1.137",
+      "version": "0.1.138",
       "dependencies": {
         "@babel/parser": "^7.29.2",
-        "@jskit-ai/crud-core": "0.1.136",
-        "@jskit-ai/database-runtime": "0.1.127",
-        "@jskit-ai/http-runtime": "0.1.126",
-        "@jskit-ai/json-rest-api-core": "0.1.72",
-        "@jskit-ai/kernel": "0.1.128",
-        "@jskit-ai/resource-crud-core": "0.1.71",
+        "@jskit-ai/crud-core": "0.1.137",
+        "@jskit-ai/database-runtime": "0.1.128",
+        "@jskit-ai/http-runtime": "0.1.127",
+        "@jskit-ai/json-rest-api-core": "0.1.73",
+        "@jskit-ai/kernel": "0.1.129",
+        "@jskit-ai/resource-crud-core": "0.1.72",
         "recast": "^0.23.11"
       }
     },
     "packages/crud-ui-generator": {
       "name": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.111",
+      "version": "0.1.112",
       "dependencies": {
-        "@jskit-ai/crud-core": "0.1.136",
-        "@jskit-ai/kernel": "0.1.128",
-        "@jskit-ai/resource-crud-core": "0.1.71"
+        "@jskit-ai/crud-core": "0.1.137",
+        "@jskit-ai/kernel": "0.1.129",
+        "@jskit-ai/resource-crud-core": "0.1.72"
       }
     },
     "packages/database-runtime": {
       "name": "@jskit-ai/database-runtime",
-      "version": "0.1.127",
+      "version": "0.1.128",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.128"
+        "@jskit-ai/kernel": "0.1.129"
       }
     },
     "packages/database-runtime-mysql": {
       "name": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.126",
+      "version": "0.1.127",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.127",
-        "@jskit-ai/kernel": "0.1.128"
+        "@jskit-ai/database-runtime": "0.1.128",
+        "@jskit-ai/kernel": "0.1.129"
       }
     },
     "packages/database-runtime-postgres": {
       "name": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.125",
+      "version": "0.1.126",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.127"
+        "@jskit-ai/database-runtime": "0.1.128"
       }
     },
     "packages/feature-server-generator": {
       "name": "@jskit-ai/feature-server-generator",
-      "version": "0.1.70"
+      "version": "0.1.71"
     },
     "packages/google-rewarded-core": {
       "name": "@jskit-ai/google-rewarded-core",
-      "version": "0.1.65"
+      "version": "0.1.66"
     },
     "packages/google-rewarded-web": {
       "name": "@jskit-ai/google-rewarded-web",
-      "version": "0.1.65"
+      "version": "0.1.66"
     },
     "packages/http-runtime": {
       "name": "@jskit-ai/http-runtime",
-      "version": "0.1.126",
+      "version": "0.1.127",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.128",
+        "@jskit-ai/kernel": "0.1.129",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/json-rest-api-core": {
       "name": "@jskit-ai/json-rest-api-core",
-      "version": "0.1.72",
+      "version": "0.1.73",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.128",
+        "@jskit-ai/kernel": "0.1.129",
         "hooked-api": "1.x.x",
         "json-rest-api": "^1.0.26"
       }
     },
     "packages/kernel": {
       "name": "@jskit-ai/kernel",
-      "version": "0.1.128",
+      "version": "0.1.129",
       "dependencies": {
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/mobile-capacitor": {
       "name": "@jskit-ai/mobile-capacitor",
-      "version": "0.1.64",
+      "version": "0.1.65",
       "dependencies": {
         "@capacitor/browser": "^7.0.1",
-        "@jskit-ai/kernel": "0.1.128"
+        "@jskit-ai/kernel": "0.1.129"
       }
     },
     "packages/realtime": {
       "name": "@jskit-ai/realtime",
-      "version": "0.1.125",
+      "version": "0.1.126",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.128",
+        "@jskit-ai/kernel": "0.1.129",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",
@@ -7994,24 +7994,24 @@
     },
     "packages/resource-core": {
       "name": "@jskit-ai/resource-core",
-      "version": "0.1.71",
+      "version": "0.1.72",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.128"
+        "@jskit-ai/kernel": "0.1.129"
       }
     },
     "packages/resource-crud-core": {
       "name": "@jskit-ai/resource-crud-core",
-      "version": "0.1.71",
+      "version": "0.1.72",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.128",
-        "@jskit-ai/resource-core": "0.1.71"
+        "@jskit-ai/kernel": "0.1.129",
+        "@jskit-ai/resource-core": "0.1.72"
       }
     },
     "packages/shell-web": {
       "name": "@jskit-ai/shell-web",
-      "version": "0.1.129",
+      "version": "0.1.130",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.128",
+        "@jskit-ai/kernel": "0.1.129",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -8023,25 +8023,25 @@
     },
     "packages/storage-runtime": {
       "name": "@jskit-ai/storage-runtime",
-      "version": "0.1.126",
+      "version": "0.1.127",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.128",
+        "@jskit-ai/kernel": "0.1.129",
         "unstorage": "^1.17.5"
       }
     },
     "packages/ui-generator": {
       "name": "@jskit-ai/ui-generator",
-      "version": "0.1.111",
+      "version": "0.1.112",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.128",
-        "@jskit-ai/shell-web": "0.1.129"
+        "@jskit-ai/kernel": "0.1.129",
+        "@jskit-ai/shell-web": "0.1.130"
       }
     },
     "packages/uploads-image-web": {
       "name": "@jskit-ai/uploads-image-web",
-      "version": "0.1.104",
+      "version": "0.1.105",
       "dependencies": {
-        "@jskit-ai/uploads-runtime": "0.1.104",
+        "@jskit-ai/uploads-runtime": "0.1.105",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",
@@ -8054,37 +8054,37 @@
     },
     "packages/uploads-runtime": {
       "name": "@jskit-ai/uploads-runtime",
-      "version": "0.1.104",
+      "version": "0.1.105",
       "dependencies": {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.128"
+        "@jskit-ai/kernel": "0.1.129"
       }
     },
     "packages/users-core": {
       "name": "@jskit-ai/users-core",
-      "version": "0.1.138",
+      "version": "0.1.139",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.125",
-        "@jskit-ai/database-runtime": "0.1.127",
-        "@jskit-ai/http-runtime": "0.1.126",
-        "@jskit-ai/json-rest-api-core": "0.1.72",
-        "@jskit-ai/kernel": "0.1.128",
-        "@jskit-ai/resource-core": "0.1.71",
-        "@jskit-ai/resource-crud-core": "0.1.71",
-        "@jskit-ai/uploads-runtime": "0.1.104",
+        "@jskit-ai/auth-core": "0.1.126",
+        "@jskit-ai/database-runtime": "0.1.128",
+        "@jskit-ai/http-runtime": "0.1.127",
+        "@jskit-ai/json-rest-api-core": "0.1.73",
+        "@jskit-ai/kernel": "0.1.129",
+        "@jskit-ai/resource-core": "0.1.72",
+        "@jskit-ai/resource-crud-core": "0.1.72",
+        "@jskit-ai/uploads-runtime": "0.1.105",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/users-web": {
       "name": "@jskit-ai/users-web",
-      "version": "0.1.144",
+      "version": "0.1.145",
       "dependencies": {
-        "@jskit-ai/http-runtime": "0.1.126",
-        "@jskit-ai/kernel": "0.1.128",
-        "@jskit-ai/realtime": "0.1.125",
-        "@jskit-ai/shell-web": "0.1.129",
-        "@jskit-ai/uploads-image-web": "0.1.104",
-        "@jskit-ai/users-core": "0.1.138",
+        "@jskit-ai/http-runtime": "0.1.127",
+        "@jskit-ai/kernel": "0.1.129",
+        "@jskit-ai/realtime": "0.1.126",
+        "@jskit-ai/shell-web": "0.1.130",
+        "@jskit-ai/uploads-image-web": "0.1.105",
+        "@jskit-ai/users-core": "0.1.139",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -8096,30 +8096,30 @@
     },
     "packages/workspaces-core": {
       "name": "@jskit-ai/workspaces-core",
-      "version": "0.1.105",
+      "version": "0.1.106",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.125",
-        "@jskit-ai/database-runtime": "0.1.127",
-        "@jskit-ai/http-runtime": "0.1.126",
-        "@jskit-ai/json-rest-api-core": "0.1.72",
-        "@jskit-ai/kernel": "0.1.128",
-        "@jskit-ai/resource-core": "0.1.71",
-        "@jskit-ai/resource-crud-core": "0.1.71",
-        "@jskit-ai/users-core": "0.1.138",
+        "@jskit-ai/auth-core": "0.1.126",
+        "@jskit-ai/database-runtime": "0.1.128",
+        "@jskit-ai/http-runtime": "0.1.127",
+        "@jskit-ai/json-rest-api-core": "0.1.73",
+        "@jskit-ai/kernel": "0.1.129",
+        "@jskit-ai/resource-core": "0.1.72",
+        "@jskit-ai/resource-crud-core": "0.1.72",
+        "@jskit-ai/users-core": "0.1.139",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/workspaces-web": {
       "name": "@jskit-ai/workspaces-web",
-      "version": "0.1.106",
+      "version": "0.1.107",
       "dependencies": {
-        "@jskit-ai/auth-web": "0.1.128",
-        "@jskit-ai/http-runtime": "0.1.126",
-        "@jskit-ai/kernel": "0.1.128",
-        "@jskit-ai/shell-web": "0.1.129",
-        "@jskit-ai/users-core": "0.1.138",
-        "@jskit-ai/users-web": "0.1.144",
-        "@jskit-ai/workspaces-core": "0.1.105",
+        "@jskit-ai/auth-web": "0.1.129",
+        "@jskit-ai/http-runtime": "0.1.127",
+        "@jskit-ai/kernel": "0.1.129",
+        "@jskit-ai/shell-web": "0.1.130",
+        "@jskit-ai/users-core": "0.1.139",
+        "@jskit-ai/users-web": "0.1.145",
+        "@jskit-ai/workspaces-core": "0.1.106",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -8131,7 +8131,7 @@
     },
     "tooling/config-eslint": {
       "name": "@jskit-ai/config-eslint",
-      "version": "0.1.126",
+      "version": "0.1.127",
       "dependencies": {
         "@eslint/js": "^9.39.4",
         "eslint-plugin-vue": "^10.5.1",
@@ -8149,9 +8149,9 @@
     },
     "tooling/create-app": {
       "name": "@jskit-ai/create-app",
-      "version": "0.1.145",
+      "version": "0.1.146",
       "dependencies": {
-        "@jskit-ai/jskit-cli": "0.2.148"
+        "@jskit-ai/jskit-cli": "0.2.149"
       },
       "bin": {
         "jskit-create-app": "bin/jskit-create-app.js"
@@ -8162,18 +8162,18 @@
     },
     "tooling/jskit-catalog": {
       "name": "@jskit-ai/jskit-catalog",
-      "version": "0.1.142",
+      "version": "0.1.143",
       "engines": {
         "node": "^22.12.0 || ^24.0.0 || ^26.0.0"
       }
     },
     "tooling/jskit-cli": {
       "name": "@jskit-ai/jskit-cli",
-      "version": "0.2.148",
+      "version": "0.2.149",
       "dependencies": {
-        "@jskit-ai/jskit-catalog": "0.1.142",
-        "@jskit-ai/kernel": "0.1.128",
-        "@jskit-ai/shell-web": "0.1.129",
+        "@jskit-ai/jskit-catalog": "0.1.143",
+        "@jskit-ai/kernel": "0.1.129",
+        "@jskit-ai/shell-web": "0.1.130",
         "@vue/compiler-sfc": "^3.5.29",
         "ts-morph": "^28.0.0",
         "yaml": "^2.8.3"

--- a/packages/agent-docs/package.json
+++ b/packages/agent-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/agent-docs",
-  "version": "0.1.94",
+  "version": "0.1.95",
   "description": "Distributed JSKIT agent references, prompts, guides, and generated reference maps.",
   "type": "module",
   "files": [

--- a/packages/assistant-core/package.descriptor.mjs
+++ b/packages/assistant-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-core",
-  version: "0.1.105",
+  version: "0.1.106",
   kind: "runtime",
   description: "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
   dependsOn: [
@@ -47,11 +47,11 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/http-runtime": "0.1.126",
-        "@jskit-ai/kernel": "0.1.128",
-        "@jskit-ai/resource-core": "0.1.71",
-        "@jskit-ai/resource-crud-core": "0.1.71",
-        "@jskit-ai/users-core": "0.1.138",
+        "@jskit-ai/http-runtime": "0.1.127",
+        "@jskit-ai/kernel": "0.1.129",
+        "@jskit-ai/resource-core": "0.1.72",
+        "@jskit-ai/resource-crud-core": "0.1.72",
+        "@jskit-ai/users-core": "0.1.139",
         "dompurify": "^3.3.3",
         "json-rest-schema": "1.x.x",
         "marked": "^17.0.4",

--- a/packages/assistant-core/package.json
+++ b/packages/assistant-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-core",
-  "version": "0.1.105",
+  "version": "0.1.106",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,12 +11,12 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.127",
-    "@jskit-ai/http-runtime": "0.1.126",
-    "@jskit-ai/kernel": "0.1.128",
-    "@jskit-ai/resource-crud-core": "0.1.71",
-    "@jskit-ai/resource-core": "0.1.71",
-    "@jskit-ai/users-core": "0.1.138",
+    "@jskit-ai/database-runtime": "0.1.128",
+    "@jskit-ai/http-runtime": "0.1.127",
+    "@jskit-ai/kernel": "0.1.129",
+    "@jskit-ai/resource-crud-core": "0.1.72",
+    "@jskit-ai/resource-core": "0.1.72",
+    "@jskit-ai/users-core": "0.1.139",
     "dompurify": "^3.4.12",
     "json-rest-schema": "1.x.x",
     "marked": "^17.0.4",

--- a/packages/assistant-runtime/package.descriptor.mjs
+++ b/packages/assistant-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-runtime",
-  version: "0.1.100",
+  version: "0.1.101",
   kind: "runtime",
   description: "Shared assistant runtime with per-surface assistant registration.",
   dependsOn: [
@@ -95,13 +95,13 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/assistant-core": "0.1.105",
-        "@jskit-ai/database-runtime": "0.1.127",
-        "@jskit-ai/http-runtime": "0.1.126",
-        "@jskit-ai/kernel": "0.1.128",
-        "@jskit-ai/shell-web": "0.1.129",
-        "@jskit-ai/users-core": "0.1.138",
-        "@jskit-ai/users-web": "0.1.144"
+        "@jskit-ai/assistant-core": "0.1.106",
+        "@jskit-ai/database-runtime": "0.1.128",
+        "@jskit-ai/http-runtime": "0.1.127",
+        "@jskit-ai/kernel": "0.1.129",
+        "@jskit-ai/shell-web": "0.1.130",
+        "@jskit-ai/users-core": "0.1.139",
+        "@jskit-ai/users-web": "0.1.145"
       },
       dev: {}
     },

--- a/packages/assistant-runtime/package.json
+++ b/packages/assistant-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-runtime",
-  "version": "0.1.100",
+  "version": "0.1.101",
   "type": "module",
   "exports": {
     "./client": "./src/client/index.js",
@@ -8,13 +8,13 @@
     "./server/actionIds": "./src/server/actionIds.js"
   },
   "dependencies": {
-    "@jskit-ai/assistant-core": "0.1.105",
-    "@jskit-ai/database-runtime": "0.1.127",
-    "@jskit-ai/http-runtime": "0.1.126",
-    "@jskit-ai/kernel": "0.1.128",
-    "@jskit-ai/shell-web": "0.1.129",
-    "@jskit-ai/users-core": "0.1.138",
-    "@jskit-ai/users-web": "0.1.144",
+    "@jskit-ai/assistant-core": "0.1.106",
+    "@jskit-ai/database-runtime": "0.1.128",
+    "@jskit-ai/http-runtime": "0.1.127",
+    "@jskit-ai/kernel": "0.1.129",
+    "@jskit-ai/shell-web": "0.1.130",
+    "@jskit-ai/users-core": "0.1.139",
+    "@jskit-ai/users-web": "0.1.145",
     "json-rest-schema": "1.x.x"
   },
   "peerDependencies": {

--- a/packages/assistant/package.descriptor.mjs
+++ b/packages/assistant/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant",
-  version: "0.1.137",
+  version: "0.1.138",
   kind: "generator",
   description: "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
   options: {

--- a/packages/assistant/package.json
+++ b/packages/assistant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant",
-  "version": "0.1.137",
+  "version": "0.1.138",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.128"
+    "@jskit-ai/kernel": "0.1.129"
   }
 }

--- a/packages/auth-core/package.descriptor.mjs
+++ b/packages/auth-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-core",
-  "version": "0.1.125",
+  "version": "0.1.126",
   "kind": "runtime",
   "dependsOn": [
     "@jskit-ai/value-app-config-shared"
@@ -74,7 +74,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.128",
+        "@jskit-ai/kernel": "0.1.129",
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0"

--- a/packages/auth-core/package.json
+++ b/packages/auth-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-core",
-  "version": "0.1.125",
+  "version": "0.1.126",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -56,7 +56,7 @@
     "./shared/commands/authSessionReadCommand": "./src/shared/commands/authSessionReadCommand.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.128",
+    "@jskit-ai/kernel": "0.1.129",
     "@fastify/cookie": "^11.0.2",
     "@fastify/csrf-protection": "^7.1.0",
     "@fastify/rate-limit": "^10.3.0",

--- a/packages/auth-provider-local-core/package.descriptor.mjs
+++ b/packages/auth-provider-local-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-provider-local-core",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "kind": "runtime",
   "description": "Local auth provider with a file backend default and no database requirement.",
   "dependsOn": [
@@ -64,8 +64,8 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/auth-core": "0.1.125",
-        "@jskit-ai/kernel": "0.1.128",
+        "@jskit-ai/auth-core": "0.1.126",
+        "@jskit-ai/kernel": "0.1.129",
         "nodemailer": "^9.0.3",
         "dotenv": "^16.4.5"
       },

--- a/packages/auth-provider-local-core/package.json
+++ b/packages/auth-provider-local-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-local-core",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,8 +11,8 @@
     "./server/lib/index": "./src/server/lib/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.125",
-    "@jskit-ai/kernel": "0.1.128",
+    "@jskit-ai/auth-core": "0.1.126",
+    "@jskit-ai/kernel": "0.1.129",
     "nodemailer": "^9.0.3"
   }
 }

--- a/packages/auth-provider-local-db-core/package.descriptor.mjs
+++ b/packages/auth-provider-local-db-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/auth-provider-local-db-core",
-  version: "0.1.20",
+  version: "0.1.21",
   kind: "runtime",
   description: "Database-backed local auth storage backend for JSKIT local auth.",
   dependsOn: [
@@ -80,9 +80,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-provider-local-core": "0.1.29",
-        "@jskit-ai/database-runtime": "0.1.127",
-        "@jskit-ai/kernel": "0.1.128"
+        "@jskit-ai/auth-provider-local-core": "0.1.30",
+        "@jskit-ai/database-runtime": "0.1.128",
+        "@jskit-ai/kernel": "0.1.129"
       },
       dev: {}
     },

--- a/packages/auth-provider-local-db-core/package.json
+++ b/packages/auth-provider-local-db-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-local-db-core",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,8 +10,8 @@
     "./server/lib/index": "./src/server/lib/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-provider-local-core": "0.1.29",
-    "@jskit-ai/database-runtime": "0.1.127",
-    "@jskit-ai/kernel": "0.1.128"
+    "@jskit-ai/auth-provider-local-core": "0.1.30",
+    "@jskit-ai/database-runtime": "0.1.128",
+    "@jskit-ai/kernel": "0.1.129"
   }
 }

--- a/packages/auth-provider-supabase-core/package.descriptor.mjs
+++ b/packages/auth-provider-supabase-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.126",
+  "version": "0.1.127",
   "kind": "runtime",
   "options": {
     "auth-supabase-url": {
@@ -83,8 +83,8 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/auth-core": "0.1.125",
-        "@jskit-ai/kernel": "0.1.128",
+        "@jskit-ai/auth-core": "0.1.126",
+        "@jskit-ai/kernel": "0.1.129",
         "dotenv": "^16.4.5",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0"

--- a/packages/auth-provider-supabase-core/package.json
+++ b/packages/auth-provider-supabase-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.126",
+  "version": "0.1.127",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,8 +12,8 @@
     "./client": "./src/client/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.125",
-    "@jskit-ai/kernel": "0.1.128",
+    "@jskit-ai/auth-core": "0.1.126",
+    "@jskit-ai/kernel": "0.1.129",
     "json-rest-schema": "1.x.x",
     "jose": "^6.1.0",
     "@supabase/supabase-js": "^2.57.4",

--- a/packages/auth-web/package.descriptor.mjs
+++ b/packages/auth-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-web",
-  "version": "0.1.128",
+  "version": "0.1.129",
   "kind": "runtime",
   "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
   "dependsOn": [
@@ -264,10 +264,10 @@ export default Object.freeze({
     "dependencies": {
       "runtime": {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/auth-core": "0.1.125",
-        "@jskit-ai/http-runtime": "0.1.126",
-        "@jskit-ai/kernel": "0.1.128",
-        "@jskit-ai/shell-web": "0.1.129"
+        "@jskit-ai/auth-core": "0.1.126",
+        "@jskit-ai/http-runtime": "0.1.127",
+        "@jskit-ai/kernel": "0.1.129",
+        "@jskit-ai/shell-web": "0.1.130"
       },
       "dev": {}
     },

--- a/packages/auth-web/package.json
+++ b/packages/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-web",
-  "version": "0.1.128",
+  "version": "0.1.129",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -20,11 +20,11 @@
     "./test/playwright": "./src/test/playwright.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.125",
+    "@jskit-ai/auth-core": "0.1.126",
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/kernel": "0.1.128",
-    "@jskit-ai/shell-web": "0.1.129",
-    "@jskit-ai/http-runtime": "0.1.126"
+    "@jskit-ai/kernel": "0.1.129",
+    "@jskit-ai/shell-web": "0.1.130",
+    "@jskit-ai/http-runtime": "0.1.127"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/console-core/package.descriptor.mjs
+++ b/packages/console-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-core",
-  version: "0.1.92",
+  version: "0.1.93",
   kind: "runtime",
   description: "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
   dependsOn: [
@@ -85,12 +85,12 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.125",
-        "@jskit-ai/database-runtime": "0.1.127",
-        "@jskit-ai/http-runtime": "0.1.126",
-        "@jskit-ai/kernel": "0.1.128",
-        "@jskit-ai/resource-crud-core": "0.1.71",
-        "@jskit-ai/users-core": "0.1.138"
+        "@jskit-ai/auth-core": "0.1.126",
+        "@jskit-ai/database-runtime": "0.1.128",
+        "@jskit-ai/http-runtime": "0.1.127",
+        "@jskit-ai/kernel": "0.1.129",
+        "@jskit-ai/resource-crud-core": "0.1.72",
+        "@jskit-ai/users-core": "0.1.139"
       },
       dev: {}
     },

--- a/packages/console-core/package.json
+++ b/packages/console-core/package.json
@@ -1,17 +1,17 @@
 {
   "name": "@jskit-ai/console-core",
-  "version": "0.1.92",
+  "version": "0.1.93",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.125",
-    "@jskit-ai/database-runtime": "0.1.127",
-    "@jskit-ai/http-runtime": "0.1.126",
-    "@jskit-ai/kernel": "0.1.128",
-    "@jskit-ai/resource-crud-core": "0.1.71",
-    "@jskit-ai/users-core": "0.1.138",
+    "@jskit-ai/auth-core": "0.1.126",
+    "@jskit-ai/database-runtime": "0.1.128",
+    "@jskit-ai/http-runtime": "0.1.127",
+    "@jskit-ai/kernel": "0.1.129",
+    "@jskit-ai/resource-crud-core": "0.1.72",
+    "@jskit-ai/users-core": "0.1.139",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/console-web/package.descriptor.mjs
+++ b/packages/console-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-web",
-  version: "0.1.97",
+  version: "0.1.98",
   kind: "runtime",
   description: "Authenticated console surface scaffold and surface policy wiring.",
   dependsOn: [
@@ -103,9 +103,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-web": "0.1.128",
-        "@jskit-ai/console-core": "0.1.92",
-        "@jskit-ai/shell-web": "0.1.129",
+        "@jskit-ai/auth-web": "0.1.129",
+        "@jskit-ai/console-core": "0.1.93",
+        "@jskit-ai/shell-web": "0.1.130",
       },
       dev: {}
     },

--- a/packages/console-web/package.json
+++ b/packages/console-web/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/console-web",
-  "version": "0.1.97",
+  "version": "0.1.98",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-web": "0.1.128",
-    "@jskit-ai/console-core": "0.1.92",
-    "@jskit-ai/shell-web": "0.1.129"
+    "@jskit-ai/auth-web": "0.1.129",
+    "@jskit-ai/console-core": "0.1.93",
+    "@jskit-ai/shell-web": "0.1.130"
   }
 }

--- a/packages/crud-core/package.descriptor.mjs
+++ b/packages/crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-core",
-  version: "0.1.136",
+  version: "0.1.137",
   kind: "runtime",
   description: "Shared CRUD helpers used by CRUD modules.",
   dependsOn: [
@@ -28,7 +28,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/crud-core": "0.1.136"
+        "@jskit-ai/crud-core": "0.1.137"
       },
       dev: {}
     },

--- a/packages/crud-core/package.json
+++ b/packages/crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-core",
-  "version": "0.1.136",
+  "version": "0.1.137",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -27,15 +27,15 @@
     "./server/routeContracts": "./src/server/routeContracts.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.127",
-    "@jskit-ai/http-runtime": "0.1.126",
-    "@jskit-ai/kernel": "0.1.128",
+    "@jskit-ai/database-runtime": "0.1.128",
+    "@jskit-ai/http-runtime": "0.1.127",
+    "@jskit-ai/kernel": "0.1.129",
     "json-rest-schema": "1.x.x",
-    "@jskit-ai/realtime": "0.1.125",
-    "@jskit-ai/resource-crud-core": "0.1.71",
-    "@jskit-ai/shell-web": "0.1.129",
-    "@jskit-ai/users-core": "0.1.138",
-    "@jskit-ai/users-web": "0.1.144"
+    "@jskit-ai/realtime": "0.1.126",
+    "@jskit-ai/resource-crud-core": "0.1.72",
+    "@jskit-ai/shell-web": "0.1.130",
+    "@jskit-ai/users-core": "0.1.139",
+    "@jskit-ai/users-web": "0.1.145"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/crud-server-generator/package.descriptor.mjs
+++ b/packages/crud-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-server-generator",
-  version: "0.1.137",
+  version: "0.1.138",
   kind: "generator",
   description: "CRUD server generator with routes, actions, and persistence scaffolding.",
   options: {
@@ -184,14 +184,14 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.125",
-        "@jskit-ai/crud-core": "0.1.136",
-        "@jskit-ai/database-runtime": "0.1.127",
-        "@jskit-ai/http-runtime": "0.1.126",
-        "@jskit-ai/json-rest-api-core": "0.1.72",
-        "@jskit-ai/kernel": "0.1.128",
-        "@jskit-ai/realtime": "0.1.125",
-        "@jskit-ai/resource-crud-core": "0.1.71",
+        "@jskit-ai/auth-core": "0.1.126",
+        "@jskit-ai/crud-core": "0.1.137",
+        "@jskit-ai/database-runtime": "0.1.128",
+        "@jskit-ai/http-runtime": "0.1.127",
+        "@jskit-ai/json-rest-api-core": "0.1.73",
+        "@jskit-ai/kernel": "0.1.129",
+        "@jskit-ai/realtime": "0.1.126",
+        "@jskit-ai/resource-crud-core": "0.1.72",
         "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}"
       },
       dev: {}

--- a/packages/crud-server-generator/package.json
+++ b/packages/crud-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-server-generator",
-  "version": "0.1.137",
+  "version": "0.1.138",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,12 +13,12 @@
   },
   "dependencies": {
     "@babel/parser": "^7.29.2",
-    "@jskit-ai/crud-core": "0.1.136",
-    "@jskit-ai/database-runtime": "0.1.127",
-    "@jskit-ai/http-runtime": "0.1.126",
-    "@jskit-ai/json-rest-api-core": "0.1.72",
-    "@jskit-ai/kernel": "0.1.128",
-    "@jskit-ai/resource-crud-core": "0.1.71",
+    "@jskit-ai/crud-core": "0.1.137",
+    "@jskit-ai/database-runtime": "0.1.128",
+    "@jskit-ai/http-runtime": "0.1.127",
+    "@jskit-ai/json-rest-api-core": "0.1.73",
+    "@jskit-ai/kernel": "0.1.129",
+    "@jskit-ai/resource-crud-core": "0.1.72",
     "recast": "^0.23.11"
   }
 }

--- a/packages/crud-ui-generator/package.descriptor.mjs
+++ b/packages/crud-ui-generator/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { GENERATED_UI_NAVIGATION_ROLE_OPTION } from "@jskit-ai/kernel/shared/sup
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-ui-generator",
-  version: "0.1.111",
+  version: "0.1.112",
   kind: "generator",
   description: "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
   options: {
@@ -175,7 +175,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.144"
+        "@jskit-ai/users-web": "0.1.145"
       },
       dev: {}
     },

--- a/packages/crud-ui-generator/package.json
+++ b/packages/crud-ui-generator/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@jskit-ai/crud-ui-generator",
-  "version": "0.1.111",
+  "version": "0.1.112",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/crud-core": "0.1.136",
-    "@jskit-ai/kernel": "0.1.128",
-    "@jskit-ai/resource-crud-core": "0.1.71"
+    "@jskit-ai/crud-core": "0.1.137",
+    "@jskit-ai/kernel": "0.1.129",
+    "@jskit-ai/resource-crud-core": "0.1.72"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/database-runtime-mysql/package.descriptor.mjs
+++ b/packages/database-runtime-mysql/package.descriptor.mjs
@@ -13,7 +13,7 @@ const CI_DATABASE = Object.freeze({
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-mysql",
-  version: "0.1.126",
+  version: "0.1.127",
   kind: "runtime",
   options: {
     "db-host": {
@@ -133,7 +133,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.127",
+        "@jskit-ai/database-runtime": "0.1.128",
         "mysql2": "^3.11.2"
       },
       dev: {}

--- a/packages/database-runtime-mysql/package.json
+++ b/packages/database-runtime-mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-mysql",
-  "version": "0.1.126",
+  "version": "0.1.127",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,7 +12,7 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.127",
-    "@jskit-ai/kernel": "0.1.128"
+    "@jskit-ai/database-runtime": "0.1.128",
+    "@jskit-ai/kernel": "0.1.129"
   }
 }

--- a/packages/database-runtime-postgres/package.descriptor.mjs
+++ b/packages/database-runtime-postgres/package.descriptor.mjs
@@ -12,7 +12,7 @@ const CI_DATABASE = Object.freeze({
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-postgres",
-  version: "0.1.125",
+  version: "0.1.126",
   kind: "runtime",
   options: {
     "db-host": {
@@ -131,7 +131,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.127",
+        "@jskit-ai/database-runtime": "0.1.128",
         "pg": "^8.13.1"
       },
       dev: {}

--- a/packages/database-runtime-postgres/package.json
+++ b/packages/database-runtime-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-postgres",
-  "version": "0.1.125",
+  "version": "0.1.126",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,6 +12,6 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.127"
+    "@jskit-ai/database-runtime": "0.1.128"
   }
 }

--- a/packages/database-runtime/package.descriptor.mjs
+++ b/packages/database-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime",
-  version: "0.1.127",
+  version: "0.1.128",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -70,7 +70,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.128",
+        "@jskit-ai/kernel": "0.1.129",
         "dotenv": "^16.4.5",
         "knex": "^3.1.0"
       },

--- a/packages/database-runtime/package.json
+++ b/packages/database-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime",
-  "version": "0.1.127",
+  "version": "0.1.128",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -25,6 +25,6 @@
     "./shared/transactions": "./src/shared/transactions.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.128"
+    "@jskit-ai/kernel": "0.1.129"
   }
 }

--- a/packages/feature-server-generator/package.descriptor.mjs
+++ b/packages/feature-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/feature-server-generator",
-  version: "0.1.70",
+  version: "0.1.71",
   kind: "generator",
   description: "Scaffold substantial non-CRUD server feature packages with provider, actions, service, and optional persistence seams.",
   options: {
@@ -154,27 +154,27 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@jskit-ai/database-runtime": {
-          version: "0.1.127",
+          version: "0.1.128",
           when: {
             option: "mode",
             notEquals: "orchestrator"
           }
         },
         "@jskit-ai/database-runtime-mysql": {
-          version: "0.1.126",
+          version: "0.1.127",
           when: {
             option: "mode",
             notEquals: "orchestrator"
           }
         },
         "@jskit-ai/json-rest-api-core": {
-          version: "0.1.72",
+          version: "0.1.73",
           when: {
             option: "mode",
             equals: "json-rest"
           }
         },
-        "@jskit-ai/kernel": "0.1.128",
+        "@jskit-ai/kernel": "0.1.129",
         "json-rest-schema": "1.x.x",
         "@local/${option:feature-name|kebab}": "file:packages/${option:feature-name|kebab}"
       },

--- a/packages/feature-server-generator/package.json
+++ b/packages/feature-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/feature-server-generator",
-  "version": "0.1.70",
+  "version": "0.1.71",
   "type": "module",
   "scripts": {
     "test": "node --test"

--- a/packages/google-rewarded-core/package.descriptor.mjs
+++ b/packages/google-rewarded-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/google-rewarded-core",
-  version: "0.1.65",
+  version: "0.1.66",
   kind: "runtime",
   description: "Google rewarded workflow runtime plus internal CRUD providers for rules, provider configs, watch sessions, and unlock receipts.",
   dependsOn: [
@@ -128,14 +128,14 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.125",
-        "@jskit-ai/crud-core": "0.1.136",
-        "@jskit-ai/database-runtime": "0.1.127",
-        "@jskit-ai/http-runtime": "0.1.126",
-        "@jskit-ai/json-rest-api-core": "0.1.72",
-        "@jskit-ai/kernel": "0.1.128",
-        "@jskit-ai/resource-crud-core": "0.1.71",
-        "@jskit-ai/workspaces-core": "0.1.105"
+        "@jskit-ai/auth-core": "0.1.126",
+        "@jskit-ai/crud-core": "0.1.137",
+        "@jskit-ai/database-runtime": "0.1.128",
+        "@jskit-ai/http-runtime": "0.1.127",
+        "@jskit-ai/json-rest-api-core": "0.1.73",
+        "@jskit-ai/kernel": "0.1.129",
+        "@jskit-ai/resource-crud-core": "0.1.72",
+        "@jskit-ai/workspaces-core": "0.1.106"
       },
       dev: {}
     },

--- a/packages/google-rewarded-core/package.json
+++ b/packages/google-rewarded-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/google-rewarded-core",
-  "version": "0.1.65",
+  "version": "0.1.66",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/google-rewarded-web/package.descriptor.mjs
+++ b/packages/google-rewarded-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/google-rewarded-web",
-  version: "0.1.65",
+  version: "0.1.66",
   kind: "runtime",
   description: "Google rewarded client runtime with a fullscreen gate host and GPT orchestration.",
   dependsOn: [
@@ -46,10 +46,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/google-rewarded-core": "0.1.65",
-        "@jskit-ai/http-runtime": "0.1.126",
-        "@jskit-ai/kernel": "0.1.128",
-        "@jskit-ai/shell-web": "0.1.129"
+        "@jskit-ai/google-rewarded-core": "0.1.66",
+        "@jskit-ai/http-runtime": "0.1.127",
+        "@jskit-ai/kernel": "0.1.129",
+        "@jskit-ai/shell-web": "0.1.130"
       },
       dev: {}
     },

--- a/packages/google-rewarded-web/package.json
+++ b/packages/google-rewarded-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/google-rewarded-web",
-  "version": "0.1.65",
+  "version": "0.1.66",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/http-runtime/package.descriptor.mjs
+++ b/packages/http-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/http-runtime",
-  "version": "0.1.126",
+  "version": "0.1.127",
   "kind": "runtime",
   "dependsOn": [],
   "capabilities": {
@@ -67,7 +67,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.128"
+        "@jskit-ai/kernel": "0.1.129"
       },
       "dev": {}
     },

--- a/packages/http-runtime/package.json
+++ b/packages/http-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/http-runtime",
-  "version": "0.1.126",
+  "version": "0.1.127",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -18,7 +18,7 @@
     "./shared/validators/operationValidation": "./src/shared/validators/operationValidation.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.128",
+    "@jskit-ai/kernel": "0.1.129",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/json-rest-api-core/package.descriptor.mjs
+++ b/packages/json-rest-api-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/json-rest-api-core",
-  version: "0.1.72",
+  version: "0.1.73",
   kind: "runtime",
   description: "Shared internal json-rest-api host runtime with autofilter, query-projection, and row-policy support.",
   dependsOn: [

--- a/packages/json-rest-api-core/package.json
+++ b/packages/json-rest-api-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/json-rest-api-core",
-  "version": "0.1.72",
+  "version": "0.1.73",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,6 +11,6 @@
   "dependencies": {
     "hooked-api": "1.x.x",
     "json-rest-api": "^1.0.26",
-    "@jskit-ai/kernel": "0.1.128"
+    "@jskit-ai/kernel": "0.1.129"
   }
 }

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/kernel",
-  "version": "0.1.128",
+  "version": "0.1.129",
   "type": "module",
   "dependencies": {
     "json-rest-schema": "1.x.x"

--- a/packages/mobile-capacitor/package.descriptor.mjs
+++ b/packages/mobile-capacitor/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/mobile-capacitor",
-  version: "0.1.64",
+  version: "0.1.65",
   kind: "runtime",
   description: "Thin Capacitor client integration for JSKIT mobile-shell launch routing and auth callback completion.",
   dependsOn: [
@@ -62,8 +62,8 @@ export default Object.freeze({
         "@capacitor/app": "^7.1.0",
         "@capacitor/browser": "^7.0.1",
         "@capacitor/core": "^7.4.3",
-        "@jskit-ai/kernel": "0.1.128",
-        "@jskit-ai/shell-web": "0.1.129"
+        "@jskit-ai/kernel": "0.1.129",
+        "@jskit-ai/shell-web": "0.1.130"
       },
       dev: {
         "@capacitor/cli": "^7.4.3"

--- a/packages/mobile-capacitor/package.json
+++ b/packages/mobile-capacitor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/mobile-capacitor",
-  "version": "0.1.64",
+  "version": "0.1.65",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,6 +12,6 @@
   },
   "dependencies": {
     "@capacitor/browser": "^7.0.1",
-    "@jskit-ai/kernel": "0.1.128"
+    "@jskit-ai/kernel": "0.1.129"
   }
 }

--- a/packages/realtime/package.descriptor.mjs
+++ b/packages/realtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/realtime",
-  version: "0.1.125",
+  version: "0.1.126",
   kind: "runtime",
   description: "Thin, generic realtime runtime wrappers for socket.io server and client.",
   options: {
@@ -95,7 +95,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.128",
+        "@jskit-ai/kernel": "0.1.129",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/realtime",
-  "version": "0.1.125",
+  "version": "0.1.126",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@socket.io/redis-adapter": "^8.3.0",
-    "@jskit-ai/kernel": "0.1.128",
+    "@jskit-ai/kernel": "0.1.129",
     "redis": "^5.8.2",
     "socket.io": "^4.8.3",
     "socket.io-client": "^4.8.3"

--- a/packages/resource-core/package.descriptor.mjs
+++ b/packages/resource-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/resource-core",
-  version: "0.1.71",
+  version: "0.1.72",
   kind: "runtime",
   description: "Generic resource-definition helpers and schema-definition normalization.",
   dependsOn: [
@@ -22,7 +22,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/resource-core": "0.1.71"
+        "@jskit-ai/resource-core": "0.1.72"
       },
       dev: {}
     },

--- a/packages/resource-core/package.json
+++ b/packages/resource-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/resource-core",
-  "version": "0.1.71",
+  "version": "0.1.72",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./shared/resource": "./src/shared/resource.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.128"
+    "@jskit-ai/kernel": "0.1.129"
   }
 }

--- a/packages/resource-crud-core/package.descriptor.mjs
+++ b/packages/resource-crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/resource-crud-core",
-  version: "0.1.71",
+  version: "0.1.72",
   kind: "runtime",
   description: "CRUD-specific resource-definition helpers and namespace support.",
   dependsOn: [
@@ -23,7 +23,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/resource-crud-core": "0.1.71"
+        "@jskit-ai/resource-crud-core": "0.1.72"
       },
       dev: {}
     },

--- a/packages/resource-crud-core/package.json
+++ b/packages/resource-crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/resource-crud-core",
-  "version": "0.1.71",
+  "version": "0.1.72",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./shared/crudResource": "./src/shared/crudResource.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.128",
-    "@jskit-ai/resource-core": "0.1.71"
+    "@jskit-ai/kernel": "0.1.129",
+    "@jskit-ai/resource-core": "0.1.72"
   }
 }

--- a/packages/shell-web/package.descriptor.mjs
+++ b/packages/shell-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/shell-web",
-  version: "0.1.129",
+  version: "0.1.130",
   kind: "runtime",
   description: "Web shell layout runtime with outlet-based placement contributions.",
   dependsOn: [],
@@ -311,7 +311,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/kernel": "0.1.128"
+        "@jskit-ai/kernel": "0.1.129"
       },
       dev: {
         "@playwright/test": "1.61.1"

--- a/packages/shell-web/package.json
+++ b/packages/shell-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/shell-web",
-  "version": "0.1.129",
+  "version": "0.1.130",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/kernel": "0.1.128"
+    "@jskit-ai/kernel": "0.1.129"
   },
   "peerDependencies": {
     "pinia": "^3.0.4",

--- a/packages/storage-runtime/package.descriptor.mjs
+++ b/packages/storage-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/storage-runtime",
-  version: "0.1.126",
+  version: "0.1.127",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -50,7 +50,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.128",
+        "@jskit-ai/kernel": "0.1.129",
         "unstorage": "^1.17.3"
       },
       dev: {}

--- a/packages/storage-runtime/package.json
+++ b/packages/storage-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/storage-runtime",
-  "version": "0.1.126",
+  "version": "0.1.127",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./server/providers/StorageRuntimeServiceProvider": "./src/server/providers/StorageRuntimeServiceProvider.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.128",
+    "@jskit-ai/kernel": "0.1.129",
     "unstorage": "^1.17.5"
   }
 }

--- a/packages/ui-generator/package.descriptor.mjs
+++ b/packages/ui-generator/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { GENERATED_UI_NAVIGATION_ROLE_OPTION } from "@jskit-ai/kernel/shared/sup
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/ui-generator",
-  version: "0.1.111",
+  version: "0.1.112",
   kind: "generator",
   description: "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
   options: {
@@ -371,7 +371,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.144"
+        "@jskit-ai/users-web": "0.1.145"
       },
       dev: {}
     },

--- a/packages/ui-generator/package.json
+++ b/packages/ui-generator/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/ui-generator",
-  "version": "0.1.111",
+  "version": "0.1.112",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.128",
-    "@jskit-ai/shell-web": "0.1.129"
+    "@jskit-ai/kernel": "0.1.129",
+    "@jskit-ai/shell-web": "0.1.130"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/uploads-image-web/package.descriptor.mjs
+++ b/packages/uploads-image-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-image-web",
-  version: "0.1.104",
+  version: "0.1.105",
   kind: "runtime",
   description: "Reusable client-side image upload runtime with pre-upload image editing.",
   dependsOn: [
@@ -65,7 +65,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/uploads-runtime": "0.1.104",
+        "@jskit-ai/uploads-runtime": "0.1.105",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-image-web/package.json
+++ b/packages/uploads-image-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-image-web",
-  "version": "0.1.104",
+  "version": "0.1.105",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,7 +13,7 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/uploads-runtime": "0.1.104",
+    "@jskit-ai/uploads-runtime": "0.1.105",
     "@uppy/compressor": "^3.1.0",
     "@uppy/core": "^5.2.0",
     "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-runtime/package.descriptor.mjs
+++ b/packages/uploads-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-runtime",
-  version: "0.1.104",
+  version: "0.1.105",
   kind: "runtime",
   description: "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
   dependsOn: [
@@ -71,7 +71,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.128"
+        "@jskit-ai/kernel": "0.1.129"
       },
       dev: {}
     },

--- a/packages/uploads-runtime/package.json
+++ b/packages/uploads-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-runtime",
-  "version": "0.1.104",
+  "version": "0.1.105",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,6 +16,6 @@
   },
   "dependencies": {
     "@fastify/multipart": "^9.4.0",
-    "@jskit-ai/kernel": "0.1.128"
+    "@jskit-ai/kernel": "0.1.129"
   }
 }

--- a/packages/users-core/package.descriptor.mjs
+++ b/packages/users-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-core",
-  version: "0.1.138",
+  version: "0.1.139",
   kind: "runtime",
   description: "Users/account runtime plus HTTP routes for account features.",
   dependsOn: [
@@ -146,16 +146,16 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.125",
-        "@jskit-ai/crud-core": "0.1.136",
-        "@jskit-ai/database-runtime": "0.1.127",
-        "@jskit-ai/http-runtime": "0.1.126",
-        "@jskit-ai/json-rest-api-core": "0.1.72",
-        "@jskit-ai/kernel": "0.1.128",
-        "@jskit-ai/resource-core": "0.1.71",
-        "@jskit-ai/resource-crud-core": "0.1.71",
+        "@jskit-ai/auth-core": "0.1.126",
+        "@jskit-ai/crud-core": "0.1.137",
+        "@jskit-ai/database-runtime": "0.1.128",
+        "@jskit-ai/http-runtime": "0.1.127",
+        "@jskit-ai/json-rest-api-core": "0.1.73",
+        "@jskit-ai/kernel": "0.1.129",
+        "@jskit-ai/resource-core": "0.1.72",
+        "@jskit-ai/resource-crud-core": "0.1.72",
         "@local/users": "file:packages/users",
-        "@jskit-ai/uploads-runtime": "0.1.104"
+        "@jskit-ai/uploads-runtime": "0.1.105"
       },
       dev: {}
     },

--- a/packages/users-core/package.json
+++ b/packages/users-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-core",
-  "version": "0.1.138",
+  "version": "0.1.139",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,14 +11,14 @@
     "./shared/resources/userSettingsResource": "./src/shared/resources/userSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.125",
-    "@jskit-ai/database-runtime": "0.1.127",
-    "@jskit-ai/http-runtime": "0.1.126",
-    "@jskit-ai/json-rest-api-core": "0.1.72",
-    "@jskit-ai/kernel": "0.1.128",
-    "@jskit-ai/resource-crud-core": "0.1.71",
-    "@jskit-ai/resource-core": "0.1.71",
-    "@jskit-ai/uploads-runtime": "0.1.104",
+    "@jskit-ai/auth-core": "0.1.126",
+    "@jskit-ai/database-runtime": "0.1.128",
+    "@jskit-ai/http-runtime": "0.1.127",
+    "@jskit-ai/json-rest-api-core": "0.1.73",
+    "@jskit-ai/kernel": "0.1.129",
+    "@jskit-ai/resource-crud-core": "0.1.72",
+    "@jskit-ai/resource-core": "0.1.72",
+    "@jskit-ai/uploads-runtime": "0.1.105",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/users-web/package.descriptor.mjs
+++ b/packages/users-web/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { HOME_COG_OUTLET } from "./src/shared/toolsOutletContracts.js";
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-web",
-  version: "0.1.144",
+  version: "0.1.145",
   kind: "runtime",
   description: "Users web module: account/profile UI plus shared users web widgets.",
   dependsOn: [
@@ -286,12 +286,12 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/http-runtime": "0.1.126",
-        "@jskit-ai/realtime": "0.1.125",
-        "@jskit-ai/kernel": "0.1.128",
-        "@jskit-ai/shell-web": "0.1.129",
-        "@jskit-ai/uploads-image-web": "0.1.104",
-        "@jskit-ai/users-core": "0.1.138"
+        "@jskit-ai/http-runtime": "0.1.127",
+        "@jskit-ai/realtime": "0.1.126",
+        "@jskit-ai/kernel": "0.1.129",
+        "@jskit-ai/shell-web": "0.1.130",
+        "@jskit-ai/uploads-image-web": "0.1.105",
+        "@jskit-ai/users-core": "0.1.139"
       },
       dev: {}
     },

--- a/packages/users-web/package.json
+++ b/packages/users-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-web",
-  "version": "0.1.144",
+  "version": "0.1.145",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -46,12 +46,12 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/http-runtime": "0.1.126",
-    "@jskit-ai/kernel": "0.1.128",
-    "@jskit-ai/realtime": "0.1.125",
-    "@jskit-ai/shell-web": "0.1.129",
-    "@jskit-ai/uploads-image-web": "0.1.104",
-    "@jskit-ai/users-core": "0.1.138"
+    "@jskit-ai/http-runtime": "0.1.127",
+    "@jskit-ai/kernel": "0.1.129",
+    "@jskit-ai/realtime": "0.1.126",
+    "@jskit-ai/shell-web": "0.1.130",
+    "@jskit-ai/uploads-image-web": "0.1.105",
+    "@jskit-ai/users-core": "0.1.139"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/workspaces-core/package.descriptor.mjs
+++ b/packages/workspaces-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-core",
-  version: "0.1.105",
+  version: "0.1.106",
   kind: "runtime",
   description: "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
   dependsOn: [
@@ -147,10 +147,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/json-rest-api-core": "0.1.72",
-        "@jskit-ai/resource-core": "0.1.71",
-        "@jskit-ai/resource-crud-core": "0.1.71",
-        "@jskit-ai/users-core": "0.1.138"
+        "@jskit-ai/json-rest-api-core": "0.1.73",
+        "@jskit-ai/resource-core": "0.1.72",
+        "@jskit-ai/resource-crud-core": "0.1.72",
+        "@jskit-ai/users-core": "0.1.139"
       },
       dev: {}
     },

--- a/packages/workspaces-core/package.json
+++ b/packages/workspaces-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-core",
-  "version": "0.1.105",
+  "version": "0.1.106",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -17,14 +17,14 @@
     "./shared/resources/workspaceSettingsResource": "./src/shared/resources/workspaceSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.125",
-    "@jskit-ai/database-runtime": "0.1.127",
-    "@jskit-ai/http-runtime": "0.1.126",
-    "@jskit-ai/json-rest-api-core": "0.1.72",
-    "@jskit-ai/kernel": "0.1.128",
-    "@jskit-ai/resource-crud-core": "0.1.71",
-    "@jskit-ai/resource-core": "0.1.71",
-    "@jskit-ai/users-core": "0.1.138",
+    "@jskit-ai/auth-core": "0.1.126",
+    "@jskit-ai/database-runtime": "0.1.128",
+    "@jskit-ai/http-runtime": "0.1.127",
+    "@jskit-ai/json-rest-api-core": "0.1.73",
+    "@jskit-ai/kernel": "0.1.129",
+    "@jskit-ai/resource-crud-core": "0.1.72",
+    "@jskit-ai/resource-core": "0.1.72",
+    "@jskit-ai/users-core": "0.1.139",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/workspaces-web/package.descriptor.mjs
+++ b/packages/workspaces-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-web",
-  version: "0.1.106",
+  version: "0.1.107",
   kind: "runtime",
   description: "Workspace web module: workspace selector, tools widget, workspace surfaces, members UI, and settings hosts.",
   dependsOn: [
@@ -232,9 +232,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-web": "0.1.128",
-        "@jskit-ai/workspaces-core": "0.1.105",
-        "@jskit-ai/users-web": "0.1.144"
+        "@jskit-ai/auth-web": "0.1.129",
+        "@jskit-ai/workspaces-core": "0.1.106",
+        "@jskit-ai/users-web": "0.1.145"
       },
       dev: {}
     },

--- a/packages/workspaces-web/package.json
+++ b/packages/workspaces-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-web",
-  "version": "0.1.106",
+  "version": "0.1.107",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -15,13 +15,13 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/auth-web": "0.1.128",
-    "@jskit-ai/http-runtime": "0.1.126",
-    "@jskit-ai/kernel": "0.1.128",
-    "@jskit-ai/shell-web": "0.1.129",
-    "@jskit-ai/users-core": "0.1.138",
-    "@jskit-ai/users-web": "0.1.144",
-    "@jskit-ai/workspaces-core": "0.1.105"
+    "@jskit-ai/auth-web": "0.1.129",
+    "@jskit-ai/http-runtime": "0.1.127",
+    "@jskit-ai/kernel": "0.1.129",
+    "@jskit-ai/shell-web": "0.1.130",
+    "@jskit-ai/users-core": "0.1.139",
+    "@jskit-ai/users-web": "0.1.145",
+    "@jskit-ai/workspaces-core": "0.1.106"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/tooling/config-eslint/package.json
+++ b/tooling/config-eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/config-eslint",
-  "version": "0.1.126",
+  "version": "0.1.127",
   "description": "Shared flat ESLint presets for JSKIT projects.",
   "type": "module",
   "files": [

--- a/tooling/create-app/package.descriptor.mjs
+++ b/tooling/create-app/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/create-app",
-  "version": "0.1.145",
+  "version": "0.1.146",
   "dependsOn": [],
   "capabilities": {
     "provides": [

--- a/tooling/create-app/package.json
+++ b/tooling/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/create-app",
-  "version": "0.1.145",
+  "version": "0.1.146",
   "description": "Scaffold JSKIT app shells.",
   "type": "module",
   "files": [
@@ -20,7 +20,7 @@
     "./client": "./src/client/index.js"
   },
   "dependencies": {
-    "@jskit-ai/jskit-cli": "0.2.148"
+    "@jskit-ai/jskit-cli": "0.2.149"
   },
   "engines": {
     "node": "^22.12.0 || ^24.0.0 || ^26.0.0"

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -6,11 +6,11 @@
   "packages": [
     {
       "packageId": "@jskit-ai/assistant",
-      "version": "0.1.137",
+      "version": "0.1.138",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant",
-        "version": "0.1.137",
+        "version": "0.1.138",
         "kind": "generator",
         "description": "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
         "options": {
@@ -347,11 +347,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-core",
-      "version": "0.1.105",
+      "version": "0.1.106",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-core",
-        "version": "0.1.105",
+        "version": "0.1.106",
         "kind": "runtime",
         "description": "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
         "dependsOn": [
@@ -399,11 +399,11 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/http-runtime": "0.1.126",
-              "@jskit-ai/kernel": "0.1.128",
-              "@jskit-ai/resource-core": "0.1.71",
-              "@jskit-ai/resource-crud-core": "0.1.71",
-              "@jskit-ai/users-core": "0.1.138",
+              "@jskit-ai/http-runtime": "0.1.127",
+              "@jskit-ai/kernel": "0.1.129",
+              "@jskit-ai/resource-core": "0.1.72",
+              "@jskit-ai/resource-crud-core": "0.1.72",
+              "@jskit-ai/users-core": "0.1.139",
               "dompurify": "^3.3.3",
               "json-rest-schema": "1.x.x",
               "marked": "^17.0.4",
@@ -422,11 +422,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-runtime",
-      "version": "0.1.100",
+      "version": "0.1.101",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-runtime",
-        "version": "0.1.100",
+        "version": "0.1.101",
         "kind": "runtime",
         "description": "Shared assistant runtime with per-surface assistant registration.",
         "dependsOn": [
@@ -522,13 +522,13 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/assistant-core": "0.1.105",
-              "@jskit-ai/database-runtime": "0.1.127",
-              "@jskit-ai/http-runtime": "0.1.126",
-              "@jskit-ai/kernel": "0.1.128",
-              "@jskit-ai/shell-web": "0.1.129",
-              "@jskit-ai/users-core": "0.1.138",
-              "@jskit-ai/users-web": "0.1.144"
+              "@jskit-ai/assistant-core": "0.1.106",
+              "@jskit-ai/database-runtime": "0.1.128",
+              "@jskit-ai/http-runtime": "0.1.127",
+              "@jskit-ai/kernel": "0.1.129",
+              "@jskit-ai/shell-web": "0.1.130",
+              "@jskit-ai/users-core": "0.1.139",
+              "@jskit-ai/users-web": "0.1.145"
             },
             "dev": {}
           },
@@ -583,11 +583,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-core",
-      "version": "0.1.125",
+      "version": "0.1.126",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-core",
-        "version": "0.1.125",
+        "version": "0.1.126",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/value-app-config-shared"
@@ -660,7 +660,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.128",
+              "@jskit-ai/kernel": "0.1.129",
               "@fastify/cookie": "^11.0.2",
               "@fastify/csrf-protection": "^7.1.0",
               "@fastify/rate-limit": "^10.3.0"
@@ -678,11 +678,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-local-core",
-      "version": "0.1.29",
+      "version": "0.1.30",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-local-core",
-        "version": "0.1.29",
+        "version": "0.1.30",
         "kind": "runtime",
         "description": "Local auth provider with a file backend default and no database requirement.",
         "dependsOn": [
@@ -745,8 +745,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.125",
-              "@jskit-ai/kernel": "0.1.128",
+              "@jskit-ai/auth-core": "0.1.126",
+              "@jskit-ai/kernel": "0.1.129",
               "nodemailer": "^9.0.3",
               "dotenv": "^16.4.5"
             },
@@ -792,11 +792,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-local-db-core",
-      "version": "0.1.20",
+      "version": "0.1.21",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-local-db-core",
-        "version": "0.1.20",
+        "version": "0.1.21",
         "kind": "runtime",
         "description": "Database-backed local auth storage backend for JSKIT local auth.",
         "dependsOn": [
@@ -875,9 +875,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-provider-local-core": "0.1.29",
-              "@jskit-ai/database-runtime": "0.1.127",
-              "@jskit-ai/kernel": "0.1.128"
+              "@jskit-ai/auth-provider-local-core": "0.1.30",
+              "@jskit-ai/database-runtime": "0.1.128",
+              "@jskit-ai/kernel": "0.1.129"
             },
             "dev": {}
           },
@@ -912,11 +912,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.126",
+      "version": "0.1.127",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-supabase-core",
-        "version": "0.1.126",
+        "version": "0.1.127",
         "kind": "runtime",
         "options": {
           "auth-supabase-url": {
@@ -998,8 +998,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.125",
-              "@jskit-ai/kernel": "0.1.128",
+              "@jskit-ai/auth-core": "0.1.126",
+              "@jskit-ai/kernel": "0.1.129",
               "dotenv": "^16.4.5",
               "@supabase/supabase-js": "^2.57.4",
               "jose": "^6.1.0"
@@ -1077,11 +1077,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-web",
-      "version": "0.1.128",
+      "version": "0.1.129",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-web",
-        "version": "0.1.128",
+        "version": "0.1.129",
         "kind": "runtime",
         "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
         "dependsOn": [
@@ -1354,10 +1354,10 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/auth-core": "0.1.125",
-              "@jskit-ai/http-runtime": "0.1.126",
-              "@jskit-ai/kernel": "0.1.128",
-              "@jskit-ai/shell-web": "0.1.129"
+              "@jskit-ai/auth-core": "0.1.126",
+              "@jskit-ai/http-runtime": "0.1.127",
+              "@jskit-ai/kernel": "0.1.129",
+              "@jskit-ai/shell-web": "0.1.130"
             },
             "dev": {}
           },
@@ -1456,11 +1456,11 @@
     },
     {
       "packageId": "@jskit-ai/console-core",
-      "version": "0.1.92",
+      "version": "0.1.93",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-core",
-        "version": "0.1.92",
+        "version": "0.1.93",
         "kind": "runtime",
         "description": "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
         "dependsOn": [
@@ -1544,12 +1544,12 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.125",
-              "@jskit-ai/database-runtime": "0.1.127",
-              "@jskit-ai/http-runtime": "0.1.126",
-              "@jskit-ai/kernel": "0.1.128",
-              "@jskit-ai/resource-crud-core": "0.1.71",
-              "@jskit-ai/users-core": "0.1.138"
+              "@jskit-ai/auth-core": "0.1.126",
+              "@jskit-ai/database-runtime": "0.1.128",
+              "@jskit-ai/http-runtime": "0.1.127",
+              "@jskit-ai/kernel": "0.1.129",
+              "@jskit-ai/resource-crud-core": "0.1.72",
+              "@jskit-ai/users-core": "0.1.139"
             },
             "dev": {}
           },
@@ -1574,11 +1574,11 @@
     },
     {
       "packageId": "@jskit-ai/console-web",
-      "version": "0.1.97",
+      "version": "0.1.98",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-web",
-        "version": "0.1.97",
+        "version": "0.1.98",
         "kind": "runtime",
         "description": "Authenticated console surface scaffold and surface policy wiring.",
         "dependsOn": [
@@ -1688,9 +1688,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-web": "0.1.128",
-              "@jskit-ai/console-core": "0.1.92",
-              "@jskit-ai/shell-web": "0.1.129"
+              "@jskit-ai/auth-web": "0.1.129",
+              "@jskit-ai/console-core": "0.1.93",
+              "@jskit-ai/shell-web": "0.1.130"
             },
             "dev": {}
           },
@@ -1797,11 +1797,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-core",
-      "version": "0.1.136",
+      "version": "0.1.137",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-core",
-        "version": "0.1.136",
+        "version": "0.1.137",
         "kind": "runtime",
         "description": "Shared CRUD helpers used by CRUD modules.",
         "dependsOn": [
@@ -1830,7 +1830,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/crud-core": "0.1.136"
+              "@jskit-ai/crud-core": "0.1.137"
             },
             "dev": {}
           },
@@ -1844,11 +1844,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-server-generator",
-      "version": "0.1.137",
+      "version": "0.1.138",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-server-generator",
-        "version": "0.1.137",
+        "version": "0.1.138",
         "kind": "generator",
         "description": "CRUD server generator with routes, actions, and persistence scaffolding.",
         "options": {
@@ -2039,14 +2039,14 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.125",
-              "@jskit-ai/crud-core": "0.1.136",
-              "@jskit-ai/database-runtime": "0.1.127",
-              "@jskit-ai/http-runtime": "0.1.126",
-              "@jskit-ai/json-rest-api-core": "0.1.72",
-              "@jskit-ai/kernel": "0.1.128",
-              "@jskit-ai/realtime": "0.1.125",
-              "@jskit-ai/resource-crud-core": "0.1.71",
+              "@jskit-ai/auth-core": "0.1.126",
+              "@jskit-ai/crud-core": "0.1.137",
+              "@jskit-ai/database-runtime": "0.1.128",
+              "@jskit-ai/http-runtime": "0.1.127",
+              "@jskit-ai/json-rest-api-core": "0.1.73",
+              "@jskit-ai/kernel": "0.1.129",
+              "@jskit-ai/realtime": "0.1.126",
+              "@jskit-ai/resource-crud-core": "0.1.72",
               "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}"
             },
             "dev": {}
@@ -2178,11 +2178,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.111",
+      "version": "0.1.112",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-ui-generator",
-        "version": "0.1.111",
+        "version": "0.1.112",
         "kind": "generator",
         "description": "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
         "options": {
@@ -2381,7 +2381,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.144"
+              "@jskit-ai/users-web": "0.1.145"
             },
             "dev": {}
           },
@@ -2640,11 +2640,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime",
-      "version": "0.1.127",
+      "version": "0.1.128",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime",
-        "version": "0.1.127",
+        "version": "0.1.128",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -2713,7 +2713,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.128",
+              "@jskit-ai/kernel": "0.1.129",
               "dotenv": "^16.4.5",
               "knex": "^3.1.0"
             },
@@ -2749,11 +2749,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.126",
+      "version": "0.1.127",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-mysql",
-        "version": "0.1.126",
+        "version": "0.1.127",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -2875,7 +2875,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.127",
+              "@jskit-ai/database-runtime": "0.1.128",
               "mysql2": "^3.11.2"
             },
             "dev": {}
@@ -2946,11 +2946,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.125",
+      "version": "0.1.126",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-postgres",
-        "version": "0.1.125",
+        "version": "0.1.126",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -3071,7 +3071,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.127",
+              "@jskit-ai/database-runtime": "0.1.128",
               "pg": "^8.13.1"
             },
             "dev": {}
@@ -3142,11 +3142,11 @@
     },
     {
       "packageId": "@jskit-ai/feature-server-generator",
-      "version": "0.1.70",
+      "version": "0.1.71",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/feature-server-generator",
-        "version": "0.1.70",
+        "version": "0.1.71",
         "kind": "generator",
         "description": "Scaffold substantial non-CRUD server feature packages with provider, actions, service, and optional persistence seams.",
         "options": {
@@ -3311,27 +3311,27 @@
           "dependencies": {
             "runtime": {
               "@jskit-ai/database-runtime": {
-                "version": "0.1.127",
+                "version": "0.1.128",
                 "when": {
                   "option": "mode",
                   "notEquals": "orchestrator"
                 }
               },
               "@jskit-ai/database-runtime-mysql": {
-                "version": "0.1.126",
+                "version": "0.1.127",
                 "when": {
                   "option": "mode",
                   "notEquals": "orchestrator"
                 }
               },
               "@jskit-ai/json-rest-api-core": {
-                "version": "0.1.72",
+                "version": "0.1.73",
                 "when": {
                   "option": "mode",
                   "equals": "json-rest"
                 }
               },
-              "@jskit-ai/kernel": "0.1.128",
+              "@jskit-ai/kernel": "0.1.129",
               "json-rest-schema": "1.x.x",
               "@local/${option:feature-name|kebab}": "file:packages/${option:feature-name|kebab}"
             },
@@ -3444,11 +3444,11 @@
     },
     {
       "packageId": "@jskit-ai/google-rewarded-core",
-      "version": "0.1.65",
+      "version": "0.1.66",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/google-rewarded-core",
-        "version": "0.1.65",
+        "version": "0.1.66",
         "kind": "runtime",
         "description": "Google rewarded workflow runtime plus internal CRUD providers for rules, provider configs, watch sessions, and unlock receipts.",
         "dependsOn": [
@@ -3575,14 +3575,14 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.125",
-              "@jskit-ai/crud-core": "0.1.136",
-              "@jskit-ai/database-runtime": "0.1.127",
-              "@jskit-ai/http-runtime": "0.1.126",
-              "@jskit-ai/json-rest-api-core": "0.1.72",
-              "@jskit-ai/kernel": "0.1.128",
-              "@jskit-ai/resource-crud-core": "0.1.71",
-              "@jskit-ai/workspaces-core": "0.1.105"
+              "@jskit-ai/auth-core": "0.1.126",
+              "@jskit-ai/crud-core": "0.1.137",
+              "@jskit-ai/database-runtime": "0.1.128",
+              "@jskit-ai/http-runtime": "0.1.127",
+              "@jskit-ai/json-rest-api-core": "0.1.73",
+              "@jskit-ai/kernel": "0.1.129",
+              "@jskit-ai/resource-crud-core": "0.1.72",
+              "@jskit-ai/workspaces-core": "0.1.106"
             },
             "dev": {}
           },
@@ -3634,11 +3634,11 @@
     },
     {
       "packageId": "@jskit-ai/google-rewarded-web",
-      "version": "0.1.65",
+      "version": "0.1.66",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/google-rewarded-web",
-        "version": "0.1.65",
+        "version": "0.1.66",
         "kind": "runtime",
         "description": "Google rewarded client runtime with a fullscreen gate host and GPT orchestration.",
         "dependsOn": [
@@ -3685,10 +3685,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/google-rewarded-core": "0.1.65",
-              "@jskit-ai/http-runtime": "0.1.126",
-              "@jskit-ai/kernel": "0.1.128",
-              "@jskit-ai/shell-web": "0.1.129"
+              "@jskit-ai/google-rewarded-core": "0.1.66",
+              "@jskit-ai/http-runtime": "0.1.127",
+              "@jskit-ai/kernel": "0.1.129",
+              "@jskit-ai/shell-web": "0.1.130"
             },
             "dev": {}
           },
@@ -3706,11 +3706,11 @@
     },
     {
       "packageId": "@jskit-ai/http-runtime",
-      "version": "0.1.126",
+      "version": "0.1.127",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/http-runtime",
-        "version": "0.1.126",
+        "version": "0.1.127",
         "kind": "runtime",
         "dependsOn": [],
         "capabilities": {
@@ -3776,7 +3776,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.128"
+              "@jskit-ai/kernel": "0.1.129"
             },
             "dev": {}
           },
@@ -3790,11 +3790,11 @@
     },
     {
       "packageId": "@jskit-ai/json-rest-api-core",
-      "version": "0.1.72",
+      "version": "0.1.73",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/json-rest-api-core",
-        "version": "0.1.72",
+        "version": "0.1.73",
         "kind": "runtime",
         "description": "Shared internal json-rest-api host runtime with autofilter, query-projection, and row-policy support.",
         "dependsOn": [
@@ -3854,11 +3854,11 @@
     },
     {
       "packageId": "@jskit-ai/mobile-capacitor",
-      "version": "0.1.64",
+      "version": "0.1.65",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/mobile-capacitor",
-        "version": "0.1.64",
+        "version": "0.1.65",
         "kind": "runtime",
         "description": "Thin Capacitor client integration for JSKIT mobile-shell launch routing and auth callback completion.",
         "dependsOn": [
@@ -3921,8 +3921,8 @@
               "@capacitor/app": "^7.1.0",
               "@capacitor/browser": "^7.0.1",
               "@capacitor/core": "^7.4.3",
-              "@jskit-ai/kernel": "0.1.128",
-              "@jskit-ai/shell-web": "0.1.129"
+              "@jskit-ai/kernel": "0.1.129",
+              "@jskit-ai/shell-web": "0.1.130"
             },
             "dev": {
               "@capacitor/cli": "^7.4.3"
@@ -3974,11 +3974,11 @@
     },
     {
       "packageId": "@jskit-ai/realtime",
-      "version": "0.1.125",
+      "version": "0.1.126",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/realtime",
-        "version": "0.1.125",
+        "version": "0.1.126",
         "kind": "runtime",
         "description": "Thin, generic realtime runtime wrappers for socket.io server and client.",
         "options": {
@@ -4074,7 +4074,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.128",
+              "@jskit-ai/kernel": "0.1.129",
               "@socket.io/redis-adapter": "^8.3.0",
               "redis": "^5.8.2",
               "socket.io": "^4.8.3",
@@ -4123,11 +4123,11 @@
     },
     {
       "packageId": "@jskit-ai/resource-core",
-      "version": "0.1.71",
+      "version": "0.1.72",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/resource-core",
-        "version": "0.1.71",
+        "version": "0.1.72",
         "kind": "runtime",
         "description": "Generic resource-definition helpers and schema-definition normalization.",
         "dependsOn": [
@@ -4150,7 +4150,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/resource-core": "0.1.71"
+              "@jskit-ai/resource-core": "0.1.72"
             },
             "dev": {}
           },
@@ -4165,11 +4165,11 @@
     },
     {
       "packageId": "@jskit-ai/resource-crud-core",
-      "version": "0.1.71",
+      "version": "0.1.72",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/resource-crud-core",
-        "version": "0.1.71",
+        "version": "0.1.72",
         "kind": "runtime",
         "description": "CRUD-specific resource-definition helpers and namespace support.",
         "dependsOn": [
@@ -4193,7 +4193,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/resource-crud-core": "0.1.71"
+              "@jskit-ai/resource-crud-core": "0.1.72"
             },
             "dev": {}
           },
@@ -4208,11 +4208,11 @@
     },
     {
       "packageId": "@jskit-ai/shell-web",
-      "version": "0.1.129",
+      "version": "0.1.130",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/shell-web",
-        "version": "0.1.129",
+        "version": "0.1.130",
         "kind": "runtime",
         "description": "Web shell layout runtime with outlet-based placement contributions.",
         "dependsOn": [],
@@ -4558,7 +4558,7 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/kernel": "0.1.128"
+              "@jskit-ai/kernel": "0.1.129"
             },
             "dev": {
               "@playwright/test": "1.61.1"
@@ -4787,11 +4787,11 @@
     },
     {
       "packageId": "@jskit-ai/storage-runtime",
-      "version": "0.1.126",
+      "version": "0.1.127",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/storage-runtime",
-        "version": "0.1.126",
+        "version": "0.1.127",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -4840,7 +4840,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.128",
+              "@jskit-ai/kernel": "0.1.129",
               "unstorage": "^1.17.3"
             },
             "dev": {}
@@ -4856,11 +4856,11 @@
     },
     {
       "packageId": "@jskit-ai/ui-generator",
-      "version": "0.1.111",
+      "version": "0.1.112",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/ui-generator",
-        "version": "0.1.111",
+        "version": "0.1.112",
         "kind": "generator",
         "description": "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
         "options": {
@@ -5293,7 +5293,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.144"
+              "@jskit-ai/users-web": "0.1.145"
             },
             "dev": {}
           },
@@ -5308,11 +5308,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-image-web",
-      "version": "0.1.104",
+      "version": "0.1.105",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-image-web",
-        "version": "0.1.104",
+        "version": "0.1.105",
         "kind": "runtime",
         "description": "Reusable client-side image upload runtime with pre-upload image editing.",
         "dependsOn": [
@@ -5376,7 +5376,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/uploads-runtime": "0.1.104",
+              "@jskit-ai/uploads-runtime": "0.1.105",
               "@uppy/compressor": "^3.1.0",
               "@uppy/core": "^5.2.0",
               "@uppy/dashboard": "^5.1.1",
@@ -5396,11 +5396,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-runtime",
-      "version": "0.1.104",
+      "version": "0.1.105",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-runtime",
-        "version": "0.1.104",
+        "version": "0.1.105",
         "kind": "runtime",
         "description": "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
         "dependsOn": [
@@ -5470,7 +5470,7 @@
           "dependencies": {
             "runtime": {
               "@fastify/multipart": "^9.4.0",
-              "@jskit-ai/kernel": "0.1.128"
+              "@jskit-ai/kernel": "0.1.129"
             },
             "dev": {}
           },
@@ -5485,11 +5485,11 @@
     },
     {
       "packageId": "@jskit-ai/users-core",
-      "version": "0.1.138",
+      "version": "0.1.139",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-core",
-        "version": "0.1.138",
+        "version": "0.1.139",
         "kind": "runtime",
         "description": "Users/account runtime plus HTTP routes for account features.",
         "dependsOn": [
@@ -5633,16 +5633,16 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.125",
-              "@jskit-ai/crud-core": "0.1.136",
-              "@jskit-ai/database-runtime": "0.1.127",
-              "@jskit-ai/http-runtime": "0.1.126",
-              "@jskit-ai/json-rest-api-core": "0.1.72",
-              "@jskit-ai/kernel": "0.1.128",
-              "@jskit-ai/resource-core": "0.1.71",
-              "@jskit-ai/resource-crud-core": "0.1.71",
+              "@jskit-ai/auth-core": "0.1.126",
+              "@jskit-ai/crud-core": "0.1.137",
+              "@jskit-ai/database-runtime": "0.1.128",
+              "@jskit-ai/http-runtime": "0.1.127",
+              "@jskit-ai/json-rest-api-core": "0.1.73",
+              "@jskit-ai/kernel": "0.1.129",
+              "@jskit-ai/resource-core": "0.1.72",
+              "@jskit-ai/resource-crud-core": "0.1.72",
               "@local/users": "file:packages/users",
-              "@jskit-ai/uploads-runtime": "0.1.104"
+              "@jskit-ai/uploads-runtime": "0.1.105"
             },
             "dev": {}
           },
@@ -5869,11 +5869,11 @@
     },
     {
       "packageId": "@jskit-ai/users-web",
-      "version": "0.1.144",
+      "version": "0.1.145",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-web",
-        "version": "0.1.144",
+        "version": "0.1.145",
         "kind": "runtime",
         "description": "Users web module: account/profile UI plus shared users web widgets.",
         "dependsOn": [
@@ -6176,12 +6176,12 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/http-runtime": "0.1.126",
-              "@jskit-ai/realtime": "0.1.125",
-              "@jskit-ai/kernel": "0.1.128",
-              "@jskit-ai/shell-web": "0.1.129",
-              "@jskit-ai/uploads-image-web": "0.1.104",
-              "@jskit-ai/users-core": "0.1.138"
+              "@jskit-ai/http-runtime": "0.1.127",
+              "@jskit-ai/realtime": "0.1.126",
+              "@jskit-ai/kernel": "0.1.129",
+              "@jskit-ai/shell-web": "0.1.130",
+              "@jskit-ai/uploads-image-web": "0.1.105",
+              "@jskit-ai/users-core": "0.1.139"
             },
             "dev": {}
           },
@@ -6362,11 +6362,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-core",
-      "version": "0.1.105",
+      "version": "0.1.106",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-core",
-        "version": "0.1.105",
+        "version": "0.1.106",
         "kind": "runtime",
         "description": "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
         "dependsOn": [
@@ -6512,10 +6512,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/json-rest-api-core": "0.1.72",
-              "@jskit-ai/resource-core": "0.1.71",
-              "@jskit-ai/resource-crud-core": "0.1.71",
-              "@jskit-ai/users-core": "0.1.138"
+              "@jskit-ai/json-rest-api-core": "0.1.73",
+              "@jskit-ai/resource-core": "0.1.72",
+              "@jskit-ai/resource-crud-core": "0.1.72",
+              "@jskit-ai/users-core": "0.1.139"
             },
             "dev": {}
           },
@@ -6719,11 +6719,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-web",
-      "version": "0.1.106",
+      "version": "0.1.107",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-web",
-        "version": "0.1.106",
+        "version": "0.1.107",
         "kind": "runtime",
         "description": "Workspace web module: workspace selector, tools widget, workspace surfaces, members UI, and settings hosts.",
         "dependsOn": [
@@ -6980,9 +6980,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-web": "0.1.128",
-              "@jskit-ai/workspaces-core": "0.1.105",
-              "@jskit-ai/users-web": "0.1.144"
+              "@jskit-ai/auth-web": "0.1.129",
+              "@jskit-ai/workspaces-core": "0.1.106",
+              "@jskit-ai/users-web": "0.1.145"
             },
             "dev": {}
           },

--- a/tooling/jskit-catalog/package.json
+++ b/tooling/jskit-catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-catalog",
-  "version": "0.1.142",
+  "version": "0.1.143",
   "description": "Published metadata catalog for JSKIT package descriptors.",
   "type": "module",
   "files": [

--- a/tooling/jskit-cli/package.json
+++ b/tooling/jskit-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-cli",
-  "version": "0.2.148",
+  "version": "0.2.149",
   "description": "Bundle and package orchestration CLI for JSKIT apps.",
   "type": "module",
   "files": [
@@ -21,9 +21,9 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/jskit-catalog": "0.1.142",
-    "@jskit-ai/kernel": "0.1.128",
-    "@jskit-ai/shell-web": "0.1.129",
+    "@jskit-ai/jskit-catalog": "0.1.143",
+    "@jskit-ai/kernel": "0.1.129",
+    "@jskit-ai/shell-web": "0.1.130",
     "@vue/compiler-sfc": "^3.5.29",
     "ts-morph": "^28.0.0",
     "yaml": "^2.8.3"


### PR DESCRIPTION
Publishes the serial JSKIT release graph containing the 48px shell/auth tap-target fix. All 40 packages were published with concurrency 1.