### PR TITLE
Enforce canonical CRUD validator groups

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7475,28 +7475,28 @@
     },
     "packages/agent-docs": {
       "name": "@jskit-ai/agent-docs",
-      "version": "0.1.106",
+      "version": "0.1.107",
       "engines": {
         "node": "^22.13.0 || ^24.0.0 || ^26.0.0"
       }
     },
     "packages/assistant": {
       "name": "@jskit-ai/assistant",
-      "version": "0.1.148",
+      "version": "0.1.149",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.139"
+        "@jskit-ai/kernel": "0.1.140"
       }
     },
     "packages/assistant-core": {
       "name": "@jskit-ai/assistant-core",
-      "version": "0.1.116",
+      "version": "0.1.117",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.138",
-        "@jskit-ai/http-runtime": "0.1.137",
-        "@jskit-ai/kernel": "0.1.139",
-        "@jskit-ai/resource-core": "0.1.82",
-        "@jskit-ai/resource-crud-core": "0.1.82",
-        "@jskit-ai/users-core": "0.1.152",
+        "@jskit-ai/database-runtime": "0.1.139",
+        "@jskit-ai/http-runtime": "0.1.138",
+        "@jskit-ai/kernel": "0.1.140",
+        "@jskit-ai/resource-core": "0.1.83",
+        "@jskit-ai/resource-crud-core": "0.1.83",
+        "@jskit-ai/users-core": "0.1.153",
         "dompurify": "^3.4.12",
         "json-rest-schema": "1.x.x",
         "marked": "^17.0.4",
@@ -7509,15 +7509,15 @@
     },
     "packages/assistant-runtime": {
       "name": "@jskit-ai/assistant-runtime",
-      "version": "0.1.111",
+      "version": "0.1.112",
       "dependencies": {
-        "@jskit-ai/assistant-core": "0.1.116",
-        "@jskit-ai/database-runtime": "0.1.138",
-        "@jskit-ai/http-runtime": "0.1.137",
-        "@jskit-ai/kernel": "0.1.139",
-        "@jskit-ai/shell-web": "0.1.140",
-        "@jskit-ai/users-core": "0.1.152",
-        "@jskit-ai/users-web": "0.1.156",
+        "@jskit-ai/assistant-core": "0.1.117",
+        "@jskit-ai/database-runtime": "0.1.139",
+        "@jskit-ai/http-runtime": "0.1.138",
+        "@jskit-ai/kernel": "0.1.140",
+        "@jskit-ai/shell-web": "0.1.141",
+        "@jskit-ai/users-core": "0.1.153",
+        "@jskit-ai/users-web": "0.1.157",
         "json-rest-schema": "1.x.x"
       },
       "peerDependencies": {
@@ -7528,39 +7528,39 @@
     },
     "packages/auth-core": {
       "name": "@jskit-ai/auth-core",
-      "version": "0.1.137",
+      "version": "0.1.138",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0",
-        "@jskit-ai/kernel": "0.1.139",
+        "@jskit-ai/kernel": "0.1.140",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/auth-provider-local-core": {
       "name": "@jskit-ai/auth-provider-local-core",
-      "version": "0.1.41",
+      "version": "0.1.42",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.137",
-        "@jskit-ai/kernel": "0.1.139",
+        "@jskit-ai/auth-core": "0.1.138",
+        "@jskit-ai/kernel": "0.1.140",
         "nodemailer": "^9.0.3"
       }
     },
     "packages/auth-provider-local-db-core": {
       "name": "@jskit-ai/auth-provider-local-db-core",
-      "version": "0.1.32",
+      "version": "0.1.33",
       "dependencies": {
-        "@jskit-ai/auth-provider-local-core": "0.1.41",
-        "@jskit-ai/database-runtime": "0.1.138",
-        "@jskit-ai/kernel": "0.1.139"
+        "@jskit-ai/auth-provider-local-core": "0.1.42",
+        "@jskit-ai/database-runtime": "0.1.139",
+        "@jskit-ai/kernel": "0.1.140"
       }
     },
     "packages/auth-provider-supabase-core": {
       "name": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.137",
+      "version": "0.1.138",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.137",
-        "@jskit-ai/kernel": "0.1.139",
+        "@jskit-ai/auth-core": "0.1.138",
+        "@jskit-ai/kernel": "0.1.140",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0",
         "json-rest-schema": "1.x.x",
@@ -7569,12 +7569,12 @@
     },
     "packages/auth-web": {
       "name": "@jskit-ai/auth-web",
-      "version": "0.1.140",
+      "version": "0.1.141",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.137",
-        "@jskit-ai/http-runtime": "0.1.137",
-        "@jskit-ai/kernel": "0.1.139",
-        "@jskit-ai/shell-web": "0.1.140",
+        "@jskit-ai/auth-core": "0.1.138",
+        "@jskit-ai/http-runtime": "0.1.138",
+        "@jskit-ai/kernel": "0.1.140",
+        "@jskit-ai/shell-web": "0.1.141",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -7587,38 +7587,38 @@
     },
     "packages/console-core": {
       "name": "@jskit-ai/console-core",
-      "version": "0.1.103",
+      "version": "0.1.104",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.137",
-        "@jskit-ai/database-runtime": "0.1.138",
-        "@jskit-ai/http-runtime": "0.1.137",
-        "@jskit-ai/kernel": "0.1.139",
-        "@jskit-ai/resource-crud-core": "0.1.82",
-        "@jskit-ai/users-core": "0.1.152",
+        "@jskit-ai/auth-core": "0.1.138",
+        "@jskit-ai/database-runtime": "0.1.139",
+        "@jskit-ai/http-runtime": "0.1.138",
+        "@jskit-ai/kernel": "0.1.140",
+        "@jskit-ai/resource-crud-core": "0.1.83",
+        "@jskit-ai/users-core": "0.1.153",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/console-web": {
       "name": "@jskit-ai/console-web",
-      "version": "0.1.108",
+      "version": "0.1.109",
       "dependencies": {
-        "@jskit-ai/auth-web": "0.1.140",
-        "@jskit-ai/console-core": "0.1.103",
-        "@jskit-ai/shell-web": "0.1.140"
+        "@jskit-ai/auth-web": "0.1.141",
+        "@jskit-ai/console-core": "0.1.104",
+        "@jskit-ai/shell-web": "0.1.141"
       }
     },
     "packages/crud-core": {
       "name": "@jskit-ai/crud-core",
-      "version": "0.1.149",
+      "version": "0.1.150",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.138",
-        "@jskit-ai/http-runtime": "0.1.137",
-        "@jskit-ai/kernel": "0.1.139",
-        "@jskit-ai/realtime": "0.1.136",
-        "@jskit-ai/resource-crud-core": "0.1.82",
-        "@jskit-ai/shell-web": "0.1.140",
-        "@jskit-ai/users-core": "0.1.152",
-        "@jskit-ai/users-web": "0.1.156",
+        "@jskit-ai/database-runtime": "0.1.139",
+        "@jskit-ai/http-runtime": "0.1.138",
+        "@jskit-ai/kernel": "0.1.140",
+        "@jskit-ai/realtime": "0.1.137",
+        "@jskit-ai/resource-crud-core": "0.1.83",
+        "@jskit-ai/shell-web": "0.1.141",
+        "@jskit-ai/users-core": "0.1.153",
+        "@jskit-ai/users-web": "0.1.157",
         "json-rest-schema": "1.x.x"
       },
       "peerDependencies": {
@@ -7629,99 +7629,99 @@
     },
     "packages/crud-server-generator": {
       "name": "@jskit-ai/crud-server-generator",
-      "version": "0.1.151",
+      "version": "0.1.152",
       "dependencies": {
         "@babel/parser": "^7.29.2",
-        "@jskit-ai/crud-core": "0.1.149",
-        "@jskit-ai/database-runtime": "0.1.138",
-        "@jskit-ai/http-runtime": "0.1.137",
-        "@jskit-ai/json-rest-api-core": "0.1.83",
-        "@jskit-ai/kernel": "0.1.139",
-        "@jskit-ai/resource-crud-core": "0.1.82",
+        "@jskit-ai/crud-core": "0.1.150",
+        "@jskit-ai/database-runtime": "0.1.139",
+        "@jskit-ai/http-runtime": "0.1.138",
+        "@jskit-ai/json-rest-api-core": "0.1.84",
+        "@jskit-ai/kernel": "0.1.140",
+        "@jskit-ai/resource-crud-core": "0.1.83",
         "recast": "^0.23.11"
       }
     },
     "packages/crud-ui-generator": {
       "name": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.122",
+      "version": "0.1.123",
       "dependencies": {
-        "@jskit-ai/crud-core": "0.1.149",
-        "@jskit-ai/kernel": "0.1.139",
-        "@jskit-ai/resource-crud-core": "0.1.82"
+        "@jskit-ai/crud-core": "0.1.150",
+        "@jskit-ai/kernel": "0.1.140",
+        "@jskit-ai/resource-crud-core": "0.1.83"
       }
     },
     "packages/database-runtime": {
       "name": "@jskit-ai/database-runtime",
-      "version": "0.1.138",
+      "version": "0.1.139",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.139"
+        "@jskit-ai/kernel": "0.1.140"
       }
     },
     "packages/database-runtime-mysql": {
       "name": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.137",
+      "version": "0.1.138",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.138",
-        "@jskit-ai/kernel": "0.1.139"
+        "@jskit-ai/database-runtime": "0.1.139",
+        "@jskit-ai/kernel": "0.1.140"
       }
     },
     "packages/database-runtime-postgres": {
       "name": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.136",
+      "version": "0.1.137",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.138"
+        "@jskit-ai/database-runtime": "0.1.139"
       }
     },
     "packages/feature-server-generator": {
       "name": "@jskit-ai/feature-server-generator",
-      "version": "0.1.81"
+      "version": "0.1.82"
     },
     "packages/google-rewarded-core": {
       "name": "@jskit-ai/google-rewarded-core",
-      "version": "0.1.76"
+      "version": "0.1.77"
     },
     "packages/google-rewarded-web": {
       "name": "@jskit-ai/google-rewarded-web",
-      "version": "0.1.76"
+      "version": "0.1.77"
     },
     "packages/http-runtime": {
       "name": "@jskit-ai/http-runtime",
-      "version": "0.1.137",
+      "version": "0.1.138",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.139",
+        "@jskit-ai/kernel": "0.1.140",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/json-rest-api-core": {
       "name": "@jskit-ai/json-rest-api-core",
-      "version": "0.1.83",
+      "version": "0.1.84",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.139",
+        "@jskit-ai/kernel": "0.1.140",
         "hooked-api": "1.x.x",
         "json-rest-api": "^1.0.26"
       }
     },
     "packages/kernel": {
       "name": "@jskit-ai/kernel",
-      "version": "0.1.139",
+      "version": "0.1.140",
       "dependencies": {
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/mobile-capacitor": {
       "name": "@jskit-ai/mobile-capacitor",
-      "version": "0.1.75",
+      "version": "0.1.76",
       "dependencies": {
         "@capacitor/browser": "^7.0.1",
         "@capacitor/core": "^7.4.3",
-        "@jskit-ai/kernel": "0.1.139"
+        "@jskit-ai/kernel": "0.1.140"
       }
     },
     "packages/realtime": {
       "name": "@jskit-ai/realtime",
-      "version": "0.1.136",
+      "version": "0.1.137",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.139",
+        "@jskit-ai/kernel": "0.1.140",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",
@@ -7733,24 +7733,24 @@
     },
     "packages/resource-core": {
       "name": "@jskit-ai/resource-core",
-      "version": "0.1.82",
+      "version": "0.1.83",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.139"
+        "@jskit-ai/kernel": "0.1.140"
       }
     },
     "packages/resource-crud-core": {
       "name": "@jskit-ai/resource-crud-core",
-      "version": "0.1.82",
+      "version": "0.1.83",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.139",
-        "@jskit-ai/resource-core": "0.1.82"
+        "@jskit-ai/kernel": "0.1.140",
+        "@jskit-ai/resource-core": "0.1.83"
       }
     },
     "packages/shell-web": {
       "name": "@jskit-ai/shell-web",
-      "version": "0.1.140",
+      "version": "0.1.141",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.139",
+        "@jskit-ai/kernel": "0.1.140",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -7762,25 +7762,25 @@
     },
     "packages/storage-runtime": {
       "name": "@jskit-ai/storage-runtime",
-      "version": "0.1.137",
+      "version": "0.1.138",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.139",
+        "@jskit-ai/kernel": "0.1.140",
         "unstorage": "^1.17.5"
       }
     },
     "packages/ui-generator": {
       "name": "@jskit-ai/ui-generator",
-      "version": "0.1.122",
+      "version": "0.1.123",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.139",
-        "@jskit-ai/shell-web": "0.1.140"
+        "@jskit-ai/kernel": "0.1.140",
+        "@jskit-ai/shell-web": "0.1.141"
       }
     },
     "packages/uploads-image-web": {
       "name": "@jskit-ai/uploads-image-web",
-      "version": "0.1.115",
+      "version": "0.1.116",
       "dependencies": {
-        "@jskit-ai/uploads-runtime": "0.1.115",
+        "@jskit-ai/uploads-runtime": "0.1.116",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",
@@ -7793,37 +7793,37 @@
     },
     "packages/uploads-runtime": {
       "name": "@jskit-ai/uploads-runtime",
-      "version": "0.1.115",
+      "version": "0.1.116",
       "dependencies": {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.139"
+        "@jskit-ai/kernel": "0.1.140"
       }
     },
     "packages/users-core": {
       "name": "@jskit-ai/users-core",
-      "version": "0.1.152",
+      "version": "0.1.153",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.137",
-        "@jskit-ai/database-runtime": "0.1.138",
-        "@jskit-ai/http-runtime": "0.1.137",
-        "@jskit-ai/json-rest-api-core": "0.1.83",
-        "@jskit-ai/kernel": "0.1.139",
-        "@jskit-ai/resource-core": "0.1.82",
-        "@jskit-ai/resource-crud-core": "0.1.82",
-        "@jskit-ai/uploads-runtime": "0.1.115",
+        "@jskit-ai/auth-core": "0.1.138",
+        "@jskit-ai/database-runtime": "0.1.139",
+        "@jskit-ai/http-runtime": "0.1.138",
+        "@jskit-ai/json-rest-api-core": "0.1.84",
+        "@jskit-ai/kernel": "0.1.140",
+        "@jskit-ai/resource-core": "0.1.83",
+        "@jskit-ai/resource-crud-core": "0.1.83",
+        "@jskit-ai/uploads-runtime": "0.1.116",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/users-web": {
       "name": "@jskit-ai/users-web",
-      "version": "0.1.156",
+      "version": "0.1.157",
       "dependencies": {
-        "@jskit-ai/http-runtime": "0.1.137",
-        "@jskit-ai/kernel": "0.1.139",
-        "@jskit-ai/realtime": "0.1.136",
-        "@jskit-ai/shell-web": "0.1.140",
-        "@jskit-ai/uploads-image-web": "0.1.115",
-        "@jskit-ai/users-core": "0.1.152",
+        "@jskit-ai/http-runtime": "0.1.138",
+        "@jskit-ai/kernel": "0.1.140",
+        "@jskit-ai/realtime": "0.1.137",
+        "@jskit-ai/shell-web": "0.1.141",
+        "@jskit-ai/uploads-image-web": "0.1.116",
+        "@jskit-ai/users-core": "0.1.153",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -7835,30 +7835,30 @@
     },
     "packages/workspaces-core": {
       "name": "@jskit-ai/workspaces-core",
-      "version": "0.1.118",
+      "version": "0.1.119",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.137",
-        "@jskit-ai/database-runtime": "0.1.138",
-        "@jskit-ai/http-runtime": "0.1.137",
-        "@jskit-ai/json-rest-api-core": "0.1.83",
-        "@jskit-ai/kernel": "0.1.139",
-        "@jskit-ai/resource-core": "0.1.82",
-        "@jskit-ai/resource-crud-core": "0.1.82",
-        "@jskit-ai/users-core": "0.1.152",
+        "@jskit-ai/auth-core": "0.1.138",
+        "@jskit-ai/database-runtime": "0.1.139",
+        "@jskit-ai/http-runtime": "0.1.138",
+        "@jskit-ai/json-rest-api-core": "0.1.84",
+        "@jskit-ai/kernel": "0.1.140",
+        "@jskit-ai/resource-core": "0.1.83",
+        "@jskit-ai/resource-crud-core": "0.1.83",
+        "@jskit-ai/users-core": "0.1.153",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/workspaces-web": {
       "name": "@jskit-ai/workspaces-web",
-      "version": "0.1.119",
+      "version": "0.1.120",
       "dependencies": {
-        "@jskit-ai/auth-web": "0.1.140",
-        "@jskit-ai/http-runtime": "0.1.137",
-        "@jskit-ai/kernel": "0.1.139",
-        "@jskit-ai/shell-web": "0.1.140",
-        "@jskit-ai/users-core": "0.1.152",
-        "@jskit-ai/users-web": "0.1.156",
-        "@jskit-ai/workspaces-core": "0.1.118",
+        "@jskit-ai/auth-web": "0.1.141",
+        "@jskit-ai/http-runtime": "0.1.138",
+        "@jskit-ai/kernel": "0.1.140",
+        "@jskit-ai/shell-web": "0.1.141",
+        "@jskit-ai/users-core": "0.1.153",
+        "@jskit-ai/users-web": "0.1.157",
+        "@jskit-ai/workspaces-core": "0.1.119",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -7870,7 +7870,7 @@
     },
     "tooling/config-eslint": {
       "name": "@jskit-ai/config-eslint",
-      "version": "0.1.137",
+      "version": "0.1.138",
       "dependencies": {
         "@eslint/js": "^10.0.1",
         "eslint-plugin-vue": "^10.5.1",
@@ -7909,9 +7909,9 @@
     },
     "tooling/create-app": {
       "name": "@jskit-ai/create-app",
-      "version": "0.1.158",
+      "version": "0.1.159",
       "dependencies": {
-        "@jskit-ai/jskit-cli": "0.2.166"
+        "@jskit-ai/jskit-cli": "0.2.167"
       },
       "bin": {
         "jskit-create-app": "bin/jskit-create-app.js"
@@ -7922,18 +7922,18 @@
     },
     "tooling/jskit-catalog": {
       "name": "@jskit-ai/jskit-catalog",
-      "version": "0.1.160",
+      "version": "0.1.161",
       "engines": {
         "node": "^22.13.0 || ^24.0.0 || ^26.0.0"
       }
     },
     "tooling/jskit-cli": {
       "name": "@jskit-ai/jskit-cli",
-      "version": "0.2.166",
+      "version": "0.2.167",
       "dependencies": {
-        "@jskit-ai/jskit-catalog": "0.1.160",
-        "@jskit-ai/kernel": "0.1.139",
-        "@jskit-ai/shell-web": "0.1.140",
+        "@jskit-ai/jskit-catalog": "0.1.161",
+        "@jskit-ai/kernel": "0.1.140",
+        "@jskit-ai/shell-web": "0.1.141",
         "@vue/compiler-sfc": "^3.5.29",
         "semver": "^7.7.4",
         "ts-morph": "^28.0.0",

--- a/packages/agent-docs/guide/agent/generators/advanced-cruds.md
+++ b/packages/agent-docs/guide/agent/generators/advanced-cruds.md
@@ -1336,8 +1336,8 @@ If the filter contract should be shared with server code, promote it into a CRUD
 
 - create `packages/contacts/src/shared/contactListFilters.js`
 - create `packages/contacts/src/server/contactListFilterContract.js` with `createCrudListFilterContract(...)`
-- update `packages/contacts/src/server/registerRoutes.js` so the list route query validator includes `contactListFilterContract.queryValidator`
-- update `packages/contacts/src/server/actions.js` so the list action input validator includes the same `queryValidator`
+- update `packages/contacts/src/server/registerRoutes.js` so `createCrudJsonApiRouteContracts(...)` receives `listFilterQueryValidator: contactListFilterContract.queryValidator`
+- update `packages/contacts/src/server/actions.js` so `createStandardCrudListQueryValidators(...)` receives the same `listFilterQueryValidator`
 - update the provider's `createJsonRestResourceScopeOptions(...)` call so it merges `searchSchema: contactListFilterContract.jsonRestSearchSchema`
 - update `packages/contacts/src/server/repository.js` so the list query path passes `contactListFilterContract.toJsonRestQuery(query)` into `buildJsonRestQueryParams(...)`
 
@@ -1466,21 +1466,49 @@ That one contract gives the server:
 - `toJsonRestQuery(query)` for repository query normalization
 - `applyQuery(...)` when a non-JSON REST repository still needs direct Knex filtering
 
-Wire the contract into route and action validators:
+Wire the contract independently into the standard route and action query
+groups:
 
 ```js
-const listRouteQueryValidator = composeSchemaDefinitions([
-  listCursorPaginationQueryValidator,
-  listSearchQueryValidator,
-  listParentFilterQueryValidator,
-  contactListFilterContract.queryValidator,
-  lookupIncludeQueryValidator
-], {
-  mode: "patch"
+const {
+  listRouteContract
+} = createCrudJsonApiRouteContracts({
+  resource,
+  listFilterQueryValidator: contactListFilterContract.queryValidator
 });
 ```
 
-Use the same `contactListFilterContract.queryValidator` anywhere else the list query is validated, such as the composed list action input validator if your CRUD package validates query shape at both the route and action boundaries.
+```js
+input: composeSchemaDefinitions([
+  workspaceSlugParamsValidator,
+  ...createStandardCrudListQueryValidators({
+    resource,
+    listFilterQueryValidator: contactListFilterContract.queryValidator
+  })
+])
+```
+
+This does not couple route and action layers together. Each layer still owns
+its validator; both consume the same explicit standard group so pagination,
+search, parent filters, includes, typed sparse fieldsets, and structured
+filters cannot drift.
+
+If `resource.contract.listFilters.queryValidator` already owns the filter
+validator, call `createStandardCrudListQueryValidators({ resource })` instead.
+Append a validator after the standard group only for genuinely additional,
+non-filter query input. Never provide the same filter validator through both
+paths.
+
+Do not manually reconstruct the standard list group from its individual
+validators. Standard view actions likewise compose:
+
+```js
+input: composeSchemaDefinitions([
+  workspaceSlugParamsValidator,
+  recordIdParamsValidator,
+  ...createStandardCrudViewQueryValidators()
+])
+```
 
 Merge the JSON REST search schema when the provider registers the resource:
 
@@ -1532,6 +1560,13 @@ Choose the invalid-value contract deliberately:
 - Keep client-only filters in the generated page-local `listFilters.js`. Move definitions into a CRUD package only when server code or another page needs to share them.
 - Keep the filter keys identical all the way through: definition key, query param key, and repository meaning.
 - Prefer `createCrudListFilterContract(...)` for server-backed structured filters so route/action validators, JSON REST search schema, and repository query normalization stay derived from one shared definition.
+- Compose standard list and view query validators with
+  `createStandardCrudListQueryValidators(...)` and
+  `createStandardCrudViewQueryValidators()` rather than repeating the
+  individual standard validators.
+- Pass a server-backed structured-filter validator through
+  `listFilterQueryValidator`; append validators separately only for
+  additional non-filter query input.
 - Use `type: "presence"` for null/not-null filters such as assigned vs unassigned storage. Do not model those as custom enums plus `applyQuery(...)` overrides unless the SQL semantics are genuinely different from `whereNotNull(...)` / `whereNull(...)`.
 - Use `createCrudListFilters(...)` directly only for non-JSON REST repository code that needs direct Knex filtering without JSON REST registration.
 - Use `q` for free-text and explicit query params for structured filters.

--- a/packages/agent-docs/guide/agent/generators/crud-generators.md
+++ b/packages/agent-docs/guide/agent/generators/crud-generators.md
@@ -424,6 +424,22 @@ The same rule applies after later server scaffolds such as `addresses` and `comm
 
 For standard CRUDs, that file is intentionally compact. It uses `defineCrudResource(...)` from `@jskit-ai/resource-crud-core`, authors the canonical `schema` / `searchSchema` / `defaultSort` / `autofilter` shape once, and lets JSKIT derive the standard CRUD operation contracts from it.
 
+The generated server action validators are compact for the same reason.
+Standard list actions compose
+`createStandardCrudListQueryValidators({ resource })`; standard view actions
+compose `createStandardCrudViewQueryValidators()`. Do not expand those groups
+back into individual pagination, search, parent-filter, include, or
+sparse-field validators.
+
+When a CRUD adds a server-backed structured-filter contract, pass its
+`queryValidator` through the list group's dedicated
+`listFilterQueryValidator` option. If
+`resource.contract.listFilters.queryValidator` already owns it, `{ resource }`
+is sufficient. A validator belongs after the standard group only when it is
+genuinely additional, non-filter query input. This keeps route and action
+validation independent while preventing the two boundaries from drifting as
+the standard query contract evolves.
+
 ### Step 3: scaffold the UI
 
 Once the resource file exists, generate the UI route tree:

--- a/packages/agent-docs/package.json
+++ b/packages/agent-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/agent-docs",
-  "version": "0.1.106",
+  "version": "0.1.107",
   "description": "Distributed JSKIT agent references, prompts, guides, and generated reference maps.",
   "type": "module",
   "files": [

--- a/packages/agent-docs/patterns/filters.md
+++ b/packages/agent-docs/patterns/filters.md
@@ -60,18 +60,57 @@ Server-side pattern, only when implementing real backend filter semantics:
 1. Put reusable filter definitions in the CRUD package if server code or multiple pages need the same contract.
    Example path: `packages/<crud>/src/shared/<crud>ListFilters.js`
 2. Build a server contract from that module with `createCrudListFilterContract(...)`.
-3. Use the contract's `queryValidator` in route/action input composition.
+3. Pass the contract's `queryValidator` through the dedicated
+   `listFilterQueryValidator` option of the standard CRUD list validator group
+   at both the route and action boundaries.
 4. Pass the contract's `jsonRestSearchSchema` into `createJsonRestResourceScopeOptions(..., { searchSchema })`.
 5. Call `contract.toJsonRestQuery(query)` before `buildJsonRestQueryParams(...)` in the JSON REST repository path.
 
 Exact file checklist:
 - create `packages/<crud>/src/shared/<crud>ListFilters.js`
 - create `packages/<crud>/src/server/<crud>ListFilterContract.js` with `createCrudListFilterContract(...)`
-- update `packages/<crud>/src/server/registerRoutes.js` and `packages/<crud>/src/server/actions.js` so the list query validator includes `listFilterContract.queryValidator`
+- update `packages/<crud>/src/server/registerRoutes.js` so
+  `createCrudJsonApiRouteContracts(...)` receives
+  `listFilterQueryValidator: listFilterContract.queryValidator`
+- update `packages/<crud>/src/server/actions.js` so
+  `createStandardCrudListQueryValidators(...)` receives the same
+  `listFilterQueryValidator`
 - update the provider's `createJsonRestResourceScopeOptions(...)` call so `searchSchema: listFilterContract.jsonRestSearchSchema` is merged into the internal JSON REST resource
 - update `packages/<crud>/src/server/repository.js` so list queries pass `listFilterContract.toJsonRestQuery(query)` into `buildJsonRestQueryParams(...)`
 - update the generated page-local `listFilters.js` first; only edit `index.vue` if a specialist lookup label/runtime integration is needed
 - for lookup-backed filters, wire `useCrudListFilterLookups(...)` beside the existing generated filter runtime instead of replacing `CrudListFilterSurface`
+
+Standard route and action query composition:
+
+```js
+const {
+  listRouteContract
+} = createCrudJsonApiRouteContracts({
+  resource,
+  listFilterQueryValidator: recordsListFilterContract.queryValidator
+});
+```
+
+```js
+input: composeSchemaDefinitions([
+  workspaceSlugParamsValidator,
+  ...createStandardCrudListQueryValidators({
+    resource,
+    listFilterQueryValidator: recordsListFilterContract.queryValidator
+  })
+])
+```
+
+If `resource.contract.listFilters.queryValidator` already owns the filter
+validator, pass only `{ resource }`. Append a validator after the standard
+group only for genuinely additional, non-filter query input. Never supply the
+same filter validator through both paths.
+
+Do not reconstruct the standard list group from individual pagination,
+search, parent-filter, include, or sparse-field validators. The group keeps
+the independently validated route and action layers aligned as standard query
+features evolve. Standard view actions use
+`createStandardCrudViewQueryValidators()` for the same reason.
 
 Validation mode is part of the contract:
 - `createCrudListFilterContract(...)` defaults to `invalidValues: "reject"` for a strict server boundary
@@ -111,6 +150,8 @@ Avoid:
 - local filter composables that duplicate the same keys the server already knows about
 - a custom validator shape that does not match the page state
 - hand-rolled route/action validators or repository filters that duplicate `createCrudListFilterContract(...)`
+- manually rebuilding the standard CRUD list/view validator groups from individual validators
+- appending a list-filter validator after `createStandardCrudListQueryValidators(...)` when it belongs in the dedicated `listFilterQueryValidator` option
 - hand-rolled preset apply/reset/active-state helpers when `useCrudListFilters(..., { presets })`, `applyPreset(...)`, and `matchesPreset(...)` fit
 - per-screen `useList()` wrappers for lookup-backed filters when `useCrudListFilterLookups(...)` fits
 - editing generated `.vue` files just to add basic filter controls; use the page-local `listFilters.js` seam first
@@ -139,6 +180,10 @@ Preset contract notes:
 Review checks:
 - one filter definition source of truth: generated page-local `listFilters.js` for client-only filters, or a shared CRUD-package module when server code imports the same definitions
 - server validator, JSON REST search schema, and repository query projection derived from that source through `createCrudListFilterContract(...)`
+- route and action boundaries independently compose
+  `createStandardCrudListQueryValidators(...)`, using the dedicated
+  `listFilterQueryValidator` option when the resource does not already own it
+- standard view actions compose `createStandardCrudViewQueryValidators()`
 - client query params/chips/reset logic derived from that source
 - initial route/default resolution completes before the first list request
 - lookup-backed filters use the shared lookup helper, not a page-local mini-framework

--- a/packages/agent-docs/patterns/server-search.md
+++ b/packages/agent-docs/patterns/server-search.md
@@ -128,25 +128,39 @@ Keep `applyFilter` focused on query semantics:
 - do not put permission checks there
 - do not turn it into a second service layer
 
-Add route validators when:
+Add public query validation when:
 - the filter key is public and may arrive from HTTP query params
 - the page/UI needs a stable, validated query contract
 - malformed values should either be rejected or deliberately discarded
 
-Example route layer:
+For standard CRUD routes and actions, pass the structured-filter validator
+through the standard group's dedicated option:
 
 ```js
 input: composeSchemaDefinitions([
   workspaceSlugParamsValidator,
-  listCursorPaginationQueryValidator,
-  listSearchQueryValidator,
-  vetsListFiltersQueryValidator,
+  ...createStandardCrudListQueryValidators({
+    resource,
+    listFilterQueryValidator: vetsListFilterContract.queryValidator
+  })
 ])
 ```
 
 That means:
-- `q` and the structured filter keys are accepted publicly
+- pagination, `q`, parent filters, includes, sparse fieldsets, and the
+  structured filter keys remain one standard group
 - the repository may still add internal-only keys later
+
+Use the same `listFilterQueryValidator` option with
+`createCrudJsonApiRouteContracts(...)` at the route boundary. The layers
+remain independently validated; they share a small standard validator group
+rather than duplicating its current members.
+
+If `resource.contract.listFilters.queryValidator` already owns the filter
+validator, call `createStandardCrudListQueryValidators({ resource })`.
+Append validators separately only for genuinely additional, non-filter query
+input. Standard view actions use
+`createStandardCrudViewQueryValidators()`.
 
 For structured list filters, prefer the generated contract shape:
 
@@ -229,5 +243,5 @@ function buildScopedQuery(query = {}, context = null) {
 - Same key, same field, simple behavior: `search: true`
 - Public alias or multi-field search: `searchSchema`
 - Complex SQL semantics: `searchSchema` + `applyFilter`
-- Public HTTP query key: add a route validator
+- Public HTTP query key: add it through the standard route/action query group
 - Internal-only repository key: inject it in `repository.js`, skip the public validator

--- a/packages/agent-docs/site/guide/generators/advanced-cruds.md
+++ b/packages/agent-docs/site/guide/generators/advanced-cruds.md
@@ -1334,8 +1334,8 @@ If the filter contract should be shared with server code, promote it into a CRUD
 
 - create `packages/contacts/src/shared/contactListFilters.js`
 - create `packages/contacts/src/server/contactListFilterContract.js` with `createCrudListFilterContract(...)`
-- update `packages/contacts/src/server/registerRoutes.js` so the list route query validator includes `contactListFilterContract.queryValidator`
-- update `packages/contacts/src/server/actions.js` so the list action input validator includes the same `queryValidator`
+- update `packages/contacts/src/server/registerRoutes.js` so `createCrudJsonApiRouteContracts(...)` receives `listFilterQueryValidator: contactListFilterContract.queryValidator`
+- update `packages/contacts/src/server/actions.js` so `createStandardCrudListQueryValidators(...)` receives the same `listFilterQueryValidator`
 - update the provider's `createJsonRestResourceScopeOptions(...)` call so it merges `searchSchema: contactListFilterContract.jsonRestSearchSchema`
 - update `packages/contacts/src/server/repository.js` so the list query path passes `contactListFilterContract.toJsonRestQuery(query)` into `buildJsonRestQueryParams(...)`
 
@@ -1464,21 +1464,49 @@ That one contract gives the server:
 - `toJsonRestQuery(query)` for repository query normalization
 - `applyQuery(...)` when a non-JSON REST repository still needs direct Knex filtering
 
-Wire the contract into route and action validators:
+Wire the contract independently into the standard route and action query
+groups:
 
 ```js
-const listRouteQueryValidator = composeSchemaDefinitions([
-  listCursorPaginationQueryValidator,
-  listSearchQueryValidator,
-  listParentFilterQueryValidator,
-  contactListFilterContract.queryValidator,
-  lookupIncludeQueryValidator
-], {
-  mode: "patch"
+const {
+  listRouteContract
+} = createCrudJsonApiRouteContracts({
+  resource,
+  listFilterQueryValidator: contactListFilterContract.queryValidator
 });
 ```
 
-Use the same `contactListFilterContract.queryValidator` anywhere else the list query is validated, such as the composed list action input validator if your CRUD package validates query shape at both the route and action boundaries.
+```js
+input: composeSchemaDefinitions([
+  workspaceSlugParamsValidator,
+  ...createStandardCrudListQueryValidators({
+    resource,
+    listFilterQueryValidator: contactListFilterContract.queryValidator
+  })
+])
+```
+
+This does not couple route and action layers together. Each layer still owns
+its validator; both consume the same explicit standard group so pagination,
+search, parent filters, includes, typed sparse fieldsets, and structured
+filters cannot drift.
+
+If `resource.contract.listFilters.queryValidator` already owns the filter
+validator, call `createStandardCrudListQueryValidators({ resource })` instead.
+Append a validator after the standard group only for genuinely additional,
+non-filter query input. Never provide the same filter validator through both
+paths.
+
+Do not manually reconstruct the standard list group from its individual
+validators. Standard view actions likewise compose:
+
+```js
+input: composeSchemaDefinitions([
+  workspaceSlugParamsValidator,
+  recordIdParamsValidator,
+  ...createStandardCrudViewQueryValidators()
+])
+```
 
 Merge the JSON REST search schema when the provider registers the resource:
 
@@ -1530,6 +1558,13 @@ Choose the invalid-value contract deliberately:
 - Keep client-only filters in the generated page-local `listFilters.js`. Move definitions into a CRUD package only when server code or another page needs to share them.
 - Keep the filter keys identical all the way through: definition key, query param key, and repository meaning.
 - Prefer `createCrudListFilterContract(...)` for server-backed structured filters so route/action validators, JSON REST search schema, and repository query normalization stay derived from one shared definition.
+- Compose standard list and view query validators with
+  `createStandardCrudListQueryValidators(...)` and
+  `createStandardCrudViewQueryValidators()` rather than repeating the
+  individual standard validators.
+- Pass a server-backed structured-filter validator through
+  `listFilterQueryValidator`; append validators separately only for
+  additional non-filter query input.
 - Use `type: "presence"` for null/not-null filters such as assigned vs unassigned storage. Do not model those as custom enums plus `applyQuery(...)` overrides unless the SQL semantics are genuinely different from `whereNotNull(...)` / `whereNull(...)`.
 - Use `createCrudListFilters(...)` directly only for non-JSON REST repository code that needs direct Knex filtering without JSON REST registration.
 - Use `q` for free-text and explicit query params for structured filters.

--- a/packages/agent-docs/site/guide/generators/crud-generators.md
+++ b/packages/agent-docs/site/guide/generators/crud-generators.md
@@ -422,6 +422,22 @@ The same rule applies after later server scaffolds such as `addresses` and `comm
 
 For standard CRUDs, that file is intentionally compact. It uses `defineCrudResource(...)` from `@jskit-ai/resource-crud-core`, authors the canonical `schema` / `searchSchema` / `defaultSort` / `autofilter` shape once, and lets JSKIT derive the standard CRUD operation contracts from it.
 
+The generated server action validators are compact for the same reason.
+Standard list actions compose
+`createStandardCrudListQueryValidators({ resource })`; standard view actions
+compose `createStandardCrudViewQueryValidators()`. Do not expand those groups
+back into individual pagination, search, parent-filter, include, or
+sparse-field validators.
+
+When a CRUD adds a server-backed structured-filter contract, pass its
+`queryValidator` through the list group's dedicated
+`listFilterQueryValidator` option. If
+`resource.contract.listFilters.queryValidator` already owns it, `{ resource }`
+is sufficient. A validator belongs after the standard group only when it is
+genuinely additional, non-filter query input. This keeps route and action
+validation independent while preventing the two boundaries from drifting as
+the standard query contract evolves.
+
 ### Step 3: scaffold the UI
 
 Once the resource file exists, generate the UI route tree:

--- a/packages/agent-docs/test/crudGuidance.test.js
+++ b/packages/agent-docs/test/crudGuidance.test.js
@@ -91,6 +91,38 @@ test("crud guidance keeps default response selection resource-owned", async () =
   assert.doesNotMatch(generatorGuide, /UI_LIST_REQUEST_FIELDSETS|UI_VIEW_REQUEST_FIELDSETS/);
 });
 
+test("crud guidance requires the standard list and view query validator groups", async () => {
+  const relativePaths = [
+    "patterns/filters.md",
+    "patterns/server-search.md",
+    "site/guide/generators/advanced-cruds.md",
+    "site/guide/generators/crud-generators.md",
+    "guide/agent/generators/advanced-cruds.md",
+    "guide/agent/generators/crud-generators.md"
+  ];
+  const sources = await Promise.all(
+    relativePaths.map((relativePath) => readFile(path.join(packageRoot, relativePath), "utf8"))
+  );
+
+  for (const source of sources) {
+    assert.match(source, /createStandardCrudListQueryValidators/);
+    assert.match(source, /createStandardCrudViewQueryValidators/);
+    assert.match(source, /listFilterQueryValidator/);
+  }
+
+  for (const source of sources.slice(0, 3)) {
+    assert.doesNotMatch(
+      source,
+      /listCursorPaginationQueryValidator,\s*listSearchQueryValidator,\s*listParentFilterQueryValidator/s
+    );
+  }
+
+  const filtersPattern = sources[0];
+  const advancedGuide = sources[2];
+  assert.match(filtersPattern, /Never supply the\s+same filter validator through both\s+paths/);
+  assert.match(advancedGuide, /Never provide the\s+same filter validator through both\s+paths/);
+});
+
 test("crud guidance keeps canonical ownership columns distinct from domain relationships", async () => {
   const pattern = await readFile(path.join(packageRoot, "patterns/crud-scaffolding.md"), "utf8");
   const generatorGuide = await readFile(path.join(packageRoot, "site/guide/generators/crud-generators.md"), "utf8");

--- a/packages/assistant-core/package.descriptor.mjs
+++ b/packages/assistant-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-core",
-  version: "0.1.116",
+  version: "0.1.117",
   kind: "runtime",
   description: "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
   dependsOn: [
@@ -47,11 +47,11 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/http-runtime": "0.1.137",
-        "@jskit-ai/kernel": "0.1.139",
-        "@jskit-ai/resource-core": "0.1.82",
-        "@jskit-ai/resource-crud-core": "0.1.82",
-        "@jskit-ai/users-core": "0.1.152",
+        "@jskit-ai/http-runtime": "0.1.138",
+        "@jskit-ai/kernel": "0.1.140",
+        "@jskit-ai/resource-core": "0.1.83",
+        "@jskit-ai/resource-crud-core": "0.1.83",
+        "@jskit-ai/users-core": "0.1.153",
         "dompurify": "^3.3.3",
         "json-rest-schema": "1.x.x",
         "marked": "^17.0.4",

--- a/packages/assistant-core/package.json
+++ b/packages/assistant-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-core",
-  "version": "0.1.116",
+  "version": "0.1.117",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,12 +11,12 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.138",
-    "@jskit-ai/http-runtime": "0.1.137",
-    "@jskit-ai/kernel": "0.1.139",
-    "@jskit-ai/resource-crud-core": "0.1.82",
-    "@jskit-ai/resource-core": "0.1.82",
-    "@jskit-ai/users-core": "0.1.152",
+    "@jskit-ai/database-runtime": "0.1.139",
+    "@jskit-ai/http-runtime": "0.1.138",
+    "@jskit-ai/kernel": "0.1.140",
+    "@jskit-ai/resource-crud-core": "0.1.83",
+    "@jskit-ai/resource-core": "0.1.83",
+    "@jskit-ai/users-core": "0.1.153",
     "dompurify": "^3.4.12",
     "json-rest-schema": "1.x.x",
     "marked": "^17.0.4",

--- a/packages/assistant-runtime/package.descriptor.mjs
+++ b/packages/assistant-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-runtime",
-  version: "0.1.111",
+  version: "0.1.112",
   kind: "runtime",
   description: "Shared assistant runtime with per-surface assistant registration.",
   dependsOn: [
@@ -95,13 +95,13 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/assistant-core": "0.1.116",
-        "@jskit-ai/database-runtime": "0.1.138",
-        "@jskit-ai/http-runtime": "0.1.137",
-        "@jskit-ai/kernel": "0.1.139",
-        "@jskit-ai/shell-web": "0.1.140",
-        "@jskit-ai/users-core": "0.1.152",
-        "@jskit-ai/users-web": "0.1.156"
+        "@jskit-ai/assistant-core": "0.1.117",
+        "@jskit-ai/database-runtime": "0.1.139",
+        "@jskit-ai/http-runtime": "0.1.138",
+        "@jskit-ai/kernel": "0.1.140",
+        "@jskit-ai/shell-web": "0.1.141",
+        "@jskit-ai/users-core": "0.1.153",
+        "@jskit-ai/users-web": "0.1.157"
       },
       dev: {}
     },

--- a/packages/assistant-runtime/package.json
+++ b/packages/assistant-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-runtime",
-  "version": "0.1.111",
+  "version": "0.1.112",
   "type": "module",
   "exports": {
     "./client": "./src/client/index.js",
@@ -8,13 +8,13 @@
     "./server/actionIds": "./src/server/actionIds.js"
   },
   "dependencies": {
-    "@jskit-ai/assistant-core": "0.1.116",
-    "@jskit-ai/database-runtime": "0.1.138",
-    "@jskit-ai/http-runtime": "0.1.137",
-    "@jskit-ai/kernel": "0.1.139",
-    "@jskit-ai/shell-web": "0.1.140",
-    "@jskit-ai/users-core": "0.1.152",
-    "@jskit-ai/users-web": "0.1.156",
+    "@jskit-ai/assistant-core": "0.1.117",
+    "@jskit-ai/database-runtime": "0.1.139",
+    "@jskit-ai/http-runtime": "0.1.138",
+    "@jskit-ai/kernel": "0.1.140",
+    "@jskit-ai/shell-web": "0.1.141",
+    "@jskit-ai/users-core": "0.1.153",
+    "@jskit-ai/users-web": "0.1.157",
     "json-rest-schema": "1.x.x"
   },
   "peerDependencies": {

--- a/packages/assistant/package.descriptor.mjs
+++ b/packages/assistant/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant",
-  version: "0.1.148",
+  version: "0.1.149",
   kind: "generator",
   description: "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
   options: {

--- a/packages/assistant/package.json
+++ b/packages/assistant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant",
-  "version": "0.1.148",
+  "version": "0.1.149",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.139"
+    "@jskit-ai/kernel": "0.1.140"
   }
 }

--- a/packages/auth-core/package.descriptor.mjs
+++ b/packages/auth-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-core",
-  "version": "0.1.137",
+  "version": "0.1.138",
   "kind": "runtime",
   "dependsOn": [
     "@jskit-ai/value-app-config-shared"
@@ -74,7 +74,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.139",
+        "@jskit-ai/kernel": "0.1.140",
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0"

--- a/packages/auth-core/package.json
+++ b/packages/auth-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-core",
-  "version": "0.1.137",
+  "version": "0.1.138",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -56,7 +56,7 @@
     "./shared/commands/authSessionReadCommand": "./src/shared/commands/authSessionReadCommand.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.139",
+    "@jskit-ai/kernel": "0.1.140",
     "@fastify/cookie": "^11.0.2",
     "@fastify/csrf-protection": "^7.1.0",
     "@fastify/rate-limit": "^10.3.0",

--- a/packages/auth-provider-local-core/package.descriptor.mjs
+++ b/packages/auth-provider-local-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-provider-local-core",
-  "version": "0.1.41",
+  "version": "0.1.42",
   "kind": "runtime",
   "description": "Local auth provider with a file backend default and no database requirement.",
   "dependsOn": [
@@ -64,8 +64,8 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/auth-core": "0.1.137",
-        "@jskit-ai/kernel": "0.1.139",
+        "@jskit-ai/auth-core": "0.1.138",
+        "@jskit-ai/kernel": "0.1.140",
         "nodemailer": "^9.0.3",
         "dotenv": "^16.4.5"
       },

--- a/packages/auth-provider-local-core/package.json
+++ b/packages/auth-provider-local-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-local-core",
-  "version": "0.1.41",
+  "version": "0.1.42",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,8 +11,8 @@
     "./server/lib/index": "./src/server/lib/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.137",
-    "@jskit-ai/kernel": "0.1.139",
+    "@jskit-ai/auth-core": "0.1.138",
+    "@jskit-ai/kernel": "0.1.140",
     "nodemailer": "^9.0.3"
   }
 }

--- a/packages/auth-provider-local-db-core/package.descriptor.mjs
+++ b/packages/auth-provider-local-db-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/auth-provider-local-db-core",
-  version: "0.1.32",
+  version: "0.1.33",
   kind: "runtime",
   description: "Database-backed local auth storage backend for JSKIT local auth.",
   dependsOn: [
@@ -80,9 +80,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-provider-local-core": "0.1.41",
-        "@jskit-ai/database-runtime": "0.1.138",
-        "@jskit-ai/kernel": "0.1.139"
+        "@jskit-ai/auth-provider-local-core": "0.1.42",
+        "@jskit-ai/database-runtime": "0.1.139",
+        "@jskit-ai/kernel": "0.1.140"
       },
       dev: {}
     },

--- a/packages/auth-provider-local-db-core/package.json
+++ b/packages/auth-provider-local-db-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-local-db-core",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,8 +10,8 @@
     "./server/lib/index": "./src/server/lib/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-provider-local-core": "0.1.41",
-    "@jskit-ai/database-runtime": "0.1.138",
-    "@jskit-ai/kernel": "0.1.139"
+    "@jskit-ai/auth-provider-local-core": "0.1.42",
+    "@jskit-ai/database-runtime": "0.1.139",
+    "@jskit-ai/kernel": "0.1.140"
   }
 }

--- a/packages/auth-provider-supabase-core/package.descriptor.mjs
+++ b/packages/auth-provider-supabase-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.137",
+  "version": "0.1.138",
   "kind": "runtime",
   "options": {
     "auth-supabase-url": {
@@ -83,8 +83,8 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/auth-core": "0.1.137",
-        "@jskit-ai/kernel": "0.1.139",
+        "@jskit-ai/auth-core": "0.1.138",
+        "@jskit-ai/kernel": "0.1.140",
         "dotenv": "^16.4.5",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0"

--- a/packages/auth-provider-supabase-core/package.json
+++ b/packages/auth-provider-supabase-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.137",
+  "version": "0.1.138",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,8 +12,8 @@
     "./client": "./src/client/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.137",
-    "@jskit-ai/kernel": "0.1.139",
+    "@jskit-ai/auth-core": "0.1.138",
+    "@jskit-ai/kernel": "0.1.140",
     "json-rest-schema": "1.x.x",
     "jose": "^6.1.0",
     "@supabase/supabase-js": "^2.57.4",

--- a/packages/auth-web/package.descriptor.mjs
+++ b/packages/auth-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-web",
-  "version": "0.1.140",
+  "version": "0.1.141",
   "kind": "runtime",
   "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
   "dependsOn": [
@@ -264,10 +264,10 @@ export default Object.freeze({
     "dependencies": {
       "runtime": {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/auth-core": "0.1.137",
-        "@jskit-ai/http-runtime": "0.1.137",
-        "@jskit-ai/kernel": "0.1.139",
-        "@jskit-ai/shell-web": "0.1.140"
+        "@jskit-ai/auth-core": "0.1.138",
+        "@jskit-ai/http-runtime": "0.1.138",
+        "@jskit-ai/kernel": "0.1.140",
+        "@jskit-ai/shell-web": "0.1.141"
       },
       "dev": {}
     },

--- a/packages/auth-web/package.json
+++ b/packages/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-web",
-  "version": "0.1.140",
+  "version": "0.1.141",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -20,11 +20,11 @@
     "./test/playwright": "./src/test/playwright.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.137",
+    "@jskit-ai/auth-core": "0.1.138",
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/kernel": "0.1.139",
-    "@jskit-ai/shell-web": "0.1.140",
-    "@jskit-ai/http-runtime": "0.1.137"
+    "@jskit-ai/kernel": "0.1.140",
+    "@jskit-ai/shell-web": "0.1.141",
+    "@jskit-ai/http-runtime": "0.1.138"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/console-core/package.descriptor.mjs
+++ b/packages/console-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-core",
-  version: "0.1.103",
+  version: "0.1.104",
   kind: "runtime",
   description: "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
   dependsOn: [
@@ -85,12 +85,12 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.137",
-        "@jskit-ai/database-runtime": "0.1.138",
-        "@jskit-ai/http-runtime": "0.1.137",
-        "@jskit-ai/kernel": "0.1.139",
-        "@jskit-ai/resource-crud-core": "0.1.82",
-        "@jskit-ai/users-core": "0.1.152"
+        "@jskit-ai/auth-core": "0.1.138",
+        "@jskit-ai/database-runtime": "0.1.139",
+        "@jskit-ai/http-runtime": "0.1.138",
+        "@jskit-ai/kernel": "0.1.140",
+        "@jskit-ai/resource-crud-core": "0.1.83",
+        "@jskit-ai/users-core": "0.1.153"
       },
       dev: {}
     },

--- a/packages/console-core/package.json
+++ b/packages/console-core/package.json
@@ -1,17 +1,17 @@
 {
   "name": "@jskit-ai/console-core",
-  "version": "0.1.103",
+  "version": "0.1.104",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.137",
-    "@jskit-ai/database-runtime": "0.1.138",
-    "@jskit-ai/http-runtime": "0.1.137",
-    "@jskit-ai/kernel": "0.1.139",
-    "@jskit-ai/resource-crud-core": "0.1.82",
-    "@jskit-ai/users-core": "0.1.152",
+    "@jskit-ai/auth-core": "0.1.138",
+    "@jskit-ai/database-runtime": "0.1.139",
+    "@jskit-ai/http-runtime": "0.1.138",
+    "@jskit-ai/kernel": "0.1.140",
+    "@jskit-ai/resource-crud-core": "0.1.83",
+    "@jskit-ai/users-core": "0.1.153",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/console-web/package.descriptor.mjs
+++ b/packages/console-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-web",
-  version: "0.1.108",
+  version: "0.1.109",
   kind: "runtime",
   description: "Authenticated console surface scaffold and surface policy wiring.",
   dependsOn: [
@@ -103,9 +103,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-web": "0.1.140",
-        "@jskit-ai/console-core": "0.1.103",
-        "@jskit-ai/shell-web": "0.1.140",
+        "@jskit-ai/auth-web": "0.1.141",
+        "@jskit-ai/console-core": "0.1.104",
+        "@jskit-ai/shell-web": "0.1.141",
       },
       dev: {}
     },

--- a/packages/console-web/package.json
+++ b/packages/console-web/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/console-web",
-  "version": "0.1.108",
+  "version": "0.1.109",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-web": "0.1.140",
-    "@jskit-ai/console-core": "0.1.103",
-    "@jskit-ai/shell-web": "0.1.140"
+    "@jskit-ai/auth-web": "0.1.141",
+    "@jskit-ai/console-core": "0.1.104",
+    "@jskit-ai/shell-web": "0.1.141"
   }
 }

--- a/packages/crud-core/package.descriptor.mjs
+++ b/packages/crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-core",
-  version: "0.1.149",
+  version: "0.1.150",
   kind: "runtime",
   description: "Shared CRUD helpers used by CRUD modules.",
   dependsOn: [
@@ -28,7 +28,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/crud-core": "0.1.149"
+        "@jskit-ai/crud-core": "0.1.150"
       },
       dev: {}
     },

--- a/packages/crud-core/package.json
+++ b/packages/crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-core",
-  "version": "0.1.149",
+  "version": "0.1.150",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -27,15 +27,15 @@
     "./server/routeContracts": "./src/server/routeContracts.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.138",
-    "@jskit-ai/http-runtime": "0.1.137",
-    "@jskit-ai/kernel": "0.1.139",
+    "@jskit-ai/database-runtime": "0.1.139",
+    "@jskit-ai/http-runtime": "0.1.138",
+    "@jskit-ai/kernel": "0.1.140",
     "json-rest-schema": "1.x.x",
-    "@jskit-ai/realtime": "0.1.136",
-    "@jskit-ai/resource-crud-core": "0.1.82",
-    "@jskit-ai/shell-web": "0.1.140",
-    "@jskit-ai/users-core": "0.1.152",
-    "@jskit-ai/users-web": "0.1.156"
+    "@jskit-ai/realtime": "0.1.137",
+    "@jskit-ai/resource-crud-core": "0.1.83",
+    "@jskit-ai/shell-web": "0.1.141",
+    "@jskit-ai/users-core": "0.1.153",
+    "@jskit-ai/users-web": "0.1.157"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/crud-server-generator/package.descriptor.mjs
+++ b/packages/crud-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-server-generator",
-  version: "0.1.151",
+  version: "0.1.152",
   kind: "generator",
   description: "CRUD server generator with routes, actions, and persistence scaffolding.",
   options: {
@@ -184,14 +184,14 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.137",
-        "@jskit-ai/crud-core": "0.1.149",
-        "@jskit-ai/database-runtime": "0.1.138",
-        "@jskit-ai/http-runtime": "0.1.137",
-        "@jskit-ai/json-rest-api-core": "0.1.83",
-        "@jskit-ai/kernel": "0.1.139",
-        "@jskit-ai/realtime": "0.1.136",
-        "@jskit-ai/resource-crud-core": "0.1.82",
+        "@jskit-ai/auth-core": "0.1.138",
+        "@jskit-ai/crud-core": "0.1.150",
+        "@jskit-ai/database-runtime": "0.1.139",
+        "@jskit-ai/http-runtime": "0.1.138",
+        "@jskit-ai/json-rest-api-core": "0.1.84",
+        "@jskit-ai/kernel": "0.1.140",
+        "@jskit-ai/realtime": "0.1.137",
+        "@jskit-ai/resource-crud-core": "0.1.83",
         "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}"
       },
       dev: {}

--- a/packages/crud-server-generator/package.json
+++ b/packages/crud-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-server-generator",
-  "version": "0.1.151",
+  "version": "0.1.152",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,12 +13,12 @@
   },
   "dependencies": {
     "@babel/parser": "^7.29.2",
-    "@jskit-ai/crud-core": "0.1.149",
-    "@jskit-ai/database-runtime": "0.1.138",
-    "@jskit-ai/http-runtime": "0.1.137",
-    "@jskit-ai/json-rest-api-core": "0.1.83",
-    "@jskit-ai/kernel": "0.1.139",
-    "@jskit-ai/resource-crud-core": "0.1.82",
+    "@jskit-ai/crud-core": "0.1.150",
+    "@jskit-ai/database-runtime": "0.1.139",
+    "@jskit-ai/http-runtime": "0.1.138",
+    "@jskit-ai/json-rest-api-core": "0.1.84",
+    "@jskit-ai/kernel": "0.1.140",
+    "@jskit-ai/resource-crud-core": "0.1.83",
     "recast": "^0.23.11"
   }
 }

--- a/packages/crud-ui-generator/package.descriptor.mjs
+++ b/packages/crud-ui-generator/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { GENERATED_UI_NAVIGATION_ROLE_OPTION } from "@jskit-ai/kernel/shared/sup
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-ui-generator",
-  version: "0.1.122",
+  version: "0.1.123",
   kind: "generator",
   description: "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
   options: {
@@ -175,7 +175,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.156"
+        "@jskit-ai/users-web": "0.1.157"
       },
       dev: {}
     },

--- a/packages/crud-ui-generator/package.json
+++ b/packages/crud-ui-generator/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@jskit-ai/crud-ui-generator",
-  "version": "0.1.122",
+  "version": "0.1.123",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/crud-core": "0.1.149",
-    "@jskit-ai/kernel": "0.1.139",
-    "@jskit-ai/resource-crud-core": "0.1.82"
+    "@jskit-ai/crud-core": "0.1.150",
+    "@jskit-ai/kernel": "0.1.140",
+    "@jskit-ai/resource-crud-core": "0.1.83"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/database-runtime-mysql/package.descriptor.mjs
+++ b/packages/database-runtime-mysql/package.descriptor.mjs
@@ -13,7 +13,7 @@ const CI_DATABASE = Object.freeze({
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-mysql",
-  version: "0.1.137",
+  version: "0.1.138",
   kind: "runtime",
   options: {
     "db-host": {
@@ -133,7 +133,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.138",
+        "@jskit-ai/database-runtime": "0.1.139",
         "mysql2": "^3.11.2"
       },
       dev: {}

--- a/packages/database-runtime-mysql/package.json
+++ b/packages/database-runtime-mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-mysql",
-  "version": "0.1.137",
+  "version": "0.1.138",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,7 +12,7 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.138",
-    "@jskit-ai/kernel": "0.1.139"
+    "@jskit-ai/database-runtime": "0.1.139",
+    "@jskit-ai/kernel": "0.1.140"
   }
 }

--- a/packages/database-runtime-postgres/package.descriptor.mjs
+++ b/packages/database-runtime-postgres/package.descriptor.mjs
@@ -12,7 +12,7 @@ const CI_DATABASE = Object.freeze({
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-postgres",
-  version: "0.1.136",
+  version: "0.1.137",
   kind: "runtime",
   options: {
     "db-host": {
@@ -131,7 +131,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.138",
+        "@jskit-ai/database-runtime": "0.1.139",
         "pg": "^8.13.1"
       },
       dev: {}

--- a/packages/database-runtime-postgres/package.json
+++ b/packages/database-runtime-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-postgres",
-  "version": "0.1.136",
+  "version": "0.1.137",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,6 +12,6 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.138"
+    "@jskit-ai/database-runtime": "0.1.139"
   }
 }

--- a/packages/database-runtime/package.descriptor.mjs
+++ b/packages/database-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime",
-  version: "0.1.138",
+  version: "0.1.139",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -70,7 +70,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.139",
+        "@jskit-ai/kernel": "0.1.140",
         "dotenv": "^16.4.5",
         "knex": "^3.1.0"
       },

--- a/packages/database-runtime/package.json
+++ b/packages/database-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime",
-  "version": "0.1.138",
+  "version": "0.1.139",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -25,6 +25,6 @@
     "./shared/transactions": "./src/shared/transactions.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.139"
+    "@jskit-ai/kernel": "0.1.140"
   }
 }

--- a/packages/feature-server-generator/package.descriptor.mjs
+++ b/packages/feature-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/feature-server-generator",
-  version: "0.1.81",
+  version: "0.1.82",
   kind: "generator",
   description: "Scaffold substantial non-CRUD server feature packages with provider, actions, service, and optional persistence seams.",
   options: {
@@ -154,27 +154,27 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@jskit-ai/database-runtime": {
-          version: "0.1.138",
+          version: "0.1.139",
           when: {
             option: "mode",
             notEquals: "orchestrator"
           }
         },
         "@jskit-ai/database-runtime-mysql": {
-          version: "0.1.137",
+          version: "0.1.138",
           when: {
             option: "mode",
             notEquals: "orchestrator"
           }
         },
         "@jskit-ai/json-rest-api-core": {
-          version: "0.1.83",
+          version: "0.1.84",
           when: {
             option: "mode",
             equals: "json-rest"
           }
         },
-        "@jskit-ai/kernel": "0.1.139",
+        "@jskit-ai/kernel": "0.1.140",
         "json-rest-schema": "1.x.x",
         "@local/${option:feature-name|kebab}": "file:packages/${option:feature-name|kebab}"
       },

--- a/packages/feature-server-generator/package.json
+++ b/packages/feature-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/feature-server-generator",
-  "version": "0.1.81",
+  "version": "0.1.82",
   "type": "module",
   "scripts": {
     "test": "node --test"

--- a/packages/google-rewarded-core/package.descriptor.mjs
+++ b/packages/google-rewarded-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/google-rewarded-core",
-  version: "0.1.76",
+  version: "0.1.77",
   kind: "runtime",
   description: "Google rewarded workflow runtime plus internal CRUD providers for rules, provider configs, watch sessions, and unlock receipts.",
   dependsOn: [
@@ -128,14 +128,14 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.137",
-        "@jskit-ai/crud-core": "0.1.149",
-        "@jskit-ai/database-runtime": "0.1.138",
-        "@jskit-ai/http-runtime": "0.1.137",
-        "@jskit-ai/json-rest-api-core": "0.1.83",
-        "@jskit-ai/kernel": "0.1.139",
-        "@jskit-ai/resource-crud-core": "0.1.82",
-        "@jskit-ai/workspaces-core": "0.1.118"
+        "@jskit-ai/auth-core": "0.1.138",
+        "@jskit-ai/crud-core": "0.1.150",
+        "@jskit-ai/database-runtime": "0.1.139",
+        "@jskit-ai/http-runtime": "0.1.138",
+        "@jskit-ai/json-rest-api-core": "0.1.84",
+        "@jskit-ai/kernel": "0.1.140",
+        "@jskit-ai/resource-crud-core": "0.1.83",
+        "@jskit-ai/workspaces-core": "0.1.119"
       },
       dev: {}
     },

--- a/packages/google-rewarded-core/package.json
+++ b/packages/google-rewarded-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/google-rewarded-core",
-  "version": "0.1.76",
+  "version": "0.1.77",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/google-rewarded-web/package.descriptor.mjs
+++ b/packages/google-rewarded-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/google-rewarded-web",
-  version: "0.1.76",
+  version: "0.1.77",
   kind: "runtime",
   description: "Google rewarded client runtime with a fullscreen gate host and GPT orchestration.",
   dependsOn: [
@@ -46,10 +46,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/google-rewarded-core": "0.1.76",
-        "@jskit-ai/http-runtime": "0.1.137",
-        "@jskit-ai/kernel": "0.1.139",
-        "@jskit-ai/shell-web": "0.1.140"
+        "@jskit-ai/google-rewarded-core": "0.1.77",
+        "@jskit-ai/http-runtime": "0.1.138",
+        "@jskit-ai/kernel": "0.1.140",
+        "@jskit-ai/shell-web": "0.1.141"
       },
       dev: {}
     },

--- a/packages/google-rewarded-web/package.json
+++ b/packages/google-rewarded-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/google-rewarded-web",
-  "version": "0.1.76",
+  "version": "0.1.77",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/http-runtime/package.descriptor.mjs
+++ b/packages/http-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/http-runtime",
-  "version": "0.1.137",
+  "version": "0.1.138",
   "kind": "runtime",
   "dependsOn": [],
   "capabilities": {
@@ -67,7 +67,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.139"
+        "@jskit-ai/kernel": "0.1.140"
       },
       "dev": {}
     },

