### PR TITLE
Preserve omitted optional action inputs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7505,6 +7505,22 @@
         "vuetify": "^4.0.0"
       }
     },
+    "packages/assistant-core/node_modules/@jskit-ai/users-core": {
+      "version": "0.1.146",
+      "resolved": "https://registry.npmjs.org/@jskit-ai/users-core/-/users-core-0.1.146.tgz",
+      "integrity": "sha512-JD2Lyo024eKWi9hCNpiorU9QRpYaK8LJ+ksz1kC+Qb5hQgXZ3jWsnYFNeXg9/fJLH/+29Pl2i1LVNC+pwww8OQ==",
+      "dependencies": {
+        "@jskit-ai/auth-core": "0.1.133",
+        "@jskit-ai/database-runtime": "0.1.134",
+        "@jskit-ai/http-runtime": "0.1.133",
+        "@jskit-ai/json-rest-api-core": "0.1.79",
+        "@jskit-ai/kernel": "0.1.135",
+        "@jskit-ai/resource-core": "0.1.78",
+        "@jskit-ai/resource-crud-core": "0.1.78",
+        "@jskit-ai/uploads-runtime": "0.1.111",
+        "json-rest-schema": "1.x.x"
+      }
+    },
     "packages/assistant-runtime": {
       "name": "@jskit-ai/assistant-runtime",
       "version": "0.1.107",
@@ -7522,6 +7538,22 @@
         "@tanstack/vue-query": "^5.90.5",
         "vue": "^3.5.13",
         "vuetify": "^4.0.0"
+      }
+    },
+    "packages/assistant-runtime/node_modules/@jskit-ai/users-core": {
+      "version": "0.1.146",
+      "resolved": "https://registry.npmjs.org/@jskit-ai/users-core/-/users-core-0.1.146.tgz",
+      "integrity": "sha512-JD2Lyo024eKWi9hCNpiorU9QRpYaK8LJ+ksz1kC+Qb5hQgXZ3jWsnYFNeXg9/fJLH/+29Pl2i1LVNC+pwww8OQ==",
+      "dependencies": {
+        "@jskit-ai/auth-core": "0.1.133",
+        "@jskit-ai/database-runtime": "0.1.134",
+        "@jskit-ai/http-runtime": "0.1.133",
+        "@jskit-ai/json-rest-api-core": "0.1.79",
+        "@jskit-ai/kernel": "0.1.135",
+        "@jskit-ai/resource-core": "0.1.78",
+        "@jskit-ai/resource-crud-core": "0.1.78",
+        "@jskit-ai/uploads-runtime": "0.1.111",
+        "json-rest-schema": "1.x.x"
       }
     },
     "packages/auth-core": {
@@ -7596,6 +7628,22 @@
         "json-rest-schema": "1.x.x"
       }
     },
+    "packages/console-core/node_modules/@jskit-ai/users-core": {
+      "version": "0.1.146",
+      "resolved": "https://registry.npmjs.org/@jskit-ai/users-core/-/users-core-0.1.146.tgz",
+      "integrity": "sha512-JD2Lyo024eKWi9hCNpiorU9QRpYaK8LJ+ksz1kC+Qb5hQgXZ3jWsnYFNeXg9/fJLH/+29Pl2i1LVNC+pwww8OQ==",
+      "dependencies": {
+        "@jskit-ai/auth-core": "0.1.133",
+        "@jskit-ai/database-runtime": "0.1.134",
+        "@jskit-ai/http-runtime": "0.1.133",
+        "@jskit-ai/json-rest-api-core": "0.1.79",
+        "@jskit-ai/kernel": "0.1.135",
+        "@jskit-ai/resource-core": "0.1.78",
+        "@jskit-ai/resource-crud-core": "0.1.78",
+        "@jskit-ai/uploads-runtime": "0.1.111",
+        "json-rest-schema": "1.x.x"
+      }
+    },
     "packages/console-web": {
       "name": "@jskit-ai/console-web",
       "version": "0.1.104",
@@ -7623,6 +7671,22 @@
         "@tanstack/vue-query": "^5.90.5",
         "vue": "^3.5.13",
         "vue-router": "^5.0.4"
+      }
+    },
+    "packages/crud-core/node_modules/@jskit-ai/users-core": {
+      "version": "0.1.146",
+      "resolved": "https://registry.npmjs.org/@jskit-ai/users-core/-/users-core-0.1.146.tgz",
+      "integrity": "sha512-JD2Lyo024eKWi9hCNpiorU9QRpYaK8LJ+ksz1kC+Qb5hQgXZ3jWsnYFNeXg9/fJLH/+29Pl2i1LVNC+pwww8OQ==",
+      "dependencies": {
+        "@jskit-ai/auth-core": "0.1.133",
+        "@jskit-ai/database-runtime": "0.1.134",
+        "@jskit-ai/http-runtime": "0.1.133",
+        "@jskit-ai/json-rest-api-core": "0.1.79",
+        "@jskit-ai/kernel": "0.1.135",
+        "@jskit-ai/resource-core": "0.1.78",
+        "@jskit-ai/resource-crud-core": "0.1.78",
+        "@jskit-ai/uploads-runtime": "0.1.111",
+        "json-rest-schema": "1.x.x"
       }
     },
     "packages/crud-server-generator": {
@@ -7798,7 +7862,7 @@
     },
     "packages/users-core": {
       "name": "@jskit-ai/users-core",
-      "version": "0.1.146",
+      "version": "0.1.147",
       "dependencies": {
         "@jskit-ai/auth-core": "0.1.133",
         "@jskit-ai/database-runtime": "0.1.134",
@@ -7830,9 +7894,10 @@
         "vuetify": "^4.0.0"
       }
     },
