### PR TITLE
Use typed JSON REST fieldset errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4077,9 +4077,9 @@
       "license": "MIT"
     },
     "node_modules/json-rest-api": {
-      "version": "1.0.26",
-      "resolved": "https://registry.npmjs.org/json-rest-api/-/json-rest-api-1.0.26.tgz",
-      "integrity": "sha512-bGSRwOW/2jQ6CUhHYC+2Gpgai+IEq2moa56fpx++uPNbn823j5PVD+jFfTMVS96JoWiPkaWDzfkxjgnVn/Nftg==",
+      "version": "1.0.27",
+      "resolved": "https://registry.npmjs.org/json-rest-api/-/json-rest-api-1.0.27.tgz",
+      "integrity": "sha512-zQ7b1ti9Y7xkMS1T05dFhC63rxQ1kiUVuynSx48PorbU2xUwC2NImyImnGfO+61zv8MWuh59V5MbcaXBRkOqVg==",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "hooked-api": "^1.0.24",
@@ -7475,28 +7475,28 @@
     },
     "packages/agent-docs": {
       "name": "@jskit-ai/agent-docs",
-      "version": "0.1.107",
+      "version": "0.1.108",
       "engines": {
         "node": "^22.13.0 || ^24.0.0 || ^26.0.0"
       }
     },
     "packages/assistant": {
       "name": "@jskit-ai/assistant",
-      "version": "0.1.149",
+      "version": "0.1.150",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.140"
+        "@jskit-ai/kernel": "0.1.141"
       }
     },
     "packages/assistant-core": {
       "name": "@jskit-ai/assistant-core",
-      "version": "0.1.117",
+      "version": "0.1.118",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.139",
-        "@jskit-ai/http-runtime": "0.1.138",
-        "@jskit-ai/kernel": "0.1.140",
-        "@jskit-ai/resource-core": "0.1.83",
-        "@jskit-ai/resource-crud-core": "0.1.83",
-        "@jskit-ai/users-core": "0.1.153",
+        "@jskit-ai/database-runtime": "0.1.140",
+        "@jskit-ai/http-runtime": "0.1.139",
+        "@jskit-ai/kernel": "0.1.141",
+        "@jskit-ai/resource-core": "0.1.84",
+        "@jskit-ai/resource-crud-core": "0.1.84",
+        "@jskit-ai/users-core": "0.1.154",
         "dompurify": "^3.4.12",
         "json-rest-schema": "1.x.x",
         "marked": "^17.0.4",
@@ -7509,15 +7509,15 @@
     },
     "packages/assistant-runtime": {
       "name": "@jskit-ai/assistant-runtime",
-      "version": "0.1.112",
+      "version": "0.1.113",
       "dependencies": {
-        "@jskit-ai/assistant-core": "0.1.117",
-        "@jskit-ai/database-runtime": "0.1.139",
-        "@jskit-ai/http-runtime": "0.1.138",
-        "@jskit-ai/kernel": "0.1.140",
-        "@jskit-ai/shell-web": "0.1.141",
-        "@jskit-ai/users-core": "0.1.153",
-        "@jskit-ai/users-web": "0.1.157",
+        "@jskit-ai/assistant-core": "0.1.118",
+        "@jskit-ai/database-runtime": "0.1.140",
+        "@jskit-ai/http-runtime": "0.1.139",
+        "@jskit-ai/kernel": "0.1.141",
+        "@jskit-ai/shell-web": "0.1.142",
+        "@jskit-ai/users-core": "0.1.154",
+        "@jskit-ai/users-web": "0.1.158",
         "json-rest-schema": "1.x.x"
       },
       "peerDependencies": {
@@ -7528,39 +7528,39 @@
     },
     "packages/auth-core": {
       "name": "@jskit-ai/auth-core",
-      "version": "0.1.138",
+      "version": "0.1.139",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0",
-        "@jskit-ai/kernel": "0.1.140",
+        "@jskit-ai/kernel": "0.1.141",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/auth-provider-local-core": {
       "name": "@jskit-ai/auth-provider-local-core",
-      "version": "0.1.42",
+      "version": "0.1.43",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.138",
-        "@jskit-ai/kernel": "0.1.140",
+        "@jskit-ai/auth-core": "0.1.139",
+        "@jskit-ai/kernel": "0.1.141",
         "nodemailer": "^9.0.3"
       }
     },
     "packages/auth-provider-local-db-core": {
       "name": "@jskit-ai/auth-provider-local-db-core",
-      "version": "0.1.33",
+      "version": "0.1.34",
       "dependencies": {
-        "@jskit-ai/auth-provider-local-core": "0.1.42",
-        "@jskit-ai/database-runtime": "0.1.139",
-        "@jskit-ai/kernel": "0.1.140"
+        "@jskit-ai/auth-provider-local-core": "0.1.43",
+        "@jskit-ai/database-runtime": "0.1.140",
+        "@jskit-ai/kernel": "0.1.141"
       }
     },
     "packages/auth-provider-supabase-core": {
       "name": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.138",
+      "version": "0.1.139",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.138",
-        "@jskit-ai/kernel": "0.1.140",
+        "@jskit-ai/auth-core": "0.1.139",
+        "@jskit-ai/kernel": "0.1.141",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0",
         "json-rest-schema": "1.x.x",
@@ -7569,12 +7569,12 @@
     },
     "packages/auth-web": {
       "name": "@jskit-ai/auth-web",
-      "version": "0.1.141",
+      "version": "0.1.142",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.138",
-        "@jskit-ai/http-runtime": "0.1.138",
-        "@jskit-ai/kernel": "0.1.140",
-        "@jskit-ai/shell-web": "0.1.141",
+        "@jskit-ai/auth-core": "0.1.139",
+        "@jskit-ai/http-runtime": "0.1.139",
+        "@jskit-ai/kernel": "0.1.141",
+        "@jskit-ai/shell-web": "0.1.142",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -7587,38 +7587,38 @@
     },
     "packages/console-core": {
       "name": "@jskit-ai/console-core",
-      "version": "0.1.104",
+      "version": "0.1.105",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.138",
-        "@jskit-ai/database-runtime": "0.1.139",
-        "@jskit-ai/http-runtime": "0.1.138",
-        "@jskit-ai/kernel": "0.1.140",
-        "@jskit-ai/resource-crud-core": "0.1.83",
-        "@jskit-ai/users-core": "0.1.153",
+        "@jskit-ai/auth-core": "0.1.139",
+        "@jskit-ai/database-runtime": "0.1.140",
+        "@jskit-ai/http-runtime": "0.1.139",
+        "@jskit-ai/kernel": "0.1.141",
+        "@jskit-ai/resource-crud-core": "0.1.84",
+        "@jskit-ai/users-core": "0.1.154",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/console-web": {
       "name": "@jskit-ai/console-web",
-      "version": "0.1.109",
+      "version": "0.1.110",
       "dependencies": {
-        "@jskit-ai/auth-web": "0.1.141",
-        "@jskit-ai/console-core": "0.1.104",
-        "@jskit-ai/shell-web": "0.1.141"
+        "@jskit-ai/auth-web": "0.1.142",
+        "@jskit-ai/console-core": "0.1.105",
+        "@jskit-ai/shell-web": "0.1.142"
       }
     },
     "packages/crud-core": {
       "name": "@jskit-ai/crud-core",
-      "version": "0.1.150",
+      "version": "0.1.151",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.139",
-        "@jskit-ai/http-runtime": "0.1.138",
-        "@jskit-ai/kernel": "0.1.140",
-        "@jskit-ai/realtime": "0.1.137",
-        "@jskit-ai/resource-crud-core": "0.1.83",
-        "@jskit-ai/shell-web": "0.1.141",
-        "@jskit-ai/users-core": "0.1.153",
-        "@jskit-ai/users-web": "0.1.157",
+        "@jskit-ai/database-runtime": "0.1.140",
+        "@jskit-ai/http-runtime": "0.1.139",
+        "@jskit-ai/kernel": "0.1.141",
+        "@jskit-ai/realtime": "0.1.138",
+        "@jskit-ai/resource-crud-core": "0.1.84",
+        "@jskit-ai/shell-web": "0.1.142",
+        "@jskit-ai/users-core": "0.1.154",
+        "@jskit-ai/users-web": "0.1.158",
         "json-rest-schema": "1.x.x"
       },
       "peerDependencies": {
@@ -7629,99 +7629,99 @@
     },
     "packages/crud-server-generator": {
       "name": "@jskit-ai/crud-server-generator",
-      "version": "0.1.152",
+      "version": "0.1.153",
       "dependencies": {
         "@babel/parser": "^7.29.2",
-        "@jskit-ai/crud-core": "0.1.150",
-        "@jskit-ai/database-runtime": "0.1.139",
-        "@jskit-ai/http-runtime": "0.1.138",
-        "@jskit-ai/json-rest-api-core": "0.1.84",
-        "@jskit-ai/kernel": "0.1.140",
-        "@jskit-ai/resource-crud-core": "0.1.83",
+        "@jskit-ai/crud-core": "0.1.151",
+        "@jskit-ai/database-runtime": "0.1.140",
+        "@jskit-ai/http-runtime": "0.1.139",
+        "@jskit-ai/json-rest-api-core": "0.1.85",
+        "@jskit-ai/kernel": "0.1.141",
+        "@jskit-ai/resource-crud-core": "0.1.84",
         "recast": "^0.23.11"
       }
     },
     "packages/crud-ui-generator": {
       "name": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.123",
+      "version": "0.1.124",
       "dependencies": {
-        "@jskit-ai/crud-core": "0.1.150",
-        "@jskit-ai/kernel": "0.1.140",
-        "@jskit-ai/resource-crud-core": "0.1.83"
+        "@jskit-ai/crud-core": "0.1.151",
+        "@jskit-ai/kernel": "0.1.141",
+        "@jskit-ai/resource-crud-core": "0.1.84"
       }
     },
     "packages/database-runtime": {
       "name": "@jskit-ai/database-runtime",
-      "version": "0.1.139",
+      "version": "0.1.140",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.140"
+        "@jskit-ai/kernel": "0.1.141"
       }
     },
     "packages/database-runtime-mysql": {
       "name": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.138",
+      "version": "0.1.139",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.139",
-        "@jskit-ai/kernel": "0.1.140"
+        "@jskit-ai/database-runtime": "0.1.140",
+        "@jskit-ai/kernel": "0.1.141"
       }
     },
     "packages/database-runtime-postgres": {
       "name": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.137",
+      "version": "0.1.138",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.139"
+        "@jskit-ai/database-runtime": "0.1.140"
       }
     },
     "packages/feature-server-generator": {
       "name": "@jskit-ai/feature-server-generator",
-      "version": "0.1.82"
+      "version": "0.1.83"
     },
     "packages/google-rewarded-core": {
       "name": "@jskit-ai/google-rewarded-core",
-      "version": "0.1.77"
+      "version": "0.1.78"
     },
     "packages/google-rewarded-web": {
       "name": "@jskit-ai/google-rewarded-web",
-      "version": "0.1.77"
+      "version": "0.1.78"
     },
     "packages/http-runtime": {
       "name": "@jskit-ai/http-runtime",
-      "version": "0.1.138",
+      "version": "0.1.139",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.140",
+        "@jskit-ai/kernel": "0.1.141",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/json-rest-api-core": {
       "name": "@jskit-ai/json-rest-api-core",
-      "version": "0.1.84",
+      "version": "0.1.85",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.140",
+        "@jskit-ai/kernel": "0.1.141",
         "hooked-api": "1.x.x",
-        "json-rest-api": "^1.0.26"
+        "json-rest-api": "^1.0.27"
       }
     },
     "packages/kernel": {
       "name": "@jskit-ai/kernel",
-      "version": "0.1.140",
+      "version": "0.1.141",
       "dependencies": {
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/mobile-capacitor": {
       "name": "@jskit-ai/mobile-capacitor",
-      "version": "0.1.76",
+      "version": "0.1.77",
       "dependencies": {
         "@capacitor/browser": "^7.0.1",
         "@capacitor/core": "^7.4.3",
-        "@jskit-ai/kernel": "0.1.140"
+        "@jskit-ai/kernel": "0.1.141"
       }
     },
     "packages/realtime": {
       "name": "@jskit-ai/realtime",
-      "version": "0.1.137",
+      "version": "0.1.138",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.140",
+        "@jskit-ai/kernel": "0.1.141",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",
@@ -7733,24 +7733,24 @@
     },
     "packages/resource-core": {
       "name": "@jskit-ai/resource-core",
-      "version": "0.1.83",
+      "version": "0.1.84",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.140"
+        "@jskit-ai/kernel": "0.1.141"
       }
     },
     "packages/resource-crud-core": {
       "name": "@jskit-ai/resource-crud-core",
-      "version": "0.1.83",
+      "version": "0.1.84",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.140",
-        "@jskit-ai/resource-core": "0.1.83"
+        "@jskit-ai/kernel": "0.1.141",
+        "@jskit-ai/resource-core": "0.1.84"
       }
     },
     "packages/shell-web": {
       "name": "@jskit-ai/shell-web",
-      "version": "0.1.141",
+      "version": "0.1.142",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.140",
+        "@jskit-ai/kernel": "0.1.141",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -7762,25 +7762,25 @@
     },
     "packages/storage-runtime": {
       "name": "@jskit-ai/storage-runtime",
-      "version": "0.1.138",
+      "version": "0.1.139",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.140",
+        "@jskit-ai/kernel": "0.1.141",
         "unstorage": "^1.17.5"
       }
     },
     "packages/ui-generator": {
       "name": "@jskit-ai/ui-generator",
-      "version": "0.1.123",
+      "version": "0.1.124",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.140",
-        "@jskit-ai/shell-web": "0.1.141"
+        "@jskit-ai/kernel": "0.1.141",
+        "@jskit-ai/shell-web": "0.1.142"
       }
     },
     "packages/uploads-image-web": {
       "name": "@jskit-ai/uploads-image-web",
-      "version": "0.1.116",
+      "version": "0.1.117",
       "dependencies": {
-        "@jskit-ai/uploads-runtime": "0.1.116",
+        "@jskit-ai/uploads-runtime": "0.1.117",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",
@@ -7793,37 +7793,37 @@
     },
     "packages/uploads-runtime": {
       "name": "@jskit-ai/uploads-runtime",
-      "version": "0.1.116",
+      "version": "0.1.117",
       "dependencies": {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.140"
+        "@jskit-ai/kernel": "0.1.141"
       }
     },
     "packages/users-core": {
       "name": "@jskit-ai/users-core",
-      "version": "0.1.153",
+      "version": "0.1.154",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.138",
-        "@jskit-ai/database-runtime": "0.1.139",
-        "@jskit-ai/http-runtime": "0.1.138",
-        "@jskit-ai/json-rest-api-core": "0.1.84",
-        "@jskit-ai/kernel": "0.1.140",
-        "@jskit-ai/resource-core": "0.1.83",
-        "@jskit-ai/resource-crud-core": "0.1.83",
-        "@jskit-ai/uploads-runtime": "0.1.116",
+        "@jskit-ai/auth-core": "0.1.139",
+        "@jskit-ai/database-runtime": "0.1.140",
+        "@jskit-ai/http-runtime": "0.1.139",
+        "@jskit-ai/json-rest-api-core": "0.1.85",
+        "@jskit-ai/kernel": "0.1.141",
+        "@jskit-ai/resource-core": "0.1.84",
+        "@jskit-ai/resource-crud-core": "0.1.84",
+        "@jskit-ai/uploads-runtime": "0.1.117",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/users-web": {
       "name": "@jskit-ai/users-web",
-      "version": "0.1.157",
+      "version": "0.1.158",
       "dependencies": {
-        "@jskit-ai/http-runtime": "0.1.138",
-        "@jskit-ai/kernel": "0.1.140",
-        "@jskit-ai/realtime": "0.1.137",
-        "@jskit-ai/shell-web": "0.1.141",
-        "@jskit-ai/uploads-image-web": "0.1.116",
-        "@jskit-ai/users-core": "0.1.153",
+        "@jskit-ai/http-runtime": "0.1.139",
+        "@jskit-ai/kernel": "0.1.141",
+        "@jskit-ai/realtime": "0.1.138",
+        "@jskit-ai/shell-web": "0.1.142",
+        "@jskit-ai/uploads-image-web": "0.1.117",
+        "@jskit-ai/users-core": "0.1.154",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -7835,30 +7835,30 @@
     },
     "packages/workspaces-core": {
       "name": "@jskit-ai/workspaces-core",
-      "version": "0.1.119",
+      "version": "0.1.120",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.138",
-        "@jskit-ai/database-runtime": "0.1.139",
-        "@jskit-ai/http-runtime": "0.1.138",
-        "@jskit-ai/json-rest-api-core": "0.1.84",
-        "@jskit-ai/kernel": "0.1.140",
-        "@jskit-ai/resource-core": "0.1.83",
-        "@jskit-ai/resource-crud-core": "0.1.83",
-        "@jskit-ai/users-core": "0.1.153",
+        "@jskit-ai/auth-core": "0.1.139",
+        "@jskit-ai/database-runtime": "0.1.140",
+        "@jskit-ai/http-runtime": "0.1.139",
+        "@jskit-ai/json-rest-api-core": "0.1.85",
+        "@jskit-ai/kernel": "0.1.141",
+        "@jskit-ai/resource-core": "0.1.84",
+        "@jskit-ai/resource-crud-core": "0.1.84",
+        "@jskit-ai/users-core": "0.1.154",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/workspaces-web": {
       "name": "@jskit-ai/workspaces-web",
-      "version": "0.1.120",
+      "version": "0.1.121",
       "dependencies": {
-        "@jskit-ai/auth-web": "0.1.141",
-        "@jskit-ai/http-runtime": "0.1.138",
-        "@jskit-ai/kernel": "0.1.140",
-        "@jskit-ai/shell-web": "0.1.141",
-        "@jskit-ai/users-core": "0.1.153",
-        "@jskit-ai/users-web": "0.1.157",
-        "@jskit-ai/workspaces-core": "0.1.119",
+        "@jskit-ai/auth-web": "0.1.142",
+        "@jskit-ai/http-runtime": "0.1.139",
+        "@jskit-ai/kernel": "0.1.141",
+        "@jskit-ai/shell-web": "0.1.142",
+        "@jskit-ai/users-core": "0.1.154",
+        "@jskit-ai/users-web": "0.1.158",
+        "@jskit-ai/workspaces-core": "0.1.120",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -7870,7 +7870,7 @@
     },
     "tooling/config-eslint": {
       "name": "@jskit-ai/config-eslint",
-      "version": "0.1.138",
+      "version": "0.1.139",
       "dependencies": {
         "@eslint/js": "^10.0.1",
         "eslint-plugin-vue": "^10.5.1",
@@ -7909,9 +7909,9 @@
     },
     "tooling/create-app": {
       "name": "@jskit-ai/create-app",
-      "version": "0.1.159",
+      "version": "0.1.160",
       "dependencies": {
-        "@jskit-ai/jskit-cli": "0.2.167"
+        "@jskit-ai/jskit-cli": "0.2.168"
       },
       "bin": {
         "jskit-create-app": "bin/jskit-create-app.js"
@@ -7922,18 +7922,18 @@
     },
     "tooling/jskit-catalog": {
       "name": "@jskit-ai/jskit-catalog",
-      "version": "0.1.161",
+      "version": "0.1.162",
       "engines": {
         "node": "^22.13.0 || ^24.0.0 || ^26.0.0"
       }
     },
     "tooling/jskit-cli": {
       "name": "@jskit-ai/jskit-cli",
-      "version": "0.2.167",
+      "version": "0.2.168",
       "dependencies": {
-        "@jskit-ai/jskit-catalog": "0.1.161",
-        "@jskit-ai/kernel": "0.1.140",
-        "@jskit-ai/shell-web": "0.1.141",
+        "@jskit-ai/jskit-catalog": "0.1.162",
+        "@jskit-ai/kernel": "0.1.141",
+        "@jskit-ai/shell-web": "0.1.142",
         "@vue/compiler-sfc": "^3.5.29",
         "semver": "^7.7.4",
         "ts-morph": "^28.0.0",

--- a/packages/agent-docs/package.json
+++ b/packages/agent-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/agent-docs",
-  "version": "0.1.107",
+  "version": "0.1.108",
   "description": "Distributed JSKIT agent references, prompts, guides, and generated reference maps.",
   "type": "module",
   "files": [

--- a/packages/assistant-core/package.descriptor.mjs
+++ b/packages/assistant-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-core",
-  version: "0.1.117",
+  version: "0.1.118",
   kind: "runtime",
   description: "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
   dependsOn: [
@@ -47,11 +47,11 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/http-runtime": "0.1.138",
-        "@jskit-ai/kernel": "0.1.140",
-        "@jskit-ai/resource-core": "0.1.83",
-        "@jskit-ai/resource-crud-core": "0.1.83",
-        "@jskit-ai/users-core": "0.1.153",
+        "@jskit-ai/http-runtime": "0.1.139",
+        "@jskit-ai/kernel": "0.1.141",
+        "@jskit-ai/resource-core": "0.1.84",
+        "@jskit-ai/resource-crud-core": "0.1.84",
+        "@jskit-ai/users-core": "0.1.154",
         "dompurify": "^3.3.3",
         "json-rest-schema": "1.x.x",
         "marked": "^17.0.4",

--- a/packages/assistant-core/package.json
+++ b/packages/assistant-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-core",
-  "version": "0.1.117",
+  "version": "0.1.118",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,12 +11,12 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.139",
-    "@jskit-ai/http-runtime": "0.1.138",
-    "@jskit-ai/kernel": "0.1.140",
-    "@jskit-ai/resource-crud-core": "0.1.83",
-    "@jskit-ai/resource-core": "0.1.83",
-    "@jskit-ai/users-core": "0.1.153",
+    "@jskit-ai/database-runtime": "0.1.140",
+    "@jskit-ai/http-runtime": "0.1.139",
+    "@jskit-ai/kernel": "0.1.141",
+    "@jskit-ai/resource-crud-core": "0.1.84",
+    "@jskit-ai/resource-core": "0.1.84",
+    "@jskit-ai/users-core": "0.1.154",
     "dompurify": "^3.4.12",
     "json-rest-schema": "1.x.x",
     "marked": "^17.0.4",

--- a/packages/assistant-runtime/package.descriptor.mjs
+++ b/packages/assistant-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-runtime",
-  version: "0.1.112",
+  version: "0.1.113",
   kind: "runtime",
   description: "Shared assistant runtime with per-surface assistant registration.",
   dependsOn: [
@@ -95,13 +95,13 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/assistant-core": "0.1.117",
-        "@jskit-ai/database-runtime": "0.1.139",
-        "@jskit-ai/http-runtime": "0.1.138",
-        "@jskit-ai/kernel": "0.1.140",
-        "@jskit-ai/shell-web": "0.1.141",
-        "@jskit-ai/users-core": "0.1.153",
-        "@jskit-ai/users-web": "0.1.157"
+        "@jskit-ai/assistant-core": "0.1.118",
+        "@jskit-ai/database-runtime": "0.1.140",
+        "@jskit-ai/http-runtime": "0.1.139",
+        "@jskit-ai/kernel": "0.1.141",
+        "@jskit-ai/shell-web": "0.1.142",
+        "@jskit-ai/users-core": "0.1.154",
+        "@jskit-ai/users-web": "0.1.158"
       },
       dev: {}
     },

--- a/packages/assistant-runtime/package.json
+++ b/packages/assistant-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-runtime",
-  "version": "0.1.112",
+  "version": "0.1.113",
   "type": "module",
   "exports": {
     "./client": "./src/client/index.js",
@@ -8,13 +8,13 @@
     "./server/actionIds": "./src/server/actionIds.js"
   },
   "dependencies": {
-    "@jskit-ai/assistant-core": "0.1.117",
-    "@jskit-ai/database-runtime": "0.1.139",
-    "@jskit-ai/http-runtime": "0.1.138",
-    "@jskit-ai/kernel": "0.1.140",
-    "@jskit-ai/shell-web": "0.1.141",
-    "@jskit-ai/users-core": "0.1.153",
-    "@jskit-ai/users-web": "0.1.157",
+    "@jskit-ai/assistant-core": "0.1.118",
+    "@jskit-ai/database-runtime": "0.1.140",
+    "@jskit-ai/http-runtime": "0.1.139",
+    "@jskit-ai/kernel": "0.1.141",
+    "@jskit-ai/shell-web": "0.1.142",
+    "@jskit-ai/users-core": "0.1.154",
+    "@jskit-ai/users-web": "0.1.158",
     "json-rest-schema": "1.x.x"
   },
   "peerDependencies": {

--- a/packages/assistant/package.descriptor.mjs
+++ b/packages/assistant/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant",
-  version: "0.1.149",
+  version: "0.1.150",
   kind: "generator",
   description: "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
   options: {

--- a/packages/assistant/package.json
+++ b/packages/assistant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant",
-  "version": "0.1.149",
+  "version": "0.1.150",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.140"
+    "@jskit-ai/kernel": "0.1.141"
   }
 }

--- a/packages/auth-core/package.descriptor.mjs
+++ b/packages/auth-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-core",
-  "version": "0.1.138",
+  "version": "0.1.139",
   "kind": "runtime",
   "dependsOn": [
     "@jskit-ai/value-app-config-shared"
@@ -74,7 +74,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.140",
+        "@jskit-ai/kernel": "0.1.141",
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0"

--- a/packages/auth-core/package.json
+++ b/packages/auth-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-core",
-  "version": "0.1.138",
+  "version": "0.1.139",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -56,7 +56,7 @@
     "./shared/commands/authSessionReadCommand": "./src/shared/commands/authSessionReadCommand.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.140",
+    "@jskit-ai/kernel": "0.1.141",
     "@fastify/cookie": "^11.0.2",
     "@fastify/csrf-protection": "^7.1.0",
     "@fastify/rate-limit": "^10.3.0",

--- a/packages/auth-provider-local-core/package.descriptor.mjs
+++ b/packages/auth-provider-local-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-provider-local-core",
-  "version": "0.1.42",
+  "version": "0.1.43",
   "kind": "runtime",
   "description": "Local auth provider with a file backend default and no database requirement.",
   "dependsOn": [
@@ -64,8 +64,8 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/auth-core": "0.1.138",
-        "@jskit-ai/kernel": "0.1.140",
+        "@jskit-ai/auth-core": "0.1.139",
+        "@jskit-ai/kernel": "0.1.141",
         "nodemailer": "^9.0.3",
         "dotenv": "^16.4.5"
       },

--- a/packages/auth-provider-local-core/package.json
+++ b/packages/auth-provider-local-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-local-core",
-  "version": "0.1.42",
+  "version": "0.1.43",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,8 +11,8 @@
     "./server/lib/index": "./src/server/lib/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.138",
-    "@jskit-ai/kernel": "0.1.140",
+    "@jskit-ai/auth-core": "0.1.139",
+    "@jskit-ai/kernel": "0.1.141",
     "nodemailer": "^9.0.3"
   }
 }

--- a/packages/auth-provider-local-db-core/package.descriptor.mjs
+++ b/packages/auth-provider-local-db-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/auth-provider-local-db-core",
-  version: "0.1.33",
+  version: "0.1.34",
   kind: "runtime",
   description: "Database-backed local auth storage backend for JSKIT local auth.",
   dependsOn: [
@@ -80,9 +80,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-provider-local-core": "0.1.42",
-        "@jskit-ai/database-runtime": "0.1.139",
-        "@jskit-ai/kernel": "0.1.140"
+        "@jskit-ai/auth-provider-local-core": "0.1.43",
+        "@jskit-ai/database-runtime": "0.1.140",
+        "@jskit-ai/kernel": "0.1.141"
       },
       dev: {}
     },

--- a/packages/auth-provider-local-db-core/package.json
+++ b/packages/auth-provider-local-db-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-local-db-core",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,8 +10,8 @@
     "./server/lib/index": "./src/server/lib/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-provider-local-core": "0.1.42",
-    "@jskit-ai/database-runtime": "0.1.139",
-    "@jskit-ai/kernel": "0.1.140"
+    "@jskit-ai/auth-provider-local-core": "0.1.43",
+    "@jskit-ai/database-runtime": "0.1.140",
+    "@jskit-ai/kernel": "0.1.141"
   }
 }

--- a/packages/auth-provider-supabase-core/package.descriptor.mjs
+++ b/packages/auth-provider-supabase-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.138",
+  "version": "0.1.139",
   "kind": "runtime",
   "options": {
     "auth-supabase-url": {
@@ -83,8 +83,8 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/auth-core": "0.1.138",
-        "@jskit-ai/kernel": "0.1.140",
+        "@jskit-ai/auth-core": "0.1.139",
+        "@jskit-ai/kernel": "0.1.141",
         "dotenv": "^16.4.5",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0"

--- a/packages/auth-provider-supabase-core/package.json
+++ b/packages/auth-provider-supabase-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.138",
+  "version": "0.1.139",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,8 +12,8 @@
     "./client": "./src/client/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.138",
-    "@jskit-ai/kernel": "0.1.140",
+    "@jskit-ai/auth-core": "0.1.139",
+    "@jskit-ai/kernel": "0.1.141",
     "json-rest-schema": "1.x.x",
     "jose": "^6.1.0",
     "@supabase/supabase-js": "^2.57.4",

--- a/packages/auth-web/package.descriptor.mjs
+++ b/packages/auth-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-web",
-  "version": "0.1.141",
+  "version": "0.1.142",
   "kind": "runtime",
   "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
   "dependsOn": [
@@ -264,10 +264,10 @@ export default Object.freeze({
     "dependencies": {
       "runtime": {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/auth-core": "0.1.138",
-        "@jskit-ai/http-runtime": "0.1.138",
-        "@jskit-ai/kernel": "0.1.140",
-        "@jskit-ai/shell-web": "0.1.141"
+        "@jskit-ai/auth-core": "0.1.139",
+        "@jskit-ai/http-runtime": "0.1.139",
+        "@jskit-ai/kernel": "0.1.141",
+        "@jskit-ai/shell-web": "0.1.142"
       },
       "dev": {}
     },

--- a/packages/auth-web/package.json
+++ b/packages/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-web",
-  "version": "0.1.141",
+  "version": "0.1.142",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -20,11 +20,11 @@
     "./test/playwright": "./src/test/playwright.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.138",
+    "@jskit-ai/auth-core": "0.1.139",
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/kernel": "0.1.140",
-    "@jskit-ai/shell-web": "0.1.141",
-    "@jskit-ai/http-runtime": "0.1.138"
+    "@jskit-ai/kernel": "0.1.141",
+    "@jskit-ai/shell-web": "0.1.142",
+    "@jskit-ai/http-runtime": "0.1.139"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/console-core/package.descriptor.mjs
+++ b/packages/console-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-core",
-  version: "0.1.104",
+  version: "0.1.105",
   kind: "runtime",
   description: "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
   dependsOn: [
@@ -85,12 +85,12 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.138",
-        "@jskit-ai/database-runtime": "0.1.139",
-        "@jskit-ai/http-runtime": "0.1.138",
-        "@jskit-ai/kernel": "0.1.140",
-        "@jskit-ai/resource-crud-core": "0.1.83",
-        "@jskit-ai/users-core": "0.1.153"
+        "@jskit-ai/auth-core": "0.1.139",
+        "@jskit-ai/database-runtime": "0.1.140",
+        "@jskit-ai/http-runtime": "0.1.139",
+        "@jskit-ai/kernel": "0.1.141",
+        "@jskit-ai/resource-crud-core": "0.1.84",
+        "@jskit-ai/users-core": "0.1.154"
       },
       dev: {}
     },

--- a/packages/console-core/package.json
+++ b/packages/console-core/package.json
@@ -1,17 +1,17 @@
 {
   "name": "@jskit-ai/console-core",
-  "version": "0.1.104",
+  "version": "0.1.105",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.138",
-    "@jskit-ai/database-runtime": "0.1.139",
-    "@jskit-ai/http-runtime": "0.1.138",
-    "@jskit-ai/kernel": "0.1.140",
-    "@jskit-ai/resource-crud-core": "0.1.83",
-    "@jskit-ai/users-core": "0.1.153",
+    "@jskit-ai/auth-core": "0.1.139",
+    "@jskit-ai/database-runtime": "0.1.140",
+    "@jskit-ai/http-runtime": "0.1.139",
+    "@jskit-ai/kernel": "0.1.141",
+    "@jskit-ai/resource-crud-core": "0.1.84",
+    "@jskit-ai/users-core": "0.1.154",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/console-web/package.descriptor.mjs
+++ b/packages/console-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-web",
-  version: "0.1.109",
+  version: "0.1.110",
   kind: "runtime",
   description: "Authenticated console surface scaffold and surface policy wiring.",
   dependsOn: [
@@ -103,9 +103,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-web": "0.1.141",
-        "@jskit-ai/console-core": "0.1.104",
-        "@jskit-ai/shell-web": "0.1.141",
+        "@jskit-ai/auth-web": "0.1.142",
+        "@jskit-ai/console-core": "0.1.105",
+        "@jskit-ai/shell-web": "0.1.142",
       },
       dev: {}
     },

--- a/packages/console-web/package.json
+++ b/packages/console-web/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/console-web",
-  "version": "0.1.109",
+  "version": "0.1.110",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-web": "0.1.141",
-    "@jskit-ai/console-core": "0.1.104",
-    "@jskit-ai/shell-web": "0.1.141"
+    "@jskit-ai/auth-web": "0.1.142",
+    "@jskit-ai/console-core": "0.1.105",
+    "@jskit-ai/shell-web": "0.1.142"
   }
 }

--- a/packages/crud-core/package.descriptor.mjs
+++ b/packages/crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-core",
-  version: "0.1.150",
+  version: "0.1.151",
   kind: "runtime",
   description: "Shared CRUD helpers used by CRUD modules.",
   dependsOn: [
@@ -28,7 +28,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/crud-core": "0.1.150"
+        "@jskit-ai/crud-core": "0.1.151"
       },
       dev: {}
     },

--- a/packages/crud-core/package.json
+++ b/packages/crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-core",
-  "version": "0.1.150",
+  "version": "0.1.151",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -27,15 +27,15 @@
     "./server/routeContracts": "./src/server/routeContracts.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.139",
-    "@jskit-ai/http-runtime": "0.1.138",
-    "@jskit-ai/kernel": "0.1.140",
+    "@jskit-ai/database-runtime": "0.1.140",
+    "@jskit-ai/http-runtime": "0.1.139",
+    "@jskit-ai/kernel": "0.1.141",
     "json-rest-schema": "1.x.x",
-    "@jskit-ai/realtime": "0.1.137",
-    "@jskit-ai/resource-crud-core": "0.1.83",
-    "@jskit-ai/shell-web": "0.1.141",
-    "@jskit-ai/users-core": "0.1.153",
-    "@jskit-ai/users-web": "0.1.157"
+    "@jskit-ai/realtime": "0.1.138",
+    "@jskit-ai/resource-crud-core": "0.1.84",
+    "@jskit-ai/shell-web": "0.1.142",
+    "@jskit-ai/users-core": "0.1.154",
+    "@jskit-ai/users-web": "0.1.158"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/crud-server-generator/package.descriptor.mjs
+++ b/packages/crud-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-server-generator",
-  version: "0.1.152",
+  version: "0.1.153",
   kind: "generator",
   description: "CRUD server generator with routes, actions, and persistence scaffolding.",
   options: {
@@ -184,14 +184,14 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.138",
-        "@jskit-ai/crud-core": "0.1.150",
-        "@jskit-ai/database-runtime": "0.1.139",
-        "@jskit-ai/http-runtime": "0.1.138",
-        "@jskit-ai/json-rest-api-core": "0.1.84",
-        "@jskit-ai/kernel": "0.1.140",
-        "@jskit-ai/realtime": "0.1.137",
-        "@jskit-ai/resource-crud-core": "0.1.83",
+        "@jskit-ai/auth-core": "0.1.139",
+        "@jskit-ai/crud-core": "0.1.151",
+        "@jskit-ai/database-runtime": "0.1.140",
+        "@jskit-ai/http-runtime": "0.1.139",
+        "@jskit-ai/json-rest-api-core": "0.1.85",
+        "@jskit-ai/kernel": "0.1.141",
+        "@jskit-ai/realtime": "0.1.138",
+        "@jskit-ai/resource-crud-core": "0.1.84",
         "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}"
       },
       dev: {}

--- a/packages/crud-server-generator/package.json
+++ b/packages/crud-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-server-generator",
-  "version": "0.1.152",
+  "version": "0.1.153",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,12 +13,12 @@
   },
   "dependencies": {
     "@babel/parser": "^7.29.2",
-    "@jskit-ai/crud-core": "0.1.150",
-    "@jskit-ai/database-runtime": "0.1.139",
-    "@jskit-ai/http-runtime": "0.1.138",
-    "@jskit-ai/json-rest-api-core": "0.1.84",
-    "@jskit-ai/kernel": "0.1.140",
-    "@jskit-ai/resource-crud-core": "0.1.83",
+    "@jskit-ai/crud-core": "0.1.151",
+    "@jskit-ai/database-runtime": "0.1.140",
+    "@jskit-ai/http-runtime": "0.1.139",
+    "@jskit-ai/json-rest-api-core": "0.1.85",
+    "@jskit-ai/kernel": "0.1.141",
+    "@jskit-ai/resource-crud-core": "0.1.84",
     "recast": "^0.23.11"
   }
 }

--- a/packages/crud-ui-generator/package.descriptor.mjs
+++ b/packages/crud-ui-generator/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { GENERATED_UI_NAVIGATION_ROLE_OPTION } from "@jskit-ai/kernel/shared/sup
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-ui-generator",
-  version: "0.1.123",
+  version: "0.1.124",
   kind: "generator",
   description: "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
   options: {
@@ -175,7 +175,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.157"
+        "@jskit-ai/users-web": "0.1.158"
       },
       dev: {}
     },

--- a/packages/crud-ui-generator/package.json
+++ b/packages/crud-ui-generator/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@jskit-ai/crud-ui-generator",
-  "version": "0.1.123",
+  "version": "0.1.124",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/crud-core": "0.1.150",
-    "@jskit-ai/kernel": "0.1.140",
-    "@jskit-ai/resource-crud-core": "0.1.83"
+    "@jskit-ai/crud-core": "0.1.151",
+    "@jskit-ai/kernel": "0.1.141",
+    "@jskit-ai/resource-crud-core": "0.1.84"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/database-runtime-mysql/package.descriptor.mjs
+++ b/packages/database-runtime-mysql/package.descriptor.mjs
@@ -13,7 +13,7 @@ const CI_DATABASE = Object.freeze({
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-mysql",
-  version: "0.1.138",
+  version: "0.1.139",
   kind: "runtime",
   options: {
     "db-host": {
@@ -133,7 +133,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.139",
+        "@jskit-ai/database-runtime": "0.1.140",
         "mysql2": "^3.11.2"
       },
       dev: {}

--- a/packages/database-runtime-mysql/package.json
+++ b/packages/database-runtime-mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-mysql",
-  "version": "0.1.138",
+  "version": "0.1.139",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,7 +12,7 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.139",
-    "@jskit-ai/kernel": "0.1.140"
+    "@jskit-ai/database-runtime": "0.1.140",
+    "@jskit-ai/kernel": "0.1.141"
   }
 }

--- a/packages/database-runtime-postgres/package.descriptor.mjs
+++ b/packages/database-runtime-postgres/package.descriptor.mjs
@@ -12,7 +12,7 @@ const CI_DATABASE = Object.freeze({
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-postgres",
-  version: "0.1.137",
+  version: "0.1.138",
   kind: "runtime",
   options: {
     "db-host": {
@@ -131,7 +131,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.139",
+        "@jskit-ai/database-runtime": "0.1.140",
         "pg": "^8.13.1"
       },
       dev: {}

--- a/packages/database-runtime-postgres/package.json
+++ b/packages/database-runtime-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-postgres",
-  "version": "0.1.137",
+  "version": "0.1.138",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,6 +12,6 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.139"
+    "@jskit-ai/database-runtime": "0.1.140"
   }
 }

--- a/packages/database-runtime/package.descriptor.mjs
+++ b/packages/database-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime",
-  version: "0.1.139",
+  version: "0.1.140",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -70,7 +70,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.140",
+        "@jskit-ai/kernel": "0.1.141",
         "dotenv": "^16.4.5",
         "knex": "^3.1.0"
       },

--- a/packages/database-runtime/package.json
+++ b/packages/database-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime",
-  "version": "0.1.139",
+  "version": "0.1.140",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -25,6 +25,6 @@
     "./shared/transactions": "./src/shared/transactions.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.140"
+    "@jskit-ai/kernel": "0.1.141"
   }
 }

--- a/packages/feature-server-generator/package.descriptor.mjs
+++ b/packages/feature-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/feature-server-generator",
-  version: "0.1.82",
+  version: "0.1.83",
   kind: "generator",
   description: "Scaffold substantial non-CRUD server feature packages with provider, actions, service, and optional persistence seams.",
   options: {
@@ -154,27 +154,27 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@jskit-ai/database-runtime": {
-          version: "0.1.139",
+          version: "0.1.140",
           when: {
             option: "mode",
             notEquals: "orchestrator"
           }
         },
         "@jskit-ai/database-runtime-mysql": {
-          version: "0.1.138",
+          version: "0.1.139",
           when: {
             option: "mode",
             notEquals: "orchestrator"
           }
         },
         "@jskit-ai/json-rest-api-core": {
-          version: "0.1.84",
+          version: "0.1.85",
           when: {
             option: "mode",
             equals: "json-rest"
           }
         },
-        "@jskit-ai/kernel": "0.1.140",
+        "@jskit-ai/kernel": "0.1.141",
         "json-rest-schema": "1.x.x",
         "@local/${option:feature-name|kebab}": "file:packages/${option:feature-name|kebab}"
       },