--- a/packages/http-runtime/package.json
+++ b/packages/http-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/http-runtime",
-  "version": "0.1.137",
+  "version": "0.1.138",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -18,7 +18,7 @@
     "./shared/validators/operationValidation": "./src/shared/validators/operationValidation.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.139",
+    "@jskit-ai/kernel": "0.1.140",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/json-rest-api-core/package.descriptor.mjs
+++ b/packages/json-rest-api-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/json-rest-api-core",
-  version: "0.1.83",
+  version: "0.1.84",
   kind: "runtime",
   description: "Shared internal json-rest-api host runtime with autofilter, query-projection, and row-policy support.",
   dependsOn: [

--- a/packages/json-rest-api-core/package.json
+++ b/packages/json-rest-api-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/json-rest-api-core",
-  "version": "0.1.83",
+  "version": "0.1.84",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,6 +11,6 @@
   "dependencies": {
     "hooked-api": "1.x.x",
     "json-rest-api": "^1.0.26",
-    "@jskit-ai/kernel": "0.1.139"
+    "@jskit-ai/kernel": "0.1.140"
   }
 }

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/kernel",
-  "version": "0.1.139",
+  "version": "0.1.140",
   "type": "module",
   "dependencies": {
     "json-rest-schema": "1.x.x"

--- a/packages/mobile-capacitor/package.descriptor.mjs
+++ b/packages/mobile-capacitor/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/mobile-capacitor",
-  version: "0.1.75",
+  version: "0.1.76",
   kind: "runtime",
   description: "Thin Capacitor client integration for JSKIT mobile-shell launch routing and auth callback completion.",
   dependsOn: [
@@ -62,8 +62,8 @@ export default Object.freeze({
         "@capacitor/app": "^7.1.0",
         "@capacitor/browser": "^7.0.1",
         "@capacitor/core": "^7.4.3",
-        "@jskit-ai/kernel": "0.1.139",
-        "@jskit-ai/shell-web": "0.1.140"
+        "@jskit-ai/kernel": "0.1.140",
+        "@jskit-ai/shell-web": "0.1.141"
       },
       dev: {
         "@capacitor/cli": "^7.4.3"

--- a/packages/mobile-capacitor/package.json
+++ b/packages/mobile-capacitor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/mobile-capacitor",
-  "version": "0.1.75",
+  "version": "0.1.76",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,6 +13,6 @@
   "dependencies": {
     "@capacitor/browser": "^7.0.1",
     "@capacitor/core": "^7.4.3",
-    "@jskit-ai/kernel": "0.1.139"
+    "@jskit-ai/kernel": "0.1.140"
   }
 }

--- a/packages/realtime/package.descriptor.mjs
+++ b/packages/realtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/realtime",
-  version: "0.1.136",
+  version: "0.1.137",
   kind: "runtime",
   description: "Thin, generic realtime runtime wrappers for socket.io server and client.",
   options: {
@@ -95,7 +95,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.139",
+        "@jskit-ai/kernel": "0.1.140",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/realtime",
-  "version": "0.1.136",
+  "version": "0.1.137",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@socket.io/redis-adapter": "^8.3.0",
-    "@jskit-ai/kernel": "0.1.139",
+    "@jskit-ai/kernel": "0.1.140",
     "redis": "^5.8.2",
     "socket.io": "^4.8.3",
     "socket.io-client": "^4.8.3"

--- a/packages/resource-core/package.descriptor.mjs
+++ b/packages/resource-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/resource-core",
-  version: "0.1.82",
+  version: "0.1.83",
   kind: "runtime",
   description: "Generic resource-definition helpers and schema-definition normalization.",
   dependsOn: [
@@ -22,7 +22,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/resource-core": "0.1.82"
+        "@jskit-ai/resource-core": "0.1.83"
       },
       dev: {}
     },

--- a/packages/resource-core/package.json
+++ b/packages/resource-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/resource-core",
-  "version": "0.1.82",
+  "version": "0.1.83",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./shared/resource": "./src/shared/resource.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.139"
+    "@jskit-ai/kernel": "0.1.140"
   }
 }

--- a/packages/resource-crud-core/package.descriptor.mjs
+++ b/packages/resource-crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/resource-crud-core",
-  version: "0.1.82",
+  version: "0.1.83",
   kind: "runtime",
   description: "CRUD-specific resource-definition helpers and namespace support.",
   dependsOn: [
@@ -23,7 +23,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/resource-crud-core": "0.1.82"
+        "@jskit-ai/resource-crud-core": "0.1.83"
       },
       dev: {}
     },

