### PR TITLE
Complete exact JSKIT root update contract

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7475,28 +7475,28 @@
     },
     "packages/agent-docs": {
       "name": "@jskit-ai/agent-docs",
-      "version": "0.1.110",
+      "version": "0.1.111",
       "engines": {
         "node": "^22.13.0 || ^24.0.0 || ^26.0.0"
       }
     },
     "packages/assistant": {
       "name": "@jskit-ai/assistant",
-      "version": "0.1.152",
+      "version": "0.1.153",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.143"
+        "@jskit-ai/kernel": "0.1.144"
       }
     },
     "packages/assistant-core": {
       "name": "@jskit-ai/assistant-core",
-      "version": "0.1.120",
+      "version": "0.1.121",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.142",
-        "@jskit-ai/http-runtime": "0.1.141",
-        "@jskit-ai/kernel": "0.1.143",
-        "@jskit-ai/resource-core": "0.1.86",
-        "@jskit-ai/resource-crud-core": "0.1.86",
-        "@jskit-ai/users-core": "0.1.156",
+        "@jskit-ai/database-runtime": "0.1.143",
+        "@jskit-ai/http-runtime": "0.1.142",
+        "@jskit-ai/kernel": "0.1.144",
+        "@jskit-ai/resource-core": "0.1.87",
+        "@jskit-ai/resource-crud-core": "0.1.87",
+        "@jskit-ai/users-core": "0.1.157",
         "dompurify": "^3.4.12",
         "json-rest-schema": "1.x.x",
         "marked": "^17.0.4",
@@ -7509,15 +7509,15 @@
     },
     "packages/assistant-runtime": {
       "name": "@jskit-ai/assistant-runtime",
-      "version": "0.1.115",
+      "version": "0.1.116",
       "dependencies": {
-        "@jskit-ai/assistant-core": "0.1.120",
-        "@jskit-ai/database-runtime": "0.1.142",
-        "@jskit-ai/http-runtime": "0.1.141",
-        "@jskit-ai/kernel": "0.1.143",
-        "@jskit-ai/shell-web": "0.1.144",
-        "@jskit-ai/users-core": "0.1.156",
-        "@jskit-ai/users-web": "0.1.160",
+        "@jskit-ai/assistant-core": "0.1.121",
+        "@jskit-ai/database-runtime": "0.1.143",
+        "@jskit-ai/http-runtime": "0.1.142",
+        "@jskit-ai/kernel": "0.1.144",
+        "@jskit-ai/shell-web": "0.1.145",
+        "@jskit-ai/users-core": "0.1.157",
+        "@jskit-ai/users-web": "0.1.161",
         "json-rest-schema": "1.x.x"
       },
       "peerDependencies": {
@@ -7528,39 +7528,39 @@
     },
     "packages/auth-core": {
       "name": "@jskit-ai/auth-core",
-      "version": "0.1.141",
+      "version": "0.1.142",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0",
-        "@jskit-ai/kernel": "0.1.143",
+        "@jskit-ai/kernel": "0.1.144",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/auth-provider-local-core": {
       "name": "@jskit-ai/auth-provider-local-core",
-      "version": "0.1.45",
+      "version": "0.1.46",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.141",
-        "@jskit-ai/kernel": "0.1.143",
+        "@jskit-ai/auth-core": "0.1.142",
+        "@jskit-ai/kernel": "0.1.144",
         "nodemailer": "^9.0.3"
       }
     },
     "packages/auth-provider-local-db-core": {
       "name": "@jskit-ai/auth-provider-local-db-core",
-      "version": "0.1.36",
+      "version": "0.1.37",
       "dependencies": {
-        "@jskit-ai/auth-provider-local-core": "0.1.45",
-        "@jskit-ai/database-runtime": "0.1.142",
-        "@jskit-ai/kernel": "0.1.143"
+        "@jskit-ai/auth-provider-local-core": "0.1.46",
+        "@jskit-ai/database-runtime": "0.1.143",
+        "@jskit-ai/kernel": "0.1.144"
       }
     },
     "packages/auth-provider-supabase-core": {
       "name": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.141",
+      "version": "0.1.142",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.141",
-        "@jskit-ai/kernel": "0.1.143",
+        "@jskit-ai/auth-core": "0.1.142",
+        "@jskit-ai/kernel": "0.1.144",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0",
         "json-rest-schema": "1.x.x",
@@ -7569,12 +7569,12 @@
     },
     "packages/auth-web": {
       "name": "@jskit-ai/auth-web",
-      "version": "0.1.144",
+      "version": "0.1.145",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.141",
-        "@jskit-ai/http-runtime": "0.1.141",
-        "@jskit-ai/kernel": "0.1.143",
-        "@jskit-ai/shell-web": "0.1.144",
+        "@jskit-ai/auth-core": "0.1.142",
+        "@jskit-ai/http-runtime": "0.1.142",
+        "@jskit-ai/kernel": "0.1.144",
+        "@jskit-ai/shell-web": "0.1.145",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -7587,38 +7587,38 @@
     },
     "packages/console-core": {
       "name": "@jskit-ai/console-core",
-      "version": "0.1.107",
+      "version": "0.1.108",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.141",
-        "@jskit-ai/database-runtime": "0.1.142",
-        "@jskit-ai/http-runtime": "0.1.141",
-        "@jskit-ai/kernel": "0.1.143",
-        "@jskit-ai/resource-crud-core": "0.1.86",
-        "@jskit-ai/users-core": "0.1.156",
+        "@jskit-ai/auth-core": "0.1.142",
+        "@jskit-ai/database-runtime": "0.1.143",
+        "@jskit-ai/http-runtime": "0.1.142",
+        "@jskit-ai/kernel": "0.1.144",
+        "@jskit-ai/resource-crud-core": "0.1.87",
+        "@jskit-ai/users-core": "0.1.157",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/console-web": {
       "name": "@jskit-ai/console-web",
-      "version": "0.1.112",
+      "version": "0.1.113",
       "dependencies": {
-        "@jskit-ai/auth-web": "0.1.144",
-        "@jskit-ai/console-core": "0.1.107",
-        "@jskit-ai/shell-web": "0.1.144"
+        "@jskit-ai/auth-web": "0.1.145",
+        "@jskit-ai/console-core": "0.1.108",
+        "@jskit-ai/shell-web": "0.1.145"
       }
     },
     "packages/crud-core": {
       "name": "@jskit-ai/crud-core",
-      "version": "0.1.153",
+      "version": "0.1.154",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.142",
-        "@jskit-ai/http-runtime": "0.1.141",
-        "@jskit-ai/kernel": "0.1.143",
-        "@jskit-ai/realtime": "0.1.140",
-        "@jskit-ai/resource-crud-core": "0.1.86",
-        "@jskit-ai/shell-web": "0.1.144",
-        "@jskit-ai/users-core": "0.1.156",
-        "@jskit-ai/users-web": "0.1.160",
+        "@jskit-ai/database-runtime": "0.1.143",
+        "@jskit-ai/http-runtime": "0.1.142",
+        "@jskit-ai/kernel": "0.1.144",
+        "@jskit-ai/realtime": "0.1.141",
+        "@jskit-ai/resource-crud-core": "0.1.87",
+        "@jskit-ai/shell-web": "0.1.145",
+        "@jskit-ai/users-core": "0.1.157",
+        "@jskit-ai/users-web": "0.1.161",
         "json-rest-schema": "1.x.x"
       },
       "peerDependencies": {
@@ -7629,99 +7629,99 @@
     },
     "packages/crud-server-generator": {
       "name": "@jskit-ai/crud-server-generator",
-      "version": "0.1.155",
+      "version": "0.1.156",
       "dependencies": {
         "@babel/parser": "^7.29.2",
-        "@jskit-ai/crud-core": "0.1.153",
-        "@jskit-ai/database-runtime": "0.1.142",
-        "@jskit-ai/http-runtime": "0.1.141",
-        "@jskit-ai/json-rest-api-core": "0.1.87",
-        "@jskit-ai/kernel": "0.1.143",
-        "@jskit-ai/resource-crud-core": "0.1.86",
+        "@jskit-ai/crud-core": "0.1.154",
+        "@jskit-ai/database-runtime": "0.1.143",
+        "@jskit-ai/http-runtime": "0.1.142",
+        "@jskit-ai/json-rest-api-core": "0.1.88",
+        "@jskit-ai/kernel": "0.1.144",
+        "@jskit-ai/resource-crud-core": "0.1.87",
         "recast": "^0.23.11"
       }
     },
     "packages/crud-ui-generator": {
       "name": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.126",
+      "version": "0.1.127",
       "dependencies": {
-        "@jskit-ai/crud-core": "0.1.153",
-        "@jskit-ai/kernel": "0.1.143",
-        "@jskit-ai/resource-crud-core": "0.1.86"
+        "@jskit-ai/crud-core": "0.1.154",
+        "@jskit-ai/kernel": "0.1.144",
+        "@jskit-ai/resource-crud-core": "0.1.87"
       }
     },
     "packages/database-runtime": {
       "name": "@jskit-ai/database-runtime",
-      "version": "0.1.142",
+      "version": "0.1.143",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.143"
+        "@jskit-ai/kernel": "0.1.144"
       }
     },
     "packages/database-runtime-mysql": {
       "name": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.141",
+      "version": "0.1.142",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.142",
-        "@jskit-ai/kernel": "0.1.143"
+        "@jskit-ai/database-runtime": "0.1.143",
+        "@jskit-ai/kernel": "0.1.144"
       }
     },
     "packages/database-runtime-postgres": {
       "name": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.140",
+      "version": "0.1.141",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.142"
+        "@jskit-ai/database-runtime": "0.1.143"
       }
     },
     "packages/feature-server-generator": {
       "name": "@jskit-ai/feature-server-generator",
-      "version": "0.1.85"
+      "version": "0.1.86"
     },
     "packages/google-rewarded-core": {
       "name": "@jskit-ai/google-rewarded-core",
-      "version": "0.1.80"
+      "version": "0.1.81"
     },
     "packages/google-rewarded-web": {
       "name": "@jskit-ai/google-rewarded-web",
-      "version": "0.1.80"
+      "version": "0.1.81"
     },
     "packages/http-runtime": {
       "name": "@jskit-ai/http-runtime",
-      "version": "0.1.141",
+      "version": "0.1.142",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.143",
+        "@jskit-ai/kernel": "0.1.144",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/json-rest-api-core": {
       "name": "@jskit-ai/json-rest-api-core",
-      "version": "0.1.87",
+      "version": "0.1.88",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.143",
+        "@jskit-ai/kernel": "0.1.144",
         "hooked-api": "1.x.x",
         "json-rest-api": "^1.0.27"
       }
     },
     "packages/kernel": {
       "name": "@jskit-ai/kernel",
-      "version": "0.1.143",
+      "version": "0.1.144",
       "dependencies": {
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/mobile-capacitor": {
       "name": "@jskit-ai/mobile-capacitor",
-      "version": "0.1.79",
+      "version": "0.1.80",
       "dependencies": {
         "@capacitor/browser": "^7.0.1",
         "@capacitor/core": "^7.4.3",
-        "@jskit-ai/kernel": "0.1.143"
+        "@jskit-ai/kernel": "0.1.144"
       }
     },
     "packages/realtime": {
       "name": "@jskit-ai/realtime",
-      "version": "0.1.140",
+      "version": "0.1.141",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.143",
+        "@jskit-ai/kernel": "0.1.144",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",
@@ -7733,24 +7733,24 @@
     },
     "packages/resource-core": {
       "name": "@jskit-ai/resource-core",
-      "version": "0.1.86",
+      "version": "0.1.87",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.143"
+        "@jskit-ai/kernel": "0.1.144"
       }
     },
     "packages/resource-crud-core": {
       "name": "@jskit-ai/resource-crud-core",
-      "version": "0.1.86",
+      "version": "0.1.87",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.143",
-        "@jskit-ai/resource-core": "0.1.86"
+        "@jskit-ai/kernel": "0.1.144",
+        "@jskit-ai/resource-core": "0.1.87"
       }
     },
     "packages/shell-web": {
       "name": "@jskit-ai/shell-web",
-      "version": "0.1.144",
+      "version": "0.1.145",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.143",
+        "@jskit-ai/kernel": "0.1.144",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -7762,25 +7762,25 @@
     },
     "packages/storage-runtime": {
       "name": "@jskit-ai/storage-runtime",
-      "version": "0.1.141",
+      "version": "0.1.142",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.143",
+        "@jskit-ai/kernel": "0.1.144",
         "unstorage": "^1.17.5"
       }
     },
     "packages/ui-generator": {
       "name": "@jskit-ai/ui-generator",
-      "version": "0.1.126",
+      "version": "0.1.127",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.143",
-        "@jskit-ai/shell-web": "0.1.144"
+        "@jskit-ai/kernel": "0.1.144",
+        "@jskit-ai/shell-web": "0.1.145"
       }
     },
     "packages/uploads-image-web": {
       "name": "@jskit-ai/uploads-image-web",
-      "version": "0.1.119",
+      "version": "0.1.120",
       "dependencies": {
-        "@jskit-ai/uploads-runtime": "0.1.119",
+        "@jskit-ai/uploads-runtime": "0.1.120",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",
@@ -7793,37 +7793,37 @@
     },
     "packages/uploads-runtime": {
       "name": "@jskit-ai/uploads-runtime",
-      "version": "0.1.119",
+      "version": "0.1.120",
       "dependencies": {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.143"
+        "@jskit-ai/kernel": "0.1.144"
       }
     },
     "packages/users-core": {
       "name": "@jskit-ai/users-core",
-      "version": "0.1.156",
+      "version": "0.1.157",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.141",
-        "@jskit-ai/database-runtime": "0.1.142",
-        "@jskit-ai/http-runtime": "0.1.141",
-        "@jskit-ai/json-rest-api-core": "0.1.87",
-        "@jskit-ai/kernel": "0.1.143",
-        "@jskit-ai/resource-core": "0.1.86",
-        "@jskit-ai/resource-crud-core": "0.1.86",
-        "@jskit-ai/uploads-runtime": "0.1.119",
+        "@jskit-ai/auth-core": "0.1.142",
+        "@jskit-ai/database-runtime": "0.1.143",
+        "@jskit-ai/http-runtime": "0.1.142",
+        "@jskit-ai/json-rest-api-core": "0.1.88",
+        "@jskit-ai/kernel": "0.1.144",
+        "@jskit-ai/resource-core": "0.1.87",
+        "@jskit-ai/resource-crud-core": "0.1.87",
+        "@jskit-ai/uploads-runtime": "0.1.120",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/users-web": {
       "name": "@jskit-ai/users-web",
-      "version": "0.1.160",
+      "version": "0.1.161",
       "dependencies": {
-        "@jskit-ai/http-runtime": "0.1.141",
-        "@jskit-ai/kernel": "0.1.143",
-        "@jskit-ai/realtime": "0.1.140",
-        "@jskit-ai/shell-web": "0.1.144",
-        "@jskit-ai/uploads-image-web": "0.1.119",
-        "@jskit-ai/users-core": "0.1.156",
+        "@jskit-ai/http-runtime": "0.1.142",
+        "@jskit-ai/kernel": "0.1.144",
+        "@jskit-ai/realtime": "0.1.141",
+        "@jskit-ai/shell-web": "0.1.145",
+        "@jskit-ai/uploads-image-web": "0.1.120",
+        "@jskit-ai/users-core": "0.1.157",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -7835,30 +7835,30 @@
     },
     "packages/workspaces-core": {
       "name": "@jskit-ai/workspaces-core",
-      "version": "0.1.122",
+      "version": "0.1.123",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.141",
-        "@jskit-ai/database-runtime": "0.1.142",
-        "@jskit-ai/http-runtime": "0.1.141",
-        "@jskit-ai/json-rest-api-core": "0.1.87",
-        "@jskit-ai/kernel": "0.1.143",
-        "@jskit-ai/resource-core": "0.1.86",
-        "@jskit-ai/resource-crud-core": "0.1.86",
-        "@jskit-ai/users-core": "0.1.156",
+        "@jskit-ai/auth-core": "0.1.142",
+        "@jskit-ai/database-runtime": "0.1.143",
+        "@jskit-ai/http-runtime": "0.1.142",
+        "@jskit-ai/json-rest-api-core": "0.1.88",
+        "@jskit-ai/kernel": "0.1.144",
+        "@jskit-ai/resource-core": "0.1.87",
+        "@jskit-ai/resource-crud-core": "0.1.87",
+        "@jskit-ai/users-core": "0.1.157",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/workspaces-web": {
       "name": "@jskit-ai/workspaces-web",
-      "version": "0.1.123",
+      "version": "0.1.124",
       "dependencies": {
-        "@jskit-ai/auth-web": "0.1.144",
-        "@jskit-ai/http-runtime": "0.1.141",
-        "@jskit-ai/kernel": "0.1.143",
-        "@jskit-ai/shell-web": "0.1.144",
-        "@jskit-ai/users-core": "0.1.156",
-        "@jskit-ai/users-web": "0.1.160",
-        "@jskit-ai/workspaces-core": "0.1.122",
+        "@jskit-ai/auth-web": "0.1.145",
+        "@jskit-ai/http-runtime": "0.1.142",
+        "@jskit-ai/kernel": "0.1.144",
+        "@jskit-ai/shell-web": "0.1.145",
+        "@jskit-ai/users-core": "0.1.157",
+        "@jskit-ai/users-web": "0.1.161",
+        "@jskit-ai/workspaces-core": "0.1.123",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -7870,7 +7870,7 @@
     },
     "tooling/config-eslint": {
       "name": "@jskit-ai/config-eslint",
-      "version": "0.1.141",
+      "version": "0.1.142",
       "dependencies": {
         "@eslint/js": "^10.0.1",
         "eslint-plugin-vue": "^10.5.1",
@@ -7909,9 +7909,9 @@
     },
     "tooling/create-app": {
       "name": "@jskit-ai/create-app",
-      "version": "0.1.162",
+      "version": "0.1.163",
       "dependencies": {
-        "@jskit-ai/jskit-cli": "0.2.170"
+        "@jskit-ai/jskit-cli": "0.2.171"
       },
       "bin": {
         "jskit-create-app": "bin/jskit-create-app.js"
@@ -7922,18 +7922,18 @@
     },
     "tooling/jskit-catalog": {
       "name": "@jskit-ai/jskit-catalog",
-      "version": "0.1.164",
+      "version": "0.1.165",
       "engines": {
         "node": "^22.13.0 || ^24.0.0 || ^26.0.0"
       }
     },
     "tooling/jskit-cli": {
       "name": "@jskit-ai/jskit-cli",
-      "version": "0.2.170",
+      "version": "0.2.171",
       "dependencies": {
-        "@jskit-ai/jskit-catalog": "0.1.164",
-        "@jskit-ai/kernel": "0.1.143",
-        "@jskit-ai/shell-web": "0.1.144",
+        "@jskit-ai/jskit-catalog": "0.1.165",
+        "@jskit-ai/kernel": "0.1.144",
+        "@jskit-ai/shell-web": "0.1.145",
         "@vue/compiler-sfc": "^3.5.29",
         "semver": "^7.7.4",
         "ts-morph": "^28.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7475,28 +7475,28 @@
     },
     "packages/agent-docs": {
       "name": "@jskit-ai/agent-docs",
-      "version": "0.1.111",
+      "version": "0.1.112",
       "engines": {
         "node": "^22.13.0 || ^24.0.0 || ^26.0.0"
       }
     },
     "packages/assistant": {
       "name": "@jskit-ai/assistant",
-      "version": "0.1.153",
+      "version": "0.1.154",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.144"
+        "@jskit-ai/kernel": "0.1.145"
       }
     },
     "packages/assistant-core": {
       "name": "@jskit-ai/assistant-core",
-      "version": "0.1.121",
+      "version": "0.1.122",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.143",
-        "@jskit-ai/http-runtime": "0.1.142",
-        "@jskit-ai/kernel": "0.1.144",
-        "@jskit-ai/resource-core": "0.1.87",
-        "@jskit-ai/resource-crud-core": "0.1.87",
-        "@jskit-ai/users-core": "0.1.157",
+        "@jskit-ai/database-runtime": "0.1.144",
+        "@jskit-ai/http-runtime": "0.1.143",
+        "@jskit-ai/kernel": "0.1.145",
+        "@jskit-ai/resource-core": "0.1.88",
+        "@jskit-ai/resource-crud-core": "0.1.88",
+        "@jskit-ai/users-core": "0.1.158",
         "dompurify": "^3.4.12",
         "json-rest-schema": "1.x.x",
         "marked": "^17.0.4",
@@ -7509,15 +7509,15 @@
     },
     "packages/assistant-runtime": {
       "name": "@jskit-ai/assistant-runtime",
-      "version": "0.1.116",
+      "version": "0.1.117",
       "dependencies": {
-        "@jskit-ai/assistant-core": "0.1.121",
-        "@jskit-ai/database-runtime": "0.1.143",
-        "@jskit-ai/http-runtime": "0.1.142",
-        "@jskit-ai/kernel": "0.1.144",
-        "@jskit-ai/shell-web": "0.1.145",
-        "@jskit-ai/users-core": "0.1.157",
-        "@jskit-ai/users-web": "0.1.161",
+        "@jskit-ai/assistant-core": "0.1.122",
+        "@jskit-ai/database-runtime": "0.1.144",
+        "@jskit-ai/http-runtime": "0.1.143",
+        "@jskit-ai/kernel": "0.1.145",
+        "@jskit-ai/shell-web": "0.1.146",
+        "@jskit-ai/users-core": "0.1.158",
+        "@jskit-ai/users-web": "0.1.162",
         "json-rest-schema": "1.x.x"
       },
       "peerDependencies": {
@@ -7528,39 +7528,39 @@
     },
     "packages/auth-core": {
       "name": "@jskit-ai/auth-core",
-      "version": "0.1.142",
+      "version": "0.1.143",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0",
-        "@jskit-ai/kernel": "0.1.144",
+        "@jskit-ai/kernel": "0.1.145",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/auth-provider-local-core": {
       "name": "@jskit-ai/auth-provider-local-core",
-      "version": "0.1.46",
+      "version": "0.1.47",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.142",
-        "@jskit-ai/kernel": "0.1.144",
+        "@jskit-ai/auth-core": "0.1.143",
+        "@jskit-ai/kernel": "0.1.145",
         "nodemailer": "^9.0.3"
       }
     },
     "packages/auth-provider-local-db-core": {
       "name": "@jskit-ai/auth-provider-local-db-core",
-      "version": "0.1.37",
+      "version": "0.1.38",
       "dependencies": {
-        "@jskit-ai/auth-provider-local-core": "0.1.46",
-        "@jskit-ai/database-runtime": "0.1.143",
-        "@jskit-ai/kernel": "0.1.144"
+        "@jskit-ai/auth-provider-local-core": "0.1.47",
+        "@jskit-ai/database-runtime": "0.1.144",
+        "@jskit-ai/kernel": "0.1.145"
       }
     },
     "packages/auth-provider-supabase-core": {
       "name": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.142",
+      "version": "0.1.143",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.142",
-        "@jskit-ai/kernel": "0.1.144",
+        "@jskit-ai/auth-core": "0.1.143",
+        "@jskit-ai/kernel": "0.1.145",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0",
         "json-rest-schema": "1.x.x",
@@ -7569,12 +7569,12 @@
     },
     "packages/auth-web": {
       "name": "@jskit-ai/auth-web",
-      "version": "0.1.145",
+      "version": "0.1.146",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.142",
-        "@jskit-ai/http-runtime": "0.1.142",
-        "@jskit-ai/kernel": "0.1.144",
-        "@jskit-ai/shell-web": "0.1.145",
+        "@jskit-ai/auth-core": "0.1.143",
+        "@jskit-ai/http-runtime": "0.1.143",
+        "@jskit-ai/kernel": "0.1.145",
+        "@jskit-ai/shell-web": "0.1.146",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -7587,38 +7587,38 @@
     },
     "packages/console-core": {
       "name": "@jskit-ai/console-core",
-      "version": "0.1.108",
+      "version": "0.1.109",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.142",
-        "@jskit-ai/database-runtime": "0.1.143",
-        "@jskit-ai/http-runtime": "0.1.142",
-        "@jskit-ai/kernel": "0.1.144",
-        "@jskit-ai/resource-crud-core": "0.1.87",
-        "@jskit-ai/users-core": "0.1.157",
+        "@jskit-ai/auth-core": "0.1.143",
+        "@jskit-ai/database-runtime": "0.1.144",
+        "@jskit-ai/http-runtime": "0.1.143",
+        "@jskit-ai/kernel": "0.1.145",
+        "@jskit-ai/resource-crud-core": "0.1.88",
+        "@jskit-ai/users-core": "0.1.158",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/console-web": {
       "name": "@jskit-ai/console-web",
-      "version": "0.1.113",
+      "version": "0.1.114",
       "dependencies": {
-        "@jskit-ai/auth-web": "0.1.145",
-        "@jskit-ai/console-core": "0.1.108",
-        "@jskit-ai/shell-web": "0.1.145"
+        "@jskit-ai/auth-web": "0.1.146",
+        "@jskit-ai/console-core": "0.1.109",
+        "@jskit-ai/shell-web": "0.1.146"
       }
     },
     "packages/crud-core": {
       "name": "@jskit-ai/crud-core",
-      "version": "0.1.154",
+      "version": "0.1.155",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.143",
-        "@jskit-ai/http-runtime": "0.1.142",
-        "@jskit-ai/kernel": "0.1.144",
-        "@jskit-ai/realtime": "0.1.141",
-        "@jskit-ai/resource-crud-core": "0.1.87",
-        "@jskit-ai/shell-web": "0.1.145",
-        "@jskit-ai/users-core": "0.1.157",
-        "@jskit-ai/users-web": "0.1.161",
+        "@jskit-ai/database-runtime": "0.1.144",
+        "@jskit-ai/http-runtime": "0.1.143",
+        "@jskit-ai/kernel": "0.1.145",
+        "@jskit-ai/realtime": "0.1.142",
+        "@jskit-ai/resource-crud-core": "0.1.88",
+        "@jskit-ai/shell-web": "0.1.146",
+        "@jskit-ai/users-core": "0.1.158",
+        "@jskit-ai/users-web": "0.1.162",
         "json-rest-schema": "1.x.x"
       },
       "peerDependencies": {
@@ -7629,99 +7629,99 @@
     },
     "packages/crud-server-generator": {
       "name": "@jskit-ai/crud-server-generator",
-      "version": "0.1.156",
+      "version": "0.1.157",
       "dependencies": {
         "@babel/parser": "^7.29.2",
-        "@jskit-ai/crud-core": "0.1.154",
-        "@jskit-ai/database-runtime": "0.1.143",
-        "@jskit-ai/http-runtime": "0.1.142",
-        "@jskit-ai/json-rest-api-core": "0.1.88",
-        "@jskit-ai/kernel": "0.1.144",
-        "@jskit-ai/resource-crud-core": "0.1.87",
+        "@jskit-ai/crud-core": "0.1.155",
+        "@jskit-ai/database-runtime": "0.1.144",
+        "@jskit-ai/http-runtime": "0.1.143",
+        "@jskit-ai/json-rest-api-core": "0.1.89",
+        "@jskit-ai/kernel": "0.1.145",
+        "@jskit-ai/resource-crud-core": "0.1.88",
         "recast": "^0.23.11"
       }
     },
     "packages/crud-ui-generator": {
       "name": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.127",
+      "version": "0.1.128",
       "dependencies": {
-        "@jskit-ai/crud-core": "0.1.154",
-        "@jskit-ai/kernel": "0.1.144",
-        "@jskit-ai/resource-crud-core": "0.1.87"
+        "@jskit-ai/crud-core": "0.1.155",
+        "@jskit-ai/kernel": "0.1.145",
+        "@jskit-ai/resource-crud-core": "0.1.88"
       }
     },
     "packages/database-runtime": {
       "name": "@jskit-ai/database-runtime",
-      "version": "0.1.143",
+      "version": "0.1.144",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.144"
+        "@jskit-ai/kernel": "0.1.145"
       }
     },
     "packages/database-runtime-mysql": {
       "name": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.142",
+      "version": "0.1.143",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.143",
-        "@jskit-ai/kernel": "0.1.144"
+        "@jskit-ai/database-runtime": "0.1.144",
+        "@jskit-ai/kernel": "0.1.145"
       }
     },
     "packages/database-runtime-postgres": {
       "name": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.141",
+      "version": "0.1.142",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.143"
+        "@jskit-ai/database-runtime": "0.1.144"
       }
     },
     "packages/feature-server-generator": {
       "name": "@jskit-ai/feature-server-generator",
-      "version": "0.1.86"
+      "version": "0.1.87"
     },
     "packages/google-rewarded-core": {
       "name": "@jskit-ai/google-rewarded-core",
-      "version": "0.1.81"
+      "version": "0.1.82"
     },
     "packages/google-rewarded-web": {
       "name": "@jskit-ai/google-rewarded-web",
-      "version": "0.1.81"
+      "version": "0.1.82"
     },
     "packages/http-runtime": {
       "name": "@jskit-ai/http-runtime",
-      "version": "0.1.142",
+      "version": "0.1.143",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.144",
+        "@jskit-ai/kernel": "0.1.145",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/json-rest-api-core": {
       "name": "@jskit-ai/json-rest-api-core",
-      "version": "0.1.88",
+      "version": "0.1.89",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.144",
+        "@jskit-ai/kernel": "0.1.145",
         "hooked-api": "1.x.x",
         "json-rest-api": "^1.0.27"
       }
     },
     "packages/kernel": {
       "name": "@jskit-ai/kernel",
-      "version": "0.1.144",
+      "version": "0.1.145",
       "dependencies": {
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/mobile-capacitor": {
       "name": "@jskit-ai/mobile-capacitor",
-      "version": "0.1.80",
+      "version": "0.1.81",
       "dependencies": {
         "@capacitor/browser": "^7.0.1",
         "@capacitor/core": "^7.4.3",
-        "@jskit-ai/kernel": "0.1.144"
+        "@jskit-ai/kernel": "0.1.145"
       }
     },
     "packages/realtime": {
       "name": "@jskit-ai/realtime",
-      "version": "0.1.141",
+      "version": "0.1.142",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.144",
+        "@jskit-ai/kernel": "0.1.145",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",
@@ -7733,24 +7733,24 @@
     },
     "packages/resource-core": {
       "name": "@jskit-ai/resource-core",
-      "version": "0.1.87",
+      "version": "0.1.88",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.144"
+        "@jskit-ai/kernel": "0.1.145"
       }
     },
     "packages/resource-crud-core": {
       "name": "@jskit-ai/resource-crud-core",
-      "version": "0.1.87",
+      "version": "0.1.88",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.144",
-        "@jskit-ai/resource-core": "0.1.87"
+        "@jskit-ai/kernel": "0.1.145",
+        "@jskit-ai/resource-core": "0.1.88"
       }
     },
     "packages/shell-web": {
       "name": "@jskit-ai/shell-web",
-      "version": "0.1.145",
+      "version": "0.1.146",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.144",
+        "@jskit-ai/kernel": "0.1.145",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -7762,25 +7762,25 @@
     },
     "packages/storage-runtime": {
       "name": "@jskit-ai/storage-runtime",
-      "version": "0.1.142",
+      "version": "0.1.143",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.144",
+        "@jskit-ai/kernel": "0.1.145",
         "unstorage": "^1.17.5"
       }
     },
     "packages/ui-generator": {
       "name": "@jskit-ai/ui-generator",
-      "version": "0.1.127",
+      "version": "0.1.128",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.144",
-        "@jskit-ai/shell-web": "0.1.145"
+        "@jskit-ai/kernel": "0.1.145",
+        "@jskit-ai/shell-web": "0.1.146"
       }
     },
     "packages/uploads-image-web": {
       "name": "@jskit-ai/uploads-image-web",
-      "version": "0.1.120",
+      "version": "0.1.121",
       "dependencies": {
-        "@jskit-ai/uploads-runtime": "0.1.120",
+        "@jskit-ai/uploads-runtime": "0.1.121",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",
@@ -7793,37 +7793,37 @@
     },
     "packages/uploads-runtime": {
       "name": "@jskit-ai/uploads-runtime",
-      "version": "0.1.120",
+      "version": "0.1.121",
       "dependencies": {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.144"
+        "@jskit-ai/kernel": "0.1.145"
       }
     },
     "packages/users-core": {
       "name": "@jskit-ai/users-core",
-      "version": "0.1.157",
+      "version": "0.1.158",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.142",
-        "@jskit-ai/database-runtime": "0.1.143",
-        "@jskit-ai/http-runtime": "0.1.142",
-        "@jskit-ai/json-rest-api-core": "0.1.88",
-        "@jskit-ai/kernel": "0.1.144",
-        "@jskit-ai/resource-core": "0.1.87",
-        "@jskit-ai/resource-crud-core": "0.1.87",
-        "@jskit-ai/uploads-runtime": "0.1.120",
+        "@jskit-ai/auth-core": "0.1.143",
+        "@jskit-ai/database-runtime": "0.1.144",
+        "@jskit-ai/http-runtime": "0.1.143",
+        "@jskit-ai/json-rest-api-core": "0.1.89",
+        "@jskit-ai/kernel": "0.1.145",
+        "@jskit-ai/resource-core": "0.1.88",
+        "@jskit-ai/resource-crud-core": "0.1.88",
+        "@jskit-ai/uploads-runtime": "0.1.121",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/users-web": {
       "name": "@jskit-ai/users-web",
-      "version": "0.1.161",
+      "version": "0.1.162",
       "dependencies": {
-        "@jskit-ai/http-runtime": "0.1.142",
-        "@jskit-ai/kernel": "0.1.144",
-        "@jskit-ai/realtime": "0.1.141",
-        "@jskit-ai/shell-web": "0.1.145",
-        "@jskit-ai/uploads-image-web": "0.1.120",
-        "@jskit-ai/users-core": "0.1.157",
+        "@jskit-ai/http-runtime": "0.1.143",
+        "@jskit-ai/kernel": "0.1.145",
+        "@jskit-ai/realtime": "0.1.142",
+        "@jskit-ai/shell-web": "0.1.146",
+        "@jskit-ai/uploads-image-web": "0.1.121",
+        "@jskit-ai/users-core": "0.1.158",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -7835,30 +7835,30 @@
     },
     "packages/workspaces-core": {
       "name": "@jskit-ai/workspaces-core",
-      "version": "0.1.123",
+      "version": "0.1.124",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.142",
-        "@jskit-ai/database-runtime": "0.1.143",
-        "@jskit-ai/http-runtime": "0.1.142",
-        "@jskit-ai/json-rest-api-core": "0.1.88",
-        "@jskit-ai/kernel": "0.1.144",
-        "@jskit-ai/resource-core": "0.1.87",
-        "@jskit-ai/resource-crud-core": "0.1.87",
-        "@jskit-ai/users-core": "0.1.157",
+        "@jskit-ai/auth-core": "0.1.143",
+        "@jskit-ai/database-runtime": "0.1.144",
+        "@jskit-ai/http-runtime": "0.1.143",
+        "@jskit-ai/json-rest-api-core": "0.1.89",
+        "@jskit-ai/kernel": "0.1.145",
+        "@jskit-ai/resource-core": "0.1.88",
+        "@jskit-ai/resource-crud-core": "0.1.88",
+        "@jskit-ai/users-core": "0.1.158",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/workspaces-web": {
       "name": "@jskit-ai/workspaces-web",
-      "version": "0.1.124",
+      "version": "0.1.125",
       "dependencies": {
-        "@jskit-ai/auth-web": "0.1.145",
-        "@jskit-ai/http-runtime": "0.1.142",
-        "@jskit-ai/kernel": "0.1.144",
-        "@jskit-ai/shell-web": "0.1.145",
-        "@jskit-ai/users-core": "0.1.157",
-        "@jskit-ai/users-web": "0.1.161",
-        "@jskit-ai/workspaces-core": "0.1.123",
+        "@jskit-ai/auth-web": "0.1.146",
+        "@jskit-ai/http-runtime": "0.1.143",
+        "@jskit-ai/kernel": "0.1.145",
+        "@jskit-ai/shell-web": "0.1.146",
+        "@jskit-ai/users-core": "0.1.158",
+        "@jskit-ai/users-web": "0.1.162",
+        "@jskit-ai/workspaces-core": "0.1.124",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -7870,7 +7870,7 @@
     },
     "tooling/config-eslint": {
       "name": "@jskit-ai/config-eslint",
-      "version": "0.1.142",
+      "version": "0.1.143",
       "dependencies": {
         "@eslint/js": "^10.0.1",
         "eslint-plugin-vue": "^10.5.1",
@@ -7909,9 +7909,9 @@
     },
     "tooling/create-app": {
       "name": "@jskit-ai/create-app",
-      "version": "0.1.163",
+      "version": "0.1.164",
       "dependencies": {
-        "@jskit-ai/jskit-cli": "0.2.171"
+        "@jskit-ai/jskit-cli": "0.2.172"
       },
       "bin": {
         "jskit-create-app": "bin/jskit-create-app.js"
@@ -7922,18 +7922,18 @@
     },
     "tooling/jskit-catalog": {
       "name": "@jskit-ai/jskit-catalog",
-      "version": "0.1.165",
+      "version": "0.1.166",
       "engines": {
         "node": "^22.13.0 || ^24.0.0 || ^26.0.0"
       }
     },
     "tooling/jskit-cli": {
       "name": "@jskit-ai/jskit-cli",
-      "version": "0.2.171",
+      "version": "0.2.172",
       "dependencies": {
-        "@jskit-ai/jskit-catalog": "0.1.165",
-        "@jskit-ai/kernel": "0.1.144",
-        "@jskit-ai/shell-web": "0.1.145",
+        "@jskit-ai/jskit-catalog": "0.1.166",
+        "@jskit-ai/kernel": "0.1.145",
+        "@jskit-ai/shell-web": "0.1.146",
         "@vue/compiler-sfc": "^3.5.29",
         "semver": "^7.7.4",
         "ts-morph": "^28.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7475,28 +7475,28 @@
     },
     "packages/agent-docs": {
       "name": "@jskit-ai/agent-docs",
-      "version": "0.1.109",
+      "version": "0.1.110",
       "engines": {
         "node": "^22.13.0 || ^24.0.0 || ^26.0.0"
       }
     },
     "packages/assistant": {
       "name": "@jskit-ai/assistant",
-      "version": "0.1.151",
+      "version": "0.1.152",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.142"
+        "@jskit-ai/kernel": "0.1.143"
       }
     },
     "packages/assistant-core": {
       "name": "@jskit-ai/assistant-core",
-      "version": "0.1.119",
+      "version": "0.1.120",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.141",
-        "@jskit-ai/http-runtime": "0.1.140",
-        "@jskit-ai/kernel": "0.1.142",
-        "@jskit-ai/resource-core": "0.1.85",
-        "@jskit-ai/resource-crud-core": "0.1.85",
-        "@jskit-ai/users-core": "0.1.155",
+        "@jskit-ai/database-runtime": "0.1.142",
+        "@jskit-ai/http-runtime": "0.1.141",
+        "@jskit-ai/kernel": "0.1.143",
+        "@jskit-ai/resource-core": "0.1.86",
+        "@jskit-ai/resource-crud-core": "0.1.86",
+        "@jskit-ai/users-core": "0.1.156",
         "dompurify": "^3.4.12",
         "json-rest-schema": "1.x.x",
         "marked": "^17.0.4",
@@ -7509,15 +7509,15 @@
     },
     "packages/assistant-runtime": {
       "name": "@jskit-ai/assistant-runtime",
-      "version": "0.1.114",
+      "version": "0.1.115",
       "dependencies": {
-        "@jskit-ai/assistant-core": "0.1.119",
-        "@jskit-ai/database-runtime": "0.1.141",
-        "@jskit-ai/http-runtime": "0.1.140",
-        "@jskit-ai/kernel": "0.1.142",
-        "@jskit-ai/shell-web": "0.1.143",
-        "@jskit-ai/users-core": "0.1.155",
-        "@jskit-ai/users-web": "0.1.159",
+        "@jskit-ai/assistant-core": "0.1.120",
+        "@jskit-ai/database-runtime": "0.1.142",
+        "@jskit-ai/http-runtime": "0.1.141",
+        "@jskit-ai/kernel": "0.1.143",
+        "@jskit-ai/shell-web": "0.1.144",
+        "@jskit-ai/users-core": "0.1.156",
+        "@jskit-ai/users-web": "0.1.160",
         "json-rest-schema": "1.x.x"
       },
       "peerDependencies": {
@@ -7528,39 +7528,39 @@
     },
     "packages/auth-core": {
       "name": "@jskit-ai/auth-core",
-      "version": "0.1.140",
+      "version": "0.1.141",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0",
-        "@jskit-ai/kernel": "0.1.142",
+        "@jskit-ai/kernel": "0.1.143",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/auth-provider-local-core": {
       "name": "@jskit-ai/auth-provider-local-core",
-      "version": "0.1.44",
+      "version": "0.1.45",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.140",
-        "@jskit-ai/kernel": "0.1.142",
+        "@jskit-ai/auth-core": "0.1.141",
+        "@jskit-ai/kernel": "0.1.143",
         "nodemailer": "^9.0.3"
       }
     },
     "packages/auth-provider-local-db-core": {
       "name": "@jskit-ai/auth-provider-local-db-core",
-      "version": "0.1.35",
+      "version": "0.1.36",
       "dependencies": {
-        "@jskit-ai/auth-provider-local-core": "0.1.44",
-        "@jskit-ai/database-runtime": "0.1.141",
-        "@jskit-ai/kernel": "0.1.142"
+        "@jskit-ai/auth-provider-local-core": "0.1.45",
+        "@jskit-ai/database-runtime": "0.1.142",
+        "@jskit-ai/kernel": "0.1.143"
       }
     },
     "packages/auth-provider-supabase-core": {
       "name": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.140",
+      "version": "0.1.141",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.140",
-        "@jskit-ai/kernel": "0.1.142",
+        "@jskit-ai/auth-core": "0.1.141",
+        "@jskit-ai/kernel": "0.1.143",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0",
         "json-rest-schema": "1.x.x",
@@ -7569,12 +7569,12 @@
     },
     "packages/auth-web": {
       "name": "@jskit-ai/auth-web",
-      "version": "0.1.143",
+      "version": "0.1.144",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.140",
-        "@jskit-ai/http-runtime": "0.1.140",
-        "@jskit-ai/kernel": "0.1.142",
-        "@jskit-ai/shell-web": "0.1.143",
+        "@jskit-ai/auth-core": "0.1.141",
+        "@jskit-ai/http-runtime": "0.1.141",
+        "@jskit-ai/kernel": "0.1.143",
+        "@jskit-ai/shell-web": "0.1.144",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -7587,38 +7587,38 @@
     },
     "packages/console-core": {
       "name": "@jskit-ai/console-core",
-      "version": "0.1.106",
+      "version": "0.1.107",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.140",
-        "@jskit-ai/database-runtime": "0.1.141",
-        "@jskit-ai/http-runtime": "0.1.140",
-        "@jskit-ai/kernel": "0.1.142",
-        "@jskit-ai/resource-crud-core": "0.1.85",
-        "@jskit-ai/users-core": "0.1.155",
+        "@jskit-ai/auth-core": "0.1.141",
+        "@jskit-ai/database-runtime": "0.1.142",
+        "@jskit-ai/http-runtime": "0.1.141",
+        "@jskit-ai/kernel": "0.1.143",
+        "@jskit-ai/resource-crud-core": "0.1.86",
+        "@jskit-ai/users-core": "0.1.156",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/console-web": {
       "name": "@jskit-ai/console-web",
-      "version": "0.1.111",
+      "version": "0.1.112",
       "dependencies": {
-        "@jskit-ai/auth-web": "0.1.143",
-        "@jskit-ai/console-core": "0.1.106",
-        "@jskit-ai/shell-web": "0.1.143"
+        "@jskit-ai/auth-web": "0.1.144",
+        "@jskit-ai/console-core": "0.1.107",
+        "@jskit-ai/shell-web": "0.1.144"
       }
     },
     "packages/crud-core": {
       "name": "@jskit-ai/crud-core",
-      "version": "0.1.152",
+      "version": "0.1.153",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.141",
-        "@jskit-ai/http-runtime": "0.1.140",
-        "@jskit-ai/kernel": "0.1.142",
-        "@jskit-ai/realtime": "0.1.139",
-        "@jskit-ai/resource-crud-core": "0.1.85",
-        "@jskit-ai/shell-web": "0.1.143",
-        "@jskit-ai/users-core": "0.1.155",
-        "@jskit-ai/users-web": "0.1.159",
+        "@jskit-ai/database-runtime": "0.1.142",
+        "@jskit-ai/http-runtime": "0.1.141",
+        "@jskit-ai/kernel": "0.1.143",
+        "@jskit-ai/realtime": "0.1.140",
+        "@jskit-ai/resource-crud-core": "0.1.86",
+        "@jskit-ai/shell-web": "0.1.144",
+        "@jskit-ai/users-core": "0.1.156",
+        "@jskit-ai/users-web": "0.1.160",
         "json-rest-schema": "1.x.x"
       },
       "peerDependencies": {
@@ -7629,99 +7629,99 @@
     },
     "packages/crud-server-generator": {
       "name": "@jskit-ai/crud-server-generator",
-      "version": "0.1.154",
+      "version": "0.1.155",
       "dependencies": {
         "@babel/parser": "^7.29.2",
-        "@jskit-ai/crud-core": "0.1.152",
-        "@jskit-ai/database-runtime": "0.1.141",
-        "@jskit-ai/http-runtime": "0.1.140",
-        "@jskit-ai/json-rest-api-core": "0.1.86",
-        "@jskit-ai/kernel": "0.1.142",
-        "@jskit-ai/resource-crud-core": "0.1.85",
+        "@jskit-ai/crud-core": "0.1.153",
+        "@jskit-ai/database-runtime": "0.1.142",
+        "@jskit-ai/http-runtime": "0.1.141",
+        "@jskit-ai/json-rest-api-core": "0.1.87",
+        "@jskit-ai/kernel": "0.1.143",
+        "@jskit-ai/resource-crud-core": "0.1.86",
         "recast": "^0.23.11"
       }
     },
     "packages/crud-ui-generator": {
       "name": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.125",
+      "version": "0.1.126",
       "dependencies": {
-        "@jskit-ai/crud-core": "0.1.152",
-        "@jskit-ai/kernel": "0.1.142",
-        "@jskit-ai/resource-crud-core": "0.1.85"
+        "@jskit-ai/crud-core": "0.1.153",
+        "@jskit-ai/kernel": "0.1.143",
+        "@jskit-ai/resource-crud-core": "0.1.86"
       }
     },
     "packages/database-runtime": {
       "name": "@jskit-ai/database-runtime",
-      "version": "0.1.141",
+      "version": "0.1.142",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.142"
+        "@jskit-ai/kernel": "0.1.143"
       }
     },
     "packages/database-runtime-mysql": {
       "name": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.140",
+      "version": "0.1.141",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.141",
-        "@jskit-ai/kernel": "0.1.142"
+        "@jskit-ai/database-runtime": "0.1.142",
+        "@jskit-ai/kernel": "0.1.143"
       }
     },
     "packages/database-runtime-postgres": {
       "name": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.139",
+      "version": "0.1.140",
       "dependencies": {
-        "@jskit-ai/database-runtime": "0.1.141"
+        "@jskit-ai/database-runtime": "0.1.142"
       }
     },
     "packages/feature-server-generator": {
       "name": "@jskit-ai/feature-server-generator",
-      "version": "0.1.84"
+      "version": "0.1.85"
     },
     "packages/google-rewarded-core": {
       "name": "@jskit-ai/google-rewarded-core",
-      "version": "0.1.79"
+      "version": "0.1.80"
     },
     "packages/google-rewarded-web": {
       "name": "@jskit-ai/google-rewarded-web",
-      "version": "0.1.79"
+      "version": "0.1.80"
     },
     "packages/http-runtime": {
       "name": "@jskit-ai/http-runtime",
-      "version": "0.1.140",
+      "version": "0.1.141",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.142",
+        "@jskit-ai/kernel": "0.1.143",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/json-rest-api-core": {
       "name": "@jskit-ai/json-rest-api-core",
-      "version": "0.1.86",
+      "version": "0.1.87",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.142",
+        "@jskit-ai/kernel": "0.1.143",
         "hooked-api": "1.x.x",
         "json-rest-api": "^1.0.27"
       }
     },
     "packages/kernel": {
       "name": "@jskit-ai/kernel",
-      "version": "0.1.142",
+      "version": "0.1.143",
       "dependencies": {
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/mobile-capacitor": {
       "name": "@jskit-ai/mobile-capacitor",
-      "version": "0.1.78",
+      "version": "0.1.79",
       "dependencies": {
         "@capacitor/browser": "^7.0.1",
         "@capacitor/core": "^7.4.3",
-        "@jskit-ai/kernel": "0.1.142"
+        "@jskit-ai/kernel": "0.1.143"
       }
     },
     "packages/realtime": {
       "name": "@jskit-ai/realtime",
-      "version": "0.1.139",
+      "version": "0.1.140",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.142",
+        "@jskit-ai/kernel": "0.1.143",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",
@@ -7733,24 +7733,24 @@
     },
     "packages/resource-core": {
       "name": "@jskit-ai/resource-core",
-      "version": "0.1.85",
+      "version": "0.1.86",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.142"
+        "@jskit-ai/kernel": "0.1.143"
       }
     },
     "packages/resource-crud-core": {
       "name": "@jskit-ai/resource-crud-core",
-      "version": "0.1.85",
+      "version": "0.1.86",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.142",
-        "@jskit-ai/resource-core": "0.1.85"
+        "@jskit-ai/kernel": "0.1.143",
+        "@jskit-ai/resource-core": "0.1.86"
       }
     },
     "packages/shell-web": {
       "name": "@jskit-ai/shell-web",
-      "version": "0.1.143",
+      "version": "0.1.144",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.142",
+        "@jskit-ai/kernel": "0.1.143",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -7762,25 +7762,25 @@
     },
     "packages/storage-runtime": {
       "name": "@jskit-ai/storage-runtime",
-      "version": "0.1.140",
+      "version": "0.1.141",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.142",
+        "@jskit-ai/kernel": "0.1.143",
         "unstorage": "^1.17.5"
       }
     },
     "packages/ui-generator": {
       "name": "@jskit-ai/ui-generator",
-      "version": "0.1.125",
+      "version": "0.1.126",
       "dependencies": {
-        "@jskit-ai/kernel": "0.1.142",
-        "@jskit-ai/shell-web": "0.1.143"
+        "@jskit-ai/kernel": "0.1.143",
+        "@jskit-ai/shell-web": "0.1.144"
       }
     },
     "packages/uploads-image-web": {
       "name": "@jskit-ai/uploads-image-web",
-      "version": "0.1.118",
+      "version": "0.1.119",
       "dependencies": {
-        "@jskit-ai/uploads-runtime": "0.1.118",
+        "@jskit-ai/uploads-runtime": "0.1.119",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",
@@ -7793,37 +7793,37 @@
     },
     "packages/uploads-runtime": {
       "name": "@jskit-ai/uploads-runtime",
-      "version": "0.1.118",
+      "version": "0.1.119",
       "dependencies": {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.142"
+        "@jskit-ai/kernel": "0.1.143"
       }
     },
     "packages/users-core": {
       "name": "@jskit-ai/users-core",
-      "version": "0.1.155",
+      "version": "0.1.156",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.140",
-        "@jskit-ai/database-runtime": "0.1.141",
-        "@jskit-ai/http-runtime": "0.1.140",
-        "@jskit-ai/json-rest-api-core": "0.1.86",
-        "@jskit-ai/kernel": "0.1.142",
-        "@jskit-ai/resource-core": "0.1.85",
-        "@jskit-ai/resource-crud-core": "0.1.85",
-        "@jskit-ai/uploads-runtime": "0.1.118",
+        "@jskit-ai/auth-core": "0.1.141",
+        "@jskit-ai/database-runtime": "0.1.142",
+        "@jskit-ai/http-runtime": "0.1.141",
+        "@jskit-ai/json-rest-api-core": "0.1.87",
+        "@jskit-ai/kernel": "0.1.143",
+        "@jskit-ai/resource-core": "0.1.86",
+        "@jskit-ai/resource-crud-core": "0.1.86",
+        "@jskit-ai/uploads-runtime": "0.1.119",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/users-web": {
       "name": "@jskit-ai/users-web",
-      "version": "0.1.159",
+      "version": "0.1.160",
       "dependencies": {
-        "@jskit-ai/http-runtime": "0.1.140",
-        "@jskit-ai/kernel": "0.1.142",
-        "@jskit-ai/realtime": "0.1.139",
-        "@jskit-ai/shell-web": "0.1.143",
-        "@jskit-ai/uploads-image-web": "0.1.118",
-        "@jskit-ai/users-core": "0.1.155",
+        "@jskit-ai/http-runtime": "0.1.141",
+        "@jskit-ai/kernel": "0.1.143",
+        "@jskit-ai/realtime": "0.1.140",
+        "@jskit-ai/shell-web": "0.1.144",
+        "@jskit-ai/uploads-image-web": "0.1.119",
+        "@jskit-ai/users-core": "0.1.156",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -7835,30 +7835,30 @@
     },
     "packages/workspaces-core": {
       "name": "@jskit-ai/workspaces-core",
-      "version": "0.1.121",
+      "version": "0.1.122",
       "dependencies": {
-        "@jskit-ai/auth-core": "0.1.140",
-        "@jskit-ai/database-runtime": "0.1.141",
-        "@jskit-ai/http-runtime": "0.1.140",
-        "@jskit-ai/json-rest-api-core": "0.1.86",
-        "@jskit-ai/kernel": "0.1.142",
-        "@jskit-ai/resource-core": "0.1.85",
-        "@jskit-ai/resource-crud-core": "0.1.85",
-        "@jskit-ai/users-core": "0.1.155",
+        "@jskit-ai/auth-core": "0.1.141",
+        "@jskit-ai/database-runtime": "0.1.142",
+        "@jskit-ai/http-runtime": "0.1.141",
+        "@jskit-ai/json-rest-api-core": "0.1.87",
+        "@jskit-ai/kernel": "0.1.143",
+        "@jskit-ai/resource-core": "0.1.86",
+        "@jskit-ai/resource-crud-core": "0.1.86",
+        "@jskit-ai/users-core": "0.1.156",
         "json-rest-schema": "1.x.x"
       }
     },
     "packages/workspaces-web": {
       "name": "@jskit-ai/workspaces-web",
-      "version": "0.1.122",
+      "version": "0.1.123",
       "dependencies": {
-        "@jskit-ai/auth-web": "0.1.143",
-        "@jskit-ai/http-runtime": "0.1.140",
-        "@jskit-ai/kernel": "0.1.142",
-        "@jskit-ai/shell-web": "0.1.143",
-        "@jskit-ai/users-core": "0.1.155",
-        "@jskit-ai/users-web": "0.1.159",
-        "@jskit-ai/workspaces-core": "0.1.121",
+        "@jskit-ai/auth-web": "0.1.144",
+        "@jskit-ai/http-runtime": "0.1.141",
+        "@jskit-ai/kernel": "0.1.143",
+        "@jskit-ai/shell-web": "0.1.144",
+        "@jskit-ai/users-core": "0.1.156",
+        "@jskit-ai/users-web": "0.1.160",
+        "@jskit-ai/workspaces-core": "0.1.122",
         "@mdi/js": "^7.4.47"
       },
       "peerDependencies": {
@@ -7870,7 +7870,7 @@
     },
     "tooling/config-eslint": {
       "name": "@jskit-ai/config-eslint",
-      "version": "0.1.140",
+      "version": "0.1.141",
       "dependencies": {
         "@eslint/js": "^10.0.1",
         "eslint-plugin-vue": "^10.5.1",
@@ -7909,9 +7909,9 @@
     },
     "tooling/create-app": {
       "name": "@jskit-ai/create-app",
-      "version": "0.1.161",
+      "version": "0.1.162",
       "dependencies": {
-        "@jskit-ai/jskit-cli": "0.2.169"
+        "@jskit-ai/jskit-cli": "0.2.170"
       },
       "bin": {
         "jskit-create-app": "bin/jskit-create-app.js"
@@ -7922,18 +7922,18 @@
     },
     "tooling/jskit-catalog": {
       "name": "@jskit-ai/jskit-catalog",
-      "version": "0.1.163",
+      "version": "0.1.164",
       "engines": {
         "node": "^22.13.0 || ^24.0.0 || ^26.0.0"
       }
     },
     "tooling/jskit-cli": {
       "name": "@jskit-ai/jskit-cli",
-      "version": "0.2.169",
+      "version": "0.2.170",
       "dependencies": {
-        "@jskit-ai/jskit-catalog": "0.1.163",
-        "@jskit-ai/kernel": "0.1.142",
-        "@jskit-ai/shell-web": "0.1.143",
+        "@jskit-ai/jskit-catalog": "0.1.164",
+        "@jskit-ai/kernel": "0.1.143",
+        "@jskit-ai/shell-web": "0.1.144",
         "@vue/compiler-sfc": "^3.5.29",
         "semver": "^7.7.4",
         "ts-morph": "^28.0.0",

--- a/packages/agent-docs/package.json
+++ b/packages/agent-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/agent-docs",
-  "version": "0.1.111",
+  "version": "0.1.112",
   "description": "Distributed JSKIT agent references, prompts, guides, and generated reference maps.",
   "type": "module",
   "files": [

--- a/packages/agent-docs/package.json
+++ b/packages/agent-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/agent-docs",
-  "version": "0.1.109",
+  "version": "0.1.110",
   "description": "Distributed JSKIT agent references, prompts, guides, and generated reference maps.",
   "type": "module",
   "files": [

--- a/packages/agent-docs/package.json
+++ b/packages/agent-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/agent-docs",
-  "version": "0.1.110",
+  "version": "0.1.111",
   "description": "Distributed JSKIT agent references, prompts, guides, and generated reference maps.",
   "type": "module",
   "files": [

--- a/packages/agent-docs/reference/autogen/tooling/jskit-cli.md
+++ b/packages/agent-docs/reference/autogen/tooling/jskit-cli.md
@@ -247,6 +247,7 @@ Exports
 - `createLocalPackageScaffoldFiles({ packageId, packageDescription })`
 - `resolveLocalDependencyOrder(initialPackageIds, packageRegistry)`
 Local functions
+- `normalizeJskitDependencySpecifier(packageId, dependencySpecifier)`
 - `createLocalPackageDescriptorTemplate({ packageId, description })`
 
 ### `src/server/cliRuntime/mutationApplication.js`

--- a/packages/agent-docs/reference/autogen/tooling/jskit-cli.md
+++ b/packages/agent-docs/reference/autogen/tooling/jskit-cli.md
@@ -238,7 +238,6 @@ Local functions
 ### `src/server/cliRuntime/localPackageSupport.js`
 Exports
 - `resolvePackageDependencySpecifier(packageEntry, { existingValue = "" } = {})`
-- `normalizeJskitDependencySpecifier(packageId, dependencySpecifier)`
 - `normalizePackageNameSegment(rawValue, { label = "package name" } = {})`
 - `normalizeScopeName(rawScope)`
 - `resolveDefaultLocalScopeFromAppName(appPackageName)`

--- a/packages/assistant-core/package.descriptor.mjs
+++ b/packages/assistant-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-core",
-  version: "0.1.121",
+  version: "0.1.122",
   kind: "runtime",
   description: "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
   dependsOn: [
@@ -47,11 +47,11 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/http-runtime": "0.1.142",
-        "@jskit-ai/kernel": "0.1.144",
-        "@jskit-ai/resource-core": "0.1.87",
-        "@jskit-ai/resource-crud-core": "0.1.87",
-        "@jskit-ai/users-core": "0.1.157",
+        "@jskit-ai/http-runtime": "0.1.143",
+        "@jskit-ai/kernel": "0.1.145",
+        "@jskit-ai/resource-core": "0.1.88",
+        "@jskit-ai/resource-crud-core": "0.1.88",
+        "@jskit-ai/users-core": "0.1.158",
         "dompurify": "^3.3.3",
         "json-rest-schema": "1.x.x",
         "marked": "^17.0.4",

--- a/packages/assistant-core/package.descriptor.mjs
+++ b/packages/assistant-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-core",
-  version: "0.1.120",
+  version: "0.1.121",
   kind: "runtime",
   description: "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
   dependsOn: [
@@ -47,11 +47,11 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/http-runtime": "0.1.141",
-        "@jskit-ai/kernel": "0.1.143",
-        "@jskit-ai/resource-core": "0.1.86",
-        "@jskit-ai/resource-crud-core": "0.1.86",
-        "@jskit-ai/users-core": "0.1.156",
+        "@jskit-ai/http-runtime": "0.1.142",
+        "@jskit-ai/kernel": "0.1.144",
+        "@jskit-ai/resource-core": "0.1.87",
+        "@jskit-ai/resource-crud-core": "0.1.87",
+        "@jskit-ai/users-core": "0.1.157",
         "dompurify": "^3.3.3",
         "json-rest-schema": "1.x.x",
         "marked": "^17.0.4",

--- a/packages/assistant-core/package.descriptor.mjs
+++ b/packages/assistant-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-core",
-  version: "0.1.119",
+  version: "0.1.120",
   kind: "runtime",
   description: "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
   dependsOn: [
@@ -47,11 +47,11 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/http-runtime": "0.1.140",
-        "@jskit-ai/kernel": "0.1.142",
-        "@jskit-ai/resource-core": "0.1.85",
-        "@jskit-ai/resource-crud-core": "0.1.85",
-        "@jskit-ai/users-core": "0.1.155",
+        "@jskit-ai/http-runtime": "0.1.141",
+        "@jskit-ai/kernel": "0.1.143",
+        "@jskit-ai/resource-core": "0.1.86",
+        "@jskit-ai/resource-crud-core": "0.1.86",
+        "@jskit-ai/users-core": "0.1.156",
         "dompurify": "^3.3.3",
         "json-rest-schema": "1.x.x",
         "marked": "^17.0.4",

--- a/packages/assistant-core/package.json
+++ b/packages/assistant-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-core",
-  "version": "0.1.121",
+  "version": "0.1.122",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,12 +11,12 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.143",
-    "@jskit-ai/http-runtime": "0.1.142",
-    "@jskit-ai/kernel": "0.1.144",
-    "@jskit-ai/resource-crud-core": "0.1.87",
-    "@jskit-ai/resource-core": "0.1.87",
-    "@jskit-ai/users-core": "0.1.157",
+    "@jskit-ai/database-runtime": "0.1.144",
+    "@jskit-ai/http-runtime": "0.1.143",
+    "@jskit-ai/kernel": "0.1.145",
+    "@jskit-ai/resource-crud-core": "0.1.88",
+    "@jskit-ai/resource-core": "0.1.88",
+    "@jskit-ai/users-core": "0.1.158",
     "dompurify": "^3.4.12",
     "json-rest-schema": "1.x.x",
     "marked": "^17.0.4",

--- a/packages/assistant-core/package.json
+++ b/packages/assistant-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-core",
-  "version": "0.1.119",
+  "version": "0.1.120",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,12 +11,12 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.141",
-    "@jskit-ai/http-runtime": "0.1.140",
-    "@jskit-ai/kernel": "0.1.142",
-    "@jskit-ai/resource-crud-core": "0.1.85",
-    "@jskit-ai/resource-core": "0.1.85",
-    "@jskit-ai/users-core": "0.1.155",
+    "@jskit-ai/database-runtime": "0.1.142",
+    "@jskit-ai/http-runtime": "0.1.141",
+    "@jskit-ai/kernel": "0.1.143",
+    "@jskit-ai/resource-crud-core": "0.1.86",
+    "@jskit-ai/resource-core": "0.1.86",
+    "@jskit-ai/users-core": "0.1.156",
     "dompurify": "^3.4.12",
     "json-rest-schema": "1.x.x",
     "marked": "^17.0.4",

--- a/packages/assistant-core/package.json
+++ b/packages/assistant-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-core",
-  "version": "0.1.120",
+  "version": "0.1.121",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,12 +11,12 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.142",
-    "@jskit-ai/http-runtime": "0.1.141",
-    "@jskit-ai/kernel": "0.1.143",
-    "@jskit-ai/resource-crud-core": "0.1.86",
-    "@jskit-ai/resource-core": "0.1.86",
-    "@jskit-ai/users-core": "0.1.156",
+    "@jskit-ai/database-runtime": "0.1.143",
+    "@jskit-ai/http-runtime": "0.1.142",
+    "@jskit-ai/kernel": "0.1.144",
+    "@jskit-ai/resource-crud-core": "0.1.87",
+    "@jskit-ai/resource-core": "0.1.87",
+    "@jskit-ai/users-core": "0.1.157",
     "dompurify": "^3.4.12",
     "json-rest-schema": "1.x.x",
     "marked": "^17.0.4",

--- a/packages/assistant-runtime/package.descriptor.mjs
+++ b/packages/assistant-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-runtime",
-  version: "0.1.116",
+  version: "0.1.117",
   kind: "runtime",
   description: "Shared assistant runtime with per-surface assistant registration.",
   dependsOn: [
@@ -95,13 +95,13 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/assistant-core": "0.1.121",
-        "@jskit-ai/database-runtime": "0.1.143",
-        "@jskit-ai/http-runtime": "0.1.142",
-        "@jskit-ai/kernel": "0.1.144",
-        "@jskit-ai/shell-web": "0.1.145",
-        "@jskit-ai/users-core": "0.1.157",
-        "@jskit-ai/users-web": "0.1.161"
+        "@jskit-ai/assistant-core": "0.1.122",
+        "@jskit-ai/database-runtime": "0.1.144",
+        "@jskit-ai/http-runtime": "0.1.143",
+        "@jskit-ai/kernel": "0.1.145",
+        "@jskit-ai/shell-web": "0.1.146",
+        "@jskit-ai/users-core": "0.1.158",
+        "@jskit-ai/users-web": "0.1.162"
       },
       dev: {}
     },

--- a/packages/assistant-runtime/package.descriptor.mjs
+++ b/packages/assistant-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-runtime",
-  version: "0.1.114",
+  version: "0.1.115",
   kind: "runtime",
   description: "Shared assistant runtime with per-surface assistant registration.",
   dependsOn: [
@@ -95,13 +95,13 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/assistant-core": "0.1.119",
-        "@jskit-ai/database-runtime": "0.1.141",
-        "@jskit-ai/http-runtime": "0.1.140",
-        "@jskit-ai/kernel": "0.1.142",
-        "@jskit-ai/shell-web": "0.1.143",
-        "@jskit-ai/users-core": "0.1.155",
-        "@jskit-ai/users-web": "0.1.159"
+        "@jskit-ai/assistant-core": "0.1.120",
+        "@jskit-ai/database-runtime": "0.1.142",
+        "@jskit-ai/http-runtime": "0.1.141",
+        "@jskit-ai/kernel": "0.1.143",
+        "@jskit-ai/shell-web": "0.1.144",
+        "@jskit-ai/users-core": "0.1.156",
+        "@jskit-ai/users-web": "0.1.160"
       },
       dev: {}
     },

--- a/packages/assistant-runtime/package.descriptor.mjs
+++ b/packages/assistant-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant-runtime",
-  version: "0.1.115",
+  version: "0.1.116",
   kind: "runtime",
   description: "Shared assistant runtime with per-surface assistant registration.",
   dependsOn: [
@@ -95,13 +95,13 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/assistant-core": "0.1.120",
-        "@jskit-ai/database-runtime": "0.1.142",
-        "@jskit-ai/http-runtime": "0.1.141",
-        "@jskit-ai/kernel": "0.1.143",
-        "@jskit-ai/shell-web": "0.1.144",
-        "@jskit-ai/users-core": "0.1.156",
-        "@jskit-ai/users-web": "0.1.160"
+        "@jskit-ai/assistant-core": "0.1.121",
+        "@jskit-ai/database-runtime": "0.1.143",
+        "@jskit-ai/http-runtime": "0.1.142",
+        "@jskit-ai/kernel": "0.1.144",
+        "@jskit-ai/shell-web": "0.1.145",
+        "@jskit-ai/users-core": "0.1.157",
+        "@jskit-ai/users-web": "0.1.161"
       },
       dev: {}
     },

--- a/packages/assistant-runtime/package.json
+++ b/packages/assistant-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-runtime",
-  "version": "0.1.114",
+  "version": "0.1.115",
   "type": "module",
   "exports": {
     "./client": "./src/client/index.js",
@@ -8,13 +8,13 @@
     "./server/actionIds": "./src/server/actionIds.js"
   },
   "dependencies": {
-    "@jskit-ai/assistant-core": "0.1.119",
-    "@jskit-ai/database-runtime": "0.1.141",
-    "@jskit-ai/http-runtime": "0.1.140",
-    "@jskit-ai/kernel": "0.1.142",
-    "@jskit-ai/shell-web": "0.1.143",
-    "@jskit-ai/users-core": "0.1.155",
-    "@jskit-ai/users-web": "0.1.159",
+    "@jskit-ai/assistant-core": "0.1.120",
+    "@jskit-ai/database-runtime": "0.1.142",
+    "@jskit-ai/http-runtime": "0.1.141",
+    "@jskit-ai/kernel": "0.1.143",
+    "@jskit-ai/shell-web": "0.1.144",
+    "@jskit-ai/users-core": "0.1.156",
+    "@jskit-ai/users-web": "0.1.160",
     "json-rest-schema": "1.x.x"
   },
   "peerDependencies": {

--- a/packages/assistant-runtime/package.json
+++ b/packages/assistant-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-runtime",
-  "version": "0.1.116",
+  "version": "0.1.117",
   "type": "module",
   "exports": {
     "./client": "./src/client/index.js",
@@ -8,13 +8,13 @@
     "./server/actionIds": "./src/server/actionIds.js"
   },
   "dependencies": {
-    "@jskit-ai/assistant-core": "0.1.121",
-    "@jskit-ai/database-runtime": "0.1.143",
-    "@jskit-ai/http-runtime": "0.1.142",
-    "@jskit-ai/kernel": "0.1.144",
-    "@jskit-ai/shell-web": "0.1.145",
-    "@jskit-ai/users-core": "0.1.157",
-    "@jskit-ai/users-web": "0.1.161",
+    "@jskit-ai/assistant-core": "0.1.122",
+    "@jskit-ai/database-runtime": "0.1.144",
+    "@jskit-ai/http-runtime": "0.1.143",
+    "@jskit-ai/kernel": "0.1.145",
+    "@jskit-ai/shell-web": "0.1.146",
+    "@jskit-ai/users-core": "0.1.158",
+    "@jskit-ai/users-web": "0.1.162",
     "json-rest-schema": "1.x.x"
   },
   "peerDependencies": {

--- a/packages/assistant-runtime/package.json
+++ b/packages/assistant-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant-runtime",
-  "version": "0.1.115",
+  "version": "0.1.116",
   "type": "module",
   "exports": {
     "./client": "./src/client/index.js",
@@ -8,13 +8,13 @@
     "./server/actionIds": "./src/server/actionIds.js"
   },
   "dependencies": {
-    "@jskit-ai/assistant-core": "0.1.120",
-    "@jskit-ai/database-runtime": "0.1.142",
-    "@jskit-ai/http-runtime": "0.1.141",
-    "@jskit-ai/kernel": "0.1.143",
-    "@jskit-ai/shell-web": "0.1.144",
-    "@jskit-ai/users-core": "0.1.156",
-    "@jskit-ai/users-web": "0.1.160",
+    "@jskit-ai/assistant-core": "0.1.121",
+    "@jskit-ai/database-runtime": "0.1.143",
+    "@jskit-ai/http-runtime": "0.1.142",
+    "@jskit-ai/kernel": "0.1.144",
+    "@jskit-ai/shell-web": "0.1.145",
+    "@jskit-ai/users-core": "0.1.157",
+    "@jskit-ai/users-web": "0.1.161",
     "json-rest-schema": "1.x.x"
   },
   "peerDependencies": {

--- a/packages/assistant/package.descriptor.mjs
+++ b/packages/assistant/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant",
-  version: "0.1.153",
+  version: "0.1.154",
   kind: "generator",
   description: "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
   options: {

--- a/packages/assistant/package.descriptor.mjs
+++ b/packages/assistant/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant",
-  version: "0.1.152",
+  version: "0.1.153",
   kind: "generator",
   description: "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
   options: {

--- a/packages/assistant/package.descriptor.mjs
+++ b/packages/assistant/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/assistant",
-  version: "0.1.151",
+  version: "0.1.152",
   kind: "generator",
   description: "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
   options: {

--- a/packages/assistant/package.json
+++ b/packages/assistant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant",
-  "version": "0.1.152",
+  "version": "0.1.153",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.143"
+    "@jskit-ai/kernel": "0.1.144"
   }
 }

--- a/packages/assistant/package.json
+++ b/packages/assistant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant",
-  "version": "0.1.153",
+  "version": "0.1.154",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.144"
+    "@jskit-ai/kernel": "0.1.145"
   }
 }

--- a/packages/assistant/package.json
+++ b/packages/assistant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/assistant",
-  "version": "0.1.151",
+  "version": "0.1.152",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.142"
+    "@jskit-ai/kernel": "0.1.143"
   }
 }

--- a/packages/auth-core/package.descriptor.mjs
+++ b/packages/auth-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-core",
-  "version": "0.1.141",
+  "version": "0.1.142",
   "kind": "runtime",
   "dependsOn": [
     "@jskit-ai/value-app-config-shared"
@@ -74,7 +74,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.143",
+        "@jskit-ai/kernel": "0.1.144",
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0"

--- a/packages/auth-core/package.descriptor.mjs
+++ b/packages/auth-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-core",
-  "version": "0.1.142",
+  "version": "0.1.143",
   "kind": "runtime",
   "dependsOn": [
     "@jskit-ai/value-app-config-shared"
@@ -74,7 +74,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.144",
+        "@jskit-ai/kernel": "0.1.145",
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0"

--- a/packages/auth-core/package.descriptor.mjs
+++ b/packages/auth-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-core",
-  "version": "0.1.140",
+  "version": "0.1.141",
   "kind": "runtime",
   "dependsOn": [
     "@jskit-ai/value-app-config-shared"
@@ -74,7 +74,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.142",
+        "@jskit-ai/kernel": "0.1.143",
         "@fastify/cookie": "^11.0.2",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/rate-limit": "^10.3.0"

--- a/packages/auth-core/package.json
+++ b/packages/auth-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-core",
-  "version": "0.1.141",
+  "version": "0.1.142",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -56,7 +56,7 @@
     "./shared/commands/authSessionReadCommand": "./src/shared/commands/authSessionReadCommand.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.143",
+    "@jskit-ai/kernel": "0.1.144",
     "@fastify/cookie": "^11.0.2",
     "@fastify/csrf-protection": "^7.1.0",
     "@fastify/rate-limit": "^10.3.0",

--- a/packages/auth-core/package.json
+++ b/packages/auth-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-core",
-  "version": "0.1.142",
+  "version": "0.1.143",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -56,7 +56,7 @@
     "./shared/commands/authSessionReadCommand": "./src/shared/commands/authSessionReadCommand.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.144",
+    "@jskit-ai/kernel": "0.1.145",
     "@fastify/cookie": "^11.0.2",
     "@fastify/csrf-protection": "^7.1.0",
     "@fastify/rate-limit": "^10.3.0",

--- a/packages/auth-core/package.json
+++ b/packages/auth-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-core",
-  "version": "0.1.140",
+  "version": "0.1.141",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -56,7 +56,7 @@
     "./shared/commands/authSessionReadCommand": "./src/shared/commands/authSessionReadCommand.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.142",
+    "@jskit-ai/kernel": "0.1.143",
     "@fastify/cookie": "^11.0.2",
     "@fastify/csrf-protection": "^7.1.0",
     "@fastify/rate-limit": "^10.3.0",

--- a/packages/auth-provider-local-core/package.descriptor.mjs
+++ b/packages/auth-provider-local-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-provider-local-core",
-  "version": "0.1.45",
+  "version": "0.1.46",
   "kind": "runtime",
   "description": "Local auth provider with a file backend default and no database requirement.",
   "dependsOn": [
@@ -64,8 +64,8 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/auth-core": "0.1.141",
-        "@jskit-ai/kernel": "0.1.143",
+        "@jskit-ai/auth-core": "0.1.142",
+        "@jskit-ai/kernel": "0.1.144",
         "nodemailer": "^9.0.3",
         "dotenv": "^16.4.5"
       },

--- a/packages/auth-provider-local-core/package.descriptor.mjs
+++ b/packages/auth-provider-local-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-provider-local-core",
-  "version": "0.1.44",
+  "version": "0.1.45",
   "kind": "runtime",
   "description": "Local auth provider with a file backend default and no database requirement.",
   "dependsOn": [
@@ -64,8 +64,8 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/auth-core": "0.1.140",
-        "@jskit-ai/kernel": "0.1.142",
+        "@jskit-ai/auth-core": "0.1.141",
+        "@jskit-ai/kernel": "0.1.143",
         "nodemailer": "^9.0.3",
         "dotenv": "^16.4.5"
       },

--- a/packages/auth-provider-local-core/package.descriptor.mjs
+++ b/packages/auth-provider-local-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-provider-local-core",
-  "version": "0.1.46",
+  "version": "0.1.47",
   "kind": "runtime",
   "description": "Local auth provider with a file backend default and no database requirement.",
   "dependsOn": [
@@ -64,8 +64,8 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/auth-core": "0.1.142",
-        "@jskit-ai/kernel": "0.1.144",
+        "@jskit-ai/auth-core": "0.1.143",
+        "@jskit-ai/kernel": "0.1.145",
         "nodemailer": "^9.0.3",
         "dotenv": "^16.4.5"
       },

--- a/packages/auth-provider-local-core/package.json
+++ b/packages/auth-provider-local-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-local-core",
-  "version": "0.1.46",
+  "version": "0.1.47",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,8 +11,8 @@
     "./server/lib/index": "./src/server/lib/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.142",
-    "@jskit-ai/kernel": "0.1.144",
+    "@jskit-ai/auth-core": "0.1.143",
+    "@jskit-ai/kernel": "0.1.145",
     "nodemailer": "^9.0.3"
   }
 }

--- a/packages/auth-provider-local-core/package.json
+++ b/packages/auth-provider-local-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-local-core",
-  "version": "0.1.44",
+  "version": "0.1.45",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,8 +11,8 @@
     "./server/lib/index": "./src/server/lib/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.140",
-    "@jskit-ai/kernel": "0.1.142",
+    "@jskit-ai/auth-core": "0.1.141",
+    "@jskit-ai/kernel": "0.1.143",
     "nodemailer": "^9.0.3"
   }
 }

--- a/packages/auth-provider-local-core/package.json
+++ b/packages/auth-provider-local-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-local-core",
-  "version": "0.1.45",
+  "version": "0.1.46",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,8 +11,8 @@
     "./server/lib/index": "./src/server/lib/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.141",
-    "@jskit-ai/kernel": "0.1.143",
+    "@jskit-ai/auth-core": "0.1.142",
+    "@jskit-ai/kernel": "0.1.144",
     "nodemailer": "^9.0.3"
   }
 }

--- a/packages/auth-provider-local-db-core/package.descriptor.mjs
+++ b/packages/auth-provider-local-db-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/auth-provider-local-db-core",
-  version: "0.1.37",
+  version: "0.1.38",
   kind: "runtime",
   description: "Database-backed local auth storage backend for JSKIT local auth.",
   dependsOn: [
@@ -80,9 +80,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-provider-local-core": "0.1.46",
-        "@jskit-ai/database-runtime": "0.1.143",
-        "@jskit-ai/kernel": "0.1.144"
+        "@jskit-ai/auth-provider-local-core": "0.1.47",
+        "@jskit-ai/database-runtime": "0.1.144",
+        "@jskit-ai/kernel": "0.1.145"
       },
       dev: {}
     },

--- a/packages/auth-provider-local-db-core/package.descriptor.mjs
+++ b/packages/auth-provider-local-db-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/auth-provider-local-db-core",
-  version: "0.1.35",
+  version: "0.1.36",
   kind: "runtime",
   description: "Database-backed local auth storage backend for JSKIT local auth.",
   dependsOn: [
@@ -80,9 +80,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-provider-local-core": "0.1.44",
-        "@jskit-ai/database-runtime": "0.1.141",
-        "@jskit-ai/kernel": "0.1.142"
+        "@jskit-ai/auth-provider-local-core": "0.1.45",
+        "@jskit-ai/database-runtime": "0.1.142",
+        "@jskit-ai/kernel": "0.1.143"
       },
       dev: {}
     },

--- a/packages/auth-provider-local-db-core/package.descriptor.mjs
+++ b/packages/auth-provider-local-db-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/auth-provider-local-db-core",
-  version: "0.1.36",
+  version: "0.1.37",
   kind: "runtime",
   description: "Database-backed local auth storage backend for JSKIT local auth.",
   dependsOn: [
@@ -80,9 +80,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-provider-local-core": "0.1.45",
-        "@jskit-ai/database-runtime": "0.1.142",
-        "@jskit-ai/kernel": "0.1.143"
+        "@jskit-ai/auth-provider-local-core": "0.1.46",
+        "@jskit-ai/database-runtime": "0.1.143",
+        "@jskit-ai/kernel": "0.1.144"
       },
       dev: {}
     },

--- a/packages/auth-provider-local-db-core/package.json
+++ b/packages/auth-provider-local-db-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-local-db-core",
-  "version": "0.1.35",
+  "version": "0.1.36",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,8 +10,8 @@
     "./server/lib/index": "./src/server/lib/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-provider-local-core": "0.1.44",
-    "@jskit-ai/database-runtime": "0.1.141",
-    "@jskit-ai/kernel": "0.1.142"
+    "@jskit-ai/auth-provider-local-core": "0.1.45",
+    "@jskit-ai/database-runtime": "0.1.142",
+    "@jskit-ai/kernel": "0.1.143"
   }
 }

--- a/packages/auth-provider-local-db-core/package.json
+++ b/packages/auth-provider-local-db-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-local-db-core",
-  "version": "0.1.36",
+  "version": "0.1.37",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,8 +10,8 @@
     "./server/lib/index": "./src/server/lib/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-provider-local-core": "0.1.45",
-    "@jskit-ai/database-runtime": "0.1.142",
-    "@jskit-ai/kernel": "0.1.143"
+    "@jskit-ai/auth-provider-local-core": "0.1.46",
+    "@jskit-ai/database-runtime": "0.1.143",
+    "@jskit-ai/kernel": "0.1.144"
   }
 }

