### PR TITLE
Fix CRUD string ID search schema generation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7473,28 +7473,28 @@
     },
     "packages/agent-docs": {
       "name": "@jskit-ai/agent-docs",
-      "version": "0.1.99",
+      "version": "0.1.101",
       "engines": {
         "node": "^22.13.0 || ^24.0.0 || ^26.0.0"
       }
     },
     "packages/assistant": {
       "name": "@jskit-ai/assistant",
-      "version": "0.1.142",
+      "version": "0.1.144",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.133"
+        "@jskit-ai/kernel": "0.1.135"
       }
     },
     "packages/assistant-core": {
       "name": "@jskit-ai/assistant-core",
-      "version": "0.1.110",
+      "version": "0.1.112",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.132",
-        "@jskit-ai/http-runtime": "0.1.131",
-        "@jskit-ai/kernel": "0.1.133",
-        "@jskit-ai/resource-core": "0.1.76",
-        "@jskit-ai/resource-crud-core": "0.1.76",
-        "@jskit-ai/users-core": "0.1.143",
+        "@jskit-ai/database-runtime": "0.1.134",
+        "@jskit-ai/http-runtime": "0.1.133",
+        "@jskit-ai/kernel": "0.1.135",
+        "@jskit-ai/resource-core": "0.1.78",
+        "@jskit-ai/resource-crud-core": "0.1.78",
+        "@jskit-ai/users-core": "0.1.146",
         "dompurify": "^3.4.12",
         "json-rest-schema": "1.x.x",
         "marked": "^17.0.4",
@@ -7507,15 +7507,15 @@
     },
     "packages/assistant-runtime": {
       "name": "@jskit-ai/assistant-runtime",
-      "version": "0.1.105",
+      "version": "0.1.107",
       "dependencies": {
-        "@jskit-ai/assistant-core": "0.1.110",
-        "@jskit-ai/database-runtime": "0.1.132",
-        "@jskit-ai/http-runtime": "0.1.131",
-        "@jskit-ai/kernel": "0.1.133",
-        "@jskit-ai/shell-web": "0.1.134",
-        "@jskit-ai/users-core": "0.1.143",
-        "@jskit-ai/users-web": "0.1.149",
+        "@jskit-ai/assistant-core": "0.1.112",
+        "@jskit-ai/database-runtime": "0.1.134",
+        "@jskit-ai/http-runtime": "0.1.133",
+        "@jskit-ai/kernel": "0.1.135",
+        "@jskit-ai/shell-web": "0.1.136",
+        "@jskit-ai/users-core": "0.1.146",
+        "@jskit-ai/users-web": "0.1.152",
         "json-rest-schema": "1.x.x"
       },
       "peerDependencies": {
@@ -7526,39 +7526,39 @@
     },
     "packages/auth-core": {
       "name": "@jskit-ai/auth-core",
-      "version": "0.1.130",
+      "version": "0.1.133",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0",
-        "@jskit-ai/kernel": "0.1.133",
+        "@jskit-ai/kernel": "0.1.135",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/auth-provider-local-core": {
       "name": "@jskit-ai/auth-provider-local-core",
-      "version": "0.1.34",
+      "version": "0.1.37",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.130",
-        "@jskit-ai/kernel": "0.1.133",
+        "@jskit-ai/auth-core": "0.1.133",
+        "@jskit-ai/kernel": "0.1.135",
         "nodemailer": "^9.0.3"
       }
     },
     "packages/auth-provider-local-db-core": {
       "name": "@jskit-ai/auth-provider-local-db-core",
-      "version": "0.1.25",
+      "version": "0.1.28",
       "dependencies": {
-        "@jskit-ai/auth-provider-local-core": "0.1.34",
-        "@jskit-ai/database-runtime": "0.1.132",
-        "@jskit-ai/kernel": "0.1.133"
+        "@jskit-ai/auth-provider-local-core": "0.1.37",
+        "@jskit-ai/database-runtime": "0.1.134",
+        "@jskit-ai/kernel": "0.1.135"
       }
     },
     "packages/auth-provider-supabase-core": {
       "name": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.131",
+      "version": "0.1.133",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.130",
-        "@jskit-ai/kernel": "0.1.133",
+        "@jskit-ai/auth-core": "0.1.133",
+        "@jskit-ai/kernel": "0.1.135",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0",
         "json-rest-schema": "1.x.x",
@@ -7567,12 +7567,12 @@
     },
     "packages/auth-web": {
       "name": "@jskit-ai/auth-web",
-      "version": "0.1.133",
+      "version": "0.1.136",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.130",
-        "@jskit-ai/http-runtime": "0.1.131",
-        "@jskit-ai/kernel": "0.1.133",
-        "@jskit-ai/shell-web": "0.1.134",
+        "@jskit-ai/auth-core": "0.1.133",
+        "@jskit-ai/http-runtime": "0.1.133",
+        "@jskit-ai/kernel": "0.1.135",
+        "@jskit-ai/shell-web": "0.1.136",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -7585,38 +7585,38 @@
     },
     "packages/console-core": {
       "name": "@jskit-ai/console-core",
-      "version": "0.1.97",
+      "version": "0.1.99",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.130",
-        "@jskit-ai/database-runtime": "0.1.132",
-        "@jskit-ai/http-runtime": "0.1.131",
-        "@jskit-ai/kernel": "0.1.133",
-        "@jskit-ai/resource-crud-core": "0.1.76",
-        "@jskit-ai/users-core": "0.1.143",
+        "@jskit-ai/auth-core": "0.1.133",
+        "@jskit-ai/database-runtime": "0.1.134",
+        "@jskit-ai/http-runtime": "0.1.133",
+        "@jskit-ai/kernel": "0.1.135",
+        "@jskit-ai/resource-crud-core": "0.1.78",
+        "@jskit-ai/users-core": "0.1.146",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/console-web": {
       "name": "@jskit-ai/console-web",
-      "version": "0.1.102",
+      "version": "0.1.104",
       "dependencies": {
-        "@jskit-ai/auth-web": "0.1.133",
-        "@jskit-ai/console-core": "0.1.97",
-        "@jskit-ai/shell-web": "0.1.134"
+        "@jskit-ai/auth-web": "0.1.136",
+        "@jskit-ai/console-core": "0.1.99",
+        "@jskit-ai/shell-web": "0.1.136"
       }
     },
     "packages/crud-core": {
       "name": "@jskit-ai/crud-core",
-      "version": "0.1.141",
+      "version": "0.1.144",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.132",
-        "@jskit-ai/http-runtime": "0.1.131",
-        "@jskit-ai/kernel": "0.1.133",
-        "@jskit-ai/realtime": "0.1.130",
-        "@jskit-ai/resource-crud-core": "0.1.76",
-        "@jskit-ai/shell-web": "0.1.134",
-        "@jskit-ai/users-core": "0.1.143",
-        "@jskit-ai/users-web": "0.1.149",
+        "@jskit-ai/database-runtime": "0.1.134",
+        "@jskit-ai/http-runtime": "0.1.133",
+        "@jskit-ai/kernel": "0.1.135",
+        "@jskit-ai/realtime": "0.1.132",
+        "@jskit-ai/resource-crud-core": "0.1.78",
+        "@jskit-ai/shell-web": "0.1.136",
+        "@jskit-ai/users-core": "0.1.146",
+        "@jskit-ai/users-web": "0.1.152",
         "json-rest-schema": "1.x.x"
       },
       "peerDependencies": {
@@ -7627,98 +7627,98 @@
     },
     "packages/crud-server-generator": {
       "name": "@jskit-ai/crud-server-generator",
-      "version": "0.1.143",
+      "version": "0.1.145",
       "dependencies": {
         "@babel/parser": "^7.29.2",
-        "@jskit-ai/crud-core": "0.1.141",
-        "@jskit-ai/database-runtime": "0.1.132",
-        "@jskit-ai/http-runtime": "0.1.131",
-        "@jskit-ai/json-rest-api-core": "0.1.77",
-        "@jskit-ai/kernel": "0.1.133",
-        "@jskit-ai/resource-crud-core": "0.1.76",
+        "@jskit-ai/crud-core": "0.1.144",
+        "@jskit-ai/database-runtime": "0.1.134",
+        "@jskit-ai/http-runtime": "0.1.133",
+        "@jskit-ai/json-rest-api-core": "0.1.79",
+        "@jskit-ai/kernel": "0.1.135",
+        "@jskit-ai/resource-crud-core": "0.1.78",
         "recast": "^0.23.11"
       }
     },
     "packages/crud-ui-generator": {
       "name": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.116",
+      "version": "0.1.118",
       "dependencies": {
-        "@jskit-ai/crud-core": "0.1.141",
-        "@jskit-ai/kernel": "0.1.133",
-        "@jskit-ai/resource-crud-core": "0.1.76"
+        "@jskit-ai/crud-core": "0.1.144",
+        "@jskit-ai/kernel": "0.1.135",
+        "@jskit-ai/resource-crud-core": "0.1.78"
       }
     },
     "packages/database-runtime": {
       "name": "@jskit-ai/database-runtime",
-      "version": "0.1.132",
+      "version": "0.1.134",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.133"
+        "@jskit-ai/kernel": "0.1.135"
       }
     },
     "packages/database-runtime-mysql": {
       "name": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.131",
+      "version": "0.1.133",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.132",
-        "@jskit-ai/kernel": "0.1.133"
+        "@jskit-ai/database-runtime": "0.1.134",
+        "@jskit-ai/kernel": "0.1.135"
       }
     },
     "packages/database-runtime-postgres": {
       "name": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.130",
+      "version": "0.1.132",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.132"
+        "@jskit-ai/database-runtime": "0.1.134"
       }
     },
     "packages/feature-server-generator": {
       "name": "@jskit-ai/feature-server-generator",
-      "version": "0.1.75"
+      "version": "0.1.77"
     },
     "packages/google-rewarded-core": {
       "name": "@jskit-ai/google-rewarded-core",
-      "version": "0.1.70"
+      "version": "0.1.72"
     },
     "packages/google-rewarded-web": {
       "name": "@jskit-ai/google-rewarded-web",
-      "version": "0.1.70"
+      "version": "0.1.72"
     },
     "packages/http-runtime": {
       "name": "@jskit-ai/http-runtime",
-      "version": "0.1.131",
+      "version": "0.1.133",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.133",
+        "@jskit-ai/kernel": "0.1.135",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/json-rest-api-core": {
       "name": "@jskit-ai/json-rest-api-core",
-      "version": "0.1.77",
+      "version": "0.1.79",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.133",
+        "@jskit-ai/kernel": "0.1.135",
         "hooked-api": "1.x.x",
         "json-rest-api": "^1.0.26"
       }
     },
     "packages/kernel": {
       "name": "@jskit-ai/kernel",
-      "version": "0.1.133",
+      "version": "0.1.135",
       "dependencies": {
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/mobile-capacitor": {
       "name": "@jskit-ai/mobile-capacitor",
-      "version": "0.1.69",
+      "version": "0.1.71",
       "dependencies": {
         "@capacitor/browser": "^7.0.1",
-        "@jskit-ai/kernel": "0.1.133"
+        "@jskit-ai/kernel": "0.1.135"
       }
     },
     "packages/realtime": {
       "name": "@jskit-ai/realtime",
-      "version": "0.1.130",
+      "version": "0.1.132",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.133",
+        "@jskit-ai/kernel": "0.1.135",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",
@@ -7730,24 +7730,24 @@
     },
     "packages/resource-core": {
       "name": "@jskit-ai/resource-core",
-      "version": "0.1.76",
+      "version": "0.1.78",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.133"
+        "@jskit-ai/kernel": "0.1.135"
       }
     },
     "packages/resource-crud-core": {
       "name": "@jskit-ai/resource-crud-core",
-      "version": "0.1.76",
+      "version": "0.1.78",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.133",
-        "@jskit-ai/resource-core": "0.1.76"
+        "@jskit-ai/kernel": "0.1.135",
+        "@jskit-ai/resource-core": "0.1.78"
       }
     },
     "packages/shell-web": {
       "name": "@jskit-ai/shell-web",
-      "version": "0.1.134",
+      "version": "0.1.136",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.133",
+        "@jskit-ai/kernel": "0.1.135",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -7759,25 +7759,25 @@
     },
     "packages/storage-runtime": {
       "name": "@jskit-ai/storage-runtime",
-      "version": "0.1.131",
+      "version": "0.1.133",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.133",
+        "@jskit-ai/kernel": "0.1.135",
         "unstorage": "^1.17.5"
       }
     },
     "packages/ui-generator": {
       "name": "@jskit-ai/ui-generator",
-      "version": "0.1.116",
+      "version": "0.1.118",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.133",
-        "@jskit-ai/shell-web": "0.1.134"
+        "@jskit-ai/kernel": "0.1.135",
+        "@jskit-ai/shell-web": "0.1.136"
       }
     },
     "packages/uploads-image-web": {
       "name": "@jskit-ai/uploads-image-web",
-      "version": "0.1.109",
+      "version": "0.1.111",
       "dependencies": {
-        "@jskit-ai/uploads-runtime": "0.1.109",
+        "@jskit-ai/uploads-runtime": "0.1.111",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",
@@ -7790,37 +7790,37 @@
     },
     "packages/uploads-runtime": {
       "name": "@jskit-ai/uploads-runtime",
-      "version": "0.1.109",
+      "version": "0.1.111",
       "dependencies": {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.133"
+        "@jskit-ai/kernel": "0.1.135"
       }
     },
     "packages/users-core": {
       "name": "@jskit-ai/users-core",
-      "version": "0.1.143",
+      "version": "0.1.146",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.130",
-        "@jskit-ai/database-runtime": "0.1.132",
-        "@jskit-ai/http-runtime": "0.1.131",
-        "@jskit-ai/json-rest-api-core": "0.1.77",
-        "@jskit-ai/kernel": "0.1.133",
-        "@jskit-ai/resource-core": "0.1.76",
-        "@jskit-ai/resource-crud-core": "0.1.76",
-        "@jskit-ai/uploads-runtime": "0.1.109",
+        "@jskit-ai/auth-core": "0.1.133",
+        "@jskit-ai/database-runtime": "0.1.134",
+        "@jskit-ai/http-runtime": "0.1.133",
+        "@jskit-ai/json-rest-api-core": "0.1.79",
+        "@jskit-ai/kernel": "0.1.135",
+        "@jskit-ai/resource-core": "0.1.78",
+        "@jskit-ai/resource-crud-core": "0.1.78",
+        "@jskit-ai/uploads-runtime": "0.1.111",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/users-web": {
       "name": "@jskit-ai/users-web",
-      "version": "0.1.149",
+      "version": "0.1.152",
       "dependencies": {
-        "@jskit-ai/http-runtime": "0.1.131",
-        "@jskit-ai/kernel": "0.1.133",
-        "@jskit-ai/realtime": "0.1.130",
-        "@jskit-ai/shell-web": "0.1.134",
-        "@jskit-ai/uploads-image-web": "0.1.109",
-        "@jskit-ai/users-core": "0.1.143",
+        "@jskit-ai/http-runtime": "0.1.133",
+        "@jskit-ai/kernel": "0.1.135",
+        "@jskit-ai/realtime": "0.1.132",
+        "@jskit-ai/shell-web": "0.1.136",
+        "@jskit-ai/uploads-image-web": "0.1.111",
+        "@jskit-ai/users-core": "0.1.146",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -7832,30 +7832,30 @@
     },
     "packages/workspaces-core": {
       "name": "@jskit-ai/workspaces-core",
-      "version": "0.1.110",
+      "version": "0.1.113",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.130",
-        "@jskit-ai/database-runtime": "0.1.132",
-        "@jskit-ai/http-runtime": "0.1.131",
-        "@jskit-ai/json-rest-api-core": "0.1.77",
-        "@jskit-ai/kernel": "0.1.133",
-        "@jskit-ai/resource-core": "0.1.76",
-        "@jskit-ai/resource-crud-core": "0.1.76",
-        "@jskit-ai/users-core": "0.1.143",
+        "@jskit-ai/auth-core": "0.1.133",
+        "@jskit-ai/database-runtime": "0.1.134",
+        "@jskit-ai/http-runtime": "0.1.133",
+        "@jskit-ai/json-rest-api-core": "0.1.79",
+        "@jskit-ai/kernel": "0.1.135",
+        "@jskit-ai/resource-core": "0.1.78",
+        "@jskit-ai/resource-crud-core": "0.1.78",
+        "@jskit-ai/users-core": "0.1.146",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/workspaces-web": {
       "name": "@jskit-ai/workspaces-web",
-      "version": "0.1.112",
+      "version": "0.1.115",
       "dependencies": {
-        "@jskit-ai/auth-web": "0.1.133",
-        "@jskit-ai/http-runtime": "0.1.131",
-        "@jskit-ai/kernel": "0.1.133",
-        "@jskit-ai/shell-web": "0.1.134",
-        "@jskit-ai/users-core": "0.1.143",
-        "@jskit-ai/users-web": "0.1.149",
-        "@jskit-ai/workspaces-core": "0.1.110",
+        "@jskit-ai/auth-web": "0.1.136",
+        "@jskit-ai/http-runtime": "0.1.133",
+        "@jskit-ai/kernel": "0.1.135",
+        "@jskit-ai/shell-web": "0.1.136",
+        "@jskit-ai/users-core": "0.1.146",
+        "@jskit-ai/users-web": "0.1.152",
+        "@jskit-ai/workspaces-core": "0.1.113",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -7867,7 +7867,7 @@
     },
     "tooling/config-eslint": {
       "name": "@jskit-ai/config-eslint",
-      "version": "0.1.131",
+      "version": "0.1.133",
       "dependencies": {
         "@eslint/js": "^10.0.1",
         "eslint-plugin-vue": "^10.5.1",
@@ -7905,9 +7905,9 @@
     },
     "tooling/create-app": {
       "name": "@jskit-ai/create-app",
-      "version": "0.1.151",
+      "version": "0.1.154",
       "dependencies": {
-        "@jskit-ai/jskit-cli": "0.2.154"
+        "@jskit-ai/jskit-cli": "0.2.158"
       },
       "bin": {
         "jskit-create-app": "bin/jskit-create-app.js"
@@ -7916,48 +7916,20 @@
         "node": "^22.13.0 || ^24.0.0 || ^26.0.0"
       }
     },
-    "tooling/create-app/node_modules/@jskit-ai/jskit-catalog": {
-      "version": "0.1.148",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/jskit-catalog/-/jskit-catalog-0.1.148.tgz",
-      "integrity": "sha512-8Ryhoev/KgeVRV/2xIaUYLueyg66Xa4BxjnU9GX8TnRMTQ3sFnMpfGqT3XL1gbdUhmaGF3+jMfqngOfF0vHkLw==",
-      "engines": {
-        "node": "^22.13.0 || ^24.0.0 || ^26.0.0"
-      }
-    },
-    "tooling/create-app/node_modules/@jskit-ai/jskit-cli": {
-      "version": "0.2.154",
-      "resolved": "https://registry.npmjs.org/@jskit-ai/jskit-cli/-/jskit-cli-0.2.154.tgz",
-      "integrity": "sha512-U377JtWhoqG/vgBi1kyyj1/L+Hix5IMOh5x7fA8eJZHeQWzGBCdXU7xzmoB85gEUWh+U/VR/Xpvwje5UK/if6Q==",
-      "dependencies": {
-        "@jskit-ai/jskit-catalog": "0.1.148",
-        "@jskit-ai/kernel": "0.1.133",
-        "@jskit-ai/shell-web": "0.1.134",
-        "@vue/compiler-sfc": "^3.5.29",
-        "semver": "^7.7.4",
-        "ts-morph": "^28.0.0",
-        "yaml": "^2.8.3"
-      },
-      "bin": {
-        "jskit": "bin/jskit.js"
-      },
-      "engines": {
-        "node": "^22.13.0 || ^24.0.0 || ^26.0.0"
-      }
-    },
     "tooling/jskit-catalog": {
       "name": "@jskit-ai/jskit-catalog",
-      "version": "0.1.149",
+      "version": "0.1.152",
       "engines": {
         "node": "^22.13.0 || ^24.0.0 || ^26.0.0"
       }
     },
     "tooling/jskit-cli": {
       "name": "@jskit-ai/jskit-cli",
-      "version": "0.2.155",
+      "version": "0.2.158",
       "dependencies": {
-        "@jskit-ai/jskit-catalog": "0.1.149",
-        "@jskit-ai/kernel": "0.1.133",
-        "@jskit-ai/shell-web": "0.1.134",
+        "@jskit-ai/jskit-catalog": "0.1.152",
+        "@jskit-ai/kernel": "0.1.135",
+        "@jskit-ai/shell-web": "0.1.136",
         "@vue/compiler-sfc": "^3.5.29",
         "semver": "^7.7.4",
         "ts-morph": "^28.0.0",

--- a/packages/agent-docs/package.json
+++ b/packages/agent-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/agent-docs",
-  "version": "0.1.99",
+  "version": "0.1.101",
   "description": "Distributed JSKIT agent references, prompts, guides, and generated reference maps.",
   "type": "module",
   "files": [

--- a/packages/assistant-core/package.descriptor.mjs
+++ b/packages/assistant-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-core",
-  version: "0.1.110",
+  version: "0.1.112",
   kind: "runtime",
   description: "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
   dependsOn: [
@@ -47,11 +47,11 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/http-runtime": "0.1.131",
-        "@jskit-ai/kernel": "0.1.133",
-        "@jskit-ai/resource-core": "0.1.76",
-        "@jskit-ai/resource-crud-core": "0.1.76",
-        "@jskit-ai/users-core": "0.1.143",
+        "@jskit-ai/http-runtime": "0.1.133",
+        "@jskit-ai/kernel": "0.1.135",
+        "@jskit-ai/resource-core": "0.1.78",
+        "@jskit-ai/resource-crud-core": "0.1.78",
+        "@jskit-ai/users-core": "0.1.146",
         "dompurify": "^3.3.3",
         "json-rest-schema": "1.x.x",
         "marked": "^17.0.4",

--- a/packages/assistant-core/package.json
+++ b/packages/assistant-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-core",
-  "version": "0.1.110",
+  "version": "0.1.112",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,12 +11,12 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.132",
-    "@jskit-ai/http-runtime": "0.1.131",
-    "@jskit-ai/kernel": "0.1.133",
-    "@jskit-ai/resource-crud-core": "0.1.76",
-    "@jskit-ai/resource-core": "0.1.76",
-    "@jskit-ai/users-core": "0.1.143",
+    "@jskit-ai/database-runtime": "0.1.134",
+    "@jskit-ai/http-runtime": "0.1.133",
+    "@jskit-ai/kernel": "0.1.135",
+    "@jskit-ai/resource-crud-core": "0.1.78",
+    "@jskit-ai/resource-core": "0.1.78",
+    "@jskit-ai/users-core": "0.1.146",
     "dompurify": "^3.4.12",
     "json-rest-schema": "1.x.x",
     "marked": "^17.0.4",

--- a/packages/assistant-runtime/package.descriptor.mjs
+++ b/packages/assistant-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-runtime",
-  version: "0.1.105",
+  version: "0.1.107",
   kind: "runtime",
   description: "Shared assistant runtime with per-surface assistant registration.",
   dependsOn: [
@@ -95,13 +95,13 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/assistant-core": "0.1.110",
-        "@jskit-ai/database-runtime": "0.1.132",
-        "@jskit-ai/http-runtime": "0.1.131",
-        "@jskit-ai/kernel": "0.1.133",
-        "@jskit-ai/shell-web": "0.1.134",
-        "@jskit-ai/users-core": "0.1.143",
-        "@jskit-ai/users-web": "0.1.149"
+        "@jskit-ai/assistant-core": "0.1.112",
+        "@jskit-ai/database-runtime": "0.1.134",
+        "@jskit-ai/http-runtime": "0.1.133",
+        "@jskit-ai/kernel": "0.1.135",
+        "@jskit-ai/shell-web": "0.1.136",
+        "@jskit-ai/users-core": "0.1.146",
+        "@jskit-ai/users-web": "0.1.152"
       },
       dev: {}
     },

--- a/packages/assistant-runtime/package.json
+++ b/packages/assistant-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-runtime",
-  "version": "0.1.105",
+  "version": "0.1.107",
   "type": "module",
   "exports": {
     "./client": "./src/client/index.js",
@@ -8,13 +8,13 @@
     "./server/actionIds": "./src/server/actionIds.js"
   },
   "dependencies": {
-    "@jskit-ai/assistant-core": "0.1.110",
-    "@jskit-ai/database-runtime": "0.1.132",
-    "@jskit-ai/http-runtime": "0.1.131",
-    "@jskit-ai/kernel": "0.1.133",
-    "@jskit-ai/shell-web": "0.1.134",
-    "@jskit-ai/users-core": "0.1.143",
-    "@jskit-ai/users-web": "0.1.149",
+    "@jskit-ai/assistant-core": "0.1.112",
+    "@jskit-ai/database-runtime": "0.1.134",
+    "@jskit-ai/http-runtime": "0.1.133",
+    "@jskit-ai/kernel": "0.1.135",
+    "@jskit-ai/shell-web": "0.1.136",
+    "@jskit-ai/users-core": "0.1.146",
+    "@jskit-ai/users-web": "0.1.152",
     "json-rest-schema": "1.x.x"
   },
   "peerDependencies": {

--- a/packages/assistant/package.descriptor.mjs
+++ b/packages/assistant/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant",
-  version: "0.1.142",
+  version: "0.1.144",
   kind: "generator",
   description: "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
   options: {

--- a/packages/assistant/package.json
+++ b/packages/assistant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant",
-  "version": "0.1.142",
+  "version": "0.1.144",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.133"
+    "@jskit-ai/kernel": "0.1.135"
   }
 }

--- a/packages/auth-core/package.descriptor.mjs
+++ b/packages/auth-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-core",
-  "version": "0.1.130",
+  "version": "0.1.133",
   "kind": "runtime",
   "dependsOn": [
     "@jskit-ai/value-app-config-shared"
@@ -74,7 +74,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.133",
+        "@jskit-ai/kernel": "0.1.135",
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0"

--- a/packages/auth-core/package.json
+++ b/packages/auth-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-core",
-  "version": "0.1.130",
+  "version": "0.1.133",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -56,7 +56,7 @@
     "./shared/commands/authSessionReadCommand": "./src/shared/commands/authSessionReadCommand.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.133",
+    "@jskit-ai/kernel": "0.1.135",
     "@fastify/cookie": "^11.0.2",
     "@fastify/csrf-protection": "^7.1.0",
     "@fastify/rate-limit": "^10.3.0",

--- a/packages/auth-provider-local-core/package.descriptor.mjs
+++ b/packages/auth-provider-local-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-provider-local-core",
-  "version": "0.1.34",
+  "version": "0.1.37",
   "kind": "runtime",
   "description": "Local auth provider with a file backend default and no database requirement.",
   "dependsOn": [
@@ -64,8 +64,8 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/auth-core": "0.1.130",
-        "@jskit-ai/kernel": "0.1.133",
+        "@jskit-ai/auth-core": "0.1.133",
+        "@jskit-ai/kernel": "0.1.135",
         "nodemailer": "^9.0.3",
         "dotenv": "^16.4.5"
       },

--- a/packages/auth-provider-local-core/package.json
+++ b/packages/auth-provider-local-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-local-core",
-  "version": "0.1.34",
+  "version": "0.1.37",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,8 +11,8 @@
     "./server/lib/index": "./src/server/lib/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.130",
-    "@jskit-ai/kernel": "0.1.133",
+    "@jskit-ai/auth-core": "0.1.133",
+    "@jskit-ai/kernel": "0.1.135",
     "nodemailer": "^9.0.3"
   }
 }

--- a/packages/auth-provider-local-db-core/package.descriptor.mjs
+++ b/packages/auth-provider-local-db-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/auth-provider-local-db-core",
-  version: "0.1.25",
+  version: "0.1.28",
   kind: "runtime",
   description: "Database-backed local auth storage backend for JSKIT local auth.",
   dependsOn: [
@@ -80,9 +80,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-provider-local-core": "0.1.34",
-        "@jskit-ai/database-runtime": "0.1.132",
-        "@jskit-ai/kernel": "0.1.133"
+        "@jskit-ai/auth-provider-local-core": "0.1.37",
+        "@jskit-ai/database-runtime": "0.1.134",
+        "@jskit-ai/kernel": "0.1.135"
       },
       dev: {}
     },

--- a/packages/auth-provider-local-db-core/package.json
+++ b/packages/auth-provider-local-db-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-local-db-core",
-  "version": "0.1.25",
+  "version": "0.1.28",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,8 +10,8 @@
     "./server/lib/index": "./src/server/lib/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-provider-local-core": "0.1.34",
-    "@jskit-ai/database-runtime": "0.1.132",
-    "@jskit-ai/kernel": "0.1.133"
+    "@jskit-ai/auth-provider-local-core": "0.1.37",
+    "@jskit-ai/database-runtime": "0.1.134",
+    "@jskit-ai/kernel": "0.1.135"
   }
 }

--- a/packages/auth-provider-supabase-core/package.descriptor.mjs
+++ b/packages/auth-provider-supabase-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.131",
+  "version": "0.1.133",
   "kind": "runtime",
   "options": {
     "auth-supabase-url": {
@@ -83,8 +83,8 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/auth-core": "0.1.130",
-        "@jskit-ai/kernel": "0.1.133",
+        "@jskit-ai/auth-core": "0.1.133",
+        "@jskit-ai/kernel": "0.1.135",
         "dotenv": "^16.4.5",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0"

--- a/packages/auth-provider-supabase-core/package.json
+++ b/packages/auth-provider-supabase-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.131",
+  "version": "0.1.133",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,8 +12,8 @@
     "./client": "./src/client/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.130",
-    "@jskit-ai/kernel": "0.1.133",
+    "@jskit-ai/auth-core": "0.1.133",
+    "@jskit-ai/kernel": "0.1.135",
     "json-rest-schema": "1.x.x",
     "jose": "^6.1.0",
     "@supabase/supabase-js": "^2.57.4",

--- a/packages/auth-web/package.descriptor.mjs
+++ b/packages/auth-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-web",
-  "version": "0.1.133",
+  "version": "0.1.136",
   "kind": "runtime",
   "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
   "dependsOn": [
@@ -264,10 +264,10 @@ export default Object.freeze({
     "dependencies": {
       "runtime": {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/auth-core": "0.1.130",
-        "@jskit-ai/http-runtime": "0.1.131",
-        "@jskit-ai/kernel": "0.1.133",
-        "@jskit-ai/shell-web": "0.1.134"
+        "@jskit-ai/auth-core": "0.1.133",
+        "@jskit-ai/http-runtime": "0.1.133",
+        "@jskit-ai/kernel": "0.1.135",
+        "@jskit-ai/shell-web": "0.1.136"
       },
       "dev": {}
     },

--- a/packages/auth-web/package.json
+++ b/packages/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-web",
-  "version": "0.1.133",
+  "version": "0.1.136",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -20,11 +20,11 @@
     "./test/playwright": "./src/test/playwright.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.130",
+    "@jskit-ai/auth-core": "0.1.133",
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/kernel": "0.1.133",
-    "@jskit-ai/shell-web": "0.1.134",
-    "@jskit-ai/http-runtime": "0.1.131"
+    "@jskit-ai/kernel": "0.1.135",
+    "@jskit-ai/shell-web": "0.1.136",
+    "@jskit-ai/http-runtime": "0.1.133"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/console-core/package.descriptor.mjs
+++ b/packages/console-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-core",
-  version: "0.1.97",
+  version: "0.1.99",
   kind: "runtime",
   description: "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
   dependsOn: [
@@ -85,12 +85,12 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.130",
-        "@jskit-ai/database-runtime": "0.1.132",
-        "@jskit-ai/http-runtime": "0.1.131",
-        "@jskit-ai/kernel": "0.1.133",
-        "@jskit-ai/resource-crud-core": "0.1.76",
-        "@jskit-ai/users-core": "0.1.143"
+        "@jskit-ai/auth-core": "0.1.133",
+        "@jskit-ai/database-runtime": "0.1.134",
+        "@jskit-ai/http-runtime": "0.1.133",
+        "@jskit-ai/kernel": "0.1.135",
+        "@jskit-ai/resource-crud-core": "0.1.78",
+        "@jskit-ai/users-core": "0.1.146"
       },
       dev: {}
     },

--- a/packages/console-core/package.json
+++ b/packages/console-core/package.json
@@ -1,17 +1,17 @@
 {
   "name": "@jskit-ai/console-core",
-  "version": "0.1.97",
+  "version": "0.1.99",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.130",
-    "@jskit-ai/database-runtime": "0.1.132",
-    "@jskit-ai/http-runtime": "0.1.131",
-    "@jskit-ai/kernel": "0.1.133",
-    "@jskit-ai/resource-crud-core": "0.1.76",
-    "@jskit-ai/users-core": "0.1.143",
+    "@jskit-ai/auth-core": "0.1.133",
+    "@jskit-ai/database-runtime": "0.1.134",
+    "@jskit-ai/http-runtime": "0.1.133",
+    "@jskit-ai/kernel": "0.1.135",
+    "@jskit-ai/resource-crud-core": "0.1.78",
+    "@jskit-ai/users-core": "0.1.146",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/console-web/package.descriptor.mjs
+++ b/packages/console-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-web",
-  version: "0.1.102",
+  version: "0.1.104",
   kind: "runtime",
   description: "Authenticated console surface scaffold and surface policy wiring.",
   dependsOn: [
@@ -103,9 +103,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-web": "0.1.133",
-        "@jskit-ai/console-core": "0.1.97",
-        "@jskit-ai/shell-web": "0.1.134",
+        "@jskit-ai/auth-web": "0.1.136",
+        "@jskit-ai/console-core": "0.1.99",
+        "@jskit-ai/shell-web": "0.1.136",
       },
       dev: {}
     },

--- a/packages/console-web/package.json
+++ b/packages/console-web/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/console-web",
-  "version": "0.1.102",
+  "version": "0.1.104",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-web": "0.1.133",
-    "@jskit-ai/console-core": "0.1.97",
-    "@jskit-ai/shell-web": "0.1.134"
+    "@jskit-ai/auth-web": "0.1.136",
+    "@jskit-ai/console-core": "0.1.99",
+    "@jskit-ai/shell-web": "0.1.136"
   }
 }

--- a/packages/crud-core/package.descriptor.mjs
+++ b/packages/crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-core",
-  version: "0.1.141",
+  version: "0.1.144",
   kind: "runtime",
   description: "Shared CRUD helpers used by CRUD modules.",
   dependsOn: [
@@ -28,7 +28,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/crud-core": "0.1.141"
+        "@jskit-ai/crud-core": "0.1.144"
       },
       dev: {}
     },

--- a/packages/crud-core/package.json
+++ b/packages/crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-core",
-  "version": "0.1.141",
+  "version": "0.1.144",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -27,15 +27,15 @@
     "./server/routeContracts": "./src/server/routeContracts.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.132",
-    "@jskit-ai/http-runtime": "0.1.131",
-    "@jskit-ai/kernel": "0.1.133",
+    "@jskit-ai/database-runtime": "0.1.134",
+    "@jskit-ai/http-runtime": "0.1.133",
+    "@jskit-ai/kernel": "0.1.135",
     "json-rest-schema": "1.x.x",
-    "@jskit-ai/realtime": "0.1.130",
-    "@jskit-ai/resource-crud-core": "0.1.76",
-    "@jskit-ai/shell-web": "0.1.134",
-    "@jskit-ai/users-core": "0.1.143",
-    "@jskit-ai/users-web": "0.1.149"
+    "@jskit-ai/realtime": "0.1.132",
+    "@jskit-ai/resource-crud-core": "0.1.78",
+    "@jskit-ai/shell-web": "0.1.136",
+    "@jskit-ai/users-core": "0.1.146",
+    "@jskit-ai/users-web": "0.1.152"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/crud-server-generator/package.descriptor.mjs
+++ b/packages/crud-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-server-generator",
-  version: "0.1.143",
+  version: "0.1.145",
   kind: "generator",
   description: "CRUD server generator with routes, actions, and persistence scaffolding.",
   options: {
@@ -184,14 +184,14 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.130",
-        "@jskit-ai/crud-core": "0.1.141",
-        "@jskit-ai/database-runtime": "0.1.132",
-        "@jskit-ai/http-runtime": "0.1.131",
-        "@jskit-ai/json-rest-api-core": "0.1.77",
-        "@jskit-ai/kernel": "0.1.133",
-        "@jskit-ai/realtime": "0.1.130",
-        "@jskit-ai/resource-crud-core": "0.1.76",
+        "@jskit-ai/auth-core": "0.1.133",
+        "@jskit-ai/crud-core": "0.1.144",
+        "@jskit-ai/database-runtime": "0.1.134",
+        "@jskit-ai/http-runtime": "0.1.133",
+        "@jskit-ai/json-rest-api-core": "0.1.79",
+        "@jskit-ai/kernel": "0.1.135",
+        "@jskit-ai/realtime": "0.1.132",
+        "@jskit-ai/resource-crud-core": "0.1.78",
         "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}"
       },
       dev: {}

--- a/packages/crud-server-generator/package.json
+++ b/packages/crud-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-server-generator",
-  "version": "0.1.143",
+  "version": "0.1.145",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,12 +13,12 @@
   },
   "dependencies": {
     "@babel/parser": "^7.29.2",
-    "@jskit-ai/crud-core": "0.1.141",
-    "@jskit-ai/database-runtime": "0.1.132",
-    "@jskit-ai/http-runtime": "0.1.131",
-    "@jskit-ai/json-rest-api-core": "0.1.77",
-    "@jskit-ai/kernel": "0.1.133",
-    "@jskit-ai/resource-crud-core": "0.1.76",
+    "@jskit-ai/crud-core": "0.1.144",
+    "@jskit-ai/database-runtime": "0.1.134",
+    "@jskit-ai/http-runtime": "0.1.133",
+    "@jskit-ai/json-rest-api-core": "0.1.79",
+    "@jskit-ai/kernel": "0.1.135",
+    "@jskit-ai/resource-crud-core": "0.1.78",
     "recast": "^0.23.11"
   }
 }

--- a/packages/crud-server-generator/src/server/buildTemplateContext.js
+++ b/packages/crud-server-generator/src/server/buildTemplateContext.js
@@ -930,11 +930,14 @@ function resolveJsonRestRelationshipAlias(column = null) {
 }
 
 function resolveJsonRestFieldType(column = {}) {
-  if (column?.isRecordIdColumn === true) {
+  const typeKind = normalizeText(column?.typeKind).toLowerCase();
+  if (
+    column?.isIdColumn === true ||
+    (typeKind === "integer" && column?.isRecordIdColumn === true)
+  ) {
     return "id";
   }
 
-  const typeKind = normalizeText(column?.typeKind).toLowerCase();
   if (typeKind === "string") {
     return "string";
   }
@@ -1093,9 +1096,10 @@ function renderJsonRestSearchSchemaLines(columns = []) {
     }
 
     const actualField = normalizeText(column?.name) || key;
+    const type = resolveJsonRestFieldType(column);
     exactFilterKeys.add(key);
     exactFilterLines.push(
-      `    ${renderObjectPropertyKey(key)}: { type: "id", actualField: ${JSON.stringify(actualField)}, filterOperator: "=" },`
+      `    ${renderObjectPropertyKey(key)}: { type: ${JSON.stringify(type)}, actualField: ${JSON.stringify(actualField)}, filterOperator: "=" },`
     );
   }
 

--- a/packages/crud-server-generator/test/buildTemplateContext.test.js
+++ b/packages/crud-server-generator/test/buildTemplateContext.test.js
@@ -4,6 +4,9 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
+import { runInNewContext } from "node:vm";
+
+import { createSchema } from "@jskit-ai/kernel/shared/validators";
 
 import {
   __testables,
@@ -809,6 +812,81 @@ test("buildReplacementsFromSnapshot renders inline field relation metadata from 
     replacements.__JSKIT_CRUD_MIGRATION_DROP_FOREIGN_KEY_LINES__,
     /table\.dropForeign\(\["vet_id"\], "contacts_vet_id_foreign"\)/
   );
+});
+
+test("buildReplacementsFromSnapshot derives _id search types from database column types", async () => {
+  const baseSnapshot = createSnapshot({
+    tableName: "record_links",
+    hasWorkspaceIdColumn: false,
+    hasUserIdColumn: false
+  });
+  const snapshot = {
+    ...baseSnapshot,
+    columns: Object.freeze([
+      ...baseSnapshot.columns,
+      Object.freeze({
+        name: "target_id",
+        key: "targetId",
+        dataType: "varchar",
+        columnType: "varchar(191)",
+        typeKind: "string",
+        nullable: false,
+        hasDefault: false,
+        defaultValue: null,
+        autoIncrement: false,
+        unsigned: false,
+        extra: "",
+        maxLength: 191,
+        numericPrecision: null,
+        numericScale: null,
+        datetimePrecision: null,
+        characterSetName: "utf8mb4",
+        collationName: "utf8mb4_general_ci",
+        enumValues: Object.freeze([])
+      }),
+      Object.freeze({
+        name: "owner_user_id",
+        key: "ownerUserId",
+        dataType: "bigint",
+        columnType: "bigint unsigned",
+        typeKind: "integer",
+        nullable: false,
+        hasDefault: false,
+        defaultValue: null,
+        autoIncrement: false,
+        unsigned: true,
+        extra: "",
+        maxLength: null,
+        numericPrecision: 20,
+        numericScale: 0,
+        datetimePrecision: null,
+        characterSetName: "",
+        collationName: "",
+        enumValues: Object.freeze([])
+      })
+    ])
+  };
+
+  const replacements = __testables.buildReplacementsFromSnapshot({
+    namespace: "record-links",
+    snapshot,
+    resolvedOwnershipFilter: "public",
+    surfaceRequiresWorkspace: false
+  });
+  const searchSchema = runInNewContext(
+    `({${replacements.__JSKIT_CRUD_RESOURCE_SEARCH_SCHEMA_LINES__}})`
+  );
+
+  assert.equal(searchSchema.targetId.type, "string");
+  assert.equal(searchSchema.targetId.actualField, "target_id");
+  assert.equal(searchSchema.targetId.filterOperator, "=");
+  assert.equal(searchSchema.ownerUserId.type, "id");
+
+  const targetFilterResult = await createSchema(searchSchema).patch({
+    targetId: "external-record-abc"
+  });
+  assert.deepEqual(targetFilterResult.errors, {});
+  assert.equal(targetFilterResult.validatedObject.targetId, "external-record-abc");
 });
 
 test("buildReplacementsFromSnapshot renders inline enum field ui options as select controls", () => {

--- a/packages/crud-ui-generator/package.descriptor.mjs
+++ b/packages/crud-ui-generator/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { GENERATED_UI_NAVIGATION_ROLE_OPTION } from "@jskit-ai/kernel/shared/sup
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-ui-generator",
-  version: "0.1.116",
+  version: "0.1.118",
   kind: "generator",
   description: "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
   options: {
@@ -175,7 +175,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.149"
+        "@jskit-ai/users-web": "0.1.152"
       },
       dev: {}
     },

--- a/packages/crud-ui-generator/package.json
+++ b/packages/crud-ui-generator/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@jskit-ai/crud-ui-generator",
-  "version": "0.1.116",
+  "version": "0.1.118",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/crud-core": "0.1.141",
-    "@jskit-ai/kernel": "0.1.133",
-    "@jskit-ai/resource-crud-core": "0.1.76"
+    "@jskit-ai/crud-core": "0.1.144",
+    "@jskit-ai/kernel": "0.1.135",
+    "@jskit-ai/resource-crud-core": "0.1.78"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/database-runtime-mysql/package.descriptor.mjs
+++ b/packages/database-runtime-mysql/package.descriptor.mjs
@@ -13,7 +13,7 @@ const CI_DATABASE = Object.freeze({
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-mysql",
-  version: "0.1.131",
+  version: "0.1.133",
   kind: "runtime",
   options: {
     "db-host": {
@@ -133,7 +133,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.132",
+        "@jskit-ai/database-runtime": "0.1.134",
         "mysql2": "^3.11.2"
       },
       dev: {}

--- a/packages/database-runtime-mysql/package.json
+++ b/packages/database-runtime-mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-mysql",
-  "version": "0.1.131",
+  "version": "0.1.133",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,7 +12,7 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.132",
-    "@jskit-ai/kernel": "0.1.133"
+    "@jskit-ai/database-runtime": "0.1.134",
+    "@jskit-ai/kernel": "0.1.135"
   }
 }

--- a/packages/database-runtime-postgres/package.descriptor.mjs
+++ b/packages/database-runtime-postgres/package.descriptor.mjs
@@ -12,7 +12,7 @@ const CI_DATABASE = Object.freeze({
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-postgres",
-  version: "0.1.130",
+  version: "0.1.132",
   kind: "runtime",
   options: {
     "db-host": {
@@ -131,7 +131,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.132",
+        "@jskit-ai/database-runtime": "0.1.134",
         "pg": "^8.13.1"
       },
       dev: {}

--- a/packages/database-runtime-postgres/package.json
+++ b/packages/database-runtime-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-postgres",
-  "version": "0.1.130",
+  "version": "0.1.132",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,6 +12,6 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.132"
+    "@jskit-ai/database-runtime": "0.1.134"
   }
 }

--- a/packages/database-runtime/package.descriptor.mjs
+++ b/packages/database-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime",
-  version: "0.1.132",
+  version: "0.1.134",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -70,7 +70,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.133",
+        "@jskit-ai/kernel": "0.1.135",
         "dotenv": "^16.4.5",
         "knex": "^3.1.0"
       },

--- a/packages/database-runtime/package.json
+++ b/packages/database-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime",
-  "version": "0.1.132",
+  "version": "0.1.134",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -25,6 +25,6 @@
     "./shared/transactions": "./src/shared/transactions.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.133"
+    "@jskit-ai/kernel": "0.1.135"
   }
 }

--- a/packages/feature-server-generator/package.descriptor.mjs
+++ b/packages/feature-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/feature-server-generator",
-  version: "0.1.75",
+  version: "0.1.77",
   kind: "generator",
   description: "Scaffold substantial non-CRUD server feature packages with provider, actions, service, and optional persistence seams.",
   options: {
@@ -154,27 +154,27 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@jskit-ai/database-runtime": {
-          version: "0.1.132",
+          version: "0.1.134",
           when: {
             option: "mode",
             notEquals: "orchestrator"
           }
         },
         "@jskit-ai/database-runtime-mysql": {
-          version: "0.1.131",
+          version: "0.1.133",
           when: {
             option: "mode",
             notEquals: "orchestrator"
           }
         },
         "@jskit-ai/json-rest-api-core": {
-          version: "0.1.77",
+          version: "0.1.79",
           when: {
             option: "mode",
             equals: "json-rest"
           }
         },
-        "@jskit-ai/kernel": "0.1.133",
+        "@jskit-ai/kernel": "0.1.135",
         "json-rest-schema": "1.x.x",
         "@local/${option:feature-name|kebab}": "file:packages/${option:feature-name|kebab}"
       },

--- a/packages/feature-server-generator/package.json
+++ b/packages/feature-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/feature-server-generator",
-  "version": "0.1.75",
+  "version": "0.1.77",
   "type": "module",
   "scripts": {
     "test": "node --test"

--- a/packages/google-rewarded-core/package.descriptor.mjs
+++ b/packages/google-rewarded-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/google-rewarded-core",
-  version: "0.1.70",
+  version: "0.1.72",
   kind: "runtime",
   description: "Google rewarded workflow runtime plus internal CRUD providers for rules, provider configs, watch sessions, and unlock receipts.",
   dependsOn: [
@@ -128,14 +128,14 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.130",
-        "@jskit-ai/crud-core": "0.1.141",
-        "@jskit-ai/database-runtime": "0.1.132",
-        "@jskit-ai/http-runtime": "0.1.131",
-        "@jskit-ai/json-rest-api-core": "0.1.77",
-        "@jskit-ai/kernel": "0.1.133",
-        "@jskit-ai/resource-crud-core": "0.1.76",
-        "@jskit-ai/workspaces-core": "0.1.110"
+        "@jskit-ai/auth-core": "0.1.133",
+        "@jskit-ai/crud-core": "0.1.144",
+        "@jskit-ai/database-runtime": "0.1.134",
+        "@jskit-ai/http-runtime": "0.1.133",
+        "@jskit-ai/json-rest-api-core": "0.1.79",
+        "@jskit-ai/kernel": "0.1.135",
+        "@jskit-ai/resource-crud-core": "0.1.78",
+        "@jskit-ai/workspaces-core": "0.1.113"
       },
       dev: {}
     },

--- a/packages/google-rewarded-core/package.json
+++ b/packages/google-rewarded-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/google-rewarded-core",
-  "version": "0.1.70",
+  "version": "0.1.72",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/google-rewarded-web/package.descriptor.mjs
+++ b/packages/google-rewarded-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/google-rewarded-web",
-  version: "0.1.70",
+  version: "0.1.72",
   kind: "runtime",
   description: "Google rewarded client runtime with a fullscreen gate host and GPT orchestration.",
   dependsOn: [
@@ -46,10 +46,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/google-rewarded-core": "0.1.70",
-        "@jskit-ai/http-runtime": "0.1.131",
-        "@jskit-ai/kernel": "0.1.133",
-        "@jskit-ai/shell-web": "0.1.134"
+        "@jskit-ai/google-rewarded-core": "0.1.72",
+        "@jskit-ai/http-runtime": "0.1.133",
+        "@jskit-ai/kernel": "0.1.135",
+        "@jskit-ai/shell-web": "0.1.136"
       },
       dev: {}
     },