--- a/packages/resource-crud-core/package.json
+++ b/packages/resource-crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/resource-crud-core",
-  "version": "0.1.82",
+  "version": "0.1.83",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./shared/crudResource": "./src/shared/crudResource.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.139",
-    "@jskit-ai/resource-core": "0.1.82"
+    "@jskit-ai/kernel": "0.1.140",
+    "@jskit-ai/resource-core": "0.1.83"
   }
 }

--- a/packages/shell-web/package.descriptor.mjs
+++ b/packages/shell-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/shell-web",
-  version: "0.1.140",
+  version: "0.1.141",
   kind: "runtime",
   description: "Web shell layout runtime with outlet-based placement contributions.",
   dependsOn: [],
@@ -311,7 +311,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/kernel": "0.1.139"
+        "@jskit-ai/kernel": "0.1.140"
       },
       dev: {
         "@playwright/test": "1.61.1"

--- a/packages/shell-web/package.json
+++ b/packages/shell-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/shell-web",
-  "version": "0.1.140",
+  "version": "0.1.141",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/kernel": "0.1.139"
+    "@jskit-ai/kernel": "0.1.140"
   },
   "peerDependencies": {
     "pinia": "^3.0.4",

--- a/packages/storage-runtime/package.descriptor.mjs
+++ b/packages/storage-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/storage-runtime",
-  version: "0.1.137",
+  version: "0.1.138",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -50,7 +50,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.139",
+        "@jskit-ai/kernel": "0.1.140",
         "unstorage": "^1.17.3"
       },
       dev: {}