--- a/packages/feature-server-generator/package.json
+++ b/packages/feature-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/feature-server-generator",
-  "version": "0.1.82",
+  "version": "0.1.83",
   "type": "module",
   "scripts": {
     "test": "node --test"

--- a/packages/google-rewarded-core/package.descriptor.mjs
+++ b/packages/google-rewarded-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/google-rewarded-core",
-  version: "0.1.77",
+  version: "0.1.78",
   kind: "runtime",
   description: "Google rewarded workflow runtime plus internal CRUD providers for rules, provider configs, watch sessions, and unlock receipts.",
   dependsOn: [
@@ -128,14 +128,14 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.138",
-        "@jskit-ai/crud-core": "0.1.150",
-        "@jskit-ai/database-runtime": "0.1.139",
-        "@jskit-ai/http-runtime": "0.1.138",
-        "@jskit-ai/json-rest-api-core": "0.1.84",
-        "@jskit-ai/kernel": "0.1.140",
-        "@jskit-ai/resource-crud-core": "0.1.83",
-        "@jskit-ai/workspaces-core": "0.1.119"
+        "@jskit-ai/auth-core": "0.1.139",
+        "@jskit-ai/crud-core": "0.1.151",
+        "@jskit-ai/database-runtime": "0.1.140",
+        "@jskit-ai/http-runtime": "0.1.139",
+        "@jskit-ai/json-rest-api-core": "0.1.85",
+        "@jskit-ai/kernel": "0.1.141",
+        "@jskit-ai/resource-crud-core": "0.1.84",
+        "@jskit-ai/workspaces-core": "0.1.120"
       },
       dev: {}
     },