--- a/packages/auth-provider-local-db-core/package.json
+++ b/packages/auth-provider-local-db-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-local-db-core",
-  "version": "0.1.37",
+  "version": "0.1.38",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,8 +10,8 @@
     "./server/lib/index": "./src/server/lib/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-provider-local-core": "0.1.46",
-    "@jskit-ai/database-runtime": "0.1.143",
-    "@jskit-ai/kernel": "0.1.144"
+    "@jskit-ai/auth-provider-local-core": "0.1.47",
+    "@jskit-ai/database-runtime": "0.1.144",
+    "@jskit-ai/kernel": "0.1.145"
   }
 }

--- a/packages/auth-provider-supabase-core/package.descriptor.mjs
+++ b/packages/auth-provider-supabase-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.140",
+  "version": "0.1.141",
   "kind": "runtime",
   "options": {
     "auth-supabase-url": {
@@ -83,8 +83,8 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/auth-core": "0.1.140",
-        "@jskit-ai/kernel": "0.1.142",
+        "@jskit-ai/auth-core": "0.1.141",
+        "@jskit-ai/kernel": "0.1.143",
         "dotenv": "^16.4.5",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0"

--- a/packages/auth-provider-supabase-core/package.descriptor.mjs
+++ b/packages/auth-provider-supabase-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.142",
+  "version": "0.1.143",
   "kind": "runtime",
   "options": {
     "auth-supabase-url": {
@@ -83,8 +83,8 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/auth-core": "0.1.142",
-        "@jskit-ai/kernel": "0.1.144",
+        "@jskit-ai/auth-core": "0.1.143",
+        "@jskit-ai/kernel": "0.1.145",
         "dotenv": "^16.4.5",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0"

--- a/packages/auth-provider-supabase-core/package.descriptor.mjs
+++ b/packages/auth-provider-supabase-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.141",
+  "version": "0.1.142",
   "kind": "runtime",
   "options": {
     "auth-supabase-url": {
@@ -83,8 +83,8 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/auth-core": "0.1.141",
-        "@jskit-ai/kernel": "0.1.143",
+        "@jskit-ai/auth-core": "0.1.142",
+        "@jskit-ai/kernel": "0.1.144",
         "dotenv": "^16.4.5",
         "@supabase/supabase-js": "^2.57.4",
         "jose": "^6.1.0"

--- a/packages/auth-provider-supabase-core/package.json
+++ b/packages/auth-provider-supabase-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.141",
+  "version": "0.1.142",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,8 +12,8 @@
     "./client": "./src/client/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.141",
-    "@jskit-ai/kernel": "0.1.143",
+    "@jskit-ai/auth-core": "0.1.142",
+    "@jskit-ai/kernel": "0.1.144",
     "json-rest-schema": "1.x.x",
     "jose": "^6.1.0",
     "@supabase/supabase-js": "^2.57.4",

--- a/packages/auth-provider-supabase-core/package.json
+++ b/packages/auth-provider-supabase-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.140",
+  "version": "0.1.141",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,8 +12,8 @@
     "./client": "./src/client/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.140",
-    "@jskit-ai/kernel": "0.1.142",
+    "@jskit-ai/auth-core": "0.1.141",
+    "@jskit-ai/kernel": "0.1.143",
     "json-rest-schema": "1.x.x",
     "jose": "^6.1.0",
     "@supabase/supabase-js": "^2.57.4",

--- a/packages/auth-provider-supabase-core/package.json
+++ b/packages/auth-provider-supabase-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-provider-supabase-core",
-  "version": "0.1.142",
+  "version": "0.1.143",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,8 +12,8 @@
     "./client": "./src/client/index.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.142",
-    "@jskit-ai/kernel": "0.1.144",
+    "@jskit-ai/auth-core": "0.1.143",
+    "@jskit-ai/kernel": "0.1.145",
     "json-rest-schema": "1.x.x",
     "jose": "^6.1.0",
     "@supabase/supabase-js": "^2.57.4",

--- a/packages/auth-web/package.descriptor.mjs
+++ b/packages/auth-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-web",
-  "version": "0.1.144",
+  "version": "0.1.145",
   "kind": "runtime",
   "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
   "dependsOn": [
@@ -264,10 +264,10 @@ export default Object.freeze({
     "dependencies": {
       "runtime": {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/auth-core": "0.1.141",
-        "@jskit-ai/http-runtime": "0.1.141",
-        "@jskit-ai/kernel": "0.1.143",
-        "@jskit-ai/shell-web": "0.1.144"
+        "@jskit-ai/auth-core": "0.1.142",
+        "@jskit-ai/http-runtime": "0.1.142",
+        "@jskit-ai/kernel": "0.1.144",
+        "@jskit-ai/shell-web": "0.1.145"
       },
       "dev": {}
     },

--- a/packages/auth-web/package.descriptor.mjs
+++ b/packages/auth-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-web",
-  "version": "0.1.145",
+  "version": "0.1.146",
   "kind": "runtime",
   "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
   "dependsOn": [
@@ -264,10 +264,10 @@ export default Object.freeze({
     "dependencies": {
       "runtime": {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/auth-core": "0.1.142",
-        "@jskit-ai/http-runtime": "0.1.142",
-        "@jskit-ai/kernel": "0.1.144",
-        "@jskit-ai/shell-web": "0.1.145"
+        "@jskit-ai/auth-core": "0.1.143",
+        "@jskit-ai/http-runtime": "0.1.143",
+        "@jskit-ai/kernel": "0.1.145",
+        "@jskit-ai/shell-web": "0.1.146"
       },
       "dev": {}
     },

--- a/packages/auth-web/package.descriptor.mjs
+++ b/packages/auth-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/auth-web",
-  "version": "0.1.143",
+  "version": "0.1.144",
   "kind": "runtime",
   "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
   "dependsOn": [
@@ -264,10 +264,10 @@ export default Object.freeze({
     "dependencies": {
       "runtime": {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/auth-core": "0.1.140",
-        "@jskit-ai/http-runtime": "0.1.140",
-        "@jskit-ai/kernel": "0.1.142",
-        "@jskit-ai/shell-web": "0.1.143"
+        "@jskit-ai/auth-core": "0.1.141",
+        "@jskit-ai/http-runtime": "0.1.141",
+        "@jskit-ai/kernel": "0.1.143",
+        "@jskit-ai/shell-web": "0.1.144"
       },
       "dev": {}
     },

--- a/packages/auth-web/package.json
+++ b/packages/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-web",
-  "version": "0.1.145",
+  "version": "0.1.146",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -20,11 +20,11 @@
     "./test/playwright": "./src/test/playwright.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.142",
+    "@jskit-ai/auth-core": "0.1.143",
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/kernel": "0.1.144",
-    "@jskit-ai/shell-web": "0.1.145",
-    "@jskit-ai/http-runtime": "0.1.142"
+    "@jskit-ai/kernel": "0.1.145",
+    "@jskit-ai/shell-web": "0.1.146",
+    "@jskit-ai/http-runtime": "0.1.143"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/auth-web/package.json
+++ b/packages/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-web",
-  "version": "0.1.144",
+  "version": "0.1.145",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -20,11 +20,11 @@
     "./test/playwright": "./src/test/playwright.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.141",
+    "@jskit-ai/auth-core": "0.1.142",
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/kernel": "0.1.143",
-    "@jskit-ai/shell-web": "0.1.144",
-    "@jskit-ai/http-runtime": "0.1.141"
+    "@jskit-ai/kernel": "0.1.144",
+    "@jskit-ai/shell-web": "0.1.145",
+    "@jskit-ai/http-runtime": "0.1.142"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/auth-web/package.json
+++ b/packages/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/auth-web",
-  "version": "0.1.143",
+  "version": "0.1.144",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -20,11 +20,11 @@
     "./test/playwright": "./src/test/playwright.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.140",
+    "@jskit-ai/auth-core": "0.1.141",
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/kernel": "0.1.142",
-    "@jskit-ai/shell-web": "0.1.143",
-    "@jskit-ai/http-runtime": "0.1.140"
+    "@jskit-ai/kernel": "0.1.143",
+    "@jskit-ai/shell-web": "0.1.144",
+    "@jskit-ai/http-runtime": "0.1.141"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/console-core/package.descriptor.mjs
+++ b/packages/console-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-core",
-  version: "0.1.108",
+  version: "0.1.109",
   kind: "runtime",
   description: "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
   dependsOn: [
@@ -85,12 +85,12 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.142",
-        "@jskit-ai/database-runtime": "0.1.143",
-        "@jskit-ai/http-runtime": "0.1.142",
-        "@jskit-ai/kernel": "0.1.144",
-        "@jskit-ai/resource-crud-core": "0.1.87",
-        "@jskit-ai/users-core": "0.1.157"
+        "@jskit-ai/auth-core": "0.1.143",
+        "@jskit-ai/database-runtime": "0.1.144",
+        "@jskit-ai/http-runtime": "0.1.143",
+        "@jskit-ai/kernel": "0.1.145",
+        "@jskit-ai/resource-crud-core": "0.1.88",
+        "@jskit-ai/users-core": "0.1.158"
       },
       dev: {}
     },

--- a/packages/console-core/package.descriptor.mjs
+++ b/packages/console-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-core",
-  version: "0.1.106",
+  version: "0.1.107",
   kind: "runtime",
   description: "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
   dependsOn: [
@@ -85,12 +85,12 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.140",
-        "@jskit-ai/database-runtime": "0.1.141",
-        "@jskit-ai/http-runtime": "0.1.140",
-        "@jskit-ai/kernel": "0.1.142",
-        "@jskit-ai/resource-crud-core": "0.1.85",
-        "@jskit-ai/users-core": "0.1.155"
+        "@jskit-ai/auth-core": "0.1.141",
+        "@jskit-ai/database-runtime": "0.1.142",
+        "@jskit-ai/http-runtime": "0.1.141",
+        "@jskit-ai/kernel": "0.1.143",
+        "@jskit-ai/resource-crud-core": "0.1.86",
+        "@jskit-ai/users-core": "0.1.156"
       },
       dev: {}
     },

--- a/packages/console-core/package.descriptor.mjs
+++ b/packages/console-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-core",
-  version: "0.1.107",
+  version: "0.1.108",
   kind: "runtime",
   description: "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
   dependsOn: [
@@ -85,12 +85,12 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.141",
-        "@jskit-ai/database-runtime": "0.1.142",
-        "@jskit-ai/http-runtime": "0.1.141",
-        "@jskit-ai/kernel": "0.1.143",
-        "@jskit-ai/resource-crud-core": "0.1.86",
-        "@jskit-ai/users-core": "0.1.156"
+        "@jskit-ai/auth-core": "0.1.142",
+        "@jskit-ai/database-runtime": "0.1.143",
+        "@jskit-ai/http-runtime": "0.1.142",
+        "@jskit-ai/kernel": "0.1.144",
+        "@jskit-ai/resource-crud-core": "0.1.87",
+        "@jskit-ai/users-core": "0.1.157"
       },
       dev: {}
     },

--- a/packages/console-core/package.json
+++ b/packages/console-core/package.json
@@ -1,17 +1,17 @@
 {
   "name": "@jskit-ai/console-core",
-  "version": "0.1.108",
+  "version": "0.1.109",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.142",
-    "@jskit-ai/database-runtime": "0.1.143",
-    "@jskit-ai/http-runtime": "0.1.142",
-    "@jskit-ai/kernel": "0.1.144",
-    "@jskit-ai/resource-crud-core": "0.1.87",
-    "@jskit-ai/users-core": "0.1.157",
+    "@jskit-ai/auth-core": "0.1.143",
+    "@jskit-ai/database-runtime": "0.1.144",
+    "@jskit-ai/http-runtime": "0.1.143",
+    "@jskit-ai/kernel": "0.1.145",
+    "@jskit-ai/resource-crud-core": "0.1.88",
+    "@jskit-ai/users-core": "0.1.158",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/console-core/package.json
+++ b/packages/console-core/package.json
@@ -1,17 +1,17 @@
 {
   "name": "@jskit-ai/console-core",
-  "version": "0.1.107",
+  "version": "0.1.108",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.141",
-    "@jskit-ai/database-runtime": "0.1.142",
-    "@jskit-ai/http-runtime": "0.1.141",
-    "@jskit-ai/kernel": "0.1.143",
-    "@jskit-ai/resource-crud-core": "0.1.86",
-    "@jskit-ai/users-core": "0.1.156",
+    "@jskit-ai/auth-core": "0.1.142",
+    "@jskit-ai/database-runtime": "0.1.143",
+    "@jskit-ai/http-runtime": "0.1.142",
+    "@jskit-ai/kernel": "0.1.144",
+    "@jskit-ai/resource-crud-core": "0.1.87",
+    "@jskit-ai/users-core": "0.1.157",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/console-core/package.json
+++ b/packages/console-core/package.json
@@ -1,17 +1,17 @@
 {
   "name": "@jskit-ai/console-core",
-  "version": "0.1.106",
+  "version": "0.1.107",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.140",
-    "@jskit-ai/database-runtime": "0.1.141",
-    "@jskit-ai/http-runtime": "0.1.140",
-    "@jskit-ai/kernel": "0.1.142",
-    "@jskit-ai/resource-crud-core": "0.1.85",
-    "@jskit-ai/users-core": "0.1.155",
+    "@jskit-ai/auth-core": "0.1.141",
+    "@jskit-ai/database-runtime": "0.1.142",
+    "@jskit-ai/http-runtime": "0.1.141",
+    "@jskit-ai/kernel": "0.1.143",
+    "@jskit-ai/resource-crud-core": "0.1.86",
+    "@jskit-ai/users-core": "0.1.156",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/console-web/package.descriptor.mjs
+++ b/packages/console-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-web",
-  version: "0.1.113",
+  version: "0.1.114",
   kind: "runtime",
   description: "Authenticated console surface scaffold and surface policy wiring.",
   dependsOn: [
@@ -103,9 +103,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-web": "0.1.145",
-        "@jskit-ai/console-core": "0.1.108",
-        "@jskit-ai/shell-web": "0.1.145",
+        "@jskit-ai/auth-web": "0.1.146",
+        "@jskit-ai/console-core": "0.1.109",
+        "@jskit-ai/shell-web": "0.1.146",
       },
       dev: {}
     },

--- a/packages/console-web/package.descriptor.mjs
+++ b/packages/console-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-web",
-  version: "0.1.112",
+  version: "0.1.113",
   kind: "runtime",
   description: "Authenticated console surface scaffold and surface policy wiring.",
   dependsOn: [
@@ -103,9 +103,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-web": "0.1.144",
-        "@jskit-ai/console-core": "0.1.107",
-        "@jskit-ai/shell-web": "0.1.144",
+        "@jskit-ai/auth-web": "0.1.145",
+        "@jskit-ai/console-core": "0.1.108",
+        "@jskit-ai/shell-web": "0.1.145",
       },
       dev: {}
     },

--- a/packages/console-web/package.descriptor.mjs
+++ b/packages/console-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/console-web",
-  version: "0.1.111",
+  version: "0.1.112",
   kind: "runtime",
   description: "Authenticated console surface scaffold and surface policy wiring.",
   dependsOn: [
@@ -103,9 +103,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-web": "0.1.143",
-        "@jskit-ai/console-core": "0.1.106",
-        "@jskit-ai/shell-web": "0.1.143",
+        "@jskit-ai/auth-web": "0.1.144",
+        "@jskit-ai/console-core": "0.1.107",
+        "@jskit-ai/shell-web": "0.1.144",
       },
       dev: {}
     },

--- a/packages/console-web/package.json
+++ b/packages/console-web/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/console-web",
-  "version": "0.1.113",
+  "version": "0.1.114",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-web": "0.1.145",
-    "@jskit-ai/console-core": "0.1.108",
-    "@jskit-ai/shell-web": "0.1.145"
+    "@jskit-ai/auth-web": "0.1.146",
+    "@jskit-ai/console-core": "0.1.109",
+    "@jskit-ai/shell-web": "0.1.146"
   }
 }

--- a/packages/console-web/package.json
+++ b/packages/console-web/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/console-web",
-  "version": "0.1.111",
+  "version": "0.1.112",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-web": "0.1.143",
-    "@jskit-ai/console-core": "0.1.106",
-    "@jskit-ai/shell-web": "0.1.143"
+    "@jskit-ai/auth-web": "0.1.144",
+    "@jskit-ai/console-core": "0.1.107",
+    "@jskit-ai/shell-web": "0.1.144"
   }
 }

--- a/packages/console-web/package.json
+++ b/packages/console-web/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/console-web",
-  "version": "0.1.112",
+  "version": "0.1.113",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/auth-web": "0.1.144",
-    "@jskit-ai/console-core": "0.1.107",
-    "@jskit-ai/shell-web": "0.1.144"
+    "@jskit-ai/auth-web": "0.1.145",
+    "@jskit-ai/console-core": "0.1.108",
+    "@jskit-ai/shell-web": "0.1.145"
   }
 }

--- a/packages/crud-core/package.descriptor.mjs
+++ b/packages/crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-core",
-  version: "0.1.152",
+  version: "0.1.153",
   kind: "runtime",
   description: "Shared CRUD helpers used by CRUD modules.",
   dependsOn: [
@@ -28,7 +28,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/crud-core": "0.1.152"
+        "@jskit-ai/crud-core": "0.1.153"
       },
       dev: {}
     },

--- a/packages/crud-core/package.descriptor.mjs
+++ b/packages/crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-core",
-  version: "0.1.154",
+  version: "0.1.155",
   kind: "runtime",
   description: "Shared CRUD helpers used by CRUD modules.",
   dependsOn: [
@@ -28,7 +28,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/crud-core": "0.1.154"
+        "@jskit-ai/crud-core": "0.1.155"
       },
       dev: {}
     },

--- a/packages/crud-core/package.descriptor.mjs
+++ b/packages/crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-core",
-  version: "0.1.153",
+  version: "0.1.154",
   kind: "runtime",
   description: "Shared CRUD helpers used by CRUD modules.",
   dependsOn: [
@@ -28,7 +28,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/crud-core": "0.1.153"
+        "@jskit-ai/crud-core": "0.1.154"
       },
       dev: {}
     },

--- a/packages/crud-core/package.json
+++ b/packages/crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-core",
-  "version": "0.1.153",
+  "version": "0.1.154",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -27,15 +27,15 @@
     "./server/routeContracts": "./src/server/routeContracts.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.142",
-    "@jskit-ai/http-runtime": "0.1.141",
-    "@jskit-ai/kernel": "0.1.143",
+    "@jskit-ai/database-runtime": "0.1.143",
+    "@jskit-ai/http-runtime": "0.1.142",
+    "@jskit-ai/kernel": "0.1.144",
     "json-rest-schema": "1.x.x",
-    "@jskit-ai/realtime": "0.1.140",
-    "@jskit-ai/resource-crud-core": "0.1.86",
-    "@jskit-ai/shell-web": "0.1.144",
-    "@jskit-ai/users-core": "0.1.156",
-    "@jskit-ai/users-web": "0.1.160"
+    "@jskit-ai/realtime": "0.1.141",
+    "@jskit-ai/resource-crud-core": "0.1.87",
+    "@jskit-ai/shell-web": "0.1.145",
+    "@jskit-ai/users-core": "0.1.157",
+    "@jskit-ai/users-web": "0.1.161"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/crud-core/package.json
+++ b/packages/crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-core",
-  "version": "0.1.152",
+  "version": "0.1.153",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -27,15 +27,15 @@
     "./server/routeContracts": "./src/server/routeContracts.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.141",
-    "@jskit-ai/http-runtime": "0.1.140",
-    "@jskit-ai/kernel": "0.1.142",
+    "@jskit-ai/database-runtime": "0.1.142",
+    "@jskit-ai/http-runtime": "0.1.141",
+    "@jskit-ai/kernel": "0.1.143",
     "json-rest-schema": "1.x.x",
-    "@jskit-ai/realtime": "0.1.139",
-    "@jskit-ai/resource-crud-core": "0.1.85",
-    "@jskit-ai/shell-web": "0.1.143",
-    "@jskit-ai/users-core": "0.1.155",
-    "@jskit-ai/users-web": "0.1.159"
+    "@jskit-ai/realtime": "0.1.140",
+    "@jskit-ai/resource-crud-core": "0.1.86",
+    "@jskit-ai/shell-web": "0.1.144",
+    "@jskit-ai/users-core": "0.1.156",
+    "@jskit-ai/users-web": "0.1.160"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/crud-core/package.json
+++ b/packages/crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-core",
-  "version": "0.1.154",
+  "version": "0.1.155",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -27,15 +27,15 @@
     "./server/routeContracts": "./src/server/routeContracts.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.143",
-    "@jskit-ai/http-runtime": "0.1.142",
-    "@jskit-ai/kernel": "0.1.144",
+    "@jskit-ai/database-runtime": "0.1.144",
+    "@jskit-ai/http-runtime": "0.1.143",
+    "@jskit-ai/kernel": "0.1.145",
     "json-rest-schema": "1.x.x",
-    "@jskit-ai/realtime": "0.1.141",
-    "@jskit-ai/resource-crud-core": "0.1.87",
-    "@jskit-ai/shell-web": "0.1.145",
-    "@jskit-ai/users-core": "0.1.157",
-    "@jskit-ai/users-web": "0.1.161"
+    "@jskit-ai/realtime": "0.1.142",
+    "@jskit-ai/resource-crud-core": "0.1.88",
+    "@jskit-ai/shell-web": "0.1.146",
+    "@jskit-ai/users-core": "0.1.158",
+    "@jskit-ai/users-web": "0.1.162"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/crud-server-generator/package.descriptor.mjs
+++ b/packages/crud-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-server-generator",
-  version: "0.1.155",
+  version: "0.1.156",
   kind: "generator",
   description: "CRUD server generator with routes, actions, and persistence scaffolding.",
   options: {
@@ -184,14 +184,14 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.141",
-        "@jskit-ai/crud-core": "0.1.153",
-        "@jskit-ai/database-runtime": "0.1.142",
-        "@jskit-ai/http-runtime": "0.1.141",
-        "@jskit-ai/json-rest-api-core": "0.1.87",
-        "@jskit-ai/kernel": "0.1.143",
-        "@jskit-ai/realtime": "0.1.140",
-        "@jskit-ai/resource-crud-core": "0.1.86",
+        "@jskit-ai/auth-core": "0.1.142",
+        "@jskit-ai/crud-core": "0.1.154",
+        "@jskit-ai/database-runtime": "0.1.143",
+        "@jskit-ai/http-runtime": "0.1.142",
+        "@jskit-ai/json-rest-api-core": "0.1.88",
+        "@jskit-ai/kernel": "0.1.144",
+        "@jskit-ai/realtime": "0.1.141",
+        "@jskit-ai/resource-crud-core": "0.1.87",
         "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}"
       },
       dev: {}

--- a/packages/crud-server-generator/package.descriptor.mjs
+++ b/packages/crud-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-server-generator",
-  version: "0.1.156",
+  version: "0.1.157",
   kind: "generator",
   description: "CRUD server generator with routes, actions, and persistence scaffolding.",
   options: {
@@ -184,14 +184,14 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.142",
-        "@jskit-ai/crud-core": "0.1.154",
-        "@jskit-ai/database-runtime": "0.1.143",
-        "@jskit-ai/http-runtime": "0.1.142",
-        "@jskit-ai/json-rest-api-core": "0.1.88",
-        "@jskit-ai/kernel": "0.1.144",
-        "@jskit-ai/realtime": "0.1.141",
-        "@jskit-ai/resource-crud-core": "0.1.87",
+        "@jskit-ai/auth-core": "0.1.143",
+        "@jskit-ai/crud-core": "0.1.155",
+        "@jskit-ai/database-runtime": "0.1.144",
+        "@jskit-ai/http-runtime": "0.1.143",
+        "@jskit-ai/json-rest-api-core": "0.1.89",
+        "@jskit-ai/kernel": "0.1.145",
+        "@jskit-ai/realtime": "0.1.142",
+        "@jskit-ai/resource-crud-core": "0.1.88",
         "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}"
       },
       dev: {}

--- a/packages/crud-server-generator/package.descriptor.mjs
+++ b/packages/crud-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-server-generator",
-  version: "0.1.154",
+  version: "0.1.155",
   kind: "generator",
   description: "CRUD server generator with routes, actions, and persistence scaffolding.",
   options: {
@@ -184,14 +184,14 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.140",
-        "@jskit-ai/crud-core": "0.1.152",
-        "@jskit-ai/database-runtime": "0.1.141",
-        "@jskit-ai/http-runtime": "0.1.140",
-        "@jskit-ai/json-rest-api-core": "0.1.86",
-        "@jskit-ai/kernel": "0.1.142",
-        "@jskit-ai/realtime": "0.1.139",
-        "@jskit-ai/resource-crud-core": "0.1.85",
+        "@jskit-ai/auth-core": "0.1.141",
+        "@jskit-ai/crud-core": "0.1.153",
+        "@jskit-ai/database-runtime": "0.1.142",
+        "@jskit-ai/http-runtime": "0.1.141",
+        "@jskit-ai/json-rest-api-core": "0.1.87",
+        "@jskit-ai/kernel": "0.1.143",
+        "@jskit-ai/realtime": "0.1.140",
+        "@jskit-ai/resource-crud-core": "0.1.86",
         "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}"
       },
       dev: {}

--- a/packages/crud-server-generator/package.json
+++ b/packages/crud-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-server-generator",
-  "version": "0.1.155",
+  "version": "0.1.156",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,12 +13,12 @@
   },
   "dependencies": {
     "@babel/parser": "^7.29.2",
-    "@jskit-ai/crud-core": "0.1.153",
-    "@jskit-ai/database-runtime": "0.1.142",
-    "@jskit-ai/http-runtime": "0.1.141",
-    "@jskit-ai/json-rest-api-core": "0.1.87",
-    "@jskit-ai/kernel": "0.1.143",
-    "@jskit-ai/resource-crud-core": "0.1.86",
+    "@jskit-ai/crud-core": "0.1.154",
+    "@jskit-ai/database-runtime": "0.1.143",
+    "@jskit-ai/http-runtime": "0.1.142",
+    "@jskit-ai/json-rest-api-core": "0.1.88",
+    "@jskit-ai/kernel": "0.1.144",
+    "@jskit-ai/resource-crud-core": "0.1.87",
     "recast": "^0.23.11"
   }
 }

--- a/packages/crud-server-generator/package.json
+++ b/packages/crud-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-server-generator",
-  "version": "0.1.154",
+  "version": "0.1.155",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,12 +13,12 @@
   },
   "dependencies": {
     "@babel/parser": "^7.29.2",
-    "@jskit-ai/crud-core": "0.1.152",
-    "@jskit-ai/database-runtime": "0.1.141",
-    "@jskit-ai/http-runtime": "0.1.140",
-    "@jskit-ai/json-rest-api-core": "0.1.86",
-    "@jskit-ai/kernel": "0.1.142",
-    "@jskit-ai/resource-crud-core": "0.1.85",
+    "@jskit-ai/crud-core": "0.1.153",
+    "@jskit-ai/database-runtime": "0.1.142",
+    "@jskit-ai/http-runtime": "0.1.141",
+    "@jskit-ai/json-rest-api-core": "0.1.87",
+    "@jskit-ai/kernel": "0.1.143",
+    "@jskit-ai/resource-crud-core": "0.1.86",
     "recast": "^0.23.11"
   }
 }