--- a/packages/google-rewarded-web/package.json
+++ b/packages/google-rewarded-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/google-rewarded-web",
-  "version": "0.1.70",
+  "version": "0.1.72",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/http-runtime/package.descriptor.mjs
+++ b/packages/http-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/http-runtime",
-  "version": "0.1.131",
+  "version": "0.1.133",
   "kind": "runtime",
   "dependsOn": [],
   "capabilities": {
@@ -67,7 +67,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.133"
+        "@jskit-ai/kernel": "0.1.135"
       },
       "dev": {}
     },

--- a/packages/http-runtime/package.json
+++ b/packages/http-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/http-runtime",
-  "version": "0.1.131",
+  "version": "0.1.133",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -18,7 +18,7 @@
     "./shared/validators/operationValidation": "./src/shared/validators/operationValidation.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.133",
+    "@jskit-ai/kernel": "0.1.135",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/json-rest-api-core/package.descriptor.mjs
+++ b/packages/json-rest-api-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/json-rest-api-core",
-  version: "0.1.77",
+  version: "0.1.79",
   kind: "runtime",
   description: "Shared internal json-rest-api host runtime with autofilter, query-projection, and row-policy support.",
   dependsOn: [

--- a/packages/json-rest-api-core/package.json
+++ b/packages/json-rest-api-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/json-rest-api-core",
-  "version": "0.1.77",
+  "version": "0.1.79",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,6 +11,6 @@
   "dependencies": {
     "hooked-api": "1.x.x",
     "json-rest-api": "^1.0.26",
-    "@jskit-ai/kernel": "0.1.133"
+    "@jskit-ai/kernel": "0.1.135"
   }
 }

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/kernel",
-  "version": "0.1.133",
+  "version": "0.1.135",
   "type": "module",
   "dependencies": {
     "json-rest-schema": "1.x.x"

--- a/packages/mobile-capacitor/package.descriptor.mjs
+++ b/packages/mobile-capacitor/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/mobile-capacitor",
-  version: "0.1.69",
+  version: "0.1.71",
   kind: "runtime",
   description: "Thin Capacitor client integration for JSKIT mobile-shell launch routing and auth callback completion.",
   dependsOn: [
@@ -62,8 +62,8 @@ export default Object.freeze({
         "@capacitor/app": "^7.1.0",
         "@capacitor/browser": "^7.0.1",
         "@capacitor/core": "^7.4.3",
-        "@jskit-ai/kernel": "0.1.133",
-        "@jskit-ai/shell-web": "0.1.134"
+        "@jskit-ai/kernel": "0.1.135",
+        "@jskit-ai/shell-web": "0.1.136"
       },
       dev: {
         "@capacitor/cli": "^7.4.3"

--- a/packages/mobile-capacitor/package.json
+++ b/packages/mobile-capacitor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/mobile-capacitor",
-  "version": "0.1.69",
+  "version": "0.1.71",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,6 +12,6 @@
   },
   "dependencies": {
     "@capacitor/browser": "^7.0.1",
-    "@jskit-ai/kernel": "0.1.133"
+    "@jskit-ai/kernel": "0.1.135"
   }
 }

--- a/packages/realtime/package.descriptor.mjs
+++ b/packages/realtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/realtime",
-  version: "0.1.130",
+  version: "0.1.132",
   kind: "runtime",
   description: "Thin, generic realtime runtime wrappers for socket.io server and client.",
   options: {
@@ -95,7 +95,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.133",
+        "@jskit-ai/kernel": "0.1.135",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/realtime",
-  "version": "0.1.130",
+  "version": "0.1.132",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@socket.io/redis-adapter": "^8.3.0",
-    "@jskit-ai/kernel": "0.1.133",
+    "@jskit-ai/kernel": "0.1.135",
     "redis": "^5.8.2",
     "socket.io": "^4.8.3",
     "socket.io-client": "^4.8.3"

--- a/packages/resource-core/package.descriptor.mjs
+++ b/packages/resource-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/resource-core",
-  version: "0.1.76",
+  version: "0.1.78",
   kind: "runtime",
   description: "Generic resource-definition helpers and schema-definition normalization.",
   dependsOn: [
@@ -22,7 +22,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/resource-core": "0.1.76"
+        "@jskit-ai/resource-core": "0.1.78"
       },
       dev: {}
     },

--- a/packages/resource-core/package.json
+++ b/packages/resource-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/resource-core",
-  "version": "0.1.76",
+  "version": "0.1.78",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./shared/resource": "./src/shared/resource.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.133"
+    "@jskit-ai/kernel": "0.1.135"
   }
 }