--- a/packages/google-rewarded-core/package.json
+++ b/packages/google-rewarded-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/google-rewarded-core",
-  "version": "0.1.77",
+  "version": "0.1.78",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/google-rewarded-web/package.descriptor.mjs
+++ b/packages/google-rewarded-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/google-rewarded-web",
-  version: "0.1.77",
+  version: "0.1.78",
   kind: "runtime",
   description: "Google rewarded client runtime with a fullscreen gate host and GPT orchestration.",
   dependsOn: [
@@ -46,10 +46,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/google-rewarded-core": "0.1.77",
-        "@jskit-ai/http-runtime": "0.1.138",
-        "@jskit-ai/kernel": "0.1.140",
-        "@jskit-ai/shell-web": "0.1.141"
+        "@jskit-ai/google-rewarded-core": "0.1.78",
+        "@jskit-ai/http-runtime": "0.1.139",
+        "@jskit-ai/kernel": "0.1.141",
+        "@jskit-ai/shell-web": "0.1.142"
       },
       dev: {}
     },

--- a/packages/google-rewarded-web/package.json
+++ b/packages/google-rewarded-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/google-rewarded-web",
-  "version": "0.1.77",
+  "version": "0.1.78",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/http-runtime/package.descriptor.mjs
+++ b/packages/http-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/http-runtime",
-  "version": "0.1.138",
+  "version": "0.1.139",
   "kind": "runtime",
   "dependsOn": [],
   "capabilities": {
@@ -67,7 +67,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.140"
+        "@jskit-ai/kernel": "0.1.141"
       },
       "dev": {}
     },