--- a/packages/storage-runtime/package.json
+++ b/packages/storage-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/storage-runtime",
-  "version": "0.1.137",
+  "version": "0.1.138",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./server/providers/StorageRuntimeServiceProvider": "./src/server/providers/StorageRuntimeServiceProvider.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.139",
+    "@jskit-ai/kernel": "0.1.140",
     "unstorage": "^1.17.5"
   }
 }

--- a/packages/ui-generator/package.descriptor.mjs
+++ b/packages/ui-generator/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { GENERATED_UI_NAVIGATION_ROLE_OPTION } from "@jskit-ai/kernel/shared/sup
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/ui-generator",
-  version: "0.1.122",
+  version: "0.1.123",
   kind: "generator",
   description: "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
   options: {
@@ -371,7 +371,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.156"
+        "@jskit-ai/users-web": "0.1.157"
       },
       dev: {}
     },

--- a/packages/ui-generator/package.json
+++ b/packages/ui-generator/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/ui-generator",
-  "version": "0.1.122",
+  "version": "0.1.123",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.139",
-    "@jskit-ai/shell-web": "0.1.140"
+    "@jskit-ai/kernel": "0.1.140",
+    "@jskit-ai/shell-web": "0.1.141"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/uploads-image-web/package.descriptor.mjs
+++ b/packages/uploads-image-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-image-web",
-  version: "0.1.115",
+  version: "0.1.116",
   kind: "runtime",
   description: "Reusable client-side image upload runtime with pre-upload image editing.",
   dependsOn: [
@@ -65,7 +65,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/uploads-runtime": "0.1.115",
+        "@jskit-ai/uploads-runtime": "0.1.116",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-image-web/package.json
+++ b/packages/uploads-image-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-image-web",
-  "version": "0.1.115",
+  "version": "0.1.116",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,7 +13,7 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/uploads-runtime": "0.1.115",
+    "@jskit-ai/uploads-runtime": "0.1.116",
     "@uppy/compressor": "^3.1.0",
     "@uppy/core": "^5.2.0",
     "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-runtime/package.descriptor.mjs
+++ b/packages/uploads-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-runtime",
-  version: "0.1.115",
+  version: "0.1.116",
   kind: "runtime",
   description: "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
   dependsOn: [
@@ -71,7 +71,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.139"
+        "@jskit-ai/kernel": "0.1.140"
       },
       dev: {}
     },