--- a/packages/resource-crud-core/package.descriptor.mjs
+++ b/packages/resource-crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/resource-crud-core",
-  version: "0.1.76",
+  version: "0.1.78",
   kind: "runtime",
   description: "CRUD-specific resource-definition helpers and namespace support.",
   dependsOn: [
@@ -23,7 +23,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/resource-crud-core": "0.1.76"
+        "@jskit-ai/resource-crud-core": "0.1.78"
       },
       dev: {}
     },

--- a/packages/resource-crud-core/package.json
+++ b/packages/resource-crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/resource-crud-core",
-  "version": "0.1.76",
+  "version": "0.1.78",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./shared/crudResource": "./src/shared/crudResource.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.133",
-    "@jskit-ai/resource-core": "0.1.76"
+    "@jskit-ai/kernel": "0.1.135",
+    "@jskit-ai/resource-core": "0.1.78"
   }
 }

--- a/packages/shell-web/package.descriptor.mjs
+++ b/packages/shell-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/shell-web",
-  version: "0.1.134",
+  version: "0.1.136",
   kind: "runtime",
   description: "Web shell layout runtime with outlet-based placement contributions.",
   dependsOn: [],
@@ -311,7 +311,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/kernel": "0.1.133"
+        "@jskit-ai/kernel": "0.1.135"
       },
       dev: {
         "@playwright/test": "1.61.1"

--- a/packages/shell-web/package.json
+++ b/packages/shell-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/shell-web",
-  "version": "0.1.134",
+  "version": "0.1.136",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/kernel": "0.1.133"
+    "@jskit-ai/kernel": "0.1.135"
   },
   "peerDependencies": {
     "pinia": "^3.0.4",

--- a/packages/storage-runtime/package.descriptor.mjs
+++ b/packages/storage-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/storage-runtime",
-  version: "0.1.131",
+  version: "0.1.133",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -50,7 +50,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.133",
+        "@jskit-ai/kernel": "0.1.135",
         "unstorage": "^1.17.3"
       },
       dev: {}

