### PR TITLE
Release package-owned migration authoring

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7473,7 +7473,7 @@
     },
     "packages/agent-docs": {
       "name": "@jskit-ai/agent-docs",
-      "version": "0.1.101",
+      "version": "0.1.102",
       "engines": {
         "node": "^22.13.0 || ^24.0.0 || ^26.0.0"
       }
@@ -8058,16 +8058,16 @@
     },
     "tooling/jskit-catalog": {
       "name": "@jskit-ai/jskit-catalog",
-      "version": "0.1.154",
+      "version": "0.1.155",
       "engines": {
         "node": "^22.13.0 || ^24.0.0 || ^26.0.0"
       }
     },
     "tooling/jskit-cli": {
       "name": "@jskit-ai/jskit-cli",
-      "version": "0.2.160",
+      "version": "0.2.161",
       "dependencies": {
-        "@jskit-ai/jskit-catalog": "0.1.154",
+        "@jskit-ai/jskit-catalog": "0.1.155",
         "@jskit-ai/kernel": "0.1.135",
         "@jskit-ai/shell-web": "0.1.136",
         "@vue/compiler-sfc": "^3.5.29",

--- a/packages/agent-docs/package.json
+++ b/packages/agent-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/agent-docs",
-  "version": "0.1.101",
+  "version": "0.1.102",
   "description": "Distributed JSKIT agent references, prompts, guides, and generated reference maps.",
   "type": "module",
   "files": [

--- a/tooling/jskit-catalog/package.json
+++ b/tooling/jskit-catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-catalog",
-  "version": "0.1.154",
+  "version": "0.1.155",
   "description": "Published metadata catalog for JSKIT package descriptors.",
   "type": "module",
   "files": [

--- a/tooling/jskit-cli/package.json
+++ b/tooling/jskit-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-cli",
-  "version": "0.2.160",
+  "version": "0.2.161",
   "description": "Bundle and package orchestration CLI for JSKIT apps.",
   "type": "module",
   "files": [
@@ -21,7 +21,7 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/jskit-catalog": "0.1.154",
+    "@jskit-ai/jskit-catalog": "0.1.155",
     "@jskit-ai/kernel": "0.1.135",
     "@jskit-ai/shell-web": "0.1.136",
     "@vue/compiler-sfc": "^3.5.29",


### PR DESCRIPTION
Publishes the package-owned additive migration authoring support and agent guidance.

Published and promoted to latest:
- @jskit-ai/agent-docs@0.1.102
- @jskit-ai/jskit-catalog@0.1.155
- @jskit-ai/jskit-cli@0.2.161

The supported release script completed successfully under Node 26.