--- a/packages/http-runtime/package.json
+++ b/packages/http-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/http-runtime",
-  "version": "0.1.138",
+  "version": "0.1.139",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -18,7 +18,7 @@
     "./shared/validators/operationValidation": "./src/shared/validators/operationValidation.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.140",
+    "@jskit-ai/kernel": "0.1.141",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/json-rest-api-core/package.descriptor.mjs
+++ b/packages/json-rest-api-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/json-rest-api-core",
-  version: "0.1.84",
+  version: "0.1.85",
   kind: "runtime",
   description: "Shared internal json-rest-api host runtime with autofilter, query-projection, and row-policy support.",
   dependsOn: [

--- a/packages/json-rest-api-core/package.json
+++ b/packages/json-rest-api-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/json-rest-api-core",
-  "version": "0.1.84",
+  "version": "0.1.85",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "hooked-api": "1.x.x",
-    "json-rest-api": "^1.0.26",
-    "@jskit-ai/kernel": "0.1.140"
+    "json-rest-api": "^1.0.27",
+    "@jskit-ai/kernel": "0.1.141"
   }
 }

--- a/packages/json-rest-api-core/src/server/jsonRestApiHost.js
+++ b/packages/json-rest-api-core/src/server/jsonRestApiHost.js
@@ -2,6 +2,7 @@ import { Api } from "hooked-api";
 import {
   AutoFilterPlugin,
   QueryProjectionsPlugin,
+  REST_API_FIELDSET_ERROR_CODE,
   RestApiKnexPlugin,
   RestApiPlugin,
   RowPolicyPlugin
@@ -647,9 +648,7 @@ async function returnNullWhenJsonRestResourceMissing(run) {
 }
 
 function isJsonRestSparseFieldError(error = null) {
-  return /^Unknown sparse field '.+' requested for '.+'$/u.test(
-    normalizeJsonRestText(error?.message)
-  );
+  return normalizeJsonRestText(error?.code) === REST_API_FIELDSET_ERROR_CODE;
 }
 
 async function returnBadRequestWhenJsonRestFieldsetInvalid(run) {

--- a/packages/json-rest-api-core/test/entrypoints.boundary.test.js
+++ b/packages/json-rest-api-core/test/entrypoints.boundary.test.js
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
 import { normalizeRecordId } from "@jskit-ai/kernel/shared/support/normalize";
+import { RestApiFieldsetError } from "json-rest-api";
 
 import {
   INTERNAL_JSON_REST_API,
@@ -27,7 +28,7 @@ test("package exports include explicit server jsonRestApiHost entrypoint only", 
   const exportsMap = packageJson && typeof packageJson === "object" ? packageJson.exports : {};
   assert.equal(exportsMap["./server/jsonRestApiHost"], "./src/server/jsonRestApiHost.js");
   assert.equal(exportsMap["./server"], undefined);
-  assert.equal(packageJson.dependencies?.["json-rest-api"], "^1.0.26");
+  assert.equal(packageJson.dependencies?.["json-rest-api"], "^1.0.27");
 });
 
 test("server jsonRestApiHost entrypoint no longer exports host-side JSON:API simplification helpers", async () => {
@@ -649,8 +650,11 @@ test("returnNullWhenJsonRestResourceMissing only swallows missing-resource error
   );
 });
 
-test("invalid sparse fields become a stable 400 without swallowing unrelated failures", async () => {
-  const sparseFieldError = new Error("Unknown sparse field 'passwordHash' requested for 'contacts'");
+test("typed invalid sparse fields become a stable 400 without message matching", async () => {
+  const sparseFieldError = new RestApiFieldsetError({
+    field: "passwordHash",
+    resourceType: "contacts"
+  });
 
   await assert.rejects(
     () => returnBadRequestWhenJsonRestFieldsetInvalid(async () => {
@@ -662,6 +666,14 @@ test("invalid sparse fields become a stable 400 without swallowing unrelated fai
       assert.equal(error.message, sparseFieldError.message);
       return true;
     }
+  );
+
+  const messageOnlyError = new Error(sparseFieldError.message);
+  await assert.rejects(
+    () => returnBadRequestWhenJsonRestFieldsetInvalid(async () => {
+      throw messageOnlyError;
+    }),
+    (error) => error === messageOnlyError
   );
 
   const unrelatedError = new Error("database unavailable");

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/kernel",
-  "version": "0.1.140",
+  "version": "0.1.141",
   "type": "module",
   "dependencies": {
     "json-rest-schema": "1.x.x"

--- a/packages/mobile-capacitor/package.descriptor.mjs
+++ b/packages/mobile-capacitor/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/mobile-capacitor",
-  version: "0.1.76",
+  version: "0.1.77",
   kind: "runtime",
   description: "Thin Capacitor client integration for JSKIT mobile-shell launch routing and auth callback completion.",
   dependsOn: [
@@ -62,8 +62,8 @@ export default Object.freeze({
         "@capacitor/app": "^7.1.0",
         "@capacitor/browser": "^7.0.1",
         "@capacitor/core": "^7.4.3",
-        "@jskit-ai/kernel": "0.1.140",
-        "@jskit-ai/shell-web": "0.1.141"
+        "@jskit-ai/kernel": "0.1.141",
+        "@jskit-ai/shell-web": "0.1.142"
       },
       dev: {
         "@capacitor/cli": "^7.4.3"

--- a/packages/mobile-capacitor/package.json
+++ b/packages/mobile-capacitor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/mobile-capacitor",
-  "version": "0.1.76",
+  "version": "0.1.77",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,6 +13,6 @@
   "dependencies": {
     "@capacitor/browser": "^7.0.1",
     "@capacitor/core": "^7.4.3",
-    "@jskit-ai/kernel": "0.1.140"
+    "@jskit-ai/kernel": "0.1.141"
   }
 }

--- a/packages/realtime/package.descriptor.mjs
+++ b/packages/realtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/realtime",
-  version: "0.1.137",
+  version: "0.1.138",
   kind: "runtime",
   description: "Thin, generic realtime runtime wrappers for socket.io server and client.",
   options: {
@@ -95,7 +95,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.140",
+        "@jskit-ai/kernel": "0.1.141",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/realtime",
-  "version": "0.1.137",
+  "version": "0.1.138",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@socket.io/redis-adapter": "^8.3.0",
-    "@jskit-ai/kernel": "0.1.140",
+    "@jskit-ai/kernel": "0.1.141",
     "redis": "^5.8.2",
     "socket.io": "^4.8.3",
     "socket.io-client": "^4.8.3"

--- a/packages/resource-core/package.descriptor.mjs
+++ b/packages/resource-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/resource-core",
-  version: "0.1.83",
+  version: "0.1.84",
   kind: "runtime",
   description: "Generic resource-definition helpers and schema-definition normalization.",
   dependsOn: [
@@ -22,7 +22,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/resource-core": "0.1.83"
+        "@jskit-ai/resource-core": "0.1.84"
       },
       dev: {}
     },

--- a/packages/resource-core/package.json
+++ b/packages/resource-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/resource-core",
-  "version": "0.1.83",
+  "version": "0.1.84",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./shared/resource": "./src/shared/resource.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.140"
+    "@jskit-ai/kernel": "0.1.141"
   }
 }

--- a/packages/resource-crud-core/package.descriptor.mjs
+++ b/packages/resource-crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/resource-crud-core",
-  version: "0.1.83",
+  version: "0.1.84",
   kind: "runtime",
   description: "CRUD-specific resource-definition helpers and namespace support.",
   dependsOn: [
@@ -23,7 +23,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/resource-crud-core": "0.1.83"
+        "@jskit-ai/resource-crud-core": "0.1.84"
       },
       dev: {}
     },

--- a/packages/resource-crud-core/package.json
+++ b/packages/resource-crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/resource-crud-core",
-  "version": "0.1.83",
+  "version": "0.1.84",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./shared/crudResource": "./src/shared/crudResource.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.140",
-    "@jskit-ai/resource-core": "0.1.83"
+    "@jskit-ai/kernel": "0.1.141",
+    "@jskit-ai/resource-core": "0.1.84"
   }
 }

--- a/packages/shell-web/package.descriptor.mjs
+++ b/packages/shell-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/shell-web",
-  version: "0.1.141",
+  version: "0.1.142",
   kind: "runtime",
   description: "Web shell layout runtime with outlet-based placement contributions.",
   dependsOn: [],
@@ -311,7 +311,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/kernel": "0.1.140"
+        "@jskit-ai/kernel": "0.1.141"
       },
       dev: {
         "@playwright/test": "1.61.1"

--- a/packages/shell-web/package.json
+++ b/packages/shell-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/shell-web",
-  "version": "0.1.141",
+  "version": "0.1.142",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/kernel": "0.1.140"
+    "@jskit-ai/kernel": "0.1.141"
   },
   "peerDependencies": {
     "pinia": "^3.0.4",

--- a/packages/storage-runtime/package.descriptor.mjs
+++ b/packages/storage-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/storage-runtime",
-  version: "0.1.138",
+  version: "0.1.139",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -50,7 +50,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.140",
+        "@jskit-ai/kernel": "0.1.141",
         "unstorage": "^1.17.3"
       },
       dev: {}

--- a/packages/storage-runtime/package.json
+++ b/packages/storage-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/storage-runtime",
-  "version": "0.1.138",
+  "version": "0.1.139",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./server/providers/StorageRuntimeServiceProvider": "./src/server/providers/StorageRuntimeServiceProvider.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.140",
+    "@jskit-ai/kernel": "0.1.141",
     "unstorage": "^1.17.5"
   }
 }

--- a/packages/ui-generator/package.descriptor.mjs
+++ b/packages/ui-generator/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { GENERATED_UI_NAVIGATION_ROLE_OPTION } from "@jskit-ai/kernel/shared/sup
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/ui-generator",
-  version: "0.1.123",
+  version: "0.1.124",
   kind: "generator",
   description: "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
   options: {
@@ -371,7 +371,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.157"
+        "@jskit-ai/users-web": "0.1.158"
       },
       dev: {}
     },

--- a/packages/ui-generator/package.json
+++ b/packages/ui-generator/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/ui-generator",
-  "version": "0.1.123",
+  "version": "0.1.124",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.140",
-    "@jskit-ai/shell-web": "0.1.141"
+    "@jskit-ai/kernel": "0.1.141",
+    "@jskit-ai/shell-web": "0.1.142"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/uploads-image-web/package.descriptor.mjs
+++ b/packages/uploads-image-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-image-web",
-  version: "0.1.116",
+  version: "0.1.117",
   kind: "runtime",
   description: "Reusable client-side image upload runtime with pre-upload image editing.",
   dependsOn: [
@@ -65,7 +65,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/uploads-runtime": "0.1.116",
+        "@jskit-ai/uploads-runtime": "0.1.117",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-image-web/package.json
+++ b/packages/uploads-image-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-image-web",
-  "version": "0.1.116",
+  "version": "0.1.117",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,7 +13,7 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/uploads-runtime": "0.1.116",
+    "@jskit-ai/uploads-runtime": "0.1.117",
     "@uppy/compressor": "^3.1.0",
     "@uppy/core": "^5.2.0",
     "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-runtime/package.descriptor.mjs
+++ b/packages/uploads-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-runtime",
-  version: "0.1.116",
+  version: "0.1.117",
   kind: "runtime",
   description: "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
   dependsOn: [
@@ -71,7 +71,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.140"
+        "@jskit-ai/kernel": "0.1.141"
       },
       dev: {}
     },

--- a/packages/uploads-runtime/package.json
+++ b/packages/uploads-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-runtime",
-  "version": "0.1.116",
+  "version": "0.1.117",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,6 +16,6 @@
   },
   "dependencies": {
     "@fastify/multipart": "^9.4.0",
-    "@jskit-ai/kernel": "0.1.140"
+    "@jskit-ai/kernel": "0.1.141"
   }
 }