--- a/packages/storage-runtime/package.json
+++ b/packages/storage-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/storage-runtime",
-  "version": "0.1.131",
+  "version": "0.1.133",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./server/providers/StorageRuntimeServiceProvider": "./src/server/providers/StorageRuntimeServiceProvider.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.133",
+    "@jskit-ai/kernel": "0.1.135",
     "unstorage": "^1.17.5"
   }
 }

--- a/packages/ui-generator/package.descriptor.mjs
+++ b/packages/ui-generator/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { GENERATED_UI_NAVIGATION_ROLE_OPTION } from "@jskit-ai/kernel/shared/sup
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/ui-generator",
-  version: "0.1.116",
+  version: "0.1.118",
   kind: "generator",
   description: "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
   options: {
@@ -371,7 +371,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.149"
+        "@jskit-ai/users-web": "0.1.152"
       },
       dev: {}
     },

--- a/packages/ui-generator/package.json
+++ b/packages/ui-generator/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/ui-generator",
-  "version": "0.1.116",
+  "version": "0.1.118",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.133",
-    "@jskit-ai/shell-web": "0.1.134"
+    "@jskit-ai/kernel": "0.1.135",
+    "@jskit-ai/shell-web": "0.1.136"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/uploads-image-web/package.descriptor.mjs
+++ b/packages/uploads-image-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-image-web",
-  version: "0.1.109",
+  version: "0.1.111",
   kind: "runtime",
   description: "Reusable client-side image upload runtime with pre-upload image editing.",
   dependsOn: [
@@ -65,7 +65,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/uploads-runtime": "0.1.109",
+        "@jskit-ai/uploads-runtime": "0.1.111",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-image-web/package.json
+++ b/packages/uploads-image-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-image-web",
-  "version": "0.1.109",
+  "version": "0.1.111",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,7 +13,7 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/uploads-runtime": "0.1.109",
+    "@jskit-ai/uploads-runtime": "0.1.111",
     "@uppy/compressor": "^3.1.0",
     "@uppy/core": "^5.2.0",
     "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-runtime/package.descriptor.mjs
+++ b/packages/uploads-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-runtime",
-  version: "0.1.109",
+  version: "0.1.111",
   kind: "runtime",
   description: "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
   dependsOn: [
@@ -71,7 +71,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.133"
+        "@jskit-ai/kernel": "0.1.135"
       },
       dev: {}
     },

