### PR TITLE
Release workspace selector tap target fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8111,7 +8111,7 @@
     },
     "packages/workspaces-web": {
       "name": "@jskit-ai/workspaces-web",
-      "version": "0.1.107",
+      "version": "0.1.108",
       "dependencies": {
         "@jskit-ai/auth-web": "0.1.129",
         "@jskit-ai/http-runtime": "0.1.127",

--- a/packages/workspaces-web/package.descriptor.mjs
+++ b/packages/workspaces-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-web",
-  version: "0.1.107",
+  version: "0.1.108",
   kind: "runtime",
   description: "Workspace web module: workspace selector, tools widget, workspace surfaces, members UI, and settings hosts.",
   dependsOn: [

--- a/packages/workspaces-web/package.json
+++ b/packages/workspaces-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-web",
-  "version": "0.1.107",
+  "version": "0.1.108",
   "type": "module",
   "scripts": {
     "test": "node --test"


### PR DESCRIPTION
Publishes @jskit-ai/workspaces-web 0.1.108 with the authenticated workspace selector tap-target correction.