--- a/packages/crud-server-generator/package.json
+++ b/packages/crud-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/crud-server-generator",
-  "version": "0.1.156",
+  "version": "0.1.157",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,12 +13,12 @@
   },
   "dependencies": {
     "@babel/parser": "^7.29.2",
-    "@jskit-ai/crud-core": "0.1.154",
-    "@jskit-ai/database-runtime": "0.1.143",
-    "@jskit-ai/http-runtime": "0.1.142",
-    "@jskit-ai/json-rest-api-core": "0.1.88",
-    "@jskit-ai/kernel": "0.1.144",
-    "@jskit-ai/resource-crud-core": "0.1.87",
+    "@jskit-ai/crud-core": "0.1.155",
+    "@jskit-ai/database-runtime": "0.1.144",
+    "@jskit-ai/http-runtime": "0.1.143",
+    "@jskit-ai/json-rest-api-core": "0.1.89",
+    "@jskit-ai/kernel": "0.1.145",
+    "@jskit-ai/resource-crud-core": "0.1.88",
     "recast": "^0.23.11"
   }
 }

--- a/packages/crud-ui-generator/package.descriptor.mjs
+++ b/packages/crud-ui-generator/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { GENERATED_UI_NAVIGATION_ROLE_OPTION } from "@jskit-ai/kernel/shared/sup
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-ui-generator",
-  version: "0.1.127",
+  version: "0.1.128",
   kind: "generator",
   description: "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
   options: {
@@ -175,7 +175,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.161"
+        "@jskit-ai/users-web": "0.1.162"
       },
       dev: {}
     },