--- a/packages/users-core/package.descriptor.mjs
+++ b/packages/users-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-core",
-  version: "0.1.153",
+  version: "0.1.154",
   kind: "runtime",
   description: "Users/account runtime plus HTTP routes for account features.",
   dependsOn: [
@@ -146,16 +146,16 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.138",
-        "@jskit-ai/crud-core": "0.1.150",
-        "@jskit-ai/database-runtime": "0.1.139",
-        "@jskit-ai/http-runtime": "0.1.138",
-        "@jskit-ai/json-rest-api-core": "0.1.84",
-        "@jskit-ai/kernel": "0.1.140",
-        "@jskit-ai/resource-core": "0.1.83",
-        "@jskit-ai/resource-crud-core": "0.1.83",
+        "@jskit-ai/auth-core": "0.1.139",
+        "@jskit-ai/crud-core": "0.1.151",
+        "@jskit-ai/database-runtime": "0.1.140",
+        "@jskit-ai/http-runtime": "0.1.139",
+        "@jskit-ai/json-rest-api-core": "0.1.85",
+        "@jskit-ai/kernel": "0.1.141",
+        "@jskit-ai/resource-core": "0.1.84",
+        "@jskit-ai/resource-crud-core": "0.1.84",
         "@local/users": "file:packages/users",
-        "@jskit-ai/uploads-runtime": "0.1.116"
+        "@jskit-ai/uploads-runtime": "0.1.117"
       },
       dev: {}
     },

