### PR TITLE
Preserve MariaDB text column defaults

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7627,7 +7627,7 @@
     },
     "packages/crud-server-generator": {
       "name": "@jskit-ai/crud-server-generator",
-      "version": "0.1.142",
+      "version": "0.1.143",
       "dependencies": {
         "@babel/parser": "^7.29.2",
         "@jskit-ai/crud-core": "0.1.141",
@@ -7916,18 +7916,46 @@
         "node": "^22.13.0 || ^24.0.0 || ^26.0.0"
       }
     },
+    "tooling/create-app/node_modules/@jskit-ai/jskit-catalog": {
+      "version": "0.1.148",
+      "resolved": "https://registry.npmjs.org/@jskit-ai/jskit-catalog/-/jskit-catalog-0.1.148.tgz",
+      "integrity": "sha512-8Ryhoev/KgeVRV/2xIaUYLueyg66Xa4BxjnU9GX8TnRMTQ3sFnMpfGqT3XL1gbdUhmaGF3+jMfqngOfF0vHkLw==",
+      "engines": {
+        "node": "^22.13.0 || ^24.0.0 || ^26.0.0"
+      }
+    },
+    "tooling/create-app/node_modules/@jskit-ai/jskit-cli": {
+      "version": "0.2.154",
+      "resolved": "https://registry.npmjs.org/@jskit-ai/jskit-cli/-/jskit-cli-0.2.154.tgz",
+      "integrity": "sha512-U377JtWhoqG/vgBi1kyyj1/L+Hix5IMOh5x7fA8eJZHeQWzGBCdXU7xzmoB85gEUWh+U/VR/Xpvwje5UK/if6Q==",
+      "dependencies": {
+        "@jskit-ai/jskit-catalog": "0.1.148",
+        "@jskit-ai/kernel": "0.1.133",
+        "@jskit-ai/shell-web": "0.1.134",
+        "@vue/compiler-sfc": "^3.5.29",
+        "semver": "^7.7.4",
+        "ts-morph": "^28.0.0",
+        "yaml": "^2.8.3"
+      },
+      "bin": {
+        "jskit": "bin/jskit.js"
+      },
+      "engines": {
+        "node": "^22.13.0 || ^24.0.0 || ^26.0.0"
+      }
+    },
     "tooling/jskit-catalog": {
       "name": "@jskit-ai/jskit-catalog",
-      "version": "0.1.148",
+      "version": "0.1.149",
       "engines": {
         "node": "^22.13.0 || ^24.0.0 || ^26.0.0"
       }
     },
     "tooling/jskit-cli": {
       "name": "@jskit-ai/jskit-cli",
-      "version": "0.2.154",
+      "version": "0.2.155",
       "dependencies": {
-        "@jskit-ai/jskit-catalog": "0.1.148",
+        "@jskit-ai/jskit-catalog": "0.1.149",
         "@jskit-ai/kernel": "0.1.133",
         "@jskit-ai/shell-web": "0.1.134",
         "@vue/compiler-sfc": "^3.5.29",

--- a/packages/crud-server-generator/package.descriptor.mjs
+++ b/packages/crud-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-server-generator",
-  version: "0.1.142",
+  version: "0.1.143",
   kind: "generator",
   description: "CRUD server generator with routes, actions, and persistence scaffolding.",
   options: {

--- a/packages/crud-server-generator/package.json
+++ b/packages/crud-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-server-generator",
-  "version": "0.1.142",
+  "version": "0.1.143",
   "type": "module",
   "scripts": {
     "test": "node --test"

--- a/packages/crud-server-generator/src/server/buildTemplateContext.js
+++ b/packages/crud-server-generator/src/server/buildTemplateContext.js
@@ -1281,18 +1281,18 @@ function renderMigrationColumnLine(column, {
     }
   } else if (dataType === "char") {
     line = `table.specificType(${nameLiteral}, ${JSON.stringify(specificStringType || column.columnType || "char(255)")})`;
-  } else if (dataType === "text") {
-    if (specificStringType) {
-      line = `table.specificType(${nameLiteral}, ${JSON.stringify(specificStringType)})`;
-    } else {
-      line = `table.text(${nameLiteral})`;
-    }
-  } else if (dataType === "tinytext" || dataType === "mediumtext" || dataType === "longtext") {
-    if (specificStringType) {
-      line = `table.specificType(${nameLiteral}, ${JSON.stringify(specificStringType)})`;
-    } else {
-      line = `table.text(${nameLiteral}, ${JSON.stringify(dataType)})`;
-    }
+  } else if (
+    dataType === "text" ||
+    dataType === "tinytext" ||
+    dataType === "mediumtext" ||
+    dataType === "longtext"
+  ) {
+    // Knex's MySQL text() compiler silently omits column defaults. This
+    // migration is a dialect-specific schema snapshot, so retain the exact
+    // introspected TEXT-family type through specificType().
+    line = `table.specificType(${nameLiteral}, ${JSON.stringify(
+      specificStringType || column.columnType || dataType
+    )})`;
   } else if (dataType === "enum") {
     const enumValues = Array.isArray(column.enumValues) ? column.enumValues : [];
     line = `table.enu(${nameLiteral}, ${JSON.stringify(enumValues)})`;

--- a/packages/crud-server-generator/test/buildTemplateContext.test.js
+++ b/packages/crud-server-generator/test/buildTemplateContext.test.js
@@ -924,6 +924,38 @@ test("renderMigrationColumnLine unwraps quoted string defaults", () => {
   assert.match(enumLine, /\.defaultTo\("unknown"\)/);
 });
 
+test("renderMigrationColumnLine preserves defaults on MariaDB TEXT-family columns", () => {
+  for (const dataType of ["text", "tinytext", "mediumtext", "longtext"]) {
+    const name = `${dataType}_rules`;
+    const line = __testables.renderMigrationColumnLine({
+      name,
+      dataType,
+      columnType: dataType,
+      typeKind: "string",
+      nullable: false,
+      hasDefault: true,
+      defaultValue: "[]",
+      defaultExpression: null,
+      autoIncrement: false,
+      onUpdateExpression: null,
+      unsigned: false,
+      extra: "",
+      maxLength: null,
+      numericPrecision: null,
+      numericScale: null,
+      datetimePrecision: null,
+      characterSetName: "",
+      collationName: "",
+      enumValues: []
+    });
+
+    assert.equal(
+      line,
+      `table.specificType(${JSON.stringify(name)}, ${JSON.stringify(dataType)}).notNullable().defaultTo("[]");`
+    );
+  }
+});
+
 test("renderMigrationColumnLine preserves datetime precision", () => {
   const line = __testables.renderMigrationColumnLine({
     name: "deleted_at",

--- a/packages/crud-server-generator/test/mariaDbMigration.integration.test.js
+++ b/packages/crud-server-generator/test/mariaDbMigration.integration.test.js
@@ -11,6 +11,19 @@ const require = createRequire(import.meta.url);
 const RUN_MARIADB_INTEGRATION =
   String(process.env.JSKIT_DATABASE_INTEGRATION_DRIVER || "").trim().toLowerCase() === "mariadb";
 
+function createMariaDbKnex() {
+  return knexFactory({
+    client: "mysql2",
+    connection: {
+      host: process.env.DB_HOST,
+      port: Number(process.env.DB_PORT || 3306),
+      database: process.env.DB_NAME,
+      user: process.env.DB_USER,
+      password: process.env.DB_PASSWORD
+    }
+  });
+}
+
 function renderTemplate(source, replacements) {
   let rendered = source;
   for (const [key, value] of Object.entries(replacements)) {
@@ -39,16 +52,7 @@ test("generated MariaDB migrations rebuild mutual foreign keys from zero", {
   const currentVersionForeignKey = `fk_cycle_current_${suffix}`;
   const templateForeignKey = `fk_cycle_template_${suffix}`;
   const tempRoot = await mkdtemp(path.join(tmpdir(), "jskit-cycle-migrations-"));
-  const knex = knexFactory({
-    client: "mysql2",
-    connection: {
-      host: process.env.DB_HOST,
-      port: Number(process.env.DB_PORT || 3306),
-      database: process.env.DB_NAME,
-      user: process.env.DB_USER,
-      password: process.env.DB_PASSWORD
-    }
-  });
+  const knex = createMariaDbKnex();
 
   const dropFixtureTables = async () => {
     await knex.raw("SET FOREIGN_KEY_CHECKS = 0");
@@ -165,6 +169,103 @@ test("generated MariaDB migrations rebuild mutual foreign keys from zero", {
     assert.equal(await knex.schema.hasTable(versionsTable), false);
   } finally {
     await dropFixtureTables();
+    await knex.destroy();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("generated MariaDB migration preserves TEXT-family column defaults", {
+  skip: RUN_MARIADB_INTEGRATION
+    ? false
+    : "set JSKIT_DATABASE_INTEGRATION_DRIVER=mariadb to run the text-default test",
+  timeout: 120_000
+}, async () => {
+  const suffix = `${process.pid}_${Date.now()}`;
+  const tableName = `jskit_text_defaults_${suffix}`;
+  const tempRoot = await mkdtemp(path.join(tmpdir(), "jskit-text-default-migration-"));
+  const knex = createMariaDbKnex();
+
+  const readTextColumnMetadata = async () => {
+    const [rows] = await knex.raw(
+      `
+        SELECT
+          column_name AS columnName,
+          data_type AS dataType,
+          column_default AS columnDefault
+        FROM information_schema.columns
+        WHERE table_schema = DATABASE()
+          AND table_name = ?
+          AND column_name <> 'id'
+        ORDER BY ordinal_position
+      `,
+      [tableName]
+    );
+    return rows.map((row) => ({
+      columnName: row.columnName,
+      dataType: row.dataType,
+      columnDefault: row.columnDefault
+    }));
+  };
+
+  try {
+    await knex.schema.dropTableIfExists(tableName);
+    await knex.raw(
+      `
+        CREATE TABLE ?? (
+          id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+          text_rules TEXT NOT NULL DEFAULT 'text-default',
+          tinytext_rules TINYTEXT NOT NULL DEFAULT 'tiny-default',
+          mediumtext_rules MEDIUMTEXT NOT NULL DEFAULT 'medium-default',
+          due_date_rules_json LONGTEXT NOT NULL DEFAULT '[]'
+        )
+      `,
+      [tableName]
+    );
+
+    const sourceMetadata = await readTextColumnMetadata();
+    const { introspectCrudTableSnapshot } = await import(
+      "@jskit-ai/database-runtime-mysql/shared"
+    );
+    const snapshot = await introspectCrudTableSnapshot(knex, {
+      tableName
+    });
+    const replacements = __testables.buildReplacementsFromSnapshot({
+      namespace: tableName,
+      snapshot,
+      resolvedOwnershipFilter: "public",
+      surfaceRequiresWorkspace: false
+    });
+    assert.match(
+      replacements.__JSKIT_CRUD_MIGRATION_COLUMN_LINES__,
+      /table\.specificType\("due_date_rules_json", "longtext"\)\.notNullable\(\)\.defaultTo\("\[\]"\)/
+    );
+
+    const migration = await loadRenderedMigration(
+      tempRoot,
+      "text_defaults_initial.cjs",
+      path.resolve("packages/crud-server-generator/templates/migrations/crud_initial.cjs"),
+      replacements
+    );
+
+    await knex.schema.dropTable(tableName);
+    await migration.up(knex);
+    assert.deepEqual(await readTextColumnMetadata(), sourceMetadata);
+
+    await knex.raw("INSERT INTO ?? () VALUES ()", [tableName]);
+    const row = await knex(tableName)
+      .select("text_rules", "tinytext_rules", "mediumtext_rules", "due_date_rules_json")
+      .first();
+    assert.deepEqual(row, {
+      text_rules: "text-default",
+      tinytext_rules: "tiny-default",
+      mediumtext_rules: "medium-default",
+      due_date_rules_json: "[]"
+    });
+
+    await migration.down(knex);
+    assert.equal(await knex.schema.hasTable(tableName), false);
+  } finally {
+    await knex.schema.dropTableIfExists(tableName);
     await knex.destroy();
     await rm(tempRoot, { recursive: true, force: true });
   }

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -1844,11 +1844,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-server-generator",
-      "version": "0.1.142",
+      "version": "0.1.143",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-server-generator",
-        "version": "0.1.142",
+        "version": "0.1.143",
         "kind": "generator",
         "description": "CRUD server generator with routes, actions, and persistence scaffolding.",
         "options": {

--- a/tooling/jskit-catalog/package.json
+++ b/tooling/jskit-catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-catalog",
-  "version": "0.1.148",
+  "version": "0.1.149",
   "description": "Published metadata catalog for JSKIT package descriptors.",
   "type": "module",
   "files": [

--- a/tooling/jskit-cli/package.json
+++ b/tooling/jskit-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-cli",
-  "version": "0.2.154",
+  "version": "0.2.155",
   "description": "Bundle and package orchestration CLI for JSKIT apps.",
   "type": "module",
   "files": [
@@ -21,7 +21,7 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/jskit-catalog": "0.1.148",
+    "@jskit-ai/jskit-catalog": "0.1.149",
     "@jskit-ai/kernel": "0.1.133",
     "@jskit-ai/shell-web": "0.1.134",
     "@vue/compiler-sfc": "^3.5.29",


### PR DESCRIPTION
## Summary

- render introspected MariaDB `TEXT`, `TINYTEXT`, `MEDIUMTEXT`, and `LONGTEXT` columns through Knex `specificType()`
- preserve exact TEXT-family types, custom collation metadata, and literal defaults without raw-SQL promotion
- extend the real MariaDB migration receipt to compare `information_schema.COLUMNS.COLUMN_DEFAULT` before and after a generated rebuild

## Released versions

- `@jskit-ai/crud-server-generator@0.1.143`
- `@jskit-ai/jskit-catalog@0.1.149`
- `@jskit-ai/jskit-cli@0.2.155` -> exact catalog `0.1.149`

## Verification

- `npm test --workspace @jskit-ai/crud-server-generator` (84 passed, 2 integration tests gated)
- MariaDB 11.4 generated-migration integration suite (2 passed, including TEXT-family defaults)
- `npm run lint`
- `git diff --check`
- `npm run release -- --only @jskit-ai/crud-server-generator,@jskit-ai/jskit-catalog,@jskit-ai/jskit-cli`
- direct registry manifest verification after publication