--- a/packages/crud-ui-generator/package.descriptor.mjs
+++ b/packages/crud-ui-generator/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { GENERATED_UI_NAVIGATION_ROLE_OPTION } from "@jskit-ai/kernel/shared/sup
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-ui-generator",
-  version: "0.1.126",
+  version: "0.1.127",
   kind: "generator",
   description: "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
   options: {
@@ -175,7 +175,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.160"
+        "@jskit-ai/users-web": "0.1.161"
       },
       dev: {}
     },

--- a/packages/crud-ui-generator/package.descriptor.mjs
+++ b/packages/crud-ui-generator/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { GENERATED_UI_NAVIGATION_ROLE_OPTION } from "@jskit-ai/kernel/shared/sup
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/crud-ui-generator",
-  version: "0.1.125",
+  version: "0.1.126",
   kind: "generator",
   description: "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
   options: {
@@ -175,7 +175,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.159"
+        "@jskit-ai/users-web": "0.1.160"
       },
       dev: {}
     },

--- a/packages/crud-ui-generator/package.json
+++ b/packages/crud-ui-generator/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@jskit-ai/crud-ui-generator",
-  "version": "0.1.127",
+  "version": "0.1.128",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/crud-core": "0.1.154",
-    "@jskit-ai/kernel": "0.1.144",
-    "@jskit-ai/resource-crud-core": "0.1.87"
+    "@jskit-ai/crud-core": "0.1.155",
+    "@jskit-ai/kernel": "0.1.145",
+    "@jskit-ai/resource-crud-core": "0.1.88"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/crud-ui-generator/package.json
+++ b/packages/crud-ui-generator/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@jskit-ai/crud-ui-generator",
-  "version": "0.1.125",
+  "version": "0.1.126",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/crud-core": "0.1.152",
-    "@jskit-ai/kernel": "0.1.142",
-    "@jskit-ai/resource-crud-core": "0.1.85"
+    "@jskit-ai/crud-core": "0.1.153",
+    "@jskit-ai/kernel": "0.1.143",
+    "@jskit-ai/resource-crud-core": "0.1.86"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/crud-ui-generator/package.json
+++ b/packages/crud-ui-generator/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@jskit-ai/crud-ui-generator",
-  "version": "0.1.126",
+  "version": "0.1.127",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/crud-core": "0.1.153",
-    "@jskit-ai/kernel": "0.1.143",
-    "@jskit-ai/resource-crud-core": "0.1.86"
+    "@jskit-ai/crud-core": "0.1.154",
+    "@jskit-ai/kernel": "0.1.144",
+    "@jskit-ai/resource-crud-core": "0.1.87"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/database-runtime-mysql/package.descriptor.mjs
+++ b/packages/database-runtime-mysql/package.descriptor.mjs
@@ -13,7 +13,7 @@ const CI_DATABASE = Object.freeze({
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-mysql",
-  version: "0.1.142",
+  version: "0.1.143",
   kind: "runtime",
   options: {
     "db-host": {
@@ -133,7 +133,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.143",
+        "@jskit-ai/database-runtime": "0.1.144",
         "mysql2": "^3.11.2"
       },
       dev: {}

--- a/packages/database-runtime-mysql/package.descriptor.mjs
+++ b/packages/database-runtime-mysql/package.descriptor.mjs
@@ -13,7 +13,7 @@ const CI_DATABASE = Object.freeze({
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-mysql",
-  version: "0.1.141",
+  version: "0.1.142",
   kind: "runtime",
   options: {
     "db-host": {
@@ -133,7 +133,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.142",
+        "@jskit-ai/database-runtime": "0.1.143",
         "mysql2": "^3.11.2"
       },
       dev: {}

--- a/packages/database-runtime-mysql/package.descriptor.mjs
+++ b/packages/database-runtime-mysql/package.descriptor.mjs
@@ -13,7 +13,7 @@ const CI_DATABASE = Object.freeze({
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-mysql",
-  version: "0.1.140",
+  version: "0.1.141",
   kind: "runtime",
   options: {
     "db-host": {
@@ -133,7 +133,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.141",
+        "@jskit-ai/database-runtime": "0.1.142",
         "mysql2": "^3.11.2"
       },
       dev: {}

--- a/packages/database-runtime-mysql/package.json
+++ b/packages/database-runtime-mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-mysql",
-  "version": "0.1.142",
+  "version": "0.1.143",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,7 +12,7 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.143",
-    "@jskit-ai/kernel": "0.1.144"
+    "@jskit-ai/database-runtime": "0.1.144",
+    "@jskit-ai/kernel": "0.1.145"
   }
 }

--- a/packages/database-runtime-mysql/package.json
+++ b/packages/database-runtime-mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-mysql",
-  "version": "0.1.141",
+  "version": "0.1.142",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,7 +12,7 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.142",
-    "@jskit-ai/kernel": "0.1.143"
+    "@jskit-ai/database-runtime": "0.1.143",
+    "@jskit-ai/kernel": "0.1.144"
   }
 }

--- a/packages/database-runtime-mysql/package.json
+++ b/packages/database-runtime-mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-mysql",
-  "version": "0.1.140",
+  "version": "0.1.141",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,7 +12,7 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.141",
-    "@jskit-ai/kernel": "0.1.142"
+    "@jskit-ai/database-runtime": "0.1.142",
+    "@jskit-ai/kernel": "0.1.143"
   }
 }

--- a/packages/database-runtime-postgres/package.descriptor.mjs
+++ b/packages/database-runtime-postgres/package.descriptor.mjs
@@ -12,7 +12,7 @@ const CI_DATABASE = Object.freeze({
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-postgres",
-  version: "0.1.139",
+  version: "0.1.140",
   kind: "runtime",
   options: {
     "db-host": {
@@ -131,7 +131,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.141",
+        "@jskit-ai/database-runtime": "0.1.142",
         "pg": "^8.13.1"
       },
       dev: {}

--- a/packages/database-runtime-postgres/package.descriptor.mjs
+++ b/packages/database-runtime-postgres/package.descriptor.mjs
@@ -12,7 +12,7 @@ const CI_DATABASE = Object.freeze({
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-postgres",
-  version: "0.1.140",
+  version: "0.1.141",
   kind: "runtime",
   options: {
     "db-host": {
@@ -131,7 +131,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.142",
+        "@jskit-ai/database-runtime": "0.1.143",
         "pg": "^8.13.1"
       },
       dev: {}

--- a/packages/database-runtime-postgres/package.descriptor.mjs
+++ b/packages/database-runtime-postgres/package.descriptor.mjs
@@ -12,7 +12,7 @@ const CI_DATABASE = Object.freeze({
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime-postgres",
-  version: "0.1.141",
+  version: "0.1.142",
   kind: "runtime",
   options: {
     "db-host": {
@@ -131,7 +131,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/database-runtime": "0.1.143",
+        "@jskit-ai/database-runtime": "0.1.144",
         "pg": "^8.13.1"
       },
       dev: {}

--- a/packages/database-runtime-postgres/package.json
+++ b/packages/database-runtime-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-postgres",
-  "version": "0.1.139",
+  "version": "0.1.140",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,6 +12,6 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.141"
+    "@jskit-ai/database-runtime": "0.1.142"
   }
 }

--- a/packages/database-runtime-postgres/package.json
+++ b/packages/database-runtime-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-postgres",
-  "version": "0.1.141",
+  "version": "0.1.142",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,6 +12,6 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.143"
+    "@jskit-ai/database-runtime": "0.1.144"
   }
 }

--- a/packages/database-runtime-postgres/package.json
+++ b/packages/database-runtime-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime-postgres",
-  "version": "0.1.140",
+  "version": "0.1.141",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -12,6 +12,6 @@
     "./shared/dialect": "./src/shared/dialect.js"
   },
   "dependencies": {
-    "@jskit-ai/database-runtime": "0.1.142"
+    "@jskit-ai/database-runtime": "0.1.143"
   }
 }

--- a/packages/database-runtime/package.descriptor.mjs
+++ b/packages/database-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime",
-  version: "0.1.143",
+  version: "0.1.144",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -70,7 +70,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.144",
+        "@jskit-ai/kernel": "0.1.145",
         "dotenv": "^16.4.5",
         "knex": "^3.1.0"
       },

--- a/packages/database-runtime/package.descriptor.mjs
+++ b/packages/database-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime",
-  version: "0.1.142",
+  version: "0.1.143",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -70,7 +70,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.143",
+        "@jskit-ai/kernel": "0.1.144",
         "dotenv": "^16.4.5",
         "knex": "^3.1.0"
       },

--- a/packages/database-runtime/package.descriptor.mjs
+++ b/packages/database-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/database-runtime",
-  version: "0.1.141",
+  version: "0.1.142",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -70,7 +70,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.142",
+        "@jskit-ai/kernel": "0.1.143",
         "dotenv": "^16.4.5",
         "knex": "^3.1.0"
       },

--- a/packages/database-runtime/package.json
+++ b/packages/database-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime",
-  "version": "0.1.141",
+  "version": "0.1.142",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -25,6 +25,6 @@
     "./shared/transactions": "./src/shared/transactions.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.142"
+    "@jskit-ai/kernel": "0.1.143"
   }
 }

--- a/packages/database-runtime/package.json
+++ b/packages/database-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime",
-  "version": "0.1.142",
+  "version": "0.1.143",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -25,6 +25,6 @@
     "./shared/transactions": "./src/shared/transactions.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.143"
+    "@jskit-ai/kernel": "0.1.144"
   }
 }

--- a/packages/database-runtime/package.json
+++ b/packages/database-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/database-runtime",
-  "version": "0.1.143",
+  "version": "0.1.144",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -25,6 +25,6 @@
     "./shared/transactions": "./src/shared/transactions.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.144"
+    "@jskit-ai/kernel": "0.1.145"
   }
 }

--- a/packages/feature-server-generator/package.descriptor.mjs
+++ b/packages/feature-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/feature-server-generator",
-  version: "0.1.85",
+  version: "0.1.86",
   kind: "generator",
   description: "Scaffold substantial non-CRUD server feature packages with provider, actions, service, and optional persistence seams.",
   options: {
@@ -154,27 +154,27 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@jskit-ai/database-runtime": {
-          version: "0.1.142",
+          version: "0.1.143",
           when: {
             option: "mode",
             notEquals: "orchestrator"
           }
         },
         "@jskit-ai/database-runtime-mysql": {
-          version: "0.1.141",
+          version: "0.1.142",
           when: {
             option: "mode",
             notEquals: "orchestrator"
           }
         },
         "@jskit-ai/json-rest-api-core": {
-          version: "0.1.87",
+          version: "0.1.88",
           when: {
             option: "mode",
             equals: "json-rest"
           }
         },
-        "@jskit-ai/kernel": "0.1.143",
+        "@jskit-ai/kernel": "0.1.144",
         "json-rest-schema": "1.x.x",
         "@local/${option:feature-name|kebab}": "file:packages/${option:feature-name|kebab}"
       },

--- a/packages/feature-server-generator/package.descriptor.mjs
+++ b/packages/feature-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/feature-server-generator",
-  version: "0.1.84",
+  version: "0.1.85",
   kind: "generator",
   description: "Scaffold substantial non-CRUD server feature packages with provider, actions, service, and optional persistence seams.",
   options: {
@@ -154,27 +154,27 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@jskit-ai/database-runtime": {
-          version: "0.1.141",
+          version: "0.1.142",
           when: {
             option: "mode",
             notEquals: "orchestrator"
           }
         },
         "@jskit-ai/database-runtime-mysql": {
-          version: "0.1.140",
+          version: "0.1.141",
           when: {
             option: "mode",
             notEquals: "orchestrator"
           }
         },
         "@jskit-ai/json-rest-api-core": {
-          version: "0.1.86",
+          version: "0.1.87",
           when: {
             option: "mode",
             equals: "json-rest"
           }
         },
-        "@jskit-ai/kernel": "0.1.142",
+        "@jskit-ai/kernel": "0.1.143",
         "json-rest-schema": "1.x.x",
         "@local/${option:feature-name|kebab}": "file:packages/${option:feature-name|kebab}"
       },

--- a/packages/feature-server-generator/package.descriptor.mjs
+++ b/packages/feature-server-generator/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/feature-server-generator",
-  version: "0.1.86",
+  version: "0.1.87",
   kind: "generator",
   description: "Scaffold substantial non-CRUD server feature packages with provider, actions, service, and optional persistence seams.",
   options: {
@@ -154,27 +154,27 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@jskit-ai/database-runtime": {
-          version: "0.1.143",
+          version: "0.1.144",
           when: {
             option: "mode",
             notEquals: "orchestrator"
           }
         },
         "@jskit-ai/database-runtime-mysql": {
-          version: "0.1.142",
+          version: "0.1.143",
           when: {
             option: "mode",
             notEquals: "orchestrator"
           }
         },
         "@jskit-ai/json-rest-api-core": {
-          version: "0.1.88",
+          version: "0.1.89",
           when: {
             option: "mode",
             equals: "json-rest"
           }
         },
-        "@jskit-ai/kernel": "0.1.144",
+        "@jskit-ai/kernel": "0.1.145",
         "json-rest-schema": "1.x.x",
         "@local/${option:feature-name|kebab}": "file:packages/${option:feature-name|kebab}"
       },

--- a/packages/feature-server-generator/package.json
+++ b/packages/feature-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/feature-server-generator",
-  "version": "0.1.84",
+  "version": "0.1.85",
   "type": "module",
   "scripts": {
     "test": "node --test"

--- a/packages/feature-server-generator/package.json
+++ b/packages/feature-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/feature-server-generator",
-  "version": "0.1.85",
+  "version": "0.1.86",
   "type": "module",
   "scripts": {
     "test": "node --test"

--- a/packages/feature-server-generator/package.json
+++ b/packages/feature-server-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/feature-server-generator",
-  "version": "0.1.86",
+  "version": "0.1.87",
   "type": "module",
   "scripts": {
     "test": "node --test"

--- a/packages/google-rewarded-core/package.descriptor.mjs
+++ b/packages/google-rewarded-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/google-rewarded-core",
-  version: "0.1.79",
+  version: "0.1.80",
   kind: "runtime",
   description: "Google rewarded workflow runtime plus internal CRUD providers for rules, provider configs, watch sessions, and unlock receipts.",
   dependsOn: [
@@ -128,14 +128,14 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.140",
-        "@jskit-ai/crud-core": "0.1.152",
-        "@jskit-ai/database-runtime": "0.1.141",
-        "@jskit-ai/http-runtime": "0.1.140",
-        "@jskit-ai/json-rest-api-core": "0.1.86",
-        "@jskit-ai/kernel": "0.1.142",
-        "@jskit-ai/resource-crud-core": "0.1.85",
-        "@jskit-ai/workspaces-core": "0.1.121"
+        "@jskit-ai/auth-core": "0.1.141",
+        "@jskit-ai/crud-core": "0.1.153",
+        "@jskit-ai/database-runtime": "0.1.142",
+        "@jskit-ai/http-runtime": "0.1.141",
+        "@jskit-ai/json-rest-api-core": "0.1.87",
+        "@jskit-ai/kernel": "0.1.143",
+        "@jskit-ai/resource-crud-core": "0.1.86",
+        "@jskit-ai/workspaces-core": "0.1.122"
       },
       dev: {}
     },

--- a/packages/google-rewarded-core/package.descriptor.mjs
+++ b/packages/google-rewarded-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/google-rewarded-core",
-  version: "0.1.80",
+  version: "0.1.81",
   kind: "runtime",
   description: "Google rewarded workflow runtime plus internal CRUD providers for rules, provider configs, watch sessions, and unlock receipts.",
   dependsOn: [
@@ -128,14 +128,14 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.141",
-        "@jskit-ai/crud-core": "0.1.153",
-        "@jskit-ai/database-runtime": "0.1.142",
-        "@jskit-ai/http-runtime": "0.1.141",
-        "@jskit-ai/json-rest-api-core": "0.1.87",
-        "@jskit-ai/kernel": "0.1.143",
-        "@jskit-ai/resource-crud-core": "0.1.86",
-        "@jskit-ai/workspaces-core": "0.1.122"
+        "@jskit-ai/auth-core": "0.1.142",
+        "@jskit-ai/crud-core": "0.1.154",
+        "@jskit-ai/database-runtime": "0.1.143",
+        "@jskit-ai/http-runtime": "0.1.142",
+        "@jskit-ai/json-rest-api-core": "0.1.88",
+        "@jskit-ai/kernel": "0.1.144",
+        "@jskit-ai/resource-crud-core": "0.1.87",
+        "@jskit-ai/workspaces-core": "0.1.123"
       },
       dev: {}
     },

--- a/packages/google-rewarded-core/package.descriptor.mjs
+++ b/packages/google-rewarded-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/google-rewarded-core",
-  version: "0.1.81",
+  version: "0.1.82",
   kind: "runtime",
   description: "Google rewarded workflow runtime plus internal CRUD providers for rules, provider configs, watch sessions, and unlock receipts.",
   dependsOn: [
@@ -128,14 +128,14 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.142",
-        "@jskit-ai/crud-core": "0.1.154",
-        "@jskit-ai/database-runtime": "0.1.143",
-        "@jskit-ai/http-runtime": "0.1.142",
-        "@jskit-ai/json-rest-api-core": "0.1.88",
-        "@jskit-ai/kernel": "0.1.144",
-        "@jskit-ai/resource-crud-core": "0.1.87",
-        "@jskit-ai/workspaces-core": "0.1.123"
+        "@jskit-ai/auth-core": "0.1.143",
+        "@jskit-ai/crud-core": "0.1.155",
+        "@jskit-ai/database-runtime": "0.1.144",
+        "@jskit-ai/http-runtime": "0.1.143",
+        "@jskit-ai/json-rest-api-core": "0.1.89",
+        "@jskit-ai/kernel": "0.1.145",
+        "@jskit-ai/resource-crud-core": "0.1.88",
+        "@jskit-ai/workspaces-core": "0.1.124"
       },
       dev: {}
     },

--- a/packages/google-rewarded-core/package.json
+++ b/packages/google-rewarded-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/google-rewarded-core",
-  "version": "0.1.81",
+  "version": "0.1.82",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/google-rewarded-core/package.json
+++ b/packages/google-rewarded-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/google-rewarded-core",
-  "version": "0.1.79",
+  "version": "0.1.80",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/google-rewarded-core/package.json
+++ b/packages/google-rewarded-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/google-rewarded-core",
-  "version": "0.1.80",
+  "version": "0.1.81",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/google-rewarded-web/package.descriptor.mjs
+++ b/packages/google-rewarded-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/google-rewarded-web",
-  version: "0.1.79",
+  version: "0.1.80",
   kind: "runtime",
   description: "Google rewarded client runtime with a fullscreen gate host and GPT orchestration.",
   dependsOn: [
@@ -46,10 +46,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/google-rewarded-core": "0.1.79",
-        "@jskit-ai/http-runtime": "0.1.140",
-        "@jskit-ai/kernel": "0.1.142",
-        "@jskit-ai/shell-web": "0.1.143"
+        "@jskit-ai/google-rewarded-core": "0.1.80",
+        "@jskit-ai/http-runtime": "0.1.141",
+        "@jskit-ai/kernel": "0.1.143",
+        "@jskit-ai/shell-web": "0.1.144"
       },
       dev: {}
     },

--- a/packages/google-rewarded-web/package.descriptor.mjs
+++ b/packages/google-rewarded-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/google-rewarded-web",
-  version: "0.1.81",
+  version: "0.1.82",
   kind: "runtime",
   description: "Google rewarded client runtime with a fullscreen gate host and GPT orchestration.",
   dependsOn: [
@@ -46,10 +46,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/google-rewarded-core": "0.1.81",
-        "@jskit-ai/http-runtime": "0.1.142",
-        "@jskit-ai/kernel": "0.1.144",
-        "@jskit-ai/shell-web": "0.1.145"
+        "@jskit-ai/google-rewarded-core": "0.1.82",
+        "@jskit-ai/http-runtime": "0.1.143",
+        "@jskit-ai/kernel": "0.1.145",
+        "@jskit-ai/shell-web": "0.1.146"
       },
       dev: {}
     },

--- a/packages/google-rewarded-web/package.descriptor.mjs
+++ b/packages/google-rewarded-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/google-rewarded-web",
-  version: "0.1.80",
+  version: "0.1.81",
   kind: "runtime",
   description: "Google rewarded client runtime with a fullscreen gate host and GPT orchestration.",
   dependsOn: [
@@ -46,10 +46,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/google-rewarded-core": "0.1.80",
-        "@jskit-ai/http-runtime": "0.1.141",
-        "@jskit-ai/kernel": "0.1.143",
-        "@jskit-ai/shell-web": "0.1.144"
+        "@jskit-ai/google-rewarded-core": "0.1.81",
+        "@jskit-ai/http-runtime": "0.1.142",
+        "@jskit-ai/kernel": "0.1.144",
+        "@jskit-ai/shell-web": "0.1.145"
       },
       dev: {}
     },

--- a/packages/google-rewarded-web/package.json
+++ b/packages/google-rewarded-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/google-rewarded-web",
-  "version": "0.1.80",
+  "version": "0.1.81",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/google-rewarded-web/package.json
+++ b/packages/google-rewarded-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/google-rewarded-web",
-  "version": "0.1.79",
+  "version": "0.1.80",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/google-rewarded-web/package.json
+++ b/packages/google-rewarded-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/google-rewarded-web",
-  "version": "0.1.81",
+  "version": "0.1.82",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/http-runtime/package.descriptor.mjs
+++ b/packages/http-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/http-runtime",
-  "version": "0.1.141",
+  "version": "0.1.142",
   "kind": "runtime",
   "dependsOn": [],
   "capabilities": {
@@ -67,7 +67,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.143"
+        "@jskit-ai/kernel": "0.1.144"
       },
       "dev": {}
     },

--- a/packages/http-runtime/package.descriptor.mjs
+++ b/packages/http-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/http-runtime",
-  "version": "0.1.142",
+  "version": "0.1.143",
   "kind": "runtime",
   "dependsOn": [],
   "capabilities": {
@@ -67,7 +67,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.144"
+        "@jskit-ai/kernel": "0.1.145"
       },
       "dev": {}
     },

