### PR TITLE
Honor workspace selector tap target

### DIFF
--- a/packages/workspaces-web/src/client/components/UsersWorkspaceSelector.vue
+++ b/packages/workspaces-web/src/client/components/UsersWorkspaceSelector.vue
@@ -205,7 +205,7 @@ function workspaceAvatarStyle(workspace) {
       <v-btn
         v-bind="activatorProps"
         variant="text"
-        class="text-none"
+        class="users-workspace-selector__activator text-none"
         :prepend-icon="mdiBriefcaseOutline"
       >
         {{ activeWorkspaceLabel }}
@@ -241,3 +241,9 @@ function workspaceAvatarStyle(workspace) {
     </v-list>
   </v-menu>
 </template>
+
+<style scoped>
+.users-workspace-selector__activator {
+  min-height: 48px;
+}
+</style>

--- a/packages/workspaces-web/test/usersWorkspaceSelectorContract.test.js
+++ b/packages/workspaces-web/test/usersWorkspaceSelectorContract.test.js
@@ -17,3 +17,10 @@ test("UsersWorkspaceSelector passes workspaceSlug through generic page params", 
   );
   assert.doesNotMatch(source, /workspaceSlug:\s*normalizedSlug,\s*mode:\s*"workspace"/s);
 });
+
+test("UsersWorkspaceSelector activator preserves the generated tap-target contract", async () => {
+  const source = await readFile(COMPONENT_PATH, "utf8");
+
+  assert.match(source, /class="users-workspace-selector__activator text-none"/);
+  assert.match(source, /\.users-workspace-selector__activator\s*\{[\s\S]*min-height:\s*48px;/);
+});


### PR DESCRIPTION
Makes the authenticated workspace selector meet the 48px tap-target contract enforced by generated responsive smoke tests. Focused contract test and ESLint pass.