--- a/packages/uploads-runtime/package.json
+++ b/packages/uploads-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-runtime",
-  "version": "0.1.109",
+  "version": "0.1.111",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,6 +16,6 @@
   },
   "dependencies": {
     "@fastify/multipart": "^9.4.0",
-    "@jskit-ai/kernel": "0.1.133"
+    "@jskit-ai/kernel": "0.1.135"
   }
 }

--- a/packages/users-core/package.descriptor.mjs
+++ b/packages/users-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-core",
-  version: "0.1.143",
+  version: "0.1.146",
   kind: "runtime",
   description: "Users/account runtime plus HTTP routes for account features.",
   dependsOn: [
@@ -146,16 +146,16 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.130",
-        "@jskit-ai/crud-core": "0.1.141",
-        "@jskit-ai/database-runtime": "0.1.132",
-        "@jskit-ai/http-runtime": "0.1.131",
-        "@jskit-ai/json-rest-api-core": "0.1.77",
-        "@jskit-ai/kernel": "0.1.133",
-        "@jskit-ai/resource-core": "0.1.76",
-        "@jskit-ai/resource-crud-core": "0.1.76",
+        "@jskit-ai/auth-core": "0.1.133",
+        "@jskit-ai/crud-core": "0.1.144",
+        "@jskit-ai/database-runtime": "0.1.134",
+        "@jskit-ai/http-runtime": "0.1.133",
+        "@jskit-ai/json-rest-api-core": "0.1.79",
+        "@jskit-ai/kernel": "0.1.135",
+        "@jskit-ai/resource-core": "0.1.78",
+        "@jskit-ai/resource-crud-core": "0.1.78",
         "@local/users": "file:packages/users",
-        "@jskit-ai/uploads-runtime": "0.1.109"
+        "@jskit-ai/uploads-runtime": "0.1.111"
       },
       dev: {}
     },