--- a/packages/http-runtime/package.descriptor.mjs
+++ b/packages/http-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/http-runtime",
-  "version": "0.1.140",
+  "version": "0.1.141",
   "kind": "runtime",
   "dependsOn": [],
   "capabilities": {
@@ -67,7 +67,7 @@ export default Object.freeze({
   "mutations": {
     "dependencies": {
       "runtime": {
-        "@jskit-ai/kernel": "0.1.142"
+        "@jskit-ai/kernel": "0.1.143"
       },
       "dev": {}
     },

--- a/packages/http-runtime/package.json
+++ b/packages/http-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/http-runtime",
-  "version": "0.1.141",
+  "version": "0.1.142",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -18,7 +18,7 @@
     "./shared/validators/operationValidation": "./src/shared/validators/operationValidation.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.143",
+    "@jskit-ai/kernel": "0.1.144",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/http-runtime/package.json
+++ b/packages/http-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/http-runtime",
-  "version": "0.1.142",
+  "version": "0.1.143",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -18,7 +18,7 @@
     "./shared/validators/operationValidation": "./src/shared/validators/operationValidation.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.144",
+    "@jskit-ai/kernel": "0.1.145",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/http-runtime/package.json
+++ b/packages/http-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/http-runtime",
-  "version": "0.1.140",
+  "version": "0.1.141",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -18,7 +18,7 @@
     "./shared/validators/operationValidation": "./src/shared/validators/operationValidation.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.142",
+    "@jskit-ai/kernel": "0.1.143",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/json-rest-api-core/package.descriptor.mjs
+++ b/packages/json-rest-api-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/json-rest-api-core",
-  version: "0.1.87",
+  version: "0.1.88",
   kind: "runtime",
   description: "Shared internal json-rest-api host runtime with autofilter, query-projection, and row-policy support.",
   dependsOn: [

--- a/packages/json-rest-api-core/package.descriptor.mjs
+++ b/packages/json-rest-api-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/json-rest-api-core",
-  version: "0.1.88",
+  version: "0.1.89",
   kind: "runtime",
   description: "Shared internal json-rest-api host runtime with autofilter, query-projection, and row-policy support.",
   dependsOn: [

--- a/packages/json-rest-api-core/package.descriptor.mjs
+++ b/packages/json-rest-api-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/json-rest-api-core",
-  version: "0.1.86",
+  version: "0.1.87",
   kind: "runtime",
   description: "Shared internal json-rest-api host runtime with autofilter, query-projection, and row-policy support.",
   dependsOn: [

--- a/packages/json-rest-api-core/package.json
+++ b/packages/json-rest-api-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/json-rest-api-core",
-  "version": "0.1.88",
+  "version": "0.1.89",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,6 +11,6 @@
   "dependencies": {
     "hooked-api": "1.x.x",
     "json-rest-api": "^1.0.27",
-    "@jskit-ai/kernel": "0.1.144"
+    "@jskit-ai/kernel": "0.1.145"
   }
 }

--- a/packages/json-rest-api-core/package.json
+++ b/packages/json-rest-api-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/json-rest-api-core",
-  "version": "0.1.87",
+  "version": "0.1.88",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,6 +11,6 @@
   "dependencies": {
     "hooked-api": "1.x.x",
     "json-rest-api": "^1.0.27",
-    "@jskit-ai/kernel": "0.1.143"
+    "@jskit-ai/kernel": "0.1.144"
   }
 }

--- a/packages/json-rest-api-core/package.json
+++ b/packages/json-rest-api-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/json-rest-api-core",
-  "version": "0.1.86",
+  "version": "0.1.87",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,6 +11,6 @@
   "dependencies": {
     "hooked-api": "1.x.x",
     "json-rest-api": "^1.0.27",
-    "@jskit-ai/kernel": "0.1.142"
+    "@jskit-ai/kernel": "0.1.143"
   }
 }

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/kernel",
-  "version": "0.1.143",
+  "version": "0.1.144",
   "type": "module",
   "dependencies": {
     "json-rest-schema": "1.x.x"

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/kernel",
-  "version": "0.1.144",
+  "version": "0.1.145",
   "type": "module",
   "dependencies": {
     "json-rest-schema": "1.x.x"

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/kernel",
-  "version": "0.1.142",
+  "version": "0.1.143",
   "type": "module",
   "dependencies": {
     "json-rest-schema": "1.x.x"

--- a/packages/mobile-capacitor/package.descriptor.mjs
+++ b/packages/mobile-capacitor/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/mobile-capacitor",
-  version: "0.1.80",
+  version: "0.1.81",
   kind: "runtime",
   description: "Thin Capacitor client integration for JSKIT mobile-shell launch routing and auth callback completion.",
   dependsOn: [
@@ -62,8 +62,8 @@ export default Object.freeze({
         "@capacitor/app": "^7.1.0",
         "@capacitor/browser": "^7.0.1",
         "@capacitor/core": "^7.4.3",
-        "@jskit-ai/kernel": "0.1.144",
-        "@jskit-ai/shell-web": "0.1.145"
+        "@jskit-ai/kernel": "0.1.145",
+        "@jskit-ai/shell-web": "0.1.146"
       },
       dev: {
         "@capacitor/cli": "^7.4.3"

--- a/packages/mobile-capacitor/package.descriptor.mjs
+++ b/packages/mobile-capacitor/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/mobile-capacitor",
-  version: "0.1.79",
+  version: "0.1.80",
   kind: "runtime",
   description: "Thin Capacitor client integration for JSKIT mobile-shell launch routing and auth callback completion.",
   dependsOn: [
@@ -62,8 +62,8 @@ export default Object.freeze({
         "@capacitor/app": "^7.1.0",
         "@capacitor/browser": "^7.0.1",
         "@capacitor/core": "^7.4.3",
-        "@jskit-ai/kernel": "0.1.143",
-        "@jskit-ai/shell-web": "0.1.144"
+        "@jskit-ai/kernel": "0.1.144",
+        "@jskit-ai/shell-web": "0.1.145"
       },
       dev: {
         "@capacitor/cli": "^7.4.3"

--- a/packages/mobile-capacitor/package.descriptor.mjs
+++ b/packages/mobile-capacitor/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/mobile-capacitor",
-  version: "0.1.78",
+  version: "0.1.79",
   kind: "runtime",
   description: "Thin Capacitor client integration for JSKIT mobile-shell launch routing and auth callback completion.",
   dependsOn: [
@@ -62,8 +62,8 @@ export default Object.freeze({
         "@capacitor/app": "^7.1.0",
         "@capacitor/browser": "^7.0.1",
         "@capacitor/core": "^7.4.3",
-        "@jskit-ai/kernel": "0.1.142",
-        "@jskit-ai/shell-web": "0.1.143"
+        "@jskit-ai/kernel": "0.1.143",
+        "@jskit-ai/shell-web": "0.1.144"
       },
       dev: {
         "@capacitor/cli": "^7.4.3"

--- a/packages/mobile-capacitor/package.json
+++ b/packages/mobile-capacitor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/mobile-capacitor",
-  "version": "0.1.80",
+  "version": "0.1.81",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,6 +13,6 @@
   "dependencies": {
     "@capacitor/browser": "^7.0.1",
     "@capacitor/core": "^7.4.3",
-    "@jskit-ai/kernel": "0.1.144"
+    "@jskit-ai/kernel": "0.1.145"
   }
 }

--- a/packages/mobile-capacitor/package.json
+++ b/packages/mobile-capacitor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/mobile-capacitor",
-  "version": "0.1.79",
+  "version": "0.1.80",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,6 +13,6 @@
   "dependencies": {
     "@capacitor/browser": "^7.0.1",
     "@capacitor/core": "^7.4.3",
-    "@jskit-ai/kernel": "0.1.143"
+    "@jskit-ai/kernel": "0.1.144"
   }
 }

--- a/packages/mobile-capacitor/package.json
+++ b/packages/mobile-capacitor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/mobile-capacitor",
-  "version": "0.1.78",
+  "version": "0.1.79",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,6 +13,6 @@
   "dependencies": {
     "@capacitor/browser": "^7.0.1",
     "@capacitor/core": "^7.4.3",
-    "@jskit-ai/kernel": "0.1.142"
+    "@jskit-ai/kernel": "0.1.143"
   }
 }

--- a/packages/realtime/package.descriptor.mjs
+++ b/packages/realtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/realtime",
-  version: "0.1.139",
+  version: "0.1.140",
   kind: "runtime",
   description: "Thin, generic realtime runtime wrappers for socket.io server and client.",
   options: {
@@ -95,7 +95,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.142",
+        "@jskit-ai/kernel": "0.1.143",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",

--- a/packages/realtime/package.descriptor.mjs
+++ b/packages/realtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/realtime",
-  version: "0.1.141",
+  version: "0.1.142",
   kind: "runtime",
   description: "Thin, generic realtime runtime wrappers for socket.io server and client.",
   options: {
@@ -95,7 +95,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.144",
+        "@jskit-ai/kernel": "0.1.145",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",

--- a/packages/realtime/package.descriptor.mjs
+++ b/packages/realtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/realtime",
-  version: "0.1.140",
+  version: "0.1.141",
   kind: "runtime",
   description: "Thin, generic realtime runtime wrappers for socket.io server and client.",
   options: {
@@ -95,7 +95,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.143",
+        "@jskit-ai/kernel": "0.1.144",
         "@socket.io/redis-adapter": "^8.3.0",
         "redis": "^5.8.2",
         "socket.io": "^4.8.3",

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/realtime",
-  "version": "0.1.139",
+  "version": "0.1.140",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@socket.io/redis-adapter": "^8.3.0",
-    "@jskit-ai/kernel": "0.1.142",
+    "@jskit-ai/kernel": "0.1.143",
     "redis": "^5.8.2",
     "socket.io": "^4.8.3",
     "socket.io-client": "^4.8.3"

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/realtime",
-  "version": "0.1.141",
+  "version": "0.1.142",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@socket.io/redis-adapter": "^8.3.0",
-    "@jskit-ai/kernel": "0.1.144",
+    "@jskit-ai/kernel": "0.1.145",
     "redis": "^5.8.2",
     "socket.io": "^4.8.3",
     "socket.io-client": "^4.8.3"

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/realtime",
-  "version": "0.1.140",
+  "version": "0.1.141",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@socket.io/redis-adapter": "^8.3.0",
-    "@jskit-ai/kernel": "0.1.143",
+    "@jskit-ai/kernel": "0.1.144",
     "redis": "^5.8.2",
     "socket.io": "^4.8.3",
     "socket.io-client": "^4.8.3"

--- a/packages/resource-core/package.descriptor.mjs
+++ b/packages/resource-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/resource-core",
-  version: "0.1.85",
+  version: "0.1.86",
   kind: "runtime",
   description: "Generic resource-definition helpers and schema-definition normalization.",
   dependsOn: [
@@ -22,7 +22,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/resource-core": "0.1.85"
+        "@jskit-ai/resource-core": "0.1.86"
       },
       dev: {}
     },

--- a/packages/resource-core/package.descriptor.mjs
+++ b/packages/resource-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/resource-core",
-  version: "0.1.86",
+  version: "0.1.87",
   kind: "runtime",
   description: "Generic resource-definition helpers and schema-definition normalization.",
   dependsOn: [
@@ -22,7 +22,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/resource-core": "0.1.86"
+        "@jskit-ai/resource-core": "0.1.87"
       },
       dev: {}
     },

--- a/packages/resource-core/package.descriptor.mjs
+++ b/packages/resource-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/resource-core",
-  version: "0.1.87",
+  version: "0.1.88",
   kind: "runtime",
   description: "Generic resource-definition helpers and schema-definition normalization.",
   dependsOn: [
@@ -22,7 +22,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/resource-core": "0.1.87"
+        "@jskit-ai/resource-core": "0.1.88"
       },
       dev: {}
     },

--- a/packages/resource-core/package.json
+++ b/packages/resource-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/resource-core",
-  "version": "0.1.86",
+  "version": "0.1.87",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./shared/resource": "./src/shared/resource.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.143"
+    "@jskit-ai/kernel": "0.1.144"
   }
 }

--- a/packages/resource-core/package.json
+++ b/packages/resource-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/resource-core",
-  "version": "0.1.87",
+  "version": "0.1.88",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./shared/resource": "./src/shared/resource.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.144"
+    "@jskit-ai/kernel": "0.1.145"
   }
 }

--- a/packages/resource-core/package.json
+++ b/packages/resource-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/resource-core",
-  "version": "0.1.85",
+  "version": "0.1.86",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -9,6 +9,6 @@
     "./shared/resource": "./src/shared/resource.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.142"
+    "@jskit-ai/kernel": "0.1.143"
   }
 }

--- a/packages/resource-crud-core/package.descriptor.mjs
+++ b/packages/resource-crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/resource-crud-core",
-  version: "0.1.86",
+  version: "0.1.87",
   kind: "runtime",
   description: "CRUD-specific resource-definition helpers and namespace support.",
   dependsOn: [
@@ -23,7 +23,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/resource-crud-core": "0.1.86"
+        "@jskit-ai/resource-crud-core": "0.1.87"
       },
       dev: {}
     },

--- a/packages/resource-crud-core/package.descriptor.mjs
+++ b/packages/resource-crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/resource-crud-core",
-  version: "0.1.85",
+  version: "0.1.86",
   kind: "runtime",
   description: "CRUD-specific resource-definition helpers and namespace support.",
   dependsOn: [
@@ -23,7 +23,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/resource-crud-core": "0.1.85"
+        "@jskit-ai/resource-crud-core": "0.1.86"
       },
       dev: {}
     },

--- a/packages/resource-crud-core/package.descriptor.mjs
+++ b/packages/resource-crud-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/resource-crud-core",
-  version: "0.1.87",
+  version: "0.1.88",
   kind: "runtime",
   description: "CRUD-specific resource-definition helpers and namespace support.",
   dependsOn: [
@@ -23,7 +23,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/resource-crud-core": "0.1.87"
+        "@jskit-ai/resource-crud-core": "0.1.88"
       },
       dev: {}
     },

--- a/packages/resource-crud-core/package.json
+++ b/packages/resource-crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/resource-crud-core",
-  "version": "0.1.86",
+  "version": "0.1.87",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./shared/crudResource": "./src/shared/crudResource.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.143",
-    "@jskit-ai/resource-core": "0.1.86"
+    "@jskit-ai/kernel": "0.1.144",
+    "@jskit-ai/resource-core": "0.1.87"
   }
 }

--- a/packages/resource-crud-core/package.json
+++ b/packages/resource-crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/resource-crud-core",
-  "version": "0.1.87",
+  "version": "0.1.88",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./shared/crudResource": "./src/shared/crudResource.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.144",
-    "@jskit-ai/resource-core": "0.1.87"
+    "@jskit-ai/kernel": "0.1.145",
+    "@jskit-ai/resource-core": "0.1.88"
   }
 }

--- a/packages/resource-crud-core/package.json
+++ b/packages/resource-crud-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/resource-crud-core",
-  "version": "0.1.85",
+  "version": "0.1.86",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./shared/crudResource": "./src/shared/crudResource.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.142",
-    "@jskit-ai/resource-core": "0.1.85"
+    "@jskit-ai/kernel": "0.1.143",
+    "@jskit-ai/resource-core": "0.1.86"
   }
 }

--- a/packages/shell-web/package.descriptor.mjs
+++ b/packages/shell-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/shell-web",
-  version: "0.1.143",
+  version: "0.1.144",
   kind: "runtime",
   description: "Web shell layout runtime with outlet-based placement contributions.",
   dependsOn: [],
@@ -311,7 +311,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/kernel": "0.1.142"
+        "@jskit-ai/kernel": "0.1.143"
       },
       dev: {
         "@playwright/test": "1.61.1"

--- a/packages/shell-web/package.descriptor.mjs
+++ b/packages/shell-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/shell-web",
-  version: "0.1.144",
+  version: "0.1.145",
   kind: "runtime",
   description: "Web shell layout runtime with outlet-based placement contributions.",
   dependsOn: [],
@@ -311,7 +311,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/kernel": "0.1.143"
+        "@jskit-ai/kernel": "0.1.144"
       },
       dev: {
         "@playwright/test": "1.61.1"

--- a/packages/shell-web/package.descriptor.mjs
+++ b/packages/shell-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/shell-web",
-  version: "0.1.145",
+  version: "0.1.146",
   kind: "runtime",
   description: "Web shell layout runtime with outlet-based placement contributions.",
   dependsOn: [],
@@ -311,7 +311,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/kernel": "0.1.144"
+        "@jskit-ai/kernel": "0.1.145"
       },
       dev: {
         "@playwright/test": "1.61.1"

--- a/packages/shell-web/package.json
+++ b/packages/shell-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/shell-web",
-  "version": "0.1.144",
+  "version": "0.1.145",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/kernel": "0.1.143"
+    "@jskit-ai/kernel": "0.1.144"
   },
   "peerDependencies": {
     "pinia": "^3.0.4",

--- a/packages/shell-web/package.json
+++ b/packages/shell-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/shell-web",
-  "version": "0.1.143",
+  "version": "0.1.144",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/kernel": "0.1.142"
+    "@jskit-ai/kernel": "0.1.143"
   },
   "peerDependencies": {
     "pinia": "^3.0.4",

--- a/packages/shell-web/package.json
+++ b/packages/shell-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/shell-web",
-  "version": "0.1.145",
+  "version": "0.1.146",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/kernel": "0.1.144"
+    "@jskit-ai/kernel": "0.1.145"
   },
   "peerDependencies": {
     "pinia": "^3.0.4",

--- a/packages/storage-runtime/package.descriptor.mjs
+++ b/packages/storage-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/storage-runtime",
-  version: "0.1.141",
+  version: "0.1.142",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -50,7 +50,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.143",
+        "@jskit-ai/kernel": "0.1.144",
         "unstorage": "^1.17.3"
       },
       dev: {}

--- a/packages/storage-runtime/package.descriptor.mjs
+++ b/packages/storage-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/storage-runtime",
-  version: "0.1.140",
+  version: "0.1.141",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -50,7 +50,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.142",
+        "@jskit-ai/kernel": "0.1.143",
         "unstorage": "^1.17.3"
       },
       dev: {}

--- a/packages/storage-runtime/package.descriptor.mjs
+++ b/packages/storage-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/storage-runtime",
-  version: "0.1.142",
+  version: "0.1.143",
   kind: "runtime",
   dependsOn: [
     "@jskit-ai/kernel"
@@ -50,7 +50,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/kernel": "0.1.144",
+        "@jskit-ai/kernel": "0.1.145",
         "unstorage": "^1.17.3"
       },
       dev: {}

--- a/packages/storage-runtime/package.json
+++ b/packages/storage-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/storage-runtime",
-  "version": "0.1.140",
+  "version": "0.1.141",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./server/providers/StorageRuntimeServiceProvider": "./src/server/providers/StorageRuntimeServiceProvider.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.142",
+    "@jskit-ai/kernel": "0.1.143",
     "unstorage": "^1.17.5"
   }
 }

--- a/packages/storage-runtime/package.json
+++ b/packages/storage-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/storage-runtime",
-  "version": "0.1.141",
+  "version": "0.1.142",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./server/providers/StorageRuntimeServiceProvider": "./src/server/providers/StorageRuntimeServiceProvider.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.143",
+    "@jskit-ai/kernel": "0.1.144",
     "unstorage": "^1.17.5"
   }
 }

--- a/packages/storage-runtime/package.json
+++ b/packages/storage-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/storage-runtime",
-  "version": "0.1.142",
+  "version": "0.1.143",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -10,7 +10,7 @@
     "./server/providers/StorageRuntimeServiceProvider": "./src/server/providers/StorageRuntimeServiceProvider.js"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.144",
+    "@jskit-ai/kernel": "0.1.145",
     "unstorage": "^1.17.5"
   }
 }

--- a/packages/ui-generator/package.descriptor.mjs
+++ b/packages/ui-generator/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { GENERATED_UI_NAVIGATION_ROLE_OPTION } from "@jskit-ai/kernel/shared/sup
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/ui-generator",
-  version: "0.1.126",
+  version: "0.1.127",
   kind: "generator",
   description: "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
   options: {
@@ -371,7 +371,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.160"
+        "@jskit-ai/users-web": "0.1.161"
       },
       dev: {}
     },

--- a/packages/ui-generator/package.descriptor.mjs
+++ b/packages/ui-generator/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { GENERATED_UI_NAVIGATION_ROLE_OPTION } from "@jskit-ai/kernel/shared/sup
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/ui-generator",
-  version: "0.1.127",
+  version: "0.1.128",
   kind: "generator",
   description: "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
   options: {
@@ -371,7 +371,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.161"
+        "@jskit-ai/users-web": "0.1.162"
       },
       dev: {}
     },

--- a/packages/ui-generator/package.descriptor.mjs
+++ b/packages/ui-generator/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { GENERATED_UI_NAVIGATION_ROLE_OPTION } from "@jskit-ai/kernel/shared/sup
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/ui-generator",
-  version: "0.1.125",
+  version: "0.1.126",
   kind: "generator",
   description: "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
   options: {
@@ -371,7 +371,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/users-web": "0.1.159"
+        "@jskit-ai/users-web": "0.1.160"
       },
       dev: {}
     },

--- a/packages/ui-generator/package.json
+++ b/packages/ui-generator/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/ui-generator",
-  "version": "0.1.126",
+  "version": "0.1.127",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.143",
-    "@jskit-ai/shell-web": "0.1.144"
+    "@jskit-ai/kernel": "0.1.144",
+    "@jskit-ai/shell-web": "0.1.145"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/ui-generator/package.json
+++ b/packages/ui-generator/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/ui-generator",
-  "version": "0.1.127",
+  "version": "0.1.128",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.144",
-    "@jskit-ai/shell-web": "0.1.145"
+    "@jskit-ai/kernel": "0.1.145",
+    "@jskit-ai/shell-web": "0.1.146"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/ui-generator/package.json
+++ b/packages/ui-generator/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jskit-ai/ui-generator",
-  "version": "0.1.125",
+  "version": "0.1.126",
   "type": "module",
   "scripts": {
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/kernel": "0.1.142",
-    "@jskit-ai/shell-web": "0.1.143"
+    "@jskit-ai/kernel": "0.1.143",
+    "@jskit-ai/shell-web": "0.1.144"
   },
   "exports": {
     "./server/buildTemplateContext": "./src/server/buildTemplateContext.js"

--- a/packages/uploads-image-web/package.descriptor.mjs
+++ b/packages/uploads-image-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-image-web",
-  version: "0.1.120",
+  version: "0.1.121",
   kind: "runtime",
   description: "Reusable client-side image upload runtime with pre-upload image editing.",
   dependsOn: [
@@ -65,7 +65,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/uploads-runtime": "0.1.120",
+        "@jskit-ai/uploads-runtime": "0.1.121",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-image-web/package.descriptor.mjs
+++ b/packages/uploads-image-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-image-web",
-  version: "0.1.119",
+  version: "0.1.120",
   kind: "runtime",
   description: "Reusable client-side image upload runtime with pre-upload image editing.",
   dependsOn: [
@@ -65,7 +65,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/uploads-runtime": "0.1.119",
+        "@jskit-ai/uploads-runtime": "0.1.120",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-image-web/package.descriptor.mjs
+++ b/packages/uploads-image-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-image-web",
-  version: "0.1.118",
+  version: "0.1.119",
   kind: "runtime",
   description: "Reusable client-side image upload runtime with pre-upload image editing.",
   dependsOn: [
@@ -65,7 +65,7 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/uploads-runtime": "0.1.118",
+        "@jskit-ai/uploads-runtime": "0.1.119",
         "@uppy/compressor": "^3.1.0",
         "@uppy/core": "^5.2.0",
         "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-image-web/package.json
+++ b/packages/uploads-image-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-image-web",
-  "version": "0.1.119",
+  "version": "0.1.120",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,7 +13,7 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/uploads-runtime": "0.1.119",
+    "@jskit-ai/uploads-runtime": "0.1.120",
     "@uppy/compressor": "^3.1.0",
     "@uppy/core": "^5.2.0",
     "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-image-web/package.json
+++ b/packages/uploads-image-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-image-web",
-  "version": "0.1.118",
+  "version": "0.1.119",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,7 +13,7 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/uploads-runtime": "0.1.118",
+    "@jskit-ai/uploads-runtime": "0.1.119",
     "@uppy/compressor": "^3.1.0",
     "@uppy/core": "^5.2.0",
     "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-image-web/package.json
+++ b/packages/uploads-image-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-image-web",
-  "version": "0.1.120",
+  "version": "0.1.121",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -13,7 +13,7 @@
     "./shared": "./src/shared/index.js"
   },
   "dependencies": {
-    "@jskit-ai/uploads-runtime": "0.1.120",
+    "@jskit-ai/uploads-runtime": "0.1.121",
     "@uppy/compressor": "^3.1.0",
     "@uppy/core": "^5.2.0",
     "@uppy/dashboard": "^5.1.1",

--- a/packages/uploads-runtime/package.descriptor.mjs
+++ b/packages/uploads-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-runtime",
-  version: "0.1.118",
+  version: "0.1.119",
   kind: "runtime",
   description: "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
   dependsOn: [
@@ -71,7 +71,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.142"
+        "@jskit-ai/kernel": "0.1.143"
       },
       dev: {}
     },

--- a/packages/uploads-runtime/package.descriptor.mjs
+++ b/packages/uploads-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-runtime",
-  version: "0.1.120",
+  version: "0.1.121",
   kind: "runtime",
   description: "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
   dependsOn: [
@@ -71,7 +71,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.144"
+        "@jskit-ai/kernel": "0.1.145"
       },
       dev: {}
     },

--- a/packages/uploads-runtime/package.descriptor.mjs
+++ b/packages/uploads-runtime/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/uploads-runtime",
-  version: "0.1.119",
+  version: "0.1.120",
   kind: "runtime",
   description: "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
   dependsOn: [
@@ -71,7 +71,7 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@fastify/multipart": "^9.4.0",
-        "@jskit-ai/kernel": "0.1.143"
+        "@jskit-ai/kernel": "0.1.144"
       },
       dev: {}
     },

--- a/packages/uploads-runtime/package.json
+++ b/packages/uploads-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-runtime",
-  "version": "0.1.120",
+  "version": "0.1.121",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,6 +16,6 @@
   },
   "dependencies": {
     "@fastify/multipart": "^9.4.0",
-    "@jskit-ai/kernel": "0.1.144"
+    "@jskit-ai/kernel": "0.1.145"
   }
 }

--- a/packages/uploads-runtime/package.json
+++ b/packages/uploads-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-runtime",
-  "version": "0.1.118",
+  "version": "0.1.119",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,6 +16,6 @@
   },
   "dependencies": {
     "@fastify/multipart": "^9.4.0",
-    "@jskit-ai/kernel": "0.1.142"
+    "@jskit-ai/kernel": "0.1.143"
   }
 }

--- a/packages/uploads-runtime/package.json
+++ b/packages/uploads-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/uploads-runtime",
-  "version": "0.1.119",
+  "version": "0.1.120",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -16,6 +16,6 @@
   },
   "dependencies": {
     "@fastify/multipart": "^9.4.0",
-    "@jskit-ai/kernel": "0.1.143"
+    "@jskit-ai/kernel": "0.1.144"
   }
 }

--- a/packages/users-core/package.descriptor.mjs
+++ b/packages/users-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-core",
-  version: "0.1.156",
+  version: "0.1.157",
   kind: "runtime",
   description: "Users/account runtime plus HTTP routes for account features.",
   dependsOn: [
@@ -146,16 +146,16 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.141",
-        "@jskit-ai/crud-core": "0.1.153",
-        "@jskit-ai/database-runtime": "0.1.142",
-        "@jskit-ai/http-runtime": "0.1.141",
-        "@jskit-ai/json-rest-api-core": "0.1.87",
-        "@jskit-ai/kernel": "0.1.143",
-        "@jskit-ai/resource-core": "0.1.86",
-        "@jskit-ai/resource-crud-core": "0.1.86",
+        "@jskit-ai/auth-core": "0.1.142",
+        "@jskit-ai/crud-core": "0.1.154",
+        "@jskit-ai/database-runtime": "0.1.143",
+        "@jskit-ai/http-runtime": "0.1.142",
+        "@jskit-ai/json-rest-api-core": "0.1.88",
+        "@jskit-ai/kernel": "0.1.144",
+        "@jskit-ai/resource-core": "0.1.87",
+        "@jskit-ai/resource-crud-core": "0.1.87",
         "@local/users": "file:packages/users",
-        "@jskit-ai/uploads-runtime": "0.1.119"
+        "@jskit-ai/uploads-runtime": "0.1.120"
       },
       dev: {}
     },

--- a/packages/users-core/package.descriptor.mjs
+++ b/packages/users-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-core",
-  version: "0.1.157",
+  version: "0.1.158",
   kind: "runtime",
   description: "Users/account runtime plus HTTP routes for account features.",
   dependsOn: [
@@ -146,16 +146,16 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.142",
-        "@jskit-ai/crud-core": "0.1.154",
-        "@jskit-ai/database-runtime": "0.1.143",
-        "@jskit-ai/http-runtime": "0.1.142",
-        "@jskit-ai/json-rest-api-core": "0.1.88",
-        "@jskit-ai/kernel": "0.1.144",
-        "@jskit-ai/resource-core": "0.1.87",
-        "@jskit-ai/resource-crud-core": "0.1.87",
+        "@jskit-ai/auth-core": "0.1.143",
+        "@jskit-ai/crud-core": "0.1.155",
+        "@jskit-ai/database-runtime": "0.1.144",
+        "@jskit-ai/http-runtime": "0.1.143",
+        "@jskit-ai/json-rest-api-core": "0.1.89",
+        "@jskit-ai/kernel": "0.1.145",
+        "@jskit-ai/resource-core": "0.1.88",
+        "@jskit-ai/resource-crud-core": "0.1.88",
         "@local/users": "file:packages/users",
-        "@jskit-ai/uploads-runtime": "0.1.120"
+        "@jskit-ai/uploads-runtime": "0.1.121"
       },
       dev: {}
     },

--- a/packages/users-core/package.descriptor.mjs
+++ b/packages/users-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-core",
-  version: "0.1.155",
+  version: "0.1.156",
   kind: "runtime",
   description: "Users/account runtime plus HTTP routes for account features.",
   dependsOn: [
@@ -146,16 +146,16 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-core": "0.1.140",
-        "@jskit-ai/crud-core": "0.1.152",
-        "@jskit-ai/database-runtime": "0.1.141",
-        "@jskit-ai/http-runtime": "0.1.140",
-        "@jskit-ai/json-rest-api-core": "0.1.86",
-        "@jskit-ai/kernel": "0.1.142",
-        "@jskit-ai/resource-core": "0.1.85",
-        "@jskit-ai/resource-crud-core": "0.1.85",
+        "@jskit-ai/auth-core": "0.1.141",
+        "@jskit-ai/crud-core": "0.1.153",
+        "@jskit-ai/database-runtime": "0.1.142",
+        "@jskit-ai/http-runtime": "0.1.141",
+        "@jskit-ai/json-rest-api-core": "0.1.87",
+        "@jskit-ai/kernel": "0.1.143",
+        "@jskit-ai/resource-core": "0.1.86",
+        "@jskit-ai/resource-crud-core": "0.1.86",
         "@local/users": "file:packages/users",
-        "@jskit-ai/uploads-runtime": "0.1.118"
+        "@jskit-ai/uploads-runtime": "0.1.119"
       },
       dev: {}
     },

--- a/packages/users-core/package.json
+++ b/packages/users-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-core",
-  "version": "0.1.157",
+  "version": "0.1.158",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,14 +11,14 @@
     "./shared/resources/userSettingsResource": "./src/shared/resources/userSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.142",
-    "@jskit-ai/database-runtime": "0.1.143",
-    "@jskit-ai/http-runtime": "0.1.142",
-    "@jskit-ai/json-rest-api-core": "0.1.88",
-    "@jskit-ai/kernel": "0.1.144",
-    "@jskit-ai/resource-crud-core": "0.1.87",
-    "@jskit-ai/resource-core": "0.1.87",
-    "@jskit-ai/uploads-runtime": "0.1.120",
+    "@jskit-ai/auth-core": "0.1.143",
+    "@jskit-ai/database-runtime": "0.1.144",
+    "@jskit-ai/http-runtime": "0.1.143",
+    "@jskit-ai/json-rest-api-core": "0.1.89",
+    "@jskit-ai/kernel": "0.1.145",
+    "@jskit-ai/resource-crud-core": "0.1.88",
+    "@jskit-ai/resource-core": "0.1.88",
+    "@jskit-ai/uploads-runtime": "0.1.121",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/users-core/package.json
+++ b/packages/users-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-core",
-  "version": "0.1.155",
+  "version": "0.1.156",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,14 +11,14 @@
     "./shared/resources/userSettingsResource": "./src/shared/resources/userSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.140",
-    "@jskit-ai/database-runtime": "0.1.141",
-    "@jskit-ai/http-runtime": "0.1.140",
-    "@jskit-ai/json-rest-api-core": "0.1.86",
-    "@jskit-ai/kernel": "0.1.142",
-    "@jskit-ai/resource-crud-core": "0.1.85",
-    "@jskit-ai/resource-core": "0.1.85",
-    "@jskit-ai/uploads-runtime": "0.1.118",
+    "@jskit-ai/auth-core": "0.1.141",
+    "@jskit-ai/database-runtime": "0.1.142",
+    "@jskit-ai/http-runtime": "0.1.141",
+    "@jskit-ai/json-rest-api-core": "0.1.87",
+    "@jskit-ai/kernel": "0.1.143",
+    "@jskit-ai/resource-crud-core": "0.1.86",
+    "@jskit-ai/resource-core": "0.1.86",
+    "@jskit-ai/uploads-runtime": "0.1.119",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/users-core/package.json
+++ b/packages/users-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-core",
-  "version": "0.1.156",
+  "version": "0.1.157",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -11,14 +11,14 @@
     "./shared/resources/userSettingsResource": "./src/shared/resources/userSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.141",
-    "@jskit-ai/database-runtime": "0.1.142",
-    "@jskit-ai/http-runtime": "0.1.141",
-    "@jskit-ai/json-rest-api-core": "0.1.87",
-    "@jskit-ai/kernel": "0.1.143",
-    "@jskit-ai/resource-crud-core": "0.1.86",
-    "@jskit-ai/resource-core": "0.1.86",
-    "@jskit-ai/uploads-runtime": "0.1.119",
+    "@jskit-ai/auth-core": "0.1.142",
+    "@jskit-ai/database-runtime": "0.1.143",
+    "@jskit-ai/http-runtime": "0.1.142",
+    "@jskit-ai/json-rest-api-core": "0.1.88",
+    "@jskit-ai/kernel": "0.1.144",
+    "@jskit-ai/resource-crud-core": "0.1.87",
+    "@jskit-ai/resource-core": "0.1.87",
+    "@jskit-ai/uploads-runtime": "0.1.120",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/users-web/package.descriptor.mjs
+++ b/packages/users-web/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { HOME_COG_OUTLET } from "./src/shared/toolsOutletContracts.js";
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-web",
-  version: "0.1.160",
+  version: "0.1.161",
   kind: "runtime",
   description: "Users web module: account/profile UI plus shared users web widgets.",
   dependsOn: [
@@ -286,12 +286,12 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/http-runtime": "0.1.141",
-        "@jskit-ai/realtime": "0.1.140",
-        "@jskit-ai/kernel": "0.1.143",
-        "@jskit-ai/shell-web": "0.1.144",
-        "@jskit-ai/uploads-image-web": "0.1.119",
-        "@jskit-ai/users-core": "0.1.156"
+        "@jskit-ai/http-runtime": "0.1.142",
+        "@jskit-ai/realtime": "0.1.141",
+        "@jskit-ai/kernel": "0.1.144",
+        "@jskit-ai/shell-web": "0.1.145",
+        "@jskit-ai/uploads-image-web": "0.1.120",
+        "@jskit-ai/users-core": "0.1.157"
       },
       dev: {}
     },

--- a/packages/users-web/package.descriptor.mjs
+++ b/packages/users-web/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { HOME_COG_OUTLET } from "./src/shared/toolsOutletContracts.js";
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-web",
-  version: "0.1.159",
+  version: "0.1.160",
   kind: "runtime",
   description: "Users web module: account/profile UI plus shared users web widgets.",
   dependsOn: [
@@ -286,12 +286,12 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/http-runtime": "0.1.140",
-        "@jskit-ai/realtime": "0.1.139",
-        "@jskit-ai/kernel": "0.1.142",
-        "@jskit-ai/shell-web": "0.1.143",
-        "@jskit-ai/uploads-image-web": "0.1.118",
-        "@jskit-ai/users-core": "0.1.155"
+        "@jskit-ai/http-runtime": "0.1.141",
+        "@jskit-ai/realtime": "0.1.140",
+        "@jskit-ai/kernel": "0.1.143",
+        "@jskit-ai/shell-web": "0.1.144",
+        "@jskit-ai/uploads-image-web": "0.1.119",
+        "@jskit-ai/users-core": "0.1.156"
       },
       dev: {}
     },