--- a/packages/users-core/package.json
+++ b/packages/users-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-core",
-  "version": "0.1.153",
+  "version": "0.1.154",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,14 +11,14 @@
     "./shared/resources/userSettingsResource": "./src/shared/resources/userSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.138",
-    "@jskit-ai/database-runtime": "0.1.139",
-    "@jskit-ai/http-runtime": "0.1.138",
-    "@jskit-ai/json-rest-api-core": "0.1.84",
-    "@jskit-ai/kernel": "0.1.140",
-    "@jskit-ai/resource-crud-core": "0.1.83",
-    "@jskit-ai/resource-core": "0.1.83",
-    "@jskit-ai/uploads-runtime": "0.1.116",
+    "@jskit-ai/auth-core": "0.1.139",
+    "@jskit-ai/database-runtime": "0.1.140",
+    "@jskit-ai/http-runtime": "0.1.139",
+    "@jskit-ai/json-rest-api-core": "0.1.85",
+    "@jskit-ai/kernel": "0.1.141",
+    "@jskit-ai/resource-crud-core": "0.1.84",
+    "@jskit-ai/resource-core": "0.1.84",
+    "@jskit-ai/uploads-runtime": "0.1.117",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/users-web/package.descriptor.mjs
+++ b/packages/users-web/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { HOME_COG_OUTLET } from "./src/shared/toolsOutletContracts.js";
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-web",
-  version: "0.1.157",
+  version: "0.1.158",
   kind: "runtime",
   description: "Users web module: account/profile UI plus shared users web widgets.",
   dependsOn: [
@@ -286,12 +286,12 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/http-runtime": "0.1.138",
-        "@jskit-ai/realtime": "0.1.137",
-        "@jskit-ai/kernel": "0.1.140",
-        "@jskit-ai/shell-web": "0.1.141",
-        "@jskit-ai/uploads-image-web": "0.1.116",
-        "@jskit-ai/users-core": "0.1.153"
+        "@jskit-ai/http-runtime": "0.1.139",
+        "@jskit-ai/realtime": "0.1.138",
+        "@jskit-ai/kernel": "0.1.141",
+        "@jskit-ai/shell-web": "0.1.142",
+        "@jskit-ai/uploads-image-web": "0.1.117",
+        "@jskit-ai/users-core": "0.1.154"
       },
       dev: {}
     },

--- a/packages/users-web/package.json
+++ b/packages/users-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-web",
-  "version": "0.1.157",
+  "version": "0.1.158",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -46,12 +46,12 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/http-runtime": "0.1.138",
-    "@jskit-ai/kernel": "0.1.140",
-    "@jskit-ai/realtime": "0.1.137",
-    "@jskit-ai/shell-web": "0.1.141",
-    "@jskit-ai/uploads-image-web": "0.1.116",
-    "@jskit-ai/users-core": "0.1.153"
+    "@jskit-ai/http-runtime": "0.1.139",
+    "@jskit-ai/kernel": "0.1.141",
+    "@jskit-ai/realtime": "0.1.138",
+    "@jskit-ai/shell-web": "0.1.142",
+    "@jskit-ai/uploads-image-web": "0.1.117",
+    "@jskit-ai/users-core": "0.1.154"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/workspaces-core/package.descriptor.mjs
+++ b/packages/workspaces-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-core",
-  version: "0.1.119",
+  version: "0.1.120",
   kind: "runtime",
   description: "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
   dependsOn: [
@@ -147,10 +147,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/json-rest-api-core": "0.1.84",
-        "@jskit-ai/resource-core": "0.1.83",
-        "@jskit-ai/resource-crud-core": "0.1.83",
-        "@jskit-ai/users-core": "0.1.153"
+        "@jskit-ai/json-rest-api-core": "0.1.85",
+        "@jskit-ai/resource-core": "0.1.84",
+        "@jskit-ai/resource-crud-core": "0.1.84",
+        "@jskit-ai/users-core": "0.1.154"
       },
       dev: {}
     },

--- a/packages/workspaces-core/package.json
+++ b/packages/workspaces-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-core",
-  "version": "0.1.119",
+  "version": "0.1.120",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -17,14 +17,14 @@
     "./shared/resources/workspaceSettingsResource": "./src/shared/resources/workspaceSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.138",
-    "@jskit-ai/database-runtime": "0.1.139",
-    "@jskit-ai/http-runtime": "0.1.138",
-    "@jskit-ai/json-rest-api-core": "0.1.84",
-    "@jskit-ai/kernel": "0.1.140",
-    "@jskit-ai/resource-crud-core": "0.1.83",
-    "@jskit-ai/resource-core": "0.1.83",
-    "@jskit-ai/users-core": "0.1.153",
+    "@jskit-ai/auth-core": "0.1.139",
+    "@jskit-ai/database-runtime": "0.1.140",
+    "@jskit-ai/http-runtime": "0.1.139",
+    "@jskit-ai/json-rest-api-core": "0.1.85",
+    "@jskit-ai/kernel": "0.1.141",
+    "@jskit-ai/resource-crud-core": "0.1.84",
+    "@jskit-ai/resource-core": "0.1.84",
+    "@jskit-ai/users-core": "0.1.154",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/workspaces-web/package.descriptor.mjs
+++ b/packages/workspaces-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-web",
-  version: "0.1.120",
+  version: "0.1.121",
   kind: "runtime",
   description: "Workspace web module: workspace selector, tools widget, workspace surfaces, members UI, and settings hosts.",
   dependsOn: [
@@ -232,9 +232,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-web": "0.1.141",
-        "@jskit-ai/workspaces-core": "0.1.119",
-        "@jskit-ai/users-web": "0.1.157"
+        "@jskit-ai/auth-web": "0.1.142",
+        "@jskit-ai/workspaces-core": "0.1.120",
+        "@jskit-ai/users-web": "0.1.158"
       },
       dev: {}
     },