-    "packages/workspaces-core": {
-      "name": "@jskit-ai/workspaces-core",
-      "version": "0.1.113",
+    "packages/users-web/node_modules/@jskit-ai/users-core": {
+      "version": "0.1.146",
+      "resolved": "https://registry.npmjs.org/@jskit-ai/users-core/-/users-core-0.1.146.tgz",
+      "integrity": "sha512-JD2Lyo024eKWi9hCNpiorU9QRpYaK8LJ+ksz1kC+Qb5hQgXZ3jWsnYFNeXg9/fJLH/+29Pl2i1LVNC+pwww8OQ==",
       "dependencies": {
         "@jskit-ai/auth-core": "0.1.133",
         "@jskit-ai/database-runtime": "0.1.134",
@@ -7841,7 +7906,22 @@
         "@jskit-ai/kernel": "0.1.135",
         "@jskit-ai/resource-core": "0.1.78",
         "@jskit-ai/resource-crud-core": "0.1.78",
-        "@jskit-ai/users-core": "0.1.146",
+        "@jskit-ai/uploads-runtime": "0.1.111",
+        "json-rest-schema": "1.x.x"
+      }
+    },
+    "packages/workspaces-core": {
+      "name": "@jskit-ai/workspaces-core",
+      "version": "0.1.114",
+      "dependencies": {
+        "@jskit-ai/auth-core": "0.1.133",
+        "@jskit-ai/database-runtime": "0.1.134",
+        "@jskit-ai/http-runtime": "0.1.133",
+        "@jskit-ai/json-rest-api-core": "0.1.79",
+        "@jskit-ai/kernel": "0.1.135",
+        "@jskit-ai/resource-core": "0.1.78",
+        "@jskit-ai/resource-crud-core": "0.1.78",
+        "@jskit-ai/users-core": "0.1.147",
         "json-rest-schema": "1.x.x"
       }
     },
@@ -7863,6 +7943,38 @@
         "vue": "^3.5.13",
         "vue-router": "^5.0.4",
         "vuetify": "^4.0.0"
+      }
+    },
+    "packages/workspaces-web/node_modules/@jskit-ai/users-core": {
+      "version": "0.1.146",
+      "resolved": "https://registry.npmjs.org/@jskit-ai/users-core/-/users-core-0.1.146.tgz",
+      "integrity": "sha512-JD2Lyo024eKWi9hCNpiorU9QRpYaK8LJ+ksz1kC+Qb5hQgXZ3jWsnYFNeXg9/fJLH/+29Pl2i1LVNC+pwww8OQ==",
+      "dependencies": {
+        "@jskit-ai/auth-core": "0.1.133",
+        "@jskit-ai/database-runtime": "0.1.134",
+        "@jskit-ai/http-runtime": "0.1.133",
+        "@jskit-ai/json-rest-api-core": "0.1.79",
+        "@jskit-ai/kernel": "0.1.135",
+        "@jskit-ai/resource-core": "0.1.78",
+        "@jskit-ai/resource-crud-core": "0.1.78",
+        "@jskit-ai/uploads-runtime": "0.1.111",
+        "json-rest-schema": "1.x.x"
+      }
+    },
+    "packages/workspaces-web/node_modules/@jskit-ai/workspaces-core": {
+      "version": "0.1.113",
+      "resolved": "https://registry.npmjs.org/@jskit-ai/workspaces-core/-/workspaces-core-0.1.113.tgz",
+      "integrity": "sha512-he0WyyVK45kvnXywDKDtoNrw3TlOpQAsccMeaIKOpGyUw7WL6AaPxG5qZQfHZxtuSVkA4PA91TloZlkUMZYdCw==",
+      "dependencies": {
+        "@jskit-ai/auth-core": "0.1.133",
+        "@jskit-ai/database-runtime": "0.1.134",
+        "@jskit-ai/http-runtime": "0.1.133",
+        "@jskit-ai/json-rest-api-core": "0.1.79",
+        "@jskit-ai/kernel": "0.1.135",
+        "@jskit-ai/resource-core": "0.1.78",
+        "@jskit-ai/resource-crud-core": "0.1.78",
+        "@jskit-ai/users-core": "0.1.146",
+        "json-rest-schema": "1.x.x"
       }
     },
     "tooling/config-eslint": {
@@ -7946,16 +8058,16 @@
     },
     "tooling/jskit-catalog": {
       "name": "@jskit-ai/jskit-catalog",
-      "version": "0.1.153",
+      "version": "0.1.154",
       "engines": {
         "node": "^22.13.0 || ^24.0.0 || ^26.0.0"
       }
     },
     "tooling/jskit-cli": {
       "name": "@jskit-ai/jskit-cli",
-      "version": "0.2.159",
+      "version": "0.2.160",
       "dependencies": {
-        "@jskit-ai/jskit-catalog": "0.1.153",
+        "@jskit-ai/jskit-catalog": "0.1.154",
         "@jskit-ai/kernel": "0.1.135",
         "@jskit-ai/shell-web": "0.1.136",
         "@vue/compiler-sfc": "^3.5.29",

--- a/packages/users-core/package.descriptor.mjs
+++ b/packages/users-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-core",
-  version: "0.1.146",
+  version: "0.1.147",
   kind: "runtime",
   description: "Users/account runtime plus HTTP routes for account features.",
   dependsOn: [

--- a/packages/users-core/package.json
+++ b/packages/users-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-core",
-  "version": "0.1.146",
+  "version": "0.1.147",
   "type": "module",
   "scripts": {
     "test": "node --test"

--- a/packages/users-core/src/server/accountProfile/bootAccountProfileRoutes.js
+++ b/packages/users-core/src/server/accountProfile/bootAccountProfileRoutes.js
@@ -135,7 +135,7 @@ function bootAccountProfileRoutes(app) {
           stream: filePart.stream,
           mimeType: filePart.mimeType,
           fileName: filePart.fileName,
-          uploadDimension
+          ...(uploadDimension !== undefined ? { uploadDimension } : {})
         }
       });
 

--- a/packages/users-core/src/server/accountSecurity/bootAccountSecurityRoutes.js
+++ b/packages/users-core/src/server/accountSecurity/bootAccountSecurityRoutes.js
@@ -116,11 +116,12 @@ function bootAccountSecurityRoutes(app) {
       }
     },
     async function (request, reply) {
+      const query = request.input.query || {};
       const result = await request.executeAction({
         actionId: "settings.security.oauth.link.start",
         input: {
           provider: request.input.params.provider,
-          returnTo: request.input.query.returnTo
+          ...(Object.hasOwn(query, "returnTo") ? { returnTo: query.returnTo } : {})
         }
       });
 

--- a/packages/users-core/test/usersRouteRequestInputValidator.test.js
+++ b/packages/users-core/test/usersRouteRequestInputValidator.test.js
@@ -228,6 +228,54 @@ test("account route handlers build action input from request.input", async () =>
   assert.equal(calls[7].actionId, "settings.security.sessions.logout_others");
 });
 
+test("account route handlers preserve omitted optional action fields", async () => {
+  const routes = await registerRoutes();
+  const calls = [];
+  const executeAction = async (payload) => {
+    calls.push(payload);
+    if (payload.actionId === "settings.security.oauth.link.start") {
+      return { url: "/oauth/link" };
+    }
+    return {};
+  };
+
+  await findRoute(routes, { method: "GET", path: "/api/settings/security/oauth/:provider/start" }).handler(
+    createActionRequest({
+      input: {
+        params: { provider: "github" },
+        query: {}
+      },
+      executeAction
+    }),
+    createReplyDouble()
+  );
+
+  const avatarStream = {};
+  await findRoute(routes, { method: "POST", path: "/api/settings/profile/avatar" }).handler(
+    createActionRequest({
+      file: async () => ({
+        fieldname: "avatar",
+        filename: "avatar.png",
+        mimetype: "image/png",
+        encoding: "7bit",
+        file: avatarStream,
+        fields: {}
+      }),
+      executeAction
+    }),
+    createReplyDouble()
+  );
+
+  assert.deepEqual(calls[0].input, { provider: "github" });
+  assert.equal(Object.hasOwn(calls[0].input, "returnTo"), false);
+  assert.deepEqual(calls[1].input, {
+    stream: avatarStream,
+    mimeType: "image/png",
+    fileName: "avatar.png"
+  });
+  assert.equal(Object.hasOwn(calls[1].input, "uploadDimension"), false);
+});
+
 test("account settings jsonapi transport resolves response resource id from request user", async () => {
   const routes = await registerRoutes();
   const settingsRoute = findRoute(routes, { method: "GET", path: "/api/settings" });

--- a/packages/workspaces-core/package.descriptor.mjs
+++ b/packages/workspaces-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-core",
-  version: "0.1.113",
+  version: "0.1.114",
   kind: "runtime",
   description: "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
   dependsOn: [
@@ -150,7 +150,7 @@ export default Object.freeze({
         "@jskit-ai/json-rest-api-core": "0.1.79",
         "@jskit-ai/resource-core": "0.1.78",
         "@jskit-ai/resource-crud-core": "0.1.78",
-        "@jskit-ai/users-core": "0.1.146"
+        "@jskit-ai/users-core": "0.1.147"
       },
       dev: {}
     },

--- a/packages/workspaces-core/package.json
+++ b/packages/workspaces-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-core",
-  "version": "0.1.113",
+  "version": "0.1.114",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -24,7 +24,7 @@
     "@jskit-ai/kernel": "0.1.135",
     "@jskit-ai/resource-crud-core": "0.1.78",
     "@jskit-ai/resource-core": "0.1.78",
-    "@jskit-ai/users-core": "0.1.146",
+    "@jskit-ai/users-core": "0.1.147",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/workspaces-core/src/server/workspaceDirectory/bootWorkspaceDirectoryRoutes.js
+++ b/packages/workspaces-core/src/server/workspaceDirectory/bootWorkspaceDirectoryRoutes.js
@@ -61,7 +61,7 @@ function bootWorkspaceDirectoryRoutes(app) {
           actionId: "workspace.workspaces.create",
           input: {
             name: body.name,
-            slug: body.slug
+            ...(Object.hasOwn(body, "slug") ? { slug: body.slug } : {})
           }
         });
         reply.code(200).send(response);

--- a/packages/workspaces-core/test/workspaceService.test.js
+++ b/packages/workspaces-core/test/workspaceService.test.js
@@ -338,6 +338,37 @@ test("workspaceService.createWorkspaceForAuthenticatedUser creates non-personal 
   assert.equal(workspace.slug, "ops-team");
   assert.equal(calls.insert, 1);
   assert.equal(calls.ensureOwnerMembership, 1);
+  assert.equal(calls.ensureWorkspaceSettings, 1);
+  assert.equal(insertedPayloads[0].isPersonal, false);
+  assert.equal(insertedPayloads[0].ownerUserId, "7");
+});
+
+test("workspaceService.createWorkspaceForAuthenticatedUser generates an omitted slug and provisions ownership", async () => {
+  const { service, calls, insertedPayloads } = createWorkspaceServiceFixture({
+    tenancyMode: "workspaces",
+    tenancyPolicy: {
+      workspace: {
+        allowSelfCreate: true
+      }
+    }
+  });
+
+  const workspace = await service.createWorkspaceForAuthenticatedUser(
+    {
+      id: "7",
+      email: "chiaramobily@gmail.com",
+      displayName: "Chiara"
+    },
+    {
+      name: "Operations Team"
+    }
+  );
+
+  assert.equal(workspace.slug, "operations-team");
+  assert.equal(calls.insert, 1);
+  assert.equal(calls.ensureOwnerMembership, 1);
+  assert.equal(calls.ensureWorkspaceSettings, 1);
+  assert.equal(insertedPayloads[0].slug, "operations-team");
   assert.equal(insertedPayloads[0].isPersonal, false);
   assert.equal(insertedPayloads[0].ownerUserId, "7");
 });

--- a/packages/workspaces-core/test/workspacesRouteRequestInputValidator.test.js
+++ b/packages/workspaces-core/test/workspacesRouteRequestInputValidator.test.js
@@ -340,6 +340,34 @@ test("workspaces-core boot skips invitation redeem/list routes when workspace in
   assert.equal(findRoute(routes, { method: "DELETE", path: "/api/w/:workspaceSlug/invites/:inviteId" }), null);
 });
 
+test("workspace create handler preserves an omitted optional slug", async () => {
+  const routes = await registerRoutes();
+  const workspaceCreate = findRoute(routes, {
+    method: "POST",
+    path: "/api/workspaces"
+  });
+  const calls = [];
+
+  await workspaceCreate.handler(
+    createActionRequest({
+      input: {
+        body: { name: "Operations Team" }
+      },
+      executeAction: async (payload) => {
+        calls.push(payload);
+        return {};
+      }
+    }),
+    createReplyDouble()
+  );
+
+  assert.deepEqual(calls, [{
+    actionId: "workspace.workspaces.create",
+    input: { name: "Operations Team" }
+  }]);
+  assert.equal(Object.hasOwn(calls[0].input, "slug"), false);
+});
+
 test("workspace invite and member handlers build action input from request.input", async () => {
   const routes = await registerRoutes();
   const workspaceCreate = findRoute(routes, {

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -5505,11 +5505,11 @@
     },
     {
       "packageId": "@jskit-ai/users-core",
-      "version": "0.1.146",
+      "version": "0.1.147",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-core",
-        "version": "0.1.146",
+        "version": "0.1.147",
         "kind": "runtime",
         "description": "Users/account runtime plus HTTP routes for account features.",
         "dependsOn": [
@@ -6382,11 +6382,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-core",
-      "version": "0.1.113",
+      "version": "0.1.114",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-core",
-        "version": "0.1.113",
+        "version": "0.1.114",
         "kind": "runtime",
         "description": "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
         "dependsOn": [
@@ -6535,7 +6535,7 @@
               "@jskit-ai/json-rest-api-core": "0.1.79",
               "@jskit-ai/resource-core": "0.1.78",
               "@jskit-ai/resource-crud-core": "0.1.78",
-              "@jskit-ai/users-core": "0.1.146"
+              "@jskit-ai/users-core": "0.1.147"
             },
             "dev": {}
           },

--- a/tooling/jskit-catalog/package.json
+++ b/tooling/jskit-catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-catalog",
-  "version": "0.1.153",
+  "version": "0.1.154",
   "description": "Published metadata catalog for JSKIT package descriptors.",
   "type": "module",
   "files": [

--- a/tooling/jskit-cli/package.json
+++ b/tooling/jskit-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-cli",
-  "version": "0.2.159",
+  "version": "0.2.160",
   "description": "Bundle and package orchestration CLI for JSKIT apps.",
   "type": "module",
   "files": [
@@ -21,7 +21,7 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/jskit-catalog": "0.1.153",
+    "@jskit-ai/jskit-catalog": "0.1.154",
     "@jskit-ai/kernel": "0.1.135",
     "@jskit-ai/shell-web": "0.1.136",
     "@vue/compiler-sfc": "^3.5.29",


### PR DESCRIPTION
## Summary
- preserve omitted workspace slugs at the route-to-action boundary so server-side slug generation runs
- fix the same optional-field materialization in OAuth return paths and avatar upload metadata
- cover generated and explicit workspace slugs plus owner membership/settings provisioning
- release users-core 0.1.147, workspaces-core 0.1.114, catalogue 0.1.154, and CLI 0.2.160

## Verification
- npm run verify
- registry versions verified from the release host and v64-pass