--- a/packages/uploads-runtime/package.json
+++ b/packages/uploads-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-runtime",
-  "version": "0.1.115",
+  "version": "0.1.116",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,6 +16,6 @@
   },
   "dependencies": {
     "@fastify/multipart": "^9.4.0",
-    "@jskit-ai/kernel": "0.1.139"
+    "@jskit-ai/kernel": "0.1.140"
   }
 }

--- a/packages/users-core/package.descriptor.mjs
+++ b/packages/users-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-core",
-  version: "0.1.152",
+  version: "0.1.153",
   kind: "runtime",
   description: "Users/account runtime plus HTTP routes for account features.",
   dependsOn: [
@@ -146,16 +146,16 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.137",
-        "@jskit-ai/crud-core": "0.1.149",
-        "@jskit-ai/database-runtime": "0.1.138",
-        "@jskit-ai/http-runtime": "0.1.137",
-        "@jskit-ai/json-rest-api-core": "0.1.83",
-        "@jskit-ai/kernel": "0.1.139",
-        "@jskit-ai/resource-core": "0.1.82",
-        "@jskit-ai/resource-crud-core": "0.1.82",
+        "@jskit-ai/auth-core": "0.1.138",
+        "@jskit-ai/crud-core": "0.1.150",
+        "@jskit-ai/database-runtime": "0.1.139",
+        "@jskit-ai/http-runtime": "0.1.138",
+        "@jskit-ai/json-rest-api-core": "0.1.84",
+        "@jskit-ai/kernel": "0.1.140",
+        "@jskit-ai/resource-core": "0.1.83",
+        "@jskit-ai/resource-crud-core": "0.1.83",
         "@local/users": "file:packages/users",
-        "@jskit-ai/uploads-runtime": "0.1.115"
+        "@jskit-ai/uploads-runtime": "0.1.116"
       },
       dev: {}
     },

--- a/packages/users-core/package.json
+++ b/packages/users-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-core",
-  "version": "0.1.152",
+  "version": "0.1.153",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,14 +11,14 @@
     "./shared/resources/userSettingsResource": "./src/shared/resources/userSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.137",
-    "@jskit-ai/database-runtime": "0.1.138",
-    "@jskit-ai/http-runtime": "0.1.137",
-    "@jskit-ai/json-rest-api-core": "0.1.83",
-    "@jskit-ai/kernel": "0.1.139",
-    "@jskit-ai/resource-crud-core": "0.1.82",
-    "@jskit-ai/resource-core": "0.1.82",
-    "@jskit-ai/uploads-runtime": "0.1.115",
+    "@jskit-ai/auth-core": "0.1.138",
+    "@jskit-ai/database-runtime": "0.1.139",
+    "@jskit-ai/http-runtime": "0.1.138",
+    "@jskit-ai/json-rest-api-core": "0.1.84",
+    "@jskit-ai/kernel": "0.1.140",
+    "@jskit-ai/resource-crud-core": "0.1.83",
+    "@jskit-ai/resource-core": "0.1.83",
+    "@jskit-ai/uploads-runtime": "0.1.116",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/users-web/package.descriptor.mjs
+++ b/packages/users-web/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { HOME_COG_OUTLET } from "./src/shared/toolsOutletContracts.js";
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-web",
-  version: "0.1.156",
+  version: "0.1.157",
   kind: "runtime",
   description: "Users web module: account/profile UI plus shared users web widgets.",
   dependsOn: [
@@ -286,12 +286,12 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/http-runtime": "0.1.137",
-        "@jskit-ai/realtime": "0.1.136",
-        "@jskit-ai/kernel": "0.1.139",
-        "@jskit-ai/shell-web": "0.1.140",
-        "@jskit-ai/uploads-image-web": "0.1.115",
-        "@jskit-ai/users-core": "0.1.152"
+        "@jskit-ai/http-runtime": "0.1.138",
+        "@jskit-ai/realtime": "0.1.137",
+        "@jskit-ai/kernel": "0.1.140",
+        "@jskit-ai/shell-web": "0.1.141",
+        "@jskit-ai/uploads-image-web": "0.1.116",
+        "@jskit-ai/users-core": "0.1.153"
       },
       dev: {}
     },

--- a/packages/users-web/package.json
+++ b/packages/users-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-web",
-  "version": "0.1.156",
+  "version": "0.1.157",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -46,12 +46,12 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/http-runtime": "0.1.137",
-    "@jskit-ai/kernel": "0.1.139",
-    "@jskit-ai/realtime": "0.1.136",
-    "@jskit-ai/shell-web": "0.1.140",
-    "@jskit-ai/uploads-image-web": "0.1.115",
-    "@jskit-ai/users-core": "0.1.152"
+    "@jskit-ai/http-runtime": "0.1.138",
+    "@jskit-ai/kernel": "0.1.140",
+    "@jskit-ai/realtime": "0.1.137",
+    "@jskit-ai/shell-web": "0.1.141",
+    "@jskit-ai/uploads-image-web": "0.1.116",
+    "@jskit-ai/users-core": "0.1.153"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/workspaces-core/package.descriptor.mjs
+++ b/packages/workspaces-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-core",
-  version: "0.1.118",
+  version: "0.1.119",
   kind: "runtime",
   description: "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
   dependsOn: [
@@ -147,10 +147,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/json-rest-api-core": "0.1.83",
-        "@jskit-ai/resource-core": "0.1.82",
-        "@jskit-ai/resource-crud-core": "0.1.82",
-        "@jskit-ai/users-core": "0.1.152"
+        "@jskit-ai/json-rest-api-core": "0.1.84",
+        "@jskit-ai/resource-core": "0.1.83",
+        "@jskit-ai/resource-crud-core": "0.1.83",
+        "@jskit-ai/users-core": "0.1.153"
       },
       dev: {}
     },