--- a/packages/users-web/package.descriptor.mjs
+++ b/packages/users-web/package.descriptor.mjs
@@ -3,7 +3,7 @@ import { HOME_COG_OUTLET } from "./src/shared/toolsOutletContracts.js";
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/users-web",
-  version: "0.1.161",
+  version: "0.1.162",
   kind: "runtime",
   description: "Users web module: account/profile UI plus shared users web widgets.",
   dependsOn: [
@@ -286,12 +286,12 @@ export default Object.freeze({
     dependencies: {
       runtime: {
         "@mdi/js": "^7.4.47",
-        "@jskit-ai/http-runtime": "0.1.142",
-        "@jskit-ai/realtime": "0.1.141",
-        "@jskit-ai/kernel": "0.1.144",
-        "@jskit-ai/shell-web": "0.1.145",
-        "@jskit-ai/uploads-image-web": "0.1.120",
-        "@jskit-ai/users-core": "0.1.157"
+        "@jskit-ai/http-runtime": "0.1.143",
+        "@jskit-ai/realtime": "0.1.142",
+        "@jskit-ai/kernel": "0.1.145",
+        "@jskit-ai/shell-web": "0.1.146",
+        "@jskit-ai/uploads-image-web": "0.1.121",
+        "@jskit-ai/users-core": "0.1.158"
       },
       dev: {}
     },

--- a/packages/users-web/package.json
+++ b/packages/users-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-web",
-  "version": "0.1.160",
+  "version": "0.1.161",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -46,12 +46,12 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/http-runtime": "0.1.141",
-    "@jskit-ai/kernel": "0.1.143",
-    "@jskit-ai/realtime": "0.1.140",
-    "@jskit-ai/shell-web": "0.1.144",
-    "@jskit-ai/uploads-image-web": "0.1.119",
-    "@jskit-ai/users-core": "0.1.156"
+    "@jskit-ai/http-runtime": "0.1.142",
+    "@jskit-ai/kernel": "0.1.144",
+    "@jskit-ai/realtime": "0.1.141",
+    "@jskit-ai/shell-web": "0.1.145",
+    "@jskit-ai/uploads-image-web": "0.1.120",
+    "@jskit-ai/users-core": "0.1.157"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/users-web/package.json
+++ b/packages/users-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-web",
-  "version": "0.1.159",
+  "version": "0.1.160",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -46,12 +46,12 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/http-runtime": "0.1.140",
-    "@jskit-ai/kernel": "0.1.142",
-    "@jskit-ai/realtime": "0.1.139",
-    "@jskit-ai/shell-web": "0.1.143",
-    "@jskit-ai/uploads-image-web": "0.1.118",
-    "@jskit-ai/users-core": "0.1.155"
+    "@jskit-ai/http-runtime": "0.1.141",
+    "@jskit-ai/kernel": "0.1.143",
+    "@jskit-ai/realtime": "0.1.140",
+    "@jskit-ai/shell-web": "0.1.144",
+    "@jskit-ai/uploads-image-web": "0.1.119",
+    "@jskit-ai/users-core": "0.1.156"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/users-web/package.json
+++ b/packages/users-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/users-web",
-  "version": "0.1.161",
+  "version": "0.1.162",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -46,12 +46,12 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/http-runtime": "0.1.142",
-    "@jskit-ai/kernel": "0.1.144",
-    "@jskit-ai/realtime": "0.1.141",
-    "@jskit-ai/shell-web": "0.1.145",
-    "@jskit-ai/uploads-image-web": "0.1.120",
-    "@jskit-ai/users-core": "0.1.157"
+    "@jskit-ai/http-runtime": "0.1.143",
+    "@jskit-ai/kernel": "0.1.145",
+    "@jskit-ai/realtime": "0.1.142",
+    "@jskit-ai/shell-web": "0.1.146",
+    "@jskit-ai/uploads-image-web": "0.1.121",
+    "@jskit-ai/users-core": "0.1.158"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/workspaces-core/package.descriptor.mjs
+++ b/packages/workspaces-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-core",
-  version: "0.1.122",
+  version: "0.1.123",
   kind: "runtime",
   description: "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
   dependsOn: [
@@ -147,10 +147,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/json-rest-api-core": "0.1.87",
-        "@jskit-ai/resource-core": "0.1.86",
-        "@jskit-ai/resource-crud-core": "0.1.86",
-        "@jskit-ai/users-core": "0.1.156"
+        "@jskit-ai/json-rest-api-core": "0.1.88",
+        "@jskit-ai/resource-core": "0.1.87",
+        "@jskit-ai/resource-crud-core": "0.1.87",
+        "@jskit-ai/users-core": "0.1.157"
       },
       dev: {}
     },

--- a/packages/workspaces-core/package.descriptor.mjs
+++ b/packages/workspaces-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-core",
-  version: "0.1.123",
+  version: "0.1.124",
   kind: "runtime",
   description: "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
   dependsOn: [
@@ -147,10 +147,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/json-rest-api-core": "0.1.88",
-        "@jskit-ai/resource-core": "0.1.87",
-        "@jskit-ai/resource-crud-core": "0.1.87",
-        "@jskit-ai/users-core": "0.1.157"
+        "@jskit-ai/json-rest-api-core": "0.1.89",
+        "@jskit-ai/resource-core": "0.1.88",
+        "@jskit-ai/resource-crud-core": "0.1.88",
+        "@jskit-ai/users-core": "0.1.158"
       },
       dev: {}
     },

--- a/packages/workspaces-core/package.descriptor.mjs
+++ b/packages/workspaces-core/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-core",
-  version: "0.1.121",
+  version: "0.1.122",
   kind: "runtime",
   description: "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
   dependsOn: [
@@ -147,10 +147,10 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/json-rest-api-core": "0.1.86",
-        "@jskit-ai/resource-core": "0.1.85",
-        "@jskit-ai/resource-crud-core": "0.1.85",
-        "@jskit-ai/users-core": "0.1.155"
+        "@jskit-ai/json-rest-api-core": "0.1.87",
+        "@jskit-ai/resource-core": "0.1.86",
+        "@jskit-ai/resource-crud-core": "0.1.86",
+        "@jskit-ai/users-core": "0.1.156"
       },
       dev: {}
     },

--- a/packages/workspaces-core/package.json
+++ b/packages/workspaces-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-core",
-  "version": "0.1.123",
+  "version": "0.1.124",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -17,14 +17,14 @@
     "./shared/resources/workspaceSettingsResource": "./src/shared/resources/workspaceSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.142",
-    "@jskit-ai/database-runtime": "0.1.143",
-    "@jskit-ai/http-runtime": "0.1.142",
-    "@jskit-ai/json-rest-api-core": "0.1.88",
-    "@jskit-ai/kernel": "0.1.144",
-    "@jskit-ai/resource-crud-core": "0.1.87",
-    "@jskit-ai/resource-core": "0.1.87",
-    "@jskit-ai/users-core": "0.1.157",
+    "@jskit-ai/auth-core": "0.1.143",
+    "@jskit-ai/database-runtime": "0.1.144",
+    "@jskit-ai/http-runtime": "0.1.143",
+    "@jskit-ai/json-rest-api-core": "0.1.89",
+    "@jskit-ai/kernel": "0.1.145",
+    "@jskit-ai/resource-crud-core": "0.1.88",
+    "@jskit-ai/resource-core": "0.1.88",
+    "@jskit-ai/users-core": "0.1.158",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/workspaces-core/package.json
+++ b/packages/workspaces-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-core",
-  "version": "0.1.121",
+  "version": "0.1.122",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -17,14 +17,14 @@
     "./shared/resources/workspaceSettingsResource": "./src/shared/resources/workspaceSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.140",
-    "@jskit-ai/database-runtime": "0.1.141",
-    "@jskit-ai/http-runtime": "0.1.140",
-    "@jskit-ai/json-rest-api-core": "0.1.86",
-    "@jskit-ai/kernel": "0.1.142",
-    "@jskit-ai/resource-crud-core": "0.1.85",
-    "@jskit-ai/resource-core": "0.1.85",
-    "@jskit-ai/users-core": "0.1.155",
+    "@jskit-ai/auth-core": "0.1.141",
+    "@jskit-ai/database-runtime": "0.1.142",
+    "@jskit-ai/http-runtime": "0.1.141",
+    "@jskit-ai/json-rest-api-core": "0.1.87",
+    "@jskit-ai/kernel": "0.1.143",
+    "@jskit-ai/resource-crud-core": "0.1.86",
+    "@jskit-ai/resource-core": "0.1.86",
+    "@jskit-ai/users-core": "0.1.156",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/workspaces-core/package.json
+++ b/packages/workspaces-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-core",
-  "version": "0.1.122",
+  "version": "0.1.123",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -17,14 +17,14 @@
     "./shared/resources/workspaceSettingsResource": "./src/shared/resources/workspaceSettingsResource.js"
   },
   "dependencies": {
-    "@jskit-ai/auth-core": "0.1.141",
-    "@jskit-ai/database-runtime": "0.1.142",
-    "@jskit-ai/http-runtime": "0.1.141",
-    "@jskit-ai/json-rest-api-core": "0.1.87",
-    "@jskit-ai/kernel": "0.1.143",
-    "@jskit-ai/resource-crud-core": "0.1.86",
-    "@jskit-ai/resource-core": "0.1.86",
-    "@jskit-ai/users-core": "0.1.156",
+    "@jskit-ai/auth-core": "0.1.142",
+    "@jskit-ai/database-runtime": "0.1.143",
+    "@jskit-ai/http-runtime": "0.1.142",
+    "@jskit-ai/json-rest-api-core": "0.1.88",
+    "@jskit-ai/kernel": "0.1.144",
+    "@jskit-ai/resource-crud-core": "0.1.87",
+    "@jskit-ai/resource-core": "0.1.87",
+    "@jskit-ai/users-core": "0.1.157",
     "json-rest-schema": "1.x.x"
   }
 }

--- a/packages/workspaces-web/package.descriptor.mjs
+++ b/packages/workspaces-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-web",
-  version: "0.1.123",
+  version: "0.1.124",
   kind: "runtime",
   description: "Workspace web module: workspace selector, tools widget, workspace surfaces, members UI, and settings hosts.",
   dependsOn: [
@@ -232,9 +232,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-web": "0.1.144",
-        "@jskit-ai/workspaces-core": "0.1.122",
-        "@jskit-ai/users-web": "0.1.160"
+        "@jskit-ai/auth-web": "0.1.145",
+        "@jskit-ai/workspaces-core": "0.1.123",
+        "@jskit-ai/users-web": "0.1.161"
       },
       dev: {}
     },

--- a/packages/workspaces-web/package.descriptor.mjs
+++ b/packages/workspaces-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-web",
-  version: "0.1.124",
+  version: "0.1.125",
   kind: "runtime",
   description: "Workspace web module: workspace selector, tools widget, workspace surfaces, members UI, and settings hosts.",
   dependsOn: [
@@ -232,9 +232,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-web": "0.1.145",
-        "@jskit-ai/workspaces-core": "0.1.123",
-        "@jskit-ai/users-web": "0.1.161"
+        "@jskit-ai/auth-web": "0.1.146",
+        "@jskit-ai/workspaces-core": "0.1.124",
+        "@jskit-ai/users-web": "0.1.162"
       },
       dev: {}
     },

--- a/packages/workspaces-web/package.descriptor.mjs
+++ b/packages/workspaces-web/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   packageVersion: 1,
   packageId: "@jskit-ai/workspaces-web",
