### PR TITLE
Use installed descriptors for migration sync

### DIFF
--- a/packages/agent-docs/reference/autogen/packages/workspaces-web.md
+++ b/packages/agent-docs/reference/autogen/packages/workspaces-web.md
@@ -353,6 +353,8 @@ Exports
 ### `templates/src/surfaces/admin/index.vue`
 Exports
 - None
+Local functions
+- `adminChildPath(suffix = "")`
 
 ### `templates/src/surfaces/admin/root.vue`
 Exports

--- a/packages/agent-docs/reference/autogen/tooling/jskit-cli.md
+++ b/packages/agent-docs/reference/autogen/tooling/jskit-cli.md
@@ -465,7 +465,7 @@ Exports
 - `isSensitiveManagedTextRecord({ packageEntry = {}, record = {} } = {})`
 - `isSensitivePackageOption(packageEntry = {}, optionName = "")`
 - `isSensitiveTextMutation({ packageEntry = {}, mutation = {}, resolvedKey = "" } = {})`
-- `resolveSensitiveOptionEnvFallbacks({ packageEntry = {}, appRoot = "", optionInput = {}, readFileBufferIfExists } = {})`
+- `resolveSensitiveOptionEnvFallbacks({ packageEntry = {}, appRoot = "", optionInput = {}, readFileBufferIfExists, environment = process.env } = {})`
 - `sanitizeInstalledPackageRecordForLock(record = {}, packageEntry = {})`
 - `sanitizeLockSecretsForWrite(lock = {}, packageRegistry = null)`
 - `sanitizeManagedTextForLock(packageEntry = {}, managedText = {})`
@@ -550,8 +550,9 @@ Local functions
 - `cookieHeader(setCookie = [])`
 - `responsePayload(response = {})`
 - `upstreamError(payload = {}, response = {}, extra = {})`
+- `request(fetchImpl, href, options)`
 - `postJson(fetchImpl, href, body, headers = {})`
-- `readSession(fetchImpl, targetOrigin, setCookie = [])`
+- `readSession(fetchImpl, targetOrigin)`
 - `logout(fetchImpl, targetOrigin, session)`
 - `login(fetchImpl, targetOrigin, identity, secret, session)`
 