--- a/packages/workspaces-core/package.json
+++ b/packages/workspaces-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-core",
-  "version": "0.1.118",
+  "version": "0.1.119",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -17,14 +17,14 @@
     "./shared/resources/workspaceSettingsResource": "./src/shared/resources/workspaceSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.137",
-    "@jskit-ai/database-runtime": "0.1.138",
-    "@jskit-ai/http-runtime": "0.1.137",
-    "@jskit-ai/json-rest-api-core": "0.1.83",
-    "@jskit-ai/kernel": "0.1.139",
-    "@jskit-ai/resource-crud-core": "0.1.82",
-    "@jskit-ai/resource-core": "0.1.82",
-    "@jskit-ai/users-core": "0.1.152",
+    "@jskit-ai/auth-core": "0.1.138",
+    "@jskit-ai/database-runtime": "0.1.139",
+    "@jskit-ai/http-runtime": "0.1.138",
+    "@jskit-ai/json-rest-api-core": "0.1.84",
+    "@jskit-ai/kernel": "0.1.140",
+    "@jskit-ai/resource-crud-core": "0.1.83",
+    "@jskit-ai/resource-core": "0.1.83",
+    "@jskit-ai/users-core": "0.1.153",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/workspaces-web/package.descriptor.mjs
+++ b/packages/workspaces-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-web",
-  version: "0.1.119",
+  version: "0.1.120",
   kind: "runtime",
   description: "Workspace web module: workspace selector, tools widget, workspace surfaces, members UI, and settings hosts.",
   dependsOn: [
@@ -232,9 +232,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-web": "0.1.140",
-        "@jskit-ai/workspaces-core": "0.1.118",
-        "@jskit-ai/users-web": "0.1.156"
+        "@jskit-ai/auth-web": "0.1.141",
+        "@jskit-ai/workspaces-core": "0.1.119",
+        "@jskit-ai/users-web": "0.1.157"
       },
       dev: {}
     },

--- a/packages/workspaces-web/package.json
+++ b/packages/workspaces-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-web",
-  "version": "0.1.119",
+  "version": "0.1.120",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -15,13 +15,13 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/auth-web": "0.1.140",
-    "@jskit-ai/http-runtime": "0.1.137",
-    "@jskit-ai/kernel": "0.1.139",
-    "@jskit-ai/shell-web": "0.1.140",
-    "@jskit-ai/users-core": "0.1.152",
-    "@jskit-ai/users-web": "0.1.156",
-    "@jskit-ai/workspaces-core": "0.1.118"
+    "@jskit-ai/auth-web": "0.1.141",
+    "@jskit-ai/http-runtime": "0.1.138",
+    "@jskit-ai/kernel": "0.1.140",
+    "@jskit-ai/shell-web": "0.1.141",
+    "@jskit-ai/users-core": "0.1.153",
+    "@jskit-ai/users-web": "0.1.157",
+    "@jskit-ai/workspaces-core": "0.1.119"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/tooling/config-eslint/package.json
+++ b/tooling/config-eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/config-eslint",
-  "version": "0.1.137",
+  "version": "0.1.138",
   "description": "Shared flat ESLint presets for JSKIT projects.",
   "type": "module",
   "files": [

--- a/tooling/create-app/package.descriptor.mjs
+++ b/tooling/create-app/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/create-app",
-  "version": "0.1.158",
+  "version": "0.1.159",
   "dependsOn": [],
   "capabilities": {
     "provides": [

--- a/tooling/create-app/package.json
+++ b/tooling/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/create-app",
-  "version": "0.1.158",
+  "version": "0.1.159",
   "description": "Scaffold JSKIT app shells.",
   "type": "module",
   "files": [
@@ -20,7 +20,7 @@
     "./client": "./src/client/index.js"
   },
   "dependencies": {
-    "@jskit-ai/jskit-cli": "0.2.166"
+    "@jskit-ai/jskit-cli": "0.2.167"
   },
   "engines": {
     "node": "^22.13.0 || ^24.0.0 || ^26.0.0"

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -6,11 +6,11 @@
   "packages": [
     {
       "packageId": "@jskit-ai/assistant",
-      "version": "0.1.148",
+      "version": "0.1.149",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant",
-        "version": "0.1.148",
+        "version": "0.1.149",
         "kind": "generator",
         "description": "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
         "options": {
@@ -347,11 +347,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-core",
-      "version": "0.1.116",
+      "version": "0.1.117",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-core",
-        "version": "0.1.116",
+        "version": "0.1.117",
         "kind": "runtime",
         "description": "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
         "dependsOn": [
@@ -399,11 +399,11 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/http-runtime": "0.1.137",
-              "@jskit-ai/kernel": "0.1.139",
-              "@jskit-ai/resource-core": "0.1.82",
-              "@jskit-ai/resource-crud-core": "0.1.82",
-              "@jskit-ai/users-core": "0.1.152",
+              "@jskit-ai/http-runtime": "0.1.138",
+              "@jskit-ai/kernel": "0.1.140",
+              "@jskit-ai/resource-core": "0.1.83",
+              "@jskit-ai/resource-crud-core": "0.1.83",
+              "@jskit-ai/users-core": "0.1.153",
               "dompurify": "^3.3.3",
               "json-rest-schema": "1.x.x",
               "marked": "^17.0.4",
@@ -422,11 +422,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-runtime",
-      "version": "0.1.111",
+      "version": "0.1.112",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-runtime",
-        "version": "0.1.111",
+        "version": "0.1.112",
         "kind": "runtime",
         "description": "Shared assistant runtime with per-surface assistant registration.",
         "dependsOn": [
@@ -522,13 +522,13 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/assistant-core": "0.1.116",
-              "@jskit-ai/database-runtime": "0.1.138",
-              "@jskit-ai/http-runtime": "0.1.137",
-              "@jskit-ai/kernel": "0.1.139",
-              "@jskit-ai/shell-web": "0.1.140",
-              "@jskit-ai/users-core": "0.1.152",
-              "@jskit-ai/users-web": "0.1.156"
+              "@jskit-ai/assistant-core": "0.1.117",
+              "@jskit-ai/database-runtime": "0.1.139",
+              "@jskit-ai/http-runtime": "0.1.138",
+              "@jskit-ai/kernel": "0.1.140",
+              "@jskit-ai/shell-web": "0.1.141",
+              "@jskit-ai/users-core": "0.1.153",
+              "@jskit-ai/users-web": "0.1.157"
             },
             "dev": {}
           },
@@ -583,11 +583,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-core",
-      "version": "0.1.137",
+      "version": "0.1.138",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-core",
-        "version": "0.1.137",
+        "version": "0.1.138",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/value-app-config-shared"
@@ -660,7 +660,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.139",
+              "@jskit-ai/kernel": "0.1.140",
               "@fastify/cookie": "^11.0.2",
               "@fastify/csrf-protection": "^7.1.0",
               "@fastify/rate-limit": "^10.3.0"
@@ -678,11 +678,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-local-core",
-      "version": "0.1.41",
+      "version": "0.1.42",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-local-core",
-        "version": "0.1.41",
+        "version": "0.1.42",
         "kind": "runtime",
         "description": "Local auth provider with a file backend default and no database requirement.",
         "dependsOn": [
@@ -745,8 +745,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.137",
-              "@jskit-ai/kernel": "0.1.139",
+              "@jskit-ai/auth-core": "0.1.138",
+              "@jskit-ai/kernel": "0.1.140",
               "nodemailer": "^9.0.3",
               "dotenv": "^16.4.5"
             },
@@ -792,11 +792,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-local-db-core",
-      "version": "0.1.32",
+      "version": "0.1.33",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-local-db-core",
-        "version": "0.1.32",
+        "version": "0.1.33",
         "kind": "runtime",
         "description": "Database-backed local auth storage backend for JSKIT local auth.",
         "dependsOn": [
@@ -875,9 +875,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-provider-local-core": "0.1.41",
-              "@jskit-ai/database-runtime": "0.1.138",
-              "@jskit-ai/kernel": "0.1.139"
+              "@jskit-ai/auth-provider-local-core": "0.1.42",
+              "@jskit-ai/database-runtime": "0.1.139",
+              "@jskit-ai/kernel": "0.1.140"
             },
             "dev": {}
           },
@@ -912,11 +912,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.137",
+      "version": "0.1.138",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-supabase-core",
-        "version": "0.1.137",
+        "version": "0.1.138",
         "kind": "runtime",
         "options": {
           "auth-supabase-url": {
@@ -998,8 +998,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.137",
-              "@jskit-ai/kernel": "0.1.139",
+              "@jskit-ai/auth-core": "0.1.138",
+              "@jskit-ai/kernel": "0.1.140",
               "dotenv": "^16.4.5",
               "@supabase/supabase-js": "^2.57.4",
               "jose": "^6.1.0"
@@ -1077,11 +1077,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-web",
-      "version": "0.1.140",
+      "version": "0.1.141",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-web",
-        "version": "0.1.140",
+        "version": "0.1.141",
         "kind": "runtime",
         "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
         "dependsOn": [
@@ -1354,10 +1354,10 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/auth-core": "0.1.137",
-              "@jskit-ai/http-runtime": "0.1.137",
-              "@jskit-ai/kernel": "0.1.139",
-              "@jskit-ai/shell-web": "0.1.140"
+              "@jskit-ai/auth-core": "0.1.138",
+              "@jskit-ai/http-runtime": "0.1.138",
+              "@jskit-ai/kernel": "0.1.140",
+              "@jskit-ai/shell-web": "0.1.141"
             },
             "dev": {}
           },
@@ -1456,11 +1456,11 @@
     },
     {
       "packageId": "@jskit-ai/console-core",
-      "version": "0.1.103",
+      "version": "0.1.104",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-core",
-        "version": "0.1.103",
+        "version": "0.1.104",
         "kind": "runtime",
         "description": "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
         "dependsOn": [
@@ -1544,12 +1544,12 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.137",
-              "@jskit-ai/database-runtime": "0.1.138",
-              "@jskit-ai/http-runtime": "0.1.137",
-              "@jskit-ai/kernel": "0.1.139",
-              "@jskit-ai/resource-crud-core": "0.1.82",
-              "@jskit-ai/users-core": "0.1.152"
+              "@jskit-ai/auth-core": "0.1.138",
+              "@jskit-ai/database-runtime": "0.1.139",
+              "@jskit-ai/http-runtime": "0.1.138",
+              "@jskit-ai/kernel": "0.1.140",
+              "@jskit-ai/resource-crud-core": "0.1.83",
+              "@jskit-ai/users-core": "0.1.153"
             },
             "dev": {}
           },
@@ -1574,11 +1574,11 @@
     },
     {
       "packageId": "@jskit-ai/console-web",
-      "version": "0.1.108",
+      "version": "0.1.109",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-web",
-        "version": "0.1.108",
+        "version": "0.1.109",
         "kind": "runtime",
         "description": "Authenticated console surface scaffold and surface policy wiring.",
         "dependsOn": [
@@ -1688,9 +1688,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-web": "0.1.140",
-              "@jskit-ai/console-core": "0.1.103",
-              "@jskit-ai/shell-web": "0.1.140"
+              "@jskit-ai/auth-web": "0.1.141",
+              "@jskit-ai/console-core": "0.1.104",
+              "@jskit-ai/shell-web": "0.1.141"
             },
             "dev": {}
           },
@@ -1797,11 +1797,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-core",
-      "version": "0.1.149",
+      "version": "0.1.150",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-core",
-        "version": "0.1.149",
+        "version": "0.1.150",
         "kind": "runtime",
         "description": "Shared CRUD helpers used by CRUD modules.",
         "dependsOn": [
@@ -1830,7 +1830,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/crud-core": "0.1.149"
+              "@jskit-ai/crud-core": "0.1.150"
             },
             "dev": {}
           },
@@ -1844,11 +1844,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-server-generator",
-      "version": "0.1.151",
+      "version": "0.1.152",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-server-generator",
-        "version": "0.1.151",
+        "version": "0.1.152",
         "kind": "generator",
         "description": "CRUD server generator with routes, actions, and persistence scaffolding.",
         "options": {
@@ -2039,14 +2039,14 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.137",
-              "@jskit-ai/crud-core": "0.1.149",
-              "@jskit-ai/database-runtime": "0.1.138",
-              "@jskit-ai/http-runtime": "0.1.137",
-              "@jskit-ai/json-rest-api-core": "0.1.83",
-              "@jskit-ai/kernel": "0.1.139",
-              "@jskit-ai/realtime": "0.1.136",
-              "@jskit-ai/resource-crud-core": "0.1.82",
+              "@jskit-ai/auth-core": "0.1.138",
+              "@jskit-ai/crud-core": "0.1.150",
+              "@jskit-ai/database-runtime": "0.1.139",
+              "@jskit-ai/http-runtime": "0.1.138",
+              "@jskit-ai/json-rest-api-core": "0.1.84",
+              "@jskit-ai/kernel": "0.1.140",
+              "@jskit-ai/realtime": "0.1.137",
+              "@jskit-ai/resource-crud-core": "0.1.83",
               "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}"
             },
             "dev": {}
@@ -2191,11 +2191,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.122",
+      "version": "0.1.123",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-ui-generator",
-        "version": "0.1.122",
+        "version": "0.1.123",
         "kind": "generator",
         "description": "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
         "options": {
@@ -2394,7 +2394,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.156"
+              "@jskit-ai/users-web": "0.1.157"
             },
             "dev": {}
           },
@@ -2653,11 +2653,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime",
-      "version": "0.1.138",
+      "version": "0.1.139",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime",
-        "version": "0.1.138",
+        "version": "0.1.139",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -2726,7 +2726,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.139",
+              "@jskit-ai/kernel": "0.1.140",
               "dotenv": "^16.4.5",
               "knex": "^3.1.0"
             },
@@ -2769,11 +2769,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.137",
+      "version": "0.1.138",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-mysql",
-        "version": "0.1.137",
+        "version": "0.1.138",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -2895,7 +2895,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.138",
+              "@jskit-ai/database-runtime": "0.1.139",
               "mysql2": "^3.11.2"
             },
             "dev": {}
@@ -2966,11 +2966,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.136",
+      "version": "0.1.137",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-postgres",
-        "version": "0.1.136",
+        "version": "0.1.137",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -3091,7 +3091,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.138",
+              "@jskit-ai/database-runtime": "0.1.139",
               "pg": "^8.13.1"
             },
             "dev": {}