--- a/packages/users-core/package.json
+++ b/packages/users-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-core",
-  "version": "0.1.143",
+  "version": "0.1.146",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,14 +11,14 @@
     "./shared/resources/userSettingsResource": "./src/shared/resources/userSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.130",
-    "@jskit-ai/database-runtime": "0.1.132",
-    "@jskit-ai/http-runtime": "0.1.131",
-    "@jskit-ai/json-rest-api-core": "0.1.77",
-    "@jskit-ai/kernel": "0.1.133",
-    "@jskit-ai/resource-crud-core": "0.1.76",
-    "@jskit-ai/resource-core": "0.1.76",
-    "@jskit-ai/uploads-runtime": "0.1.109",
+    "@jskit-ai/auth-core": "0.1.133",
+    "@jskit-ai/database-runtime": "0.1.134",
+    "@jskit-ai/http-runtime": "0.1.133",
+    "@jskit-ai/json-rest-api-core": "0.1.79",
+    "@jskit-ai/kernel": "0.1.135",
+    "@jskit-ai/resource-crud-core": "0.1.78",
+    "@jskit-ai/resource-core": "0.1.78",
+    "@jskit-ai/uploads-runtime": "0.1.111",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/users-web/package.descriptor.mjs
+++ b/packages/users-web/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { HOME_COG_OUTLET } from "./src/shared/toolsOutletContracts.js";
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-web",
-  version: "0.1.149",
+  version: "0.1.152",
   kind: "runtime",
   description: "Users web module: account/profile UI plus shared users web widgets.",
   dependsOn: [
@@ -286,12 +286,12 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/http-runtime": "0.1.131",
-        "@jskit-ai/realtime": "0.1.130",
-        "@jskit-ai/kernel": "0.1.133",
-        "@jskit-ai/shell-web": "0.1.134",
-        "@jskit-ai/uploads-image-web": "0.1.109",
-        "@jskit-ai/users-core": "0.1.143"
+        "@jskit-ai/http-runtime": "0.1.133",
+        "@jskit-ai/realtime": "0.1.132",
+        "@jskit-ai/kernel": "0.1.135",
+        "@jskit-ai/shell-web": "0.1.136",
+        "@jskit-ai/uploads-image-web": "0.1.111",
+        "@jskit-ai/users-core": "0.1.146"
       },
       dev: {}
     },

--- a/packages/users-web/package.json
+++ b/packages/users-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-web",
-  "version": "0.1.149",
+  "version": "0.1.152",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -46,12 +46,12 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/http-runtime": "0.1.131",
-    "@jskit-ai/kernel": "0.1.133",
-    "@jskit-ai/realtime": "0.1.130",
-    "@jskit-ai/shell-web": "0.1.134",
-    "@jskit-ai/uploads-image-web": "0.1.109",
-    "@jskit-ai/users-core": "0.1.143"
+    "@jskit-ai/http-runtime": "0.1.133",
+    "@jskit-ai/kernel": "0.1.135",
+    "@jskit-ai/realtime": "0.1.132",
+    "@jskit-ai/shell-web": "0.1.136",
+    "@jskit-ai/uploads-image-web": "0.1.111",
+    "@jskit-ai/users-core": "0.1.146"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/workspaces-core/package.descriptor.mjs
+++ b/packages/workspaces-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-core",
-  version: "0.1.110",
+  version: "0.1.113",
   kind: "runtime",
   description: "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
   dependsOn: [
@@ -147,10 +147,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/json-rest-api-core": "0.1.77",
-        "@jskit-ai/resource-core": "0.1.76",
-        "@jskit-ai/resource-crud-core": "0.1.76",
-        "@jskit-ai/users-core": "0.1.143"
+        "@jskit-ai/json-rest-api-core": "0.1.79",
+        "@jskit-ai/resource-core": "0.1.78",
+        "@jskit-ai/resource-crud-core": "0.1.78",
+        "@jskit-ai/users-core": "0.1.146"
       },
       dev: {}
     },

--- a/packages/workspaces-core/package.json
+++ b/packages/workspaces-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-core",
-  "version": "0.1.110",
+  "version": "0.1.113",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -17,14 +17,14 @@
     "./shared/resources/workspaceSettingsResource": "./src/shared/resources/workspaceSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.130",
-    "@jskit-ai/database-runtime": "0.1.132",
-    "@jskit-ai/http-runtime": "0.1.131",
-    "@jskit-ai/json-rest-api-core": "0.1.77",
-    "@jskit-ai/kernel": "0.1.133",
-    "@jskit-ai/resource-crud-core": "0.1.76",
-    "@jskit-ai/resource-core": "0.1.76",
-    "@jskit-ai/users-core": "0.1.143",
+    "@jskit-ai/auth-core": "0.1.133",
+    "@jskit-ai/database-runtime": "0.1.134",
+    "@jskit-ai/http-runtime": "0.1.133",
+    "@jskit-ai/json-rest-api-core": "0.1.79",
+    "@jskit-ai/kernel": "0.1.135",
+    "@jskit-ai/resource-crud-core": "0.1.78",
+    "@jskit-ai/resource-core": "0.1.78",
+    "@jskit-ai/users-core": "0.1.146",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/workspaces-web/package.descriptor.mjs
+++ b/packages/workspaces-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-web",
-  version: "0.1.112",
+  version: "0.1.115",
   kind: "runtime",
   description: "Workspace web module: workspace selector, tools widget, workspace surfaces, members UI, and settings hosts.",
   dependsOn: [
@@ -232,9 +232,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-web": "0.1.133",
-        "@jskit-ai/workspaces-core": "0.1.110",
-        "@jskit-ai/users-web": "0.1.149"
+        "@jskit-ai/auth-web": "0.1.136",
+        "@jskit-ai/workspaces-core": "0.1.113",
+        "@jskit-ai/users-web": "0.1.152"
       },
       dev: {}
     },