-  version: "0.1.122",
+  version: "0.1.123",
   kind: "runtime",
   description: "Workspace web module: workspace selector, tools widget, workspace surfaces, members UI, and settings hosts.",
   dependsOn: [
@@ -232,9 +232,9 @@ export default Object.freeze({
   mutations: {
     dependencies: {
       runtime: {
-        "@jskit-ai/auth-web": "0.1.143",
-        "@jskit-ai/workspaces-core": "0.1.121",
-        "@jskit-ai/users-web": "0.1.159"
+        "@jskit-ai/auth-web": "0.1.144",
+        "@jskit-ai/workspaces-core": "0.1.122",
+        "@jskit-ai/users-web": "0.1.160"
       },
       dev: {}
     },

--- a/packages/workspaces-web/package.json
+++ b/packages/workspaces-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-web",
-  "version": "0.1.123",
+  "version": "0.1.124",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -15,13 +15,13 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/auth-web": "0.1.144",
-    "@jskit-ai/http-runtime": "0.1.141",
-    "@jskit-ai/kernel": "0.1.143",
-    "@jskit-ai/shell-web": "0.1.144",
-    "@jskit-ai/users-core": "0.1.156",
-    "@jskit-ai/users-web": "0.1.160",
-    "@jskit-ai/workspaces-core": "0.1.122"
+    "@jskit-ai/auth-web": "0.1.145",
+    "@jskit-ai/http-runtime": "0.1.142",
+    "@jskit-ai/kernel": "0.1.144",
+    "@jskit-ai/shell-web": "0.1.145",
+    "@jskit-ai/users-core": "0.1.157",
+    "@jskit-ai/users-web": "0.1.161",
+    "@jskit-ai/workspaces-core": "0.1.123"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/workspaces-web/package.json
+++ b/packages/workspaces-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-web",
-  "version": "0.1.122",
+  "version": "0.1.123",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -15,13 +15,13 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/auth-web": "0.1.143",
-    "@jskit-ai/http-runtime": "0.1.140",
-    "@jskit-ai/kernel": "0.1.142",
-    "@jskit-ai/shell-web": "0.1.143",
-    "@jskit-ai/users-core": "0.1.155",
-    "@jskit-ai/users-web": "0.1.159",
-    "@jskit-ai/workspaces-core": "0.1.121"
+    "@jskit-ai/auth-web": "0.1.144",
+    "@jskit-ai/http-runtime": "0.1.141",
+    "@jskit-ai/kernel": "0.1.143",
+    "@jskit-ai/shell-web": "0.1.144",
+    "@jskit-ai/users-core": "0.1.156",
+    "@jskit-ai/users-web": "0.1.160",
+    "@jskit-ai/workspaces-core": "0.1.122"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/packages/workspaces-web/package.json
+++ b/packages/workspaces-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/workspaces-web",
-  "version": "0.1.124",
+  "version": "0.1.125",
   "type": "module",
   "scripts": {
     "test": "node --test"
@@ -15,13 +15,13 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
-    "@jskit-ai/auth-web": "0.1.145",
-    "@jskit-ai/http-runtime": "0.1.142",
-    "@jskit-ai/kernel": "0.1.144",
-    "@jskit-ai/shell-web": "0.1.145",
-    "@jskit-ai/users-core": "0.1.157",
-    "@jskit-ai/users-web": "0.1.161",
-    "@jskit-ai/workspaces-core": "0.1.123"
+    "@jskit-ai/auth-web": "0.1.146",
+    "@jskit-ai/http-runtime": "0.1.143",
+    "@jskit-ai/kernel": "0.1.145",
+    "@jskit-ai/shell-web": "0.1.146",
+    "@jskit-ai/users-core": "0.1.158",
+    "@jskit-ai/users-web": "0.1.162",
+    "@jskit-ai/workspaces-core": "0.1.124"
   },
   "peerDependencies": {
     "@tanstack/vue-query": "^5.90.5",

--- a/scripts/release-npm.mjs
+++ b/scripts/release-npm.mjs
@@ -784,25 +784,30 @@ async function publishPackages({
   }
 }
 
-function runCatalogBuild({ dryRun, enabled = true }) {
+function runRootNpmScript({
+  dryRun,
+  enabled = true,
+  scriptName,
+  skippedMessage
+}) {
   if (!enabled) {
-    process.stdout.write("Catalog build skipped.\n");
+    process.stdout.write(`${skippedMessage}\n`);
     return;
   }
 
   if (dryRun) {
-    process.stdout.write("[dry-run] npm run catalog:build\n");
+    process.stdout.write(`[dry-run] npm run ${scriptName}\n`);
     return;
   }
 
-  const result = spawnSync("npm", ["run", "catalog:build"], {
+  const result = spawnSync("npm", ["run", scriptName], {
     cwd: REPO_ROOT,
     stdio: "inherit",
     env: process.env
   });
 
   if (result.status !== 0) {
-    throw new Error("Catalog build failed.");
+    throw new Error(`${scriptName} failed.`);
   }
 }
 
@@ -874,9 +879,17 @@ async function main() {
 
   refreshPackageLock({ dryRun: options.dryRun });
 
-  runCatalogBuild({
+  runRootNpmScript({
     dryRun: options.dryRun,
-    enabled: !onlyMode || publishSet.has("@jskit-ai/jskit-catalog")
+    enabled: !onlyMode || publishSet.has("@jskit-ai/jskit-catalog"),
+    scriptName: "catalog:build",
+    skippedMessage: "Catalog build skipped."
+  });
+  runRootNpmScript({
+    dryRun: options.dryRun,
+    enabled: !onlyMode || publishSet.has("@jskit-ai/agent-docs"),
+    scriptName: "agent-docs:build",
+    skippedMessage: "Agent docs build skipped."
   });
 
   if (options.dryRun) {

--- a/tooling/config-eslint/package.json
+++ b/tooling/config-eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/config-eslint",
-  "version": "0.1.140",
+  "version": "0.1.141",
   "description": "Shared flat ESLint presets for JSKIT projects.",
   "type": "module",
   "files": [

--- a/tooling/config-eslint/package.json
+++ b/tooling/config-eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/config-eslint",
-  "version": "0.1.142",
+  "version": "0.1.143",
   "description": "Shared flat ESLint presets for JSKIT projects.",
   "type": "module",
   "files": [

--- a/tooling/config-eslint/package.json
+++ b/tooling/config-eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/config-eslint",
-  "version": "0.1.141",
+  "version": "0.1.142",
   "description": "Shared flat ESLint presets for JSKIT projects.",
   "type": "module",
   "files": [

--- a/tooling/create-app/package.descriptor.mjs
+++ b/tooling/create-app/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/create-app",
-  "version": "0.1.161",
+  "version": "0.1.162",
   "dependsOn": [],
   "capabilities": {
     "provides": [

--- a/tooling/create-app/package.descriptor.mjs
+++ b/tooling/create-app/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/create-app",
-  "version": "0.1.162",
+  "version": "0.1.163",
   "dependsOn": [],
   "capabilities": {
     "provides": [

--- a/tooling/create-app/package.descriptor.mjs
+++ b/tooling/create-app/package.descriptor.mjs
@@ -1,7 +1,7 @@
 export default Object.freeze({
   "packageVersion": 1,
   "packageId": "@jskit-ai/create-app",
-  "version": "0.1.163",
+  "version": "0.1.164",
   "dependsOn": [],
   "capabilities": {
     "provides": [

--- a/tooling/create-app/package.json
+++ b/tooling/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/create-app",
-  "version": "0.1.161",
+  "version": "0.1.162",
   "description": "Scaffold JSKIT app shells.",
   "type": "module",
   "files": [
@@ -20,7 +20,7 @@
     "./client": "./src/client/index.js"
   },
   "dependencies": {
-    "@jskit-ai/jskit-cli": "0.2.169"
+    "@jskit-ai/jskit-cli": "0.2.170"
   },
   "engines": {
     "node": "^22.13.0 || ^24.0.0 || ^26.0.0"

--- a/tooling/create-app/package.json
+++ b/tooling/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/create-app",
-  "version": "0.1.163",
+  "version": "0.1.164",
   "description": "Scaffold JSKIT app shells.",
   "type": "module",
   "files": [
@@ -20,7 +20,7 @@
     "./client": "./src/client/index.js"
   },
   "dependencies": {
-    "@jskit-ai/jskit-cli": "0.2.171"
+    "@jskit-ai/jskit-cli": "0.2.172"
   },
   "engines": {
     "node": "^22.13.0 || ^24.0.0 || ^26.0.0"

--- a/tooling/create-app/package.json
+++ b/tooling/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/create-app",
-  "version": "0.1.162",
+  "version": "0.1.163",
   "description": "Scaffold JSKIT app shells.",
   "type": "module",
   "files": [
@@ -20,7 +20,7 @@
     "./client": "./src/client/index.js"
   },
   "dependencies": {
-    "@jskit-ai/jskit-cli": "0.2.170"
+    "@jskit-ai/jskit-cli": "0.2.171"
   },
   "engines": {
     "node": "^22.13.0 || ^24.0.0 || ^26.0.0"

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -6,11 +6,11 @@
   "packages": [
     {
       "packageId": "@jskit-ai/assistant",
-      "version": "0.1.152",
+      "version": "0.1.153",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant",
-        "version": "0.1.152",
+        "version": "0.1.153",
         "kind": "generator",
         "description": "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
         "options": {
@@ -347,11 +347,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-core",
-      "version": "0.1.120",
+      "version": "0.1.121",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-core",
-        "version": "0.1.120",
+        "version": "0.1.121",
         "kind": "runtime",
         "description": "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
         "dependsOn": [
@@ -399,11 +399,11 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/http-runtime": "0.1.141",
-              "@jskit-ai/kernel": "0.1.143",
-              "@jskit-ai/resource-core": "0.1.86",
-              "@jskit-ai/resource-crud-core": "0.1.86",
-              "@jskit-ai/users-core": "0.1.156",
+              "@jskit-ai/http-runtime": "0.1.142",
+              "@jskit-ai/kernel": "0.1.144",
+              "@jskit-ai/resource-core": "0.1.87",
+              "@jskit-ai/resource-crud-core": "0.1.87",
+              "@jskit-ai/users-core": "0.1.157",
               "dompurify": "^3.3.3",
               "json-rest-schema": "1.x.x",
               "marked": "^17.0.4",
@@ -422,11 +422,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-runtime",
-      "version": "0.1.115",
+      "version": "0.1.116",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-runtime",
-        "version": "0.1.115",
+        "version": "0.1.116",
         "kind": "runtime",
         "description": "Shared assistant runtime with per-surface assistant registration.",
         "dependsOn": [
@@ -522,13 +522,13 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/assistant-core": "0.1.120",
-              "@jskit-ai/database-runtime": "0.1.142",
-              "@jskit-ai/http-runtime": "0.1.141",
-              "@jskit-ai/kernel": "0.1.143",
-              "@jskit-ai/shell-web": "0.1.144",
-              "@jskit-ai/users-core": "0.1.156",
-              "@jskit-ai/users-web": "0.1.160"
+              "@jskit-ai/assistant-core": "0.1.121",
+              "@jskit-ai/database-runtime": "0.1.143",
+              "@jskit-ai/http-runtime": "0.1.142",
+              "@jskit-ai/kernel": "0.1.144",
+              "@jskit-ai/shell-web": "0.1.145",
+              "@jskit-ai/users-core": "0.1.157",
+              "@jskit-ai/users-web": "0.1.161"
             },
             "dev": {}
           },
@@ -583,11 +583,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-core",
-      "version": "0.1.141",
+      "version": "0.1.142",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-core",
-        "version": "0.1.141",
+        "version": "0.1.142",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/value-app-config-shared"
@@ -660,7 +660,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.143",
+              "@jskit-ai/kernel": "0.1.144",
               "@fastify/cookie": "^11.0.2",
               "@fastify/csrf-protection": "^7.1.0",
               "@fastify/rate-limit": "^10.3.0"
@@ -678,11 +678,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-local-core",
-      "version": "0.1.45",
+      "version": "0.1.46",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-local-core",
-        "version": "0.1.45",
+        "version": "0.1.46",
         "kind": "runtime",
         "description": "Local auth provider with a file backend default and no database requirement.",
         "dependsOn": [
@@ -745,8 +745,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.141",
-              "@jskit-ai/kernel": "0.1.143",
+              "@jskit-ai/auth-core": "0.1.142",
+              "@jskit-ai/kernel": "0.1.144",
               "nodemailer": "^9.0.3",
               "dotenv": "^16.4.5"
             },
@@ -792,11 +792,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-local-db-core",
-      "version": "0.1.36",
+      "version": "0.1.37",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-local-db-core",
-        "version": "0.1.36",
+        "version": "0.1.37",
         "kind": "runtime",
         "description": "Database-backed local auth storage backend for JSKIT local auth.",
         "dependsOn": [
@@ -875,9 +875,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-provider-local-core": "0.1.45",
-              "@jskit-ai/database-runtime": "0.1.142",
-              "@jskit-ai/kernel": "0.1.143"
+              "@jskit-ai/auth-provider-local-core": "0.1.46",
+              "@jskit-ai/database-runtime": "0.1.143",
+              "@jskit-ai/kernel": "0.1.144"
             },
             "dev": {}
           },
@@ -912,11 +912,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.141",
+      "version": "0.1.142",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-supabase-core",
-        "version": "0.1.141",
+        "version": "0.1.142",
         "kind": "runtime",
         "options": {
           "auth-supabase-url": {
@@ -998,8 +998,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.141",
-              "@jskit-ai/kernel": "0.1.143",
+              "@jskit-ai/auth-core": "0.1.142",
+              "@jskit-ai/kernel": "0.1.144",
               "dotenv": "^16.4.5",
               "@supabase/supabase-js": "^2.57.4",
               "jose": "^6.1.0"
@@ -1077,11 +1077,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-web",
-      "version": "0.1.144",
+      "version": "0.1.145",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-web",
-        "version": "0.1.144",
+        "version": "0.1.145",
         "kind": "runtime",
         "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
         "dependsOn": [
@@ -1354,10 +1354,10 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/auth-core": "0.1.141",
-              "@jskit-ai/http-runtime": "0.1.141",
-              "@jskit-ai/kernel": "0.1.143",
-              "@jskit-ai/shell-web": "0.1.144"
+              "@jskit-ai/auth-core": "0.1.142",
+              "@jskit-ai/http-runtime": "0.1.142",
+              "@jskit-ai/kernel": "0.1.144",
+              "@jskit-ai/shell-web": "0.1.145"
             },
             "dev": {}
           },
@@ -1456,11 +1456,11 @@
     },
     {
       "packageId": "@jskit-ai/console-core",
-      "version": "0.1.107",
+      "version": "0.1.108",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-core",
-        "version": "0.1.107",
+        "version": "0.1.108",
         "kind": "runtime",
         "description": "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
         "dependsOn": [
@@ -1544,12 +1544,12 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.141",
-              "@jskit-ai/database-runtime": "0.1.142",
-              "@jskit-ai/http-runtime": "0.1.141",
-              "@jskit-ai/kernel": "0.1.143",
-              "@jskit-ai/resource-crud-core": "0.1.86",
-              "@jskit-ai/users-core": "0.1.156"
+              "@jskit-ai/auth-core": "0.1.142",
+              "@jskit-ai/database-runtime": "0.1.143",
+              "@jskit-ai/http-runtime": "0.1.142",
+              "@jskit-ai/kernel": "0.1.144",
+              "@jskit-ai/resource-crud-core": "0.1.87",
+              "@jskit-ai/users-core": "0.1.157"
             },
             "dev": {}
           },
@@ -1574,11 +1574,11 @@
     },
     {
       "packageId": "@jskit-ai/console-web",
-      "version": "0.1.112",
+      "version": "0.1.113",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-web",
-        "version": "0.1.112",
+        "version": "0.1.113",
         "kind": "runtime",
         "description": "Authenticated console surface scaffold and surface policy wiring.",
         "dependsOn": [
@@ -1688,9 +1688,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-web": "0.1.144",
-              "@jskit-ai/console-core": "0.1.107",
-              "@jskit-ai/shell-web": "0.1.144"
+              "@jskit-ai/auth-web": "0.1.145",
+              "@jskit-ai/console-core": "0.1.108",
+              "@jskit-ai/shell-web": "0.1.145"
             },
             "dev": {}
           },
@@ -1797,11 +1797,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-core",
-      "version": "0.1.153",
+      "version": "0.1.154",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-core",
-        "version": "0.1.153",
+        "version": "0.1.154",
         "kind": "runtime",
         "description": "Shared CRUD helpers used by CRUD modules.",
         "dependsOn": [
@@ -1830,7 +1830,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/crud-core": "0.1.153"
+              "@jskit-ai/crud-core": "0.1.154"
             },
             "dev": {}
           },
@@ -1844,11 +1844,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-server-generator",
-      "version": "0.1.155",
+      "version": "0.1.156",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-server-generator",
-        "version": "0.1.155",
+        "version": "0.1.156",
         "kind": "generator",
         "description": "CRUD server generator with routes, actions, and persistence scaffolding.",
         "options": {
@@ -2039,14 +2039,14 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.141",
-              "@jskit-ai/crud-core": "0.1.153",
-              "@jskit-ai/database-runtime": "0.1.142",
-              "@jskit-ai/http-runtime": "0.1.141",
-              "@jskit-ai/json-rest-api-core": "0.1.87",
-              "@jskit-ai/kernel": "0.1.143",
-              "@jskit-ai/realtime": "0.1.140",
-              "@jskit-ai/resource-crud-core": "0.1.86",
+              "@jskit-ai/auth-core": "0.1.142",
+              "@jskit-ai/crud-core": "0.1.154",
+              "@jskit-ai/database-runtime": "0.1.143",
+              "@jskit-ai/http-runtime": "0.1.142",
+              "@jskit-ai/json-rest-api-core": "0.1.88",
+              "@jskit-ai/kernel": "0.1.144",
+              "@jskit-ai/realtime": "0.1.141",
+              "@jskit-ai/resource-crud-core": "0.1.87",
               "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}"
             },
             "dev": {}
@@ -2191,11 +2191,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.126",
+      "version": "0.1.127",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-ui-generator",
-        "version": "0.1.126",
+        "version": "0.1.127",
         "kind": "generator",
         "description": "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
         "options": {
@@ -2394,7 +2394,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.160"
+              "@jskit-ai/users-web": "0.1.161"
             },
             "dev": {}
           },
@@ -2653,11 +2653,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime",
-      "version": "0.1.142",
+      "version": "0.1.143",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime",
-        "version": "0.1.142",
+        "version": "0.1.143",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -2726,7 +2726,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.143",
+              "@jskit-ai/kernel": "0.1.144",
               "dotenv": "^16.4.5",
               "knex": "^3.1.0"
             },
@@ -2769,11 +2769,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.141",
+      "version": "0.1.142",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-mysql",
-        "version": "0.1.141",
+        "version": "0.1.142",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -2895,7 +2895,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.142",
+              "@jskit-ai/database-runtime": "0.1.143",
               "mysql2": "^3.11.2"
             },
             "dev": {}
@@ -2966,11 +2966,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.140",
+      "version": "0.1.141",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-postgres",
-        "version": "0.1.140",
+        "version": "0.1.141",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -3091,7 +3091,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.142",
+              "@jskit-ai/database-runtime": "0.1.143",
               "pg": "^8.13.1"
             },
             "dev": {}
@@ -3162,11 +3162,11 @@
     },
     {
       "packageId": "@jskit-ai/feature-server-generator",
-      "version": "0.1.85",
+      "version": "0.1.86",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/feature-server-generator",
-        "version": "0.1.85",
+        "version": "0.1.86",
         "kind": "generator",
         "description": "Scaffold substantial non-CRUD server feature packages with provider, actions, service, and optional persistence seams.",
         "options": {
@@ -3331,27 +3331,27 @@
           "dependencies": {
             "runtime": {
               "@jskit-ai/database-runtime": {
-                "version": "0.1.142",
+                "version": "0.1.143",
                 "when": {
                   "option": "mode",
                   "notEquals": "orchestrator"
                 }
               },
               "@jskit-ai/database-runtime-mysql": {
-                "version": "0.1.141",
+                "version": "0.1.142",
                 "when": {
                   "option": "mode",
                   "notEquals": "orchestrator"
                 }
               },
               "@jskit-ai/json-rest-api-core": {
-                "version": "0.1.87",
+                "version": "0.1.88",
                 "when": {
                   "option": "mode",
                   "equals": "json-rest"
                 }
               },
-              "@jskit-ai/kernel": "0.1.143",
+              "@jskit-ai/kernel": "0.1.144",
               "json-rest-schema": "1.x.x",
               "@local/${option:feature-name|kebab}": "file:packages/${option:feature-name|kebab}"
             },
@@ -3464,11 +3464,11 @@
     },
     {
       "packageId": "@jskit-ai/google-rewarded-core",
-      "version": "0.1.80",
+      "version": "0.1.81",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/google-rewarded-core",
-        "version": "0.1.80",
+        "version": "0.1.81",
         "kind": "runtime",
         "description": "Google rewarded workflow runtime plus internal CRUD providers for rules, provider configs, watch sessions, and unlock receipts.",
         "dependsOn": [
@@ -3595,14 +3595,14 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.141",
-              "@jskit-ai/crud-core": "0.1.153",
-              "@jskit-ai/database-runtime": "0.1.142",
-              "@jskit-ai/http-runtime": "0.1.141",
-              "@jskit-ai/json-rest-api-core": "0.1.87",
-              "@jskit-ai/kernel": "0.1.143",
-              "@jskit-ai/resource-crud-core": "0.1.86",
-              "@jskit-ai/workspaces-core": "0.1.122"
+              "@jskit-ai/auth-core": "0.1.142",
+              "@jskit-ai/crud-core": "0.1.154",
+              "@jskit-ai/database-runtime": "0.1.143",
+              "@jskit-ai/http-runtime": "0.1.142",
+              "@jskit-ai/json-rest-api-core": "0.1.88",
+              "@jskit-ai/kernel": "0.1.144",
+              "@jskit-ai/resource-crud-core": "0.1.87",
+              "@jskit-ai/workspaces-core": "0.1.123"
             },
             "dev": {}
           },
@@ -3654,11 +3654,11 @@
     },
     {
       "packageId": "@jskit-ai/google-rewarded-web",
-      "version": "0.1.80",
+      "version": "0.1.81",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/google-rewarded-web",
-        "version": "0.1.80",
+        "version": "0.1.81",
         "kind": "runtime",
         "description": "Google rewarded client runtime with a fullscreen gate host and GPT orchestration.",
         "dependsOn": [
@@ -3705,10 +3705,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/google-rewarded-core": "0.1.80",
-              "@jskit-ai/http-runtime": "0.1.141",
-              "@jskit-ai/kernel": "0.1.143",
-              "@jskit-ai/shell-web": "0.1.144"
+              "@jskit-ai/google-rewarded-core": "0.1.81",
+              "@jskit-ai/http-runtime": "0.1.142",
+              "@jskit-ai/kernel": "0.1.144",
+              "@jskit-ai/shell-web": "0.1.145"
             },
             "dev": {}
           },
@@ -3726,11 +3726,11 @@
     },
     {
       "packageId": "@jskit-ai/http-runtime",
-      "version": "0.1.141",
+      "version": "0.1.142",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/http-runtime",
-        "version": "0.1.141",
+        "version": "0.1.142",
         "kind": "runtime",
         "dependsOn": [],
         "capabilities": {
@@ -3796,7 +3796,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.143"
+              "@jskit-ai/kernel": "0.1.144"
             },
             "dev": {}
           },
@@ -3810,11 +3810,11 @@
     },
     {
       "packageId": "@jskit-ai/json-rest-api-core",
-      "version": "0.1.87",
+      "version": "0.1.88",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/json-rest-api-core",
-        "version": "0.1.87",
+        "version": "0.1.88",
         "kind": "runtime",
         "description": "Shared internal json-rest-api host runtime with autofilter, query-projection, and row-policy support.",
         "dependsOn": [
@@ -3874,11 +3874,11 @@
     },
     {
       "packageId": "@jskit-ai/mobile-capacitor",
-      "version": "0.1.79",
+      "version": "0.1.80",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/mobile-capacitor",
-        "version": "0.1.79",
+        "version": "0.1.80",
         "kind": "runtime",
         "description": "Thin Capacitor client integration for JSKIT mobile-shell launch routing and auth callback completion.",
         "dependsOn": [
@@ -3941,8 +3941,8 @@
               "@capacitor/app": "^7.1.0",
               "@capacitor/browser": "^7.0.1",
               "@capacitor/core": "^7.4.3",
-              "@jskit-ai/kernel": "0.1.143",
-              "@jskit-ai/shell-web": "0.1.144"
+              "@jskit-ai/kernel": "0.1.144",
+              "@jskit-ai/shell-web": "0.1.145"
             },
             "dev": {
               "@capacitor/cli": "^7.4.3"
@@ -3994,11 +3994,11 @@
     },
     {
       "packageId": "@jskit-ai/realtime",
-      "version": "0.1.140",
+      "version": "0.1.141",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/realtime",
-        "version": "0.1.140",
+        "version": "0.1.141",
         "kind": "runtime",
         "description": "Thin, generic realtime runtime wrappers for socket.io server and client.",
         "options": {
@@ -4094,7 +4094,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.143",
+              "@jskit-ai/kernel": "0.1.144",
               "@socket.io/redis-adapter": "^8.3.0",
               "redis": "^5.8.2",
               "socket.io": "^4.8.3",
@@ -4143,11 +4143,11 @@
     },
     {
       "packageId": "@jskit-ai/resource-core",
-      "version": "0.1.86",
+      "version": "0.1.87",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/resource-core",
-        "version": "0.1.86",
+        "version": "0.1.87",
         "kind": "runtime",
         "description": "Generic resource-definition helpers and schema-definition normalization.",
         "dependsOn": [
@@ -4170,7 +4170,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/resource-core": "0.1.86"
+              "@jskit-ai/resource-core": "0.1.87"
             },
             "dev": {}
           },
@@ -4185,11 +4185,11 @@
     },
     {
       "packageId": "@jskit-ai/resource-crud-core",
-      "version": "0.1.86",
+      "version": "0.1.87",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/resource-crud-core",
-        "version": "0.1.86",
+        "version": "0.1.87",
         "kind": "runtime",
         "description": "CRUD-specific resource-definition helpers and namespace support.",
         "dependsOn": [
@@ -4213,7 +4213,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/resource-crud-core": "0.1.86"
+              "@jskit-ai/resource-crud-core": "0.1.87"
             },
             "dev": {}
           },
@@ -4228,11 +4228,11 @@
     },
     {
       "packageId": "@jskit-ai/shell-web",
-      "version": "0.1.144",
+      "version": "0.1.145",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/shell-web",
-        "version": "0.1.144",
+        "version": "0.1.145",
         "kind": "runtime",
         "description": "Web shell layout runtime with outlet-based placement contributions.",
         "dependsOn": [],
@@ -4578,7 +4578,7 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/kernel": "0.1.143"
+              "@jskit-ai/kernel": "0.1.144"
             },
             "dev": {
               "@playwright/test": "1.61.1"
@@ -4807,11 +4807,11 @@
     },
     {
       "packageId": "@jskit-ai/storage-runtime",
-      "version": "0.1.141",
+      "version": "0.1.142",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/storage-runtime",
-        "version": "0.1.141",
+        "version": "0.1.142",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -4860,7 +4860,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.143",
+              "@jskit-ai/kernel": "0.1.144",
               "unstorage": "^1.17.3"
             },
             "dev": {}
@@ -4876,11 +4876,11 @@
     },
     {
       "packageId": "@jskit-ai/ui-generator",
-      "version": "0.1.126",
+      "version": "0.1.127",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/ui-generator",
-        "version": "0.1.126",
+        "version": "0.1.127",
         "kind": "generator",
         "description": "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
         "options": {
@@ -5313,7 +5313,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.160"
+              "@jskit-ai/users-web": "0.1.161"
             },
             "dev": {}
           },
@@ -5328,11 +5328,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-image-web",
-      "version": "0.1.119",
+      "version": "0.1.120",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-image-web",
-        "version": "0.1.119",
+        "version": "0.1.120",
         "kind": "runtime",
         "description": "Reusable client-side image upload runtime with pre-upload image editing.",
         "dependsOn": [
@@ -5396,7 +5396,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/uploads-runtime": "0.1.119",
+              "@jskit-ai/uploads-runtime": "0.1.120",
               "@uppy/compressor": "^3.1.0",
               "@uppy/core": "^5.2.0",
               "@uppy/dashboard": "^5.1.1",
@@ -5416,11 +5416,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-runtime",
-      "version": "0.1.119",
+      "version": "0.1.120",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-runtime",
-        "version": "0.1.119",
+        "version": "0.1.120",
         "kind": "runtime",
         "description": "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
         "dependsOn": [
@@ -5490,7 +5490,7 @@
           "dependencies": {
             "runtime": {
               "@fastify/multipart": "^9.4.0",
-              "@jskit-ai/kernel": "0.1.143"
+              "@jskit-ai/kernel": "0.1.144"
             },
             "dev": {}
           },
@@ -5505,11 +5505,11 @@
     },
     {
       "packageId": "@jskit-ai/users-core",
-      "version": "0.1.156",
+      "version": "0.1.157",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-core",
-        "version": "0.1.156",
+        "version": "0.1.157",
         "kind": "runtime",
         "description": "Users/account runtime plus HTTP routes for account features.",
         "dependsOn": [
@@ -5653,16 +5653,16 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.141",
-              "@jskit-ai/crud-core": "0.1.153",
-              "@jskit-ai/database-runtime": "0.1.142",
-              "@jskit-ai/http-runtime": "0.1.141",
-              "@jskit-ai/json-rest-api-core": "0.1.87",
-              "@jskit-ai/kernel": "0.1.143",
-              "@jskit-ai/resource-core": "0.1.86",
-              "@jskit-ai/resource-crud-core": "0.1.86",
+              "@jskit-ai/auth-core": "0.1.142",
+              "@jskit-ai/crud-core": "0.1.154",
+              "@jskit-ai/database-runtime": "0.1.143",
+              "@jskit-ai/http-runtime": "0.1.142",
+              "@jskit-ai/json-rest-api-core": "0.1.88",
+              "@jskit-ai/kernel": "0.1.144",
+              "@jskit-ai/resource-core": "0.1.87",
+              "@jskit-ai/resource-crud-core": "0.1.87",
               "@local/users": "file:packages/users",
-              "@jskit-ai/uploads-runtime": "0.1.119"
+              "@jskit-ai/uploads-runtime": "0.1.120"
             },
             "dev": {}
           },
@@ -5889,11 +5889,11 @@
     },
     {
       "packageId": "@jskit-ai/users-web",
-      "version": "0.1.160",
+      "version": "0.1.161",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-web",
-        "version": "0.1.160",
+        "version": "0.1.161",
         "kind": "runtime",
         "description": "Users web module: account/profile UI plus shared users web widgets.",
         "dependsOn": [
@@ -6196,12 +6196,12 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/http-runtime": "0.1.141",
-              "@jskit-ai/realtime": "0.1.140",
-              "@jskit-ai/kernel": "0.1.143",
-              "@jskit-ai/shell-web": "0.1.144",
-              "@jskit-ai/uploads-image-web": "0.1.119",
-              "@jskit-ai/users-core": "0.1.156"
+              "@jskit-ai/http-runtime": "0.1.142",
+              "@jskit-ai/realtime": "0.1.141",
+              "@jskit-ai/kernel": "0.1.144",
+              "@jskit-ai/shell-web": "0.1.145",
+              "@jskit-ai/uploads-image-web": "0.1.120",
+              "@jskit-ai/users-core": "0.1.157"
             },
             "dev": {}
           },
@@ -6382,11 +6382,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-core",
-      "version": "0.1.122",
+      "version": "0.1.123",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-core",
-        "version": "0.1.122",
+        "version": "0.1.123",
         "kind": "runtime",
         "description": "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
         "dependsOn": [
@@ -6532,10 +6532,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/json-rest-api-core": "0.1.87",
-              "@jskit-ai/resource-core": "0.1.86",
-              "@jskit-ai/resource-crud-core": "0.1.86",
-              "@jskit-ai/users-core": "0.1.156"
+              "@jskit-ai/json-rest-api-core": "0.1.88",
+              "@jskit-ai/resource-core": "0.1.87",
+              "@jskit-ai/resource-crud-core": "0.1.87",
+              "@jskit-ai/users-core": "0.1.157"
             },
             "dev": {}
           },
@@ -6739,11 +6739,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-web",
-      "version": "0.1.123",
+      "version": "0.1.124",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-web",
-        "version": "0.1.123",
+        "version": "0.1.124",
         "kind": "runtime",
         "description": "Workspace web module: workspace selector, tools widget, workspace surfaces, members UI, and settings hosts.",
         "dependsOn": [
@@ -7000,9 +7000,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-web": "0.1.144",
-              "@jskit-ai/workspaces-core": "0.1.122",
-              "@jskit-ai/users-web": "0.1.160"
+              "@jskit-ai/auth-web": "0.1.145",
+              "@jskit-ai/workspaces-core": "0.1.123",
+              "@jskit-ai/users-web": "0.1.161"
             },
             "dev": {}
           },

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -6,11 +6,11 @@
   "packages": [
     {
       "packageId": "@jskit-ai/assistant",
-      "version": "0.1.153",
+      "version": "0.1.154",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant",
-        "version": "0.1.153",
+        "version": "0.1.154",
         "kind": "generator",
         "description": "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
         "options": {
@@ -347,11 +347,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-core",
-      "version": "0.1.121",
+      "version": "0.1.122",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-core",
-        "version": "0.1.121",
+        "version": "0.1.122",
         "kind": "runtime",
         "description": "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
         "dependsOn": [
@@ -399,11 +399,11 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/http-runtime": "0.1.142",
-              "@jskit-ai/kernel": "0.1.144",
-              "@jskit-ai/resource-core": "0.1.87",
-              "@jskit-ai/resource-crud-core": "0.1.87",
-              "@jskit-ai/users-core": "0.1.157",
+              "@jskit-ai/http-runtime": "0.1.143",
+              "@jskit-ai/kernel": "0.1.145",
+              "@jskit-ai/resource-core": "0.1.88",
+              "@jskit-ai/resource-crud-core": "0.1.88",
+              "@jskit-ai/users-core": "0.1.158",
               "dompurify": "^3.3.3",
               "json-rest-schema": "1.x.x",
               "marked": "^17.0.4",
@@ -422,11 +422,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-runtime",
-      "version": "0.1.116",
+      "version": "0.1.117",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-runtime",
-        "version": "0.1.116",
+        "version": "0.1.117",
         "kind": "runtime",
         "description": "Shared assistant runtime with per-surface assistant registration.",
         "dependsOn": [
@@ -522,13 +522,13 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/assistant-core": "0.1.121",
-              "@jskit-ai/database-runtime": "0.1.143",
-              "@jskit-ai/http-runtime": "0.1.142",
-              "@jskit-ai/kernel": "0.1.144",
-              "@jskit-ai/shell-web": "0.1.145",
-              "@jskit-ai/users-core": "0.1.157",
-              "@jskit-ai/users-web": "0.1.161"
+              "@jskit-ai/assistant-core": "0.1.122",
+              "@jskit-ai/database-runtime": "0.1.144",
+              "@jskit-ai/http-runtime": "0.1.143",
+              "@jskit-ai/kernel": "0.1.145",
+              "@jskit-ai/shell-web": "0.1.146",
+              "@jskit-ai/users-core": "0.1.158",
+              "@jskit-ai/users-web": "0.1.162"
             },
             "dev": {}
           },
@@ -583,11 +583,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-core",
-      "version": "0.1.142",
+      "version": "0.1.143",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-core",
-        "version": "0.1.142",
+        "version": "0.1.143",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/value-app-config-shared"
@@ -660,7 +660,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.144",
+              "@jskit-ai/kernel": "0.1.145",
               "@fastify/cookie": "^11.0.2",
               "@fastify/csrf-protection": "^7.1.0",
               "@fastify/rate-limit": "^10.3.0"
@@ -678,11 +678,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-local-core",
-      "version": "0.1.46",
+      "version": "0.1.47",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-local-core",
-        "version": "0.1.46",
+        "version": "0.1.47",
         "kind": "runtime",
         "description": "Local auth provider with a file backend default and no database requirement.",
         "dependsOn": [
@@ -745,8 +745,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.142",
-              "@jskit-ai/kernel": "0.1.144",
+              "@jskit-ai/auth-core": "0.1.143",
+              "@jskit-ai/kernel": "0.1.145",
               "nodemailer": "^9.0.3",
               "dotenv": "^16.4.5"
             },
@@ -792,11 +792,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-local-db-core",
-      "version": "0.1.37",
+      "version": "0.1.38",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-local-db-core",
-        "version": "0.1.37",
+        "version": "0.1.38",
         "kind": "runtime",
         "description": "Database-backed local auth storage backend for JSKIT local auth.",
         "dependsOn": [
@@ -875,9 +875,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-provider-local-core": "0.1.46",
-              "@jskit-ai/database-runtime": "0.1.143",
-              "@jskit-ai/kernel": "0.1.144"
+              "@jskit-ai/auth-provider-local-core": "0.1.47",
+              "@jskit-ai/database-runtime": "0.1.144",
+              "@jskit-ai/kernel": "0.1.145"
             },
             "dev": {}
           },
@@ -912,11 +912,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.142",
+      "version": "0.1.143",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-supabase-core",
-        "version": "0.1.142",
+        "version": "0.1.143",
         "kind": "runtime",
         "options": {
           "auth-supabase-url": {
@@ -998,8 +998,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.142",
-              "@jskit-ai/kernel": "0.1.144",
+              "@jskit-ai/auth-core": "0.1.143",
+              "@jskit-ai/kernel": "0.1.145",
               "dotenv": "^16.4.5",
               "@supabase/supabase-js": "^2.57.4",
               "jose": "^6.1.0"
@@ -1077,11 +1077,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-web",
-      "version": "0.1.145",
+      "version": "0.1.146",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-web",
-        "version": "0.1.145",
+        "version": "0.1.146",
         "kind": "runtime",
         "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
         "dependsOn": [
@@ -1354,10 +1354,10 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/auth-core": "0.1.142",
-              "@jskit-ai/http-runtime": "0.1.142",
-              "@jskit-ai/kernel": "0.1.144",
-              "@jskit-ai/shell-web": "0.1.145"
+              "@jskit-ai/auth-core": "0.1.143",
+              "@jskit-ai/http-runtime": "0.1.143",
+              "@jskit-ai/kernel": "0.1.145",
+              "@jskit-ai/shell-web": "0.1.146"
             },
             "dev": {}
           },
@@ -1456,11 +1456,11 @@
     },
     {
       "packageId": "@jskit-ai/console-core",
-      "version": "0.1.108",
+      "version": "0.1.109",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-core",
-        "version": "0.1.108",
+        "version": "0.1.109",
         "kind": "runtime",
         "description": "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
         "dependsOn": [
@@ -1544,12 +1544,12 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.142",
-              "@jskit-ai/database-runtime": "0.1.143",
-              "@jskit-ai/http-runtime": "0.1.142",
-              "@jskit-ai/kernel": "0.1.144",
-              "@jskit-ai/resource-crud-core": "0.1.87",
-              "@jskit-ai/users-core": "0.1.157"
+              "@jskit-ai/auth-core": "0.1.143",
+              "@jskit-ai/database-runtime": "0.1.144",
+              "@jskit-ai/http-runtime": "0.1.143",
+              "@jskit-ai/kernel": "0.1.145",
+              "@jskit-ai/resource-crud-core": "0.1.88",
+              "@jskit-ai/users-core": "0.1.158"
             },
             "dev": {}
           },
@@ -1574,11 +1574,11 @@
     },
     {
       "packageId": "@jskit-ai/console-web",
-      "version": "0.1.113",
+      "version": "0.1.114",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-web",
-        "version": "0.1.113",
+        "version": "0.1.114",
         "kind": "runtime",
         "description": "Authenticated console surface scaffold and surface policy wiring.",
         "dependsOn": [
@@ -1688,9 +1688,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-web": "0.1.145",
-              "@jskit-ai/console-core": "0.1.108",
-              "@jskit-ai/shell-web": "0.1.145"
+              "@jskit-ai/auth-web": "0.1.146",
+              "@jskit-ai/console-core": "0.1.109",
+              "@jskit-ai/shell-web": "0.1.146"
             },
             "dev": {}
           },
@@ -1797,11 +1797,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-core",
-      "version": "0.1.154",
+      "version": "0.1.155",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-core",
-        "version": "0.1.154",
+        "version": "0.1.155",
         "kind": "runtime",
         "description": "Shared CRUD helpers used by CRUD modules.",
         "dependsOn": [
@@ -1830,7 +1830,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/crud-core": "0.1.154"
+              "@jskit-ai/crud-core": "0.1.155"
             },
             "dev": {}
           },
@@ -1844,11 +1844,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-server-generator",
-      "version": "0.1.156",
+      "version": "0.1.157",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-server-generator",
-        "version": "0.1.156",
+        "version": "0.1.157",
         "kind": "generator",
         "description": "CRUD server generator with routes, actions, and persistence scaffolding.",
         "options": {
@@ -2039,14 +2039,14 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.142",
-              "@jskit-ai/crud-core": "0.1.154",
-              "@jskit-ai/database-runtime": "0.1.143",
-              "@jskit-ai/http-runtime": "0.1.142",
-              "@jskit-ai/json-rest-api-core": "0.1.88",
-              "@jskit-ai/kernel": "0.1.144",
-              "@jskit-ai/realtime": "0.1.141",
-              "@jskit-ai/resource-crud-core": "0.1.87",
+              "@jskit-ai/auth-core": "0.1.143",
+              "@jskit-ai/crud-core": "0.1.155",
+              "@jskit-ai/database-runtime": "0.1.144",
+              "@jskit-ai/http-runtime": "0.1.143",
+              "@jskit-ai/json-rest-api-core": "0.1.89",
+              "@jskit-ai/kernel": "0.1.145",
+              "@jskit-ai/realtime": "0.1.142",
+              "@jskit-ai/resource-crud-core": "0.1.88",
               "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}"
             },
             "dev": {}
@@ -2191,11 +2191,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.127",
+      "version": "0.1.128",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-ui-generator",
-        "version": "0.1.127",
+        "version": "0.1.128",
         "kind": "generator",
         "description": "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
         "options": {
@@ -2394,7 +2394,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.161"
+              "@jskit-ai/users-web": "0.1.162"
             },
             "dev": {}
           },
@@ -2653,11 +2653,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime",
-      "version": "0.1.143",
+      "version": "0.1.144",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime",
-        "version": "0.1.143",
+        "version": "0.1.144",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -2726,7 +2726,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.144",
+              "@jskit-ai/kernel": "0.1.145",
               "dotenv": "^16.4.5",
               "knex": "^3.1.0"
             },
@@ -2769,11 +2769,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.142",
+      "version": "0.1.143",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-mysql",
-        "version": "0.1.142",
+        "version": "0.1.143",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -2895,7 +2895,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.143",
+              "@jskit-ai/database-runtime": "0.1.144",
               "mysql2": "^3.11.2"
             },
             "dev": {}
@@ -2966,11 +2966,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.141",
+      "version": "0.1.142",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-postgres",
-        "version": "0.1.141",
+        "version": "0.1.142",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -3091,7 +3091,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.143",
+              "@jskit-ai/database-runtime": "0.1.144",
               "pg": "^8.13.1"
             },
             "dev": {}
@@ -3162,11 +3162,11 @@
     },
     {
       "packageId": "@jskit-ai/feature-server-generator",
-      "version": "0.1.86",
+      "version": "0.1.87",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/feature-server-generator",
-        "version": "0.1.86",
+        "version": "0.1.87",
         "kind": "generator",
         "description": "Scaffold substantial non-CRUD server feature packages with provider, actions, service, and optional persistence seams.",
         "options": {
@@ -3331,27 +3331,27 @@
           "dependencies": {
             "runtime": {
               "@jskit-ai/database-runtime": {
-                "version": "0.1.143",
+                "version": "0.1.144",
                 "when": {
                   "option": "mode",
                   "notEquals": "orchestrator"
                 }
               },
               "@jskit-ai/database-runtime-mysql": {
-                "version": "0.1.142",
+                "version": "0.1.143",
                 "when": {
                   "option": "mode",
                   "notEquals": "orchestrator"
                 }
               },
               "@jskit-ai/json-rest-api-core": {
-                "version": "0.1.88",
+                "version": "0.1.89",
                 "when": {
                   "option": "mode",
                   "equals": "json-rest"
                 }
               },
-              "@jskit-ai/kernel": "0.1.144",
+              "@jskit-ai/kernel": "0.1.145",
               "json-rest-schema": "1.x.x",
               "@local/${option:feature-name|kebab}": "file:packages/${option:feature-name|kebab}"
             },
@@ -3464,11 +3464,11 @@
     },
     {
       "packageId": "@jskit-ai/google-rewarded-core",
-      "version": "0.1.81",
+      "version": "0.1.82",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/google-rewarded-core",
-        "version": "0.1.81",
+        "version": "0.1.82",
         "kind": "runtime",
         "description": "Google rewarded workflow runtime plus internal CRUD providers for rules, provider configs, watch sessions, and unlock receipts.",
         "dependsOn": [
@@ -3595,14 +3595,14 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.142",
-              "@jskit-ai/crud-core": "0.1.154",
-              "@jskit-ai/database-runtime": "0.1.143",
-              "@jskit-ai/http-runtime": "0.1.142",
-              "@jskit-ai/json-rest-api-core": "0.1.88",
-              "@jskit-ai/kernel": "0.1.144",
-              "@jskit-ai/resource-crud-core": "0.1.87",
-              "@jskit-ai/workspaces-core": "0.1.123"
+              "@jskit-ai/auth-core": "0.1.143",
+              "@jskit-ai/crud-core": "0.1.155",
+              "@jskit-ai/database-runtime": "0.1.144",
+              "@jskit-ai/http-runtime": "0.1.143",
+              "@jskit-ai/json-rest-api-core": "0.1.89",
+              "@jskit-ai/kernel": "0.1.145",
+              "@jskit-ai/resource-crud-core": "0.1.88",
+              "@jskit-ai/workspaces-core": "0.1.124"
             },
             "dev": {}
           },
@@ -3654,11 +3654,11 @@
     },
     {
       "packageId": "@jskit-ai/google-rewarded-web",
-      "version": "0.1.81",
+      "version": "0.1.82",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/google-rewarded-web",
-        "version": "0.1.81",
+        "version": "0.1.82",
         "kind": "runtime",
         "description": "Google rewarded client runtime with a fullscreen gate host and GPT orchestration.",
         "dependsOn": [
@@ -3705,10 +3705,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/google-rewarded-core": "0.1.81",
-              "@jskit-ai/http-runtime": "0.1.142",
-              "@jskit-ai/kernel": "0.1.144",
-              "@jskit-ai/shell-web": "0.1.145"
+              "@jskit-ai/google-rewarded-core": "0.1.82",
+              "@jskit-ai/http-runtime": "0.1.143",
+              "@jskit-ai/kernel": "0.1.145",
+              "@jskit-ai/shell-web": "0.1.146"
             },
             "dev": {}
           },
@@ -3726,11 +3726,11 @@
     },
     {
       "packageId": "@jskit-ai/http-runtime",
-      "version": "0.1.142",
+      "version": "0.1.143",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/http-runtime",
-        "version": "0.1.142",
+        "version": "0.1.143",
         "kind": "runtime",
         "dependsOn": [],
         "capabilities": {
@@ -3796,7 +3796,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.144"
+              "@jskit-ai/kernel": "0.1.145"
             },
             "dev": {}
           },
@@ -3810,11 +3810,11 @@
     },
     {
       "packageId": "@jskit-ai/json-rest-api-core",
-      "version": "0.1.88",
+      "version": "0.1.89",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/json-rest-api-core",
-        "version": "0.1.88",
+        "version": "0.1.89",
         "kind": "runtime",
         "description": "Shared internal json-rest-api host runtime with autofilter, query-projection, and row-policy support.",
         "dependsOn": [
@@ -3874,11 +3874,11 @@
     },
     {
       "packageId": "@jskit-ai/mobile-capacitor",
-      "version": "0.1.80",
+      "version": "0.1.81",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/mobile-capacitor",
-        "version": "0.1.80",
+        "version": "0.1.81",
         "kind": "runtime",
         "description": "Thin Capacitor client integration for JSKIT mobile-shell launch routing and auth callback completion.",
         "dependsOn": [
@@ -3941,8 +3941,8 @@
               "@capacitor/app": "^7.1.0",
               "@capacitor/browser": "^7.0.1",
               "@capacitor/core": "^7.4.3",
-              "@jskit-ai/kernel": "0.1.144",
-              "@jskit-ai/shell-web": "0.1.145"
+              "@jskit-ai/kernel": "0.1.145",
+              "@jskit-ai/shell-web": "0.1.146"
             },
             "dev": {
               "@capacitor/cli": "^7.4.3"
@@ -3994,11 +3994,11 @@
     },
     {
       "packageId": "@jskit-ai/realtime",
-      "version": "0.1.141",
+      "version": "0.1.142",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/realtime",
-        "version": "0.1.141",
+        "version": "0.1.142",
         "kind": "runtime",
         "description": "Thin, generic realtime runtime wrappers for socket.io server and client.",
         "options": {
@@ -4094,7 +4094,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.144",
+              "@jskit-ai/kernel": "0.1.145",
               "@socket.io/redis-adapter": "^8.3.0",
               "redis": "^5.8.2",
               "socket.io": "^4.8.3",
@@ -4143,11 +4143,11 @@
     },
     {
       "packageId": "@jskit-ai/resource-core",
-      "version": "0.1.87",
+      "version": "0.1.88",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/resource-core",
-        "version": "0.1.87",
+        "version": "0.1.88",
         "kind": "runtime",
         "description": "Generic resource-definition helpers and schema-definition normalization.",
         "dependsOn": [
@@ -4170,7 +4170,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/resource-core": "0.1.87"
+              "@jskit-ai/resource-core": "0.1.88"
             },
             "dev": {}
           },
@@ -4185,11 +4185,11 @@
     },
     {
       "packageId": "@jskit-ai/resource-crud-core",
-      "version": "0.1.87",
+      "version": "0.1.88",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/resource-crud-core",
-        "version": "0.1.87",
+        "version": "0.1.88",
         "kind": "runtime",
         "description": "CRUD-specific resource-definition helpers and namespace support.",
         "dependsOn": [
@@ -4213,7 +4213,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/resource-crud-core": "0.1.87"
+              "@jskit-ai/resource-crud-core": "0.1.88"
             },
             "dev": {}
           },
@@ -4228,11 +4228,11 @@
     },
     {
       "packageId": "@jskit-ai/shell-web",
-      "version": "0.1.145",
+      "version": "0.1.146",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/shell-web",
-        "version": "0.1.145",
+        "version": "0.1.146",
         "kind": "runtime",
         "description": "Web shell layout runtime with outlet-based placement contributions.",
         "dependsOn": [],
@@ -4578,7 +4578,7 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/kernel": "0.1.144"
+              "@jskit-ai/kernel": "0.1.145"
             },
             "dev": {
               "@playwright/test": "1.61.1"
@@ -4807,11 +4807,11 @@
     },
     {
       "packageId": "@jskit-ai/storage-runtime",
-      "version": "0.1.142",
+      "version": "0.1.143",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/storage-runtime",
-        "version": "0.1.142",
+        "version": "0.1.143",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -4860,7 +4860,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.144",
+              "@jskit-ai/kernel": "0.1.145",
               "unstorage": "^1.17.3"
             },
             "dev": {}
@@ -4876,11 +4876,11 @@
     },
     {
       "packageId": "@jskit-ai/ui-generator",
-      "version": "0.1.127",
+      "version": "0.1.128",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/ui-generator",
-        "version": "0.1.127",
+        "version": "0.1.128",
         "kind": "generator",
         "description": "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
         "options": {
@@ -5313,7 +5313,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.161"
+              "@jskit-ai/users-web": "0.1.162"
             },
             "dev": {}
           },
@@ -5328,11 +5328,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-image-web",
-      "version": "0.1.120",
+      "version": "0.1.121",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-image-web",
-        "version": "0.1.120",
+        "version": "0.1.121",
         "kind": "runtime",
         "description": "Reusable client-side image upload runtime with pre-upload image editing.",
         "dependsOn": [
@@ -5396,7 +5396,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/uploads-runtime": "0.1.120",
+              "@jskit-ai/uploads-runtime": "0.1.121",
               "@uppy/compressor": "^3.1.0",
               "@uppy/core": "^5.2.0",
               "@uppy/dashboard": "^5.1.1",
@@ -5416,11 +5416,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-runtime",
-      "version": "0.1.120",
+      "version": "0.1.121",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-runtime",
-        "version": "0.1.120",
+        "version": "0.1.121",
         "kind": "runtime",
         "description": "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
         "dependsOn": [
@@ -5490,7 +5490,7 @@
           "dependencies": {
             "runtime": {
               "@fastify/multipart": "^9.4.0",
-              "@jskit-ai/kernel": "0.1.144"
+              "@jskit-ai/kernel": "0.1.145"
             },
             "dev": {}
           },
@@ -5505,11 +5505,11 @@
     },
     {
       "packageId": "@jskit-ai/users-core",
-      "version": "0.1.157",
+      "version": "0.1.158",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-core",
-        "version": "0.1.157",
+        "version": "0.1.158",
         "kind": "runtime",
         "description": "Users/account runtime plus HTTP routes for account features.",
         "dependsOn": [
@@ -5653,16 +5653,16 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.142",
-              "@jskit-ai/crud-core": "0.1.154",
-              "@jskit-ai/database-runtime": "0.1.143",
-              "@jskit-ai/http-runtime": "0.1.142",
-              "@jskit-ai/json-rest-api-core": "0.1.88",
-              "@jskit-ai/kernel": "0.1.144",
-              "@jskit-ai/resource-core": "0.1.87",
-              "@jskit-ai/resource-crud-core": "0.1.87",
+              "@jskit-ai/auth-core": "0.1.143",
+              "@jskit-ai/crud-core": "0.1.155",
+              "@jskit-ai/database-runtime": "0.1.144",
+              "@jskit-ai/http-runtime": "0.1.143",
+              "@jskit-ai/json-rest-api-core": "0.1.89",
+              "@jskit-ai/kernel": "0.1.145",
+              "@jskit-ai/resource-core": "0.1.88",
+              "@jskit-ai/resource-crud-core": "0.1.88",
               "@local/users": "file:packages/users",
-              "@jskit-ai/uploads-runtime": "0.1.120"
+              "@jskit-ai/uploads-runtime": "0.1.121"
             },
             "dev": {}
           },
@@ -5889,11 +5889,11 @@
     },
     {
       "packageId": "@jskit-ai/users-web",
-      "version": "0.1.161",
+      "version": "0.1.162",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-web",
-        "version": "0.1.161",
+        "version": "0.1.162",
         "kind": "runtime",
         "description": "Users web module: account/profile UI plus shared users web widgets.",
         "dependsOn": [
@@ -6196,12 +6196,12 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/http-runtime": "0.1.142",
-              "@jskit-ai/realtime": "0.1.141",
-              "@jskit-ai/kernel": "0.1.144",
-              "@jskit-ai/shell-web": "0.1.145",
-              "@jskit-ai/uploads-image-web": "0.1.120",
-              "@jskit-ai/users-core": "0.1.157"
+              "@jskit-ai/http-runtime": "0.1.143",
+              "@jskit-ai/realtime": "0.1.142",
+              "@jskit-ai/kernel": "0.1.145",
+              "@jskit-ai/shell-web": "0.1.146",
+              "@jskit-ai/uploads-image-web": "0.1.121",
+              "@jskit-ai/users-core": "0.1.158"
             },
             "dev": {}
           },
@@ -6382,11 +6382,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-core",
-      "version": "0.1.123",
+      "version": "0.1.124",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-core",
-        "version": "0.1.123",
+        "version": "0.1.124",
         "kind": "runtime",
         "description": "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
         "dependsOn": [
@@ -6532,10 +6532,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/json-rest-api-core": "0.1.88",
-              "@jskit-ai/resource-core": "0.1.87",
-              "@jskit-ai/resource-crud-core": "0.1.87",
-              "@jskit-ai/users-core": "0.1.157"
+              "@jskit-ai/json-rest-api-core": "0.1.89",
+              "@jskit-ai/resource-core": "0.1.88",
+              "@jskit-ai/resource-crud-core": "0.1.88",
+              "@jskit-ai/users-core": "0.1.158"
             },
             "dev": {}
           },
@@ -6739,11 +6739,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-web",
-      "version": "0.1.124",
+      "version": "0.1.125",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-web",
-        "version": "0.1.124",
+        "version": "0.1.125",
         "kind": "runtime",
         "description": "Workspace web module: workspace selector, tools widget, workspace surfaces, members UI, and settings hosts.",
         "dependsOn": [
@@ -7000,9 +7000,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-web": "0.1.145",
-              "@jskit-ai/workspaces-core": "0.1.123",
-              "@jskit-ai/users-web": "0.1.161"
+              "@jskit-ai/auth-web": "0.1.146",
+              "@jskit-ai/workspaces-core": "0.1.124",
+              "@jskit-ai/users-web": "0.1.162"
             },
             "dev": {}
           },

--- a/tooling/jskit-catalog/catalog/packages.json
+++ b/tooling/jskit-catalog/catalog/packages.json
@@ -6,11 +6,11 @@
   "packages": [
     {
       "packageId": "@jskit-ai/assistant",
-      "version": "0.1.151",
+      "version": "0.1.152",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant",
-        "version": "0.1.151",
+        "version": "0.1.152",
         "kind": "generator",
         "description": "Install assistant runtime/config for one surface and scaffold assistant pages at explicit target files.",
         "options": {
@@ -347,11 +347,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-core",
-      "version": "0.1.119",
+      "version": "0.1.120",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-core",
-        "version": "0.1.119",
+        "version": "0.1.120",
         "kind": "runtime",
         "description": "Reusable assistant client/server/shared primitives without surface-specific routes or settings ownership.",
         "dependsOn": [
@@ -399,11 +399,11 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/http-runtime": "0.1.140",
-              "@jskit-ai/kernel": "0.1.142",
-              "@jskit-ai/resource-core": "0.1.85",
-              "@jskit-ai/resource-crud-core": "0.1.85",
-              "@jskit-ai/users-core": "0.1.155",
+              "@jskit-ai/http-runtime": "0.1.141",
+              "@jskit-ai/kernel": "0.1.143",
+              "@jskit-ai/resource-core": "0.1.86",
+              "@jskit-ai/resource-crud-core": "0.1.86",
+              "@jskit-ai/users-core": "0.1.156",
               "dompurify": "^3.3.3",
               "json-rest-schema": "1.x.x",
               "marked": "^17.0.4",
@@ -422,11 +422,11 @@
     },
     {
       "packageId": "@jskit-ai/assistant-runtime",
-      "version": "0.1.114",
+      "version": "0.1.115",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/assistant-runtime",
-        "version": "0.1.114",
+        "version": "0.1.115",
         "kind": "runtime",
         "description": "Shared assistant runtime with per-surface assistant registration.",
         "dependsOn": [
@@ -522,13 +522,13 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/assistant-core": "0.1.119",
-              "@jskit-ai/database-runtime": "0.1.141",
-              "@jskit-ai/http-runtime": "0.1.140",
-              "@jskit-ai/kernel": "0.1.142",
-              "@jskit-ai/shell-web": "0.1.143",
-              "@jskit-ai/users-core": "0.1.155",
-              "@jskit-ai/users-web": "0.1.159"
+              "@jskit-ai/assistant-core": "0.1.120",
+              "@jskit-ai/database-runtime": "0.1.142",
+              "@jskit-ai/http-runtime": "0.1.141",
+              "@jskit-ai/kernel": "0.1.143",
+              "@jskit-ai/shell-web": "0.1.144",
+              "@jskit-ai/users-core": "0.1.156",
+              "@jskit-ai/users-web": "0.1.160"
             },
             "dev": {}
           },
@@ -583,11 +583,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-core",
-      "version": "0.1.140",
+      "version": "0.1.141",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-core",
-        "version": "0.1.140",
+        "version": "0.1.141",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/value-app-config-shared"
@@ -660,7 +660,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.142",
+              "@jskit-ai/kernel": "0.1.143",
               "@fastify/cookie": "^11.0.2",
               "@fastify/csrf-protection": "^7.1.0",
               "@fastify/rate-limit": "^10.3.0"
@@ -678,11 +678,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-local-core",
-      "version": "0.1.44",
+      "version": "0.1.45",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-local-core",
-        "version": "0.1.44",
+        "version": "0.1.45",
         "kind": "runtime",
         "description": "Local auth provider with a file backend default and no database requirement.",
         "dependsOn": [
@@ -745,8 +745,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.140",
-              "@jskit-ai/kernel": "0.1.142",
+              "@jskit-ai/auth-core": "0.1.141",
+              "@jskit-ai/kernel": "0.1.143",
               "nodemailer": "^9.0.3",
               "dotenv": "^16.4.5"
             },
@@ -792,11 +792,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-local-db-core",
-      "version": "0.1.35",
+      "version": "0.1.36",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-local-db-core",
-        "version": "0.1.35",
+        "version": "0.1.36",
         "kind": "runtime",
         "description": "Database-backed local auth storage backend for JSKIT local auth.",
         "dependsOn": [
@@ -875,9 +875,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-provider-local-core": "0.1.44",
-              "@jskit-ai/database-runtime": "0.1.141",
-              "@jskit-ai/kernel": "0.1.142"
+              "@jskit-ai/auth-provider-local-core": "0.1.45",
+              "@jskit-ai/database-runtime": "0.1.142",
+              "@jskit-ai/kernel": "0.1.143"
             },
             "dev": {}
           },
@@ -912,11 +912,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-provider-supabase-core",
-      "version": "0.1.140",
+      "version": "0.1.141",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-provider-supabase-core",
-        "version": "0.1.140",
+        "version": "0.1.141",
         "kind": "runtime",
         "options": {
           "auth-supabase-url": {
@@ -998,8 +998,8 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.140",
-              "@jskit-ai/kernel": "0.1.142",
+              "@jskit-ai/auth-core": "0.1.141",
+              "@jskit-ai/kernel": "0.1.143",
               "dotenv": "^16.4.5",
               "@supabase/supabase-js": "^2.57.4",
               "jose": "^6.1.0"
@@ -1077,11 +1077,11 @@
     },
     {
       "packageId": "@jskit-ai/auth-web",
-      "version": "0.1.143",
+      "version": "0.1.144",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/auth-web",
-        "version": "0.1.143",
+        "version": "0.1.144",
         "kind": "runtime",
         "description": "Auth web module: Fastify auth routes plus web login/sign-out scaffolds.",
         "dependsOn": [
@@ -1354,10 +1354,10 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/auth-core": "0.1.140",
-              "@jskit-ai/http-runtime": "0.1.140",
-              "@jskit-ai/kernel": "0.1.142",
-              "@jskit-ai/shell-web": "0.1.143"
+              "@jskit-ai/auth-core": "0.1.141",
+              "@jskit-ai/http-runtime": "0.1.141",
+              "@jskit-ai/kernel": "0.1.143",
+              "@jskit-ai/shell-web": "0.1.144"
             },
             "dev": {}
           },
@@ -1456,11 +1456,11 @@
     },
     {
       "packageId": "@jskit-ai/console-core",
-      "version": "0.1.106",
+      "version": "0.1.107",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-core",
-        "version": "0.1.106",
+        "version": "0.1.107",
         "kind": "runtime",
         "description": "Console runtime: console settings schema, bootstrap flags, actions, and HTTP routes.",
         "dependsOn": [
@@ -1544,12 +1544,12 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.140",
-              "@jskit-ai/database-runtime": "0.1.141",
-              "@jskit-ai/http-runtime": "0.1.140",
-              "@jskit-ai/kernel": "0.1.142",
-              "@jskit-ai/resource-crud-core": "0.1.85",
-              "@jskit-ai/users-core": "0.1.155"
+              "@jskit-ai/auth-core": "0.1.141",
+              "@jskit-ai/database-runtime": "0.1.142",
+              "@jskit-ai/http-runtime": "0.1.141",
+              "@jskit-ai/kernel": "0.1.143",
+              "@jskit-ai/resource-crud-core": "0.1.86",
+              "@jskit-ai/users-core": "0.1.156"
             },
             "dev": {}
           },
@@ -1574,11 +1574,11 @@
     },
     {
       "packageId": "@jskit-ai/console-web",
-      "version": "0.1.111",
+      "version": "0.1.112",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/console-web",
-        "version": "0.1.111",
+        "version": "0.1.112",
         "kind": "runtime",
         "description": "Authenticated console surface scaffold and surface policy wiring.",
         "dependsOn": [
@@ -1688,9 +1688,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-web": "0.1.143",
-              "@jskit-ai/console-core": "0.1.106",
-              "@jskit-ai/shell-web": "0.1.143"
+              "@jskit-ai/auth-web": "0.1.144",
+              "@jskit-ai/console-core": "0.1.107",
+              "@jskit-ai/shell-web": "0.1.144"
             },
             "dev": {}
           },
@@ -1797,11 +1797,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-core",
-      "version": "0.1.152",
+      "version": "0.1.153",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-core",
-        "version": "0.1.152",
+        "version": "0.1.153",
         "kind": "runtime",
         "description": "Shared CRUD helpers used by CRUD modules.",
         "dependsOn": [
@@ -1830,7 +1830,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/crud-core": "0.1.152"
+              "@jskit-ai/crud-core": "0.1.153"
             },
             "dev": {}
           },
@@ -1844,11 +1844,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-server-generator",
-      "version": "0.1.154",
+      "version": "0.1.155",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-server-generator",
-        "version": "0.1.154",
+        "version": "0.1.155",
         "kind": "generator",
         "description": "CRUD server generator with routes, actions, and persistence scaffolding.",
         "options": {
@@ -2039,14 +2039,14 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.140",
-              "@jskit-ai/crud-core": "0.1.152",
-              "@jskit-ai/database-runtime": "0.1.141",
-              "@jskit-ai/http-runtime": "0.1.140",
-              "@jskit-ai/json-rest-api-core": "0.1.86",
-              "@jskit-ai/kernel": "0.1.142",
-              "@jskit-ai/realtime": "0.1.139",
-              "@jskit-ai/resource-crud-core": "0.1.85",
+              "@jskit-ai/auth-core": "0.1.141",
+              "@jskit-ai/crud-core": "0.1.153",
+              "@jskit-ai/database-runtime": "0.1.142",
+              "@jskit-ai/http-runtime": "0.1.141",
+              "@jskit-ai/json-rest-api-core": "0.1.87",
+              "@jskit-ai/kernel": "0.1.143",
+              "@jskit-ai/realtime": "0.1.140",
+              "@jskit-ai/resource-crud-core": "0.1.86",
               "@local/${option:namespace|kebab}": "file:packages/${option:namespace|kebab}"
             },
             "dev": {}
@@ -2191,11 +2191,11 @@
     },
     {
       "packageId": "@jskit-ai/crud-ui-generator",
-      "version": "0.1.125",
+      "version": "0.1.126",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/crud-ui-generator",
-        "version": "0.1.125",
+        "version": "0.1.126",
         "kind": "generator",
         "description": "Generate CRUD route trees from resource validators at an explicit route root relative to src/pages/.",
         "options": {
@@ -2394,7 +2394,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.159"
+              "@jskit-ai/users-web": "0.1.160"
             },
             "dev": {}
           },
@@ -2653,11 +2653,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime",
-      "version": "0.1.141",
+      "version": "0.1.142",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime",
-        "version": "0.1.141",
+        "version": "0.1.142",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -2726,7 +2726,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.142",
+              "@jskit-ai/kernel": "0.1.143",
               "dotenv": "^16.4.5",
               "knex": "^3.1.0"
             },
@@ -2769,11 +2769,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-mysql",
-      "version": "0.1.140",
+      "version": "0.1.141",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-mysql",
-        "version": "0.1.140",
+        "version": "0.1.141",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -2895,7 +2895,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.141",
+              "@jskit-ai/database-runtime": "0.1.142",
               "mysql2": "^3.11.2"
             },
             "dev": {}
@@ -2966,11 +2966,11 @@
     },
     {
       "packageId": "@jskit-ai/database-runtime-postgres",
-      "version": "0.1.139",
+      "version": "0.1.140",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/database-runtime-postgres",
-        "version": "0.1.139",
+        "version": "0.1.140",
         "kind": "runtime",
         "options": {
           "db-host": {
@@ -3091,7 +3091,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/database-runtime": "0.1.141",
+              "@jskit-ai/database-runtime": "0.1.142",
               "pg": "^8.13.1"
             },
             "dev": {}
@@ -3162,11 +3162,11 @@
     },
     {
       "packageId": "@jskit-ai/feature-server-generator",
-      "version": "0.1.84",
+      "version": "0.1.85",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/feature-server-generator",
-        "version": "0.1.84",
+        "version": "0.1.85",
         "kind": "generator",
         "description": "Scaffold substantial non-CRUD server feature packages with provider, actions, service, and optional persistence seams.",
         "options": {
@@ -3331,27 +3331,27 @@
           "dependencies": {
             "runtime": {
               "@jskit-ai/database-runtime": {
-                "version": "0.1.141",
+                "version": "0.1.142",
                 "when": {
                   "option": "mode",
                   "notEquals": "orchestrator"
                 }
               },
               "@jskit-ai/database-runtime-mysql": {
-                "version": "0.1.140",
+                "version": "0.1.141",
                 "when": {
                   "option": "mode",
                   "notEquals": "orchestrator"
                 }
               },
               "@jskit-ai/json-rest-api-core": {
-                "version": "0.1.86",
+                "version": "0.1.87",
                 "when": {
                   "option": "mode",
                   "equals": "json-rest"
                 }
               },
-              "@jskit-ai/kernel": "0.1.142",
+              "@jskit-ai/kernel": "0.1.143",
               "json-rest-schema": "1.x.x",
               "@local/${option:feature-name|kebab}": "file:packages/${option:feature-name|kebab}"
             },
@@ -3464,11 +3464,11 @@
     },
     {
       "packageId": "@jskit-ai/google-rewarded-core",
-      "version": "0.1.79",
+      "version": "0.1.80",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/google-rewarded-core",
-        "version": "0.1.79",
+        "version": "0.1.80",
         "kind": "runtime",
         "description": "Google rewarded workflow runtime plus internal CRUD providers for rules, provider configs, watch sessions, and unlock receipts.",
         "dependsOn": [
@@ -3595,14 +3595,14 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.140",
-              "@jskit-ai/crud-core": "0.1.152",
-              "@jskit-ai/database-runtime": "0.1.141",
-              "@jskit-ai/http-runtime": "0.1.140",
-              "@jskit-ai/json-rest-api-core": "0.1.86",
-              "@jskit-ai/kernel": "0.1.142",
-              "@jskit-ai/resource-crud-core": "0.1.85",
-              "@jskit-ai/workspaces-core": "0.1.121"
+              "@jskit-ai/auth-core": "0.1.141",
+              "@jskit-ai/crud-core": "0.1.153",
+              "@jskit-ai/database-runtime": "0.1.142",
+              "@jskit-ai/http-runtime": "0.1.141",
+              "@jskit-ai/json-rest-api-core": "0.1.87",
+              "@jskit-ai/kernel": "0.1.143",
+              "@jskit-ai/resource-crud-core": "0.1.86",
+              "@jskit-ai/workspaces-core": "0.1.122"
             },
             "dev": {}
           },
@@ -3654,11 +3654,11 @@
     },
     {
       "packageId": "@jskit-ai/google-rewarded-web",
-      "version": "0.1.79",
+      "version": "0.1.80",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/google-rewarded-web",
-        "version": "0.1.79",
+        "version": "0.1.80",
         "kind": "runtime",
         "description": "Google rewarded client runtime with a fullscreen gate host and GPT orchestration.",
         "dependsOn": [
@@ -3705,10 +3705,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/google-rewarded-core": "0.1.79",
-              "@jskit-ai/http-runtime": "0.1.140",
-              "@jskit-ai/kernel": "0.1.142",
-              "@jskit-ai/shell-web": "0.1.143"
+              "@jskit-ai/google-rewarded-core": "0.1.80",
+              "@jskit-ai/http-runtime": "0.1.141",
+              "@jskit-ai/kernel": "0.1.143",
+              "@jskit-ai/shell-web": "0.1.144"
             },
             "dev": {}
           },
@@ -3726,11 +3726,11 @@
     },
     {
       "packageId": "@jskit-ai/http-runtime",
-      "version": "0.1.140",
+      "version": "0.1.141",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/http-runtime",
-        "version": "0.1.140",
+        "version": "0.1.141",
         "kind": "runtime",
         "dependsOn": [],
         "capabilities": {
@@ -3796,7 +3796,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.142"
+              "@jskit-ai/kernel": "0.1.143"
             },
             "dev": {}
           },
@@ -3810,11 +3810,11 @@
     },
     {
       "packageId": "@jskit-ai/json-rest-api-core",
-      "version": "0.1.86",
+      "version": "0.1.87",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/json-rest-api-core",
-        "version": "0.1.86",
+        "version": "0.1.87",
         "kind": "runtime",
         "description": "Shared internal json-rest-api host runtime with autofilter, query-projection, and row-policy support.",
         "dependsOn": [
@@ -3874,11 +3874,11 @@
     },
     {
       "packageId": "@jskit-ai/mobile-capacitor",
-      "version": "0.1.78",
+      "version": "0.1.79",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/mobile-capacitor",
-        "version": "0.1.78",
+        "version": "0.1.79",
         "kind": "runtime",
         "description": "Thin Capacitor client integration for JSKIT mobile-shell launch routing and auth callback completion.",
         "dependsOn": [
@@ -3941,8 +3941,8 @@
               "@capacitor/app": "^7.1.0",
               "@capacitor/browser": "^7.0.1",
               "@capacitor/core": "^7.4.3",
-              "@jskit-ai/kernel": "0.1.142",
-              "@jskit-ai/shell-web": "0.1.143"
+              "@jskit-ai/kernel": "0.1.143",
+              "@jskit-ai/shell-web": "0.1.144"
             },
             "dev": {
               "@capacitor/cli": "^7.4.3"
@@ -3994,11 +3994,11 @@
     },
     {
       "packageId": "@jskit-ai/realtime",
-      "version": "0.1.139",
+      "version": "0.1.140",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/realtime",
-        "version": "0.1.139",
+        "version": "0.1.140",
         "kind": "runtime",
         "description": "Thin, generic realtime runtime wrappers for socket.io server and client.",
         "options": {
@@ -4094,7 +4094,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.142",
+              "@jskit-ai/kernel": "0.1.143",
               "@socket.io/redis-adapter": "^8.3.0",
               "redis": "^5.8.2",
               "socket.io": "^4.8.3",
@@ -4143,11 +4143,11 @@
     },
     {
       "packageId": "@jskit-ai/resource-core",
-      "version": "0.1.85",
+      "version": "0.1.86",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/resource-core",
-        "version": "0.1.85",
+        "version": "0.1.86",
         "kind": "runtime",
         "description": "Generic resource-definition helpers and schema-definition normalization.",
         "dependsOn": [
@@ -4170,7 +4170,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/resource-core": "0.1.85"
+              "@jskit-ai/resource-core": "0.1.86"
             },
             "dev": {}
           },
@@ -4185,11 +4185,11 @@
     },
     {
       "packageId": "@jskit-ai/resource-crud-core",
-      "version": "0.1.85",
+      "version": "0.1.86",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/resource-crud-core",
-        "version": "0.1.85",
+        "version": "0.1.86",
         "kind": "runtime",
         "description": "CRUD-specific resource-definition helpers and namespace support.",
         "dependsOn": [
@@ -4213,7 +4213,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/resource-crud-core": "0.1.85"
+              "@jskit-ai/resource-crud-core": "0.1.86"
             },
             "dev": {}
           },
@@ -4228,11 +4228,11 @@
     },
     {
       "packageId": "@jskit-ai/shell-web",
-      "version": "0.1.143",
+      "version": "0.1.144",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/shell-web",
-        "version": "0.1.143",
+        "version": "0.1.144",
         "kind": "runtime",
         "description": "Web shell layout runtime with outlet-based placement contributions.",
         "dependsOn": [],
@@ -4578,7 +4578,7 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/kernel": "0.1.142"
+              "@jskit-ai/kernel": "0.1.143"
             },
             "dev": {
               "@playwright/test": "1.61.1"
@@ -4807,11 +4807,11 @@
     },
     {
       "packageId": "@jskit-ai/storage-runtime",
-      "version": "0.1.140",
+      "version": "0.1.141",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/storage-runtime",
-        "version": "0.1.140",
+        "version": "0.1.141",
         "kind": "runtime",
         "dependsOn": [
           "@jskit-ai/kernel"
@@ -4860,7 +4860,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/kernel": "0.1.142",
+              "@jskit-ai/kernel": "0.1.143",
               "unstorage": "^1.17.3"
             },
             "dev": {}
@@ -4876,11 +4876,11 @@
     },
     {
       "packageId": "@jskit-ai/ui-generator",
-      "version": "0.1.125",
+      "version": "0.1.126",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/ui-generator",
-        "version": "0.1.125",
+        "version": "0.1.126",
         "kind": "generator",
         "description": "Create non-CRUD pages, reusable UI elements, and subpage hosts.",
         "options": {
@@ -5313,7 +5313,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/users-web": "0.1.159"
+              "@jskit-ai/users-web": "0.1.160"
             },
             "dev": {}
           },
@@ -5328,11 +5328,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-image-web",
-      "version": "0.1.118",
+      "version": "0.1.119",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-image-web",
-        "version": "0.1.118",
+        "version": "0.1.119",
         "kind": "runtime",
         "description": "Reusable client-side image upload runtime with pre-upload image editing.",
         "dependsOn": [
@@ -5396,7 +5396,7 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/uploads-runtime": "0.1.118",
+              "@jskit-ai/uploads-runtime": "0.1.119",
               "@uppy/compressor": "^3.1.0",
               "@uppy/core": "^5.2.0",
               "@uppy/dashboard": "^5.1.1",
@@ -5416,11 +5416,11 @@
     },
     {
       "packageId": "@jskit-ai/uploads-runtime",
-      "version": "0.1.118",
+      "version": "0.1.119",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/uploads-runtime",
-        "version": "0.1.118",
+        "version": "0.1.119",
         "kind": "runtime",
         "description": "Reusable upload runtime primitives for multipart parsing, policy validation, and blob storage.",
         "dependsOn": [
@@ -5490,7 +5490,7 @@
           "dependencies": {
             "runtime": {
               "@fastify/multipart": "^9.4.0",
-              "@jskit-ai/kernel": "0.1.142"
+              "@jskit-ai/kernel": "0.1.143"
             },
             "dev": {}
           },
@@ -5505,11 +5505,11 @@
     },
     {
       "packageId": "@jskit-ai/users-core",
-      "version": "0.1.155",
+      "version": "0.1.156",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-core",
-        "version": "0.1.155",
+        "version": "0.1.156",
         "kind": "runtime",
         "description": "Users/account runtime plus HTTP routes for account features.",
         "dependsOn": [
@@ -5653,16 +5653,16 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-core": "0.1.140",
-              "@jskit-ai/crud-core": "0.1.152",
-              "@jskit-ai/database-runtime": "0.1.141",
-              "@jskit-ai/http-runtime": "0.1.140",
-              "@jskit-ai/json-rest-api-core": "0.1.86",
-              "@jskit-ai/kernel": "0.1.142",
-              "@jskit-ai/resource-core": "0.1.85",
-              "@jskit-ai/resource-crud-core": "0.1.85",
+              "@jskit-ai/auth-core": "0.1.141",
+              "@jskit-ai/crud-core": "0.1.153",
+              "@jskit-ai/database-runtime": "0.1.142",
+              "@jskit-ai/http-runtime": "0.1.141",
+              "@jskit-ai/json-rest-api-core": "0.1.87",
+              "@jskit-ai/kernel": "0.1.143",
+              "@jskit-ai/resource-core": "0.1.86",
+              "@jskit-ai/resource-crud-core": "0.1.86",
               "@local/users": "file:packages/users",
-              "@jskit-ai/uploads-runtime": "0.1.118"
+              "@jskit-ai/uploads-runtime": "0.1.119"
             },
             "dev": {}
           },
@@ -5889,11 +5889,11 @@
     },
     {
       "packageId": "@jskit-ai/users-web",
-      "version": "0.1.159",
+      "version": "0.1.160",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/users-web",
-        "version": "0.1.159",
+        "version": "0.1.160",
         "kind": "runtime",
         "description": "Users web module: account/profile UI plus shared users web widgets.",
         "dependsOn": [
@@ -6196,12 +6196,12 @@
           "dependencies": {
             "runtime": {
               "@mdi/js": "^7.4.47",
-              "@jskit-ai/http-runtime": "0.1.140",
-              "@jskit-ai/realtime": "0.1.139",
-              "@jskit-ai/kernel": "0.1.142",
-              "@jskit-ai/shell-web": "0.1.143",
-              "@jskit-ai/uploads-image-web": "0.1.118",
-              "@jskit-ai/users-core": "0.1.155"
+              "@jskit-ai/http-runtime": "0.1.141",
+              "@jskit-ai/realtime": "0.1.140",
+              "@jskit-ai/kernel": "0.1.143",
+              "@jskit-ai/shell-web": "0.1.144",
+              "@jskit-ai/uploads-image-web": "0.1.119",
+              "@jskit-ai/users-core": "0.1.156"
             },
             "dev": {}
           },
@@ -6382,11 +6382,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-core",
-      "version": "0.1.121",
+      "version": "0.1.122",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-core",
-        "version": "0.1.121",
+        "version": "0.1.122",
         "kind": "runtime",
         "description": "Workspace tenancy runtime plus HTTP routes, role catalog, and workspace config scaffolding.",
         "dependsOn": [
@@ -6532,10 +6532,10 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/json-rest-api-core": "0.1.86",
-              "@jskit-ai/resource-core": "0.1.85",
-              "@jskit-ai/resource-crud-core": "0.1.85",
-              "@jskit-ai/users-core": "0.1.155"
+              "@jskit-ai/json-rest-api-core": "0.1.87",
+              "@jskit-ai/resource-core": "0.1.86",
+              "@jskit-ai/resource-crud-core": "0.1.86",
+              "@jskit-ai/users-core": "0.1.156"
             },
             "dev": {}
           },
@@ -6739,11 +6739,11 @@
     },
     {
       "packageId": "@jskit-ai/workspaces-web",
-      "version": "0.1.122",
+      "version": "0.1.123",
       "descriptor": {
         "packageVersion": 1,
         "packageId": "@jskit-ai/workspaces-web",
-        "version": "0.1.122",
+        "version": "0.1.123",
         "kind": "runtime",
         "description": "Workspace web module: workspace selector, tools widget, workspace surfaces, members UI, and settings hosts.",
         "dependsOn": [
@@ -7000,9 +7000,9 @@
         "mutations": {
           "dependencies": {
             "runtime": {
-              "@jskit-ai/auth-web": "0.1.143",
-              "@jskit-ai/workspaces-core": "0.1.121",
-              "@jskit-ai/users-web": "0.1.159"
+              "@jskit-ai/auth-web": "0.1.144",
+              "@jskit-ai/workspaces-core": "0.1.122",
+              "@jskit-ai/users-web": "0.1.160"
             },
             "dev": {}
           },

--- a/tooling/jskit-catalog/package.json
+++ b/tooling/jskit-catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-catalog",
-  "version": "0.1.165",
+  "version": "0.1.166",
   "description": "Published metadata catalog for JSKIT package descriptors.",
   "type": "module",
   "files": [

--- a/tooling/jskit-catalog/package.json
+++ b/tooling/jskit-catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-catalog",
-  "version": "0.1.164",
+  "version": "0.1.165",
   "description": "Published metadata catalog for JSKIT package descriptors.",
   "type": "module",
   "files": [

--- a/tooling/jskit-catalog/package.json
+++ b/tooling/jskit-catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-catalog",
-  "version": "0.1.163",
+  "version": "0.1.164",
   "description": "Published metadata catalog for JSKIT package descriptors.",
   "type": "module",
   "files": [

--- a/tooling/jskit-cli/package.json
+++ b/tooling/jskit-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-cli",
-  "version": "0.2.170",
+  "version": "0.2.171",
   "description": "Bundle and package orchestration CLI for JSKIT apps.",
   "type": "module",
   "files": [
@@ -21,9 +21,9 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/jskit-catalog": "0.1.164",
-    "@jskit-ai/kernel": "0.1.143",
-    "@jskit-ai/shell-web": "0.1.144",
+    "@jskit-ai/jskit-catalog": "0.1.165",
+    "@jskit-ai/kernel": "0.1.144",
+    "@jskit-ai/shell-web": "0.1.145",
     "@vue/compiler-sfc": "^3.5.29",
     "semver": "^7.7.4",
     "ts-morph": "^28.0.0",

--- a/tooling/jskit-cli/package.json
+++ b/tooling/jskit-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-cli",
-  "version": "0.2.169",
+  "version": "0.2.170",
   "description": "Bundle and package orchestration CLI for JSKIT apps.",
   "type": "module",
   "files": [
@@ -21,9 +21,9 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/jskit-catalog": "0.1.163",
-    "@jskit-ai/kernel": "0.1.142",
-    "@jskit-ai/shell-web": "0.1.143",
+    "@jskit-ai/jskit-catalog": "0.1.164",
+    "@jskit-ai/kernel": "0.1.143",
+    "@jskit-ai/shell-web": "0.1.144",
     "@vue/compiler-sfc": "^3.5.29",
     "semver": "^7.7.4",
     "ts-morph": "^28.0.0",

--- a/tooling/jskit-cli/package.json
+++ b/tooling/jskit-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jskit-ai/jskit-cli",
-  "version": "0.2.171",
+  "version": "0.2.172",
   "description": "Bundle and package orchestration CLI for JSKIT apps.",
   "type": "module",
   "files": [
@@ -21,9 +21,9 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@jskit-ai/jskit-catalog": "0.1.165",
-    "@jskit-ai/kernel": "0.1.144",
-    "@jskit-ai/shell-web": "0.1.145",
+    "@jskit-ai/jskit-catalog": "0.1.166",
+    "@jskit-ai/kernel": "0.1.145",
+    "@jskit-ai/shell-web": "0.1.146",
     "@vue/compiler-sfc": "^3.5.29",
     "semver": "^7.7.4",
     "ts-morph": "^28.0.0",

--- a/tooling/jskit-cli/src/server/cliRuntime/localPackageSupport.js
+++ b/tooling/jskit-cli/src/server/cliRuntime/localPackageSupport.js
@@ -19,19 +19,31 @@ function resolvePackageDependencySpecifier(packageEntry, { existingValue = "" } 
     packageEntry?.version || packageEntry?.packageJson?.version || ""
   ).trim();
   if (sourceType === "npm-installed-package") {
-    if (publishedVersion) {
-      return publishedVersion;
+    const normalizedExisting = String(existingValue || "").trim();
+    if (normalizedExisting) {
+      return normalizedExisting;
     }
   }
 
-  const normalizedExisting = String(existingValue || "").trim();
-  if (normalizedExisting) {
-    return normalizedExisting;
-  }
   if (publishedVersion) {
-    return publishedVersion;
+    return normalizeJskitDependencySpecifier(packageEntry?.packageId, publishedVersion);
   }
   throw createCliError(`Unable to resolve dependency specifier for ${String(packageEntry?.packageId || "unknown package")}.`);
+}
+
+function normalizeJskitDependencySpecifier(packageId, dependencySpecifier) {
+  const normalizedPackageId = String(packageId || "").trim();
+  const normalizedSpecifier = String(dependencySpecifier || "").trim();
+  if (!normalizedSpecifier || !normalizedPackageId.startsWith("@jskit-ai/")) {
+    return normalizedSpecifier;
+  }
+
+  const semverMatch = /^(\d+)\.\d+\.\d+(?:[.+-][0-9A-Za-z.-]+)?$/.exec(normalizedSpecifier);
+  if (!semverMatch) {
+    return normalizedSpecifier;
+  }
+
+  return `${semverMatch[1]}.x`;
 }
 
 function normalizePackageNameSegment(rawValue, { label = "package name" } = {}) {

--- a/tooling/jskit-cli/test/externalPackageAdoption.test.js
+++ b/tooling/jskit-cli/test/externalPackageAdoption.test.js
@@ -96,13 +96,13 @@ async function createExternalDescriptorPackage(appRoot, { packageId, version }) 
   );
 }
 
-test("managed package reapplication keeps JSKIT app-root dependencies exact", async () => {
+test("managed package reapplication preserves an exact JSKIT app-root dependency", async () => {
   await withTempDir(async (cwd) => {
     const appRoot = path.join(cwd, "jskit-root-dependency-app");
     const packageId = "@jskit-ai/example-runtime";
     await createMinimalApp(appRoot, {
       dependencies: {
-        [packageId]: "0.x"
+        [packageId]: "2.3.4"
       },
       name: "demo-app"
     });
@@ -124,6 +124,12 @@ test("managed package reapplication keeps JSKIT app-root dependencies exact", as
       packageId,
       version: "2.3.5"
     });
+    appPackageJson.dependencies[packageId] = "2.3.5";
+    await writeFile(
+      path.join(appRoot, "package.json"),
+      `${JSON.stringify(appPackageJson, null, 2)}\n`,
+      "utf8"
+    );
     const updateResult = runCli({
       cwd: appRoot,
       args: ["update", "package", packageId]


### PR DESCRIPTION
Completes the exact JSKIT app-root update contract and makes the standard release self-consistent.

- Preserves exact versions installed by `jskit app update-packages` when managed packages are reapplied.
- Retains normal major-range behavior for genuinely new package additions.
- Regenerates agent documentation during plain `npm run release`.
- Includes the published coordinated release: `@jskit-ai/jskit-cli@0.2.172` and `@jskit-ai/agent-docs@0.1.112`.

Validation:
- `npm run verify`
- Registry `latest` versions verified.