@@ -3162,11 +3162,11 @@
     },
     {
       "packageId": "@jskit-ai/feature-server-generator",
-      "version": "0.1.81",
+      "version": "0.1.82",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/feature-server-generator",
-        "version": "0.1.81",
+        "version": "0.1.82",
         "kind": "generator",
         "description": "Scaffold substantial non-CRUD server feature packages with provider, actions, service, and optional persistence seams.",
         "options": {
@@ -3331,27 +3331,27 @@
           "dependencies": {
             "runtime": {
               "@jskit-ai/database-runtime": {
-                "version": "0.1.138",
+                "version": "0.1.139",
                 "when": {
                   "option": "mode",
                   "notEquals": "orchestrator"
                 }
               },
               "@jskit-ai/database-runtime-mysql": {
-                "version": "0.1.137",
+                "version": "0.1.138",
                 "when": {
                   "option": "mode",
                   "notEquals": "orchestrator"
                 }
               },
               "@jskit-ai/json-rest-api-core": {
-                "version": "0.1.83",
+                "version": "0.1.84",
                 "when": {
                   "option": "mode",
                   "equals": "json-rest"
                 }
               },
-              "@jskit-ai/kernel": "0.1.139",
+              "@jskit-ai/kernel": "0.1.140",
               "json-rest-schema": "1.x.x",
               "@local/${option:feature-name|kebab}": "file:packages/${option:feature-name|kebab}"
             },
@@ -3464,11 +3464,11 @@
     },
     {
       "packageId": "@jskit-ai/google-rewarded-core",
-      "version": "0.1.76",
+      "version": "0.1.77",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/google-rewarded-core",
-        "version": "0.1.76",
+        "version": "0.1.77",
         "kind": "runtime",
         "description": "Google rewarded workflow runtime plus internal CRUD providers for rules, provider configs, watch sessions, and unlock receipts.",
         "dependsOn": [
@@ -3595,14 +3595,14 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.137",
-              "@jskit-ai/crud-core": "0.1.149",
-              "@jskit-ai/database-runtime": "0.1.138",
-              "@jskit-ai/http-runtime": "0.1.137",
-              "@jskit-ai/json-rest-api-core": "0.1.83",
-              "@jskit-ai/kernel": "0.1.139",
-              "@jskit-ai/resource-crud-core": "0.1.82",
-              "@jskit-ai/workspaces-core": "0.1.118"
+              "@jskit-ai/auth-core": "0.1.138",
+              "@jskit-ai/crud-core": "0.1.150",
+              "@jskit-ai/database-runtime": "0.1.139",
+              "@jskit-ai/http-runtime": "0.1.138",
+              "@jskit-ai/json-rest-api-core": "0.1.84",
+              "@jskit-ai/kernel": "0.1.140",
+              "@jskit-ai/resource-crud-core": "0.1.83",
+              "@jskit-ai/workspaces-core": "0.1.119"
             },
             "dev": {}
           },
@@ -3654,11 +3654,11 @@
     },
     {
       "packageId": "@jskit-ai/google-rewarded-web",
-      "version": "0.1.76",
+      "version": "0.1.77",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/google-rewarded-web",
-        "version": "0.1.76",
+        "version": "0.1.77",
         "kind": "runtime",
         "description": "Google rewarded client runtime with a fullscreen gate host and GPT orchestration.",
         "dependsOn": [
@@ -3705,10 +3705,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/google-rewarded-core": "0.1.76",
-              "@jskit-ai/http-runtime": "0.1.137",
-              "@jskit-ai/kernel": "0.1.139",
-              "@jskit-ai/shell-web": "0.1.140"
+              "@jskit-ai/google-rewarded-core": "0.1.77",
+              "@jskit-ai/http-runtime": "0.1.138",
+              "@jskit-ai/kernel": "0.1.140",
+              "@jskit-ai/shell-web": "0.1.141"
             },
             "dev": {}
           },
@@ -3726,11 +3726,11 @@
     },
     {
       "packageId": "@jskit-ai/http-runtime",
-      "version": "0.1.137",
+      "version": "0.1.138",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/http-runtime",
-        "version": "0.1.137",
+        "version": "0.1.138",
         "kind": "runtime",
         "dependsOn": [],
         "capabilities": {
@@ -3796,7 +3796,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.139"
+              "@jskit-ai/kernel": "0.1.140"
             },
             "dev": {}
           },
@@ -3810,11 +3810,11 @@
     },
     {
       "packageId": "@jskit-ai/json-rest-api-core",
-      "version": "0.1.83",
+      "version": "0.1.84",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/json-rest-api-core",
-        "version": "0.1.83",
+        "version": "0.1.84",
         "kind": "runtime",
         "description": "Shared internal json-rest-api host runtime with autofilter, query-projection, and row-policy support.",
         "dependsOn": [
@@ -3874,11 +3874,11 @@
     },
     {
       "packageId": "@jskit-ai/mobile-capacitor",
-      "version": "0.1.75",
+      "version": "0.1.76",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/mobile-capacitor",
-        "version": "0.1.75",
+        "version": "0.1.76",
         "kind": "runtime",
         "description": "Thin Capacitor client integration for JSKIT mobile-shell launch routing and auth callback completion.",
         "dependsOn": [
@@ -3941,8 +3941,8 @@
               "@capacitor/app": "^7.1.0",
               "@capacitor/browser": "^7.0.1",
               "@capacitor/core": "^7.4.3",
-              "@jskit-ai/kernel": "0.1.139",
-              "@jskit-ai/shell-web": "0.1.140"
+              "@jskit-ai/kernel": "0.1.140",
+              "@jskit-ai/shell-web": "0.1.141"
             },
             "dev": {
               "@capacitor/cli": "^7.4.3"
@@ -3994,11 +3994,11 @@
     },
     {
       "packageId": "@jskit-ai/realtime",
-      "version": "0.1.136",
+      "version": "0.1.137",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/realtime",
-        "version": "0.1.136",
+        "version": "0.1.137",
         "kind": "runtime",
         "description": "Thin, generic realtime runtime wrappers for socket.io server and client.",
         "options": {
@@ -4094,7 +4094,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.139",
+              "@jskit-ai/kernel": "0.1.140",
               "@socket.io/redis-adapter": "^8.3.0",
               "redis": "^5.8.2",
               "socket.io": "^4.8.3",
@@ -4143,11 +4143,11 @@
     },
     {
       "packageId": "@jskit-ai/resource-core",
-      "version": "0.1.82",
+      "version": "0.1.83",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/resource-core",
-        "version": "0.1.82",
+        "version": "0.1.83",
         "kind": "runtime",
         "description": "Generic resource-definition helpers and schema-definition normalization.",
         "dependsOn": [
@@ -4170,7 +4170,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/resource-core": "0.1.82"
+              "@jskit-ai/resource-core": "0.1.83"
             },
             "dev": {}
           },
@@ -4185,11 +4185,11 @@
     },
     {
       "packageId": "@jskit-ai/resource-crud-core",
-      "version": "0.1.82",
+      "version": "0.1.83",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/resource-crud-core",
-        "version": "0.1.82",
+        "version": "0.1.83",
         "kind": "runtime",
         "description": "CRUD-specific resource-definition helpers and namespace support.",
         "dependsOn": [
@@ -4213,7 +4213,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/resource-crud-core": "0.1.82"
+              "@jskit-ai/resource-crud-core": "0.1.83"
             },
             "dev": {}
           },
@@ -4228,11 +4228,11 @@
     },
     {
       "packageId": "@jskit-ai/shell-web",
-      "version": "0.1.140",
+      "version": "0.1.141",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/shell-web",
-        "version": "0.1.140",
+        "version": "0.1.141",
         "kind": "runtime",
         "description": "Web shell layout runtime with outlet-based placement contributions.",
         "dependsOn": [],
@@ -4578,7 +4578,7 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/kernel": "0.1.139"
+              "@jskit-ai/kernel": "0.1.140"
             },
             "dev": {
               "@playwright/test": "1.61.1"
@@ -4807,11 +4807,11 @@
     },
     {
       "packageId": "@jskit-ai/storage-runtime",
-      "version": "0.1.137",
+      "version": "0.1.138",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/storage-runtime",
-        "version": "0.1.137",
+        "version": "0.1.138",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -4860,7 +4860,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.139",
+              "@jskit-ai/kernel": "0.1.140",
               "unstorage": "^1.17.3"
             },
             "dev": {}
@@ -4876,11 +4876,11 @@
     },
     {
       "packageId": "@jskit-ai/ui-generator",
-      "version": "0.1.122",
+      "version": "0.1.123",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/ui-generator",
-        "version": "0.1.122",
+        "version": "0.1.123",
         "kind": "generator",
         "description": "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
         "options": {
@@ -5313,7 +5313,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.156"
+              "@jskit-ai/users-web": "0.1.157"
             },
             "dev": {}
           },
@@ -5328,11 +5328,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-image-web",
-      "version": "0.1.115",
+      "version": "0.1.116",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-image-web",
-        "version": "0.1.115",
+        "version": "0.1.116",
         "kind": "runtime",
         "description": "Reusable client-side image upload runtime with pre-upload image editing.",
         "dependsOn": [
@@ -5396,7 +5396,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/uploads-runtime": "0.1.115",
+              "@jskit-ai/uploads-runtime": "0.1.116",
               "@uppy/compressor": "^3.1.0",
               "@uppy/core": "^5.2.0",
               "@uppy/dashboard": "^5.1.1",
@@ -5416,11 +5416,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-runtime",
-      "version": "0.1.115",
+      "version": "0.1.116",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-runtime",
-        "version": "0.1.115",
+        "version": "0.1.116",
         "kind": "runtime",
         "description": "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
         "dependsOn": [
@@ -5490,7 +5490,7 @@
           "dependencies": {
             "runtime": {
               "@fastify/multipart": "^9.4.0",
-              "@jskit-ai/kernel": "0.1.139"
+              "@jskit-ai/kernel": "0.1.140"
             },
             "dev": {}
           },
@@ -5505,11 +5505,11 @@
     },
     {
       "packageId": "@jskit-ai/users-core",
-      "version": "0.1.152",
+      "version": "0.1.153",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-core",
-        "version": "0.1.152",
+        "version": "0.1.153",
         "kind": "runtime",
         "description": "Users/account runtime plus HTTP routes for account features.",
         "dependsOn": [
@@ -5653,16 +5653,16 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.137",
-              "@jskit-ai/crud-core": "0.1.149",
-              "@jskit-ai/database-runtime": "0.1.138",
-              "@jskit-ai/http-runtime": "0.1.137",
-              "@jskit-ai/json-rest-api-core": "0.1.83",
-              "@jskit-ai/kernel": "0.1.139",
-              "@jskit-ai/resource-core": "0.1.82",
-              "@jskit-ai/resource-crud-core": "0.1.82",
+              "@jskit-ai/auth-core": "0.1.138",
+              "@jskit-ai/crud-core": "0.1.150",
+              "@jskit-ai/database-runtime": "0.1.139",
+              "@jskit-ai/http-runtime": "0.1.138",
+              "@jskit-ai/json-rest-api-core": "0.1.84",
+              "@jskit-ai/kernel": "0.1.140",
+              "@jskit-ai/resource-core": "0.1.83",
+              "@jskit-ai/resource-crud-core": "0.1.83",
               "@local/users": "file:packages/users",
-              "@jskit-ai/uploads-runtime": "0.1.115"
+              "@jskit-ai/uploads-runtime": "0.1.116"
             },
             "dev": {}
           },
@@ -5889,11 +5889,11 @@
     },
     {
       "packageId": "@jskit-ai/users-web",
-      "version": "0.1.156",
+      "version": "0.1.157",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-web",
-        "version": "0.1.156",
+        "version": "0.1.157",
         "kind": "runtime",
         "description": "Users web module: account/profile UI plus shared users web widgets.",
         "dependsOn": [
@@ -6196,12 +6196,12 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/http-runtime": "0.1.137",
-              "@jskit-ai/realtime": "0.1.136",
-              "@jskit-ai/kernel": "0.1.139",
-              "@jskit-ai/shell-web": "0.1.140",
-              "@jskit-ai/uploads-image-web": "0.1.115",
-              "@jskit-ai/users-core": "0.1.152"
+              "@jskit-ai/http-runtime": "0.1.138",
+              "@jskit-ai/realtime": "0.1.137",
+              "@jskit-ai/kernel": "0.1.140",
+              "@jskit-ai/shell-web": "0.1.141",
+              "@jskit-ai/uploads-image-web": "0.1.116",
+              "@jskit-ai/users-core": "0.1.153"
             },
             "dev": {}
           },
@@ -6382,11 +6382,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-core",
-      "version": "0.1.118",
+      "version": "0.1.119",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-core",
-        "version": "0.1.118",
+        "version": "0.1.119",
         "kind": "runtime",
         "description": "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
         "dependsOn": [
@@ -6532,10 +6532,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/json-rest-api-core": "0.1.83",
-              "@jskit-ai/resource-core": "0.1.82",
-              "@jskit-ai/resource-crud-core": "0.1.82",
-              "@jskit-ai/users-core": "0.1.152"
+              "@jskit-ai/json-rest-api-core": "0.1.84",
+              "@jskit-ai/resource-core": "0.1.83",
+              "@jskit-ai/resource-crud-core": "0.1.83",
+              "@jskit-ai/users-core": "0.1.153"
             },
             "dev": {}
           },
@@ -6739,11 +6739,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-web",
-      "version": "0.1.119",
+      "version": "0.1.120",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-web",
-        "version": "0.1.119",
+        "version": "0.1.120",
         "kind": "runtime",
         "description": "Workspace web module: workspace selector, tools widget, workspace surfaces, members UI, and settings hosts.",
         "dependsOn": [
@@ -7000,9 +7000,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-web": "0.1.140",
-              "@jskit-ai/workspaces-core": "0.1.118",
-              "@jskit-ai/users-web": "0.1.156"
+              "@jskit-ai/auth-web": "0.1.141",
+              "@jskit-ai/workspaces-core": "0.1.119",
+              "@jskit-ai/users-web": "0.1.157"
             },
             "dev": {}
           },

