### PR TITLE
Release coherent JSKIT migration tooling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8149,9 +8149,9 @@
     },
     "tooling/create-app": {
       "name": "@jskit-ai/create-app",
-      "version": "0.1.146",
+      "version": "0.1.147",
       "dependencies": {
-        "@jskit-ai/jskit-cli": "0.2.149"
+        "@jskit-ai/jskit-cli": "0.2.150"
       },
       "bin": {
         "jskit-create-app": "bin/jskit-create-app.js"
@@ -8162,16 +8162,16 @@
     },
     "tooling/jskit-catalog": {
       "name": "@jskit-ai/jskit-catalog",
-      "version": "0.1.143",
+      "version": "0.1.144",
       "engines": {
         "node": "^22.12.0 || ^24.0.0 || ^26.0.0"
       }
     },
     "tooling/jskit-cli": {
       "name": "@jskit-ai/jskit-cli",
-      "version": "0.2.149",
+      "version": "0.2.150",
       "dependencies": {
-        "@jskit-ai/jskit-catalog": "0.1.143",
+        "@jskit-ai/jskit-catalog": "0.1.144",
         "@jskit-ai/kernel": "0.1.129",
         "@jskit-ai/shell-web": "0.1.130",
         "@vue/compiler-sfc": "^3.5.29",

--- a/tooling/create-app/package.descriptor.mjs
+++ b/tooling/create-app/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/create-app",
-  "version": "0.1.146",
+  "version": "0.1.147",
   "dependsOn": [],
   "capabilities": {
     "provides": [

--- a/tooling/create-app/package.json
+++ b/tooling/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/create-app",
-  "version": "0.1.146",
+  "version": "0.1.147",
   "description": "Scaffold JSKIT app shells.",
   "type": "module",
   "files": [
@@ -20,7 +20,7 @@
     "./client": "./src/client/index.js"
   },
   "dependencies": {
-    "@jskit-ai/jskit-cli": "0.2.149"
+    "@jskit-ai/jskit-cli": "0.2.150"
   },
   "engines": {
     "node": "^22.12.0 || ^24.0.0 || ^26.0.0"

--- a/tooling/jskit-catalog/package.json
+++ b/tooling/jskit-catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-catalog",
-  "version": "0.1.143",
+  "version": "0.1.144",
   "description": "Published metadata catalog for JSKIT package descriptors.",
   "type": "module",
   "files": [

--- a/tooling/jskit-cli/package.json
+++ b/tooling/jskit-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-cli",
-  "version": "0.2.149",
+  "version": "0.2.150",
   "description": "Bundle and package orchestration CLI for JSKIT apps.",
   "type": "module",
   "files": [
@@ -21,7 +21,7 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/jskit-catalog": "0.1.143",
+    "@jskit-ai/jskit-catalog": "0.1.144",
     "@jskit-ai/kernel": "0.1.129",
     "@jskit-ai/shell-web": "0.1.130",
     "@vue/compiler-sfc": "^3.5.29",


### PR DESCRIPTION
Records the published catalog 0.1.144, CLI 0.2.150, and create-app 0.1.147 releases. The CLI now uses installed descriptors for migration sync, the catalog includes workspaces-web 0.1.108, and create-app pins the corrected CLI.\n\nValidation: full CI passed on the source fix; focused release tests and generated checks pass.