### PR TITLE
Update typed fieldset error fixture

### DIFF
--- a/packages/crud-server-generator/test/crudServerGuards.test.js
+++ b/packages/crud-server-generator/test/crudServerGuards.test.js
@@ -351,7 +351,11 @@ test("template repository returns a stable 400 for unknown sparse fields", async
       resources: {
         customers: {
           async query() {
-            throw new Error("Unknown sparse field 'passwordHash' requested for 'customers'");
+            const error = new Error(
+              "Unknown sparse field 'passwordHash' requested for 'customers'"
+            );
+            error.code = "REST_API_FIELDSET_INVALID";
+            throw error;
           }
         }
       }


### PR DESCRIPTION
## Summary
- make the generated-repository guard simulate the new typed json-rest-api fieldset error
- stop relying on the removed English-message classification in the test fixture

## Verification
- npm test --workspace @jskit-ai/crud-server-generator
- npm run lint

This is test-only; the runtime package was already released.