--- a/tooling/jskit-catalog/package.json
+++ b/tooling/jskit-catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-catalog",
-  "version": "0.1.160",
+  "version": "0.1.161",
   "description": "Published metadata catalog for JSKIT package descriptors.",
   "type": "module",
   "files": [

--- a/tooling/jskit-cli/package.json
+++ b/tooling/jskit-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-cli",
-  "version": "0.2.166",
+  "version": "0.2.167",
   "description": "Bundle and package orchestration CLI for JSKIT apps.",
   "type": "module",
   "files": [
@@ -21,9 +21,9 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/jskit-catalog": "0.1.160",
-    "@jskit-ai/kernel": "0.1.139",
-    "@jskit-ai/shell-web": "0.1.140",
+    "@jskit-ai/jskit-catalog": "0.1.161",
+    "@jskit-ai/kernel": "0.1.140",
+    "@jskit-ai/shell-web": "0.1.141",
     "@vue/compiler-sfc": "^3.5.29",
     "semver": "^7.7.4",
     "ts-morph": "^28.0.0",

--- a/tooling/jskit-cli/src/server/commandHandlers/health.js
+++ b/tooling/jskit-cli/src/server/commandHandlers/health.js
@@ -76,6 +76,7 @@ function createHealthCommands(ctx = {}) {
   const DIRECT_MDI_BOUND_LITERAL_ICON_PATTERN =
     /<(v-[a-z0-9-]+)[^>]*?(?::|v-bind:)(icon|prepend-icon|append-icon)\s*=\s*(['"])(['"])(mdi-[^'"]+)\4\3/gi;
   const FILTER_RUNTIME_CALLEES = Object.freeze([
+    "createCrudListFilterContract",
     "createCrudListFilters",
     "useCrudListFilters"
   ]);
@@ -87,6 +88,10 @@ function createHealthCommands(ctx = {}) {
   const FEATURE_SERVER_SCAFFOLD_SHAPE = "feature-server-v1";
   const CRUD_SERVER_SCAFFOLD_SHAPE = "crud-server-v1";
   const USERS_CORE_BASELINE_CRUD_SCAFFOLD_SHAPE = "users-core-crud-v1";
+  const STANDARD_CRUD_SCAFFOLD_SHAPES = new Set([
+    CRUD_SERVER_SCAFFOLD_SHAPE,
+    USERS_CORE_BASELINE_CRUD_SCAFFOLD_SHAPE
+  ]);
   const FEATURE_SERVER_DEFAULT_LANE = "default";
   const FEATURE_SERVER_JSON_REST_MODE = "json-rest";
   const FEATURE_SERVER_PERSISTENT_MODES = new Set([
@@ -587,6 +592,13 @@ function createHealthCommands(ctx = {}) {
     return ensureObject(ensureObject(ensureObject(descriptor).metadata).jskit);
   }
 
+  function isStandardCrudPackageEntry(packageEntry) {
+    const metadata = normalizeJskitMetadata(packageEntry?.descriptor);
+    return STANDARD_CRUD_SCAFFOLD_SHAPES.has(
+      String(metadata.scaffoldShape || "").trim()
+    );
+  }
+
   function normalizeOwnedTableEntries(packageEntry) {
     const packageId = String(packageEntry?.packageId || "").trim();
     const packagePath = resolvePackageDisplayPath(packageEntry);
@@ -627,10 +639,7 @@ function createHealthCommands(ctx = {}) {
 
     const jskitMetadata = normalizeJskitMetadata(packageEntry?.descriptor);
     const scaffoldShape = String(jskitMetadata.scaffoldShape || "").trim();
-    if (
-      scaffoldShape === CRUD_SERVER_SCAFFOLD_SHAPE ||
-      scaffoldShape === USERS_CORE_BASELINE_CRUD_SCAFFOLD_SHAPE
-    ) {
+    if (STANDARD_CRUD_SCAFFOLD_SHAPES.has(scaffoldShape)) {
       return true;
     }
 
@@ -1614,11 +1623,7 @@ function createHealthCommands(ctx = {}) {
       const allowedProvenances = String(packageEntry?.packageId || "").trim() === "@local/users"
         ? new Set(["crud-server-generator", "users-core-template"])
         : new Set(["crud-server-generator"]);
-      if (
-        scaffoldShape &&
-        scaffoldShape !== CRUD_SERVER_SCAFFOLD_SHAPE &&
-        scaffoldShape !== USERS_CORE_BASELINE_CRUD_SCAFFOLD_SHAPE
-      ) {
+      if (scaffoldShape && !STANDARD_CRUD_SCAFFOLD_SHAPES.has(scaffoldShape)) {
         issues.push(
           `${packagePath}: [crud-ownership:unsupported-shape] CRUD package declares unsupported metadata.jskit.scaffoldShape="${scaffoldShape}". Use crud-server-generator for app-owned CRUDs, or the JSKIT baseline users scaffold where applicable.`
         );
@@ -2123,6 +2128,7 @@ function createHealthCommands(ctx = {}) {
       const sourceText = await readFile(absolutePath, "utf8");
       if (
         !sourceText.includes("useCrudListFilters") &&
+        !sourceText.includes("createCrudListFilterContract") &&
         !sourceText.includes("createCrudListFilters") &&
         !sourceText.includes("createQueryValidator") &&
         !sourceText.includes("useCrudList") &&
@@ -2148,6 +2154,88 @@ function createHealthCommands(ctx = {}) {
         relativePath,
         issues
       });
+    }
+  }
+
+  function hasCanonicalCrudQueryValidatorGroup({
+    sourceText = "",
+    importBindings = new Map(),
+    helperName = ""
+  } = {}) {
+    return (
+      importBindings.get(helperName) === "@jskit-ai/crud-core/server/listQueryValidators" &&
+      findCallSites(sourceText, helperName).length > 0
+    );
+  }
+
+  async function collectStandardCrudReadContractDoctorIssues({
+    appRoot,
+    appLocalRegistry,
+    issues
+  }) {
+    const packageEntries = sortStrings([...appLocalRegistry.keys()])
+      .map((packageId) => appLocalRegistry.get(packageId))
+      .filter((packageEntry) => packageEntry && isStandardCrudPackageEntry(packageEntry));
+
+    for (const packageEntry of packageEntries) {
+      const rootDir = String(packageEntry?.rootDir || "").trim();
+      if (!rootDir) {
+        continue;
+      }
+
+      const actionsPath = path.join(rootDir, "src", "server", "actions.js");
+      if (await fileExists(actionsPath)) {
+        const actionsSource = await readFile(actionsPath, "utf8");
+        const actionsRelativePath = normalizeRelativePath(appRoot, actionsPath);
+        const importBindings = collectStaticImportBindings(actionsSource);
+
+        if (!hasCanonicalCrudQueryValidatorGroup({
+          sourceText: actionsSource,
+          importBindings,
+          helperName: "createStandardCrudListQueryValidators"
+        })) {
+          issues.push(
+            `${actionsRelativePath}: [crud-read-contract:list-query-group] standard generated CRUD list actions must compose createStandardCrudListQueryValidators(...). Do not repeat pagination, search, parent-filter, include, or sparse-field validators individually; pass structured filters through listFilterQueryValidator.`
+          );
+        }
+
+        if (!hasCanonicalCrudQueryValidatorGroup({
+          sourceText: actionsSource,
+          importBindings,
+          helperName: "createStandardCrudViewQueryValidators"
+        })) {
+          issues.push(
+            `${actionsRelativePath}: [crud-read-contract:view-query-group] standard generated CRUD view actions must compose createStandardCrudViewQueryValidators(). Do not repeat include or sparse-field validators individually.`
+          );
+        }
+      }
+
+      const serverFilePaths = [];
+      await collectAppSourceFiles(
+        path.join(rootDir, "src", "server"),
+        undefined,
+        serverFilePaths
+      );
+      serverFilePaths.sort((left, right) => left.localeCompare(right));
+
+      for (const absolutePath of serverFilePaths) {
+        const sourceText = await readFile(absolutePath, "utf8");
+        const importBindings = collectStaticImportBindings(sourceText);
+        if (
+          importBindings.get("createCrudListFilters") !==
+          "@jskit-ai/crud-core/server/listFilters"
+        ) {
+          continue;
+        }
+
+        for (const callSite of findCallSites(sourceText, "createCrudListFilters")) {
+          const relativePath = normalizeRelativePath(appRoot, absolutePath);
+          const lineNumber = resolveLineNumberFromIndex(sourceText, callSite.index);
+          issues.push(
+            `${relativePath}:${lineNumber}: [filters:generated-crud-contract] standard JSON REST CRUD packages must derive server-backed filters with createCrudListFilterContract(...), not createCrudListFilters(...). Use its queryValidator through listFilterQueryValidator, register jsonRestSearchSchema, and pass toJsonRestQuery(query) through the repository.`
+          );
+        }
+      }
     }
   }
 
@@ -2316,6 +2404,11 @@ function createHealthCommands(ctx = {}) {
     });
     await collectCrudFilterDoctorIssues({
       appRoot,
+      issues
+    });
+    await collectStandardCrudReadContractDoctorIssues({
+      appRoot,
+      appLocalRegistry,
       issues
     });
     await collectUiVerificationDoctorIssues({

--- a/tooling/jskit-cli/test/doctorFilterContractValidation.test.js
+++ b/tooling/jskit-cli/test/doctorFilterContractValidation.test.js
@@ -30,6 +30,115 @@ async function createMinimalApp(appRoot, { name = "tmp-app" } = {}) {
   );
 }
 
+async function writeAppFile(appRoot, relativePath, sourceText) {
+  const absolutePath = path.join(appRoot, relativePath);
+  await mkdir(path.dirname(absolutePath), { recursive: true });
+  await writeFile(absolutePath, sourceText, "utf8");
+}
+
+async function writeStandardCrudPackage(appRoot, {
+  packageName = "contacts",
+  actionsSource = "",
+  serverFiles = {}
+} = {}) {
+  const packageRoot = `packages/${packageName}`;
+  await writeAppFile(
+    appRoot,
+    `${packageRoot}/package.json`,
+    `${JSON.stringify(
+      {
+        name: `@local/${packageName}`,
+        version: "0.1.0",
+        type: "module"
+      },
+      null,
+      2
+    )}\n`
+  );
+  await writeAppFile(
+    appRoot,
+    `${packageRoot}/package.descriptor.mjs`,
+    `export default Object.freeze({
+  packageId: "@local/${packageName}",
+  version: "0.1.0",
+  kind: "runtime",
+  capabilities: {
+    provides: ["crud.${packageName}"],
+    requires: []
+  },
+  runtime: {
+    server: {
+      providers: []
+    }
+  },
+  metadata: {
+    jskit: {
+      scaffoldShape: "crud-server-v1",
+      tableOwnership: {
+        tables: [
+          {
+            tableName: "${packageName.replaceAll("-", "_")}",
+            idColumn: "id",
+            provenance: "crud-server-generator",
+            ownerKind: "crud-package"
+          }
+        ]
+      }
+    }
+  },
+  mutations: {
+    files: []
+  }
+});
+`
+  );
+  await writeAppFile(
+    appRoot,
+    `${packageRoot}/src/server/actions.js`,
+    actionsSource
+  );
+
+  for (const [relativePath, sourceText] of Object.entries(serverFiles)) {
+    await writeAppFile(
+      appRoot,
+      `${packageRoot}/src/server/${relativePath}`,
+      sourceText
+    );
+  }
+}
+
+function createCanonicalCrudActionsSource() {
+  return `import {
+  createStandardCrudListQueryValidators,
+  createStandardCrudViewQueryValidators
+} from "@jskit-ai/crud-core/server/listQueryValidators";
+
+const resource = {};
+const customActionInput = {};
+
+const actions = [
+  {
+    id: "crud.contacts.list",
+    input: [
+      ...createStandardCrudListQueryValidators({ resource })
+    ]
+  },
+  {
+    id: "crud.contacts.view",
+    input: [
+      ...createStandardCrudViewQueryValidators()
+    ]
+  },
+  {
+    id: "contacts.rebuild-index",
+    input: customActionInput
+  }
+];
+
+export { actions };
+`;
+}
+
 test("doctor flags inline structured filter definitions in page files", async () => {
   await withTempDir(async (cwd) => {
     const appRoot = path.join(cwd, "doctor-inline-filter-definitions-app");
@@ -206,6 +315,176 @@ test("doctor accepts shared filter definitions imported into runtimes and explic
       ].join("\n"),
       "utf8"
     );
+
+    const doctorResult = runCli({
+      cwd: appRoot,
+      args: ["doctor", "--json"]
+    });
+
+    assert.equal(doctorResult.status, 0, String(doctorResult.stderr || ""));
+    const payload = JSON.parse(String(doctorResult.stdout || "{}"));
+    assert.deepEqual(payload.issues, []);
+  });
+});
+
+test("doctor flags stale query validator groups in standard generated CRUD packages", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "doctor-stale-crud-query-groups-app");
+    await createMinimalApp(appRoot, { name: "doctor-stale-crud-query-groups-app" });
+    await writeStandardCrudPackage(appRoot, {
+      actionsSource: `import {
+  listCursorPaginationQueryValidator,
+  listSearchQueryValidator,
+  lookupIncludeQueryValidator
+} from "@jskit-ai/crud-core/server/listQueryValidators";
+
+const actions = [
+  {
+    id: "crud.contacts.list",
+    input: [
+      listCursorPaginationQueryValidator,
+      listSearchQueryValidator,
+      lookupIncludeQueryValidator
+    ]
+  },
+  {
+    id: "crud.contacts.view",
+    input: [
+      lookupIncludeQueryValidator
+    ]
+  }
+];
+
+export { actions };
+`
+    });
+
+    const doctorResult = runCli({
+      cwd: appRoot,
+      args: ["doctor", "--json"]
+    });
+
+    assert.equal(doctorResult.status, 1, String(doctorResult.stderr || ""));
+    const payload = JSON.parse(String(doctorResult.stdout || "{}"));
+    assert.equal(payload.issues.length, 2);
+    assert.match(
+      String(payload.issues[0] || ""),
+      /\[crud-read-contract:list-query-group\]/
+    );
+    assert.match(
+      String(payload.issues[1] || ""),
+      /\[crud-read-contract:view-query-group\]/
+    );
+  });
+});
+
+test("doctor accepts canonical CRUD query groups without constraining custom actions", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "doctor-canonical-crud-query-groups-app");
+    await createMinimalApp(appRoot, { name: "doctor-canonical-crud-query-groups-app" });
+    await writeStandardCrudPackage(appRoot, {
+      actionsSource: createCanonicalCrudActionsSource()
+    });
+
+    const doctorResult = runCli({
+      cwd: appRoot,
+      args: ["doctor", "--json"]
+    });
+
+    assert.equal(doctorResult.status, 0, String(doctorResult.stderr || ""));
+    const payload = JSON.parse(String(doctorResult.stdout || "{}"));
+    assert.deepEqual(payload.issues, []);
+  });
+});
+
+test("doctor rejects the generic filter runtime in standard generated CRUD packages", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "doctor-generic-crud-filter-runtime-app");
+    await createMinimalApp(appRoot, { name: "doctor-generic-crud-filter-runtime-app" });
+    await writeStandardCrudPackage(appRoot, {
+      actionsSource: createCanonicalCrudActionsSource(),
+      serverFiles: {
+        "contactListFilterSupport.js": `import {
+  createCrudListFilters
+} from "@jskit-ai/crud-core/server/listFilters";
+import {
+  CONTACTS_LIST_FILTER_DEFINITIONS
+} from "../shared/contactListFilters.js";
+
+const filterRuntime = createCrudListFilters(
+  CONTACTS_LIST_FILTER_DEFINITIONS,
+  {
+    columns: {
+      onlyArchived: "archived"
+    }
+  }
+);
+const queryValidator = filterRuntime.createQueryValidator({
+  invalidValues: "reject"
+});
+
+export { queryValidator };
+`,
+        "../shared/contactListFilters.js": `export const CONTACTS_LIST_FILTER_DEFINITIONS = Object.freeze({
+  onlyArchived: {
+    type: "flag",
+    label: "Archived"
+  }
+});
+`
+      }
+    });
+
+    const doctorResult = runCli({
+      cwd: appRoot,
+      args: ["doctor", "--json"]
+    });
+
+    assert.equal(doctorResult.status, 1, String(doctorResult.stderr || ""));
+    const payload = JSON.parse(String(doctorResult.stdout || "{}"));
+    assert.equal(payload.issues.length, 1);
+    assert.match(
+      String(payload.issues[0] || ""),
+      /\[filters:generated-crud-contract\]/
+    );
+  });
+});
+
+test("doctor accepts the canonical filter contract in standard generated CRUD packages", async () => {
+  await withTempDir(async (cwd) => {
+    const appRoot = path.join(cwd, "doctor-canonical-crud-filter-contract-app");
+    await createMinimalApp(appRoot, { name: "doctor-canonical-crud-filter-contract-app" });
+    await writeStandardCrudPackage(appRoot, {
+      actionsSource: createCanonicalCrudActionsSource(),
+      serverFiles: {
+        "contactListFilterSupport.js": `import {
+  createCrudListFilterContract
+} from "@jskit-ai/crud-core/server/listFilters";
+import {
+  CONTACTS_LIST_FILTER_DEFINITIONS
+} from "../shared/contactListFilters.js";
+
+const filterContract = createCrudListFilterContract(
+  CONTACTS_LIST_FILTER_DEFINITIONS,
+  {
+    invalidValues: "reject",
+    columns: {
+      onlyArchived: "archived"
+    }
+  }
+);
+
+export { filterContract };
+`,
+        "../shared/contactListFilters.js": `export const CONTACTS_LIST_FILTER_DEFINITIONS = Object.freeze({
+  onlyArchived: {
+    type: "flag",
+    label: "Archived"
+  }
+});
+`
+      }
+    });
 
     const doctorResult = runCli({
       cwd: appRoot,


### PR DESCRIPTION
## Summary
- document the standard CRUD list/view validator groups in human and agent guidance
- enforce canonical generated CRUD read contracts through metadata-scoped Doctor checks
- reject stale generated filter runtimes while preserving custom actions and additional validators
- publish the coordinated JSKIT package graph before merge

## Verification
- npm test --workspace @jskit-ai/agent-docs
- npm test --workspace @jskit-ai/jskit-cli (333 passed)
- npm test --workspace @jskit-ai/crud-server-generator (87 passed, 2 optional DB tests skipped)
- npm run lint
- npm run docs:build
- npm run release