--- a/packages/workspaces-web/package.json
+++ b/packages/workspaces-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-web",
-  "version": "0.1.120",
+  "version": "0.1.121",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -15,13 +15,13 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/auth-web": "0.1.141",
-    "@jskit-ai/http-runtime": "0.1.138",
-    "@jskit-ai/kernel": "0.1.140",
-    "@jskit-ai/shell-web": "0.1.141",
-    "@jskit-ai/users-core": "0.1.153",
-    "@jskit-ai/users-web": "0.1.157",
-    "@jskit-ai/workspaces-core": "0.1.119"
+    "@jskit-ai/auth-web": "0.1.142",
+    "@jskit-ai/http-runtime": "0.1.139",
+    "@jskit-ai/kernel": "0.1.141",
+    "@jskit-ai/shell-web": "0.1.142",
+    "@jskit-ai/users-core": "0.1.154",
+    "@jskit-ai/users-web": "0.1.158",
+    "@jskit-ai/workspaces-core": "0.1.120"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/tooling/config-eslint/package.json
+++ b/tooling/config-eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/config-eslint",
-  "version": "0.1.138",
+  "version": "0.1.139",
   "description": "Shared flat ESLint presets for JSKIT projects.",
   "type": "module",
   "files": [

--- a/tooling/create-app/package.descriptor.mjs
+++ b/tooling/create-app/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/create-app",
-  "version": "0.1.159",
+  "version": "0.1.160",
   "dependsOn": [],
   "capabilities": {
     "provides": [

--- a/tooling/create-app/package.json
+++ b/tooling/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/create-app",
-  "version": "0.1.159",
+  "version": "0.1.160",
   "description": "Scaffold JSKIT app shells.",
   "type": "module",
   "files": [
@@ -20,7 +20,7 @@
     "./client": "./src/client/index.js"
   },
   "dependencies": {
-    "@jskit-ai/jskit-cli": "0.2.167"
+    "@jskit-ai/jskit-cli": "0.2.168"
   },
   "engines": {
     "node": "^22.13.0 || ^24.0.0 || ^26.0.0"

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -6,11 +6,11 @@
   "packages": [
     {
       "packageId": "@jskit-ai/assistant",
-      "version": "0.1.149",
+      "version": "0.1.150",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant",
-        "version": "0.1.149",
+        "version": "0.1.150",
         "kind": "generator",
         "description": "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
         "options": {
@@ -347,11 +347,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-core",
-      "version": "0.1.117",
+      "version": "0.1.118",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-core",
-        "version": "0.1.117",
+        "version": "0.1.118",
         "kind": "runtime",
         "description": "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
         "dependsOn": [
@@ -399,11 +399,11 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/http-runtime": "0.1.138",
-              "@jskit-ai/kernel": "0.1.140",
-              "@jskit-ai/resource-core": "0.1.83",
-              "@jskit-ai/resource-crud-core": "0.1.83",
-              "@jskit-ai/users-core": "0.1.153",
+              "@jskit-ai/http-runtime": "0.1.139",
+              "@jskit-ai/kernel": "0.1.141",
+              "@jskit-ai/resource-core": "0.1.84",
+              "@jskit-ai/resource-crud-core": "0.1.84",
+              "@jskit-ai/users-core": "0.1.154",
               "dompurify": "^3.3.3",
               "json-rest-schema": "1.x.x",
               "marked": "^17.0.4",
@@ -422,11 +422,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-runtime",
-      "version": "0.1.112",
+      "version": "0.1.113",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-runtime",
-        "version": "0.1.112",
+        "version": "0.1.113",
         "kind": "runtime",
         "description": "Shared assistant runtime with per-surface assistant registration.",
         "dependsOn": [
@@ -522,13 +522,13 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/assistant-core": "0.1.117",
-              "@jskit-ai/database-runtime": "0.1.139",
-              "@jskit-ai/http-runtime": "0.1.138",
-              "@jskit-ai/kernel": "0.1.140",
-              "@jskit-ai/shell-web": "0.1.141",
-              "@jskit-ai/users-core": "0.1.153",
-              "@jskit-ai/users-web": "0.1.157"
+              "@jskit-ai/assistant-core": "0.1.118",
+              "@jskit-ai/database-runtime": "0.1.140",
+              "@jskit-ai/http-runtime": "0.1.139",
+              "@jskit-ai/kernel": "0.1.141",
+              "@jskit-ai/shell-web": "0.1.142",
+              "@jskit-ai/users-core": "0.1.154",
+              "@jskit-ai/users-web": "0.1.158"
             },
             "dev": {}
           },
@@ -583,11 +583,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-core",
-      "version": "0.1.138",
+      "version": "0.1.139",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-core",
-        "version": "0.1.138",
+        "version": "0.1.139",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/value-app-config-shared"
@@ -660,7 +660,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.140",
+              "@jskit-ai/kernel": "0.1.141",
               "@fastify/cookie": "^11.0.2",
               "@fastify/csrf-protection": "^7.1.0",
               "@fastify/rate-limit": "^10.3.0"
@@ -678,11 +678,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-local-core",
-      "version": "0.1.42",
+      "version": "0.1.43",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-local-core",
-        "version": "0.1.42",
+        "version": "0.1.43",
         "kind": "runtime",
         "description": "Local auth provider with a file backend default and no database requirement.",
         "dependsOn": [
@@ -745,8 +745,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.138",
-              "@jskit-ai/kernel": "0.1.140",
+              "@jskit-ai/auth-core": "0.1.139",
+              "@jskit-ai/kernel": "0.1.141",
               "nodemailer": "^9.0.3",
               "dotenv": "^16.4.5"
             },
@@ -792,11 +792,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-local-db-core",
-      "version": "0.1.33",
+      "version": "0.1.34",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-local-db-core",
-        "version": "0.1.33",
+        "version": "0.1.34",
         "kind": "runtime",
         "description": "Database-backed local auth storage backend for JSKIT local auth.",
         "dependsOn": [
@@ -875,9 +875,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-provider-local-core": "0.1.42",
-              "@jskit-ai/database-runtime": "0.1.139",
-              "@jskit-ai/kernel": "0.1.140"
+              "@jskit-ai/auth-provider-local-core": "0.1.43",
+              "@jskit-ai/database-runtime": "0.1.140",
+              "@jskit-ai/kernel": "0.1.141"
             },
             "dev": {}
           },
@@ -912,11 +912,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.138",
+      "version": "0.1.139",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-supabase-core",
-        "version": "0.1.138",
+        "version": "0.1.139",
         "kind": "runtime",
         "options": {
           "auth-supabase-url": {
@@ -998,8 +998,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.138",
-              "@jskit-ai/kernel": "0.1.140",
+              "@jskit-ai/auth-core": "0.1.139",
+              "@jskit-ai/kernel": "0.1.141",
               "dotenv": "^16.4.5",
               "@supabase/supabase-js": "^2.57.4",
               "jose": "^6.1.0"
@@ -1077,11 +1077,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-web",
-      "version": "0.1.141",
+      "version": "0.1.142",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-web",
-        "version": "0.1.141",
+        "version": "0.1.142",
         "kind": "runtime",
         "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
         "dependsOn": [
@@ -1354,10 +1354,10 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/auth-core": "0.1.138",
-              "@jskit-ai/http-runtime": "0.1.138",
-              "@jskit-ai/kernel": "0.1.140",
-              "@jskit-ai/shell-web": "0.1.141"
+              "@jskit-ai/auth-core": "0.1.139",
+              "@jskit-ai/http-runtime": "0.1.139",
+              "@jskit-ai/kernel": "0.1.141",
+              "@jskit-ai/shell-web": "0.1.142"
             },
             "dev": {}
           },
@@ -1456,11 +1456,11 @@
     },
     {
       "packageId": "@jskit-ai/console-core",
-      "version": "0.1.104",
+      "version": "0.1.105",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-core",
-        "version": "0.1.104",
+        "version": "0.1.105",
         "kind": "runtime",
         "description": "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
         "dependsOn": [
@@ -1544,12 +1544,12 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.138",
-              "@jskit-ai/database-runtime": "0.1.139",
-              "@jskit-ai/http-runtime": "0.1.138",
-              "@jskit-ai/kernel": "0.1.140",
-              "@jskit-ai/resource-crud-core": "0.1.83",
-              "@jskit-ai/users-core": "0.1.153"
+              "@jskit-ai/auth-core": "0.1.139",
+              "@jskit-ai/database-runtime": "0.1.140",
+              "@jskit-ai/http-runtime": "0.1.139",
+              "@jskit-ai/kernel": "0.1.141",
+              "@jskit-ai/resource-crud-core": "0.1.84",
+              "@jskit-ai/users-core": "0.1.154"
             },
             "dev": {}
           },
@@ -1574,11 +1574,11 @@
     },
     {
       "packageId": "@jskit-ai/console-web",
-      "version": "0.1.109",
+      "version": "0.1.110",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-web",
-        "version": "0.1.109",
+        "version": "0.1.110",
         "kind": "runtime",
         "description": "Authenticated console surface scaffold and surface policy wiring.",
         "dependsOn": [
@@ -1688,9 +1688,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-web": "0.1.141",
-              "@jskit-ai/console-core": "0.1.104",
-              "@jskit-ai/shell-web": "0.1.141"
+              "@jskit-ai/auth-web": "0.1.142",
+              "@jskit-ai/console-core": "0.1.105",
+              "@jskit-ai/shell-web": "0.1.142"
             },
             "dev": {}
           },
@@ -1797,11 +1797,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-core",
-      "version": "0.1.150",
+      "version": "0.1.151",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-core",
-        "version": "0.1.150",
+        "version": "0.1.151",
         "kind": "runtime",
         "description": "Shared CRUD helpers used by CRUD modules.",
         "dependsOn": [
@@ -1830,7 +1830,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/crud-core": "0.1.150"
+              "@jskit-ai/crud-core": "0.1.151"
             },
             "dev": {}
           },
@@ -1844,11 +1844,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-server-generator",
-      "version": "0.1.152",
+      "version": "0.1.153",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-server-generator",
-        "version": "0.1.152",
+        "version": "0.1.153",
         "kind": "generator",
         "description": "CRUD server generator with routes, actions, and persistence scaffolding.",
         "options": {
@@ -2039,14 +2039,14 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.138",
-              "@jskit-ai/crud-core": "0.1.150",
-              "@jskit-ai/database-runtime": "0.1.139",
-              "@jskit-ai/http-runtime": "0.1.138",
-              "@jskit-ai/json-rest-api-core": "0.1.84",
-              "@jskit-ai/kernel": "0.1.140",
-              "@jskit-ai/realtime": "0.1.137",
-              "@jskit-ai/resource-crud-core": "0.1.83",
+              "@jskit-ai/auth-core": "0.1.139",
+              "@jskit-ai/crud-core": "0.1.151",
+              "@jskit-ai/database-runtime": "0.1.140",
+              "@jskit-ai/http-runtime": "0.1.139",
+              "@jskit-ai/json-rest-api-core": "0.1.85",
+              "@jskit-ai/kernel": "0.1.141",
+              "@jskit-ai/realtime": "0.1.138",
+              "@jskit-ai/resource-crud-core": "0.1.84",
               "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}"
             },
             "dev": {}
@@ -2191,11 +2191,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.123",
+      "version": "0.1.124",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-ui-generator",
-        "version": "0.1.123",
+        "version": "0.1.124",
         "kind": "generator",
         "description": "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
         "options": {
@@ -2394,7 +2394,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.157"
+              "@jskit-ai/users-web": "0.1.158"
             },
             "dev": {}
           },
@@ -2653,11 +2653,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime",
-      "version": "0.1.139",
+      "version": "0.1.140",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime",
-        "version": "0.1.139",
+        "version": "0.1.140",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -2726,7 +2726,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.140",
+              "@jskit-ai/kernel": "0.1.141",
               "dotenv": "^16.4.5",
               "knex": "^3.1.0"
             },
@@ -2769,11 +2769,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.138",
+      "version": "0.1.139",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-mysql",
-        "version": "0.1.138",
+        "version": "0.1.139",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -2895,7 +2895,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.139",
+              "@jskit-ai/database-runtime": "0.1.140",
               "mysql2": "^3.11.2"
             },
             "dev": {}
@@ -2966,11 +2966,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.137",
+      "version": "0.1.138",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-postgres",
-        "version": "0.1.137",
+        "version": "0.1.138",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -3091,7 +3091,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.139",
+              "@jskit-ai/database-runtime": "0.1.140",
               "pg": "^8.13.1"
             },
             "dev": {}
@@ -3162,11 +3162,11 @@
     },
     {
       "packageId": "@jskit-ai/feature-server-generator",
-      "version": "0.1.82",
+      "version": "0.1.83",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/feature-server-generator",
-        "version": "0.1.82",
+        "version": "0.1.83",
         "kind": "generator",
         "description": "Scaffold substantial non-CRUD server feature packages with provider, actions, service, and optional persistence seams.",
         "options": {
@@ -3331,27 +3331,27 @@
           "dependencies": {
             "runtime": {
               "@jskit-ai/database-runtime": {
-                "version": "0.1.139",
+                "version": "0.1.140",
                 "when": {
                   "option": "mode",
                   "notEquals": "orchestrator"
                 }
               },
               "@jskit-ai/database-runtime-mysql": {
-                "version": "0.1.138",
+                "version": "0.1.139",
                 "when": {
                   "option": "mode",
                   "notEquals": "orchestrator"
                 }
               },
               "@jskit-ai/json-rest-api-core": {
-                "version": "0.1.84",
+                "version": "0.1.85",
                 "when": {
                   "option": "mode",
                   "equals": "json-rest"
                 }
               },
-              "@jskit-ai/kernel": "0.1.140",
+              "@jskit-ai/kernel": "0.1.141",
               "json-rest-schema": "1.x.x",
               "@local/${option:feature-name|kebab}": "file:packages/${option:feature-name|kebab}"
             },
@@ -3464,11 +3464,11 @@
     },
     {
       "packageId": "@jskit-ai/google-rewarded-core",
-      "version": "0.1.77",
+      "version": "0.1.78",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/google-rewarded-core",
-        "version": "0.1.77",
+        "version": "0.1.78",
         "kind": "runtime",
         "description": "Google rewarded workflow runtime plus internal CRUD providers for rules, provider configs, watch sessions, and unlock receipts.",
         "dependsOn": [
@@ -3595,14 +3595,14 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.138",
-              "@jskit-ai/crud-core": "0.1.150",
-              "@jskit-ai/database-runtime": "0.1.139",
-              "@jskit-ai/http-runtime": "0.1.138",
-              "@jskit-ai/json-rest-api-core": "0.1.84",
-              "@jskit-ai/kernel": "0.1.140",
-              "@jskit-ai/resource-crud-core": "0.1.83",
-              "@jskit-ai/workspaces-core": "0.1.119"
+              "@jskit-ai/auth-core": "0.1.139",
+              "@jskit-ai/crud-core": "0.1.151",
+              "@jskit-ai/database-runtime": "0.1.140",
+              "@jskit-ai/http-runtime": "0.1.139",
+              "@jskit-ai/json-rest-api-core": "0.1.85",
+              "@jskit-ai/kernel": "0.1.141",
+              "@jskit-ai/resource-crud-core": "0.1.84",
+              "@jskit-ai/workspaces-core": "0.1.120"
             },
             "dev": {}
           },
@@ -3654,11 +3654,11 @@
     },
     {
       "packageId": "@jskit-ai/google-rewarded-web",
-      "version": "0.1.77",
+      "version": "0.1.78",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/google-rewarded-web",
-        "version": "0.1.77",
+        "version": "0.1.78",
         "kind": "runtime",
         "description": "Google rewarded client runtime with a fullscreen gate host and GPT orchestration.",
         "dependsOn": [
@@ -3705,10 +3705,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/google-rewarded-core": "0.1.77",
-              "@jskit-ai/http-runtime": "0.1.138",
-              "@jskit-ai/kernel": "0.1.140",
-              "@jskit-ai/shell-web": "0.1.141"
+              "@jskit-ai/google-rewarded-core": "0.1.78",
+              "@jskit-ai/http-runtime": "0.1.139",
+              "@jskit-ai/kernel": "0.1.141",
+              "@jskit-ai/shell-web": "0.1.142"
             },
             "dev": {}
           },
@@ -3726,11 +3726,11 @@
     },
     {
       "packageId": "@jskit-ai/http-runtime",
-      "version": "0.1.138",
+      "version": "0.1.139",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/http-runtime",
-        "version": "0.1.138",
+        "version": "0.1.139",
         "kind": "runtime",
         "dependsOn": [],
         "capabilities": {
@@ -3796,7 +3796,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.140"
+              "@jskit-ai/kernel": "0.1.141"
             },
             "dev": {}
           },