--- a/packages/users-web/test/settingsPlacementContract.test.js
+++ b/packages/users-web/test/settingsPlacementContract.test.js
@@ -375,6 +375,7 @@ test("users-web descriptor metadata advertises home cog outlet and standard home
   assert.deepEqual(findFileMutation("users-web-component-account-settings-profile"), {
     from: "templates/src/components/account/settings/AccountSettingsProfileSection.vue",
     to: "src/components/account/settings/AccountSettingsProfileSection.vue",
+    ownership: "app",
     reason: "Install app-owned account settings profile section scaffold.",
     category: "users-web",
     id: "users-web-component-account-settings-profile"
@@ -382,6 +383,7 @@ test("users-web descriptor metadata advertises home cog outlet and standard home
   assert.deepEqual(findFileMutation("users-web-component-account-settings-preferences"), {
     from: "templates/src/components/account/settings/AccountSettingsPreferencesSection.vue",
     to: "src/components/account/settings/AccountSettingsPreferencesSection.vue",
+    ownership: "app",
     reason: "Install app-owned account settings preferences section scaffold.",
     category: "users-web",
     id: "users-web-component-account-settings-preferences"
@@ -389,6 +391,7 @@ test("users-web descriptor metadata advertises home cog outlet and standard home
   assert.deepEqual(findFileMutation("users-web-component-account-settings-notifications"), {
     from: "templates/src/components/account/settings/AccountSettingsNotificationsSection.vue",
     to: "src/components/account/settings/AccountSettingsNotificationsSection.vue",
+    ownership: "app",
     reason: "Install app-owned account settings notifications section scaffold.",
     category: "users-web",
     id: "users-web-component-account-settings-notifications"

--- a/packages/workspaces-web/test/settingsPlacementContract.test.js
+++ b/packages/workspaces-web/test/settingsPlacementContract.test.js
@@ -99,6 +99,7 @@ test("workspaces-web installs an app-owned account invites section wrapper", asy
   assert.deepEqual(findFileMutation("users-web-main-component-account-settings-invites-section"), {
     from: "templates/packages/main/src/client/components/AccountSettingsInvitesSection.vue",
     to: "packages/main/src/client/components/AccountSettingsInvitesSection.vue",
+    ownership: "app",
     reason: "Install app-owned account invites section scaffold for multihoming account settings.",
     category: "workspaces-web",
     id: "users-web-main-component-account-settings-invites-section"
@@ -120,6 +121,7 @@ test("workspaces-web installs a public workspace invite route scaffold", async (
   assert.deepEqual(findFileMutation("workspaces-web-page-public-invite"), {
     from: "templates/src/pages/invite/[token].vue",
     to: "src/pages/invite/[token].vue",
+    ownership: "app",
     reason: "Install public workspace invite acceptance route scaffold.",
     category: "workspaces-web",
     id: "workspaces-web-page-public-invite"
@@ -203,6 +205,7 @@ test("workspaces-web installs an account invites cue scaffold that reads placeme
   assert.deepEqual(findFileMutation("users-web-main-component-account-pending-invites-cue"), {
     from: "templates/packages/main/src/client/components/AccountPendingInvitesCue.vue",
     to: "packages/main/src/client/components/AccountPendingInvitesCue.vue",
+    ownership: "app",
     reason: "Install app-owned account pending invites cue component scaffold.",
     category: "workspaces-web",
     id: "users-web-main-component-account-pending-invites-cue"
@@ -417,6 +420,7 @@ test("workspaces-web descriptor metadata advertises admin settings outlets", () 
     from: "templates/src/pages/admin/workspace/settings/index.vue",
     toSurface: "admin",
     toSurfacePath: "workspace/settings/index.vue",
+    ownership: "app",
     reason: "Install workspace settings index stub scaffold for app-owned landing or redirect behavior.",
     category: "workspaces-web",
     id: "users-web-page-admin-workspace-settings",

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -6719,11 +6719,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-web",
-      "version": "0.1.107",
+      "version": "0.1.108",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-web",
-        "version": "0.1.107",
+        "version": "0.1.108",
         "kind": "runtime",
         "description": "Workspace web module: workspace selector, tools widget, workspace surfaces, members UI, and settings hosts.",
         "dependsOn": [

--- a/tooling/jskit-cli/src/server/commandHandlers/packageCommands/migrations.js
+++ b/tooling/jskit-cli/src/server/commandHandlers/packageCommands/migrations.js
@@ -53,7 +53,8 @@ async function runPackageMigrationsCommand(ctx = {}, { positional, options, cwd,
   await hydratePackageRegistryFromInstalledNodeModules({
     appRoot,
     packageRegistry: combinedPackageRegistry,
-    seedPackageIds: installedPackageIds
+    seedPackageIds: installedPackageIds,
+    preferInstalledDescriptors: true
   });
 
   let requestedPackageIds = [];

--- a/tooling/jskit-cli/test/migrationsCommand.test.js
+++ b/tooling/jskit-cli/test/migrationsCommand.test.js
@@ -180,3 +180,63 @@ test("migrations changed generates only migrations for changed installed package
     assert.match(String(verboseRun.stdout || ""), /skipped migration/i);
   });
 });
+
+test("migrations changed uses the installed descriptor instead of an older catalog entry", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "installed-descriptor-app");
+    const packageId = "@jskit-ai/http-runtime";
+    const installedVersion = "99.0.0";
+    const packageRoot = path.join(appRoot, "node_modules", ...packageId.split("/"));
+    await createMinimalApp(appRoot, { name: "installed-descriptor-app" });
+    await mkdir(packageRoot, { recursive: true });
+    await mkdir(path.join(appRoot, ".jskit"), { recursive: true });
+    await writeFile(path.join(packageRoot, "package.json"), `${JSON.stringify({
+      name: packageId,
+      version: installedVersion,
+      type: "module"
+    }, null, 2)}\n`, "utf8");
+    await writeFile(path.join(packageRoot, "package.descriptor.mjs"), `export default Object.freeze({
+  packageVersion: 1,
+  packageId: "${packageId}",
+  version: "${installedVersion}",
+  kind: "runtime",
+  runtime: { server: { providers: [] }, client: { providers: [] } },
+  mutations: { files: [] }
+});\n`, "utf8");
+    await writeFile(path.join(appRoot, ".jskit", "lock.json"), `${JSON.stringify({
+      lockVersion: 1,
+      installedPackages: {
+        [packageId]: {
+          packageId,
+          version: installedVersion,
+          source: {
+            type: "npm-installed-package",
+            packagePath: `node_modules/${packageId}`,
+            descriptorPath: `node_modules/${packageId}/package.descriptor.mjs`
+          },
+          managed: {
+            packageJson: { dependencies: {}, devDependencies: {}, scripts: {} },
+            text: {},
+            source: {},
+            vite: {},
+            files: [],
+            migrations: []
+          },
+          options: {},
+          migrationSyncVersion: "0.0.0"
+        }
+      }
+    }, null, 2)}\n`, "utf8");
+
+    const result = runCli({
+      cwd: appRoot,
+      args: ["migrations", "changed", "--json"]
+    });
+    assert.equal(result.status, 0, String(result.stderr || ""));
+    const payload = JSON.parse(String(result.stdout || "{}"));
+    assert.deepEqual(payload.requestedPackages, [packageId]);
+
+    const lock = JSON.parse(await readFile(path.join(appRoot, ".jskit", "lock.json"), "utf8"));
+    assert.equal(lock.installedPackages[packageId].migrationSyncVersion, installedVersion);
+  });
+});


### PR DESCRIPTION
Use the installed package descriptor as the authority when synchronizing migrations. This prevents an older bundled catalog entry from downgrading migrationSyncVersion for a newer installed package.\n\nValidation: focused migrations command tests and ESLint pass.