### PR TITLE
Record CRUD string ID search release versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7627,7 +7627,7 @@
     },
     "packages/crud-server-generator": {
       "name": "@jskit-ai/crud-server-generator",
-      "version": "0.1.145",
+      "version": "0.1.146",
       "dependencies": {
         "@babel/parser": "^7.29.2",
         "@jskit-ai/crud-core": "0.1.144",
@@ -7916,18 +7916,46 @@
         "node": "^22.13.0 || ^24.0.0 || ^26.0.0"
       }
     },
+    "tooling/create-app/node_modules/@jskit-ai/jskit-catalog": {
+      "version": "0.1.152",
+      "resolved": "https://registry.npmjs.org/@jskit-ai/jskit-catalog/-/jskit-catalog-0.1.152.tgz",
+      "integrity": "sha512-/pZhg9Gx3HpUGwPDEQlemE2lImU5Vv9XEGOYKBhUEKjFGdxR+P4HUPeWq8ZFrFD0EOyBEKHAEFwGtR6ef64uZA==",
+      "engines": {
+        "node": "^22.13.0 || ^24.0.0 || ^26.0.0"
+      }
+    },
+    "tooling/create-app/node_modules/@jskit-ai/jskit-cli": {
+      "version": "0.2.158",
+      "resolved": "https://registry.npmjs.org/@jskit-ai/jskit-cli/-/jskit-cli-0.2.158.tgz",
+      "integrity": "sha512-H7TNWuxUvLYiAyHHFzCuFX1DPmTynaTxRtjUMVqW87Y9ys/bNgVlSt3Ml+aRhd66MTU+5iBWBkpq5aJupf48Dw==",
+      "dependencies": {
+        "@jskit-ai/jskit-catalog": "0.1.152",
+        "@jskit-ai/kernel": "0.1.135",
+        "@jskit-ai/shell-web": "0.1.136",
+        "@vue/compiler-sfc": "^3.5.29",
+        "semver": "^7.7.4",
+        "ts-morph": "^28.0.0",
+        "yaml": "^2.8.3"
+      },
+      "bin": {
+        "jskit": "bin/jskit.js"
+      },
+      "engines": {
+        "node": "^22.13.0 || ^24.0.0 || ^26.0.0"
+      }
+    },
     "tooling/jskit-catalog": {
       "name": "@jskit-ai/jskit-catalog",
-      "version": "0.1.152",
+      "version": "0.1.153",
       "engines": {
         "node": "^22.13.0 || ^24.0.0 || ^26.0.0"
       }
     },
     "tooling/jskit-cli": {
       "name": "@jskit-ai/jskit-cli",
-      "version": "0.2.158",
+      "version": "0.2.159",
       "dependencies": {
-        "@jskit-ai/jskit-catalog": "0.1.152",
+        "@jskit-ai/jskit-catalog": "0.1.153",
         "@jskit-ai/kernel": "0.1.135",
         "@jskit-ai/shell-web": "0.1.136",
         "@vue/compiler-sfc": "^3.5.29",

--- a/packages/crud-server-generator/package.descriptor.mjs
+++ b/packages/crud-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-server-generator",
-  version: "0.1.145",
+  version: "0.1.146",
   kind: "generator",
   description: "CRUD server generator with routes, actions, and persistence scaffolding.",
   options: {

--- a/packages/crud-server-generator/package.json
+++ b/packages/crud-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-server-generator",
-  "version": "0.1.145",
+  "version": "0.1.146",
   "type": "module",
   "scripts": {
     "test": "node --test"

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -1844,11 +1844,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-server-generator",
-      "version": "0.1.145",
+      "version": "0.1.146",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-server-generator",
-        "version": "0.1.145",
+        "version": "0.1.146",
         "kind": "generator",
         "description": "CRUD server generator with routes, actions, and persistence scaffolding.",
         "options": {

--- a/tooling/jskit-catalog/package.json
+++ b/tooling/jskit-catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-catalog",
-  "version": "0.1.152",
+  "version": "0.1.153",
   "description": "Published metadata catalog for JSKIT package descriptors.",
   "type": "module",
   "files": [

--- a/tooling/jskit-cli/package.json
+++ b/tooling/jskit-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-cli",
-  "version": "0.2.158",
+  "version": "0.2.159",
   "description": "Bundle and package orchestration CLI for JSKIT apps.",
   "type": "module",
   "files": [
@@ -21,7 +21,7 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/jskit-catalog": "0.1.152",
+    "@jskit-ai/jskit-catalog": "0.1.153",
     "@jskit-ai/kernel": "0.1.135",
     "@jskit-ai/shell-web": "0.1.136",
     "@vue/compiler-sfc": "^3.5.29",


### PR DESCRIPTION
## Summary
- record `@jskit-ai/crud-server-generator@0.1.146`
- publish the matching catalog as `@jskit-ai/jskit-catalog@0.1.153`
- publish `@jskit-ai/jskit-cli@0.2.159` against that catalog

All three versions are published and promoted to npm `latest`.

## Verification
- release script tests
- runtime dependency audit
- descriptor lint
- catalog build and generated-file check
- CRUD server generator package suite
- independent npm registry version reads