@@ -3810,11 +3810,11 @@
     },
     {
       "packageId": "@jskit-ai/json-rest-api-core",
-      "version": "0.1.84",
+      "version": "0.1.85",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/json-rest-api-core",
-        "version": "0.1.84",
+        "version": "0.1.85",
         "kind": "runtime",
         "description": "Shared internal json-rest-api host runtime with autofilter, query-projection, and row-policy support.",
         "dependsOn": [
@@ -3874,11 +3874,11 @@
     },
     {
       "packageId": "@jskit-ai/mobile-capacitor",
-      "version": "0.1.76",
+      "version": "0.1.77",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/mobile-capacitor",
-        "version": "0.1.76",
+        "version": "0.1.77",
         "kind": "runtime",
         "description": "Thin Capacitor client integration for JSKIT mobile-shell launch routing and auth callback completion.",
         "dependsOn": [
@@ -3941,8 +3941,8 @@
               "@capacitor/app": "^7.1.0",
               "@capacitor/browser": "^7.0.1",
               "@capacitor/core": "^7.4.3",
-              "@jskit-ai/kernel": "0.1.140",
-              "@jskit-ai/shell-web": "0.1.141"
+              "@jskit-ai/kernel": "0.1.141",
+              "@jskit-ai/shell-web": "0.1.142"
             },
             "dev": {
               "@capacitor/cli": "^7.4.3"
@@ -3994,11 +3994,11 @@
     },
     {
       "packageId": "@jskit-ai/realtime",
-      "version": "0.1.137",
+      "version": "0.1.138",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/realtime",
-        "version": "0.1.137",
+        "version": "0.1.138",
         "kind": "runtime",
         "description": "Thin, generic realtime runtime wrappers for socket.io server and client.",
         "options": {
@@ -4094,7 +4094,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.140",
+              "@jskit-ai/kernel": "0.1.141",
               "@socket.io/redis-adapter": "^8.3.0",
               "redis": "^5.8.2",
               "socket.io": "^4.8.3",
@@ -4143,11 +4143,11 @@
     },
     {
       "packageId": "@jskit-ai/resource-core",
-      "version": "0.1.83",
+      "version": "0.1.84",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/resource-core",
-        "version": "0.1.83",
+        "version": "0.1.84",
         "kind": "runtime",
         "description": "Generic resource-definition helpers and schema-definition normalization.",
         "dependsOn": [
@@ -4170,7 +4170,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/resource-core": "0.1.83"
+              "@jskit-ai/resource-core": "0.1.84"
             },
             "dev": {}
           },
@@ -4185,11 +4185,11 @@
     },
     {
       "packageId": "@jskit-ai/resource-crud-core",
-      "version": "0.1.83",
+      "version": "0.1.84",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/resource-crud-core",
-        "version": "0.1.83",
+        "version": "0.1.84",
         "kind": "runtime",
         "description": "CRUD-specific resource-definition helpers and namespace support.",
         "dependsOn": [
@@ -4213,7 +4213,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/resource-crud-core": "0.1.83"
+              "@jskit-ai/resource-crud-core": "0.1.84"
             },
             "dev": {}
           },
@@ -4228,11 +4228,11 @@
     },
     {
       "packageId": "@jskit-ai/shell-web",
-      "version": "0.1.141",
+      "version": "0.1.142",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/shell-web",
-        "version": "0.1.141",
+        "version": "0.1.142",
         "kind": "runtime",
         "description": "Web shell layout runtime with outlet-based placement contributions.",
         "dependsOn": [],
@@ -4578,7 +4578,7 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/kernel": "0.1.140"
+              "@jskit-ai/kernel": "0.1.141"
             },
             "dev": {
               "@playwright/test": "1.61.1"
@@ -4807,11 +4807,11 @@
     },
     {
       "packageId": "@jskit-ai/storage-runtime",
-      "version": "0.1.138",
+      "version": "0.1.139",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/storage-runtime",
-        "version": "0.1.138",
+        "version": "0.1.139",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -4860,7 +4860,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.140",
+              "@jskit-ai/kernel": "0.1.141",
               "unstorage": "^1.17.3"
             },
             "dev": {}
@@ -4876,11 +4876,11 @@
     },
     {
       "packageId": "@jskit-ai/ui-generator",
-      "version": "0.1.123",
+      "version": "0.1.124",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/ui-generator",
-        "version": "0.1.123",
+        "version": "0.1.124",
         "kind": "generator",
         "description": "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
         "options": {
@@ -5313,7 +5313,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.157"
+              "@jskit-ai/users-web": "0.1.158"
             },
             "dev": {}
           },
@@ -5328,11 +5328,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-image-web",
-      "version": "0.1.116",
+      "version": "0.1.117",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-image-web",
-        "version": "0.1.116",
+        "version": "0.1.117",
         "kind": "runtime",
         "description": "Reusable client-side image upload runtime with pre-upload image editing.",
         "dependsOn": [
@@ -5396,7 +5396,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/uploads-runtime": "0.1.116",
+              "@jskit-ai/uploads-runtime": "0.1.117",
               "@uppy/compressor": "^3.1.0",
               "@uppy/core": "^5.2.0",
               "@uppy/dashboard": "^5.1.1",
@@ -5416,11 +5416,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-runtime",
-      "version": "0.1.116",
+      "version": "0.1.117",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-runtime",
-        "version": "0.1.116",
+        "version": "0.1.117",
         "kind": "runtime",
         "description": "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
         "dependsOn": [
@@ -5490,7 +5490,7 @@
           "dependencies": {
             "runtime": {
               "@fastify/multipart": "^9.4.0",
-              "@jskit-ai/kernel": "0.1.140"
+              "@jskit-ai/kernel": "0.1.141"
             },
             "dev": {}
           },
@@ -5505,11 +5505,11 @@
     },
     {
       "packageId": "@jskit-ai/users-core",
-      "version": "0.1.153",
+      "version": "0.1.154",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-core",
-        "version": "0.1.153",
+        "version": "0.1.154",
         "kind": "runtime",
         "description": "Users/account runtime plus HTTP routes for account features.",
         "dependsOn": [
@@ -5653,16 +5653,16 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.138",
-              "@jskit-ai/crud-core": "0.1.150",
-              "@jskit-ai/database-runtime": "0.1.139",
-              "@jskit-ai/http-runtime": "0.1.138",
-              "@jskit-ai/json-rest-api-core": "0.1.84",
-              "@jskit-ai/kernel": "0.1.140",
-              "@jskit-ai/resource-core": "0.1.83",
-              "@jskit-ai/resource-crud-core": "0.1.83",
+              "@jskit-ai/auth-core": "0.1.139",
+              "@jskit-ai/crud-core": "0.1.151",
+              "@jskit-ai/database-runtime": "0.1.140",
+              "@jskit-ai/http-runtime": "0.1.139",
+              "@jskit-ai/json-rest-api-core": "0.1.85",
+              "@jskit-ai/kernel": "0.1.141",
+              "@jskit-ai/resource-core": "0.1.84",
+              "@jskit-ai/resource-crud-core": "0.1.84",
               "@local/users": "file:packages/users",
-              "@jskit-ai/uploads-runtime": "0.1.116"
+              "@jskit-ai/uploads-runtime": "0.1.117"
             },
             "dev": {}
           },
@@ -5889,11 +5889,11 @@
     },
     {
       "packageId": "@jskit-ai/users-web",
-      "version": "0.1.157",
+      "version": "0.1.158",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-web",
-        "version": "0.1.157",
+        "version": "0.1.158",
         "kind": "runtime",
         "description": "Users web module: account/profile UI plus shared users web widgets.",
         "dependsOn": [
@@ -6196,12 +6196,12 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/http-runtime": "0.1.138",
-              "@jskit-ai/realtime": "0.1.137",
-              "@jskit-ai/kernel": "0.1.140",
-              "@jskit-ai/shell-web": "0.1.141",
-              "@jskit-ai/uploads-image-web": "0.1.116",
-              "@jskit-ai/users-core": "0.1.153"
+              "@jskit-ai/http-runtime": "0.1.139",
+              "@jskit-ai/realtime": "0.1.138",
+              "@jskit-ai/kernel": "0.1.141",
+              "@jskit-ai/shell-web": "0.1.142",
+              "@jskit-ai/uploads-image-web": "0.1.117",
+              "@jskit-ai/users-core": "0.1.154"
             },
             "dev": {}
           },
@@ -6382,11 +6382,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-core",
-      "version": "0.1.119",
+      "version": "0.1.120",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-core",
-        "version": "0.1.119",
+        "version": "0.1.120",
         "kind": "runtime",
         "description": "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
         "dependsOn": [
@@ -6532,10 +6532,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/json-rest-api-core": "0.1.84",
-              "@jskit-ai/resource-core": "0.1.83",
-              "@jskit-ai/resource-crud-core": "0.1.83",
-              "@jskit-ai/users-core": "0.1.153"
+              "@jskit-ai/json-rest-api-core": "0.1.85",
+              "@jskit-ai/resource-core": "0.1.84",
+              "@jskit-ai/resource-crud-core": "0.1.84",
+              "@jskit-ai/users-core": "0.1.154"
             },
             "dev": {}
           },
@@ -6739,11 +6739,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-web",
-      "version": "0.1.120",
+      "version": "0.1.121",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-web",
-        "version": "0.1.120",
+        "version": "0.1.121",
         "kind": "runtime",
         "description": "Workspace web module: workspace selector, tools widget, workspace surfaces, members UI, and settings hosts.",
         "dependsOn": [
@@ -7000,9 +7000,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-web": "0.1.141",
-              "@jskit-ai/workspaces-core": "0.1.119",
-              "@jskit-ai/users-web": "0.1.157"
+              "@jskit-ai/auth-web": "0.1.142",
+              "@jskit-ai/workspaces-core": "0.1.120",
+              "@jskit-ai/users-web": "0.1.158"
             },
             "dev": {}
           },

--- a/tooling/jskit-catalog/package.json
+++ b/tooling/jskit-catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-catalog",
-  "version": "0.1.161",
+  "version": "0.1.162",
   "description": "Published metadata catalog for JSKIT package descriptors.",
   "type": "module",
   "files": [

--- a/tooling/jskit-cli/package.json
+++ b/tooling/jskit-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-cli",
-  "version": "0.2.167",
+  "version": "0.2.168",
   "description": "Bundle and package orchestration CLI for JSKIT apps.",
   "type": "module",
   "files": [
@@ -21,9 +21,9 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/jskit-catalog": "0.1.161",
-    "@jskit-ai/kernel": "0.1.140",
-    "@jskit-ai/shell-web": "0.1.141",
+    "@jskit-ai/jskit-catalog": "0.1.162",
+    "@jskit-ai/kernel": "0.1.141",
+    "@jskit-ai/shell-web": "0.1.142",
     "@vue/compiler-sfc": "^3.5.29",
     "semver": "^7.7.4",
     "ts-morph": "^28.0.0",


### PR DESCRIPTION
## Summary
- consume json-rest-api 1.0.27 typed fieldset errors
- map REST_API_FIELDSET_INVALID to the stable JSKIT 400 response
- remove English-message matching and prove message-only errors are not classified
- include the coordinated package release state

## Verification
- npm test --workspace @jskit-ai/json-rest-api-core
- npm run lint
- git diff --check
- npm run release