--- a/packages/workspaces-web/package.json
+++ b/packages/workspaces-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-web",
-  "version": "0.1.112",
+  "version": "0.1.115",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -15,13 +15,13 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/auth-web": "0.1.133",
-    "@jskit-ai/http-runtime": "0.1.131",
-    "@jskit-ai/kernel": "0.1.133",
-    "@jskit-ai/shell-web": "0.1.134",
-    "@jskit-ai/users-core": "0.1.143",
-    "@jskit-ai/users-web": "0.1.149",
-    "@jskit-ai/workspaces-core": "0.1.110"
+    "@jskit-ai/auth-web": "0.1.136",
+    "@jskit-ai/http-runtime": "0.1.133",
+    "@jskit-ai/kernel": "0.1.135",
+    "@jskit-ai/shell-web": "0.1.136",
+    "@jskit-ai/users-core": "0.1.146",
+    "@jskit-ai/users-web": "0.1.152",
+    "@jskit-ai/workspaces-core": "0.1.113"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/tooling/config-eslint/package.json
+++ b/tooling/config-eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/config-eslint",
-  "version": "0.1.131",
+  "version": "0.1.133",
   "description": "Shared flat ESLint presets for JSKIT projects.",
   "type": "module",
   "files": [

--- a/tooling/create-app/package.descriptor.mjs
+++ b/tooling/create-app/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/create-app",
-  "version": "0.1.151",
+  "version": "0.1.154",
   "dependsOn": [],
   "capabilities": {
     "provides": [

--- a/tooling/create-app/package.json
+++ b/tooling/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/create-app",
-  "version": "0.1.151",
+  "version": "0.1.154",
   "description": "Scaffold JSKIT app shells.",
   "type": "module",
   "files": [
@@ -20,7 +20,7 @@
     "./client": "./src/client/index.js"
   },
   "dependencies": {
-    "@jskit-ai/jskit-cli": "0.2.154"
+    "@jskit-ai/jskit-cli": "0.2.158"
   },
   "engines": {
     "node": "^22.13.0 || ^24.0.0 || ^26.0.0"

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -6,11 +6,11 @@
   "packages": [
     {
       "packageId": "@jskit-ai/assistant",
-      "version": "0.1.142",
+      "version": "0.1.144",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant",
-        "version": "0.1.142",
+        "version": "0.1.144",
         "kind": "generator",
         "description": "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
         "options": {
@@ -347,11 +347,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-core",
-      "version": "0.1.110",
+      "version": "0.1.112",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-core",
-        "version": "0.1.110",
+        "version": "0.1.112",
         "kind": "runtime",
         "description": "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
         "dependsOn": [
@@ -399,11 +399,11 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/http-runtime": "0.1.131",
-              "@jskit-ai/kernel": "0.1.133",
-              "@jskit-ai/resource-core": "0.1.76",
-              "@jskit-ai/resource-crud-core": "0.1.76",
-              "@jskit-ai/users-core": "0.1.143",
+              "@jskit-ai/http-runtime": "0.1.133",
+              "@jskit-ai/kernel": "0.1.135",
+              "@jskit-ai/resource-core": "0.1.78",
+              "@jskit-ai/resource-crud-core": "0.1.78",
+              "@jskit-ai/users-core": "0.1.146",
               "dompurify": "^3.3.3",
               "json-rest-schema": "1.x.x",
               "marked": "^17.0.4",
@@ -422,11 +422,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-runtime",
-      "version": "0.1.105",
+      "version": "0.1.107",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-runtime",
-        "version": "0.1.105",
+        "version": "0.1.107",
         "kind": "runtime",
         "description": "Shared assistant runtime with per-surface assistant registration.",
         "dependsOn": [
@@ -522,13 +522,13 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/assistant-core": "0.1.110",
-              "@jskit-ai/database-runtime": "0.1.132",
-              "@jskit-ai/http-runtime": "0.1.131",
-              "@jskit-ai/kernel": "0.1.133",
-              "@jskit-ai/shell-web": "0.1.134",
-              "@jskit-ai/users-core": "0.1.143",
-              "@jskit-ai/users-web": "0.1.149"
+              "@jskit-ai/assistant-core": "0.1.112",
+              "@jskit-ai/database-runtime": "0.1.134",
+              "@jskit-ai/http-runtime": "0.1.133",
+              "@jskit-ai/kernel": "0.1.135",
+              "@jskit-ai/shell-web": "0.1.136",
+              "@jskit-ai/users-core": "0.1.146",
+              "@jskit-ai/users-web": "0.1.152"
             },
             "dev": {}
           },
@@ -583,11 +583,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-core",
-      "version": "0.1.130",
+      "version": "0.1.133",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-core",
-        "version": "0.1.130",
+        "version": "0.1.133",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/value-app-config-shared"
@@ -660,7 +660,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.133",
+              "@jskit-ai/kernel": "0.1.135",
               "@fastify/cookie": "^11.0.2",
               "@fastify/csrf-protection": "^7.1.0",
               "@fastify/rate-limit": "^10.3.0"
@@ -678,11 +678,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-local-core",
-      "version": "0.1.34",
+      "version": "0.1.37",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-local-core",
-        "version": "0.1.34",
+        "version": "0.1.37",
         "kind": "runtime",
         "description": "Local auth provider with a file backend default and no database requirement.",
         "dependsOn": [
@@ -745,8 +745,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.130",
-              "@jskit-ai/kernel": "0.1.133",
+              "@jskit-ai/auth-core": "0.1.133",
+              "@jskit-ai/kernel": "0.1.135",
               "nodemailer": "^9.0.3",
               "dotenv": "^16.4.5"
             },
@@ -792,11 +792,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-local-db-core",
-      "version": "0.1.25",
+      "version": "0.1.28",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-local-db-core",
-        "version": "0.1.25",
+        "version": "0.1.28",
         "kind": "runtime",
         "description": "Database-backed local auth storage backend for JSKIT local auth.",
         "dependsOn": [
@@ -875,9 +875,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-provider-local-core": "0.1.34",
-              "@jskit-ai/database-runtime": "0.1.132",
-              "@jskit-ai/kernel": "0.1.133"
+              "@jskit-ai/auth-provider-local-core": "0.1.37",
+              "@jskit-ai/database-runtime": "0.1.134",
+              "@jskit-ai/kernel": "0.1.135"
             },
             "dev": {}
           },
@@ -912,11 +912,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.131",
+      "version": "0.1.133",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-supabase-core",
-        "version": "0.1.131",
+        "version": "0.1.133",
         "kind": "runtime",
         "options": {
           "auth-supabase-url": {
@@ -998,8 +998,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.130",
-              "@jskit-ai/kernel": "0.1.133",
+              "@jskit-ai/auth-core": "0.1.133",
+              "@jskit-ai/kernel": "0.1.135",
               "dotenv": "^16.4.5",
               "@supabase/supabase-js": "^2.57.4",
               "jose": "^6.1.0"
@@ -1077,11 +1077,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-web",
-      "version": "0.1.133",
+      "version": "0.1.136",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-web",
-        "version": "0.1.133",
+        "version": "0.1.136",
         "kind": "runtime",
         "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
         "dependsOn": [
@@ -1354,10 +1354,10 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/auth-core": "0.1.130",
-              "@jskit-ai/http-runtime": "0.1.131",
-              "@jskit-ai/kernel": "0.1.133",
-              "@jskit-ai/shell-web": "0.1.134"
+              "@jskit-ai/auth-core": "0.1.133",
+              "@jskit-ai/http-runtime": "0.1.133",
+              "@jskit-ai/kernel": "0.1.135",
+              "@jskit-ai/shell-web": "0.1.136"
             },
             "dev": {}
           },
@@ -1456,11 +1456,11 @@
     },
     {
       "packageId": "@jskit-ai/console-core",
-      "version": "0.1.97",
+      "version": "0.1.99",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-core",
-        "version": "0.1.97",
+        "version": "0.1.99",
         "kind": "runtime",
         "description": "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
         "dependsOn": [
@@ -1544,12 +1544,12 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.130",
-              "@jskit-ai/database-runtime": "0.1.132",
-              "@jskit-ai/http-runtime": "0.1.131",
-              "@jskit-ai/kernel": "0.1.133",
-              "@jskit-ai/resource-crud-core": "0.1.76",
-              "@jskit-ai/users-core": "0.1.143"
+              "@jskit-ai/auth-core": "0.1.133",
+              "@jskit-ai/database-runtime": "0.1.134",
+              "@jskit-ai/http-runtime": "0.1.133",
+              "@jskit-ai/kernel": "0.1.135",
+              "@jskit-ai/resource-crud-core": "0.1.78",
+              "@jskit-ai/users-core": "0.1.146"
             },
             "dev": {}
           },
@@ -1574,11 +1574,11 @@
     },
     {
       "packageId": "@jskit-ai/console-web",
-      "version": "0.1.102",
+      "version": "0.1.104",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-web",
-        "version": "0.1.102",
+        "version": "0.1.104",
         "kind": "runtime",
         "description": "Authenticated console surface scaffold and surface policy wiring.",
         "dependsOn": [
@@ -1688,9 +1688,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-web": "0.1.133",
-              "@jskit-ai/console-core": "0.1.97",
-              "@jskit-ai/shell-web": "0.1.134"
+              "@jskit-ai/auth-web": "0.1.136",
+              "@jskit-ai/console-core": "0.1.99",
+              "@jskit-ai/shell-web": "0.1.136"
             },
             "dev": {}
           },
@@ -1797,11 +1797,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-core",
-      "version": "0.1.141",
+      "version": "0.1.144",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-core",
-        "version": "0.1.141",
+        "version": "0.1.144",
         "kind": "runtime",
         "description": "Shared CRUD helpers used by CRUD modules.",
         "dependsOn": [
@@ -1830,7 +1830,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/crud-core": "0.1.141"
+              "@jskit-ai/crud-core": "0.1.144"
             },
             "dev": {}
           },
@@ -1844,11 +1844,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-server-generator",
-      "version": "0.1.143",
+      "version": "0.1.145",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-server-generator",
-        "version": "0.1.143",
+        "version": "0.1.145",
         "kind": "generator",
         "description": "CRUD server generator with routes, actions, and persistence scaffolding.",
         "options": {
@@ -2039,14 +2039,14 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.130",
-              "@jskit-ai/crud-core": "0.1.141",
-              "@jskit-ai/database-runtime": "0.1.132",
-              "@jskit-ai/http-runtime": "0.1.131",
-              "@jskit-ai/json-rest-api-core": "0.1.77",
-              "@jskit-ai/kernel": "0.1.133",
-              "@jskit-ai/realtime": "0.1.130",
-              "@jskit-ai/resource-crud-core": "0.1.76",
+              "@jskit-ai/auth-core": "0.1.133",
+              "@jskit-ai/crud-core": "0.1.144",
+              "@jskit-ai/database-runtime": "0.1.134",
+              "@jskit-ai/http-runtime": "0.1.133",
+              "@jskit-ai/json-rest-api-core": "0.1.79",
+              "@jskit-ai/kernel": "0.1.135",
+              "@jskit-ai/realtime": "0.1.132",
+              "@jskit-ai/resource-crud-core": "0.1.78",
               "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}"
             },
             "dev": {}
@@ -2191,11 +2191,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.116",
+      "version": "0.1.118",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-ui-generator",
-        "version": "0.1.116",
+        "version": "0.1.118",
         "kind": "generator",
         "description": "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
         "options": {
@@ -2394,7 +2394,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.149"
+              "@jskit-ai/users-web": "0.1.152"
             },
             "dev": {}
           },
@@ -2653,11 +2653,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime",
-      "version": "0.1.132",
+      "version": "0.1.134",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime",
-        "version": "0.1.132",
+        "version": "0.1.134",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -2726,7 +2726,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.133",
+              "@jskit-ai/kernel": "0.1.135",
               "dotenv": "^16.4.5",
               "knex": "^3.1.0"
             },
@@ -2769,11 +2769,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.131",
+      "version": "0.1.133",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-mysql",
-        "version": "0.1.131",
+        "version": "0.1.133",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -2895,7 +2895,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.132",
+              "@jskit-ai/database-runtime": "0.1.134",
               "mysql2": "^3.11.2"
             },
             "dev": {}
@@ -2966,11 +2966,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.130",
+      "version": "0.1.132",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-postgres",
-        "version": "0.1.130",
+        "version": "0.1.132",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -3091,7 +3091,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.132",
+              "@jskit-ai/database-runtime": "0.1.134",
               "pg": "^8.13.1"
             },
             "dev": {}
@@ -3162,11 +3162,11 @@
     },
     {
       "packageId": "@jskit-ai/feature-server-generator",
-      "version": "0.1.75",
+      "version": "0.1.77",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/feature-server-generator",
-        "version": "0.1.75",
+        "version": "0.1.77",
         "kind": "generator",
         "description": "Scaffold substantial non-CRUD server feature packages with provider, actions, service, and optional persistence seams.",
         "options": {
@@ -3331,27 +3331,27 @@
           "dependencies": {
             "runtime": {
               "@jskit-ai/database-runtime": {
-                "version": "0.1.132",
+                "version": "0.1.134",
                 "when": {
                   "option": "mode",
                   "notEquals": "orchestrator"
                 }
               },
               "@jskit-ai/database-runtime-mysql": {
-                "version": "0.1.131",
+                "version": "0.1.133",
                 "when": {
                   "option": "mode",
                   "notEquals": "orchestrator"
                 }
               },
               "@jskit-ai/json-rest-api-core": {
-                "version": "0.1.77",
+                "version": "0.1.79",
                 "when": {
                   "option": "mode",
                   "equals": "json-rest"
                 }
               },
-              "@jskit-ai/kernel": "0.1.133",
+              "@jskit-ai/kernel": "0.1.135",
               "json-rest-schema": "1.x.x",
               "@local/${option:feature-name|kebab}": "file:packages/${option:feature-name|kebab}"
             },
@@ -3464,11 +3464,11 @@
     },
     {
       "packageId": "@jskit-ai/google-rewarded-core",
-      "version": "0.1.70",
+      "version": "0.1.72",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/google-rewarded-core",
-        "version": "0.1.70",
+        "version": "0.1.72",
         "kind": "runtime",
         "description": "Google rewarded workflow runtime plus internal CRUD providers for rules, provider configs, watch sessions, and unlock receipts.",
         "dependsOn": [
@@ -3595,14 +3595,14 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.130",
-              "@jskit-ai/crud-core": "0.1.141",
-              "@jskit-ai/database-runtime": "0.1.132",
-              "@jskit-ai/http-runtime": "0.1.131",
-              "@jskit-ai/json-rest-api-core": "0.1.77",
-              "@jskit-ai/kernel": "0.1.133",
-              "@jskit-ai/resource-crud-core": "0.1.76",
-              "@jskit-ai/workspaces-core": "0.1.110"
+              "@jskit-ai/auth-core": "0.1.133",
+              "@jskit-ai/crud-core": "0.1.144",
+              "@jskit-ai/database-runtime": "0.1.134",
+              "@jskit-ai/http-runtime": "0.1.133",
+              "@jskit-ai/json-rest-api-core": "0.1.79",
+              "@jskit-ai/kernel": "0.1.135",
+              "@jskit-ai/resource-crud-core": "0.1.78",
+              "@jskit-ai/workspaces-core": "0.1.113"
             },
             "dev": {}
           },
@@ -3654,11 +3654,11 @@
     },
     {
       "packageId": "@jskit-ai/google-rewarded-web",
-      "version": "0.1.70",
+      "version": "0.1.72",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/google-rewarded-web",
-        "version": "0.1.70",
+        "version": "0.1.72",
         "kind": "runtime",
         "description": "Google rewarded client runtime with a fullscreen gate host and GPT orchestration.",
         "dependsOn": [
@@ -3705,10 +3705,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/google-rewarded-core": "0.1.70",
-              "@jskit-ai/http-runtime": "0.1.131",
-              "@jskit-ai/kernel": "0.1.133",
-              "@jskit-ai/shell-web": "0.1.134"
+              "@jskit-ai/google-rewarded-core": "0.1.72",
+              "@jskit-ai/http-runtime": "0.1.133",
+              "@jskit-ai/kernel": "0.1.135",
+              "@jskit-ai/shell-web": "0.1.136"
             },
             "dev": {}
           },
@@ -3726,11 +3726,11 @@
     },
     {
       "packageId": "@jskit-ai/http-runtime",
-      "version": "0.1.131",
+      "version": "0.1.133",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/http-runtime",
-        "version": "0.1.131",
+        "version": "0.1.133",
         "kind": "runtime",
         "dependsOn": [],
         "capabilities": {
@@ -3796,7 +3796,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.133"
+              "@jskit-ai/kernel": "0.1.135"
             },
             "dev": {}
           },
@@ -3810,11 +3810,11 @@
     },
     {
       "packageId": "@jskit-ai/json-rest-api-core",
-      "version": "0.1.77",
+      "version": "0.1.79",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/json-rest-api-core",
-        "version": "0.1.77",
+        "version": "0.1.79",
         "kind": "runtime",
         "description": "Shared internal json-rest-api host runtime with autofilter, query-projection, and row-policy support.",
         "dependsOn": [
@@ -3874,11 +3874,11 @@
     },
     {
       "packageId": "@jskit-ai/mobile-capacitor",
-      "version": "0.1.69",
+      "version": "0.1.71",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/mobile-capacitor",
-        "version": "0.1.69",
+        "version": "0.1.71",
         "kind": "runtime",
         "description": "Thin Capacitor client integration for JSKIT mobile-shell launch routing and auth callback completion.",
         "dependsOn": [
@@ -3941,8 +3941,8 @@
               "@capacitor/app": "^7.1.0",
               "@capacitor/browser": "^7.0.1",
               "@capacitor/core": "^7.4.3",
-              "@jskit-ai/kernel": "0.1.133",
-              "@jskit-ai/shell-web": "0.1.134"
+              "@jskit-ai/kernel": "0.1.135",
+              "@jskit-ai/shell-web": "0.1.136"
             },
             "dev": {
               "@capacitor/cli": "^7.4.3"
@@ -3994,11 +3994,11 @@
     },
     {
       "packageId": "@jskit-ai/realtime",
-      "version": "0.1.130",
+      "version": "0.1.132",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/realtime",
-        "version": "0.1.130",
+        "version": "0.1.132",
         "kind": "runtime",
         "description": "Thin, generic realtime runtime wrappers for socket.io server and client.",
         "options": {
@@ -4094,7 +4094,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.133",
+              "@jskit-ai/kernel": "0.1.135",
               "@socket.io/redis-adapter": "^8.3.0",
               "redis": "^5.8.2",
               "socket.io": "^4.8.3",
@@ -4143,11 +4143,11 @@
     },
     {
       "packageId": "@jskit-ai/resource-core",
-      "version": "0.1.76",
+      "version": "0.1.78",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/resource-core",
-        "version": "0.1.76",
+        "version": "0.1.78",
         "kind": "runtime",
         "description": "Generic resource-definition helpers and schema-definition normalization.",
         "dependsOn": [
@@ -4170,7 +4170,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/resource-core": "0.1.76"
+              "@jskit-ai/resource-core": "0.1.78"
             },
             "dev": {}
           },
@@ -4185,11 +4185,11 @@
     },
     {
       "packageId": "@jskit-ai/resource-crud-core",
-      "version": "0.1.76",
+      "version": "0.1.78",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/resource-crud-core",
-        "version": "0.1.76",
+        "version": "0.1.78",
         "kind": "runtime",
         "description": "CRUD-specific resource-definition helpers and namespace support.",
         "dependsOn": [
@@ -4213,7 +4213,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/resource-crud-core": "0.1.76"
+              "@jskit-ai/resource-crud-core": "0.1.78"
             },
             "dev": {}
           },
@@ -4228,11 +4228,11 @@
     },
     {
       "packageId": "@jskit-ai/shell-web",
-      "version": "0.1.134",
+      "version": "0.1.136",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/shell-web",
-        "version": "0.1.134",
+        "version": "0.1.136",
         "kind": "runtime",
         "description": "Web shell layout runtime with outlet-based placement contributions.",
         "dependsOn": [],
@@ -4578,7 +4578,7 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/kernel": "0.1.133"
+              "@jskit-ai/kernel": "0.1.135"
             },
             "dev": {
               "@playwright/test": "1.61.1"
@@ -4807,11 +4807,11 @@
     },
     {
       "packageId": "@jskit-ai/storage-runtime",
-      "version": "0.1.131",
+      "version": "0.1.133",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/storage-runtime",
-        "version": "0.1.131",
+        "version": "0.1.133",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -4860,7 +4860,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.133",
+              "@jskit-ai/kernel": "0.1.135",
               "unstorage": "^1.17.3"
             },
             "dev": {}
@@ -4876,11 +4876,11 @@
     },
     {
       "packageId": "@jskit-ai/ui-generator",
-      "version": "0.1.116",
+      "version": "0.1.118",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/ui-generator",
-        "version": "0.1.116",
+        "version": "0.1.118",
         "kind": "generator",
         "description": "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
         "options": {
@@ -5313,7 +5313,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.149"
+              "@jskit-ai/users-web": "0.1.152"
             },
             "dev": {}
           },
@@ -5328,11 +5328,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-image-web",
-      "version": "0.1.109",
+      "version": "0.1.111",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-image-web",
-        "version": "0.1.109",
+        "version": "0.1.111",
         "kind": "runtime",
         "description": "Reusable client-side image upload runtime with pre-upload image editing.",
         "dependsOn": [
@@ -5396,7 +5396,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/uploads-runtime": "0.1.109",
+              "@jskit-ai/uploads-runtime": "0.1.111",
               "@uppy/compressor": "^3.1.0",
               "@uppy/core": "^5.2.0",
               "@uppy/dashboard": "^5.1.1",
@@ -5416,11 +5416,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-runtime",
-      "version": "0.1.109",
+      "version": "0.1.111",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-runtime",
-        "version": "0.1.109",
+        "version": "0.1.111",
         "kind": "runtime",
         "description": "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
         "dependsOn": [
@@ -5490,7 +5490,7 @@
           "dependencies": {
             "runtime": {
               "@fastify/multipart": "^9.4.0",
-              "@jskit-ai/kernel": "0.1.133"
+              "@jskit-ai/kernel": "0.1.135"
             },
             "dev": {}
           },
@@ -5505,11 +5505,11 @@
     },
     {
       "packageId": "@jskit-ai/users-core",
-      "version": "0.1.143",
+      "version": "0.1.146",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-core",
-        "version": "0.1.143",
+        "version": "0.1.146",
         "kind": "runtime",
         "description": "Users/account runtime plus HTTP routes for account features.",
         "dependsOn": [
@@ -5653,16 +5653,16 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.130",
-              "@jskit-ai/crud-core": "0.1.141",
-              "@jskit-ai/database-runtime": "0.1.132",
-              "@jskit-ai/http-runtime": "0.1.131",
-              "@jskit-ai/json-rest-api-core": "0.1.77",
-              "@jskit-ai/kernel": "0.1.133",
-              "@jskit-ai/resource-core": "0.1.76",
-              "@jskit-ai/resource-crud-core": "0.1.76",
+              "@jskit-ai/auth-core": "0.1.133",
+              "@jskit-ai/crud-core": "0.1.144",
+              "@jskit-ai/database-runtime": "0.1.134",
+              "@jskit-ai/http-runtime": "0.1.133",
+              "@jskit-ai/json-rest-api-core": "0.1.79",
+              "@jskit-ai/kernel": "0.1.135",
+              "@jskit-ai/resource-core": "0.1.78",
+              "@jskit-ai/resource-crud-core": "0.1.78",
               "@local/users": "file:packages/users",
-              "@jskit-ai/uploads-runtime": "0.1.109"
+              "@jskit-ai/uploads-runtime": "0.1.111"
             },
             "dev": {}
           },
@@ -5889,11 +5889,11 @@
     },
     {
       "packageId": "@jskit-ai/users-web",
-      "version": "0.1.149",
+      "version": "0.1.152",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-web",
-        "version": "0.1.149",
+        "version": "0.1.152",
         "kind": "runtime",
         "description": "Users web module: account/profile UI plus shared users web widgets.",
         "dependsOn": [
@@ -6196,12 +6196,12 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/http-runtime": "0.1.131",
-              "@jskit-ai/realtime": "0.1.130",
-              "@jskit-ai/kernel": "0.1.133",
-              "@jskit-ai/shell-web": "0.1.134",
-              "@jskit-ai/uploads-image-web": "0.1.109",
-              "@jskit-ai/users-core": "0.1.143"
+              "@jskit-ai/http-runtime": "0.1.133",
+              "@jskit-ai/realtime": "0.1.132",
+              "@jskit-ai/kernel": "0.1.135",
+              "@jskit-ai/shell-web": "0.1.136",
+              "@jskit-ai/uploads-image-web": "0.1.111",
+              "@jskit-ai/users-core": "0.1.146"
             },
             "dev": {}
           },
@@ -6382,11 +6382,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-core",
-      "version": "0.1.110",
+      "version": "0.1.113",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-core",
-        "version": "0.1.110",
+        "version": "0.1.113",
         "kind": "runtime",
         "description": "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
         "dependsOn": [
@@ -6532,10 +6532,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/json-rest-api-core": "0.1.77",
-              "@jskit-ai/resource-core": "0.1.76",
-              "@jskit-ai/resource-crud-core": "0.1.76",
-              "@jskit-ai/users-core": "0.1.143"
+              "@jskit-ai/json-rest-api-core": "0.1.79",
+              "@jskit-ai/resource-core": "0.1.78",
+              "@jskit-ai/resource-crud-core": "0.1.78",
+              "@jskit-ai/users-core": "0.1.146"
             },
             "dev": {}
           },
@@ -6739,11 +6739,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-web",
-      "version": "0.1.112",
+      "version": "0.1.115",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-web",
-        "version": "0.1.112",
+        "version": "0.1.115",
         "kind": "runtime",
         "description": "Workspace web module: workspace selector, tools widget, workspace surfaces, members UI, and settings hosts.",
         "dependsOn": [
@@ -7000,9 +7000,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-web": "0.1.133",
-              "@jskit-ai/workspaces-core": "0.1.110",
-              "@jskit-ai/users-web": "0.1.149"
+              "@jskit-ai/auth-web": "0.1.136",
+              "@jskit-ai/workspaces-core": "0.1.113",
+              "@jskit-ai/users-web": "0.1.152"
             },
             "dev": {}
           },

--- a/tooling/jskit-catalog/package.json
+++ b/tooling/jskit-catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-catalog",
-  "version": "0.1.149",
+  "version": "0.1.152",
   "description": "Published metadata catalog for JSKIT package descriptors.",
   "type": "module",
   "files": [

--- a/tooling/jskit-cli/package.json
+++ b/tooling/jskit-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-cli",
-  "version": "0.2.155",
+  "version": "0.2.158",
   "description": "Bundle and package orchestration CLI for JSKIT apps.",
   "type": "module",
   "files": [
@@ -21,9 +21,9 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/jskit-catalog": "0.1.149",
-    "@jskit-ai/kernel": "0.1.133",
-    "@jskit-ai/shell-web": "0.1.134",
+    "@jskit-ai/jskit-catalog": "0.1.152",
+    "@jskit-ai/kernel": "0.1.135",
+    "@jskit-ai/shell-web": "0.1.136",
     "@vue/compiler-sfc": "^3.5.29",
     "semver": "^7.7.4",
     "ts-morph": "^28.0.0",


### PR DESCRIPTION
## Summary
- derive generated exact-search field types from inspected column/resource types
- keep BIGINT `_id` fields as `id` while generating VARCHAR `_id` fields as `string`
- cover opaque string filtering with a mixed VARCHAR/BIGINT regression
- record the already-published JSKIT release version refresh

## Verification
- `npm test --workspace @jskit-ai/crud-server-generator`
- `npm run verify`